### PR TITLE
Remove AtomicRefCell wrapper for condition checker

### DIFF
--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub struct PlainPayloadIndex {
-    condition_checker: Arc<AtomicRefCell<dyn ConditionChecker>>,
+    condition_checker: Arc<dyn ConditionChecker>,
     vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
     config: PayloadConfig,
     path: PathBuf,
@@ -31,7 +31,7 @@ impl PlainPayloadIndex {
     }
 
     pub fn open(
-        condition_checker: Arc<AtomicRefCell<dyn ConditionChecker>>,
+        condition_checker: Arc<dyn ConditionChecker>,
         vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
         path: &Path,
     ) -> OperationResult<Self> {
@@ -97,9 +97,8 @@ impl PayloadIndex for PlainPayloadIndex {
         query: &'a Filter,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         let mut matched_points = vec![];
-        let condition_checker = self.condition_checker.borrow();
         for i in self.vector_storage.borrow().iter_ids() {
-            if condition_checker.check(i, query) {
+            if self.condition_checker.check(i, query) {
                 matched_points.push(i);
             }
         }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -52,7 +52,7 @@ fn create_segment(
 
     let payload_storage = sp(SimplePayloadStorage::open(payload_storage_path.as_path())?);
 
-    let condition_checker = sp(SimpleConditionChecker::new(
+    let condition_checker = Arc::new(SimpleConditionChecker::new(
         payload_storage.clone(),
         id_mapper.clone(),
     ));

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -69,13 +69,11 @@ mod tests {
             .borrow()
             .estimate_cardinality(&filter);
 
-        let checker = struct_segment.condition_checker.borrow();
-
         let exact = struct_segment
             .vector_storage
             .borrow()
             .iter_ids()
-            .filter(|x| checker.check(*x, &filter))
+            .filter(|x| struct_segment.condition_checker.check(*x, &filter))
             .collect_vec()
             .len();
 


### PR DESCRIPTION
Condition checker is always borrowed immutable (and it makes sense since its internals are guarded by AtomicRefCell) so it's not needed to wrap it by AtomicRefCell.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
