### PR TITLE
Avoid sending stop signal more than once

### DIFF
--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -3,6 +3,7 @@ use sled::transaction::TransactionError;
 use sled::Error;
 use std::io::Error as IoError;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]
@@ -53,6 +54,14 @@ impl From<TransactionError> for StorageError {
 
 impl From<IoError> for StorageError {
     fn from(err: IoError) -> Self {
+        StorageError::ServiceError {
+            description: format!("{}", err),
+        }
+    }
+}
+
+impl From<JoinError> for StorageError {
+    fn from(err: JoinError) -> Self {
         StorageError::ServiceError {
             description: format!("{}", err),
         }


### PR DESCRIPTION
Closes #275 

### Bug 
The problem was in the fact that stop signal was sent twice on collection deletion, which led to the signal being sent to an already closed channel (as worker stops after the first message) on the second attempt.

### Why it broke after channels migration
- In async-channels you could clone the `Receiver`
- So the sending will fail only if all receivers were dropped
- `UpdateHandler` that spawns worker threads, cloned the receiver to put it into the worker thread, but never used its own receiver
- So when the `Collection` is dropped and worker threads are ordered to close - their communication channel will never close as there was always a receiver in `UpdateHandler`

Now:
- In tokio ordinary unbounded channel receivers cannot be cloned
- To clone a receiver you would need a broadcast channel
- So in the `UpdateHandler` I replaced receiver with `Option<UnboundedReceiver>` as I noticed that this part of the channel is never used after it is cloned into the worker
- This led to us discovering that we send the stop signal after the worker thread was dead

### Changes
1. Stop signal will be sent only on Collection drop.
2. Drop is explicitly set to happen before removing collection directory.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable? - **Not applicable**
* [X] Have you successfully ran tests with your changes locally?
