### PR TITLE
Extend clippy to workspace and fix some warnings

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -20,10 +20,12 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
+        override: true
+        components: rustfmt, clippy
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
     - name: Check code formatting
       run: cargo fmt --all -- --check
     - name: Check cargo clippy warnings
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -449,8 +449,8 @@ mod tests {
             original_segment,
             write_segment,
             deleted_points,
-            deleted_indexes.clone(),
-            created_indexes.clone(),
+            created_indexes,
+            deleted_indexes,
         );
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
@@ -527,8 +527,8 @@ mod tests {
             original_segment,
             write_segment,
             deleted_points,
-            deleted_indexes.clone(),
-            created_indexes.clone(),
+            created_indexes,
+            deleted_indexes,
         );
 
         proxy_segment.delete_point(100, 2).unwrap();

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -476,7 +476,7 @@ mod tests {
         let mut seen_points: HashSet<PointIdType> = Default::default();
         for res in search_result {
             if seen_points.contains(&res.id) {
-                assert!(false, "point {} appears multiple times", res.id);
+                panic!("point {} appears multiple times", res.id);
             }
             seen_points.insert(res.id);
         }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -69,10 +69,6 @@ impl From<ProxySegment> for LockedSegment {
     }
 }
 
-unsafe impl Sync for LockedSegment {}
-
-unsafe impl Send for LockedSegment {}
-
 #[derive(Default)]
 pub struct SegmentHolder {
     segments: HashMap<SegmentId, LockedSegment>,

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -119,18 +119,20 @@ mod tests {
 
         let mut holder = SegmentHolder::default();
 
-        let mut segments_to_merge = vec![];
+        let segments_to_merge = vec![
+            holder.add(random_segment(dir.path(), 100, 3, 4)),
+            holder.add(random_segment(dir.path(), 100, 3, 4)),
+            holder.add(random_segment(dir.path(), 100, 3, 4)),
+        ];
 
-        segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
-        segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
-        segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
 
-        let mut other_segment_ids: Vec<SegmentId> = vec![];
+        let other_segment_ids: Vec<SegmentId> = vec![
+            holder.add(random_segment(dir.path(), 100, 20, 4)),
+            holder.add(random_segment(dir.path(), 100, 20, 4)),
+            holder.add(random_segment(dir.path(), 100, 20, 4)),
+            holder.add(random_segment(dir.path(), 100, 20, 4)),
+        ];
 
-        other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
-        other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
-        other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
-        other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
 
         let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path());
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -125,14 +125,12 @@ mod tests {
             holder.add(random_segment(dir.path(), 100, 3, 4)),
         ];
 
-
         let other_segment_ids: Vec<SegmentId> = vec![
             holder.add(random_segment(dir.path(), 100, 20, 4)),
             holder.add(random_segment(dir.path(), 100, 20, 4)),
             holder.add(random_segment(dir.path(), 100, 20, 4)),
             holder.add(random_segment(dir.path(), 100, 20, 4)),
         ];
-
 
         let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path());
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -248,10 +248,8 @@ mod tests {
                 .clone();
 
             match payload {
-                PayloadType::Keyword(x) => assert_eq!(x.get(0).unwrap(), &"red".to_string()),
-                PayloadType::Integer(_) => assert!(false),
-                PayloadType::Float(_) => assert!(false),
-                PayloadType::Geo(_) => assert!(false),
+                PayloadType::Keyword(x) => assert_eq!(x[0], "red"),
+                _ => panic!(),
             }
         }
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -18,18 +18,18 @@ fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> Seg
 
     let temp_segment: LockedSegment = empty_segment(path).into();
 
-    let optimizing_segment = write_segments.get(sid).unwrap();
+    let optimizing_segment = write_segments.get(sid).unwrap().clone();
 
     let proxy_deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
     let proxy_deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
     let proxy_created_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
 
     let proxy = ProxySegment::new(
-        optimizing_segment.clone(),
-        temp_segment.clone(),
-        proxy_deleted_points.clone(),
-        proxy_deleted_indexes.clone(),
-        proxy_created_indexes.clone(),
+        optimizing_segment,
+        temp_segment,
+        proxy_deleted_points,
+        proxy_deleted_indexes,
+        proxy_created_indexes,
     );
 
     write_segments.swap(proxy, &[sid], false).unwrap()

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -56,10 +56,10 @@ mod tests {
 
                 match payload1 {
                     PayloadType::Keyword(x) => assert_eq!(x, ["hello".to_owned()]),
-                    _ => assert!(false, "Wrong payload type"),
+                    _ => panic!("Wrong payload type"),
                 }
             }
-            _ => assert!(false, "Wrong operation"),
+            _ => panic!("Wrong operation"),
         }
     }
 }

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -15,18 +15,18 @@ async fn test_optimization_process() {
 
     let mut holder = SegmentHolder::default();
 
-    let mut segments_to_merge = vec![];
-
-    segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
-    segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
-    segments_to_merge.push(holder.add(random_segment(dir.path(), 100, 3, 4)));
+    let segments_to_merge = vec![
+        holder.add(random_segment(dir.path(), 100, 3, 4)),
+        holder.add(random_segment(dir.path(), 100, 3, 4)),
+        holder.add(random_segment(dir.path(), 100, 3, 4)),
+    ];
 
     let segment_to_index = holder.add(random_segment(dir.path(), 100, 110, 4));
 
-    let mut other_segment_ids: Vec<SegmentId> = vec![];
-
-    other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
-    other_segment_ids.push(holder.add(random_segment(dir.path(), 100, 20, 4)));
+    let _other_segment_ids: Vec<SegmentId> = vec![
+        holder.add(random_segment(dir.path(), 100, 20, 4)),
+        holder.add(random_segment(dir.path(), 100, 20, 4)),
+    ];
 
     let merge_optimizer: Arc<Optimizer> =
         Arc::new(get_merge_optimizer(dir.path(), temp_dir.path()));

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -6,7 +6,8 @@ use rand::{thread_rng, SeedableRng};
 use segment::fixtures::index_fixtures::{FakeConditionChecker, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
-use segment::types::{Distance, PointOffsetType};
+use segment::spaces::simple::CosineMetric;
+use segment::types::PointOffsetType;
 
 const NUM_VECTORS: usize = 10000;
 const DIM: usize = 32;
@@ -16,7 +17,7 @@ const USE_HEURISTIC: bool = true;
 
 fn hnsw_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
-    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine, &mut rng);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, CosineMetric {}, &mut rng);
     let mut group = c.benchmark_group("hnsw-index-build-group");
     group.sample_size(10);
     group.bench_function("hnsw_index", |b| {

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -8,7 +8,8 @@ use segment::fixtures::index_fixtures::{
 };
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
-use segment::types::{Distance, PointOffsetType};
+use segment::spaces::simple::CosineMetric;
+use segment::types::PointOffsetType;
 
 const NUM_VECTORS: usize = 100000;
 const DIM: usize = 64;
@@ -20,7 +21,7 @@ const USE_HEURISTIC: bool = true;
 
 fn hnsw_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
-    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, Distance::Cosine, &mut rng);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, CosineMetric {}, &mut rng);
     let mut group = c.benchmark_group("hnsw-index-build-group");
     let mut rng = thread_rng();
     let fake_condition_checker = FakeConditionChecker {};
@@ -64,7 +65,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
                 filter: None,
             };
 
-            let mut iter = (0..NUM_VECTORS as PointOffsetType).into_iter();
+            let mut iter = 0..NUM_VECTORS as PointOffsetType;
             let mut top_score = 0.;
             scorer.score_iterable_points(&mut iter, NUM_VECTORS, |score| {
                 if score.score > top_score {

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -9,7 +9,7 @@ use tempdir::TempDir;
 use segment::spaces::tools::peek_top_scores_iterable;
 use segment::types::{Distance, PointOffsetType, VectorElementType};
 use segment::vector_storage::simple_vector_storage::open_simple_vector_storage;
-use segment::vector_storage::{ScoredPointOffset, VectorStorage};
+use segment::vector_storage::{ScoredPointOffset, VectorStorageSS};
 
 const NUM_VECTORS: usize = 50000;
 const DIM: usize = 1000; // Larger dimensionality - greater the BLAS advantage

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -25,7 +25,7 @@ fn init_vector_storage(
     dim: usize,
     num: usize,
     dist: Distance,
-) -> Arc<AtomicRefCell<dyn VectorStorage>> {
+) -> Arc<AtomicRefCell<VectorStorageSS>> {
     let storage = open_simple_vector_storage(dir.path(), dim, dist).unwrap();
     {
         let mut borrowed_storage = storage.borrow_mut();

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -48,3 +48,5 @@ pub trait IdTracker {
     /// Force persistence of current tracker state.
     fn flush(&self) -> OperationResult<()>;
 }
+
+pub type IdTrackerSS = dyn IdTracker + Sync + Send;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -4,13 +4,13 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::sample_estimation::sample_check_cardinality;
-use crate::index::{PayloadIndex, VectorIndex};
-use crate::payload_storage::ConditionChecker;
+use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex};
+use crate::payload_storage::{ConditionChecker, ConditionCheckerSS};
 use crate::types::Condition::Field;
 use crate::types::{
     FieldCondition, Filter, HnswConfig, PointOffsetType, SearchParams, VectorElementType,
 };
-use crate::vector_storage::{ScoredPointOffset, VectorStorage};
+use crate::vector_storage::{ScoredPointOffset, VectorStorage, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use log::debug;
 use rand::prelude::ThreadRng;
@@ -23,25 +23,23 @@ use std::sync::Arc;
 const HNSW_USE_HEURISTIC: bool = true;
 
 pub struct HNSWIndex {
-    condition_checker: Arc<dyn ConditionChecker>,
-    vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-    payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
+    condition_checker: Arc<ConditionCheckerSS>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+    payload_index: Arc<AtomicRefCell<PayloadIndexSS>>,
     config: HnswGraphConfig,
     path: PathBuf,
-    thread_rng: ThreadRng,
     graph: GraphLayers,
 }
 
 impl HNSWIndex {
     pub fn open(
         path: &Path,
-        condition_checker: Arc<dyn ConditionChecker>,
-        vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-        payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
+        condition_checker: Arc<ConditionCheckerSS>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+        payload_index: Arc<AtomicRefCell<PayloadIndexSS>>,
         hnsw_config: HnswConfig,
     ) -> OperationResult<Self> {
         create_dir_all(path)?;
-        let rng = thread_rng();
 
         let config_path = HnswGraphConfig::get_config_path(path);
         let config = if config_path.exists() {
@@ -75,7 +73,6 @@ impl HNSWIndex {
             payload_index,
             config,
             path: path.to_owned(),
-            thread_rng: rng,
             graph,
         })
     }
@@ -94,12 +91,6 @@ impl HNSWIndex {
         self.save_config()?;
         self.save_graph()?;
         Ok(())
-    }
-
-    pub fn link_point(&mut self, point_id: PointOffsetType, points_scorer: &FilteredScorer) {
-        let point_level = self.graph.get_random_layer(&mut self.thread_rng);
-        self.graph
-            .link_new_point(point_id, point_level, points_scorer);
     }
 
     pub fn build_filtered_graph(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -4,16 +4,14 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::sample_estimation::sample_check_cardinality;
-use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex};
-use crate::payload_storage::{ConditionChecker, ConditionCheckerSS};
+use crate::index::{PayloadIndexSS, VectorIndex};
+use crate::payload_storage::ConditionCheckerSS;
 use crate::types::Condition::Field;
-use crate::types::{
-    FieldCondition, Filter, HnswConfig, PointOffsetType, SearchParams, VectorElementType,
-};
-use crate::vector_storage::{ScoredPointOffset, VectorStorage, VectorStorageSS};
+use crate::types::{FieldCondition, Filter, HnswConfig, SearchParams, VectorElementType};
+use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use log::debug;
-use rand::prelude::ThreadRng;
+
 use rand::thread_rng;
 use std::cmp::max;
 use std::fs::create_dir_all;

--- a/lib/segment/src/index/index_base.rs
+++ b/lib/segment/src/index/index_base.rs
@@ -47,3 +47,6 @@ pub trait PayloadIndex {
         threshold: usize,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 }
+
+pub type VectorIndexSS = dyn VectorIndex + Sync + Send;
+pub type PayloadIndexSS = dyn PayloadIndex + Sync + Send;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,9 +1,9 @@
-use crate::index::{PayloadIndex, VectorIndex};
-use crate::payload_storage::ConditionChecker;
+use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex};
+use crate::payload_storage::{ConditionChecker, ConditionCheckerSS};
 use crate::types::{
     Filter, PayloadKeyType, PayloadKeyTypeRef, PointOffsetType, SearchParams, VectorElementType,
 };
-use crate::vector_storage::{ScoredPointOffset, VectorStorage};
+use crate::vector_storage::{ScoredPointOffset, VectorStorage, VectorStorageSS};
 
 use crate::entry::entry_point::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
@@ -18,8 +18,8 @@ use std::sync::Arc;
 /// Used for small segments, which are easier to keep simple for faster updates,
 /// rather than spend time for index re-building
 pub struct PlainPayloadIndex {
-    condition_checker: Arc<dyn ConditionChecker>,
-    vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
+    condition_checker: Arc<ConditionCheckerSS>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
     config: PayloadConfig,
     path: PathBuf,
 }
@@ -35,8 +35,8 @@ impl PlainPayloadIndex {
     }
 
     pub fn open(
-        condition_checker: Arc<dyn ConditionChecker>,
-        vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
+        condition_checker: Arc<ConditionCheckerSS>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
         path: &Path,
     ) -> OperationResult<Self> {
         create_dir_all(path)?;
@@ -120,14 +120,14 @@ impl PayloadIndex for PlainPayloadIndex {
 }
 
 pub struct PlainIndex {
-    vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-    payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+    payload_index: Arc<AtomicRefCell<PayloadIndexSS>>,
 }
 
 impl PlainIndex {
     pub fn new(
-        vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-        payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+        payload_index: Arc<AtomicRefCell<PayloadIndexSS>>,
     ) -> PlainIndex {
         PlainIndex {
             vector_storage,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,9 +1,9 @@
 use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex};
-use crate::payload_storage::{ConditionChecker, ConditionCheckerSS};
+use crate::payload_storage::ConditionCheckerSS;
 use crate::types::{
     Filter, PayloadKeyType, PayloadKeyTypeRef, PointOffsetType, SearchParams, VectorElementType,
 };
-use crate::vector_storage::{ScoredPointOffset, VectorStorage, VectorStorageSS};
+use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 
 use crate::entry::entry_point::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -240,7 +240,7 @@ mod tests {
         assert_eq!(estimation.primary_clauses.len(), 1);
         match &estimation.primary_clauses[0] {
             PrimaryCondition::Condition(field) => assert_eq!(&field.key, "size"),
-            PrimaryCondition::Ids(_) => assert!(false),
+            PrimaryCondition::Ids(_) => panic!(),
         }
         assert!(estimation.max <= TOTAL);
         assert!(estimation.exp <= estimation.max);
@@ -352,7 +352,7 @@ mod tests {
             PrimaryCondition::Condition(field) => {
                 assert!(vec!["price".to_owned(), "size".to_owned(),].contains(&field.key))
             }
-            PrimaryCondition::Ids(_) => assert!(false, "Should not go here"),
+            PrimaryCondition::Ids(_) => panic!("Should not go here"),
         });
         assert!(estimation.max <= TOTAL);
         assert!(estimation.exp <= estimation.max);

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use log::debug;
 
 use crate::entry::entry_point::{OperationError, OperationResult};
-use crate::id_tracker::IdTracker;
+use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::index::field_index::index_selector::index_selector;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::field_index::{FieldIndex, PayloadFieldIndex};
@@ -16,11 +16,13 @@ use crate::index::payload_config::PayloadConfig;
 use crate::index::query_estimator::estimate_filter;
 use crate::index::visited_pool::VisitedPool;
 use crate::index::PayloadIndex;
-use crate::payload_storage::{ConditionChecker, PayloadStorage};
+use crate::payload_storage::{
+    ConditionChecker, ConditionCheckerSS, PayloadStorage, PayloadStorageSS,
+};
 use crate::types::{
     Condition, FieldCondition, Filter, PayloadKeyType, PayloadKeyTypeRef, PointOffsetType,
 };
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::VectorStorageSS;
 
 pub const PAYLOAD_FIELD_INDEX_PATH: &str = "fields";
 
@@ -28,11 +30,11 @@ type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;
 
 /// `PayloadIndex` implementation, which actually uses index structures for providing faster search
 pub struct StructPayloadIndex {
-    condition_checker: Arc<dyn ConditionChecker>,
-    vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
+    condition_checker: Arc<ConditionCheckerSS>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
     /// Payload storage
-    payload: Arc<AtomicRefCell<dyn PayloadStorage>>,
-    id_tracker: Arc<AtomicRefCell<dyn IdTracker>>,
+    payload: Arc<AtomicRefCell<PayloadStorageSS>>,
+    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     /// Indexes, associated with fields
     field_indexes: IndexesMap,
     config: PayloadConfig,
@@ -152,10 +154,10 @@ impl StructPayloadIndex {
     }
 
     pub fn open(
-        condition_checker: Arc<dyn ConditionChecker>,
-        vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-        payload: Arc<AtomicRefCell<dyn PayloadStorage>>,
-        id_tracker: Arc<AtomicRefCell<dyn IdTracker>>,
+        condition_checker: Arc<ConditionCheckerSS>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+        payload: Arc<AtomicRefCell<PayloadStorageSS>>,
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         path: &Path,
     ) -> OperationResult<Self> {
         create_dir_all(path)?;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use log::debug;
 
 use crate::entry::entry_point::{OperationError, OperationResult};
-use crate::id_tracker::{IdTracker, IdTrackerSS};
+use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::index_selector::index_selector;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::field_index::{FieldIndex, PayloadFieldIndex};
@@ -16,9 +16,7 @@ use crate::index::payload_config::PayloadConfig;
 use crate::index::query_estimator::estimate_filter;
 use crate::index::visited_pool::VisitedPool;
 use crate::index::PayloadIndex;
-use crate::payload_storage::{
-    ConditionChecker, ConditionCheckerSS, PayloadStorage, PayloadStorageSS,
-};
+use crate::payload_storage::{ConditionCheckerSS, PayloadStorageSS};
 use crate::types::{
     Condition, FieldCondition, Filter, PayloadKeyType, PayloadKeyTypeRef, PointOffsetType,
 };

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -107,3 +107,6 @@ pub trait ConditionChecker {
     /// Check if point satisfies filter condition. Return true if satisfies
     fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool;
 }
+
+pub type PayloadStorageSS = dyn PayloadStorage + Sync + Send;
+pub type ConditionCheckerSS = dyn ConditionChecker + Sync + Send;

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -1,4 +1,4 @@
-use crate::id_tracker::IdTracker;
+use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::payload_storage::condition_checker::{
     match_geo, match_geo_radius, match_payload, match_range,
 };
@@ -62,13 +62,13 @@ where
 
 pub struct SimpleConditionChecker {
     payload_storage: Arc<AtomicRefCell<SimplePayloadStorage>>,
-    id_tracker: Arc<AtomicRefCell<dyn IdTracker>>,
+    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
 }
 
 impl SimpleConditionChecker {
     pub fn new(
         payload_storage: Arc<AtomicRefCell<SimplePayloadStorage>>,
-        id_tracker: Arc<AtomicRefCell<dyn IdTracker>>,
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     ) -> Self {
         SimpleConditionChecker {
             payload_storage,

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -1,4 +1,4 @@
-use crate::id_tracker::{IdTracker, IdTrackerSS};
+use crate::id_tracker::IdTrackerSS;
 use crate::payload_storage::condition_checker::{
     match_geo, match_geo_radius, match_payload, match_range,
 };
@@ -145,6 +145,7 @@ mod tests {
     use crate::types::{FieldCondition, GeoBoundingBox, Match, PayloadType, Range};
     use std::collections::HashSet;
     use tempdir::TempDir;
+    use crate::id_tracker::IdTracker;
 
     #[test]
     fn test_condition_checker() {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -140,12 +140,12 @@ impl ConditionChecker for SimpleConditionChecker {
 mod tests {
     use super::*;
     use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
+    use crate::id_tracker::IdTracker;
     use crate::payload_storage::PayloadStorage;
     use crate::types::GeoPoint;
     use crate::types::{FieldCondition, GeoBoundingBox, Match, PayloadType, Range};
     use std::collections::HashSet;
     use tempdir::TempDir;
-    use crate::id_tracker::IdTracker;
 
     #[test]
     fn test_condition_checker() {

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -248,56 +248,56 @@ mod tests {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], "John Doe".to_string());
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"age".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 43);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"floating".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 30.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"boolean".to_string()] {
             PayloadType::Keyword(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], "true");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"metadata__temperature".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 60.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"metadata__width".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 60);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"metadata__height".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 50);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"metadata__nested__feature".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 30.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"string_array".to_string()] {
             PayloadType::Keyword(x) => {
@@ -305,7 +305,7 @@ mod tests {
                 assert_eq!(x[0], "hello");
                 assert_eq!(x[1], "world");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"integer_array".to_string()] {
             PayloadType::Integer(x) => {
@@ -313,7 +313,7 @@ mod tests {
                 assert_eq!(x[0], 1);
                 assert_eq!(x[1], 2);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"metadata__integer_array".to_string()] {
             PayloadType::Integer(x) => {
@@ -321,7 +321,7 @@ mod tests {
                 assert_eq!(x[0], 1);
                 assert_eq!(x[1], 2);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"float_array".to_string()] {
             PayloadType::Float(x) => {
@@ -329,7 +329,7 @@ mod tests {
                 assert_eq!(x[0], 1.0);
                 assert_eq!(x[1], 2.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"boolean_array".to_string()] {
             PayloadType::Keyword(x) => {
@@ -337,7 +337,7 @@ mod tests {
                 assert_eq!(x[0], "true");
                 assert_eq!(x[1], "false");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &pload[&"geo_data".to_string()] {
             PayloadType::Geo(x) => {
@@ -345,7 +345,7 @@ mod tests {
                 assert_eq!(x[0].lat, 1.0);
                 assert_eq!(x[0].lon, 1.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -10,7 +10,7 @@ use crate::types::{
     PointOffsetType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentState,
     SegmentType, SeqNumberType, TheMap, VectorElementType, WithPayload,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageSS};
+use crate::vector_storage::VectorStorageSS;
 use atomic_refcell::AtomicRefCell;
 use atomicwrites::{AllowOverwrite, AtomicFile};
 use std::fs::{remove_dir_all, rename};

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,16 +1,16 @@
 use crate::entry::entry_point::{
     get_service_error, OperationError, OperationResult, SegmentEntry, SegmentFailedState,
 };
-use crate::id_tracker::IdTracker;
-use crate::index::{PayloadIndex, VectorIndex};
-use crate::payload_storage::{ConditionChecker, PayloadStorage};
+use crate::id_tracker::IdTrackerSS;
+use crate::index::{PayloadIndexSS, VectorIndexSS};
+use crate::payload_storage::{ConditionCheckerSS, PayloadStorageSS};
 use crate::spaces::tools::mertic_object;
 use crate::types::{
     Filter, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaInfo, PayloadType, PointIdType,
     PointOffsetType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentState,
     SegmentType, SeqNumberType, TheMap, VectorElementType, WithPayload,
 };
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{VectorStorage, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use atomicwrites::{AllowOverwrite, AtomicFile};
 use std::fs::{remove_dir_all, rename};
@@ -34,12 +34,12 @@ pub struct Segment {
     /// Path of the storage root
     pub current_path: PathBuf,
     /// Component for mapping external ids to internal and also keeping track of point versions
-    pub id_tracker: Arc<AtomicRefCell<dyn IdTracker>>,
-    pub vector_storage: Arc<AtomicRefCell<dyn VectorStorage>>,
-    pub payload_storage: Arc<AtomicRefCell<dyn PayloadStorage>>,
-    pub payload_index: Arc<AtomicRefCell<dyn PayloadIndex>>,
-    pub condition_checker: Arc<dyn ConditionChecker>,
-    pub vector_index: Arc<AtomicRefCell<dyn VectorIndex>>,
+    pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    pub vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
+    pub payload_storage: Arc<AtomicRefCell<PayloadStorageSS>>,
+    pub payload_index: Arc<AtomicRefCell<PayloadIndexSS>>,
+    pub condition_checker: Arc<ConditionCheckerSS>,
+    pub vector_index: Arc<AtomicRefCell<VectorIndexSS>>,
     /// Shows if it is possible to insert more points into this segment
     pub appendable_flag: bool,
     /// Shows what kind of indexes and storages are used in this segment

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -612,16 +612,12 @@ mod tests {
 
         let mut segment = build_segment(dir.path(), &config).unwrap();
         segment.upsert_point(0, 0, &[1.0, 1.0]).unwrap();
+
         let result1 = segment.set_full_payload_with_json(0, 0, &data1.to_string());
-        match result1 {
-            Ok(_) => assert!(false),
-            Err(_) => assert!(true),
-        }
+        assert!(result1.is_err());
+
         let result2 = segment.set_full_payload_with_json(0, 0, &data2.to_string());
-        match result2 {
-            Ok(_) => assert!(false),
-            Err(_) => assert!(true),
-        }
+        assert!(result2.is_err());
     }
 
     #[test]

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -3,7 +3,7 @@ use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::{PlainIndex, PlainPayloadIndex};
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex, VectorIndexSS};
+use crate::index::{PayloadIndexSS, VectorIndexSS};
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::segment::{Segment, SEGMENT_STATE_FILE};
@@ -12,7 +12,7 @@ use crate::types::{
 };
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
-use crate::vector_storage::{VectorStorage, VectorStorageSS};
+use crate::vector_storage::VectorStorageSS;
 use atomic_refcell::AtomicRefCell;
 use std::fs::{create_dir_all, File};
 use std::io::Read;

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -3,7 +3,7 @@ use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::{PlainIndex, PlainPayloadIndex};
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{PayloadIndex, VectorIndex};
+use crate::index::{PayloadIndex, PayloadIndexSS, VectorIndex, VectorIndexSS};
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::segment::{Segment, SEGMENT_STATE_FILE};
@@ -12,7 +12,7 @@ use crate::types::{
 };
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{VectorStorage, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use std::fs::{create_dir_all, File};
 use std::io::Read;
@@ -37,7 +37,7 @@ fn create_segment(
 
     let id_tracker = sp(SimpleIdTracker::open(&tracker_path)?);
 
-    let vector_storage: Arc<AtomicRefCell<dyn VectorStorage>> = match config.storage_type {
+    let vector_storage: Arc<AtomicRefCell<VectorStorageSS>> = match config.storage_type {
         StorageType::InMemory => {
             open_simple_vector_storage(&vector_storage_path, config.vector_size, config.distance)?
         }
@@ -53,7 +53,7 @@ fn create_segment(
         id_tracker.clone(),
     ));
 
-    let payload_index: Arc<AtomicRefCell<dyn PayloadIndex>> =
+    let payload_index: Arc<AtomicRefCell<PayloadIndexSS>> =
         match config.payload_index.unwrap_or_default() {
             PayloadIndexType::Plain => sp(PlainPayloadIndex::open(
                 condition_checker.clone(),
@@ -69,7 +69,7 @@ fn create_segment(
             )?),
         };
 
-    let vector_index: Arc<AtomicRefCell<dyn VectorIndex>> = match config.index {
+    let vector_index: Arc<AtomicRefCell<VectorIndexSS>> = match config.index {
         Indexes::Plain { .. } => sp(PlainIndex::new(
             vector_storage.clone(),
             payload_index.clone(),

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -57,11 +57,9 @@ mod tests {
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
         match segment.upsert_point(1, 120, &wrong_vec) {
-            Err(err) => match err {
-                OperationError::WrongVector { .. } => (),
-                _ => assert!(false, "Wrong error"),
-            },
-            Ok(_) => assert!(false, "Operation with wrong vector should fail"),
+            Err(OperationError::WrongVector { .. }) => (),
+            Err(_) => panic!("Wrong error"),
+            Ok(_) => panic!("Operation with wrong vector should fail"),
         };
 
         segment.upsert_point(2, 1, &vec1).unwrap();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -599,7 +599,7 @@ mod tests {
                 assert_eq!(x[0].lat, 1.0);
                 assert_eq!(x[0].lon, 1.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let keyword_query_non_strict = r#"["Berlin", "Barcelona", "Moscow"]"#;
@@ -616,7 +616,7 @@ mod tests {
                 assert_eq!(x[1], "Barcelona");
                 assert_eq!(x[2], "Moscow");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let keyword_query_strict =
@@ -634,7 +634,7 @@ mod tests {
                 assert_eq!(x[1], "Barcelona");
                 assert_eq!(x[2], "Moscow");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let integer_query_non_strict = r#"[1, 2, 3]"#;
@@ -651,7 +651,7 @@ mod tests {
                 assert_eq!(x[1], 2);
                 assert_eq!(x[2], 3);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let integer_query_strict = r#"{"type": "integer", "value": [1, 2, 3]}"#;
@@ -668,7 +668,7 @@ mod tests {
                 assert_eq!(x[1], 2);
                 assert_eq!(x[2], 3);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let float_query_non_strict = r#"[1.0, 2.0, 3.0]"#;
@@ -685,7 +685,7 @@ mod tests {
                 assert_eq!(x[1], 2.0);
                 assert_eq!(x[2], 3.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let float_query_strict = r#"{"type": "float", "value": [1.0, 2.0, 3.0]}"#;
@@ -702,7 +702,7 @@ mod tests {
                 assert_eq!(x[1], 2.0);
                 assert_eq!(x[2], 3.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 
@@ -890,10 +890,10 @@ mod tests {
                 let must_not = &f.must_not;
                 match must_not {
                     Some(v) => assert_eq!(v.len(), 2),
-                    None => assert!(false, "Filter expected"),
+                    None => panic!("Filter expected"),
                 }
             }
-            _ => assert!(false, "Condition expected"),
+            _ => panic!("Condition expected"),
         }
     }
 }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -329,7 +329,7 @@ mod tests {
             let storage2 = open_simple_vector_storage(dir2.path(), 4, dist).unwrap();
             {
                 let mut borrowed_storage2 = storage2.borrow_mut();
-                borrowed_storage2.put_vector(vec1.clone()).unwrap();
+                borrowed_storage2.put_vector(vec1).unwrap();
                 borrowed_storage2.put_vector(vec2.clone()).unwrap();
                 borrowed_storage2.put_vector(vec3.clone()).unwrap();
             }
@@ -351,8 +351,8 @@ mod tests {
             let storage2 = open_simple_vector_storage(dir2.path(), 4, dist).unwrap();
             {
                 let mut borrowed_storage2 = storage2.borrow_mut();
-                borrowed_storage2.put_vector(vec4.clone()).unwrap();
-                borrowed_storage2.put_vector(vec5.clone()).unwrap();
+                borrowed_storage2.put_vector(vec4).unwrap();
+                borrowed_storage2.put_vector(vec5).unwrap();
             }
             borrowed_storage.update_from(&*storage2.borrow()).unwrap();
         }
@@ -393,11 +393,11 @@ mod tests {
             let storage2 = open_simple_vector_storage(dir2.path(), 4, dist).unwrap();
             {
                 let mut borrowed_storage2 = storage2.borrow_mut();
-                borrowed_storage2.put_vector(vec1.clone()).unwrap();
-                borrowed_storage2.put_vector(vec2.clone()).unwrap();
-                borrowed_storage2.put_vector(vec3.clone()).unwrap();
-                borrowed_storage2.put_vector(vec4.clone()).unwrap();
-                borrowed_storage2.put_vector(vec5.clone()).unwrap();
+                borrowed_storage2.put_vector(vec1).unwrap();
+                borrowed_storage2.put_vector(vec2).unwrap();
+                borrowed_storage2.put_vector(vec3).unwrap();
+                borrowed_storage2.put_vector(vec4).unwrap();
+                borrowed_storage2.put_vector(vec5).unwrap();
             }
             borrowed_storage.update_from(&*storage2.borrow()).unwrap();
         }
@@ -405,7 +405,7 @@ mod tests {
         let query = vec![-1.0, -1.0, -1.0, -1.0];
         let query_points: Vec<PointOffsetType> = vec![0, 2, 4];
 
-        let scorer = borrowed_storage.raw_scorer(query.clone());
+        let scorer = borrowed_storage.raw_scorer(query);
 
         let res = scorer
             .score_points(&mut query_points.iter().cloned())

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -4,7 +4,7 @@ use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_scores_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
 use crate::vector_storage::mmap_vectors::MmapVectors;
-use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage};
+use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::Write;
@@ -79,7 +79,7 @@ pub fn open_memmap_vector_storage(
     path: &Path,
     dim: usize,
     distance: Distance,
-) -> OperationResult<Arc<AtomicRefCell<dyn VectorStorage>>> {
+) -> OperationResult<Arc<AtomicRefCell<VectorStorageSS>>> {
     create_dir_all(path)?;
 
     let vectors_path = path.join("matrix.dat");
@@ -154,10 +154,7 @@ where
         panic!("Can't directly update vector in mmap storage")
     }
 
-    fn update_from(
-        &mut self,
-        other: &dyn VectorStorage,
-    ) -> OperationResult<Range<PointOffsetType>> {
+    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
 
         let start_index = self.mmap_store.as_ref().unwrap().num_vectors as PointOffsetType;

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -353,11 +353,11 @@ mod tests {
         let vec3 = vec![1.0, 1.0, 0.0, 1.0];
         let vec4 = vec![1.0, 0.0, 0.0, 0.0];
 
-        let _id1 = borrowed_storage.put_vector(vec0.clone()).unwrap();
-        let id2 = borrowed_storage.put_vector(vec1.clone()).unwrap();
-        let _id3 = borrowed_storage.put_vector(vec2.clone()).unwrap();
-        let _id4 = borrowed_storage.put_vector(vec3.clone()).unwrap();
-        let id5 = borrowed_storage.put_vector(vec4.clone()).unwrap();
+        let _id1 = borrowed_storage.put_vector(vec0).unwrap();
+        let id2 = borrowed_storage.put_vector(vec1).unwrap();
+        let _id3 = borrowed_storage.put_vector(vec2).unwrap();
+        let _id4 = borrowed_storage.put_vector(vec3).unwrap();
+        let id5 = borrowed_storage.put_vector(vec4).unwrap();
 
         assert_eq!(id2, 1);
         assert_eq!(id5, 4);
@@ -382,7 +382,7 @@ mod tests {
         let closest =
             borrowed_storage.score_points(&query, &mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
-        let raw_scorer = borrowed_storage.raw_scorer(query.clone());
+        let raw_scorer = borrowed_storage.raw_scorer(query);
 
         let query_points = vec![0, 1, 2, 3, 4];
         let mut query_points1 = query_points.iter().cloned();

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::entry::entry_point::OperationResult;
 use crate::spaces::tools::peek_top_scores_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
-use crate::vector_storage::{RawScorer, ScoredPointOffset};
+use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorageSS};
 
 use super::vector_storage_base::VectorStorage;
 use crate::spaces::metric::Metric;
@@ -85,7 +85,7 @@ pub fn open_simple_vector_storage(
     path: &Path,
     dim: usize,
     distance: Distance,
-) -> OperationResult<Arc<AtomicRefCell<dyn VectorStorage>>> {
+) -> OperationResult<Arc<AtomicRefCell<VectorStorageSS>>> {
     let mut vectors: Vec<Array1<VectorElementType>> = vec![];
     let mut deleted = BitVec::new();
     let mut deleted_count = 0;
@@ -215,10 +215,7 @@ where
         Ok(key)
     }
 
-    fn update_from(
-        &mut self,
-        other: &dyn VectorStorage,
-    ) -> OperationResult<Range<PointOffsetType>> {
+    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
         for id in other.iter_ids() {
             let other_vector = other.get_vector(id).unwrap();

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -61,8 +61,7 @@ pub trait VectorStorage {
         key: PointOffsetType,
         vector: Vec<VectorElementType>,
     ) -> OperationResult<PointOffsetType>;
-    fn update_from(&mut self, other: &dyn VectorStorage)
-        -> OperationResult<Range<PointOffsetType>>;
+    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>>;
     fn delete(&mut self, key: PointOffsetType) -> OperationResult<()>;
     fn is_deleted(&self, key: PointOffsetType) -> bool;
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
@@ -99,6 +98,8 @@ pub trait VectorStorage {
         )
     }
 }
+
+pub type VectorStorageSS = dyn VectorStorage + Sync + Send;
 
 #[cfg(test)]
 mod tests {

--- a/lib/segment/tests/fixtures/segment.rs
+++ b/lib/segment/tests/fixtures/segment.rs
@@ -33,16 +33,16 @@ pub fn build_segment_1(path: &Path) -> Segment {
         .set_payload(6, 1, &payload_key, payload_option1.clone())
         .unwrap();
     segment1
-        .set_payload(6, 2, &payload_key, payload_option1.clone())
+        .set_payload(6, 2, &payload_key, payload_option1)
         .unwrap();
     segment1
-        .set_payload(6, 3, &payload_key, payload_option3.clone())
+        .set_payload(6, 3, &payload_key, payload_option3)
         .unwrap();
     segment1
         .set_payload(6, 4, &payload_key, payload_option2.clone())
         .unwrap();
     segment1
-        .set_payload(6, 5, &payload_key, payload_option2.clone())
+        .set_payload(6, 5, &payload_key, payload_option2)
         .unwrap();
 
     segment1
@@ -74,16 +74,16 @@ pub fn build_segment_2(path: &Path) -> Segment {
         .set_payload(16, 11, &payload_key, payload_option1.clone())
         .unwrap();
     segment2
-        .set_payload(16, 12, &payload_key, payload_option1.clone())
+        .set_payload(16, 12, &payload_key, payload_option1)
         .unwrap();
     segment2
-        .set_payload(16, 13, &payload_key, payload_option3.clone())
+        .set_payload(16, 13, &payload_key, payload_option3)
         .unwrap();
     segment2
         .set_payload(16, 14, &payload_key, payload_option2.clone())
         .unwrap();
     segment2
-        .set_payload(16, 15, &payload_key, payload_option2.clone())
+        .set_payload(16, 15, &payload_key, payload_option2)
         .unwrap();
 
     segment2

--- a/lib/segment/tests/fixtures/segment.rs
+++ b/lib/segment/tests/fixtures/segment.rs
@@ -8,6 +8,7 @@ pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()
 }
 
+#[allow(dead_code)]
 pub fn build_segment_1(path: &Path) -> Segment {
     let mut segment1 = empty_segment(path);
 

--- a/lib/segment/tests/set_payload_test.rs
+++ b/lib/segment/tests/set_payload_test.rs
@@ -69,56 +69,56 @@ mod tests {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], "John Doe".to_string());
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"age".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 43);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"floating".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 30.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"boolean".to_string()] {
             PayloadType::Keyword(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], "true");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"metadata__temperature".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 60.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"metadata__width".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 60);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"metadata__height".to_string()] {
             PayloadType::Integer(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 50);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"metadata__nested__feature".to_string()] {
             PayloadType::Float(x) => {
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 30.5);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"string_array".to_string()] {
             PayloadType::Keyword(x) => {
@@ -126,7 +126,7 @@ mod tests {
                 assert_eq!(x[0], "hello");
                 assert_eq!(x[1], "world");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"integer_array".to_string()] {
             PayloadType::Integer(x) => {
@@ -134,7 +134,7 @@ mod tests {
                 assert_eq!(x[0], 1);
                 assert_eq!(x[1], 2);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"metadata__integer_array".to_string()] {
             PayloadType::Integer(x) => {
@@ -142,7 +142,7 @@ mod tests {
                 assert_eq!(x[0], 1);
                 assert_eq!(x[1], 2);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"float_array".to_string()] {
             PayloadType::Float(x) => {
@@ -150,7 +150,7 @@ mod tests {
                 assert_eq!(x[0], 1.0);
                 assert_eq!(x[1], 2.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"boolean_array".to_string()] {
             PayloadType::Keyword(x) => {
@@ -158,7 +158,7 @@ mod tests {
                 assert_eq!(x[0], "true");
                 assert_eq!(x[1], "false");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
         match &payload[&"geo_data".to_string()] {
             PayloadType::Geo(x) => {
@@ -166,7 +166,7 @@ mod tests {
                 assert_eq!(x[0].lat, 1.0);
                 assert_eq!(x[0].lon, 1.0);
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 }


### PR DESCRIPTION
Fixes #197 
Resolves #198 

Hi!

I tried my best at describing my intents in two issues I'm referencing below. In a couple words, we have two problems with Clippy in project currently, particularly with GitHub Actions workflow step:

### Problems being solved

- linting step at workflow may potentially use an old version of clippy and rustfmt
- clippy step at workflow checks only the source code of the root package, ignoring other workspace members (`lib/`)

Additionally, I have tried to satisfy clippy warnings we have. 
I've had success with most of them: according to my UI, we've improved from 84 warnings to 10 warnings project-wide, 8 of which are temporary compilation problems not related to lints.

### What this PR does

- [x] #197 
- [x] #198 (add `--workspace` flag)
- [x] Fix clippy warnings
  - [x] [Reduntant clones](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone)
  - [x] [Calls to `push` immediately after creation](https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push)
  - [x] [Assertions on constants](https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants)
  - [x] Multiple problems with _Segment_ library benchmarks (those are compilation errors, not linting problems, so while I'm mentioning them here, they are still out of scope of this PR) - probably will be fixed by #195
  - [x] Function is never used: [build_segment_1](https://github.com/qdrant/qdrant/blob/c53a8774b223085730649a7b12b3c5f3b801a5eb/lib/segment/tests/fixtures/segment.rs#L11) - we can deliver a quick fix with `#[allow(dead_code)]`, but I'd like to propose the long-term solution of reorganizing tests, for example the same way [ripgrep](https://github.com/BurntSushi/ripgrep/tree/master/crates/matcher) did. 
  - [x] [This implementation is unsound, as some fields in `LockedSegment` are `!Send`](https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty) about [this line](https://github.com/qdrant/qdrant/blob/c53a8774b223085730649a7b12b3c5f3b801a5eb/lib/collection/src/collection_manager/holders/segment_holder.rs#L74) - in contrast to other warnings above, this one is not stylistical, thus requiring more thorough thoughts


I feel like the last two lint warnings left unsolved require more thoughts and discussions, so it would make sense to review and (hopefully) merge this PR and then discuss these two in their dedicated issues separately.
