### PR TITLE
Fix ndarray imports in segment benches

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use ndarray::Array;
+use ndarray::{Array, Array2};
 use rand::distributions::Standard;
 use rand::Rng;
 use tempdir::TempDir;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

In my last PR, a bug seems to somehow have slipped under my radar - a clippy lint autofix must have removed too many imports from the `vector_search.rs` file.
