### PR TITLE
Avoid useless vector copy during scoring

### DIFF
--- a/lib/collection/src/segment_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/segment_manager/holders/proxy_segment.rs
@@ -107,7 +107,7 @@ impl SegmentEntry for ProxySegment {
 
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
@@ -149,7 +149,7 @@ impl SegmentEntry for ProxySegment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
     ) -> OperationResult<bool> {
         if self.version() > op_num {
             return Ok(false);

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -83,7 +83,7 @@ pub trait SegmentEntry {
 
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
@@ -93,7 +93,7 @@ pub trait SegmentEntry {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
     ) -> OperationResult<bool>;
 
     fn delete_point(

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -34,7 +34,10 @@ impl TestRawScorerProducer {
         let metric = mertic_object(&distance);
 
         let vectors = (0..num_vectors)
-            .map(|_x| metric.preprocess(random_vector(&mut rnd, dim)))
+            .map(|_x| {
+                let rnd_vec = random_vector(&mut rnd, dim);
+                metric.preprocess(&rnd_vec).unwrap_or(rnd_vec)
+            })
             .collect_vec();
 
         TestRawScorerProducer {
@@ -46,7 +49,7 @@ impl TestRawScorerProducer {
 
     pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> SimpleRawScorer {
         SimpleRawScorer {
-            query: Array::from(self.metric.preprocess(query)),
+            query: Array::from(self.metric.preprocess(&query).unwrap_or(query)),
             metric: &self.metric,
             vectors: &self.vectors,
             deleted: &self.deleted,

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -551,13 +551,13 @@ mod tests {
     }
 
     fn search_in_graph(
-        query: &Vec<VectorElementType>,
+        query: &[VectorElementType],
         top: usize,
         vector_storage: &TestRawScorerProducer,
         graph: &GraphLayers,
     ) -> Vec<ScoredPointOffset> {
         let fake_condition_checker = FakeConditionChecker {};
-        let raw_scorer = vector_storage.get_raw_scorer(query.clone());
+        let raw_scorer = vector_storage.get_raw_scorer(query.to_owned());
         let scorer = FilteredScorer {
             raw_scorer: &raw_scorer,
             condition_checker: &fake_condition_checker,
@@ -715,7 +715,12 @@ mod tests {
 
         let top = 5;
         let query = random_vector(&mut rng, dim);
-        let processed_query = vector_holder.metric.preprocess(&query).unwrap_or_else(|| query.clone());
+        let processed_query = Array::from(
+            vector_holder
+                .metric
+                .preprocess(&query)
+                .unwrap_or_else(|| query.clone()),
+        );
         let mut reference_top = FixedLengthPriorityQueue::new(top);
         for (idx, vec) in vector_holder.vectors.iter().enumerate() {
             reference_top.push(ScoredPointOffset {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -715,7 +715,7 @@ mod tests {
 
         let top = 5;
         let query = random_vector(&mut rng, dim);
-        let processed_query = Array::from(vector_holder.metric.preprocess(query.clone()));
+        let processed_query = vector_holder.metric.preprocess(&query).unwrap_or_else(|| query.clone());
         let mut reference_top = FixedLengthPriorityQueue::new(top);
         for (idx, vec) in vector_holder.vectors.iter().enumerate() {
             reference_top.push(ScoredPointOffset {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -139,7 +139,7 @@ impl HNSWIndex {
 
     pub fn search_with_graph(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
@@ -152,7 +152,7 @@ impl HNSWIndex {
         let ef = max(req_ef, top);
 
         let vector_storage = self.vector_storage.borrow();
-        let raw_scorer = vector_storage.raw_scorer(vector.clone());
+        let raw_scorer = vector_storage.raw_scorer(vector.to_owned());
         let condition_checker = self.condition_checker.borrow();
 
         let points_scorer = FilteredScorer {
@@ -168,7 +168,7 @@ impl HNSWIndex {
 impl VectorIndex for HNSWIndex {
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,

--- a/lib/segment/src/index/index.rs
+++ b/lib/segment/src/index/index.rs
@@ -8,7 +8,7 @@ pub trait VectorIndex {
     /// Return list of Ids with fitting
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -134,7 +134,7 @@ impl PlainIndex {
 impl VectorIndex for PlainIndex {
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         _params: Option<&SearchParams>,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -104,7 +104,7 @@ impl SegmentEntry for Segment {
 
     fn search(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
@@ -146,7 +146,7 @@ impl SegmentEntry for Segment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
     ) -> OperationResult<bool> {
         if self.skip_by_version(op_num) {
             return Ok(false);
@@ -161,7 +161,9 @@ impl SegmentEntry for Segment {
         }
 
         let metric = mertic_object(&self.segment_config.distance);
-        let processed_vector = metric.preprocess(vector).unwrap_or_else(|| vector.clone());
+        let processed_vector = metric
+            .preprocess(vector)
+            .unwrap_or_else(|| vector.to_owned());
 
         let stored_internal_point = {
             let id_mapped = self.id_mapper.borrow();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -161,7 +161,7 @@ impl SegmentEntry for Segment {
         }
 
         let metric = mertic_object(&self.segment_config.distance);
-        let processed_vector = metric.preprocess(vector.clone());
+        let processed_vector = metric.preprocess(vector).unwrap_or_else(|| vector.clone());
 
         let stored_internal_point = {
             let id_mapped = self.id_mapper.borrow();

--- a/lib/segment/src/spaces/metric.rs
+++ b/lib/segment/src/spaces/metric.rs
@@ -15,5 +15,6 @@ pub trait Metric {
     ) -> ScoreType;
 
     /// Necessary vector transformations performed before adding it to the collection (like normalization)
-    fn preprocess(&self, vector: Vec<VectorElementType>) -> Vec<VectorElementType>;
+    /// Return None if metric does not required preprocessing
+    fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>>;
 }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -24,7 +24,7 @@ impl Metric for EuclidMetric {
             .zip(v2.iter().cloned())
             .map(|(a, b)| (a - b).powi(2))
             .sum();
-        return -s.sqrt();
+        -s.sqrt()
     }
 
     fn blas_similarity(
@@ -38,11 +38,11 @@ impl Metric for EuclidMetric {
             .zip(v2.iter().cloned())
             .map(|(a, b)| (a - b).powi(2))
             .sum();
-        return -s.sqrt();
+        -s.sqrt()
     }
 
-    fn preprocess(&self, vector: Vec<VectorElementType>) -> Vec<VectorElementType> {
-        return vector;
+    fn preprocess(&self, _vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
+        None
     }
 }
 
@@ -52,8 +52,7 @@ impl Metric for DotProductMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        let ip: ScoreType = v1.iter().zip(v2).map(|(a, b)| a * b).sum();
-        return ip;
+        v1.iter().zip(v2).map(|(a, b)| a * b).sum()
     }
 
     fn blas_similarity(
@@ -64,8 +63,8 @@ impl Metric for DotProductMetric {
         v1.dot(v2)
     }
 
-    fn preprocess(&self, vector: Vec<VectorElementType>) -> Vec<VectorElementType> {
-        return vector;
+    fn preprocess(&self, _vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
+        None
     }
 }
 
@@ -75,8 +74,7 @@ impl Metric for CosineMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        let cos: VectorElementType = v1.iter().zip(v2).map(|(a, b)| a * b).sum();
-        return cos;
+        v1.iter().zip(v2).map(|(a, b)| a * b).sum()
     }
 
     fn blas_similarity(
@@ -87,10 +85,10 @@ impl Metric for CosineMetric {
         v1.dot(v2)
     }
 
-    fn preprocess(&self, vector: Vec<VectorElementType>) -> Vec<VectorElementType> {
+    fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>>{
         let mut length: f32 = vector.iter().map(|x| x * x).sum();
         length = length.sqrt();
         let norm_vector = vector.iter().map(|x| x / length).collect();
-        return norm_vector;
+        Some(norm_vector)
     }
 }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -85,7 +85,7 @@ impl Metric for CosineMetric {
         v1.dot(v2)
     }
 
-    fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>>{
+    fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
         let mut length: f32 = vector.iter().map(|x| x * x).sum();
         length = length.sqrt();
         let norm_vector = vector.iter().map(|x| x / length).collect();

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -196,7 +196,7 @@ impl VectorStorage for MemmapVectorStorage {
 
     fn raw_scorer(&self, vector: Vec<VectorElementType>) -> Box<dyn RawScorer + '_> {
         Box::new(MemmapRawScorer {
-            query: self.metric.preprocess(vector),
+            query: self.metric.preprocess(&vector).unwrap_or(vector),
             metric: &self.metric,
             mmap_store: &self.mmap_store.as_ref().unwrap(),
         })
@@ -216,7 +216,8 @@ impl VectorStorage for MemmapVectorStorage {
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = self.metric.preprocess(vector.clone());
+        let preprocessed_vector_opt = self.metric.preprocess(vector);
+        let preprocessed_vector = preprocessed_vector_opt.as_ref().unwrap_or(vector);
         let scores = points
             .filter(|point| {
                 !self
@@ -230,14 +231,15 @@ impl VectorStorage for MemmapVectorStorage {
                 let other_vector = self.mmap_store.as_ref().unwrap().raw_vector(point).unwrap();
                 ScoredPointOffset {
                     idx: point,
-                    score: self.metric.similarity(&preprocessed_vector, &other_vector),
+                    score: self.metric.similarity(preprocessed_vector, &other_vector),
                 }
             });
         return peek_top_scores_iterable(scores, top);
     }
 
     fn score_all(&self, vector: &Vec<VectorElementType>, top: usize) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = self.metric.preprocess(vector.clone());
+        let preprocessed_vector_opt = self.metric.preprocess(vector);
+        let preprocessed_vector = preprocessed_vector_opt.as_ref().unwrap_or(vector);
         let scores = self.iter_ids().map(|point| {
             let other_vector = self.mmap_store.as_ref().unwrap().raw_vector(point).unwrap();
             ScoredPointOffset {

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -212,12 +212,15 @@ impl VectorStorage for MemmapVectorStorage {
 
     fn score_points(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset> {
         let preprocessed_vector_opt = self.metric.preprocess(vector);
-        let preprocessed_vector = preprocessed_vector_opt.as_ref().unwrap_or(vector);
+        let preprocessed_vector = preprocessed_vector_opt
+            .as_ref()
+            .map(|x| x as &[_])
+            .unwrap_or(vector);
         let scores = points
             .filter(|point| {
                 !self
@@ -237,9 +240,12 @@ impl VectorStorage for MemmapVectorStorage {
         return peek_top_scores_iterable(scores, top);
     }
 
-    fn score_all(&self, vector: &Vec<VectorElementType>, top: usize) -> Vec<ScoredPointOffset> {
+    fn score_all(&self, vector: &[VectorElementType], top: usize) -> Vec<ScoredPointOffset> {
         let preprocessed_vector_opt = self.metric.preprocess(vector);
-        let preprocessed_vector = preprocessed_vector_opt.as_ref().unwrap_or(vector);
+        let preprocessed_vector = preprocessed_vector_opt
+            .as_ref()
+            .map(|x| x as &[_])
+            .unwrap_or(vector);
         let scores = self.iter_ids().map(|point| {
             let other_vector = self.mmap_store.as_ref().unwrap().raw_vector(point).unwrap();
             ScoredPointOffset {

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -227,7 +227,7 @@ impl VectorStorage for SimpleVectorStorage {
 
     fn raw_scorer(&self, vector: Vec<VectorElementType>) -> Box<dyn RawScorer + '_> {
         Box::new(SimpleRawScorer {
-            query: Array::from(self.metric.preprocess(vector)),
+            query: Array::from(self.metric.preprocess(&vector).unwrap_or(vector)),
             metric: &self.metric,
             vectors: &self.vectors,
             deleted: &self.deleted,
@@ -249,7 +249,7 @@ impl VectorStorage for SimpleVectorStorage {
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = Array::from(self.metric.preprocess(vector.clone()));
+        let preprocessed_vector = Array::from(self.metric.preprocess(vector).unwrap_or_else(|| vector.clone()));
         let scores = points
             .filter(|point| !self.deleted[*point as usize])
             .map(|point| {
@@ -265,7 +265,7 @@ impl VectorStorage for SimpleVectorStorage {
     }
 
     fn score_all(&self, vector: &Vec<VectorElementType>, top: usize) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = Array::from(self.metric.preprocess(vector.clone()));
+        let preprocessed_vector = Array::from(self.metric.preprocess(vector).unwrap_or_else(|| vector.clone()));
         let scores = self
             .vectors
             .iter()

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -245,11 +245,15 @@ impl VectorStorage for SimpleVectorStorage {
 
     fn score_points(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = Array::from(self.metric.preprocess(vector).unwrap_or_else(|| vector.clone()));
+        let preprocessed_vector = Array::from(
+            self.metric
+                .preprocess(vector)
+                .unwrap_or_else(|| vector.to_owned()),
+        );
         let scores = points
             .filter(|point| !self.deleted[*point as usize])
             .map(|point| {
@@ -264,8 +268,12 @@ impl VectorStorage for SimpleVectorStorage {
         return peek_top_scores_iterable(scores, top);
     }
 
-    fn score_all(&self, vector: &Vec<VectorElementType>, top: usize) -> Vec<ScoredPointOffset> {
-        let preprocessed_vector = Array::from(self.metric.preprocess(vector).unwrap_or_else(|| vector.clone()));
+    fn score_all(&self, vector: &[VectorElementType], top: usize) -> Vec<ScoredPointOffset> {
+        let preprocessed_vector = Array::from(
+            self.metric
+                .preprocess(vector)
+                .unwrap_or_else(|| vector.to_owned()),
+        );
         let scores = self
             .vectors
             .iter()

--- a/lib/segment/src/vector_storage/vector_storage.rs
+++ b/lib/segment/src/vector_storage/vector_storage.rs
@@ -76,11 +76,11 @@ pub trait VectorStorage {
 
     fn score_points(
         &self,
-        vector: &Vec<VectorElementType>,
+        vector: &[VectorElementType],
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset>;
-    fn score_all(&self, vector: &Vec<VectorElementType>, top: usize) -> Vec<ScoredPointOffset>;
+    fn score_all(&self, vector: &[VectorElementType], top: usize) -> Vec<ScoredPointOffset>;
     fn score_internal(
         &self,
         point: PointOffsetType,


### PR DESCRIPTION
Imagine we have ``&Vec<VectorElementType>`` (or rather it should be ``&[VectorElementType]``, but that is not important) and we want to call  ``metric.preprocess``. As it accepts vector by value, we have to clone it. However, 2 of 3 metrics does not do any normalization, so clone is useless. For the 3rd one, the ``preprocess`` would anyway iterate over the vector and create a new one, so it would be another copying operation anyway, so it could be accepting reference.

Hence, if the caller of ``preprocess`` does not need the ``Vec<VectorElementType>``, cloning is useless in both cases. If the caller needs ``Vec<VectorElementType>`` instead of ``&Vec<VectorElementType>`` it *could* clone it only if new object was not returned by ``preprocess``.  

I think it is very critical for ``score_all`` and ``score_points`` methods.

The above is fixed in the first commit of this PR (better review it separately)

The second commit is trivial and somewhat unrelated but touches the same methods. It simply fixes the [writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg) Clippy rule, which, in our case, would probably not have any performance impact and just enforces the style.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
