### PR TITLE
size client response channel to reflect reality

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -80,7 +80,7 @@ impl Collection {
     ) -> CollectionResult<UpdateResult> {
         let sndr = self.update_sender.clone();
         let (callback_sender, callback_receiver) = if wait {
-            let (tx, rx) = async_channel::unbounded();
+            let (tx, rx) = async_channel::bounded(1);
             (Some(tx), Some(rx))
         } else {
             (None, None)


### PR DESCRIPTION
The updater pipeline reply with only one message.
We can simplify the code by using a special purpose channel which is optimized for holding at most one message.