### PR TITLE
[CLIPPY] Fix File::write and option_env!

### DIFF
--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -139,7 +139,7 @@ impl VectorStorage for MemmapVectorStorage {
             for id in other.iter_ids() {
                 let vector = &other.get_vector(id).unwrap();
                 let raw_bites = vf_to_u8(vector);
-                file.write(raw_bites)?;
+                file.write_all(raw_bites)?;
                 end_index += 1;
             }
 
@@ -155,7 +155,7 @@ impl VectorStorage for MemmapVectorStorage {
 
             let flags: Vec<u8> = vec![0; (end_index - start_index) as usize];
             let flag_bytes = vf_to_u8(&flags);
-            file.write(flag_bytes)?;
+            file.write_all(flag_bytes)?;
             file.flush()?;
         }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -47,7 +47,7 @@ fn ensure_mmap_file_exists(path: &Path, header: &[u8]) -> OperationResult<()> {
         return Ok(());
     }
     let mut file = File::create(path)?;
-    file.write(header)?;
+    file.write_all(header)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error
 pub async fn index() -> impl Responder {
     HttpResponse::Ok().json(VersionInfo {
         title: "qdrant - vector search engine".to_string(),
-        version: option_env!("CARGO_PKG_VERSION").unwrap().to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }
 


### PR DESCRIPTION
The PR fixes [unused_io_amount](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount) and [option_env_unwrap](https://rust-lang.github.io/rust-clippy/master/index.html#option_env_unwrap). They are reported as errors by clippy, not as warnings.

The first one looks a real bug:
``io::Write::write(_vectored)`` and ``io::Read::read(_vectored)`` are not guaranteed to process the entire buffer. They return how many bytes were processed, which might be smaller than a given buffer’s length. If you don’t need to deal with partial-write/read, use write_all/read_exact instead.

There is no clippy detected errors left after this fix, only the set of warnings

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally using ``cargo fmt`` command prior to submission?
