### PR TITLE
Own search runtime out of the async scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.9"
 config = "~0.10.1"
 
 actix-web = "4.0.0-beta.8"
-tokio = {version = "~1.7", features = ["full"]}
+tokio = { version = "~1.7", features = ["full"] }
 
 
 segment = {path = "lib/segment"}

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -19,7 +19,7 @@ openblas-src = { version = "0.10", default-features = false, features = ["cblas"
 
 parking_lot = "0.11"
 itertools = "0.10"
-rocksdb = "0.15.0"
+rocksdb = { version = "0.15.0", default-features = false, features = [ "snappy" ] }
 uuid = { version = "0.8", features = ["v4"] }
 bincode = "1.3"
 serde = { version = "~1.0", features = ["derive", "rc"] }

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -4,6 +4,21 @@ use actix_web::{HttpResponse, Responder};
 use serde::Serialize;
 use std::fmt::Debug;
 use storage::content_manager::errors::StorageError;
+use tokio::runtime;
+use tokio::runtime::Runtime;
+
+pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runtime> {
+    let mut search_threads = max_search_threads;
+
+    if search_threads == 0 {
+        let num_cpu = num_cpus::get();
+        search_threads = std::cmp::max(1, num_cpu - 1);
+    }
+
+    runtime::Builder::new_multi_thread()
+        .worker_threads(search_threads)
+        .build()
+}
 
 pub fn process_response<D>(response: Result<D, StorageError>, timing: Instant) -> impl Responder
 where


### PR DESCRIPTION
The following error was reported to happen on the process shutdown after Actix/Tokyo update:
```
thread 'main' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /home/generall/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.7.0/src/runtime/blocking/shutdown.rs:51:21
```

The suspected root cause is that the search context is owned by TOC and deleted inside the async context (``actix::main``).

The solution proposed is to avoid the usage of ``actix::main`` in favour on creating the actix runtime manually. The new ``main`` method does exactly the same as  ``actix::main`` - ``actix_web::rt::System::new().block_on``, but allows us to do non async operation before and after. Aslo, the toc is only having the runtime handle now, but it is not owning it

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [X] Have you checked your code using ```cargo clippy``` command?

