### PR TITLE
ensure benchmarks compile as part of CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
       run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
     - name: Run tests
       run: OPENBLAS_TARGET=CORE2 cargo test --all
+    - name: Build benchmarks
+      run: cargo bench --all --no-run
 
 #   build:
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
Benchmarks are easy to break during refactoring.

This PR ensures that benchmarks are always compiling as part of the CI.
