### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels: [dependencies]


### PR DESCRIPTION
This PR enables Dependabot #207 

The current configuration is rather naive to experiment with the tool.
Given that we have a lot of dependencies I have introduced a limit of 10 PR to avoid overflowing our capacity.

I propose to experiment with the current configuration and react if this generates too many PR by:
- changing the max number of PRs
- changing the schedule for less frequents checks (e.g. once a week only)