### PR TITLE
[WIP] Clear optimization handles 30

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -391,15 +391,20 @@ impl Drop for Collection {
 
         block_on(self.wait_update_workers_stop()).unwrap();
 
-        // The drop could be called from the tokio context, e.g. from perform_collection_operation method.
-        // Calling remove from there would lead to the following error in a new version of tokio:
-        // "Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context."
-        // So the workaround for move out the runtime handler and drop it in the separate thread.
-        // The proper solution is to reconsider the collection to be an owner of the runtime
-        let handle = self.runtime_handle.take();
-        let thread_handler = thread::spawn(move || {
-            drop(handle);
-        });
-        thread_handler.join().unwrap();
+        match self.runtime_handle.take() {
+            None => {}
+            Some(handle) => {
+                // The drop could be called from the tokio context, e.g. from perform_collection_operation method.
+                // Calling remove from there would lead to the following error in a new version of tokio:
+                // "Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context."
+                // So the workaround for move out the runtime handler and drop it in the separate thread.
+                // The proper solution is to reconsider the collection to be an owner of the runtime
+
+                let thread_handler = thread::spawn(move || {
+                    drop(handle);
+                });
+                thread_handler.join().unwrap();
+            }
+        }
     }
 }

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod stoppable_task;

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -1,0 +1,88 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
+use tokio::task::JoinHandle;
+
+pub struct StoppableTaskHandle<T> {
+    pub join_handle: JoinHandle<T>,
+    finished: Arc<AtomicBool>,
+    stopped: Weak<AtomicBool>,
+}
+
+impl<T> StoppableTaskHandle<T> {
+    pub fn is_finished(&self) -> bool {
+        self.finished.load(Ordering::Relaxed)
+    }
+
+    pub fn ask_to_stop(&self) {
+        if let Some(v) = self.stopped.upgrade() {
+            v.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn stop(self) -> JoinHandle<T> {
+        self.ask_to_stop();
+        self.join_handle
+    }
+}
+
+pub fn spawn_stoppable<F, T>(f: F) -> StoppableTaskHandle<T>
+where
+    F: FnOnce(&AtomicBool) -> T,
+    F: Send + 'static,
+    T: Send + 'static,
+{
+    let finished = Arc::new(AtomicBool::new(false));
+    let finished_c = finished.clone();
+
+    let stopped = Arc::new(AtomicBool::new(false));
+    // We are OK if original value is destroyed with the thread
+    // Weak reference is sufficient
+    let stopped_w = Arc::downgrade(&stopped);
+
+    StoppableTaskHandle {
+        join_handle: tokio::task::spawn_blocking(move || {
+            let res = f(&*stopped);
+            // We use `Release` ordering to ensure that `f` won't be moved after the `store`
+            // by the compiler
+            finished.store(true, Ordering::Release);
+            res
+        }),
+        stopped: stopped_w,
+        finished: finished_c,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    const STEP_MILLIS: u64 = 5;
+
+    fn long_task(stop: &AtomicBool) -> i32 {
+        let mut n = 0;
+        for i in 0..10 {
+            n = i;
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(STEP_MILLIS));
+        }
+        return n;
+    }
+
+    #[tokio::test]
+    async fn test_task_stop() {
+        let handle = spawn_stoppable(long_task);
+
+        thread::sleep(Duration::from_millis(STEP_MILLIS * 5));
+        handle.ask_to_stop();
+        assert!(!handle.is_finished());
+        thread::sleep(Duration::from_millis(STEP_MILLIS));
+        assert!(handle.is_finished());
+
+        let res = handle.stop().await.unwrap();
+        assert!(res < 10);
+    }
+}

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -69,7 +69,7 @@ mod tests {
             }
             thread::sleep(Duration::from_millis(STEP_MILLIS));
         }
-        return n;
+        n
     }
 
     #[tokio::test]

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod collection;
 pub mod collection_builder;
 pub mod collection_manager;
+mod common;
 pub mod config;
 pub mod operations;
 mod update_handler;

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -4,9 +4,9 @@ use crate::collection_manager::fixtures::{
 use crate::collection_manager::holders::segment_holder::{SegmentHolder, SegmentId};
 use crate::update_handler::{Optimizer, UpdateHandler};
 use futures::future::join_all;
+use itertools::Itertools;
 use parking_lot::RwLock;
 use std::sync::Arc;
-use itertools::Itertools;
 use tempdir::TempDir;
 
 #[tokio::test]

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::update_handler::{Optimizer, UpdateHandler};
 use futures::future::join_all;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use itertools::Itertools;
 use tempdir::TempDir;
 
 #[tokio::test]
@@ -40,7 +41,10 @@ async fn test_optimization_process() {
 
     assert_eq!(handles.len(), 2);
 
-    let join_res = join_all(handles).await;
+    let join_res = join_all(handles.into_iter().map(|x| x).collect_vec()).await;
+
+    let handles_2 = UpdateHandler::process_optimization(optimizers.clone(), segments.clone());
+    assert_eq!(handles_2.len(), 0);
 
     for res in join_res {
         assert!(res.is_ok());

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -37,13 +37,14 @@ async fn test_optimization_process() {
     let optimizers = Arc::new(vec![merge_optimizer, indexing_optimizer]);
 
     let segments = Arc::new(RwLock::new(holder));
-    let handles = UpdateHandler::process_optimization(optimizers.clone(), segments.clone());
+    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone());
 
     assert_eq!(handles.len(), 2);
 
-    let join_res = join_all(handles.into_iter().map(|x| x).collect_vec()).await;
+    let join_res = join_all(handles.into_iter().map(|x| x.join_handle).collect_vec()).await;
 
-    let handles_2 = UpdateHandler::process_optimization(optimizers.clone(), segments.clone());
+    let handles_2 = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone());
+
     assert_eq!(handles_2.len(), 0);
 
     for res in join_res {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -189,10 +189,7 @@ impl UpdateHandler {
         segments: LockedSegmentHolder,
         optimization_handles: Arc<Mutex<Vec<StoppableTaskHandle<bool>>>>,
     ) {
-        let mut new_handles = Self::launch_optimization(
-            optimizers.clone(),
-            segments.clone(),
-        );
+        let mut new_handles = Self::launch_optimization(optimizers.clone(), segments.clone());
         let mut handles = optimization_handles.lock().await;
         handles.append(&mut new_handles);
         handles.retain(|h| !h.is_finished())

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,10 +1,13 @@
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::optimizers::segment_optimizer::SegmentOptimizer;
+use crate::common::stoppable_task::{spawn_stoppable, StoppableTaskHandle};
 use crate::operations::types::CollectionResult;
 use crate::operations::CollectionUpdateOperations;
 use crate::wal::SerdeWal;
 use async_channel::{Receiver, Sender};
+use futures::future::join_all;
+use itertools::Itertools;
 use log::{debug, info};
 use segment::types::SeqNumberType;
 use std::cmp::min;
@@ -63,7 +66,7 @@ pub struct UpdateHandler {
     runtime_handle: Handle,
     /// WAL, required for operations
     wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
-    optimization_handles: Arc<Mutex<Vec<JoinHandle<bool>>>>,
+    optimization_handles: Arc<Mutex<Vec<StoppableTaskHandle<bool>>>>,
 }
 
 impl UpdateHandler {
@@ -109,11 +112,15 @@ impl UpdateHandler {
 
     /// Gracefully wait before all optimizations stop
     /// If some optimization is in progress - it will be finished before shutdown.
-    /// Blocking function.
     pub async fn wait_workers_stops(&mut self) -> CollectionResult<()> {
-        for handle in self.optimization_handles.lock().await.iter() {
-            handle.abort();
+        let mut opt_handles_guard = self.optimization_handles.lock().await;
+        let opt_handles = std::mem::take(&mut *opt_handles_guard);
+        let stopping_handles = opt_handles.into_iter().map(|h| h.stop()).collect_vec();
+
+        for res in join_all(stopping_handles).await {
+            res?;
         }
+
         let maybe_handle = self.update_worker.take();
         if let Some(handle) = maybe_handle {
             handle.await?;
@@ -145,10 +152,13 @@ impl UpdateHandler {
         Ok(0)
     }
 
-    pub(crate) fn process_optimization(
+    /// Checks conditions for all optimizers until there is no suggested segment
+    /// Starts a task for each optimization
+    /// Returns handles for started tasks
+    pub(crate) fn launch_optimization(
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         segments: LockedSegmentHolder,
-    ) -> Vec<JoinHandle<bool>> {
+    ) -> Vec<StoppableTaskHandle<bool>> {
         let mut scheduled_segment_ids: HashSet<_> = Default::default();
         let mut handles = vec![];
         for optimizer in optimizers.iter() {
@@ -165,7 +175,7 @@ impl UpdateHandler {
                         scheduled_segment_ids.insert(*sid);
                     }
 
-                    handles.push(tokio::task::spawn_blocking(move || {
+                    handles.push(spawn_stoppable(move |_stopped| {
                         optim.as_ref().optimize(segs, nsi).unwrap()
                     }));
                 }
@@ -174,13 +184,26 @@ impl UpdateHandler {
         handles
     }
 
+    pub(crate) async fn process_optimization(
+        optimizers: Arc<Vec<Arc<Optimizer>>>,
+        segments: LockedSegmentHolder,
+        optimizers_handles: Arc<Mutex<Vec<StoppableTaskHandle<bool>>>>,
+    ) {
+        let mut handles = optimizers_handles.lock().await;
+        handles.append(&mut Self::launch_optimization(
+            optimizers.clone(),
+            segments.clone(),
+        ));
+        handles.retain(|h| !h.is_finished())
+    }
+
     async fn optimization_worker_fn(
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         receiver: Receiver<OptimizerSignal>,
         segments: LockedSegmentHolder,
         wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
         flush_timeout_sec: u64,
-        blocking_handles: Arc<Mutex<Vec<JoinHandle<bool>>>>,
+        blocking_handles: Arc<Mutex<Vec<StoppableTaskHandle<bool>>>>,
     ) {
         let flush_timeout = Duration::from_secs(flush_timeout_sec);
         let mut last_flushed = Instant::now();
@@ -196,11 +219,12 @@ impl UpdateHandler {
                             {
                                 continue;
                             }
-                            let mut handles = blocking_handles.lock().await;
-                            handles.append(&mut Self::process_optimization(
+                            Self::process_optimization(
                                 optimizers.clone(),
                                 segments.clone(),
-                            ));
+                                blocking_handles.clone(),
+                            )
+                            .await;
                         }
                         OptimizerSignal::Operation(operation_id) => {
                             if Self::try_recover(segments.clone(), wal.clone())
@@ -209,13 +233,12 @@ impl UpdateHandler {
                             {
                                 continue;
                             }
-                            {
-                                let mut handles = blocking_handles.lock().await;
-                                handles.append(&mut Self::process_optimization(
-                                    optimizers.clone(),
-                                    segments.clone(),
-                                ));
-                            }
+                            Self::process_optimization(
+                                optimizers.clone(),
+                                segments.clone(),
+                                blocking_handles.clone(),
+                            )
+                            .await;
 
                             let elapsed = last_flushed.elapsed();
                             if elapsed > flush_timeout {

--- a/src/tonic/qdrant.rs
+++ b/src/tonic/qdrant.rs
@@ -1,87 +1,86 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetCollectionsRequest {
-}
+pub struct GetCollectionsRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionDescription {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub collections: ::prost::alloc::vec::Vec<CollectionDescription>,
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HnswConfigDiff {
-    #[prost(uint64, optional, tag="1")]
+    #[prost(uint64, optional, tag = "1")]
     pub m: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub ef_construct: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub full_scan_threshold: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {
-    #[prost(uint64, optional, tag="1")]
+    #[prost(uint64, optional, tag = "1")]
     pub wal_capacity_mb: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub wal_segments_ahead: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizersConfigDiff {
-    #[prost(double, optional, tag="1")]
+    #[prost(double, optional, tag = "1")]
     pub deleted_threshold: ::core::option::Option<f64>,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub vacuum_min_vector_number: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub max_segment_number: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="4")]
+    #[prost(uint64, optional, tag = "4")]
     pub memmap_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="5")]
+    #[prost(uint64, optional, tag = "5")]
     pub indexing_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="6")]
+    #[prost(uint64, optional, tag = "6")]
     pub payload_indexing_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="7")]
+    #[prost(uint64, optional, tag = "7")]
     pub flush_interval_sec: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="8")]
+    #[prost(uint64, optional, tag = "8")]
     pub max_optimization_threads: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollection {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub vector_size: u64,
-    #[prost(enumeration="Distance", tag="3")]
+    #[prost(enumeration = "Distance", tag = "3")]
     pub distance: i32,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub wal_config: ::core::option::Option<WalConfigDiff>,
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollection {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCollection {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionOperationResponse {
-    #[prost(bool, optional, tag="1")]
+    #[prost(bool, optional, tag = "1")]
     pub result: ::core::option::Option<bool>,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(double, tag="3")]
+    #[prost(double, tag = "3")]
     pub time: f64,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -91,76 +90,416 @@ pub enum Distance {
     Euclid = 1,
     Dot = 2,
 }
-# [doc = r" Generated client implementations."] pub mod collections_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct CollectionsClient < T > { inner : tonic :: client :: Grpc < T > , } impl CollectionsClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > CollectionsClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> CollectionsClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { CollectionsClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn get (& mut self , request : impl tonic :: IntoRequest < super :: GetCollectionsRequest > ,) -> Result < tonic :: Response < super :: GetCollectionsResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Get") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn create (& mut self , request : impl tonic :: IntoRequest < super :: CreateCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Create") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn update (& mut self , request : impl tonic :: IntoRequest < super :: UpdateCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Update") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn delete (& mut self , request : impl tonic :: IntoRequest < super :: DeleteCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Delete") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod collections_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with CollectionsServer."] # [async_trait] pub trait Collections : Send + Sync + 'static { async fn get (& self , request : tonic :: Request < super :: GetCollectionsRequest >) -> Result < tonic :: Response < super :: GetCollectionsResponse > , tonic :: Status > ; async fn create (& self , request : tonic :: Request < super :: CreateCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; async fn update (& self , request : tonic :: Request < super :: UpdateCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; async fn delete (& self , request : tonic :: Request < super :: DeleteCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; } # [derive (Debug)] pub struct CollectionsServer < T : Collections > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Collections > CollectionsServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for CollectionsServer < T > where T : Collections , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Collections/Get" => { # [allow (non_camel_case_types)] struct GetSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: GetCollectionsRequest > for GetSvc < T > { type Response = super :: GetCollectionsResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: GetCollectionsRequest >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . get (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = GetSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Create" => { # [allow (non_camel_case_types)] struct CreateSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: CreateCollection > for CreateSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: CreateCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . create (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = CreateSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Update" => { # [allow (non_camel_case_types)] struct UpdateSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: UpdateCollection > for UpdateSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: UpdateCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . update (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = UpdateSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Delete" => { # [allow (non_camel_case_types)] struct DeleteSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: DeleteCollection > for DeleteSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: DeleteCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . delete (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = DeleteSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Collections > Clone for CollectionsServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Collections > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Collections > tonic :: transport :: NamedService for CollectionsServer < T > { const NAME : & 'static str = "qdrant.Collections" ; } }#[derive(Clone, PartialEq, ::prost::Message)]
+#[doc = r" Generated client implementations."]
+pub mod collections_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct CollectionsClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CollectionsClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CollectionsClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + Sync + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CollectionsClient<InterceptedService<T, F>>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            CollectionsClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn get(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetCollectionsRequest>,
+        ) -> Result<tonic::Response<super::GetCollectionsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Get");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn create(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Create");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn update(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Update");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Delete");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+#[doc = r" Generated server implementations."]
+pub mod collections_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with CollectionsServer."]
+    #[async_trait]
+    pub trait Collections: Send + Sync + 'static {
+        async fn get(
+            &self,
+            request: tonic::Request<super::GetCollectionsRequest>,
+        ) -> Result<tonic::Response<super::GetCollectionsResponse>, tonic::Status>;
+        async fn create(
+            &self,
+            request: tonic::Request<super::CreateCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        async fn update(
+            &self,
+            request: tonic::Request<super::UpdateCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        async fn delete(
+            &self,
+            request: tonic::Request<super::DeleteCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct CollectionsServer<T: Collections> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Collections> CollectionsServer<T> {
+        pub fn new(inner: T) -> Self {
+            let inner = Arc::new(inner);
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for CollectionsServer<T>
+    where
+        T: Collections,
+        B: Body + Send + Sync + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Never;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.Collections/Get" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSvc<T: Collections>(pub Arc<T>);
+                    impl<T: Collections> tonic::server::UnaryService<super::GetCollectionsRequest> for GetSvc<T> {
+                        type Response = super::GetCollectionsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetCollectionsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).get(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/Create" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateSvc<T: Collections>(pub Arc<T>);
+                    impl<T: Collections> tonic::server::UnaryService<super::CreateCollection> for CreateSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateCollection>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).create(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/Update" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateSvc<T: Collections>(pub Arc<T>);
+                    impl<T: Collections> tonic::server::UnaryService<super::UpdateCollection> for UpdateSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdateCollection>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).update(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/Delete" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteSvc<T: Collections>(pub Arc<T>);
+                    impl<T: Collections> tonic::server::UnaryService<super::DeleteCollection> for DeleteSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteCollection>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Collections> Clone for CollectionsServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Collections> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Collections> tonic::transport::NamedService for CollectionsServer<T> {
+        const NAME: &'static str = "qdrant.Collections";
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPoints {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection: ::prost::alloc::string::String,
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub points: ::prost::alloc::vec::Vec<PointStruct>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointStruct {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub id: u64,
-    #[prost(float, repeated, tag="2")]
+    #[prost(float, repeated, tag = "2")]
     pub vector: ::prost::alloc::vec::Vec<f32>,
-    #[prost(map="string, message", tag="3")]
+    #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Payload>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payload {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub keyword: ::core::option::Option<KeywordPayload>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub integer: ::core::option::Option<IntegerPayload>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub float: ::core::option::Option<FloatPayload>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub geo: ::core::option::Option<GeoPayload>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeywordPayload {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IntegerPayload {
-    #[prost(int64, repeated, tag="1")]
+    #[prost(int64, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<i64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FloatPayload {
-    #[prost(double, repeated, tag="1")]
+    #[prost(double, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<f64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPayload {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<GeoPoint>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPoint {
-    #[prost(double, tag="1")]
+    #[prost(double, tag = "1")]
     pub lon: f64,
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub lat: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsOperationResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub result: ::core::option::Option<UpdateResult>,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(double, tag="3")]
+    #[prost(double, tag = "3")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateResult {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub operation_id: u64,
-    #[prost(enumeration="UpdateStatus", tag="2")]
+    #[prost(enumeration = "UpdateStatus", tag = "2")]
     pub status: i32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -169,14 +508,398 @@ pub enum UpdateStatus {
     Acknowledged = 0,
     Completed = 1,
 }
-# [doc = r" Generated client implementations."] pub mod points_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct PointsClient < T > { inner : tonic :: client :: Grpc < T > , } impl PointsClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > PointsClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> PointsClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { PointsClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn upsert (& mut self , request : impl tonic :: IntoRequest < super :: UpsertPoints > ,) -> Result < tonic :: Response < super :: PointsOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Points/Upsert") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod points_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with PointsServer."] # [async_trait] pub trait Points : Send + Sync + 'static { async fn upsert (& self , request : tonic :: Request < super :: UpsertPoints >) -> Result < tonic :: Response < super :: PointsOperationResponse > , tonic :: Status > ; } # [derive (Debug)] pub struct PointsServer < T : Points > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Points > PointsServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for PointsServer < T > where T : Points , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Points/Upsert" => { # [allow (non_camel_case_types)] struct UpsertSvc < T : Points > (pub Arc < T >) ; impl < T : Points > tonic :: server :: UnaryService < super :: UpsertPoints > for UpsertSvc < T > { type Response = super :: PointsOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: UpsertPoints >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . upsert (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = UpsertSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Points > Clone for PointsServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Points > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Points > tonic :: transport :: NamedService for PointsServer < T > { const NAME : & 'static str = "qdrant.Points" ; } }#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HealthCheckRequest {
+#[doc = r" Generated client implementations."]
+pub mod points_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct PointsClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl PointsClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> PointsClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + Sync + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> PointsClient<InterceptedService<T, F>>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            PointsClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn upsert(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpsertPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Upsert");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+#[doc = r" Generated server implementations."]
+pub mod points_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with PointsServer."]
+    #[async_trait]
+    pub trait Points: Send + Sync + 'static {
+        async fn upsert(
+            &self,
+            request: tonic::Request<super::UpsertPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct PointsServer<T: Points> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Points> PointsServer<T> {
+        pub fn new(inner: T) -> Self {
+            let inner = Arc::new(inner);
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for PointsServer<T>
+    where
+        T: Points,
+        B: Body + Send + Sync + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Never;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.Points/Upsert" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpsertSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints> for UpsertSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpsertPoints>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).upsert(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Points> Clone for PointsServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Points> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Points> tonic::transport::NamedService for PointsServer<T> {
+        const NAME: &'static str = "qdrant.Points";
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckRequest {}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckReply {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
 }
-# [doc = r" Generated client implementations."] pub mod qdrant_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct QdrantClient < T > { inner : tonic :: client :: Grpc < T > , } impl QdrantClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > QdrantClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> QdrantClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { QdrantClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn health_check (& mut self , request : impl tonic :: IntoRequest < super :: HealthCheckRequest > ,) -> Result < tonic :: Response < super :: HealthCheckReply > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Qdrant/HealthCheck") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod qdrant_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with QdrantServer."] # [async_trait] pub trait Qdrant : Send + Sync + 'static { async fn health_check (& self , request : tonic :: Request < super :: HealthCheckRequest >) -> Result < tonic :: Response < super :: HealthCheckReply > , tonic :: Status > ; } # [derive (Debug)] pub struct QdrantServer < T : Qdrant > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Qdrant > QdrantServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for QdrantServer < T > where T : Qdrant , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Qdrant/HealthCheck" => { # [allow (non_camel_case_types)] struct HealthCheckSvc < T : Qdrant > (pub Arc < T >) ; impl < T : Qdrant > tonic :: server :: UnaryService < super :: HealthCheckRequest > for HealthCheckSvc < T > { type Response = super :: HealthCheckReply ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: HealthCheckRequest >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . health_check (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = HealthCheckSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Qdrant > Clone for QdrantServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Qdrant > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Qdrant > tonic :: transport :: NamedService for QdrantServer < T > { const NAME : & 'static str = "qdrant.Qdrant" ; } }
+#[doc = r" Generated client implementations."]
+pub mod qdrant_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct QdrantClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QdrantClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QdrantClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + Sync + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QdrantClient<InterceptedService<T, F>>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            QdrantClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn health_check(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+        ) -> Result<tonic::Response<super::HealthCheckReply>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Qdrant/HealthCheck");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+#[doc = r" Generated server implementations."]
+pub mod qdrant_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with QdrantServer."]
+    #[async_trait]
+    pub trait Qdrant: Send + Sync + 'static {
+        async fn health_check(
+            &self,
+            request: tonic::Request<super::HealthCheckRequest>,
+        ) -> Result<tonic::Response<super::HealthCheckReply>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct QdrantServer<T: Qdrant> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Qdrant> QdrantServer<T> {
+        pub fn new(inner: T) -> Self {
+            let inner = Arc::new(inner);
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for QdrantServer<T>
+    where
+        T: Qdrant,
+        B: Body + Send + Sync + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Never;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.Qdrant/HealthCheck" => {
+                    #[allow(non_camel_case_types)]
+                    struct HealthCheckSvc<T: Qdrant>(pub Arc<T>);
+                    impl<T: Qdrant> tonic::server::UnaryService<super::HealthCheckRequest> for HealthCheckSvc<T> {
+                        type Response = super::HealthCheckReply;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HealthCheckRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).health_check(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = HealthCheckSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Qdrant> Clone for QdrantServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Qdrant> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Qdrant> tonic::transport::NamedService for QdrantServer<T> {
+        const NAME: &'static str = "qdrant.Qdrant";
+    }
+}

--- a/src/tonic/qdrant.rs
+++ b/src/tonic/qdrant.rs
@@ -1,86 +1,87 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetCollectionsRequest {}
+pub struct GetCollectionsRequest {
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionDescription {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionsResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub collections: ::prost::alloc::vec::Vec<CollectionDescription>,
-    #[prost(double, tag = "2")]
+    #[prost(double, tag="2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HnswConfigDiff {
-    #[prost(uint64, optional, tag = "1")]
+    #[prost(uint64, optional, tag="1")]
     pub m: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "2")]
+    #[prost(uint64, optional, tag="2")]
     pub ef_construct: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "3")]
+    #[prost(uint64, optional, tag="3")]
     pub full_scan_threshold: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {
-    #[prost(uint64, optional, tag = "1")]
+    #[prost(uint64, optional, tag="1")]
     pub wal_capacity_mb: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "2")]
+    #[prost(uint64, optional, tag="2")]
     pub wal_segments_ahead: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizersConfigDiff {
-    #[prost(double, optional, tag = "1")]
+    #[prost(double, optional, tag="1")]
     pub deleted_threshold: ::core::option::Option<f64>,
-    #[prost(uint64, optional, tag = "2")]
+    #[prost(uint64, optional, tag="2")]
     pub vacuum_min_vector_number: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "3")]
+    #[prost(uint64, optional, tag="3")]
     pub max_segment_number: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "4")]
+    #[prost(uint64, optional, tag="4")]
     pub memmap_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "5")]
+    #[prost(uint64, optional, tag="5")]
     pub indexing_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "6")]
+    #[prost(uint64, optional, tag="6")]
     pub payload_indexing_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "7")]
+    #[prost(uint64, optional, tag="7")]
     pub flush_interval_sec: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "8")]
+    #[prost(uint64, optional, tag="8")]
     pub max_optimization_threads: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollection {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "2")]
+    #[prost(uint64, tag="2")]
     pub vector_size: u64,
-    #[prost(enumeration = "Distance", tag = "3")]
+    #[prost(enumeration="Distance", tag="3")]
     pub distance: i32,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
-    #[prost(message, optional, tag = "5")]
+    #[prost(message, optional, tag="5")]
     pub wal_config: ::core::option::Option<WalConfigDiff>,
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag="6")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollection {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCollection {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionOperationResponse {
-    #[prost(bool, optional, tag = "1")]
+    #[prost(bool, optional, tag="1")]
     pub result: ::core::option::Option<bool>,
-    #[prost(string, optional, tag = "2")]
+    #[prost(string, optional, tag="2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(double, tag = "3")]
+    #[prost(double, tag="3")]
     pub time: f64,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -90,416 +91,76 @@ pub enum Distance {
     Euclid = 1,
     Dot = 2,
 }
-#[doc = r" Generated client implementations."]
-pub mod collections_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[derive(Debug, Clone)]
-    pub struct CollectionsClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl CollectionsClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> CollectionsClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
-        T::Error: Into<StdError>,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> CollectionsClient<InterceptedService<T, F>>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
-        {
-            CollectionsClient::new(InterceptedService::new(inner, interceptor))
-        }
-        #[doc = r" Compress requests with `gzip`."]
-        #[doc = r""]
-        #[doc = r" This requires the server to support it otherwise it might respond with an"]
-        #[doc = r" error."]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        #[doc = r" Enable decompressing responses with `gzip`."]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        pub async fn get(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetCollectionsRequest>,
-        ) -> Result<tonic::Response<super::GetCollectionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Get");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        pub async fn create(
-            &mut self,
-            request: impl tonic::IntoRequest<super::CreateCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Create");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        pub async fn update(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UpdateCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Update");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        pub async fn delete(
-            &mut self,
-            request: impl tonic::IntoRequest<super::DeleteCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Delete");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-#[doc = r" Generated server implementations."]
-pub mod collections_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with CollectionsServer."]
-    #[async_trait]
-    pub trait Collections: Send + Sync + 'static {
-        async fn get(
-            &self,
-            request: tonic::Request<super::GetCollectionsRequest>,
-        ) -> Result<tonic::Response<super::GetCollectionsResponse>, tonic::Status>;
-        async fn create(
-            &self,
-            request: tonic::Request<super::CreateCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
-        async fn update(
-            &self,
-            request: tonic::Request<super::UpdateCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
-        async fn delete(
-            &self,
-            request: tonic::Request<super::DeleteCollection>,
-        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
-    }
-    #[derive(Debug)]
-    pub struct CollectionsServer<T: Collections> {
-        inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
-    }
-    struct _Inner<T>(Arc<T>);
-    impl<T: Collections> CollectionsServer<T> {
-        pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner);
-            Self {
-                inner,
-                accept_compression_encodings: Default::default(),
-                send_compression_encodings: Default::default(),
-            }
-        }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-        {
-            InterceptedService::new(Self::new(inner), interceptor)
-        }
-    }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for CollectionsServer<T>
-    where
-        T: Collections,
-        B: Body + Send + Sync + 'static,
-        B::Error: Into<StdError> + Send + 'static,
-    {
-        type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
-        type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-        fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
-            match req.uri().path() {
-                "/qdrant.Collections/Get" => {
-                    #[allow(non_camel_case_types)]
-                    struct GetSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::GetCollectionsRequest> for GetSvc<T> {
-                        type Response = super::GetCollectionsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::GetCollectionsRequest>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).get(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = GetSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/qdrant.Collections/Create" => {
-                    #[allow(non_camel_case_types)]
-                    struct CreateSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::CreateCollection> for CreateSvc<T> {
-                        type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::CreateCollection>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).create(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = CreateSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/qdrant.Collections/Update" => {
-                    #[allow(non_camel_case_types)]
-                    struct UpdateSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::UpdateCollection> for UpdateSvc<T> {
-                        type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UpdateCollection>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).update(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = UpdateSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/qdrant.Collections/Delete" => {
-                    #[allow(non_camel_case_types)]
-                    struct DeleteSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::DeleteCollection> for DeleteSvc<T> {
-                        type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::DeleteCollection>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).delete(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = DeleteSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
-            }
-        }
-    }
-    impl<T: Collections> Clone for CollectionsServer<T> {
-        fn clone(&self) -> Self {
-            let inner = self.inner.clone();
-            Self {
-                inner,
-                accept_compression_encodings: self.accept_compression_encodings,
-                send_compression_encodings: self.send_compression_encodings,
-            }
-        }
-    }
-    impl<T: Collections> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(self.0.clone())
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
-        }
-    }
-    impl<T: Collections> tonic::transport::NamedService for CollectionsServer<T> {
-        const NAME: &'static str = "qdrant.Collections";
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
+# [doc = r" Generated client implementations."] pub mod collections_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct CollectionsClient < T > { inner : tonic :: client :: Grpc < T > , } impl CollectionsClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > CollectionsClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> CollectionsClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { CollectionsClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn get (& mut self , request : impl tonic :: IntoRequest < super :: GetCollectionsRequest > ,) -> Result < tonic :: Response < super :: GetCollectionsResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Get") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn create (& mut self , request : impl tonic :: IntoRequest < super :: CreateCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Create") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn update (& mut self , request : impl tonic :: IntoRequest < super :: UpdateCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Update") ; self . inner . unary (request . into_request () , path , codec) . await } pub async fn delete (& mut self , request : impl tonic :: IntoRequest < super :: DeleteCollection > ,) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Collections/Delete") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod collections_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with CollectionsServer."] # [async_trait] pub trait Collections : Send + Sync + 'static { async fn get (& self , request : tonic :: Request < super :: GetCollectionsRequest >) -> Result < tonic :: Response < super :: GetCollectionsResponse > , tonic :: Status > ; async fn create (& self , request : tonic :: Request < super :: CreateCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; async fn update (& self , request : tonic :: Request < super :: UpdateCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; async fn delete (& self , request : tonic :: Request < super :: DeleteCollection >) -> Result < tonic :: Response < super :: CollectionOperationResponse > , tonic :: Status > ; } # [derive (Debug)] pub struct CollectionsServer < T : Collections > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Collections > CollectionsServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for CollectionsServer < T > where T : Collections , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Collections/Get" => { # [allow (non_camel_case_types)] struct GetSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: GetCollectionsRequest > for GetSvc < T > { type Response = super :: GetCollectionsResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: GetCollectionsRequest >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . get (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = GetSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Create" => { # [allow (non_camel_case_types)] struct CreateSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: CreateCollection > for CreateSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: CreateCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . create (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = CreateSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Update" => { # [allow (non_camel_case_types)] struct UpdateSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: UpdateCollection > for UpdateSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: UpdateCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . update (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = UpdateSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } "/qdrant.Collections/Delete" => { # [allow (non_camel_case_types)] struct DeleteSvc < T : Collections > (pub Arc < T >) ; impl < T : Collections > tonic :: server :: UnaryService < super :: DeleteCollection > for DeleteSvc < T > { type Response = super :: CollectionOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: DeleteCollection >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . delete (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = DeleteSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Collections > Clone for CollectionsServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Collections > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Collections > tonic :: transport :: NamedService for CollectionsServer < T > { const NAME : & 'static str = "qdrant.Collections" ; } }#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPoints {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub collection: ::prost::alloc::string::String,
-    #[prost(bool, optional, tag = "2")]
+    #[prost(bool, optional, tag="2")]
     pub wait: ::core::option::Option<bool>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub points: ::prost::alloc::vec::Vec<PointStruct>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointStruct {
-    #[prost(uint64, tag = "1")]
+    #[prost(uint64, tag="1")]
     pub id: u64,
-    #[prost(float, repeated, tag = "2")]
+    #[prost(float, repeated, tag="2")]
     pub vector: ::prost::alloc::vec::Vec<f32>,
-    #[prost(map = "string, message", tag = "3")]
+    #[prost(map="string, message", tag="3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Payload>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payload {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub keyword: ::core::option::Option<KeywordPayload>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub integer: ::core::option::Option<IntegerPayload>,
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag="3")]
     pub float: ::core::option::Option<FloatPayload>,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub geo: ::core::option::Option<GeoPayload>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeywordPayload {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub value: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IntegerPayload {
-    #[prost(int64, repeated, tag = "1")]
+    #[prost(int64, repeated, tag="1")]
     pub value: ::prost::alloc::vec::Vec<i64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FloatPayload {
-    #[prost(double, repeated, tag = "1")]
+    #[prost(double, repeated, tag="1")]
     pub value: ::prost::alloc::vec::Vec<f64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPayload {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub value: ::prost::alloc::vec::Vec<GeoPoint>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPoint {
-    #[prost(double, tag = "1")]
+    #[prost(double, tag="1")]
     pub lon: f64,
-    #[prost(double, tag = "2")]
+    #[prost(double, tag="2")]
     pub lat: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsOperationResponse {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub result: ::core::option::Option<UpdateResult>,
-    #[prost(string, optional, tag = "2")]
+    #[prost(string, optional, tag="2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(double, tag = "3")]
+    #[prost(double, tag="3")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateResult {
-    #[prost(uint64, tag = "1")]
+    #[prost(uint64, tag="1")]
     pub operation_id: u64,
-    #[prost(enumeration = "UpdateStatus", tag = "2")]
+    #[prost(enumeration="UpdateStatus", tag="2")]
     pub status: i32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -508,398 +169,14 @@ pub enum UpdateStatus {
     Acknowledged = 0,
     Completed = 1,
 }
-#[doc = r" Generated client implementations."]
-pub mod points_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[derive(Debug, Clone)]
-    pub struct PointsClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl PointsClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> PointsClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
-        T::Error: Into<StdError>,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> PointsClient<InterceptedService<T, F>>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
-        {
-            PointsClient::new(InterceptedService::new(inner, interceptor))
-        }
-        #[doc = r" Compress requests with `gzip`."]
-        #[doc = r""]
-        #[doc = r" This requires the server to support it otherwise it might respond with an"]
-        #[doc = r" error."]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        #[doc = r" Enable decompressing responses with `gzip`."]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        pub async fn upsert(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UpsertPoints>,
-        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Upsert");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
+# [doc = r" Generated client implementations."] pub mod points_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct PointsClient < T > { inner : tonic :: client :: Grpc < T > , } impl PointsClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > PointsClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> PointsClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { PointsClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn upsert (& mut self , request : impl tonic :: IntoRequest < super :: UpsertPoints > ,) -> Result < tonic :: Response < super :: PointsOperationResponse > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Points/Upsert") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod points_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with PointsServer."] # [async_trait] pub trait Points : Send + Sync + 'static { async fn upsert (& self , request : tonic :: Request < super :: UpsertPoints >) -> Result < tonic :: Response < super :: PointsOperationResponse > , tonic :: Status > ; } # [derive (Debug)] pub struct PointsServer < T : Points > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Points > PointsServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for PointsServer < T > where T : Points , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Points/Upsert" => { # [allow (non_camel_case_types)] struct UpsertSvc < T : Points > (pub Arc < T >) ; impl < T : Points > tonic :: server :: UnaryService < super :: UpsertPoints > for UpsertSvc < T > { type Response = super :: PointsOperationResponse ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: UpsertPoints >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . upsert (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = UpsertSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Points > Clone for PointsServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Points > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Points > tonic :: transport :: NamedService for PointsServer < T > { const NAME : & 'static str = "qdrant.Points" ; } }#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckRequest {
 }
-#[doc = r" Generated server implementations."]
-pub mod points_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with PointsServer."]
-    #[async_trait]
-    pub trait Points: Send + Sync + 'static {
-        async fn upsert(
-            &self,
-            request: tonic::Request<super::UpsertPoints>,
-        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
-    }
-    #[derive(Debug)]
-    pub struct PointsServer<T: Points> {
-        inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
-    }
-    struct _Inner<T>(Arc<T>);
-    impl<T: Points> PointsServer<T> {
-        pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner);
-            Self {
-                inner,
-                accept_compression_encodings: Default::default(),
-                send_compression_encodings: Default::default(),
-            }
-        }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-        {
-            InterceptedService::new(Self::new(inner), interceptor)
-        }
-    }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for PointsServer<T>
-    where
-        T: Points,
-        B: Body + Send + Sync + 'static,
-        B::Error: Into<StdError> + Send + 'static,
-    {
-        type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
-        type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-        fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
-            match req.uri().path() {
-                "/qdrant.Points/Upsert" => {
-                    #[allow(non_camel_case_types)]
-                    struct UpsertSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints> for UpsertSvc<T> {
-                        type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UpsertPoints>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).upsert(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = UpsertSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
-            }
-        }
-    }
-    impl<T: Points> Clone for PointsServer<T> {
-        fn clone(&self) -> Self {
-            let inner = self.inner.clone();
-            Self {
-                inner,
-                accept_compression_encodings: self.accept_compression_encodings,
-                send_compression_encodings: self.send_compression_encodings,
-            }
-        }
-    }
-    impl<T: Points> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(self.0.clone())
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
-        }
-    }
-    impl<T: Points> tonic::transport::NamedService for PointsServer<T> {
-        const NAME: &'static str = "qdrant.Points";
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HealthCheckRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckReply {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub title: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
 }
-#[doc = r" Generated client implementations."]
-pub mod qdrant_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[derive(Debug, Clone)]
-    pub struct QdrantClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl QdrantClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> QdrantClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
-        T::Error: Into<StdError>,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> QdrantClient<InterceptedService<T, F>>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
-        {
-            QdrantClient::new(InterceptedService::new(inner, interceptor))
-        }
-        #[doc = r" Compress requests with `gzip`."]
-        #[doc = r""]
-        #[doc = r" This requires the server to support it otherwise it might respond with an"]
-        #[doc = r" error."]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        #[doc = r" Enable decompressing responses with `gzip`."]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        pub async fn health_check(
-            &mut self,
-            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<super::HealthCheckReply>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Qdrant/HealthCheck");
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-#[doc = r" Generated server implementations."]
-pub mod qdrant_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with QdrantServer."]
-    #[async_trait]
-    pub trait Qdrant: Send + Sync + 'static {
-        async fn health_check(
-            &self,
-            request: tonic::Request<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<super::HealthCheckReply>, tonic::Status>;
-    }
-    #[derive(Debug)]
-    pub struct QdrantServer<T: Qdrant> {
-        inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
-    }
-    struct _Inner<T>(Arc<T>);
-    impl<T: Qdrant> QdrantServer<T> {
-        pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner);
-            Self {
-                inner,
-                accept_compression_encodings: Default::default(),
-                send_compression_encodings: Default::default(),
-            }
-        }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
-        where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-        {
-            InterceptedService::new(Self::new(inner), interceptor)
-        }
-    }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for QdrantServer<T>
-    where
-        T: Qdrant,
-        B: Body + Send + Sync + 'static,
-        B::Error: Into<StdError> + Send + 'static,
-    {
-        type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
-        type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-        fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
-            match req.uri().path() {
-                "/qdrant.Qdrant/HealthCheck" => {
-                    #[allow(non_camel_case_types)]
-                    struct HealthCheckSvc<T: Qdrant>(pub Arc<T>);
-                    impl<T: Qdrant> tonic::server::UnaryService<super::HealthCheckRequest> for HealthCheckSvc<T> {
-                        type Response = super::HealthCheckReply;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::HealthCheckRequest>,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { (*inner).health_check(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = HealthCheckSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
-            }
-        }
-    }
-    impl<T: Qdrant> Clone for QdrantServer<T> {
-        fn clone(&self) -> Self {
-            let inner = self.inner.clone();
-            Self {
-                inner,
-                accept_compression_encodings: self.accept_compression_encodings,
-                send_compression_encodings: self.send_compression_encodings,
-            }
-        }
-    }
-    impl<T: Qdrant> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(self.0.clone())
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
-        }
-    }
-    impl<T: Qdrant> tonic::transport::NamedService for QdrantServer<T> {
-        const NAME: &'static str = "qdrant.Qdrant";
-    }
-}
+# [doc = r" Generated client implementations."] pub mod qdrant_client { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [derive (Debug , Clone)] pub struct QdrantClient < T > { inner : tonic :: client :: Grpc < T > , } impl QdrantClient < tonic :: transport :: Channel > { # [doc = r" Attempt to create a new client by connecting to a given endpoint."] pub async fn connect < D > (dst : D) -> Result < Self , tonic :: transport :: Error > where D : std :: convert :: TryInto < tonic :: transport :: Endpoint > , D :: Error : Into < StdError > , { let conn = tonic :: transport :: Endpoint :: new (dst) ? . connect () . await ? ; Ok (Self :: new (conn)) } } impl < T > QdrantClient < T > where T : tonic :: client :: GrpcService < tonic :: body :: BoxBody > , T :: ResponseBody : Body + Send + Sync + 'static , T :: Error : Into < StdError > , < T :: ResponseBody as Body > :: Error : Into < StdError > + Send , { pub fn new (inner : T) -> Self { let inner = tonic :: client :: Grpc :: new (inner) ; Self { inner } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> QdrantClient < InterceptedService < T , F >> where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , T : tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody > , Response = http :: Response << T as tonic :: client :: GrpcService < tonic :: body :: BoxBody >> :: ResponseBody > > , < T as tonic :: codegen :: Service < http :: Request < tonic :: body :: BoxBody >> > :: Error : Into < StdError > + Send + Sync , { QdrantClient :: new (InterceptedService :: new (inner , interceptor)) } # [doc = r" Compress requests with `gzip`."] # [doc = r""] # [doc = r" This requires the server to support it otherwise it might respond with an"] # [doc = r" error."] pub fn send_gzip (mut self) -> Self { self . inner = self . inner . send_gzip () ; self } # [doc = r" Enable decompressing responses with `gzip`."] pub fn accept_gzip (mut self) -> Self { self . inner = self . inner . accept_gzip () ; self } pub async fn health_check (& mut self , request : impl tonic :: IntoRequest < super :: HealthCheckRequest > ,) -> Result < tonic :: Response < super :: HealthCheckReply > , tonic :: Status > { self . inner . ready () . await . map_err (| e | { tonic :: Status :: new (tonic :: Code :: Unknown , format ! ("Service was not ready: {}" , e . into ())) }) ? ; let codec = tonic :: codec :: ProstCodec :: default () ; let path = http :: uri :: PathAndQuery :: from_static ("/qdrant.Qdrant/HealthCheck") ; self . inner . unary (request . into_request () , path , codec) . await } } }# [doc = r" Generated server implementations."] pub mod qdrant_server { # ! [allow (unused_variables , dead_code , missing_docs , clippy :: let_unit_value ,)] use tonic :: codegen :: * ; # [doc = "Generated trait containing gRPC methods that should be implemented for use with QdrantServer."] # [async_trait] pub trait Qdrant : Send + Sync + 'static { async fn health_check (& self , request : tonic :: Request < super :: HealthCheckRequest >) -> Result < tonic :: Response < super :: HealthCheckReply > , tonic :: Status > ; } # [derive (Debug)] pub struct QdrantServer < T : Qdrant > { inner : _Inner < T > , accept_compression_encodings : () , send_compression_encodings : () , } struct _Inner < T > (Arc < T >) ; impl < T : Qdrant > QdrantServer < T > { pub fn new (inner : T) -> Self { let inner = Arc :: new (inner) ; let inner = _Inner (inner) ; Self { inner , accept_compression_encodings : Default :: default () , send_compression_encodings : Default :: default () , } } pub fn with_interceptor < F > (inner : T , interceptor : F) -> InterceptedService < Self , F > where F : FnMut (tonic :: Request < () >) -> Result < tonic :: Request < () > , tonic :: Status > , { InterceptedService :: new (Self :: new (inner) , interceptor) } } impl < T , B > tonic :: codegen :: Service < http :: Request < B >> for QdrantServer < T > where T : Qdrant , B : Body + Send + Sync + 'static , B :: Error : Into < StdError > + Send + 'static , { type Response = http :: Response < tonic :: body :: BoxBody > ; type Error = Never ; type Future = BoxFuture < Self :: Response , Self :: Error > ; fn poll_ready (& mut self , _cx : & mut Context < '_ >) -> Poll < Result < () , Self :: Error >> { Poll :: Ready (Ok (())) } fn call (& mut self , req : http :: Request < B >) -> Self :: Future { let inner = self . inner . clone () ; match req . uri () . path () { "/qdrant.Qdrant/HealthCheck" => { # [allow (non_camel_case_types)] struct HealthCheckSvc < T : Qdrant > (pub Arc < T >) ; impl < T : Qdrant > tonic :: server :: UnaryService < super :: HealthCheckRequest > for HealthCheckSvc < T > { type Response = super :: HealthCheckReply ; type Future = BoxFuture < tonic :: Response < Self :: Response > , tonic :: Status > ; fn call (& mut self , request : tonic :: Request < super :: HealthCheckRequest >) -> Self :: Future { let inner = self . 0 . clone () ; let fut = async move { (* inner) . health_check (request) . await } ; Box :: pin (fut) } } let accept_compression_encodings = self . accept_compression_encodings ; let send_compression_encodings = self . send_compression_encodings ; let inner = self . inner . clone () ; let fut = async move { let inner = inner . 0 ; let method = HealthCheckSvc (inner) ; let codec = tonic :: codec :: ProstCodec :: default () ; let mut grpc = tonic :: server :: Grpc :: new (codec) . apply_compression_config (accept_compression_encodings , send_compression_encodings) ; let res = grpc . unary (method , req) . await ; Ok (res) } ; Box :: pin (fut) } _ => Box :: pin (async move { Ok (http :: Response :: builder () . status (200) . header ("grpc-status" , "12") . header ("content-type" , "application/grpc") . body (empty_body ()) . unwrap ()) }) , } } } impl < T : Qdrant > Clone for QdrantServer < T > { fn clone (& self) -> Self { let inner = self . inner . clone () ; Self { inner , accept_compression_encodings : self . accept_compression_encodings , send_compression_encodings : self . send_compression_encodings , } } } impl < T : Qdrant > Clone for _Inner < T > { fn clone (& self) -> Self { Self (self . 0 . clone ()) } } impl < T : std :: fmt :: Debug > std :: fmt :: Debug for _Inner < T > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { write ! (f , "{:?}" , self . 0) } } impl < T : Qdrant > tonic :: transport :: NamedService for QdrantServer < T > { const NAME : & 'static str = "qdrant.Qdrant" ; } }


### PR DESCRIPTION
Use StoppableTaskHandler instead of regular `tokio::task` for better control over launched optimizations.
This wrapper allows to check if the optimization task is finished without consuming the handle.
Additionally it provides the interface for faster stopping of the tasks, which is required for https://github.com/qdrant/qdrant/issues/31

ToDo: merge after https://github.com/qdrant/qdrant/pull/155

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

