### PR TITLE
Make operations over collections map lock-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,7 @@ name = "storage"
 version = "0.2.0"
 dependencies = [
  "collection",
+ "crossbeam-epoch",
  "num_cpus",
  "parking_lot",
  "rand 0.7.3",

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -17,7 +17,7 @@ wal = { git = "https://github.com/generall/wal.git" }
 tokio = {version = "~1.7", features = ["rt-multi-thread"]}
 serde = { version = "~1.0", features = ["derive"] }
 schemars = "0.8.0"
-
+crossbeam-epoch = "0.9.5"
 
 segment = {path = "../segment"}
 collection = {path = "../collection"}

--- a/lib/storage/src/content_manager/cow_map.rs
+++ b/lib/storage/src/content_manager/cow_map.rs
@@ -1,0 +1,231 @@
+use core::mem;
+use std::borrow::Borrow;
+use std::collections::hash_map::Keys;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use crossbeam_epoch::{Atomic, Owned, pin};
+
+/// Thread-safe lock-free implementation of hash table that re-creates an underlying `HashMap` on
+/// each modification. Memory reclamation is implemented by epoch-based GC from `crossbeam-epoch`
+/// crate (https://github.com/crossbeam-rs/crossbeam).
+pub(crate) struct CopyOnWriteMap<K: Hash + Eq + Clone, V> {
+    ptr: Atomic<Arc<HashMap<K, Arc<V>>>>,
+}
+
+impl<K: Hash + Eq + Clone, V> CopyOnWriteMap<K, V> {
+    pub fn new(new_map: HashMap<K, Arc<V>>) -> Self {
+        Self {
+            ptr: Atomic::new(Arc::new(new_map)),
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<Arc<V>> {
+        self.load().get(key).cloned()
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        let arc_value = Arc::new(value);
+        self.cas_modify(|new_map| {
+            new_map.insert(key.clone(), arc_value.clone());
+        });
+    }
+
+    pub fn remove<Q>(&self, key: &Q) -> Option<Arc<V>>
+        where
+            Q: ?Sized + Hash + Eq,
+            K: Borrow<Q>,
+    {
+        self.cas_modify(|new_map| new_map.remove(key))
+    }
+
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: ?Sized + Hash + Eq,
+            K: Borrow<Q>,
+    {
+        self.load().contains_key(key)
+    }
+
+    pub fn clone_keys(&self) -> Vec<K> {
+        self.load().keys().cloned().collect()
+    }
+
+    pub fn visit_keys<F, R>(&self, visitor: F) -> R
+        where
+            F: Fn(Keys<K, Arc<V>>) -> R,
+    {
+        visitor(self.load().keys())
+    }
+
+    fn cas_modify<F, R>(&self, updater: F) -> R
+        where
+            F: Fn(&mut HashMap<K, Arc<V>>) -> R,
+    {
+        loop {
+            let guard = &pin();
+            let current_shared = self.ptr.load(Ordering::Acquire, guard);
+            // Safety: After we pinned current thread it's safe to deref current shared pointer
+            // since no de-allocations are allowed now.
+            let current_map = unsafe { current_shared.deref() };
+            let mut cloned_map = HashMap::clone(current_map);
+            let update_result = updater(&mut cloned_map);
+            match self.ptr.compare_exchange_weak(
+                current_shared,
+                Owned::new(Arc::new(cloned_map)),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+                guard,
+            ) {
+                Ok(_) => {
+                    // Safety: We atomically successfully exchanged value. Only one thread proceeds to
+                    // this point for particular `current_shared`, hence it's safe to schedule it for destroying.
+                    unsafe { guard.defer_destroy(current_shared) }
+                    guard.flush();
+                    break update_result;
+                }
+                Err(_) => {
+                    std::thread::yield_now();
+                }
+            }
+        }
+    }
+
+    fn load(&self) -> Arc<HashMap<K, Arc<V>>> {
+        let guard = &pin();
+        let shared = self.ptr.load(Ordering::Acquire, guard);
+        // Safety: After we pinned current thread it's safe to deref current shared pointer
+        // since no de-allocations are allowed now.
+        unsafe { shared.deref() }.clone()
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> Drop for CopyOnWriteMap<K, V> {
+    fn drop(&mut self) {
+        let replaced = mem::replace(&mut self.ptr, Atomic::null());
+        // Safety: If we drop our instance it means no other threads can access it, so we can drop the inner value.
+        unsafe {
+            drop(replaced.into_owned());
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    struct Droppable(String);
+
+    impl Drop for Droppable {
+        fn drop(&mut self) {
+            println!("dropping {:?}", self.0)
+        }
+    }
+
+    #[test]
+    fn insert_and_delete_works() {
+        //given
+        let cow_map = CopyOnWriteMap::new(HashMap::default());
+        let key1 = "key1".to_owned();
+        let key2 = "key2".to_owned();
+        let value1 = Droppable("value1".to_owned());
+        let value2 = Droppable("value2".to_owned());
+
+        //when
+        cow_map.insert(key1.clone(), value1.clone());
+        cow_map.insert(key2.clone(), value2.clone());
+
+        //then
+        assert_eq!(*cow_map.get(&key1).unwrap(), value1);
+        cow_map.remove(&key1);
+        assert_eq!(cow_map.get(&key1), None);
+        assert_eq!(*cow_map.get(&key2).unwrap(), value2);
+    }
+
+    #[test]
+    fn keys_works() {
+        //given
+        let cow_map = CopyOnWriteMap::new(HashMap::default());
+        let key1 = "key1".to_owned();
+        let key2 = "key2".to_owned();
+        let value1 = Droppable("value1".to_owned());
+        let value2 = Droppable("value2".to_owned());
+        cow_map.insert(key1.clone(), value1);
+        cow_map.insert(key2.clone(), value2);
+
+        //when
+        let keys = cow_map.clone_keys();
+        let keys2 = cow_map.clone_keys();
+        cow_map.remove(&key1);
+        cow_map.remove(&key2);
+
+        //then
+        assert_eq!(keys.contains(&&key1), true);
+        assert_eq!(keys.contains(&&key2), true);
+        assert_eq!(keys2.contains(&&key1), true);
+        assert_eq!(keys2.contains(&&key2), true);
+
+        assert_eq!(cow_map.clone_keys().is_empty(), true);
+    }
+
+    #[test]
+    fn keys_lives_enough() {
+        //given
+        let cow_map = CopyOnWriteMap::new(HashMap::default());
+        let key1 = "key1".to_owned();
+        let value = Droppable("value1".to_owned());
+        cow_map.insert(key1.clone(), value);
+
+        //when
+        let keys = cow_map.clone_keys();
+
+        //then
+        assert_eq!(keys.contains(&key1), true);
+        cow_map.remove(&key1);
+        drop(cow_map);
+        assert_eq!(keys.contains(&key1), true);
+    }
+
+    #[test]
+    fn contains_key_works() {
+        //given
+        let cow_map = CopyOnWriteMap::new(HashMap::default());
+        let key1 = "key1".to_owned();
+        let key2 = "key2".to_owned();
+        let value = Droppable("value1".to_owned());
+
+        //when
+        cow_map.insert(key1.clone(), value);
+
+        //then
+        assert_eq!(cow_map.contains_key(&key1), true);
+        assert_eq!(cow_map.contains_key(&key2), false);
+        cow_map.remove(&key1);
+        cow_map.remove(&key2);
+        assert_eq!(cow_map.contains_key(&key1), false);
+        assert_eq!(cow_map.contains_key(&key2), false);
+    }
+
+    #[test]
+    fn collect_keys_via_visiting() {
+        //given
+        let cow_map = CopyOnWriteMap::new(HashMap::default());
+        let key1 = "key1".to_owned();
+        let key2 = "key2".to_owned();
+        let value1 = Droppable("value1".to_owned());
+        let value2 = Droppable("value2".to_owned());
+        cow_map.insert(key1.clone(), value1);
+        cow_map.insert(key2.clone(), value2);
+
+        //when
+        let collected = cow_map.visit_keys(|keys| keys.cloned().collect::<Vec<String>>());
+
+        //then
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected.contains(&key1), true);
+        assert_eq!(collected.contains(&key2), true);
+    }
+}

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,4 +1,4 @@
+mod cow_map;
 pub mod errors;
 pub mod storage_ops;
 pub mod toc;
-mod cow_map;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod storage_ops;
 pub mod toc;
+mod cow_map;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::str::from_utf8;
 use std::sync::Arc;
 
-use sled::{Config, Db};
 use sled::transaction::UnabortableTransactionError;
+use sled::{Config, Db};
 use tokio::runtime::Handle;
 
 use collection::collection::Collection;
@@ -268,7 +268,9 @@ impl TableOfContent {
     }
 
     pub fn visit_all_collection_names<F, R>(&self, visitor: F) -> R
-        where F: Fn(std::collections::hash_map::Keys<String, Arc<Collection>>) -> R {
+    where
+        F: Fn(std::collections::hash_map::Keys<String, Arc<Collection>>) -> R,
+    {
         self.collections.visit_keys(visitor)
     }
 

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -1,22 +1,21 @@
-use crate::actix::api::models::{CollectionDescription, CollectionsResponse};
-use crate::actix::helpers::process_response;
-use actix_web::rt::time::Instant;
-use actix_web::{get, post, web, Responder};
-use itertools::Itertools;
 use std::sync::Arc;
+
+use actix_web::{get, post, Responder, web};
+use actix_web::rt::time::Instant;
+
 use storage::content_manager::storage_ops::StorageOperations;
 use storage::content_manager::toc::TableOfContent;
+
+use crate::actix::api::models::{CollectionDescription, CollectionsResponse};
+use crate::actix::helpers::process_response;
 
 #[get("/collections")]
 pub async fn get_collections(toc: web::Data<Arc<TableOfContent>>) -> impl Responder {
     let timing = Instant::now();
 
     let response = {
-        let collections = toc
-            .all_collections()
-            .into_iter()
-            .map(|name| CollectionDescription { name })
-            .collect_vec();
+        let collections = toc.get_all_collection_names().into_iter()
+            .map(|name| CollectionDescription { name }).collect();
 
         Ok(CollectionsResponse { collections })
     };

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use actix_web::{get, post, Responder, web};
 use actix_web::rt::time::Instant;
+use actix_web::{get, post, web, Responder};
 
 use storage::content_manager::storage_ops::StorageOperations;
 use storage::content_manager::toc::TableOfContent;
@@ -14,8 +14,11 @@ pub async fn get_collections(toc: web::Data<Arc<TableOfContent>>) -> impl Respon
     let timing = Instant::now();
 
     let response = {
-        let collections = toc.get_all_collection_names().into_iter()
-            .map(|name| CollectionDescription { name }).collect();
+        let collections = toc
+            .get_all_collection_names()
+            .into_iter()
+            .map(|name| CollectionDescription { name })
+            .collect();
 
         Ok(CollectionsResponse { collections })
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,9 @@ fn main() {
     let handle = runtime.handle().clone();
     let toc = TableOfContent::new(&settings.storage, handle);
 
-    for collection in toc.all_collections() {
-        info!("loaded collection: {}", collection);
-    }
+    toc.visit_all_collection_names(|keys| {
+        for collection in keys {
+            info!("loaded collection: {}", collection);
+        }
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,12 @@ fn main() -> std::io::Result<()> {
     let search_runtime_handle = runtime.handle().clone();
 
     let toc = TableOfContent::new(&settings.storage, search_runtime_handle);
-    for collection in toc.all_collections() {
-        info!("loaded collection: {}", collection);
-    }
+    toc.visit_all_collection_names(|keys| {
+        for collection in keys {
+            info!("loaded collection: {}", collection);
+        }
+    });
+
     let toc_arc = Arc::new(toc);
 
     let mut handles: Vec<JoinHandle<Result<(), Error>>> = vec![];


### PR DESCRIPTION
Added lock-free container for collections in `TableOfContent`. Lock-freedom is implemented using atomic pointers to underlying map and epoch-based garbage collection from the `crossbeam` crate.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
