### PR TITLE
Avoid cloning ScoredPointOffset when peeking the top scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.idea
+/storage

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -55,7 +55,7 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     }
 }
 
-pub fn peek_top_scores_iterable<I, E: Ord + Clone>(scores: I, top: usize) -> Vec<E>
+pub fn peek_top_scores_iterable<I, E: Ord>(scores: I, top: usize) -> Vec<E>
     where
         I: Iterator<Item=E>,
 {
@@ -67,7 +67,7 @@ pub fn peek_top_scores_iterable<I, E: Ord + Clone>(scores: I, top: usize) -> Vec
     // Hence is should be min-heap
     let mut pq = FixedLengthPriorityQueue::new(top);
     for score_point in scores {
-        pq.push(score_point.clone());
+        pq.push(score_point);
     }
     pq.into_vec()
 }


### PR DESCRIPTION
The ``peek_top_scores_iterable`` method already accepts ``scores`` by value. The ``Iterator<Item=E>`` yelds ``E``, not ``&E``, so there is no need to call ``clone`` and have ``+Clone`` trait constraint

Also added a few lines to .gitignore: clion project and storage folder

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?
