### PR TITLE
Rust 1.58.1 in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.56.1 as builder
+FROM rust:1.58.1 as builder
 
 COPY . ./qdrant
 WORKDIR ./qdrant


### PR DESCRIPTION
[1.58.1](https://github.com/rust-lang/rust/releases/tag/1.58.1) fixes a CVE