### PR TITLE
Improve error reporting in collection_loader

### DIFF
--- a/lib/collection/src/collection_builder/collection_loader.rs
+++ b/lib/collection/src/collection_builder/collection_loader.rs
@@ -17,9 +17,10 @@ pub fn load_collection(collection_path: &Path) -> Collection {
     let segments_path = collection_path.join("segments");
     let mut segment_holder = SegmentHolder::default();
 
-    let collection_config = CollectionConfig::load(collection_path).unwrap_or_else(|_| {
+    let collection_config = CollectionConfig::load(collection_path).unwrap_or_else(|err| {
         panic!(
-            "Can't read collection config at {}",
+            "Can't read collection config due to {}\nat {}",
+            err,
             collection_path.to_str().unwrap()
         )
     });
@@ -30,9 +31,10 @@ pub fn load_collection(collection_path: &Path) -> Collection {
     )
     .expect("Can't read WAL");
 
-    let segment_dirs = read_dir(&segments_path).unwrap_or_else(|_| {
+    let segment_dirs = read_dir(&segments_path).unwrap_or_else(|err| {
         panic!(
-            "Can't read segments directory {}",
+            "Can't read segments directory due to {}\nat {}",
+            err,
             segments_path.to_str().unwrap()
         )
     });


### PR DESCRIPTION
This PR improves the error reporting in `collection_loader`.

My existing stored data can no longer be accessed when using master, the following error is thrown:

```
thread 'main' panicked at 'Can't read collection config at ./storage/collections/test_collection', lib/collection/src/collection_builder/collection_loader.rs:21:9
```

Improving the error handling shows that the issue is caused by the work in https://github.com/qdrant/qdrant/pull/134

```
thread 'main' panicked at 'Can't read collection config due to Service internal error: Json error: missing field `max_optimization_threads` at line 1 column 324
at ./storage/collections/test_collection', lib/collection/src/collection_builder/collection_loader.rs:22:9
```

I am not sure what is the backward compatibility story for `qdrant` but in any case I believe it makes sense to improve the error reporting to help the users. 