### PR TITLE
Turn geo query into set of geohashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "geohash"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2531fb8e2edacf602fd1f2672da559dc1527509cf90940b7a0ebd06b998a004f"
+dependencies = [
+ "geo-types",
+ "libm",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1563,12 @@ dependencies = [
  "cfg-if",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "librocksdb-sys"
@@ -2634,6 +2650,7 @@ dependencies = [
  "blas-src",
  "criterion",
  "geo",
+ "geohash",
  "itertools",
  "log 0.4.14",
  "memmap 0.7.0",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -34,6 +34,7 @@ memmap = "0.7.0"
 schemars = { version = "0.8.8", features = ["uuid"] }
 log = "0.4"
 geo = "0.19.0"
+geohash = "0.12.0"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 rand = "0.8"

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -82,7 +82,6 @@ impl From<&GeoBoundingBox> for FullGeoBoundingBox {
     }
 }
 
-
 impl FullGeoBoundingBox {
     fn shortest_side_length_in_km(&self) -> f64 {
         // the projection on the sphere is a trapeze - calculate 3 distances
@@ -204,7 +203,7 @@ fn filter_hashes_within_circle(hashes: Vec<GeoHash>, circle: GeoRadius) -> Vec<G
             };
             (h, geo_point)
         })
-        .filter(|(h, hash_point)| {
+        .filter(|(_, hash_point)| {
             distance_in_km_between_coordinates(&circle.center, hash_point) <= radius_km
         })
         .map(|(h, _)| h)

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn circle_meridian() {
+    fn wide_circle_meridian() {
         let query = GeoRadius {
             center: GeoPoint {
                 lon: -17.81718188959701,
@@ -581,10 +581,27 @@ mod tests {
         let max_hashes = 10;
         let hashes = circle_hashes(&query, max_hashes);
         assert!(hashes.len() <= max_hashes);
+        assert_eq!(hashes, ["b"]);
     }
 
     #[test]
-    fn circle_south_pole() {
+    fn tight_circle_meridian() {
+        let query = GeoRadius {
+            center: GeoPoint {
+                lon: -17.81718188959701,
+                lat: 89.9811609411936,
+            },
+            radius: 1000.0,
+        };
+
+        let max_hashes = 10;
+        let hashes = circle_hashes(&query, max_hashes);
+        assert!(hashes.len() <= max_hashes);
+        assert_eq!(hashes, ["fz", "gp", "gr", "gx", "gz", "up"]);
+    }
+
+    #[test]
+    fn wide_circle_south_pole() {
         let query = GeoRadius {
             center: GeoPoint {
                 lon: 155.85591760141335,
@@ -595,6 +612,22 @@ mod tests {
         let max_hashes = 10;
         let hashes = circle_hashes(&query, max_hashes);
         assert!(hashes.len() <= max_hashes);
+        assert_eq!(hashes, ["p"]);
+    }
+
+    #[test]
+    fn tight_circle_south_pole() {
+        let query = GeoRadius {
+            center: GeoPoint {
+                lon: 155.85591760141335,
+                lat: -74.19418872656166,
+            },
+            radius: 1000.0,
+        };
+        let max_hashes = 10;
+        let hashes = circle_hashes(&query, max_hashes);
+        assert!(hashes.len() <= max_hashes);
+        assert_eq!(hashes, ["p6ycc", "p6ycf", "p6ycg"]);
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -164,7 +164,7 @@ fn circle_hashes(circle: &GeoRadius, max_regions: usize) -> Vec<GeoHash> {
     let geo_bounding_box = minimum_bounding_rectangle_for_circle(circle);
     let full_geohash_bounding_box: GeohashBoundingBox = geo_bounding_box.into();
 
-    let hashes = (0..=GEOHASH_MAX_LENGTH)
+    (0..=GEOHASH_MAX_LENGTH)
         .map(|precision| {
             full_geohash_bounding_box
                 .geohash_regions(precision, max_regions)
@@ -178,9 +178,7 @@ fn circle_hashes(circle: &GeoRadius, max_regions: usize) -> Vec<GeoHash> {
         .take_while(|hashes| hashes.is_some())
         .last()
         .expect("no hash coverage for any precision")
-        .expect("geo-hash coverage is empty");
-
-    hashes
+        .expect("geo-hash coverage is empty")
 }
 
 /// Return as-high-as-possible with maximum of `max_regions`
@@ -189,14 +187,12 @@ fn rectangle_hashes(rectangle: &GeoBoundingBox, max_regions: usize) -> Vec<GeoHa
     assert_ne!(max_regions, 0, "max_regions cannot be equal to zero");
     let full_geohash_bounding_box: GeohashBoundingBox = rectangle.clone().into();
 
-    let hashes = (0..=GEOHASH_MAX_LENGTH)
+    (0..=GEOHASH_MAX_LENGTH)
         .map(|precision| full_geohash_bounding_box.geohash_regions(precision, max_regions))
         .take_while(|hashes| hashes.is_some())
         .last()
         .expect("no hash coverage for any precision")
-        .expect("geo-hash coverage is empty");
-
-    hashes
+        .expect("geo-hash coverage is empty")
 }
 
 /// A globally-average value is usually considered to be 6,371 kilometres (3,959 mi) with a 0.3% variability (±10 km).
@@ -379,11 +375,11 @@ mod tests {
         assert!(nyc_hashes.iter().all(|h| h.len() == 7)); // geohash precision
 
         let mut nyc_hashes = rectangle_hashes(&near_nyc_rectangle, 10);
-        nyc_hashes.sort();
+        nyc_hashes.sort_unstable();
         let mut expected = vec![
             "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
         ];
-        expected.sort();
+        expected.sort_unstable();
 
         assert_eq!(nyc_hashes, expected);
 
@@ -430,7 +426,7 @@ mod tests {
     fn test_lon_threshold() {
         let query = GeoRadius {
             center: GeoPoint {
-                lon: 179.98718188959701,
+                lon: 179.987181,
                 lat: 44.9811609411936,
             },
             radius: 100000.,
@@ -514,11 +510,11 @@ mod tests {
         assert!(nyc_hashes.iter().all(|h| h.len() == 7)); // geohash precision
 
         let mut nyc_hashes = circle_hashes(&near_nyc_circle, 10);
-        nyc_hashes.sort();
+        nyc_hashes.sort_unstable();
         let mut expected = [
             "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
         ];
-        expected.sort();
+        expected.sort_unstable();
         assert_eq!(nyc_hashes, expected);
 
         // falls back to finest region that encompasses the whole area

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -476,6 +476,7 @@ mod tests {
         assert_eq!(precisions_for_distance_range(2.0).len(), 4);
         assert_eq!(precisions_for_distance_range(0.15).len(), 3);
         assert_eq!(precisions_for_distance_range(0.1).len(), 2);
+        assert_eq!(precisions_for_distance_range(0.01).len(), 1);
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -1,6 +1,7 @@
+use crate::types::{GeoBoundingBox, GeoPoint, GeoRadius};
 use geo::Coordinate;
-use geohash::encode;
-use crate::types::{GeoPoint, GeoRadius};
+use geohash::{decode, encode, neighbor, Direction};
+use std::ops::Range;
 
 type GeoHash = String;
 
@@ -12,7 +13,7 @@ const GEOHASH_MAX_LENGTH: usize = 12;
 ///   For hash length: N = 4
 ///   let (lat_length_in_meters, long_length_in_meters) = HASH_GRID_SIZE[N - 1];
 /// Source: <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator>
-const HASH_GRID_SIZE: &'static [(f64, f64)] = &[
+const HASH_GRID_SIZE: &[(f64, f64)] = &[
     (5009.4 * 1000.0, 4992.6 * 1000.0),
     (1252.3 * 1000.0, 624.1 * 1000.0),
     (156.5 * 1000.0, 156.0 * 1000.0),
@@ -31,37 +32,500 @@ impl From<GeoPoint> for Coordinate<f64> {
     fn from(point: GeoPoint) -> Self {
         Self {
             x: point.lat,
-            y: point.lon
+            y: point.lon,
         }
     }
 }
 
-/// Return as-small-as-possible with maximum of `max_regions`
-/// number of geo-hash guaranteed to contain whole circle.
-fn circle_hashes(circle: GeoRadius, max_regions: usize) -> Vec<GeoHash> {
-    // Unwrap is acceptable, as data should be validated before
-    let center_full_hash = encode(circle.center.into(), GEOHASH_MAX_LENGTH).unwrap();
-
-    vec![center_full_hash]
+#[derive(Debug)]
+struct FullGeoBoundingBox {
+    north_west: GeoPoint,
+    south_west: GeoPoint,
+    south_east: GeoPoint,
+    north_east: GeoPoint,
 }
 
+impl FullGeoBoundingBox {
+    fn from_geo_bounding_box(bounding_box: &GeoBoundingBox) -> Self {
+        let GeoPoint {
+            lat: max_lat,
+            lon: min_lon,
+        } = bounding_box.top_left;
+        let GeoPoint {
+            lat: min_lat,
+            lon: max_lon,
+        } = bounding_box.bottom_right;
+
+        let north_west = GeoPoint {
+            lon: min_lon,
+            lat: max_lat,
+        };
+        let south_west = GeoPoint {
+            lon: min_lon,
+            lat: min_lat,
+        };
+        let south_east = GeoPoint {
+            lon: max_lon,
+            lat: min_lat,
+        };
+        let north_east = GeoPoint {
+            lon: max_lon,
+            lat: max_lat,
+        };
+
+        Self {
+            north_west,
+            south_west,
+            south_east,
+            north_east,
+        }
+    }
+
+    fn shortest_side_length_in_km(&self) -> f64 {
+        // the projection on the sphere is a trapeze - calculate 3 distances
+        let upper_width = distance_in_km_between_coordinates(&self.north_west, &self.north_east);
+        let lower_width = distance_in_km_between_coordinates(&self.south_west, &self.south_east);
+        // both height sides are equal in a trapeze - pick only one
+        let height = distance_in_km_between_coordinates(&self.north_west, &self.south_west);
+        f64::min(f64::min(upper_width, lower_width), height)
+    }
+}
+
+#[derive(Debug)]
+struct RectangleGeoHash {
+    north_west: GeoHash,
+    south_west: GeoHash,
+    south_east: GeoHash,
+    north_east: GeoHash,
+}
+
+impl RectangleGeoHash {
+    /// warning: this could generate a huge result depending on the size of the rectangle and the precision of the geohashes
+    fn geohash_regions(&self) -> Vec<GeoHash> {
+        let width = self.area_width_region_count();
+        let height = self.area_height_region_count();
+
+        let mut seen: Vec<String> = Vec::new();
+        let mut top = self.north_west.clone();
+        // traverse square by columns top to bottom
+        for _i in 0..width {
+            let mut current = top.clone();
+            for _j in 0..height {
+                seen.push(current.clone());
+                current = neighbor(&current, Direction::S).unwrap();
+            }
+            // move top column to the east
+            top = neighbor(&top, Direction::E).unwrap();
+        }
+        seen
+    }
+
+    fn area_width_region_count(&self) -> usize {
+        let mut width_region = 0;
+        // count starting tile
+        if self.north_west != self.north_east {
+            width_region += 1;
+        }
+        let mut current = self.north_west.clone();
+        while current != self.north_east {
+            let east_neighbor = neighbor(&current, Direction::E).unwrap();
+            current = east_neighbor;
+            width_region += 1;
+        }
+        width_region
+    }
+
+    fn area_height_region_count(&self) -> usize {
+        let mut height_region = 0;
+        // count starting tile
+        if self.north_west != self.south_west {
+            height_region += 1;
+        }
+        let mut current = self.north_west.clone();
+        while current != self.south_west {
+            let south_neighbor = neighbor(&current, Direction::S).unwrap();
+            current = south_neighbor;
+            height_region += 1;
+        }
+        height_region
+    }
+
+    /// number of geohashes within the rectangle
+    fn area_region_count(&self) -> usize {
+        self.area_height_region_count() * self.area_width_region_count()
+    }
+
+    fn compute_from_bounding_box(bounding_box: &GeoBoundingBox, geohash_precision: usize) -> Self {
+        let GeoPoint {
+            lat: max_lat,
+            lon: min_lon,
+        } = bounding_box.top_left;
+        let GeoPoint {
+            lat: min_lat,
+            lon: max_lon,
+        } = bounding_box.bottom_right;
+
+        // Unwrap is acceptable, as data should be validated before
+        let north_west = encode((min_lon, max_lat).into(), geohash_precision).unwrap();
+        let south_west = encode((min_lon, min_lat).into(), geohash_precision).unwrap();
+        let south_east = encode((max_lon, min_lat).into(), geohash_precision).unwrap();
+        let north_east = encode((max_lon, max_lat).into(), geohash_precision).unwrap();
+
+        Self {
+            north_west,
+            south_west,
+            south_east,
+            north_east,
+        }
+    }
+}
+
+/// Return as-high-as-possible with maximum of `max_regions`
+/// number of geo-hash guaranteed to contain the whole circle.
+fn circle_hashes(circle: GeoRadius, max_regions: usize) -> Vec<GeoHash> {
+    let rectangle = minimum_bounding_rectangle_for_circle(&circle);
+    let inner_hashes = rectangle_hashes(rectangle, max_regions);
+    filter_hashes_within_circle(inner_hashes, circle)
+}
+
+/// filter geo hashes for which the center is within a circle
+fn filter_hashes_within_circle(hashes: Vec<GeoHash>, circle: GeoRadius) -> Vec<GeoHash> {
+    let radius_km = circle.radius / 1000.0;
+    hashes
+        .into_iter()
+        .map(|h| {
+            let coord = decode(&h).unwrap().0;
+            let geo_point = GeoPoint {
+                lon: coord.x,
+                lat: coord.y,
+            };
+            (h, geo_point)
+        })
+        .filter(|(h, hash_point)| {
+            distance_in_km_between_coordinates(&circle.center, hash_point) <= radius_km
+        })
+        .map(|(h, _)| h)
+        .collect()
+}
+
+/// Return as-high-as-possible with maximum of `max_regions`
+/// number of geo-hash guaranteed to contain the whole rectangle.
+fn rectangle_hashes(rectangle: GeoBoundingBox, max_regions: usize) -> Vec<GeoHash> {
+    let full_geo_bounding_box = FullGeoBoundingBox::from_geo_bounding_box(&rectangle);
+    let shortest_side_km = full_geo_bounding_box.shortest_side_length_in_km();
+    let possible_precisions = geohash_precisions_for_distance(shortest_side_km * 1000.0);
+    // filter precision which generates less than `max_regions`.
+    let rectangle_geohash = possible_precisions
+        .into_iter()
+        .map(|p| RectangleGeoHash::compute_from_bounding_box(&rectangle, p))
+        .take_while(|rectangle_geohash| rectangle_geohash.area_region_count() <= max_regions)
+        .last();
+    match rectangle_geohash {
+        None => Vec::new(),
+        Some(r) => r.geohash_regions(),
+    }
+}
+
+/// Finding the geo precisions fine enough to not completely wrap the `distance_in_meter` with a single tile.
+fn geohash_precisions_for_distance(distance_in_meter: f64) -> Range<usize> {
+    HASH_GRID_SIZE
+        .iter()
+        .enumerate()
+        .find(|(_, (lat_length_in_meters, _))| distance_in_meter > *lat_length_in_meters) // lat > long for all HASH_GRID_SIZE
+        .map(|(index, (_, _))| Range {
+            start: index + 1,
+            end: GEOHASH_MAX_LENGTH + 1, // The upper bound of the range (exclusive).
+        })
+        .unwrap_or_else(|| Range { start: 1, end: 1 })
+}
+
+/// A globally-average value is usually considered to be 6,371 kilometres (3,959 mi) with a 0.3% variability (±10 km).
+/// https://en.wikipedia.org/wiki/Earth_radius.
+const EARTH_RADIUS_KM: f64 = 6371.0;
+
+/// https://rust-lang-nursery.github.io/rust-cookbook/science/mathematics/trigonometry.html#distance-between-two-points-on-the-earth
+fn distance_in_km_between_coordinates(p1: &GeoPoint, p2: &GeoPoint) -> f64 {
+    let GeoPoint {
+        lon: lon1_deg,
+        lat: lat1_deg,
+    } = p1;
+    let GeoPoint {
+        lon: lon2_deg,
+        lat: lat2_deg,
+    } = p2;
+
+    let lat1 = lat1_deg.to_radians();
+    let lat2 = lat2_deg.to_radians();
+
+    let delta_latitude = (lat2_deg - lat1_deg).to_radians();
+    let delta_longitude = (lon2_deg - lon1_deg).to_radians();
+
+    let central_angle_inner = (delta_latitude / 2.0).sin().powi(2)
+        + lat1.cos() * lat2.cos() * (delta_longitude / 2.0).sin().powi(2);
+    let central_angle = 2.0 * central_angle_inner.sqrt().asin();
+
+    let distance = EARTH_RADIUS_KM * central_angle;
+    // rounding decimals
+    (distance * 100.0).round() / 100.0
+}
+
+/// Returns the GeoBoundingBox that defines the MBR
+/// http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates#Longitude
+fn minimum_bounding_rectangle_for_circle(circle: &GeoRadius) -> GeoBoundingBox {
+    // circle.radius is in meter
+    let angular_radius: f64 = (circle.radius / 1000.0) / EARTH_RADIUS_KM;
+    let angular_lat = circle.center.lat.to_radians();
+    let min_lat = (angular_lat - angular_radius).to_degrees();
+    let max_lat = (angular_lat + angular_radius).to_degrees();
+
+    let angular_lon = circle.center.lon.to_radians();
+
+    let delta_lon = (angular_radius.sin() / angular_lat.cos()).asin();
+    let min_lon = (angular_lon - delta_lon).to_degrees();
+    let max_lon = (angular_lon + delta_lon).to_degrees();
+
+    let top_left = GeoPoint {
+        lat: max_lat,
+        lon: min_lon,
+    };
+    let bottom_right = GeoPoint {
+        lat: min_lat,
+        lon: max_lon,
+    };
+
+    GeoBoundingBox {
+        top_left,
+        bottom_right,
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const BERLIN: GeoPoint = GeoPoint {
+        lat: 52.52437,
+        lon: 13.41053,
+    };
+
+    const NYC: GeoPoint = GeoPoint {
+        lat: 40.75798,
+        lon: -73.991516,
+    };
+
     #[test]
-    fn test_circle_hashes() {
-        let near_berlin_circle = GeoRadius {
-            center: GeoPoint {
-                lat: 52.511,
-                lon: 13.423637,
-            },
-            radius: 1000.0,
+    fn geohash_encode_longitude_first() {
+        let center_hash = encode((NYC.lon, NYC.lat).into(), GEOHASH_MAX_LENGTH).unwrap();
+        assert_eq!(center_hash, "dr5ru7c02wnv");
+        let center_hash = encode((NYC.lon, NYC.lat).into(), 6).unwrap();
+        assert_eq!(center_hash, "dr5ru7");
+        let center_hash = encode((BERLIN.lon, BERLIN.lat).into(), GEOHASH_MAX_LENGTH).unwrap();
+        assert_eq!(center_hash, "u33dc1v0xupz");
+        let center_hash = encode((BERLIN.lon, BERLIN.lat).into(), 6).unwrap();
+        assert_eq!(center_hash, "u33dc1");
+    }
+
+    #[test]
+    fn rectangle_geo_hash_nyc() {
+        // data from https://www.titanwolf.org/Network/q/a98ba365-14c5-48f4-8839-86a0962e0ab9/y
+        let near_nyc_circle = GeoRadius {
+            center: NYC,
+            radius: 800.0,
         };
 
-        let berlin_hashes = circle_hashes(near_berlin_circle, 8);
+        let bounding_box = minimum_bounding_rectangle_for_circle(&near_nyc_circle);
+        let rectangle =
+            RectangleGeoHash::compute_from_bounding_box(&bounding_box, GEOHASH_MAX_LENGTH);
+        assert_eq!(rectangle.north_west, "dr5ruj4477kd");
+        assert_eq!(rectangle.south_west, "dr5ru46ne2ux");
+        assert_eq!(rectangle.south_east, "dr5ru6ryw0cp");
+        assert_eq!(rectangle.north_east, "dr5rumpfq534");
+    }
 
-        eprintln!("berlin_hashes = {:#?}", berlin_hashes);
+    #[test]
+    fn top_level_rectangle_geo_area() {
+        let rect = RectangleGeoHash {
+            north_west: "u".to_string(),
+            south_west: "s".to_string(),
+            south_east: "t".to_string(),
+            north_east: "v".to_string(),
+        };
+
+        assert_eq!(rect.area_width_region_count(), 2);
+        assert_eq!(rect.area_height_region_count(), 2);
+        assert_eq!(rect.area_region_count(), 4);
+        assert_eq!(rect.geohash_regions(), vec!["u", "s", "v", "t"]);
+    }
+
+    #[test]
+    fn nyc_rectangle_geo_area_high_precision() {
+        let rect = RectangleGeoHash {
+            north_west: "dr5ruj4477kd".to_string(),
+            south_west: "dr5ru46ne2ux".to_string(),
+            south_east: "dr5ru6ryw0cp".to_string(),
+            north_east: "dr5rumpfq534".to_string(),
+        };
+
+        assert_eq!(rect.area_width_region_count(), 56659);
+        assert_eq!(rect.area_height_region_count(), 85836);
+        assert_eq!(rect.area_region_count(), 56659 * 85836);
+        // calling `rect.geohash_regions()` is too expensive
+    }
+
+    #[test]
+    fn nyc_rectangle_geo_area_medium_precision() {
+        let rect = RectangleGeoHash {
+            north_west: "dr5ruj4".to_string(),
+            south_west: "dr5ru46".to_string(),
+            south_east: "dr5ru6r".to_string(),
+            north_east: "dr5rump".to_string(),
+        };
+
+        assert_eq!(rect.area_width_region_count(), 14);
+        assert_eq!(rect.area_height_region_count(), 12);
+        let region_count = rect.area_region_count();
+        let geo_area = rect.geohash_regions();
+        assert_eq!(region_count, 14 * 12);
+        assert_eq!(region_count, geo_area.len());
+    }
+
+    #[test]
+    fn nyc_rectangle_geo_area_low_precision() {
+        let rect = RectangleGeoHash {
+            north_west: "dr5ruj".to_string(),
+            south_west: "dr5ru4".to_string(),
+            south_east: "dr5ru6".to_string(),
+            north_east: "dr5rum".to_string(),
+        };
+
+        assert_eq!(rect.area_width_region_count(), 2);
+        assert_eq!(rect.area_height_region_count(), 4);
+        let region_count = rect.area_region_count();
+        let geo_area = rect.geohash_regions();
+        assert_eq!(region_count, 2 * 4);
+        assert_eq!(region_count, geo_area.len());
+        assert_eq!(
+            geo_area,
+            vec!["dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6"]
+        );
+    }
+
+    #[test]
+    fn distance_between_points() {
+        let distance = distance_in_km_between_coordinates(&BERLIN, &NYC);
+        assert_eq!(distance, 6380.77);
+        // symmetric
+        let distance = distance_in_km_between_coordinates(&NYC, &BERLIN);
+        assert_eq!(distance, 6380.77);
+        // identity
+        let distance = distance_in_km_between_coordinates(&BERLIN, &BERLIN);
+        assert_eq!(distance, 0.0)
+    }
+
+    #[test]
+    fn validate_possible_geohash_precisions_for_distance() {
+        // based on the dimensions from GEOHASH_MAX_LENGTH
+        assert_eq!(geohash_precisions_for_distance(5010.0 * 1000.0).len(), 12);
+        assert_eq!(geohash_precisions_for_distance(1300.0 * 1000.0).len(), 11);
+        assert_eq!(geohash_precisions_for_distance(157.0 * 1000.0).len(), 10);
+        assert_eq!(geohash_precisions_for_distance(40.0 * 1000.0).len(), 9);
+        assert_eq!(geohash_precisions_for_distance(5.0 * 1000.0).len(), 8);
+        assert_eq!(geohash_precisions_for_distance(2.0 * 1000.0).len(), 7);
+        assert_eq!(geohash_precisions_for_distance(153.0).len(), 6);
+        assert_eq!(geohash_precisions_for_distance(39.0).len(), 5);
+        assert_eq!(geohash_precisions_for_distance(5.0).len(), 4);
+        assert_eq!(geohash_precisions_for_distance(2.0).len(), 3);
+        assert_eq!(geohash_precisions_for_distance(0.15).len(), 2);
+        assert_eq!(geohash_precisions_for_distance(0.1).len(), 1);
+    }
+
+    #[test]
+    fn rectangle_hashes_nyc() {
+        // conversion to lon/lat http://geohash.co/
+        // "dr5ruj4477kd"
+        let top_left = GeoPoint {
+            lon: -74.00101399,
+            lat: 40.76517460,
+        };
+
+        // "dr5ru6ryw0cp"
+        let bottom_right = GeoPoint {
+            lon: -73.98201792,
+            lat: 40.75078539,
+        };
+
+        let near_nyc_rectangle = GeoBoundingBox {
+            top_left,
+            bottom_right,
+        };
+
+        let nyc_hashes = rectangle_hashes(near_nyc_rectangle.clone(), 200);
+        assert_eq!(nyc_hashes.len(), 168);
+        assert!(nyc_hashes.iter().all(|h| h.len() == 7)); // geohash precision
+
+        let nyc_hashes = rectangle_hashes(near_nyc_rectangle.clone(), 10);
+        assert_eq!(nyc_hashes.len(), 8);
+        assert!(nyc_hashes.iter().all(|h| h.len() == 6)); // geohash precision
+        assert_eq!(
+            nyc_hashes,
+            ["dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6"]
+        );
+
+        // Graphical proof using https://www.movable-type.co.uk/scripts/geohash.html
+
+        // dr5rgy dr5run dr5ruq dr5ruw
+        // dr5rgv dr5ruj dr5rum dr5rut
+        // dr5rgu dr5ruh dr5ruk dr5rus
+        // dr5rgg dr5ru5 dr5ru7 dr5rue
+        // dr5rgf dr5ru4 dr5ru6 dr5rud
+        // dr5rgc dr5ru1 dr5ru3 dr5ru9
+
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+        // XXXXXX dr5ruj dr5rum XXXXXX
+        // XXXXXX dr5ruh dr5ruk XXXXXX
+        // XXXXXX dr5ru5 dr5ru7 XXXXXX
+        // XXXXXX dr5ru4 Xr5ru6 XXXXXX
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+
+        // empty result if `max_regions` can not be honored
+        let nyc_hashes = rectangle_hashes(near_nyc_rectangle, 7);
+        assert!(nyc_hashes.is_empty());
+    }
+
+    #[test]
+    fn circle_hashes_nyc() {
+        let near_nyc_circle = GeoRadius {
+            center: NYC,
+            radius: 800.0,
+        };
+
+        let nyc_hashes = circle_hashes(near_nyc_circle.clone(), 200);
+        assert_eq!(nyc_hashes.len(), 115);
+        assert!(nyc_hashes.iter().all(|h| h.len() == 7)); // geohash precision
+
+        let nyc_hashes = circle_hashes(near_nyc_circle.clone(), 10);
+        assert_eq!(nyc_hashes.len(), 4);
+        assert!(nyc_hashes.iter().all(|h| h.len() == 6)); // geohash precision
+        assert_eq!(nyc_hashes, ["dr5ruh", "dr5ru5", "dr5ruk", "dr5ru7"]);
+
+        // Graphical proof using https://www.movable-type.co.uk/scripts/geohash.html
+
+        // dr5rgy dr5run dr5ruq dr5ruw
+        // dr5rgv dr5ruj dr5rum dr5rut
+        // dr5rgu dr5ruh dr5ruk dr5rus
+        // dr5rgg dr5ru5 dr5ru7 dr5rue
+        // dr5rgf dr5ru4 dr5ru6 dr5rud
+        // dr5rgc dr5ru1 dr5ru3 dr5ru9
+
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+        // XXXXXX dr5ruh dr5ruk XXXXXX
+        // XXXXXX dr5ru5 dr5ru7 XXXXXX
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+        // XXXXXX XXXXXX XXXXXX XXXXXX
+
+        // empty result if `max_regions` can not be honored
+        let nyc_hashes = circle_hashes(near_nyc_circle, 7);
+        assert!(nyc_hashes.is_empty());
     }
 }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -297,12 +297,12 @@ mod tests {
             south_east: "t".to_string(),
             north_east: "v".to_string(),
         };
-        let area = rect.geohash_regions(1, 100).unwrap();
+        let mut geo_area = rect.geohash_regions(1, 100).unwrap();
+        let mut expected = vec!["u", "s", "v", "t"];
 
-        assert!(area.contains(&"u".to_string()));
-        assert!(area.contains(&"s".to_string()));
-        assert!(area.contains(&"t".to_string()));
-        assert!(area.contains(&"v".to_string()));
+        geo_area.sort_unstable();
+        expected.sort_unstable();
+        assert_eq!(geo_area, expected);
     }
 
     #[test]
@@ -315,7 +315,6 @@ mod tests {
         };
 
         // calling `rect.geohash_regions()` is too expensive
-
         assert!(rect.geohash_regions(12, 100).is_none());
     }
 
@@ -341,13 +340,14 @@ mod tests {
             north_east: "dr5rum".to_string(),
         };
 
-        let geo_area = rect.geohash_regions(6, 100).unwrap();
-        let expected = vec![
-            "dr5ruj", "dr5ruh", "dr5ru5", "dr5ru4", "dr5rum", "dr5ruk", "dr5ru7", "dr5ru6",
+        let mut geo_area = rect.geohash_regions(6, 100).unwrap();
+        let mut expected = vec![
+            "dr5ru4", "dr5ru5", "dr5ru6", "dr5ru7", "dr5ruh", "dr5ruj", "dr5rum", "dr5ruk",
         ];
-        for geohash in expected {
-            assert!(geo_area.contains(&geohash.to_owned()))
-        }
+
+        expected.sort_unstable();
+        geo_area.sort_unstable();
+        assert_eq!(geo_area, expected);
     }
 
     #[test]
@@ -411,8 +411,8 @@ mod tests {
             let r_meters = rnd.gen_range(1.0..10000.0);
             let query = GeoRadius {
                 center: GeoPoint {
-                    lon: rnd.gen_range(-180.0..180.0),
-                    lat: rnd.gen_range(-90.0..90.0),
+                    lon: rnd.gen_range(LON_RANGE),
+                    lat: rnd.gen_range(LAT_RANGE),
                 },
                 radius: r_meters,
             };

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -60,10 +60,10 @@ fn sphere_lat(lat: f64) -> f64 {
     let min_lat = -90f64;
     let mut res_lat = lat;
     if res_lat > max_lat {
-        res_lat = max_lat - 1e-16;
+        res_lat = max_lat - 1e-10;
     }
     if res_lat < min_lat {
-        res_lat = min_lat + 1e-16;
+        res_lat = min_lat + 1e-10;
     }
     res_lat
 }
@@ -667,27 +667,37 @@ mod tests {
 
     #[test]
     fn go_west() {
-        let mut geohash = sphere_neighbor("ww8p", Direction::W).unwrap();
+        let starting_hash = "ww8";
+        let mut geohash = sphere_neighbor(starting_hash, Direction::W).unwrap();
+        let mut is_earth_round = false;
         for _ in 0..1000 {
             geohash = sphere_neighbor(&geohash, Direction::W).unwrap();
+            if &geohash == starting_hash {
+                is_earth_round = true;
+            }
         }
+        assert!(is_earth_round)
     }
 
     #[test]
     fn sphere_neighbor_corner_cases() {
-        assert_eq!(
-            sphere_neighbor("ww8p1r4t8", Direction::SE).unwrap(),
-            geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap()
-        );
+
+        assert_eq!(&sphere_neighbor("z", Direction::NE).unwrap(), "b");
+        assert_eq!(&sphere_neighbor("zz", Direction::NE).unwrap(), "bp");
+        assert_eq!(&sphere_neighbor("0", Direction::SW).unwrap(), "p");
+        assert_eq!(&sphere_neighbor("00", Direction::SW).unwrap(), "pb");
 
         assert_eq!(&sphere_neighbor("8", Direction::W).unwrap(), "x");
         assert_eq!(&sphere_neighbor("8h", Direction::W).unwrap(), "xu");
         assert_eq!(&sphere_neighbor("r", Direction::E).unwrap(), "2");
         assert_eq!(&sphere_neighbor("ru", Direction::E).unwrap(), "2h");
-        assert_eq!(&sphere_neighbor("z", Direction::NE).unwrap(), "b");
-        assert_eq!(&sphere_neighbor("zz", Direction::NE).unwrap(), "bp");
-        assert_eq!(&sphere_neighbor("0", Direction::SW).unwrap(), "p");
-        assert_eq!(&sphere_neighbor("00", Direction::SW).unwrap(), "pb");
+
+
+        assert_eq!(
+            sphere_neighbor("ww8p1r4t8", Direction::SE).unwrap(),
+            geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap()
+        );
+
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -343,8 +343,8 @@ fn minimum_bounding_rectangle_for_circle(circle: &GeoRadius) -> GeoBoundingBox {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, SeedableRng};
     use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     const BERLIN: GeoPoint = GeoPoint {
         lat: 52.52437,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -45,8 +45,8 @@ struct FullGeoBoundingBox {
     north_east: GeoPoint,
 }
 
-impl FullGeoBoundingBox {
-    fn from_geo_bounding_box(bounding_box: &GeoBoundingBox) -> Self {
+impl From<&GeoBoundingBox> for FullGeoBoundingBox {
+    fn from(bounding_box: &GeoBoundingBox) -> Self {
         let GeoPoint {
             lat: max_lat,
             lon: min_lon,
@@ -80,7 +80,10 @@ impl FullGeoBoundingBox {
             north_east,
         }
     }
+}
 
+
+impl FullGeoBoundingBox {
     fn shortest_side_length_in_km(&self) -> f64 {
         // the projection on the sphere is a trapeze - calculate 3 distances
         let upper_width = distance_in_km_between_coordinates(&self.north_west, &self.north_east);
@@ -107,10 +110,10 @@ impl RectangleGeoHash {
 
         let mut seen: Vec<String> = Vec::new();
         let mut top = self.north_west.clone();
-        // traverse square by columns top to bottom
-        for _i in 0..width {
+        // traverse tiles matrix by columns - top to bottom
+        for _ in 0..width {
             let mut current = top.clone();
-            for _j in 0..height {
+            for _ in 0..height {
                 seen.push(current.clone());
                 current = neighbor(&current, Direction::S).unwrap();
             }
@@ -211,7 +214,7 @@ fn filter_hashes_within_circle(hashes: Vec<GeoHash>, circle: GeoRadius) -> Vec<G
 /// Return as-high-as-possible with maximum of `max_regions`
 /// number of geo-hash guaranteed to contain the whole rectangle.
 fn rectangle_hashes(rectangle: GeoBoundingBox, max_regions: usize) -> Vec<GeoHash> {
-    let full_geo_bounding_box = FullGeoBoundingBox::from_geo_bounding_box(&rectangle);
+    let full_geo_bounding_box: FullGeoBoundingBox = (&rectangle).into();
     let shortest_side_km = full_geo_bounding_box.shortest_side_length_in_km();
     let possible_precisions = geohash_precisions_for_distance(shortest_side_km * 1000.0);
     // filter precision which generates less than `max_regions`.

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -1,1 +1,67 @@
+use geo::Coordinate;
+use geohash::encode;
+use crate::types::{GeoPoint, GeoRadius};
 
+type GeoHash = String;
+
+/// Max size of geo-hash used for indexing. size=12 is about 6cm2
+const GEOHASH_MAX_LENGTH: usize = 12;
+
+/// Size of geo-hash grid depending of the length of hash.
+/// Format:
+///   For hash length: N = 4
+///   let (lat_length_in_meters, long_length_in_meters) = HASH_GRID_SIZE[N - 1];
+/// Source: <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator>
+const HASH_GRID_SIZE: &'static [(f64, f64)] = &[
+    (5009.4 * 1000.0, 4992.6 * 1000.0),
+    (1252.3 * 1000.0, 624.1 * 1000.0),
+    (156.5 * 1000.0, 156.0 * 1000.0),
+    (39.1 * 1000.0, 19.5 * 1000.0),
+    (4.9 * 1000.0, 4.9 * 1000.0),
+    (1.2 * 1000.0, 609.4),
+    (152.9, 152.4),
+    (38.2, 19.),
+    (4.8, 4.8),
+    (1.2, 0.595),
+    (0.149, 0.149),
+    (0.037, 0.019),
+];
+
+impl From<GeoPoint> for Coordinate<f64> {
+    fn from(point: GeoPoint) -> Self {
+        Self {
+            x: point.lat,
+            y: point.lon
+        }
+    }
+}
+
+/// Return as-small-as-possible with maximum of `max_regions`
+/// number of geo-hash guaranteed to contain whole circle.
+fn circle_hashes(circle: GeoRadius, max_regions: usize) -> Vec<GeoHash> {
+    // Unwrap is acceptable, as data should be validated before
+    let center_full_hash = encode(circle.center.into(), GEOHASH_MAX_LENGTH).unwrap();
+
+    vec![center_full_hash]
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_circle_hashes() {
+        let near_berlin_circle = GeoRadius {
+            center: GeoPoint {
+                lat: 52.511,
+                lon: 13.423637,
+            },
+            radius: 1000.0,
+        };
+
+        let berlin_hashes = circle_hashes(near_berlin_circle, 8);
+
+        eprintln!("berlin_hashes = {:#?}", berlin_hashes);
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -681,7 +681,6 @@ mod tests {
 
     #[test]
     fn sphere_neighbor_corner_cases() {
-
         assert_eq!(&sphere_neighbor("z", Direction::NE).unwrap(), "b");
         assert_eq!(&sphere_neighbor("zz", Direction::NE).unwrap(), "bp");
         assert_eq!(&sphere_neighbor("0", Direction::SW).unwrap(), "p");
@@ -692,12 +691,10 @@ mod tests {
         assert_eq!(&sphere_neighbor("r", Direction::E).unwrap(), "2");
         assert_eq!(&sphere_neighbor("ru", Direction::E).unwrap(), "2h");
 
-
         assert_eq!(
             sphere_neighbor("ww8p1r4t8", Direction::SE).unwrap(),
             geohash::neighbor("ww8p1r4t8", Direction::SE).unwrap()
         );
-
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -2,6 +2,7 @@ use crate::types::{FieldCondition, PointOffsetType};
 use std::collections::HashSet;
 
 mod field_index_base;
+#[allow(dead_code)]
 pub mod geo_index;
 pub mod index_selector;
 pub mod map_index;

--- a/lib/segment/src/lib.rs
+++ b/lib/segment/src/lib.rs
@@ -12,6 +12,7 @@ pub mod vector_storage;
 
 #[macro_use]
 extern crate num_derive;
+extern crate core;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
issue context: https://github.com/qdrant/qdrant/issues/313

The goal of this PR is to turn a geo query into a set of [geohashes](https://en.wikipedia.org/wiki/Geohash) to probe later on the indexer for matching points (in a follow up PR).

To do so it introduces two main functions to deal with either circle or rectangle areas:

```rust
/// Return as-high-as-possible with maximum of `max_regions`
/// number of geo-hash guaranteed to contain the whole circle.
fn circle_hashes(circle: GeoRadius, max_regions: usize) -> Vec<GeoHash> {}

/// Return as-high-as-possible with maximum of `max_regions`
/// number of geo-hash guaranteed to contain the whole rectangle.
fn rectangle_hashes(rectangles: GeoBoundingBox, max_regions: usize) -> Vec<GeoHash> {}
```

Those functions work by estimating the `geohash` precisions possible to describe the area and select the highest precision which yields less than `max_regions`.

Notes for the reviewers:
- ~~the circle implementation relies on the rectangles implementation with additional filtering~~
- some unit tests contain comments to visualize the results in 2D

