### PR TITLE
Fix benches compilation for TestRawScorerProducer::new

### DIFF
--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -1,7 +1,8 @@
 mod prof;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
+use rand::rngs::StdRng;
+use rand::{thread_rng, SeedableRng};
 use segment::fixtures::index_fixtures::{FakeConditionChecker, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
@@ -14,7 +15,8 @@ const EF_CONSTRUCT: usize = 64;
 const USE_HEURISTIC: bool = true;
 
 fn hnsw_benchmark(c: &mut Criterion) {
-    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine);
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine, &mut rng);
     let mut group = c.benchmark_group("hnsw-index-build-group");
     group.sample_size(10);
     group.bench_function("hnsw_index", |b| {

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -1,7 +1,8 @@
 mod prof;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
+use rand::rngs::StdRng;
+use rand::{thread_rng, SeedableRng};
 use segment::fixtures::index_fixtures::{
     random_vector, FakeConditionChecker, TestRawScorerProducer,
 };
@@ -18,7 +19,8 @@ const EF: usize = 100;
 const USE_HEURISTIC: bool = true;
 
 fn hnsw_benchmark(c: &mut Criterion) {
-    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine);
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine, &mut rng);
     let mut group = c.benchmark_group("hnsw-index-build-group");
     let mut rng = thread_rng();
     let fake_condition_checker = FakeConditionChecker {};


### PR DESCRIPTION
This PR fixes the compilation of benches in `hnsw_build_graph` and `hnsw_search_graph`

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> lib/segment/benches/hnsw_search_graph.rs:21:25
   |
21 |     let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine);
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ ---  -----------  ---------------- supplied 3 arguments
   |                         |
   |                         expected 4 arguments
```

I have decided to provide a fixed seed to keep the benchmark deterministic.
