### PR TITLE
use existing integration tests as CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,29 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
+      - name: Run integration tests
+        run: |
+          ./tests/integration-tests.sh
+        shell: bash

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -117,7 +117,7 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_alias/points/search" \
 curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/delete?wait=true" \
   -H 'Content-Type: application/json' \
   --fail -s \
-  --data-raw '{ 
+  --data-raw '{
     "filter": {
       "must": [
         { "has_id": [5] }
@@ -137,7 +137,7 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/delete?w
   -H 'Content-Type: application/json' \
   --fail -s \
   --data-raw '{
-    "points" : [ 1, 2, 3, 4, 5 ]
+    "points" : [ 1, 2, 3, 4 ]
   }' | jq
 
 SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/../"
 
 QDRANT_HOST='localhost:6334'
 
-docker_grpcurl="docker run --rm -it --network=host -v ${PWD}/src/tonic/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+docker_grpcurl="docker run --rm --network=host -v ${PWD}/src/tonic/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
 
 $docker_grpcurl -d '{
    "name": "test_collection"

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This runs all integration test in isolation
+
+set -ex
+
+# Ensure current path is project root
+cd "$(dirname "$0")/../"
+
+QDRANT_HOST='localhost:6333'
+
+# Build
+$(cargo build --features grpc)
+# Run in background
+$(./target/debug/qdrant) &
+
+# Sleep to make sure the process has started (workaround for empty pidof)
+sleep 5
+
+## Capture PID of the run
+PID=$(pidof "./target/debug/qdrant")
+echo $PID
+
+until $(curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/collections); do
+  printf 'waiting for server to start...'
+  sleep 5
+done
+
+echo "server ready to serve traffic"
+
+./tests/basic_api_test.sh
+
+./tests/basic_grpc_test.sh
+
+echo "server is going down"
+$(kill -9 $PID)
+echo "END"


### PR DESCRIPTION
This PR is related to our effort to improve integration testing #232 

The goal of this change is to setup a safety net to avoid regressions while we decide on a long term strategy for integration testing. 

**This PR is not a long term solution**.

The change consists in executing our existing bash scripts tests as part of the CI pipeline.

It took me some time to make it work exactly like I wanted. 

1. build in debug mode
2. run binary in the background and capture PID for later
3. wait for the server to be up by probing it at regular interval
4. run REST tests
5. run gRPC tests
6. shutdown server with PID

Currently the main drawback is that the server is not shutdown if a tests fail, which is only a problem locally.