### PR TITLE
refactor: replace parking_lot with tokio mutex for WAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,6 @@ dependencies = [
  "collection",
  "itertools 0.9.0",
  "num_cpus",
- "parking_lot",
  "rand 0.7.3",
  "schemars",
  "segment",

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -6,9 +6,9 @@ use std::thread;
 
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use tokio::sync::Mutex;
 use parking_lot::RwLock;
 use tokio::runtime::{Handle, Runtime};
+use tokio::sync::Mutex;
 
 use segment::types::{
     Condition, Filter, HasIdCondition, PayloadKeyType, PayloadSchemaInfo, PointIdType, ScoredPoint,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -6,7 +6,8 @@ use std::thread;
 
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use parking_lot::{Mutex, RwLock};
+use tokio::sync::Mutex;
+use parking_lot::RwLock;
 use tokio::runtime::{Handle, Runtime};
 
 use segment::types::{
@@ -37,7 +38,7 @@ pub struct Collection {
     segments: Arc<RwLock<SegmentHolder>>,
     config: Arc<tokio::sync::RwLock<CollectionConfig>>,
     wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
-    update_handler: Arc<tokio::sync::Mutex<UpdateHandler>>,
+    update_handler: Arc<Mutex<UpdateHandler>>,
     runtime_handle: Option<Runtime>,
     update_sender: Sender<UpdateSignal>,
     path: PathBuf,
@@ -86,7 +87,7 @@ impl Collection {
         };
 
         let operation_id = {
-            let mut wal_lock = self.wal.lock();
+            let mut wal_lock = self.wal.lock().await;
             let operation_id = wal_lock.write(&operation)?;
             sndr.send(UpdateSignal::Operation(OperationData {
                 op_num: operation_id,
@@ -361,8 +362,8 @@ impl Collection {
     }
 
     /// Loads latest collection operations from WAL
-    pub fn load_from_wal(&self) {
-        let wal = self.wal.lock();
+    pub async fn load_from_wal(&self) {
+        let wal = self.wal.lock().await;
         let bar = ProgressBar::new(wal.len());
         bar.set_message("Recovering collection");
         let segments = self.segments();

--- a/lib/collection/src/collection_builder/collection_builder_base.rs
+++ b/lib/collection/src/collection_builder/collection_builder_base.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use num_cpus;
-use parking_lot::{Mutex, RwLock};
+use tokio::sync::{Mutex};
+use parking_lot::RwLock;
 use tokio::runtime;
 
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;

--- a/lib/collection/src/collection_builder/collection_builder_base.rs
+++ b/lib/collection/src/collection_builder/collection_builder_base.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use num_cpus;
-use tokio::sync::{Mutex};
 use parking_lot::RwLock;
 use tokio::runtime;
+use tokio::sync::Mutex;
 
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::HnswConfig;

--- a/lib/collection/src/collection_builder/collection_loader.rs
+++ b/lib/collection/src/collection_builder/collection_loader.rs
@@ -1,6 +1,6 @@
+use futures::executor::block_on;
 use std::fs::{read_dir, remove_dir_all};
 use std::path::Path;
-use futures::executor::block_on;
 
 use segment::segment_constructor::load_segment;
 

--- a/lib/collection/src/collection_builder/collection_loader.rs
+++ b/lib/collection/src/collection_builder/collection_loader.rs
@@ -1,5 +1,6 @@
 use std::fs::{read_dir, remove_dir_all};
 use std::path::Path;
+use futures::executor::block_on;
 
 use segment::segment_constructor::load_segment;
 
@@ -73,7 +74,7 @@ pub fn load_collection(collection_path: &Path) -> Collection {
         collection_path,
     );
 
-    collection.load_from_wal();
+    block_on(collection.load_from_wal());
 
     collection
 }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -6,11 +6,11 @@ use crate::operations::CollectionUpdateOperations;
 use crate::wal::SerdeWal;
 use async_channel::{Receiver, Sender};
 use log::{debug, info};
-use tokio::sync::Mutex;
 use segment::types::SeqNumberType;
 use std::cmp::min;
 use std::sync::Arc;
 use tokio::runtime::Handle;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
 
@@ -183,7 +183,10 @@ impl UpdateHandler {
                 Ok(signal) => {
                     match signal {
                         OptimizerSignal::Nop => {
-                            if Self::try_recover(segments.clone(), wal.clone()).await.is_err() {
+                            if Self::try_recover(segments.clone(), wal.clone())
+                                .await
+                                .is_err()
+                            {
                                 continue;
                             }
                             let mut handles = blocking_handles.lock().await;
@@ -193,7 +196,10 @@ impl UpdateHandler {
                             ));
                         }
                         OptimizerSignal::Operation(operation_id) => {
-                            if Self::try_recover(segments.clone(), wal.clone()).await.is_err() {
+                            if Self::try_recover(segments.clone(), wal.clone())
+                                .await
+                                .is_err()
+                            {
                                 continue;
                             }
                             {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -6,7 +6,7 @@ use crate::operations::CollectionUpdateOperations;
 use crate::wal::SerdeWal;
 use async_channel::{Receiver, Sender};
 use log::{debug, info};
-use parking_lot::Mutex;
+use tokio::sync::Mutex;
 use segment::types::SeqNumberType;
 use std::cmp::min;
 use std::sync::Arc;
@@ -110,7 +110,7 @@ impl UpdateHandler {
     /// If some optimization is in progress - it will be finished before shutdown.
     /// Blocking function.
     pub async fn wait_workers_stops(&mut self) -> CollectionResult<()> {
-        for handle in self.optimization_handles.lock().iter() {
+        for handle in self.optimization_handles.lock().await.iter() {
             handle.abort();
         }
         let maybe_handle = self.update_worker.take();
@@ -126,7 +126,7 @@ impl UpdateHandler {
 
     /// Checks if there are any failed operations.
     /// If so - attempts to re-apply all failed operations.
-    fn try_recover(
+    async fn try_recover(
         segments: LockedSegmentHolder,
         wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
     ) -> CollectionResult<usize> {
@@ -135,7 +135,7 @@ impl UpdateHandler {
         match first_failed_operation_option {
             None => {}
             Some(first_failed_op) => {
-                let wal_lock = wal.lock();
+                let wal_lock = wal.lock().await;
                 for (op_num, operation) in wal_lock.read(first_failed_op) {
                     CollectionUpdater::update(&segments, op_num, operation)?;
                 }
@@ -183,21 +183,21 @@ impl UpdateHandler {
                 Ok(signal) => {
                     match signal {
                         OptimizerSignal::Nop => {
-                            if Self::try_recover(segments.clone(), wal.clone()).is_err() {
+                            if Self::try_recover(segments.clone(), wal.clone()).await.is_err() {
                                 continue;
                             }
-                            let mut handles = blocking_handles.lock();
+                            let mut handles = blocking_handles.lock().await;
                             handles.append(&mut Self::process_optimization(
                                 optimizers.clone(),
                                 segments.clone(),
                             ));
                         }
                         OptimizerSignal::Operation(operation_id) => {
-                            if Self::try_recover(segments.clone(), wal.clone()).is_err() {
+                            if Self::try_recover(segments.clone(), wal.clone()).await.is_err() {
                                 continue;
                             }
                             {
-                                let mut handles = blocking_handles.lock();
+                                let mut handles = blocking_handles.lock().await;
                                 handles.append(&mut Self::process_optimization(
                                     optimizers.clone(),
                                     segments.clone(),
@@ -218,7 +218,7 @@ impl UpdateHandler {
                                         }
                                     }
                                 };
-                                wal.lock().ack(confirmed_version).unwrap();
+                                wal.lock().await.ack(confirmed_version).unwrap();
                             }
                         }
                         OptimizerSignal::Stop => break, // Stop gracefully

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -10,7 +10,6 @@ tempdir = "0.3.7"
 
 [dependencies]
 
-parking_lot = "0.11"
 sled = "0.34"
 num_cpus = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
Fixes following check error:

```
error[E0277]: `*mut ()` cannot be sent between threads safely
  --> src/tonic/api/points_api.rs:35:60
   |
35 |       ) -> Result<Response<PointsOperationResponse>, Status> {
   |  ____________________________________________________________^
36 | |         let UpsertPoints {
37 | |             collection,
38 | |             wait,
...  |
60 | |         Ok(Response::new(response))
61 | |     }
   | |_____^ `*mut ()` cannot be sent between threads safely
```



### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

