### PR TITLE
Small cosmetics

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -408,6 +408,14 @@ pub struct Filter {
 }
 
 impl Filter {
+    pub fn new_should(condition: Condition) -> Self {
+        Filter {
+            should: Some(vec![condition]),
+            must: None,
+            must_not: None,
+        }
+    }
+
     pub fn new_must(condition: Condition) -> Self {
         Filter {
             should: None,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -37,12 +37,15 @@ impl TableOfContent {
 
         create_dir_all(&collections_path).expect("Can't create Collections directory");
 
-        let collection_paths = read_dir(&collections_path).expect("Can't read Collections directory");
+        let collection_paths =
+            read_dir(&collections_path).expect("Can't read Collections directory");
 
         let mut collections: HashMap<String, Arc<Collection>> = Default::default();
 
         for entry in collection_paths {
-            let collection_path = entry.expect("Can't access of one of the collection files").path();
+            let collection_path = entry
+                .expect("Can't access of one of the collection files")
+                .path();
             let collection_name = collection_path
                 .file_name()
                 .expect("Can't resolve a filename of one of the collection files")

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -35,19 +35,19 @@ impl TableOfContent {
     pub fn new(storage_config: &StorageConfig, search_runtime_handle: Handle) -> Self {
         let collections_path = Path::new(&storage_config.storage_path).join(&COLLECTIONS_DIR);
 
-        create_dir_all(&collections_path).unwrap();
+        create_dir_all(&collections_path).expect("Can't create Collections directory");
 
-        let collection_paths = read_dir(&collections_path).unwrap();
+        let collection_paths = read_dir(&collections_path).expect("Can't read Collections directory");
 
         let mut collections: HashMap<String, Arc<Collection>> = Default::default();
 
         for entry in collection_paths {
-            let collection_path = entry.unwrap().path();
+            let collection_path = entry.expect("Can't access of one of the collection files").path();
             let collection_name = collection_path
                 .file_name()
-                .unwrap()
+                .expect("Can't resolve a filename of one of the collection files")
                 .to_str()
-                .unwrap()
+                .expect("A filename of one of the collection files is not a valid UTF-8")
                 .to_string();
 
             let collection =
@@ -62,7 +62,7 @@ impl TableOfContent {
             .cache_capacity(SLED_CACHE_SIZE)
             .path(alias_path.as_path())
             .open()
-            .unwrap();
+            .expect("Can't open database by the provided config");
 
         TableOfContent {
             collections: Arc::new(RwLock::new(collections)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,8 @@ fn main() -> std::io::Result<()> {
 
     // Create and own search runtime out of the scope of async context to ensure correct
     // destruction of it
-    let runtime = create_search_runtime(settings.storage.performance.max_search_threads).expect("Can't create runtime.");
+    let runtime = create_search_runtime(settings.storage.performance.max_search_threads)
+        .expect("Can't create runtime.");
     let handle = runtime.handle().clone();
 
     actix_web::rt::System::new().block_on(async {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> std::io::Result<()> {
 
     // Create and own search runtime out of the scope of async context to ensure correct
     // destruction of it
-    let runtime = create_search_runtime(settings.storage.performance.max_search_threads).unwrap();
+    let runtime = create_search_runtime(settings.storage.performance.max_search_threads).expect("Can't create runtime.");
     let handle = runtime.handle().clone();
 
     actix_web::rt::System::new().block_on(async {
@@ -72,7 +72,7 @@ fn main() -> std::io::Result<()> {
                 .app_data(toc_data.clone())
                 .app_data(Data::new(
                     web::JsonConfig::default()
-                        .limit(33554432)
+                        .limit(32 * 1024 * 1024)
                         .error_handler(json_error_handler),
                 )) // 32 Mb
                 .service(index)


### PR DESCRIPTION
I did some cosmetic fixes. Some of them just replacing `unwrap` with more verbose `expect`. But in the next one I would rewrite constructor methods with moving some parts which can fail into initiation methods to allow error handling. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?