### PR TITLE
Decouple searcher and updater from collection

### DIFF
--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = "~0.14"
 wal = { git = "https://github.com/generall/wal.git" }
 ordered-float = "1.0"
 
-tokio = {version = "~1.7", features = ["rt-multi-thread", "time"]}
+tokio = {version = "~1.7", features = ["rt-multi-thread", "time", "macros"]}
 futures = "0.3.5"
 crossbeam-channel = "0.4.3"
 atomicwrites = "0.2.5"

--- a/lib/collection/src/collection_builder/collection_builder_base.rs
+++ b/lib/collection/src/collection_builder/collection_builder_base.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crossbeam_channel::unbounded;
 use parking_lot::{Mutex, RwLock};
 use tokio::runtime;
-use tokio::runtime::Handle;
 
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::HnswConfig;
@@ -17,8 +16,6 @@ use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
 use crate::segment_manager::holders::segment_holder::SegmentHolder;
-use crate::segment_manager::simple_segment_searcher::SimpleSegmentSearcher;
-use crate::segment_manager::simple_segment_updater::SimpleSegmentUpdater;
 use crate::update_handler::{Optimizer, UpdateHandler};
 use crate::wal::SerdeWal;
 
@@ -26,7 +23,6 @@ pub fn construct_collection(
     segment_holder: SegmentHolder,
     config: CollectionConfig,
     wal: SerdeWal<CollectionUpdateOperations>,
-    search_runtime: Handle, // from service
     optimizers: Arc<Vec<Box<Optimizer>>>,
     collection_path: &Path,
 ) -> Collection {
@@ -39,32 +35,27 @@ pub fn construct_collection(
 
     let locked_wal = Arc::new(Mutex::new(wal));
 
-    let searcher = SimpleSegmentSearcher::new(segment_holder.clone(), search_runtime);
-
-    let updater = SimpleSegmentUpdater::new(segment_holder.clone());
     // ToDo: Move tx-rx into updater, so Collection should not know about it.
     let (tx, rx) = unbounded();
 
-    let update_handler = Arc::new(Mutex::new(UpdateHandler::new(
+    let update_handler = UpdateHandler::new(
         optimizers,
         rx,
         optimize_runtime.handle().clone(),
         segment_holder.clone(),
         locked_wal.clone(),
         config.optimizer_config.flush_interval_sec,
-    )));
+    );
 
-    Collection {
-        segments: segment_holder,
-        config: Arc::new(RwLock::new(config)),
-        wal: locked_wal,
-        searcher: Arc::new(searcher),
+    Collection::new(
+        segment_holder,
+        config,
+        locked_wal,
         update_handler,
-        updater: Arc::new(updater),
-        runtime_handle: Some(optimize_runtime),
-        update_sender: tx,
-        path: collection_path.to_owned(),
-    }
+        optimize_runtime,
+        tx,
+        collection_path.to_owned(),
+    )
 }
 
 /// Creates new empty collection with given configuration
@@ -72,7 +63,6 @@ pub fn build_collection(
     collection_path: &Path,
     wal_config: &WalConfig,               // from config
     collection_params: &CollectionParams, //  from user
-    search_runtime: Handle,               // from service
     optimizers_config: &OptimizersConfig,
     hnsw_config: &HnswConfig,
 ) -> CollectionResult<Collection> {
@@ -122,7 +112,6 @@ pub fn build_collection(
         segment_holder,
         collection_config,
         wal,
-        search_runtime,
         optimizers,
         collection_path,
     );

--- a/lib/collection/src/collection_builder/collection_loader.rs
+++ b/lib/collection/src/collection_builder/collection_loader.rs
@@ -2,7 +2,6 @@ use std::fs::{read_dir, remove_dir_all};
 use std::path::Path;
 
 use indicatif::ProgressBar;
-use tokio::runtime::Handle;
 
 use segment::segment_constructor::load_segment;
 
@@ -15,10 +14,7 @@ use crate::operations::CollectionUpdateOperations;
 use crate::segment_manager::holders::segment_holder::SegmentHolder;
 use crate::wal::SerdeWal;
 
-pub fn load_collection(
-    collection_path: &Path,
-    search_runtime: Handle, // from service
-) -> Collection {
+pub fn load_collection(collection_path: &Path) -> Collection {
     let wal_path = collection_path.join("wal");
     let segments_path = collection_path.join("segments");
     let mut segment_holder = SegmentHolder::default();
@@ -76,20 +72,19 @@ pub fn load_collection(
         segment_holder,
         collection_config,
         wal,
-        search_runtime,
         optimizers,
         collection_path,
     );
 
     {
-        let wal = collection.wal.lock();
+        let wal = collection.get_wal().lock();
         let bar = ProgressBar::new(wal.len());
         bar.set_message("Recovering collection");
 
         for (op_num, update) in wal.read_all() {
             // Panic only in case of internal error. If wrong formatting - skip
             if let Err(CollectionError::ServiceError { error }) =
-                collection.updater.update(op_num, update)
+                collection.update_segment(op_num, update)
             {
                 panic!("Can't apply WAL operation: {}", error)
             }

--- a/lib/collection/src/segment_manager/fixtures.rs
+++ b/lib/collection/src/segment_manager/fixtures.rs
@@ -1,5 +1,4 @@
 use crate::segment_manager::holders::segment_holder::SegmentHolder;
-use crate::segment_manager::simple_segment_searcher::SimpleSegmentSearcher;
 use parking_lot::RwLock;
 use rand::Rng;
 use segment::entry::entry_point::SegmentEntry;
@@ -7,8 +6,6 @@ use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{Distance, PayloadType, SeqNumberType};
 use std::path::Path;
-use std::sync::Arc;
-use tokio::runtime::Handle;
 
 pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()
@@ -101,7 +98,7 @@ pub fn build_segment_2(path: &Path) -> Segment {
     segment2
 }
 
-pub fn build_test_holder(path: &Path) -> SegmentHolder {
+pub fn build_test_holder(path: &Path) -> RwLock<SegmentHolder> {
     let segment1 = build_segment_1(path);
     let segment2 = build_segment_2(path);
 
@@ -110,11 +107,5 @@ pub fn build_test_holder(path: &Path) -> SegmentHolder {
     let _sid1 = holder.add(segment1);
     let _sid2 = holder.add(segment2);
 
-    holder
-}
-
-pub async fn build_searcher(path: &Path) -> SimpleSegmentSearcher {
-    let segment_holder = build_test_holder(path);
-
-    SimpleSegmentSearcher::new(Arc::new(RwLock::new(segment_holder)), Handle::current())
+    RwLock::new(holder)
 }

--- a/lib/collection/src/segment_manager/segment_managers.rs
+++ b/lib/collection/src/segment_manager/segment_managers.rs
@@ -1,20 +1,25 @@
 use std::sync::Arc;
 
+use parking_lot::RwLock;
+use tokio::runtime::Handle;
+
 use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
 
 use crate::operations::types::{CollectionResult, Record, SearchRequest};
 use crate::operations::CollectionUpdateOperations;
+use crate::segment_manager::holders::segment_holder::SegmentHolder;
 
 #[async_trait::async_trait]
 pub trait SegmentSearcher {
     async fn search(
-        &self,
+        segments: &RwLock<SegmentHolder>,
         // Request is supposed to be a read only, that is why no mutex used
         request: Arc<SearchRequest>,
+        runtime_handle: &Handle,
     ) -> CollectionResult<Vec<ScoredPoint>>;
 
     async fn retrieve(
-        &self,
+        segments: &RwLock<SegmentHolder>,
         points: &[PointIdType],
         with_payload: bool,
         with_vector: bool,
@@ -23,7 +28,7 @@ pub trait SegmentSearcher {
 
 pub trait SegmentUpdater {
     fn update(
-        &self,
+        segments: &RwLock<SegmentHolder>,
         op_num: SeqNumberType,
         operation: CollectionUpdateOperations,
     ) -> CollectionResult<usize>;

--- a/lib/collection/src/segment_manager/simple_segment_updater.rs
+++ b/lib/collection/src/segment_manager/simple_segment_updater.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use parking_lot::RwLock;
+
 use segment::types::{
     PayloadInterface, PayloadKeyType, PayloadKeyTypeRef, PointIdType, SeqNumberType,
 };
@@ -8,295 +10,14 @@ use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{PointInsertOperations, PointOperations};
 use crate::operations::types::{CollectionError, CollectionResult, VectorType};
 use crate::operations::{CollectionUpdateOperations, FieldIndexOperations};
-use crate::segment_manager::holders::segment_holder::LockedSegmentHolder;
+use crate::segment_manager::holders::segment_holder::SegmentHolder;
 use crate::segment_manager::segment_managers::SegmentUpdater;
 
-pub struct SimpleSegmentUpdater {
-    segments: LockedSegmentHolder,
-    // update_lock: Mutex<bool>,
-}
-
-impl SimpleSegmentUpdater {
-    pub fn new(segments: LockedSegmentHolder) -> Self {
-        SimpleSegmentUpdater {
-            segments,
-            // update_lock: Mutex::new(false),
-        }
-    }
-
-    fn check_unprocessed_points(
-        points: &[PointIdType],
-        processed: &HashSet<PointIdType>,
-    ) -> CollectionResult<usize> {
-        let missed_point = points.iter().cloned().find(|p| !processed.contains(p));
-        match missed_point {
-            None => Ok(processed.len()),
-            Some(missed_point) => Err(CollectionError::NotFound {
-                missed_point_id: missed_point,
-            }),
-        }
-    }
-
-    /// Tries to delete points from all segments, returns number of actually deleted points
-    fn delete_points(&self, op_num: SeqNumberType, ids: &[PointIdType]) -> CollectionResult<usize> {
-        let res = self
-            .segments
-            .read()
-            .apply_points(op_num, ids, |id, write_segment| {
-                write_segment.delete_point(op_num, id)
-            })?;
-        Ok(res)
-    }
-
-    /// Checks point id in each segment, update point if found.
-    /// All not found points are inserted into random segment.
-    /// Returns: number of updated points.
-    fn upsert_points(
-        &self,
-        op_num: SeqNumberType,
-        ids: &[PointIdType],
-        vectors: &[VectorType],
-        payloads: &Option<Vec<Option<HashMap<PayloadKeyType, PayloadInterface>>>>,
-    ) -> CollectionResult<usize> {
-        if ids.len() != vectors.len() {
-            return Err(CollectionError::BadInput {
-                description: format!(
-                    "Amount of ids ({}) and vectors ({}) does not match",
-                    ids.len(),
-                    vectors.len()
-                ),
-            });
-        }
-
-        match payloads {
-            None => {}
-            Some(payload_vector) => {
-                if payload_vector.len() != ids.len() {
-                    return Err(CollectionError::BadInput {
-                        description: format!(
-                            "Amount of ids ({}) and payloads ({}) does not match",
-                            ids.len(),
-                            payload_vector.len()
-                        ),
-                    });
-                }
-            }
-        }
-
-        let mut updated_points: HashSet<PointIdType> = Default::default();
-        let points_map: HashMap<PointIdType, &VectorType> =
-            ids.iter().cloned().zip(vectors).collect();
-
-        let segments = self.segments.read();
-
-        // Get points, which presence in segments with higher version
-        self.segments.read().read_points(ids, |id, segment| {
-            if segment.version() > op_num {
-                updated_points.insert(id);
-            }
-            Ok(true)
-        })?;
-
-        // Update points in writable segments
-        let res = segments.apply_points_to_appendable(op_num, ids, |id, write_segment| {
-            updated_points.insert(id);
-            write_segment.upsert_point(op_num, id, points_map[&id])
-        })?;
-
-        // Insert new points, which was not updated.
-        let new_point_ids = ids.iter().cloned().filter(|x| !updated_points.contains(x));
-
-        {
-            let default_write_segment =
-                segments
-                    .random_appendable_segment()
-                    .ok_or(CollectionError::ServiceError {
-                        error: "No segments exists, expected at least one".to_string(),
-                    })?;
-
-            let segment_arc = default_write_segment.get();
-            let mut write_segment = segment_arc.write();
-            for point_id in new_point_ids {
-                write_segment.upsert_point(op_num, point_id, points_map[&point_id])?;
-            }
-        }
-
-        if let Some(payload_vector) = payloads {
-            for (point_id, payload) in ids.iter().zip(payload_vector.iter()) {
-                if payload.is_some() {
-                    self.set_payload(op_num, payload.as_ref().unwrap(), &[*point_id])?;
-                }
-            }
-        }
-
-        Ok(res)
-    }
-
-    fn set_payload(
-        &self,
-        op_num: SeqNumberType,
-        payload: &HashMap<PayloadKeyType, PayloadInterface>,
-        points: &[PointIdType],
-    ) -> CollectionResult<usize> {
-        let mut updated_points: HashSet<PointIdType> = Default::default();
-
-        let res = self.segments.read().apply_points_to_appendable(
-            op_num,
-            points,
-            |id, write_segment| {
-                updated_points.insert(id);
-                let mut res = true;
-                for (key, payload) in payload {
-                    res = write_segment.set_payload(op_num, id, key, payload.into())? && res;
-                }
-                Ok(res)
-            },
-        )?;
-
-        SimpleSegmentUpdater::check_unprocessed_points(points, &updated_points)?;
-        Ok(res)
-    }
-
-    fn delete_payload(
-        &self,
-        op_num: SeqNumberType,
-        points: &[PointIdType],
-        keys: &[PayloadKeyType],
-    ) -> CollectionResult<usize> {
-        let mut updated_points: HashSet<PointIdType> = Default::default();
-
-        let res = self.segments.read().apply_points_to_appendable(
-            op_num,
-            points,
-            |id, write_segment| {
-                updated_points.insert(id);
-                let mut res = true;
-                for key in keys {
-                    res = write_segment.delete_payload(op_num, id, key)? && res;
-                }
-                Ok(res)
-            },
-        )?;
-
-        SimpleSegmentUpdater::check_unprocessed_points(points, &updated_points)?;
-        Ok(res)
-    }
-
-    fn clear_payload(
-        &self,
-        op_num: SeqNumberType,
-        points: &[PointIdType],
-    ) -> CollectionResult<usize> {
-        let mut updated_points: HashSet<PointIdType> = Default::default();
-        let res = self.segments.read().apply_points_to_appendable(
-            op_num,
-            points,
-            |id, write_segment| {
-                updated_points.insert(id);
-                write_segment.clear_payload(op_num, id)
-            },
-        )?;
-
-        SimpleSegmentUpdater::check_unprocessed_points(points, &updated_points)?;
-        Ok(res)
-    }
-
-    fn create_field_index(
-        &self,
-        op_num: SeqNumberType,
-        field_name: PayloadKeyTypeRef,
-    ) -> CollectionResult<usize> {
-        let res = self
-            .segments
-            .read()
-            .apply_segments(op_num, |write_segment| {
-                write_segment.create_field_index(op_num, field_name)
-            })?;
-        Ok(res)
-    }
-
-    fn delete_field_index(
-        &self,
-        op_num: SeqNumberType,
-        field_name: PayloadKeyTypeRef,
-    ) -> CollectionResult<usize> {
-        let res = self
-            .segments
-            .read()
-            .apply_segments(op_num, |write_segment| {
-                write_segment.delete_field_index(op_num, field_name)
-            })?;
-        Ok(res)
-    }
-
-    pub fn process_point_operation(
-        &self,
-        op_num: SeqNumberType,
-        point_operation: PointOperations,
-    ) -> CollectionResult<usize> {
-        match point_operation {
-            PointOperations::DeletePoints { ids, .. } => self.delete_points(op_num, &ids),
-            PointOperations::UpsertPoints(operation) => {
-                let (ids, vectors, payloads) = match operation {
-                    PointInsertOperations::BatchPoints {
-                        ids,
-                        vectors,
-                        payloads,
-                        ..
-                    } => (ids, vectors, payloads),
-                    PointInsertOperations::PointsList(points) => {
-                        let mut ids = vec![];
-                        let mut vectors = vec![];
-                        let mut payloads = vec![];
-                        for point in points {
-                            ids.push(point.id);
-                            vectors.push(point.vector);
-                            payloads.push(point.payload)
-                        }
-                        (ids, vectors, Some(payloads))
-                    }
-                };
-                let res = self.upsert_points(op_num, &ids, &vectors, &payloads)?;
-                Ok(res)
-            }
-        }
-    }
-
-    pub fn process_payload_operation(
-        &self,
-        op_num: SeqNumberType,
-        payload_operation: &PayloadOps,
-    ) -> CollectionResult<usize> {
-        match payload_operation {
-            PayloadOps::SetPayload {
-                payload, points, ..
-            } => self.set_payload(op_num, payload, points),
-            PayloadOps::DeletePayload { keys, points, .. } => {
-                self.delete_payload(op_num, points, keys)
-            }
-            PayloadOps::ClearPayload { points, .. } => self.clear_payload(op_num, points),
-        }
-    }
-
-    pub fn process_field_index_operation(
-        &self,
-        op_num: SeqNumberType,
-        field_index_operation: &FieldIndexOperations,
-    ) -> CollectionResult<usize> {
-        match field_index_operation {
-            FieldIndexOperations::CreateIndex(field_name) => {
-                self.create_field_index(op_num, field_name)
-            }
-            FieldIndexOperations::DeleteIndex(field_name) => {
-                self.delete_field_index(op_num, field_name)
-            }
-        }
-    }
-}
+pub struct SimpleSegmentUpdater {}
 
 impl SegmentUpdater for SimpleSegmentUpdater {
     fn update(
-        &self,
+        segments: &RwLock<SegmentHolder>,
         op_num: SeqNumberType,
         operation: CollectionUpdateOperations,
     ) -> CollectionResult<usize> {
@@ -304,25 +25,286 @@ impl SegmentUpdater for SimpleSegmentUpdater {
         // let _lock = self.update_lock.lock().unwrap();
         match operation {
             CollectionUpdateOperations::PointOperation(point_operation) => {
-                self.process_point_operation(op_num, point_operation)
+                process_point_operation(segments, op_num, point_operation)
             }
             CollectionUpdateOperations::PayloadOperation(payload_operation) => {
-                self.process_payload_operation(op_num, &payload_operation)
+                process_payload_operation(segments, op_num, &payload_operation)
             }
             CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
-                self.process_field_index_operation(op_num, &index_operation)
+                process_field_index_operation(segments, op_num, &index_operation)
             }
         }
     }
+}
+
+/// Checks point id in each segment, update point if found.
+/// All not found points are inserted into random segment.
+/// Returns: number of updated points.
+fn upsert_points(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    ids: &[PointIdType],
+    vectors: &[VectorType],
+    payloads: &Option<Vec<Option<HashMap<PayloadKeyType, PayloadInterface>>>>,
+) -> CollectionResult<usize> {
+    if ids.len() != vectors.len() {
+        return Err(CollectionError::BadInput {
+            description: format!(
+                "Amount of ids ({}) and vectors ({}) does not match",
+                ids.len(),
+                vectors.len()
+            ),
+        });
+    }
+
+    match payloads {
+        None => {}
+        Some(payload_vector) => {
+            if payload_vector.len() != ids.len() {
+                return Err(CollectionError::BadInput {
+                    description: format!(
+                        "Amount of ids ({}) and payloads ({}) does not match",
+                        ids.len(),
+                        payload_vector.len()
+                    ),
+                });
+            }
+        }
+    }
+
+    let mut updated_points: HashSet<PointIdType> = Default::default();
+    let points_map: HashMap<PointIdType, &VectorType> = ids.iter().cloned().zip(vectors).collect();
+
+    let segment_holder = segments.read();
+
+    // Get points, which presence in segments with higher version
+    segment_holder.read_points(ids, |id, segment| {
+        if segment.version() > op_num {
+            updated_points.insert(id);
+        }
+        Ok(true)
+    })?;
+
+    // Update points in writable segments
+    let res = segment_holder.apply_points_to_appendable(op_num, ids, |id, write_segment| {
+        updated_points.insert(id);
+        write_segment.upsert_point(op_num, id, points_map[&id])
+    })?;
+
+    // Insert new points, which was not updated.
+    let new_point_ids = ids.iter().cloned().filter(|x| !updated_points.contains(x));
+
+    {
+        let default_write_segment =
+            segment_holder
+                .random_appendable_segment()
+                .ok_or(CollectionError::ServiceError {
+                    error: "No segments exists, expected at least one".to_string(),
+                })?;
+
+        let segment_arc = default_write_segment.get();
+        let mut write_segment = segment_arc.write();
+        for point_id in new_point_ids {
+            write_segment.upsert_point(op_num, point_id, points_map[&point_id])?;
+        }
+    }
+
+    if let Some(payload_vector) = payloads {
+        for (point_id, payload) in ids.iter().zip(payload_vector.iter()) {
+            if payload.is_some() {
+                set_payload(segments, op_num, payload.as_ref().unwrap(), &[*point_id])?;
+            }
+        }
+    }
+
+    Ok(res)
+}
+
+fn check_unprocessed_points(
+    points: &[PointIdType],
+    processed: &HashSet<PointIdType>,
+) -> CollectionResult<usize> {
+    let missed_point = points.iter().cloned().find(|p| !processed.contains(p));
+    match missed_point {
+        None => Ok(processed.len()),
+        Some(missed_point) => Err(CollectionError::NotFound {
+            missed_point_id: missed_point,
+        }),
+    }
+}
+
+/// Tries to delete points from all segments, returns number of actually deleted points
+fn delete_points(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    ids: &[PointIdType],
+) -> CollectionResult<usize> {
+    let res = segments
+        .read()
+        .apply_points(op_num, ids, |id, write_segment| {
+            write_segment.delete_point(op_num, id)
+        })?;
+    Ok(res)
+}
+
+fn process_payload_operation(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    payload_operation: &PayloadOps,
+) -> CollectionResult<usize> {
+    match payload_operation {
+        PayloadOps::SetPayload {
+            payload, points, ..
+        } => set_payload(segments, op_num, payload, points),
+        PayloadOps::DeletePayload { keys, points, .. } => {
+            delete_payload(segments, op_num, points, keys)
+        }
+        PayloadOps::ClearPayload { points, .. } => clear_payload(segments, op_num, points),
+    }
+}
+
+pub(crate) fn process_field_index_operation(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    field_index_operation: &FieldIndexOperations,
+) -> CollectionResult<usize> {
+    match field_index_operation {
+        FieldIndexOperations::CreateIndex(field_name) => {
+            create_field_index(segments, op_num, field_name)
+        }
+        FieldIndexOperations::DeleteIndex(field_name) => {
+            delete_field_index(segments, op_num, field_name)
+        }
+    }
+}
+
+pub(crate) fn process_point_operation(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    point_operation: PointOperations,
+) -> CollectionResult<usize> {
+    match point_operation {
+        PointOperations::DeletePoints { ids, .. } => delete_points(segments, op_num, &ids),
+        PointOperations::UpsertPoints(operation) => {
+            let (ids, vectors, payloads) = match operation {
+                PointInsertOperations::BatchPoints {
+                    ids,
+                    vectors,
+                    payloads,
+                    ..
+                } => (ids, vectors, payloads),
+                PointInsertOperations::PointsList(points) => {
+                    let mut ids = vec![];
+                    let mut vectors = vec![];
+                    let mut payloads = vec![];
+                    for point in points {
+                        ids.push(point.id);
+                        vectors.push(point.vector);
+                        payloads.push(point.payload)
+                    }
+                    (ids, vectors, Some(payloads))
+                }
+            };
+            let res = upsert_points(segments, op_num, &ids, &vectors, &payloads)?;
+            Ok(res)
+        }
+    }
+}
+
+fn set_payload(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    payload: &HashMap<PayloadKeyType, PayloadInterface>,
+    points: &[PointIdType],
+) -> CollectionResult<usize> {
+    let mut updated_points: HashSet<PointIdType> = Default::default();
+
+    let res = segments
+        .read()
+        .apply_points_to_appendable(op_num, points, |id, write_segment| {
+            updated_points.insert(id);
+            let mut res = true;
+            for (key, payload) in payload {
+                res = write_segment.set_payload(op_num, id, key, payload.into())? && res;
+            }
+            Ok(res)
+        })?;
+
+    check_unprocessed_points(points, &updated_points)?;
+    Ok(res)
+}
+
+fn delete_payload(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+    keys: &[PayloadKeyType],
+) -> CollectionResult<usize> {
+    let mut updated_points: HashSet<PointIdType> = Default::default();
+
+    let res = segments
+        .read()
+        .apply_points_to_appendable(op_num, points, |id, write_segment| {
+            updated_points.insert(id);
+            let mut res = true;
+            for key in keys {
+                res = write_segment.delete_payload(op_num, id, key)? && res;
+            }
+            Ok(res)
+        })?;
+
+    check_unprocessed_points(points, &updated_points)?;
+    Ok(res)
+}
+
+fn clear_payload(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+) -> CollectionResult<usize> {
+    let mut updated_points: HashSet<PointIdType> = Default::default();
+    let res = segments
+        .read()
+        .apply_points_to_appendable(op_num, points, |id, write_segment| {
+            updated_points.insert(id);
+            write_segment.clear_payload(op_num, id)
+        })?;
+
+    check_unprocessed_points(points, &updated_points)?;
+    Ok(res)
+}
+
+fn create_field_index(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    field_name: PayloadKeyTypeRef,
+) -> CollectionResult<usize> {
+    let res = segments.read().apply_segments(op_num, |write_segment| {
+        write_segment.create_field_index(op_num, field_name)
+    })?;
+    Ok(res)
+}
+
+fn delete_field_index(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    field_name: PayloadKeyTypeRef,
+) -> CollectionResult<usize> {
+    let res = segments.read().apply_segments(op_num, |write_segment| {
+        write_segment.delete_field_index(op_num, field_name)
+    })?;
+    Ok(res)
 }
 
 #[cfg(test)]
 mod tests {
     use tempdir::TempDir;
 
-    use crate::segment_manager::fixtures::build_searcher;
-    use crate::segment_manager::segment_managers::SegmentSearcher;
     use segment::types::PayloadVariant;
+
+    use crate::segment_manager::fixtures::build_test_holder;
+    use crate::segment_manager::segment_managers::SegmentSearcher;
+    use crate::segment_manager::simple_segment_searcher::SimpleSegmentSearcher;
 
     use super::*;
 
@@ -330,19 +312,18 @@ mod tests {
     async fn test_point_ops() {
         let dir = TempDir::new("segment_dir").unwrap();
 
-        let searcher = build_searcher(dir.path()).await;
+        let segment_holder = build_test_holder(dir.path());
 
-        let updater = SimpleSegmentUpdater {
-            segments: searcher.segments.clone(),
-        };
         let points = vec![1, 500];
 
         let vectors = vec![vec![2., 2., 2., 2.], vec![2., 0., 2., 0.]];
 
-        let res = updater.upsert_points(100, &points, &vectors, &None);
+        let res = upsert_points(&segment_holder, 100, &points, &vectors, &None);
         assert!(matches!(res, Ok(1)));
 
-        let records = searcher.retrieve(&[1, 2, 500], true, true).await.unwrap();
+        let records = SimpleSegmentSearcher::retrieve(&segment_holder, &[1, 2, 500], true, true)
+            .await
+            .unwrap();
 
         assert_eq!(records.len(), 3);
 
@@ -357,9 +338,11 @@ mod tests {
             }
         }
 
-        updater.delete_points(101, &[500]).unwrap();
+        delete_points(&segment_holder, 101, &[500]).unwrap();
 
-        let records = searcher.retrieve(&[1, 2, 500], true, true).await.unwrap();
+        let records = SimpleSegmentSearcher::retrieve(&segment_holder, &[1, 2, 500], true, true)
+            .await
+            .unwrap();
 
         for record in records {
             let _v = record.vector.unwrap();
@@ -370,11 +353,7 @@ mod tests {
     #[tokio::test]
     async fn test_payload_ops() {
         let dir = TempDir::new("segment_dir").unwrap();
-        let searcher = build_searcher(dir.path()).await;
-
-        let updater = SimpleSegmentUpdater {
-            segments: searcher.segments.clone(),
-        };
+        let segment_holder = build_test_holder(dir.path());
 
         let mut payload: HashMap<PayloadKeyType, PayloadInterface> = Default::default();
 
@@ -385,17 +364,19 @@ mod tests {
 
         let points = vec![1, 2, 3];
 
-        updater
-            .process_payload_operation(
-                100,
-                &PayloadOps::SetPayload {
-                    payload,
-                    points: points.clone(),
-                },
-            )
-            .unwrap();
+        process_payload_operation(
+            &segment_holder,
+            100,
+            &PayloadOps::SetPayload {
+                payload,
+                points: points.clone(),
+            },
+        )
+        .unwrap();
 
-        let res = searcher.retrieve(&points, true, false).await.unwrap();
+        let res = SimpleSegmentSearcher::retrieve(&segment_holder, &points, true, false)
+            .await
+            .unwrap();
 
         assert_eq!(res.len(), 3);
 
@@ -411,21 +392,31 @@ mod tests {
 
         // Test payload delete
 
-        updater
-            .delete_payload(101, &[3], &["color".to_string(), "empty".to_string()])
+        delete_payload(
+            &segment_holder,
+            101,
+            &[3],
+            &["color".to_string(), "empty".to_string()],
+        )
+        .unwrap();
+        let res = SimpleSegmentSearcher::retrieve(&segment_holder, &[3], true, false)
+            .await
             .unwrap();
-        let res = searcher.retrieve(&[3], true, false).await.unwrap();
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
 
         // Test clear payload
 
-        let res = searcher.retrieve(&[2], true, false).await.unwrap();
+        let res = SimpleSegmentSearcher::retrieve(&segment_holder, &[2], true, false)
+            .await
+            .unwrap();
         assert_eq!(res.len(), 1);
         assert!(res[0].payload.as_ref().unwrap().contains_key("color"));
 
-        updater.clear_payload(102, &[2]).unwrap();
-        let res = searcher.retrieve(&[2], true, false).await.unwrap();
+        clear_payload(&segment_holder, 102, &[2]).unwrap();
+        let res = SimpleSegmentSearcher::retrieve(&segment_holder, &[2], true, false)
+            .await
+            .unwrap();
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
     }

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -8,7 +8,6 @@ use collection::operations::CollectionUpdateOperations;
 use segment::types::PayloadType;
 use std::sync::Arc;
 use tempdir::TempDir;
-use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn test_collection_reloading() {
@@ -19,7 +18,7 @@ async fn test_collection_reloading() {
     }
 
     for _i in 0..5 {
-        let collection = load_collection(collection_dir.path(), Handle::current());
+        let collection = load_collection(collection_dir.path());
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::BatchPoints {
                 ids: vec![0, 1],
@@ -30,7 +29,7 @@ async fn test_collection_reloading() {
         collection.update(insert_points, true).await.unwrap();
     }
 
-    let collection = load_collection(collection_dir.path(), Handle::current());
+    let collection = load_collection(collection_dir.path());
     assert_eq!(collection.info().unwrap().vectors_count, 2)
 }
 
@@ -53,7 +52,7 @@ async fn test_collection_payload_reloading() {
         collection.update(insert_points, true).await.unwrap();
     }
 
-    let collection = load_collection(collection_dir.path(), Handle::current());
+    let collection = load_collection(collection_dir.path());
 
     let res = collection
         .scroll(Arc::new(ScrollRequest {

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -4,7 +4,6 @@ use collection::collection_builder::optimizers_builder::OptimizersConfig;
 use collection::config::{CollectionParams, WalConfig};
 use segment::types::Distance;
 use std::path::Path;
-use tokio::runtime::Handle;
 
 pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     deleted_threshold: 0.9,
@@ -32,7 +31,6 @@ pub async fn simple_collection_fixture(collection_path: &Path) -> Collection {
         collection_path,
         &wal_config,
         &collection_params,
-        Handle::current(),
         &TEST_OPTIMIZERS_CONFIG,
         &Default::default(),
     )

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -1,19 +1,21 @@
-use crate::actix::helpers::process_response;
+use std::sync::Arc;
+
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
+
 use collection::operations::types::RecommendRequest;
 use segment::types::ScoredPoint;
-use std::sync::Arc;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
+
+use crate::actix::helpers::process_response;
 
 async fn do_recommend_points(
     toc: &TableOfContent,
     collection_name: &str,
     request: RecommendRequest,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
-    let collection = toc.get_collection(collection_name)?;
-    Ok(collection.recommend(Arc::new(request)).await?)
+    toc.recommend(collection_name, Arc::new(request)).await
 }
 
 #[post("/collections/{name}/points/recommend")]

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -1,21 +1,21 @@
-use crate::actix::helpers::process_response;
+use std::sync::Arc;
+
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
+
 use collection::operations::types::SearchRequest;
 use segment::types::ScoredPoint;
-use std::sync::Arc;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
+
+use crate::actix::helpers::process_response;
 
 async fn do_search_points(
     toc: &TableOfContent,
     name: &str,
     request: SearchRequest,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
-    toc.get_collection(name)?
-        .search(Arc::new(request))
-        .await
-        .map_err(|err| err.into())
+    toc.search(name, request).await
 }
 
 #[post("/collections/{name}/points/search")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,8 +13,7 @@ fn main() {
     env_logger::init();
 
     let runtime = create_search_runtime(settings.storage.performance.max_search_threads).unwrap();
-    let handle = runtime.handle().clone();
-    let toc = TableOfContent::new(&settings.storage, handle);
+    let toc = TableOfContent::new(&settings.storage, runtime);
 
     for collection in toc.all_collections() {
         info!("loaded collection: {}", collection);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,8 @@ fn main() -> std::io::Result<()> {
     // destruction of it
     let runtime = create_search_runtime(settings.storage.performance.max_search_threads)
         .expect("Can't create runtime.");
-    let search_runtime_handle = runtime.handle().clone();
 
-    let toc = TableOfContent::new(&settings.storage, search_runtime_handle);
+    let toc = TableOfContent::new(&settings.storage, runtime);
     for collection in toc.all_collections() {
         info!("loaded collection: {}", collection);
     }


### PR DESCRIPTION
The main goal of this PR is to simplify `Collection` a bit.

Currently, `Collection` holds the searcher and updater and can't be instantiated without them (because of searcher, it also needs a search runtime), which seems to me not optimal, since search and update it just operations (among others) over collection, or more precisely, over segments. They need segments as an input argument, but there is no need to hold a reference to them. Using segments as an input argument instead of field reduces using `Arc` and also makes more clear where sharing between threads is actually needed.
One more small point why it is better to have segments for searcher and updater as an argument: traits `SegmentSearcher` and `SegmentUpdater` don't have any appearances of segments in signatures, which may imply that some implementation could work without segments, but that will never be happening.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
