### PR TITLE
Update docker usage example for pre-built images

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Qdrant does not rely on any external database or orchestration controller, which
 Build your own from source
 
 ```bash
-docker build . --tag=qdrant
+docker build . --tag=generall/qdrant
 ```
 
 Or use latest pre-built image from [DockerHub](https://hub.docker.com/r/generall/qdrant)
@@ -155,7 +155,7 @@ To run container use command:
 docker run -p 6333:6333 \
     -v $(pwd)/path/to/data:/qdrant/storage \
     -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
-    qdrant
+    generall/qdrant
 ```
 
 * `/qdrant/storage` - is a place where Qdrant persists all your data. 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

The docker example in README is not directly useful as it refers to a locally built image:
```
docker run -p 6333:6333 \
>     -v $(pwd)/path/to/data:/qdrant/storage \
>     -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
>     qdrant
Unable to find image 'qdrant:latest' locally
docker: Error response from daemon: pull access denied for qdrant, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

This PR updates docker examples in README to use `generall/qdrant` as image tag to be directly useful (by copy pasting).