### PR TITLE
Remove dyn Metric from vector storage and use generics

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -43,10 +43,13 @@ fn benchmark_naive(c: &mut Criterion) {
 
     let dist = Distance::Dot;
     let storage = init_vector_storage(&dir, DIM, NUM_VECTORS, dist);
+    let borrowed_storage = storage.borrow();
 
-    c.bench_function("storage vector search", |b| {
+    let mut group = c.benchmark_group("storage-score-all");
+    group.sample_size(1000);
+
+    group.bench_function("storage vector search", |b| {
         b.iter(|| {
-            let borrowed_storage = storage.borrow();
             let vector = random_vector(DIM);
             borrowed_storage.score_all(&vector, 10)
         })

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -1,14 +1,14 @@
-use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use criterion::{criterion_group, criterion_main, Criterion};
 use ndarray::{Array, Array2};
 use rand::distributions::Standard;
 use rand::Rng;
+use std::sync::Arc;
 use tempdir::TempDir;
 
 use segment::spaces::tools::peek_top_scores_iterable;
 use segment::types::{Distance, PointOffsetType, VectorElementType};
-use segment::vector_storage::simple_vector_storage::{open_simple_vector_storage};
+use segment::vector_storage::simple_vector_storage::open_simple_vector_storage;
 use segment::vector_storage::{ScoredPointOffset, VectorStorage};
 
 const NUM_VECTORS: usize = 50000;

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -1,7 +1,6 @@
 use crate::payload_storage::ConditionChecker;
 use crate::spaces::metric::Metric;
-use crate::spaces::tools::mertic_object;
-use crate::types::{Distance, Filter, PointOffsetType, VectorElementType};
+use crate::types::{Filter, PointOffsetType, VectorElementType};
 use crate::vector_storage::simple_vector_storage::SimpleRawScorer;
 use bit_vec::BitVec;
 use itertools::Itertools;
@@ -20,19 +19,20 @@ impl ConditionChecker for FakeConditionChecker {
     }
 }
 
-pub struct TestRawScorerProducer {
+pub struct TestRawScorerProducer<TMetric: Metric> {
     pub vectors: Vec<Array1<VectorElementType>>,
     pub deleted: BitVec,
-    pub metric: Box<dyn Metric>,
+    pub metric: TMetric,
 }
 
-impl TestRawScorerProducer {
-    pub fn new<R>(dim: usize, num_vectors: usize, distance: Distance, rng: &mut R) -> Self
+impl<TMetric> TestRawScorerProducer<TMetric>
+where
+    TMetric: Metric,
+{
+    pub fn new<R>(dim: usize, num_vectors: usize, metric: TMetric, rng: &mut R) -> Self
     where
         R: Rng + ?Sized,
     {
-        let metric = mertic_object(&distance);
-
         let vectors = (0..num_vectors)
             .map(|_x| {
                 let rnd_vec = random_vector(rng, dim);
@@ -47,10 +47,10 @@ impl TestRawScorerProducer {
         }
     }
 
-    pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> SimpleRawScorer {
+    pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> SimpleRawScorer<TMetric> {
         SimpleRawScorer {
             query: Array::from(self.metric.preprocess(&query).unwrap_or(query)),
-            metric: self.metric.as_ref(),
+            metric: &self.metric,
             vectors: &self.vectors,
             deleted: &self.deleted,
         }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -489,7 +489,9 @@ mod tests {
     use crate::fixtures::index_fixtures::{
         random_vector, FakeConditionChecker, TestRawScorerProducer,
     };
-    use crate::types::{Distance, VectorElementType};
+    use crate::spaces::metric::Metric;
+    use crate::spaces::simple::{CosineMetric, DotProductMetric};
+    use crate::types::VectorElementType;
     use itertools::Itertools;
     use ndarray::Array;
     use rand::rngs::StdRng;
@@ -560,7 +562,7 @@ mod tests {
     fn search_in_graph(
         query: &[VectorElementType],
         top: usize,
-        vector_storage: &TestRawScorerProducer,
+        vector_storage: &TestRawScorerProducer<CosineMetric>,
         graph: &GraphLayers,
     ) -> Vec<ScoredPointOffset> {
         let fake_condition_checker = FakeConditionChecker {};
@@ -581,7 +583,7 @@ mod tests {
         dim: usize,
         use_heuristic: bool,
         rng: &mut R,
-    ) -> (TestRawScorerProducer, GraphLayers)
+    ) -> (TestRawScorerProducer<CosineMetric>, GraphLayers)
     where
         R: Rng + ?Sized,
     {
@@ -589,7 +591,7 @@ mod tests {
         let ef_construct = 16;
         let entry_points_num = 10;
 
-        let vector_holder = TestRawScorerProducer::new(dim, num_vectors, Distance::Cosine, rng);
+        let vector_holder = TestRawScorerProducer::new(dim, num_vectors, CosineMetric {}, rng);
 
         let mut graph_layers = GraphLayers::new(
             num_vectors,
@@ -626,7 +628,8 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(42);
 
-        let vector_holder = TestRawScorerProducer::new(dim, num_vectors, Distance::Dot, &mut rng);
+        let vector_holder =
+            TestRawScorerProducer::new(dim, num_vectors, DotProductMetric {}, &mut rng);
 
         let mut graph_layers =
             GraphLayers::new(num_vectors, m, m * 2, ef_construct, entry_points_num, false);


### PR DESCRIPTION
Simple performance proposition. At now, Metric in vector storage is used as dyn type. Dynamic typing for each comparison may be slower than using generic types.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
