### PR TITLE
new gRPC points update API #242

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -12,7 +12,7 @@ pub type PointOffsetType = u32;
 pub type PayloadKeyType = String;
 pub type PayloadKeyTypeRef<'a> = &'a str;
 pub type SeqNumberType = u64;
-/// Sequential number of modification, applied to segemnt
+/// Sequential number of modification, applied to segment
 pub type ScoreType = f32;
 /// Type of vector matching score
 pub type TagType = u64;

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -9,7 +9,7 @@ use storage::content_manager::toc::TableOfContent;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CreateFieldIndex {
-    field_name: String,
+    pub field_name: String,
 }
 
 // Deprecated

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -1,17 +1,31 @@
 use tonic::{Request, Response, Status};
 
-use crate::common::points::do_update_points;
+use crate::common::points::{
+    do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points,
+    do_set_payload, do_update_points, CreateFieldIndex,
+};
 use crate::tonic::api::common::error_to_status;
+use crate::tonic::qdrant::condition::ConditionOneOf;
+use crate::tonic::qdrant::payload::PayloadOneOf::{Float, Geo, Integer, Keyword};
+use crate::tonic::qdrant::points_selector::PointsSelectorOneOf;
 use crate::tonic::qdrant::points_server::Points;
 use crate::tonic::qdrant::{
-    FloatPayload, GeoPayload, GeoPoint, IntegerPayload, KeywordPayload, PointStruct,
-    PointsOperationResponse, UpdateResult, UpsertPoints,
+    ClearPayloadPoints, Condition, CreateFieldIndexCollection, DeleteFieldIndexCollection,
+    DeletePayloadPoints, DeletePoints, FieldCondition, Filter, FilterSelector, FloatPayload,
+    GeoBoundingBox, GeoPayload, GeoPoint, GeoRadius, HasIdCondition, IntegerPayload,
+    KeywordPayload, Match, Payload, PointStruct, PointsOperationResponse, PointsSelector, Range,
+    SetPayloadPoints, UpdateResult, UpsertPoints,
 };
-use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointsList};
+use collection::operations::payload_ops::DeletePayload;
+use collection::operations::point_ops::{
+    PointIdsList, PointInsertOperations, PointOperations, PointsList,
+};
 use collection::operations::types::UpdateResult as CollectionUpdateResult;
 use collection::operations::CollectionUpdateOperations;
-use segment::types::{PayloadInterface, PayloadInterfaceStrict, PayloadVariant, PointIdType};
-use std::collections::HashMap;
+use segment::types::{
+    PayloadInterface, PayloadInterfaceStrict, PayloadKeyType, PayloadVariant, PointIdType,
+};
+use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 use std::time::Instant;
@@ -43,6 +57,7 @@ impl Points for PointsService {
             .into_iter()
             .map(|point| point.try_into())
             .collect::<Result<_, _>>()?;
+
         let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperations::PointsList(PointsList { points }),
         ));
@@ -52,6 +67,174 @@ impl Points for PointsService {
             self.toc.as_ref(),
             &collection,
             operation,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn delete(
+        &self,
+        request: Request<DeletePoints>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeletePoints {
+            collection,
+            wait,
+            points,
+        } = request.into_inner();
+
+        let points_selector = match points {
+            None => return Err(Status::invalid_argument("PointSelector is missing")),
+            Some(p) => p.try_into()?,
+        };
+
+        let timing = Instant::now();
+        let result = do_delete_points(
+            self.toc.as_ref(),
+            &collection,
+            points_selector,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn set_payload(
+        &self,
+        request: Request<SetPayloadPoints>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let SetPayloadPoints {
+            collection,
+            wait,
+            payload,
+            points,
+        } = request.into_inner();
+
+        let operation = collection::operations::payload_ops::SetPayload {
+            payload: payload_to_interface(payload)?,
+            points: points.into_iter().map(|p| p.into()).collect(),
+        };
+
+        let timing = Instant::now();
+        let result = do_set_payload(
+            self.toc.as_ref(),
+            &collection,
+            operation,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn delete_payload(
+        &self,
+        request: Request<DeletePayloadPoints>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeletePayloadPoints {
+            collection,
+            wait,
+            keys,
+            points,
+        } = request.into_inner();
+
+        let operation = DeletePayload {
+            keys,
+            points: points.into_iter().map(|p| p.into()).collect(),
+        };
+
+        let timing = Instant::now();
+        let result = do_delete_payload(
+            self.toc.as_ref(),
+            &collection,
+            operation,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn clear_payload(
+        &self,
+        request: Request<ClearPayloadPoints>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let ClearPayloadPoints {
+            collection,
+            wait,
+            points,
+        } = request.into_inner();
+
+        let points_selector = match points {
+            None => return Err(Status::invalid_argument("PointSelector is missing")),
+            Some(p) => p.try_into()?,
+        };
+
+        let timing = Instant::now();
+        let result = do_clear_payload(
+            self.toc.as_ref(),
+            &collection,
+            points_selector,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn create_field_index(
+        &self,
+        request: Request<CreateFieldIndexCollection>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let CreateFieldIndexCollection {
+            collection,
+            wait,
+            field_name,
+        } = request.into_inner();
+
+        let operation = CreateFieldIndex { field_name };
+
+        let timing = Instant::now();
+        let result = do_create_index(
+            self.toc.as_ref(),
+            &collection,
+            operation,
+            wait.unwrap_or(false),
+        )
+        .await
+        .map_err(error_to_status)?;
+
+        let response = PointsOperationResponse::from((timing, result));
+        Ok(Response::new(response))
+    }
+
+    async fn delete_field_index(
+        &self,
+        request: Request<DeleteFieldIndexCollection>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeleteFieldIndexCollection {
+            collection,
+            wait,
+            field_name,
+        } = request.into_inner();
+
+        let timing = Instant::now();
+        let result = do_delete_index(
+            self.toc.as_ref(),
+            &collection,
+            field_name,
             wait.unwrap_or(false),
         )
         .await
@@ -72,27 +255,134 @@ impl TryFrom<PointStruct> for collection::operations::point_ops::PointStruct {
             payload,
         } = value;
 
-        let mut converted_payload = HashMap::new();
-        for (key, payload_value) in payload.into_iter() {
-            let value = if let Some(keyword) = payload_value.keyword {
-                keyword.into()
-            } else if let Some(integer) = payload_value.integer {
-                integer.into()
-            } else if let Some(float) = payload_value.float {
-                float.into()
-            } else if let Some(geo) = payload_value.geo {
-                geo.into()
-            } else {
-                return Err(Status::failed_precondition("Unknown payload type"));
-            };
-            converted_payload.insert(key, value);
-        }
+        let converted_payload = payload_to_interface(payload)?;
 
         Ok(Self {
             id: PointIdType::NumId(id),
             vector,
             payload: Some(converted_payload),
         })
+    }
+}
+
+fn payload_to_interface(
+    payload: HashMap<String, Payload>,
+) -> Result<HashMap<PayloadKeyType, PayloadInterface>, Status> {
+    let mut converted_payload = HashMap::new();
+    for (key, payload_value) in payload.into_iter() {
+        let value = match payload_value.payload_one_of {
+            Some(Keyword(k)) => k.into(),
+            Some(Integer(i)) => i.into(),
+            Some(Float(f)) => f.into(),
+            Some(Geo(g)) => g.into(),
+            None => return Err(Status::invalid_argument("Unknown payload type")),
+        };
+        converted_payload.insert(key, value);
+    }
+    Ok(converted_payload)
+}
+
+impl TryFrom<PointsSelector> for collection::operations::point_ops::PointsSelector {
+    type Error = Status;
+
+    fn try_from(value: PointsSelector) -> Result<Self, Self::Error> {
+        match value.points_selector_one_of {
+            Some(PointsSelectorOneOf::Ids(ids)) => Ok(
+                collection::operations::point_ops::PointsSelector::PointIdsSelector(PointIdsList {
+                    points: ids.ids.into_iter().map(|p| p.into()).collect(),
+                }),
+            ),
+            Some(PointsSelectorOneOf::FilterSelector(FilterSelector { filter: Some(f) })) => Ok(
+                collection::operations::point_ops::PointsSelector::FilterSelector(
+                    collection::operations::point_ops::FilterSelector {
+                        filter: f.try_into()?,
+                    },
+                ),
+            ),
+            _ => Err(Status::invalid_argument("Malformed PointsSelector type")),
+        }
+    }
+}
+
+fn conditions_helper(
+    conditions: Vec<Condition>,
+) -> Result<Option<Vec<segment::types::Condition>>, tonic::Status> {
+    if conditions.is_empty() {
+        Ok(None)
+    } else {
+        let vec = conditions
+            .into_iter()
+            .map(|c| c.try_into())
+            .collect::<Result<_, _>>()?;
+        Ok(Some(vec))
+    }
+}
+
+impl TryFrom<Filter> for segment::types::Filter {
+    type Error = Status;
+
+    fn try_from(value: Filter) -> Result<Self, Self::Error> {
+        Ok(Self {
+            should: conditions_helper(value.should)?,
+            must: conditions_helper(value.must)?,
+            must_not: conditions_helper(value.must_not)?,
+        })
+    }
+}
+
+impl TryFrom<Condition> for segment::types::Condition {
+    type Error = Status;
+
+    fn try_from(value: Condition) -> Result<Self, Self::Error> {
+        match value.condition_one_of {
+            Some(ConditionOneOf::Field(field)) => {
+                Ok(segment::types::Condition::Field(field.try_into()?))
+            }
+            Some(ConditionOneOf::HasId(has_id)) => {
+                Ok(segment::types::Condition::HasId(has_id.try_into()?))
+            }
+            Some(ConditionOneOf::Filter(filter)) => {
+                Ok(segment::types::Condition::Filter(filter.try_into()?))
+            }
+            _ => Err(Status::invalid_argument("Malformed Condition type")),
+        }
+    }
+}
+
+impl TryFrom<HasIdCondition> for segment::types::HasIdCondition {
+    type Error = Status;
+
+    fn try_from(value: HasIdCondition) -> Result<Self, Self::Error> {
+        let set: HashSet<PointIdType> = value.has_id.into_iter().map(|p| p.into()).collect();
+        Ok(Self { has_id: set })
+    }
+}
+
+impl TryFrom<FieldCondition> for segment::types::FieldCondition {
+    type Error = Status;
+
+    fn try_from(value: FieldCondition) -> Result<Self, Self::Error> {
+        match value {
+            FieldCondition {
+                key: Some(k),
+                r#match,
+                range,
+                geo_bounding_box,
+                geo_radius,
+            } => {
+                let geo_bounding_box =
+                    geo_bounding_box.map_or_else(|| Ok(None), |g| g.try_into().map(Some))?;
+                let geo_radius = geo_radius.map_or_else(|| Ok(None), |g| g.try_into().map(Some))?;
+                Ok(Self {
+                    key: k.value,
+                    r#match: r#match.map(|m| m.into()),
+                    range: range.map(|r| r.into()),
+                    geo_bounding_box,
+                    geo_radius,
+                })
+            }
+            _ => Err(Status::invalid_argument("Malformed FieldCondition type")),
+        }
     }
 }
 
@@ -128,11 +418,65 @@ impl From<GeoPayload> for PayloadInterface {
     }
 }
 
+impl TryFrom<GeoBoundingBox> for segment::types::GeoBoundingBox {
+    type Error = Status;
+
+    fn try_from(value: GeoBoundingBox) -> Result<Self, Self::Error> {
+        match value {
+            GeoBoundingBox {
+                top_left: Some(t),
+                bottom_right: Some(b),
+            } => Ok(Self {
+                top_left: t.into(),
+                bottom_right: b.into(),
+            }),
+            _ => Err(Status::invalid_argument("Malformed GeoBoundingBox type")),
+        }
+    }
+}
+
+impl TryFrom<GeoRadius> for segment::types::GeoRadius {
+    type Error = Status;
+
+    fn try_from(value: GeoRadius) -> Result<Self, Self::Error> {
+        match value {
+            GeoRadius {
+                center: Some(c),
+                radius,
+            } => Ok(Self {
+                center: c.into(),
+                radius: radius.into(),
+            }),
+            _ => Err(Status::invalid_argument("Malformed GeoRadius type")),
+        }
+    }
+}
+
 impl From<GeoPoint> for segment::types::GeoPoint {
     fn from(value: GeoPoint) -> Self {
         Self {
             lon: value.lon,
             lat: value.lat,
+        }
+    }
+}
+
+impl From<Range> for segment::types::Range {
+    fn from(value: Range) -> Self {
+        Self {
+            lt: value.lt.map(|v| v.value),
+            gt: value.gt.map(|v| v.value),
+            gte: value.gte.map(|v| v.value),
+            lte: value.lte.map(|v| v.value),
+        }
+    }
+}
+
+impl From<Match> for segment::types::Match {
+    fn from(value: Match) -> Self {
+        Self {
+            keyword: value.keyword,
+            integer: value.integer.map(|i| i.value),
         }
     }
 }

--- a/src/tonic/proto/points.proto
+++ b/src/tonic/proto/points.proto
@@ -8,6 +8,114 @@ package qdrant;
 
 service Points {
   rpc Upsert (UpsertPoints) returns (PointsOperationResponse) {}
+  rpc Delete (DeletePoints) returns (PointsOperationResponse) {}
+  rpc SetPayload (SetPayloadPoints) returns (PointsOperationResponse) {}
+  rpc DeletePayload (DeletePayloadPoints) returns (PointsOperationResponse) {}
+  rpc ClearPayload (ClearPayloadPoints) returns (PointsOperationResponse) {}
+  rpc CreateFieldIndex (CreateFieldIndexCollection) returns (PointsOperationResponse) {}
+  rpc DeleteFieldIndex (DeleteFieldIndexCollection) returns (PointsOperationResponse) {}
+}
+
+message CreateFieldIndexCollection {
+  string collection = 1;
+  optional bool wait = 2;
+  string field_name = 3;
+}
+
+message DeleteFieldIndexCollection {
+  string collection = 1;
+  optional bool wait = 2;
+  string field_name = 3;
+}
+
+message DeletePayloadPoints {
+  string collection = 1;
+  optional bool wait = 2;
+  repeated string keys = 3;
+  repeated uint64 points = 4;
+}
+
+message SetPayloadPoints {
+  string collection = 1;
+  optional bool wait = 2;
+  map<string, Payload> payload = 3;
+  repeated uint64 points = 4;
+}
+
+message ClearPayloadPoints {
+  string collection = 1;
+  optional bool wait = 2;
+  PointsSelector points = 3;
+}
+
+message DeletePoints {
+  string collection = 1;
+  optional bool wait = 2;
+  PointsSelector points = 3;
+}
+
+
+message PointsSelector {
+  oneof points_selector_one_of {
+    PointsIdsList ids = 1;
+    FilterSelector filter_selector = 2;
+  }
+}
+
+message PointsIdsList {
+  repeated uint64 ids = 1;
+}
+
+message FilterSelector {
+  Filter filter = 1;
+}
+
+message Filter {
+  repeated Condition should = 1;
+  repeated Condition must = 2;
+  repeated Condition must_not = 3;
+}
+
+message Condition {
+  oneof condition_one_of {
+    FieldCondition field = 1;
+    HasIdCondition hasId = 2;
+    Filter filter = 3;
+  }
+}
+
+message FieldCondition {
+  KeywordPayloadRequest key = 1;
+  Match match = 2;
+  Range range = 3;
+  GeoBoundingBox geo_bounding_box = 4;
+  GeoRadius geo_radius = 5;
+}
+
+message GeoBoundingBox {
+  GeoPoint top_left = 1;
+  GeoPoint bottom_right = 2;
+}
+
+message GeoRadius {
+  GeoPoint center = 1;
+  float radius = 2;
+}
+
+message HasIdCondition {
+  repeated uint64 has_id = 1;
+}
+
+message Range {
+  FloatPayloadRequest lt = 1;
+  FloatPayloadRequest gt = 2;
+  FloatPayloadRequest gte = 3;
+  FloatPayloadRequest lte = 4;
+}
+
+message Match {
+  optional string keyword = 1;
+  IntegerPayloadRequest integer = 2;
 }
 
 message UpsertPoints {
@@ -22,16 +130,31 @@ message PointStruct {
   map<string, Payload> payload = 3;
 }
 
+message KeywordPayloadRequest {
+  string value = 1;
+}
+
+message IntegerPayloadRequest {
+  int64 value = 1;
+}
+
+message FloatPayloadRequest {
+  double value = 1;
+}
+
 message Payload {
-  optional KeywordPayload keyword = 1;
-  optional IntegerPayload integer = 2;
-  optional FloatPayload float = 3;
-  optional GeoPayload geo = 4;
+  oneof payload_one_of {
+    KeywordPayload keyword = 1;
+    IntegerPayload integer = 2;
+    FloatPayload float = 3;
+    GeoPayload geo = 4;
+  }
 }
 
 message KeywordPayload {
   repeated string value = 1;
 }
+
 message IntegerPayload {
   repeated int64 value = 1;
 }

--- a/src/tonic/qdrant.rs
+++ b/src/tonic/qdrant.rs
@@ -552,6 +552,165 @@ pub mod collections_server {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateFieldIndexCollection {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(string, tag = "3")]
+    pub field_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteFieldIndexCollection {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(string, tag = "3")]
+    pub field_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePayloadPoints {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(string, repeated, tag = "3")]
+    pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(uint64, repeated, tag = "4")]
+    pub points: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPayloadPoints {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(map = "string, message", tag = "3")]
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Payload>,
+    #[prost(uint64, repeated, tag = "4")]
+    pub points: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClearPayloadPoints {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(message, optional, tag = "3")]
+    pub points: ::core::option::Option<PointsSelector>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePoints {
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(message, optional, tag = "3")]
+    pub points: ::core::option::Option<PointsSelector>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointsSelector {
+    #[prost(oneof = "points_selector::PointsSelectorOneOf", tags = "1, 2")]
+    pub points_selector_one_of: ::core::option::Option<points_selector::PointsSelectorOneOf>,
+}
+/// Nested message and enum types in `PointsSelector`.
+pub mod points_selector {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum PointsSelectorOneOf {
+        #[prost(message, tag = "1")]
+        Ids(super::PointsIdsList),
+        #[prost(message, tag = "2")]
+        FilterSelector(super::FilterSelector),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointsIdsList {
+    #[prost(uint64, repeated, tag = "1")]
+    pub ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FilterSelector {
+    #[prost(message, optional, tag = "1")]
+    pub filter: ::core::option::Option<Filter>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Filter {
+    #[prost(message, repeated, tag = "1")]
+    pub should: ::prost::alloc::vec::Vec<Condition>,
+    #[prost(message, repeated, tag = "2")]
+    pub must: ::prost::alloc::vec::Vec<Condition>,
+    #[prost(message, repeated, tag = "3")]
+    pub must_not: ::prost::alloc::vec::Vec<Condition>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Condition {
+    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3")]
+    pub condition_one_of: ::core::option::Option<condition::ConditionOneOf>,
+}
+/// Nested message and enum types in `Condition`.
+pub mod condition {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum ConditionOneOf {
+        #[prost(message, tag = "1")]
+        Field(super::FieldCondition),
+        #[prost(message, tag = "2")]
+        HasId(super::HasIdCondition),
+        #[prost(message, tag = "3")]
+        Filter(super::Filter),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldCondition {
+    #[prost(message, optional, tag = "1")]
+    pub key: ::core::option::Option<KeywordPayloadRequest>,
+    #[prost(message, optional, tag = "2")]
+    pub r#match: ::core::option::Option<Match>,
+    #[prost(message, optional, tag = "3")]
+    pub range: ::core::option::Option<Range>,
+    #[prost(message, optional, tag = "4")]
+    pub geo_bounding_box: ::core::option::Option<GeoBoundingBox>,
+    #[prost(message, optional, tag = "5")]
+    pub geo_radius: ::core::option::Option<GeoRadius>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeoBoundingBox {
+    #[prost(message, optional, tag = "1")]
+    pub top_left: ::core::option::Option<GeoPoint>,
+    #[prost(message, optional, tag = "2")]
+    pub bottom_right: ::core::option::Option<GeoPoint>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeoRadius {
+    #[prost(message, optional, tag = "1")]
+    pub center: ::core::option::Option<GeoPoint>,
+    #[prost(float, tag = "2")]
+    pub radius: f32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HasIdCondition {
+    #[prost(uint64, repeated, tag = "1")]
+    pub has_id: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Range {
+    #[prost(message, optional, tag = "1")]
+    pub lt: ::core::option::Option<FloatPayloadRequest>,
+    #[prost(message, optional, tag = "2")]
+    pub gt: ::core::option::Option<FloatPayloadRequest>,
+    #[prost(message, optional, tag = "3")]
+    pub gte: ::core::option::Option<FloatPayloadRequest>,
+    #[prost(message, optional, tag = "4")]
+    pub lte: ::core::option::Option<FloatPayloadRequest>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Match {
+    #[prost(string, optional, tag = "1")]
+    pub keyword: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "2")]
+    pub integer: ::core::option::Option<IntegerPayloadRequest>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPoints {
     #[prost(string, tag = "1")]
     pub collection: ::prost::alloc::string::String,
@@ -570,15 +729,38 @@ pub struct PointStruct {
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Payload>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeywordPayloadRequest {
+    #[prost(string, tag = "1")]
+    pub value: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IntegerPayloadRequest {
+    #[prost(int64, tag = "1")]
+    pub value: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FloatPayloadRequest {
+    #[prost(double, tag = "1")]
+    pub value: f64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payload {
-    #[prost(message, optional, tag = "1")]
-    pub keyword: ::core::option::Option<KeywordPayload>,
-    #[prost(message, optional, tag = "2")]
-    pub integer: ::core::option::Option<IntegerPayload>,
-    #[prost(message, optional, tag = "3")]
-    pub float: ::core::option::Option<FloatPayload>,
-    #[prost(message, optional, tag = "4")]
-    pub geo: ::core::option::Option<GeoPayload>,
+    #[prost(oneof = "payload::PayloadOneOf", tags = "1, 2, 3, 4")]
+    pub payload_one_of: ::core::option::Option<payload::PayloadOneOf>,
+}
+/// Nested message and enum types in `Payload`.
+pub mod payload {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum PayloadOneOf {
+        #[prost(message, tag = "1")]
+        Keyword(super::KeywordPayload),
+        #[prost(message, tag = "2")]
+        Integer(super::IntegerPayload),
+        #[prost(message, tag = "3")]
+        Float(super::FloatPayload),
+        #[prost(message, tag = "4")]
+        Geo(super::GeoPayload),
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeywordPayload {
@@ -701,6 +883,90 @@ pub mod points_client {
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Upsert");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn delete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeletePoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Delete");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn set_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetPayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/SetPayload");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeletePayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeletePayload");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn clear_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ClearPayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/ClearPayload");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn create_field_index(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateFieldIndexCollection>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/CreateFieldIndex");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_field_index(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteFieldIndexCollection>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeleteFieldIndex");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 #[doc = r" Generated server implementations."]
@@ -713,6 +979,30 @@ pub mod points_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete(
+            &self,
+            request: tonic::Request<super::DeletePoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn set_payload(
+            &self,
+            request: tonic::Request<super::SetPayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete_payload(
+            &self,
+            request: tonic::Request<super::DeletePayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn clear_payload(
+            &self,
+            request: tonic::Request<super::ClearPayloadPoints>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn create_field_index(
+            &self,
+            request: tonic::Request<super::CreateFieldIndexCollection>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete_field_index(
+            &self,
+            request: tonic::Request<super::DeleteFieldIndexCollection>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -775,6 +1065,196 @@ pub mod points_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UpsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/Delete" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::DeletePoints> for DeleteSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeletePoints>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/SetPayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct SetPayloadSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints> for SetPayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SetPayloadPoints>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).set_payload(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SetPayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/DeletePayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeletePayloadSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::DeletePayloadPoints> for DeletePayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeletePayloadPoints>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete_payload(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeletePayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/ClearPayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct ClearPayloadSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::ClearPayloadPoints> for ClearPayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ClearPayloadPoints>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).clear_payload(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ClearPayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/CreateFieldIndex" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateFieldIndexSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::CreateFieldIndexCollection>
+                        for CreateFieldIndexSvc<T>
+                    {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateFieldIndexCollection>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).create_field_index(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateFieldIndexSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/DeleteFieldIndex" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteFieldIndexSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::DeleteFieldIndexCollection>
+                        for DeleteFieldIndexSvc<T>
+                    {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteFieldIndexCollection>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete_field_index(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteFieldIndexSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,


### PR DESCRIPTION
This PR performs the change to the gRPC API described in https://github.com/qdrant/qdrant/issues/242.

Interesting points for the reviewers:
- gRPC enums are modeled using [one_of](https://developers.google.com/protocol-buffers/docs/proto3#oneof).
- as `one_of` worked fine I decided to refactor existing enums as well for consistency
- decided to remove to not implement the `Upsert` API to keep things simple.
- introduced several dedicated `PayloadRequest` type as the regular ones hold a vector of data instead of a single element
