### PR TITLE
validate storage compatibility - (#286)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/storage-compat/storage.tar.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/storage-compat.yml
+++ b/.github/workflows/storage-compat.yml
@@ -1,0 +1,31 @@
+name: Storage compatibility tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran git-lfs
+      - name: Setup git-lfs
+        run: git lfs install
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions/checkout@v2
+      - name: Run storage compatibility test
+        run: |
+          ./tests/storage-compat/storage-compatibility.sh
+        shell: bash

--- a/tests/storage-compat/README.md
+++ b/tests/storage-compat/README.md
@@ -1,0 +1,9 @@
+# storage compatibility test
+
+In order to detect quickly breakage of storage compatibility, we make sure any PRs results in a system that is still able to read a snapshot of a previous storage folder.
+
+The data is created by running `/tests/basic_api_test.sh` and saved compressed for reference.
+
+- compression scheme: `tar -cjvf storage.tar.bz2 storage/`
+
+To not burden the git repository with tracking the storage file, it is hosted using [Git Large File Storage](https://git-lfs.github.com/).

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This runs validates the storage compatibility
+
+set -ex
+echo $PWD
+# Ensure current path is project root
+cd "$(dirname "$0")/../../"
+
+QDRANT_HOST='localhost:6333'
+
+# Build
+$(cargo build)
+
+# Sync git large file
+git lfs pull
+
+# Uncompress snapshot storage
+tar -xvjf ./tests/storage-compat/storage.tar.bz2
+
+# Run in background
+$(./target/debug/qdrant) &
+
+# Sleep to make sure the process has started (workaround for empty pidof)
+sleep 5
+
+## Capture PID of the run
+PID=$(pidof "./target/debug/qdrant")
+echo $PID
+
+until $(curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/collections); do
+  printf 'waiting for server to start...'
+  sleep 5
+done
+
+echo "server ready to serve traffic"
+
+echo "server is going down"
+$(kill -9 $PID)
+echo "END"

--- a/tests/storage-compat/storage.tar.bz2
+++ b/tests/storage-compat/storage.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3bc3fe1a858d02ce711bd6b0fcb927e7f6a5a51ca34f412832dcf983b464f15
+size 33694


### PR DESCRIPTION
This PR tackles the validation of storage compatibility #286 

The goal is to detect when a PR breaks the storage compatibility with CI.

The strategy is to save the `storage` folder resulting from running `./tests/basic_api_test.sh` once and then check that we can still read it for each PR.

`storage.tar.bz2` needs to be refreshed every time we break the compatibility

```
du -sh storage.tar.bz2 
36K	storage.tar.bz2
```

edit: due to the size of the file, it is managed using https://git-lfs.github.com/