### PR TITLE
[Clippy] Fix a range of warnings

### DIFF
--- a/lib/collection/src/collection_builder/optimizers_builder.rs
+++ b/lib/collection/src/collection_builder/optimizers_builder.rs
@@ -51,7 +51,7 @@ pub fn build_optimizers(
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
-            hnsw_config.clone(),
+            *hnsw_config,
         )),
         Box::new(MergeOptimizer::new(
             optimizers_config.max_segment_number,
@@ -59,16 +59,16 @@ pub fn build_optimizers(
             segments_path.clone(),
             temp_segments_path.clone(),
             collection_params.clone(),
-            hnsw_config.clone(),
+            *hnsw_config,
         )),
         Box::new(VacuumOptimizer::new(
             optimizers_config.deleted_threshold,
             optimizers_config.vacuum_min_vector_number,
-            threshold_config.clone(),
-            segments_path.clone(),
-            temp_segments_path.clone(),
+            threshold_config,
+            segments_path,
+            temp_segments_path,
             collection_params.clone(),
-            hnsw_config.clone(),
+            *hnsw_config,
         )),
     ])
 }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -64,10 +64,8 @@ impl CollectionConfig {
         let af = AtomicFile::new(&config_path, AllowOverwrite);
         let state_bytes = serde_json::to_vec(self).unwrap();
         af.write(|f| f.write_all(&state_bytes))
-            .or_else(move |err| {
-                Err(CollectionError::ServiceError {
-                    error: format!("Can't write {:?}, error: {}", config_path, err),
-                })
+            .map_err(|err| CollectionError::ServiceError {
+                error: format!("Can't write {:?}, error: {}", config_path, err),
             })?;
         Ok(())
     }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -198,7 +198,7 @@ impl From<WalError> for CollectionError {
 impl<T> From<SendError<T>> for CollectionError {
     fn from(_err: SendError<T>) -> Self {
         Self::ServiceError {
-            error: format!("Can't reach one of the workers"),
+            error: "Can't reach one of the workers".to_owned(),
         }
     }
 }

--- a/lib/collection/src/segment_manager/fixtures.rs
+++ b/lib/collection/src/segment_manager/fixtures.rs
@@ -12,8 +12,7 @@ use tokio::runtime;
 use tokio::runtime::Runtime;
 
 pub fn empty_segment(path: &Path) -> Segment {
-    let segment = build_simple_segment(path, 4, Distance::Dot).unwrap();
-    return segment;
+    build_simple_segment(path, 4, Distance::Dot).unwrap()
 }
 
 pub fn random_segment(path: &Path, opnum: SeqNumberType, num_vectors: u64, dim: usize) -> Segment {
@@ -64,19 +63,19 @@ pub fn build_segment_1(path: &Path) -> Segment {
         .set_payload(6, 1, &payload_key, payload_option1.clone())
         .unwrap();
     segment1
-        .set_payload(6, 2, &payload_key, payload_option1.clone())
+        .set_payload(6, 2, &payload_key, payload_option1)
         .unwrap();
     segment1
-        .set_payload(6, 3, &payload_key, payload_option3.clone())
+        .set_payload(6, 3, &payload_key, payload_option3)
         .unwrap();
     segment1
         .set_payload(6, 4, &payload_key, payload_option2.clone())
         .unwrap();
     segment1
-        .set_payload(6, 5, &payload_key, payload_option2.clone())
+        .set_payload(6, 5, &payload_key, payload_option2)
         .unwrap();
 
-    return segment1;
+    segment1
 }
 
 pub fn build_segment_2(path: &Path) -> Segment {
@@ -100,19 +99,19 @@ pub fn build_segment_2(path: &Path) -> Segment {
     segment2.upsert_point(14, 14, &vec14).unwrap();
     segment2.upsert_point(15, 15, &vec15).unwrap();
 
-    return segment2;
+    segment2
 }
 
 pub fn build_test_holder(path: &Path) -> SegmentHolder {
     let segment1 = build_segment_1(path);
     let segment2 = build_segment_2(path);
 
-    let mut holder = SegmentHolder::new();
+    let mut holder = SegmentHolder::default();
 
     let _sid1 = holder.add(segment1);
     let _sid2 = holder.add(segment2);
 
-    return holder;
+    holder
 }
 
 pub fn build_searcher(path: &Path) -> (Runtime, SimpleSegmentSearcher) {

--- a/lib/collection/src/segment_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/segment_manager/holders/proxy_segment.rs
@@ -76,7 +76,7 @@ impl ProxySegment {
     fn add_deleted_points_condition_to_filter(&self, filter: Option<&Filter>) -> Filter {
         let deleted_points = self.deleted_points.read();
         let wrapper_condition = Condition::HasId(deleted_points.clone().into());
-        let wrapped_filter = match filter {
+        match filter {
             None => Filter::new_must_not(wrapper_condition),
             Some(f) => {
                 let mut new_filter = f.clone();
@@ -92,8 +92,7 @@ impl ProxySegment {
                 new_filter.must_not = new_must_not;
                 new_filter
             }
-        };
-        wrapped_filter
+        }
     }
 }
 
@@ -142,7 +141,7 @@ impl SegmentEntry for ProxySegment {
             .search(vector, filter, top, params)?;
 
         wrapped_result.append(&mut write_result);
-        return Ok(wrapped_result);
+        Ok(wrapped_result)
     }
 
     fn upsert_point(
@@ -339,7 +338,7 @@ impl SegmentEntry for ProxySegment {
         let wrapped_info = self.wrapped_segment.get().read().info();
         let write_info = self.write_segment.get().read().info();
 
-        return SegmentInfo {
+        SegmentInfo {
             segment_type: SegmentType::Special,
             num_vectors: self.vectors_count(),
             num_deleted_vectors: write_info.num_deleted_vectors,
@@ -347,7 +346,7 @@ impl SegmentEntry for ProxySegment {
             disk_usage_bytes: wrapped_info.disk_usage_bytes + write_info.disk_usage_bytes,
             is_appendable: false,
             schema: wrapped_info.schema,
-        };
+        }
     }
 
     fn config(&self) -> SegmentConfig {

--- a/lib/collection/src/segment_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/segment_manager/optimizers/indexing_optimizer.rs
@@ -81,7 +81,7 @@ impl IndexingOptimizer {
                 }
             })
             .max_by_key(|(_, num_vectors)| *num_vectors)
-            .and_then(|(idx, _)| Some((idx, segments.read().get(idx).unwrap().clone())))
+            .map(|(idx, _)| (idx, segments.read().get(idx).unwrap().clone()))
     }
 }
 
@@ -99,7 +99,7 @@ impl SegmentOptimizer for IndexingOptimizer {
     }
 
     fn hnsw_config(&self) -> HnswConfig {
-        self.hnsw_config.clone()
+        self.hnsw_config
     }
 
     fn threshold_config(&self) -> &OptimizerThresholds {
@@ -136,7 +136,7 @@ mod tests {
     fn test_indexing_optimizer() {
         init();
 
-        let mut holder = SegmentHolder::new();
+        let mut holder = SegmentHolder::default();
 
         let payload_field = "number".to_owned();
 

--- a/lib/collection/src/segment_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/segment_manager/optimizers/merge_optimizer.rs
@@ -26,14 +26,14 @@ impl MergeOptimizer {
         collection_params: CollectionParams,
         hnsw_config: HnswConfig,
     ) -> Self {
-        return MergeOptimizer {
+        MergeOptimizer {
             max_segments,
             thresholds_config,
             segments_path,
             collection_temp_dir,
             collection_params,
             hnsw_config,
-        };
+        }
     }
 }
 
@@ -51,7 +51,7 @@ impl SegmentOptimizer for MergeOptimizer {
     }
 
     fn hnsw_config(&self) -> HnswConfig {
-        self.hnsw_config.clone()
+        self.hnsw_config
     }
 
     fn threshold_config(&self) -> &OptimizerThresholds {
@@ -100,7 +100,7 @@ mod tests {
         let dir = TempDir::new("segment_dir").unwrap();
         let temp_dir = TempDir::new("segment_temp_dir").unwrap();
 
-        let mut holder = SegmentHolder::new();
+        let mut holder = SegmentHolder::default();
 
         let mut segments_to_merge = vec![];
 

--- a/lib/collection/src/segment_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/segment_manager/optimizers/segment_optimizer.rs
@@ -64,7 +64,7 @@ pub trait SegmentOptimizer {
     /// Build optimized segment
     fn optimized_segment_builder(
         &self,
-        optimizing_segments: &Vec<LockedSegment>,
+        optimizing_segments: &[LockedSegment],
     ) -> CollectionResult<SegmentBuilder> {
         let total_vectors: usize = optimizing_segments
             .iter()
@@ -132,7 +132,7 @@ pub trait SegmentOptimizer {
             ids.iter()
                 .cloned()
                 .map(|id| read_segments.get(id))
-                .filter_map(|x| x.and_then(|x| Some(x.clone())))
+                .filter_map(|x| x.cloned())
                 .collect()
         };
 
@@ -156,7 +156,7 @@ pub trait SegmentOptimizer {
             proxies
                 .into_iter()
                 .zip(ids.iter().cloned())
-                .map(|(proxy, idx)| write_segments.swap(proxy, &vec![idx], false).unwrap())
+                .map(|(proxy, idx)| write_segments.swap(proxy, &[idx], false).unwrap())
                 .collect()
         };
 

--- a/lib/collection/src/segment_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/segment_manager/optimizers/vacuum_optimizer.rs
@@ -61,7 +61,7 @@ impl VacuumOptimizer {
                 }
             })
             .max_by_key(|(_, ratio)| OrderedFloat(*ratio))
-            .and_then(|(idx, _)| Some((idx, segments.read().get(idx).unwrap().clone())))
+            .map(|(idx, _)| (idx, segments.read().get(idx).unwrap().clone()))
     }
 }
 
@@ -79,7 +79,7 @@ impl SegmentOptimizer for VacuumOptimizer {
     }
 
     fn hnsw_config(&self) -> HnswConfig {
-        self.hnsw_config.clone()
+        self.hnsw_config
     }
 
     fn threshold_config(&self) -> &OptimizerThresholds {
@@ -110,7 +110,7 @@ mod tests {
     fn test_vacuum_conditions() {
         let temp_dir = TempDir::new("segment_temp_dir").unwrap();
         let dir = TempDir::new("segment_dir").unwrap();
-        let mut holder = SegmentHolder::new();
+        let mut holder = SegmentHolder::default();
         let segment_id = holder.add(random_segment(dir.path(), 100, 200, 4));
 
         let segment = holder.get(segment_id).unwrap();

--- a/lib/collection/src/segment_manager/segment_managers.rs
+++ b/lib/collection/src/segment_manager/segment_managers.rs
@@ -14,7 +14,7 @@ pub trait SegmentSearcher {
 
     fn retrieve(
         &self,
-        points: &Vec<PointIdType>,
+        points: &[PointIdType],
         with_payload: bool,
         with_vector: bool,
     ) -> CollectionResult<Vec<Record>>;

--- a/lib/collection/src/segment_manager/simple_segment_searcher.rs
+++ b/lib/collection/src/segment_manager/simple_segment_searcher.rs
@@ -21,10 +21,10 @@ pub struct SimpleSegmentSearcher {
 
 impl SimpleSegmentSearcher {
     pub fn new(segments: LockedSegmentHolder, runtime_handle: Handle) -> Self {
-        return SimpleSegmentSearcher {
+        SimpleSegmentSearcher {
             segments,
             runtime_handle,
-        };
+        }
     }
 
     pub async fn search_in_segment(
@@ -92,7 +92,7 @@ impl SegmentSearcher for SimpleSegmentSearcher {
 
     fn retrieve(
         &self,
-        points: &Vec<PointIdType>,
+        points: &[PointIdType],
         with_payload: bool,
         with_vector: bool,
     ) -> CollectionResult<Vec<Record>> {

--- a/lib/collection/src/update_handler/update_handler.rs
+++ b/lib/collection/src/update_handler/update_handler.rs
@@ -102,7 +102,7 @@ impl UpdateHandler {
         segments: LockedSegmentHolder,
         wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
         flush_timeout_sec: u64,
-    ) -> () {
+    ) {
         let flush_timeout = Duration::from_secs(flush_timeout_sec);
         let mut last_flushed = Instant::now();
         loop {

--- a/lib/segment/src/common/file_operations.rs
+++ b/lib/segment/src/common/file_operations.rs
@@ -35,15 +35,14 @@ pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResul
     let mut file = File::open(path)?;
     file.read_to_string(&mut contents)?;
 
-    let result: N = serde_json::from_str(&contents).or_else(|err| {
-        Err(OperationError::ServiceError {
+    let result: N =
+        serde_json::from_str(&contents).map_err(|err| OperationError::ServiceError {
             description: format!(
                 "Failed to read data {}. Error: {}",
                 path.to_str().unwrap(),
                 err
             ),
-        })
-    })?;
+        })?;
 
     Ok(result)
 }
@@ -51,15 +50,14 @@ pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResul
 pub fn read_bin<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResult<N> {
     let mut file = File::open(path)?;
 
-    let result: N = bincode::deserialize_from(&mut file).or_else(|err| {
-        Err(OperationError::ServiceError {
+    let result: N =
+        bincode::deserialize_from(&mut file).map_err(|err| OperationError::ServiceError {
             description: format!(
                 "Failed to read data {}. Error: {}",
                 path.to_str().unwrap(),
                 err
             ),
-        })
-    })?;
+        })?;
 
     Ok(result)
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -42,7 +42,7 @@ impl<E> From<AtomicIoError<E>> for OperationError {
         match err {
             AtomicIoError::Internal(io_err) => OperationError::from(io_err),
             AtomicIoError::User(_user_err) => OperationError::ServiceError {
-                description: format!("Unknown atomic write error"),
+                description: "Unknown atomic write error".to_owned(),
             },
         }
     }

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -41,7 +41,7 @@ impl TestRawScorerProducer {
             .collect_vec();
 
         TestRawScorerProducer {
-            vectors: vectors.into_iter().map(|v| Array::from(v)).collect(),
+            vectors: vectors.into_iter().map(Array::from).collect(),
             deleted: BitVec::from_elem(num_vectors, false),
             metric,
         }
@@ -50,7 +50,7 @@ impl TestRawScorerProducer {
     pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> SimpleRawScorer {
         SimpleRawScorer {
             query: Array::from(self.metric.preprocess(&query).unwrap_or(query)),
-            metric: &self.metric,
+            metric: self.metric.as_ref(),
             vectors: &self.vectors,
             deleted: &self.deleted,
         }

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -8,7 +8,7 @@ use rand::seq::SliceRandom;
 use rand::Rng;
 use std::ops::Range;
 
-const ADJECTIVE: &'static [&'static str] = &[
+const ADJECTIVE: &[&str] = &[
     "jobless",
     "rightful",
     "breakable",
@@ -22,7 +22,7 @@ const ADJECTIVE: &'static [&'static str] = &[
     "broad",
 ];
 
-const NOUN: &'static [&'static str] = &[
+const NOUN: &[&str] = &[
     "territory",
     "jam",
     "neck",

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -5,13 +5,15 @@ use crate::types::{FloatPayloadType, IntPayloadType, PayloadSchemaType};
 
 pub fn index_selector(payload_type: &PayloadSchemaType) -> Vec<Box<dyn PayloadFieldIndexBuilder>> {
     match payload_type {
-        PayloadSchemaType::Keyword => vec![Box::new(PersistedMapIndex::<String>::new())],
+        PayloadSchemaType::Keyword => vec![Box::new(PersistedMapIndex::<String>::default())],
         PayloadSchemaType::Integer => vec![
-            Box::new(PersistedMapIndex::<IntPayloadType>::new()),
-            Box::new(PersistedNumericIndex::<IntPayloadType>::new()),
+            Box::new(PersistedMapIndex::<IntPayloadType>::default()),
+            Box::new(PersistedNumericIndex::<IntPayloadType>::default()),
         ],
         PayloadSchemaType::Float => {
-            vec![Box::new(PersistedNumericIndex::<FloatPayloadType>::new())]
+            vec![Box::new(
+                PersistedNumericIndex::<FloatPayloadType>::default(),
+            )]
         }
         PayloadSchemaType::Geo => vec![],
     }

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -87,7 +87,7 @@ impl EntryPoints {
             point_id: new_point,
             level,
         };
-        self.entry_points.push(new_entry.clone());
+        self.entry_points.push(new_entry);
         None
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -110,7 +110,11 @@ impl GraphLayers {
 
     /// Get M based on current level
     fn get_m(&self, level: usize) -> usize {
-        return if level == 0 { self.m0 } else { self.m };
+        if level == 0 {
+            self.m0
+        } else {
+            self.m
+        }
     }
 
     /// Generate random level for a new point, according to geometric distribution
@@ -118,7 +122,7 @@ impl GraphLayers {
         let distribution = Uniform::new(0.0, 1.0);
         let sample: f64 = thread_rng.sample(distribution);
         let picked_level = -sample.ln() * self.level_factor;
-        return picked_level.round() as usize;
+        picked_level.round() as usize
     }
 
     fn set_levels(&mut self, point_id: PointOffsetType, level: usize) {
@@ -230,8 +234,8 @@ impl GraphLayers {
         let new_to_target = score_internal(target_point_id, new_point_id);
 
         let mut id_to_insert = links.len();
-        for i in 0..links.len() {
-            let target_to_link = score_internal(target_point_id, links[i]);
+        for (i, &item) in links.iter().enumerate() {
+            let target_to_link = score_internal(target_point_id, item);
             if target_to_link < new_to_target {
                 id_to_insert = i;
                 break;
@@ -240,11 +244,9 @@ impl GraphLayers {
 
         if links.len() < level_m {
             links.insert(id_to_insert, new_point_id)
-        } else {
-            if id_to_insert != links.len() {
-                links.pop();
-                links.insert(id_to_insert, new_point_id)
-            }
+        } else if id_to_insert != links.len() {
+            links.pop();
+            links.insert(id_to_insert, new_point_id)
         }
     }
 
@@ -289,7 +291,7 @@ impl GraphLayers {
         F: FnMut(PointOffsetType, PointOffsetType) -> ScoreType,
     {
         let closest_iter = candidates.into_iter();
-        return Self::select_candidate_with_heuristic_from_sorted(closest_iter, m, score_internal);
+        Self::select_candidate_with_heuristic_from_sorted(closest_iter, m, score_internal)
     }
 
     pub fn link_new_point(
@@ -405,7 +407,7 @@ impl GraphLayers {
                                 scorer,
                             );
                             if nearest_point.score > level_entry.score {
-                                level_entry = nearest_point.clone()
+                                level_entry = *nearest_point
                             }
                         }
                     }

--- a/lib/segment/src/index/hnsw_index/search_context.rs
+++ b/lib/segment/src/index/hnsw_index/search_context.rs
@@ -30,7 +30,7 @@ impl SearchContext {
     /// Updates search context with new scored point.
     /// If it is closer than existing - also add it to candidates for further search
     pub fn process_candidate(&mut self, score_point: ScoredPointOffset) {
-        let was_added = match self.nearest.push(score_point.clone()) {
+        let was_added = match self.nearest.push(score_point) {
             None => true,
             Some(removed) => removed.idx != score_point.idx,
         };

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -101,7 +101,7 @@ impl PayloadIndex for PlainPayloadIndex {
                 matched_points.push(i);
             }
         }
-        return Box::new(matched_points.into_iter());
+        Box::new(matched_points.into_iter())
     }
 
     fn payload_blocks(
@@ -124,10 +124,10 @@ impl PlainIndex {
         vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
         payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
     ) -> PlainIndex {
-        return PlainIndex {
+        PlainIndex {
             vector_storage,
             payload_index,
-        };
+        }
     }
 }
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use std::cmp::{max, min};
 
 fn combine_must_estimations(
-    estimations: &Vec<CardinalityEstimation>,
+    estimations: &[CardinalityEstimation],
     total: usize,
 ) -> CardinalityEstimation {
     let min_estimation = estimations
@@ -28,7 +28,7 @@ fn combine_must_estimations(
         .filter(|x| !x.primary_clauses.is_empty())
         .min_by_key(|x| x.exp)
         .map(|x| x.primary_clauses.clone())
-        .unwrap_or(vec![]);
+        .unwrap_or_default();
 
     CardinalityEstimation {
         primary_clauses: clauses,
@@ -88,7 +88,7 @@ where
 
 fn estimate_should<F>(
     estimator: &F,
-    conditions: &Vec<Condition>,
+    conditions: &[Condition],
     total: usize,
 ) -> CardinalityEstimation
 where
@@ -122,11 +122,7 @@ where
     }
 }
 
-fn estimate_must<F>(
-    estimator: &F,
-    conditions: &Vec<Condition>,
-    total: usize,
-) -> CardinalityEstimation
+fn estimate_must<F>(estimator: &F, conditions: &[Condition], total: usize) -> CardinalityEstimation
 where
     F: Fn(&Condition) -> CardinalityEstimation,
 {
@@ -147,7 +143,7 @@ fn invert_estimation(estimation: &CardinalityEstimation, total: usize) -> Cardin
 
 fn estimate_must_not<F>(
     estimator: &F,
-    conditions: &Vec<Condition>,
+    conditions: &[Condition],
     total: usize,
 ) -> CardinalityEstimation
 where

--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -12,7 +12,7 @@ fn estimate_required_sample_size(total: usize, confidence_interval: usize) -> us
     let index_fraction = confidence_interval as f64 / total as f64 / 2.0;
     let h = 0.5; // success rate which requires most number of estimations
     let estimated_size = h * (1. - h) / (index_fraction / z).powi(2);
-    return max(estimated_size as usize, 10);
+    max(estimated_size as usize, 10)
 }
 
 /// Returns (expected cardinality ± confidence interval at 0.99)
@@ -25,7 +25,7 @@ fn confidence_agresti_coull_interval(trials: usize, positive: usize, total: usiz
 
     let expected = (phat * total as f64) as i64;
     let delta = (interval * total as f64) as i64;
-    return (expected, delta);
+    (expected, delta)
 }
 
 /// Tests if given `query` have cardinality higher than the `threshold`

--- a/lib/segment/src/payload_storage/payload_storage.rs
+++ b/lib/segment/src/payload_storage/payload_storage.rs
@@ -26,7 +26,7 @@ pub trait PayloadStorage {
             ) -> Vec<(PayloadKeyType, PayloadType)> {
                 let key = match &prefix {
                     None => k.to_string(),
-                    Some(_k) => (_k.to_owned() + "__" + k).to_string(),
+                    Some(_k) => (_k.to_owned() + "__" + k),
                 };
 
                 let opt_payload_interface: Result<PayloadInterface, _> =

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -22,9 +22,9 @@ fn check_filter<F>(checker: &F, filter: &Filter) -> bool
 where
     F: Fn(&Condition) -> bool,
 {
-    return check_should(checker, &filter.should)
+    check_should(checker, &filter.should)
         && check_must(checker, &filter.must)
-        && check_must_not(checker, &filter.must_not);
+        && check_must_not(checker, &filter.must_not)
 }
 
 fn check_should<F>(checker: &F, should: &Option<Vec<Condition>>) -> bool

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -10,7 +10,7 @@ use crate::payload_storage::payload_storage::PayloadStorage;
 /// Since sled is used for reading only during the initialization, large read cache is not required
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024;
 // 10 mb
-const DB_NAME: &'static str = "payload";
+const DB_NAME: &str = "payload";
 
 pub struct SimplePayloadStorage {
     payload: HashMap<PointOffsetType, TheMap<PayloadKeyType, PayloadType>>,
@@ -168,11 +168,11 @@ impl PayloadStorage for SimplePayloadStorage {
     }
 
     fn schema(&self) -> TheMap<PayloadKeyType, PayloadSchemaType> {
-        return self.schema.clone();
+        self.schema.clone()
     }
 
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
-        return Box::new(self.payload.keys().cloned());
+        Box::new(self.payload.keys().cloned())
     }
 }
 

--- a/lib/segment/src/segment_constructor/segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor.rs
@@ -98,7 +98,7 @@ fn create_segment(
     let appendable_flag =
         segment_type == SegmentType::Plain {} && config.storage_type == StorageType::InMemory;
 
-    return Ok(Segment {
+    Ok(Segment {
         version,
         persisted_version: Arc::new(Mutex::new(version)),
         current_path: segment_path.to_owned(),
@@ -111,7 +111,7 @@ fn create_segment(
         appendable_flag,
         segment_type,
         segment_config: config.clone(),
-    });
+    })
 }
 
 pub fn load_segment(path: &Path) -> OperationResult<Segment> {
@@ -121,15 +121,14 @@ pub fn load_segment(path: &Path) -> OperationResult<Segment> {
     let mut file = File::open(segment_config_path)?;
     file.read_to_string(&mut contents)?;
 
-    let segment_state: SegmentState = serde_json::from_str(&contents).or_else(|err| {
-        Err(OperationError::ServiceError {
+    let segment_state: SegmentState =
+        serde_json::from_str(&contents).map_err(|err| OperationError::ServiceError {
             description: format!(
                 "Failed to read segment {}. Error: {}",
                 path.to_str().unwrap(),
                 err
             ),
-        })
-    })?;
+        })?;
 
     create_segment(segment_state.version, path, &segment_state.config)
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -377,9 +377,9 @@ pub struct HasIdCondition {
     pub has_id: HashSet<PointIdType>,
 }
 
-impl Into<HasIdCondition> for HashSet<PointIdType> {
-    fn into(self) -> HasIdCondition {
-        HasIdCondition { has_id: self }
+impl From<HashSet<PointIdType>> for HasIdCondition {
+    fn from(set: HashSet<PointIdType>) -> Self {
+        HasIdCondition { has_id: set }
     }
 }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -27,8 +27,7 @@ fn open_read(path: &Path) -> OperationResult<Mmap> {
         .create(true)
         .open(path)?;
 
-    let mmap = unsafe { MmapOptions::new().map(&file)? };
-    return Ok(mmap);
+    Ok(unsafe { MmapOptions::new().map(&file)? })
 }
 
 fn open_write(path: &Path) -> OperationResult<MmapMut> {
@@ -38,8 +37,7 @@ fn open_write(path: &Path) -> OperationResult<MmapMut> {
         .create(false)
         .open(path)?;
 
-    let mmap = unsafe { MmapMut::map_mut(&file)? };
-    return Ok(mmap);
+    Ok(unsafe { MmapMut::map_mut(&file)? })
 }
 
 fn ensure_mmap_file_exists(path: &Path, header: &[u8]) -> OperationResult<()> {
@@ -91,7 +89,7 @@ impl MmapVectors {
     pub fn raw_vector_offset(&self, offset: usize) -> &[VectorElementType] {
         let byte_slice = &self.mmap[offset..(offset + self.raw_size())];
         let arr: &[VectorElementType] = unsafe { transmute(byte_slice) };
-        return &arr[0..self.dim];
+        &arr[0..self.dim]
     }
 
     pub fn raw_vector(&self, key: PointOffsetType) -> Option<&[VectorElementType]> {

--- a/src/api/retrieve_api.rs
+++ b/src/api/retrieve_api.rs
@@ -24,7 +24,7 @@ pub async fn get_point(
     let response = {
         toc.get_collection(&name).and_then(|collection| {
             collection
-                .retrieve(&vec![point_id], true, true)
+                .retrieve(&[point_id], true, true)
                 .map_err(|err| err.into())
                 .map(|points| points.into_iter().next())
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ use crate::api::recommend_api::recommend_points;
 use crate::api::retrieve_api::{get_point, get_points, scroll_points};
 use crate::api::search_api::search_points;
 use crate::api::update_api::update_points;
-use env_logger;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::toc::TableOfContent;
 
@@ -62,7 +61,7 @@ async fn main() -> std::io::Result<()> {
     let toc_data = web::Data::new(toc);
 
     HttpServer::new(move || {
-        let app = App::new()
+        App::new()
             .wrap(Logger::default())
             .app_data(toc_data.clone())
             .data(
@@ -79,9 +78,7 @@ async fn main() -> std::io::Result<()> {
             .service(get_points)
             .service(scroll_points)
             .service(search_points)
-            .service(recommend_points);
-
-        app
+            .service(recommend_points)
     })
     // .workers(4)
     .bind(format!(

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -2,7 +2,6 @@ mod api;
 mod common;
 
 use schemars::{schema_for, JsonSchema};
-use serde_json;
 
 use crate::api::models::CollectionsResponse;
 use crate::api::retrieve_api::PointRequest;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,7 +28,7 @@ impl Settings {
         // Add in the current environment file
         // Default to 'development' env
         // Note that this file is _optional_
-        let env = env::var("RUN_MODE").unwrap_or("development".into());
+        let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
         s.merge(File::with_name(&format!("config/{}", env)).required(false))?;
 
         // Add in a local configuration file


### PR DESCRIPTION
The PR fixes the whole pack of clippy warnings
- unnecessary parentheses around block return value
- [constants have by default a `'static` lifetime](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes)
- [module has the same name as its containing module](https://rust-lang.github.io/rust-clippy/master/index.html#module_inception)
- [`else { if .. }` block can be collapsed](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if)
- [using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as `map_err(|x| y)`](https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map)
- [useless use of `format!`](https://rust-lang.github.io/rust-clippy/master/index.html#useless_format)
- [writing `&String` instead of `&str` involves a new object where a slice will do](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)
- [redundant closure](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure)
- [consider adding a `Default` implementation](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default)
- [use of `unwrap_or` followed by a function call](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call)
- [replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default)
- [unneeded `return` statement](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)
- [called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`](https://rust-lang.github.io/rust-clippy/master/index.html#option_map_unit_fn)
- [writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)
- [redundant clone](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone)
- [the loop variable `i` is used to index](https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop)
- [using `clone` on type which implements the `Copy` trait](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy)
- [use of `unwrap_or` followed by a call to `new`](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call)
- [called `skip_while(<p>).next()` on an `Iterator`](https://rust-lang.github.io/rust-clippy/master/index.html#skip_while_next)
- [you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`](https://rust-lang.github.io/rust-clippy/master/index.html#single_match)
- [an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into)
- [you seem to be trying to use `&Box<T>`. Consider using just `&T](https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box)
- [unneeded unit return type](https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit)
- [manual implementation of an assign operation](https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern)
- [manual implementation of `Option::map`](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call)
- [useless use of `vec!`](https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec)
- [use of `expect` followed by a function call](https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call)
- [returning the result of a `let` binding from a block](https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return)
- [you are using an explicit closure for cloning elements](https://rust-lang.github.io/rust-clippy/master/index.html#map_clone)
- [using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)](https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?

