### PR TITLE
tokio 1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,9 +3231,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3261,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ itertools = "0.9"
 
 config = "~0.10.1"
 
-tokio = { version = "~1.7", features = ["full"] }
+tokio = { version = "~1.14", features = ["full"] }
 
 actix-web = { version = "4.0.0-beta.8", optional = true }
 tonic =  { version = "0.5.0", optional = true }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = "~0.14"
 wal = { git = "https://github.com/generall/wal.git" }
 ordered-float = "1.0"
 
-tokio = {version = "~1.7", features = ["full"]}
+tokio = {version = "~1.14", features = ["full"]}
 futures = "0.3.5"
 atomicwrites = "0.2.5"
 log = "0.4"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -15,7 +15,7 @@ num_cpus = "1.0"
 thiserror = "1.0"
 rand = "0.7.3"
 wal = { git = "https://github.com/generall/wal.git" }
-tokio = {version = "~1.7", features = ["rt-multi-thread"]}
+tokio = {version = "~1.14", features = ["rt-multi-thread"]}
 serde = { version = "~1.0", features = ["derive"] }
 schemars = "0.8.0"
 itertools = "0.9"


### PR DESCRIPTION
This PR updates tokio to the last version `1.14.0`.

The current dependency `1.7.0` is 6 months old and a lot has been improved in the meantime.

Given the place of tokio in the architecture, it is better to update early in order to not fall behind the release train.