### PR TITLE
Better optimizer error reporting + small bug fixes

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -112,6 +112,9 @@
             "minimum": 0,
             "type": "integer"
           },
+          "optimizer_status": {
+            "$ref": "#/components/schemas/OptimizersStatus"
+          },
           "payload_schema": {
             "additionalProperties": {
               "$ref": "#/components/schemas/PayloadSchemaInfo"
@@ -144,6 +147,7 @@
         "required": [
           "config",
           "disk_data_size",
+          "optimizer_status",
           "payload_schema",
           "ram_data_size",
           "segments_count",
@@ -882,6 +886,30 @@
           }
         },
         "type": "object"
+      },
+      "OptimizersStatus": {
+        "description": "Current state of the collection",
+        "oneOf": [
+          {
+            "enum": [
+              "ok"
+            ],
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Something wrong happened with optimizers",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "error"
+            ],
+            "type": "object"
+          }
+        ]
       },
       "PayloadInterface": {
         "anyOf": [

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -22,7 +22,10 @@ use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::config::CollectionConfig;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
-use crate::operations::types::{CollectionError, CollectionInfo, CollectionResult, CollectionStatus, OptimizersStatus, RecommendRequest, ScrollRequest, ScrollResult, SearchRequest, UpdateResult, UpdateStatus};
+use crate::operations::types::{
+    CollectionError, CollectionInfo, CollectionResult, CollectionStatus, OptimizersStatus,
+    RecommendRequest, ScrollRequest, ScrollResult, SearchRequest, UpdateResult, UpdateStatus,
+};
 use crate::operations::CollectionUpdateOperations;
 use crate::update_handler::{OperationData, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
@@ -298,7 +301,7 @@ impl Collection {
 
         let optimizer_status = match &segments.optimizer_errors {
             None => OptimizersStatus::Ok,
-            Some(error) => OptimizersStatus::Error(error.to_string())
+            Some(error) => OptimizersStatus::Error(error.to_string()),
         };
 
         Ok(CollectionInfo {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -13,6 +13,7 @@ use segment::types::{PointIdType, SeqNumberType};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use std::ops::Mul;
 use std::time::Duration;
+use crate::operations::types::CollectionError;
 
 pub type SegmentId = usize;
 
@@ -75,6 +76,9 @@ pub struct SegmentHolder {
     /// Seq number of the first un-recovered operation.
     /// If there are no failed operation - None
     pub failed_operation: BTreeSet<SeqNumberType>,
+
+    /// Holds the first uncorrected error happened with optimizer
+    pub optimizer_errors: Option<CollectionError>,
 }
 
 pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;
@@ -118,18 +122,15 @@ impl<'s> SegmentHolder {
         key
     }
 
-    pub fn remove(&mut self, remove_ids: &[SegmentId], drop_data: bool) -> OperationResult<()> {
+    pub fn remove(&mut self, remove_ids: &[SegmentId]) -> Vec<LockedSegment> {
+        let mut removed_segments = vec![];
         for remove_id in remove_ids {
             let removed_segment = self.segments.remove(remove_id);
-
-            if drop_data {
-                match removed_segment {
-                    None => {}
-                    Some(segment) => segment.drop_data()?,
-                }
+            if let Some(segment) = removed_segment {
+                removed_segments.push(segment);
             }
         }
-        Ok(())
+        removed_segments
     }
 
     /// Replace old segments with a new one
@@ -138,24 +139,21 @@ impl<'s> SegmentHolder {
     ///
     /// * `segment` - segment to insert
     /// * `remove_ids` - ids of segments to replace
-    /// * `drop_data` - if `true` - also drop data of removed segments
     ///
     /// # Result
     ///
-    /// id of newly inserted segment
+    /// Pair of (id of newly inserted segment, Vector of replaced segments)
     ///
     pub fn swap<T>(
         &mut self,
         segment: T,
         remove_ids: &[SegmentId],
-        drop_data: bool,
-    ) -> OperationResult<SegmentId>
+    ) -> (SegmentId, Vec<LockedSegment>)
     where
         T: Into<LockedSegment>,
     {
         let new_id = self.add(segment);
-        self.remove(remove_ids, drop_data)?;
-        Ok(new_id)
+        (new_id, self.remove(remove_ids))
     }
 
     pub fn get(&self, id: SegmentId) -> Option<&LockedSegment> {
@@ -243,9 +241,9 @@ impl<'s> SegmentHolder {
         F: FnMut(SegmentId, &mut RwLockWriteGuard<dyn SegmentEntry>) -> OperationResult<bool>,
     {
         if segment_ids.is_empty() {
-            return Err(OperationError::ServiceError {
-                description: "No appendable segments exists, expected at least one".to_string(),
-            });
+            return Err(OperationError::service_error(
+                "No appendable segments exists, expected at least one",
+            ));
         }
 
         let mut entries: Vec<_> = Default::default();
@@ -405,7 +403,10 @@ mod tests {
             build_simple_segment(dir.path(), 4, Distance::Dot, Arc::new(SchemaStorage::new()))
                 .unwrap();
 
-        let _sid3 = holder.swap(segment3, &[sid1, sid2], true).unwrap();
+        let (_sid3, replaced_segments) = holder.swap(segment3, &[sid1, sid2]);
+        replaced_segments
+            .into_iter()
+            .for_each(|s| s.drop_data().unwrap());
     }
 
     #[test]

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -11,9 +11,9 @@ use segment::segment::Segment;
 use segment::types::{PointIdType, SeqNumberType};
 
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
+use crate::operations::types::CollectionError;
 use std::ops::Mul;
 use std::time::Duration;
-use crate::operations::types::CollectionError;
 
 pub type SegmentId = usize;
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -162,10 +162,8 @@ pub trait SegmentOptimizer {
                     }
                     LockedSegment::Proxy(proxy_segment) => {
                         let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
-                        let (restored_id, _proxies) = segments_lock.swap(
-                            wrapped_segment,
-                            &[proxy_id],
-                        );
+                        let (restored_id, _proxies) =
+                            segments_lock.swap(wrapped_segment, &[proxy_id]);
                         restored_segment_ids.push(restored_id);
                     }
                 }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -149,7 +149,7 @@ pub trait SegmentOptimizer {
         &self,
         segments: &LockedSegmentHolder,
         proxy_ids: &[SegmentId],
-    ) -> CollectionResult<Vec<SegmentId>> {
+    ) -> Vec<SegmentId> {
         let mut segments_lock = segments.write();
         let mut restored_segment_ids = vec![];
         for &proxy_id in proxy_ids {
@@ -162,16 +162,16 @@ pub trait SegmentOptimizer {
                     }
                     LockedSegment::Proxy(proxy_segment) => {
                         let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
-                        restored_segment_ids.push(segments_lock.swap(
+                        let (restored_id, _proxies) = segments_lock.swap(
                             wrapped_segment,
                             &[proxy_id],
-                            false,
-                        )?);
+                        );
+                        restored_segment_ids.push(restored_id);
                     }
                 }
             }
         }
-        Ok(restored_segment_ids)
+        restored_segment_ids
     }
 
     /// Checks if optimization cancellation is requested.
@@ -203,13 +203,12 @@ pub trait SegmentOptimizer {
         segments: &LockedSegmentHolder,
         proxy_ids: &[SegmentId],
         temp_segment: &LockedSegment,
-    ) -> CollectionResult<()> {
-        self.unwrap_proxy(segments, proxy_ids)?;
+    ) {
+        self.unwrap_proxy(segments, proxy_ids);
         if temp_segment.get().read().vectors_count() > 0 {
             let mut write_segments = segments.write();
             write_segments.add_locked(temp_segment.clone());
         }
-        Ok(())
     }
 
     /// Function to wrap slow part of optimization. Performs proxy rollback in case of cancellation.
@@ -358,7 +357,7 @@ pub trait SegmentOptimizer {
 
             proxies
                 .zip(ids.iter().cloned())
-                .map(|(proxy, idx)| write_segments.swap(proxy, &[idx], false).unwrap())
+                .map(|(proxy, idx)| write_segments.swap(proxy, &[idx]).0)
                 .collect()
         };
 
@@ -373,7 +372,7 @@ pub trait SegmentOptimizer {
             Ok(segment) => segment,
             Err(error) => {
                 if matches!(error, CollectionError::Cancelled { .. }) {
-                    self.handle_cancellation(&segments, &proxy_ids, &tmp_segment)?;
+                    self.handle_cancellation(&segments, &proxy_ids, &tmp_segment);
                 }
                 return Err(error);
             }
@@ -414,7 +413,7 @@ pub trait SegmentOptimizer {
                     .create_field_index(optimized_segment.version(), created_field_name)?;
             }
 
-            write_segments.swap(optimized_segment, &proxy_ids, true)?;
+            let (_, proxies) = write_segments.swap(optimized_segment, &proxy_ids);
 
             let has_appendable_segments = write_segments.random_appendable_segment().is_some();
 
@@ -423,6 +422,12 @@ pub trait SegmentOptimizer {
                 write_segments.add_locked(tmp_segment);
             } else {
                 tmp_segment.drop_data()?;
+            }
+
+            // Only remove data after we ensure the consistency of the collection.
+            // If remove fails - we will till have operational collection with reported error.
+            for proxy in proxies {
+                proxy.drop_data()?;
             }
         }
         Ok(true)

--- a/lib/collection/src/collection_manager/simple_collection_searcher.rs
+++ b/lib/collection/src/collection_manager/simple_collection_searcher.rs
@@ -97,9 +97,7 @@ impl CollectionSearcher for SimpleCollectionSearcher {
         segments.read().read_points(points, |id, segment| {
             let version = segment
                 .point_version(id)
-                .ok_or(OperationError::ServiceError {
-                    description: format!("No version for point {}", id),
-                })?;
+                .ok_or(OperationError::service_error( &format!("No version for point {}", id)))?;
             // If this point was not found yet or this segment have later version
             if !point_version.contains_key(&id) || point_version[&id] < version {
                 point_records.insert(

--- a/lib/collection/src/collection_manager/simple_collection_searcher.rs
+++ b/lib/collection/src/collection_manager/simple_collection_searcher.rs
@@ -97,7 +97,10 @@ impl CollectionSearcher for SimpleCollectionSearcher {
         segments.read().read_points(points, |id, segment| {
             let version = segment
                 .point_version(id)
-                .ok_or(OperationError::service_error( &format!("No version for point {}", id)))?;
+                .ok_or(OperationError::service_error(&format!(
+                    "No version for point {}",
+                    id
+                )))?;
             // If this point was not found yet or this segment have later version
             if !point_version.contains_key(&id) || point_version[&id] < version {
                 point_records.insert(

--- a/lib/collection/src/collection_manager/simple_collection_searcher.rs
+++ b/lib/collection/src/collection_manager/simple_collection_searcher.rs
@@ -95,12 +95,9 @@ impl CollectionSearcher for SimpleCollectionSearcher {
         let mut point_records: HashMap<PointIdType, Record> = Default::default();
 
         segments.read().read_points(points, |id, segment| {
-            let version = segment
-                .point_version(id)
-                .ok_or(OperationError::service_error(&format!(
-                    "No version for point {}",
-                    id
-                )))?;
+            let version = segment.point_version(id).ok_or_else(|| {
+                OperationError::service_error(&format!("No version for point {}", id))
+            })?;
             // If this point was not found yet or this segment have later version
             if !point_version.contains_key(&id) || point_version[&id] < version {
                 point_records.insert(

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -32,7 +32,8 @@ fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> Seg
         proxy_created_indexes,
     );
 
-    write_segments.swap(proxy, &[sid], false).unwrap()
+    let (new_id, _replaced_segments) = write_segments.swap(proxy, &[sid]);
+    new_id
 }
 
 #[test]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -36,6 +36,16 @@ pub enum CollectionStatus {
     Red,
 }
 
+/// Current state of the collection
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OptimizersStatus {
+    /// Optimizers are reporting as expected
+    Ok,
+    /// Something wrong happened with optimizers
+    Error(String),
+}
+
 /// Point data
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -53,6 +63,8 @@ pub struct Record {
 pub struct CollectionInfo {
     /// Status of the collection
     pub status: CollectionStatus,
+    /// Status of optimizers
+    pub optimizer_status: OptimizersStatus,
     /// Number of vectors in collection
     pub vectors_count: usize,
     /// Number of segments in collection

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -39,13 +39,13 @@ async fn test_optimization_process() {
     let optimizers = Arc::new(vec![merge_optimizer, indexing_optimizer]);
 
     let segments = Arc::new(RwLock::new(holder));
-    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone());
+    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
 
     assert_eq!(handles.len(), 2);
 
     let join_res = join_all(handles.into_iter().map(|x| x.join_handle).collect_vec()).await;
 
-    let handles_2 = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone());
+    let handles_2 = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
 
     assert_eq!(handles_2.len(), 0);
 
@@ -82,7 +82,7 @@ async fn test_cancel_optimization() {
     let now = Instant::now();
 
     let segments = Arc::new(RwLock::new(holder));
-    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone());
+    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
 
     sleep(Duration::from_millis(100)).await;
 

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -45,7 +45,8 @@ async fn test_optimization_process() {
 
     let join_res = join_all(handles.into_iter().map(|x| x.join_handle).collect_vec()).await;
 
-    let handles_2 = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
+    let handles_2 =
+        UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
 
     assert_eq!(handles_2.len(), 0);
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -162,7 +162,7 @@ impl UpdateHandler {
     where
         F: FnOnce(bool) -> (),
         F: Send + 'static,
-        F: Clone
+        F: Clone,
     {
         let mut scheduled_segment_ids: HashSet<_> = Default::default();
         let mut handles = vec![];

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -94,6 +94,7 @@ impl UpdateHandler {
         let (tx, rx) = mpsc::unbounded_channel();
         self.optimizer_worker = Some(self.runtime_handle.spawn(Self::optimization_worker_fn(
             self.optimizers.clone(),
+            tx.clone(),
             rx,
             self.segments.clone(),
             self.wal.clone(),
@@ -153,10 +154,16 @@ impl UpdateHandler {
     /// Checks conditions for all optimizers until there is no suggested segment
     /// Starts a task for each optimization
     /// Returns handles for started tasks
-    pub(crate) fn launch_optimization(
+    pub(crate) fn launch_optimization<F>(
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         segments: LockedSegmentHolder,
-    ) -> Vec<StoppableTaskHandle<bool>> {
+        callback: F,
+    ) -> Vec<StoppableTaskHandle<bool>>
+    where
+        F: FnOnce(bool) -> (),
+        F: Send + 'static,
+        F: Clone
+    {
         let mut scheduled_segment_ids: HashSet<_> = Default::default();
         let mut handles = vec![];
         for optimizer in optimizers.iter() {
@@ -172,20 +179,33 @@ impl UpdateHandler {
                     for sid in &nsi {
                         scheduled_segment_ids.insert(*sid);
                     }
+                    let callback_cloned = callback.clone();
 
                     handles.push(spawn_stoppable(move |stopped| {
-                        match optim.as_ref().optimize(segs, nsi, stopped) {
-                            Ok(result) => result,
+                        match optim.as_ref().optimize(segs.clone(), nsi, stopped) {
+                            Ok(result) => {
+                                callback_cloned(result); // Perform some actions when optimization if finished
+                                result
+                            }
                             Err(error) => match error {
                                 CollectionError::Cancelled { description } => {
                                     log::info!("Optimization cancelled - {}", description);
                                     false
                                 }
                                 _ => {
+                                    {
+                                        let mut segments_write = segs.write();
+                                        if segments_write.optimizer_errors.is_none() {
+                                            // Save only the first error
+                                            // If is more likely to be the real cause of all further problems
+                                            segments_write.optimizer_errors = Some(error.clone());
+                                        }
+                                    }
                                     // Error of the optimization can not be handled by API user
                                     // It is only possible to fix after full restart,
                                     // so the best available action here is to stop whole
                                     // optimization thread and log the error
+                                    log::error!("Optimization error: {}", error);
                                     panic!("Optimization error: {}", error);
                                 }
                             },
@@ -201,8 +221,18 @@ impl UpdateHandler {
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         segments: LockedSegmentHolder,
         optimization_handles: Arc<Mutex<Vec<StoppableTaskHandle<bool>>>>,
+        sender: UnboundedSender<OptimizerSignal>,
     ) {
-        let mut new_handles = Self::launch_optimization(optimizers.clone(), segments.clone());
+        let mut new_handles = Self::launch_optimization(
+            optimizers.clone(),
+            segments.clone(),
+            move |_optimization_result| {
+                // After optimization is finished, we still need to check if there are
+                // some further optimizations possible.
+                // If receiver is already dead - we do not care.
+                let _ = sender.send(OptimizerSignal::Nop);
+            },
+        );
         let mut handles = optimization_handles.lock().await;
         handles.append(&mut new_handles);
         handles.retain(|h| !h.is_finished())
@@ -210,6 +240,7 @@ impl UpdateHandler {
 
     async fn optimization_worker_fn(
         optimizers: Arc<Vec<Arc<Optimizer>>>,
+        sender: UnboundedSender<OptimizerSignal>,
         mut receiver: UnboundedReceiver<OptimizerSignal>,
         segments: LockedSegmentHolder,
         wal: Arc<Mutex<SerdeWal<CollectionUpdateOperations>>>,
@@ -231,6 +262,7 @@ impl UpdateHandler {
                         optimizers.clone(),
                         segments.clone(),
                         optimization_handles.clone(),
+                        sender.clone(),
                     )
                     .await;
                 }
@@ -245,6 +277,7 @@ impl UpdateHandler {
                         optimizers.clone(),
                         segments.clone(),
                         optimization_handles.clone(),
+                        sender.clone(),
                     )
                     .await;
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -160,7 +160,7 @@ impl UpdateHandler {
         callback: F,
     ) -> Vec<StoppableTaskHandle<bool>>
     where
-        F: FnOnce(bool) -> (),
+        F: FnOnce(bool),
         F: Send + 'static,
         F: Clone,
     {

--- a/lib/segment/src/common/file_operations.rs
+++ b/lib/segment/src/common/file_operations.rs
@@ -35,14 +35,13 @@ pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResul
     let mut file = File::open(path)?;
     file.read_to_string(&mut contents)?;
 
-    let result: N =
-        serde_json::from_str(&contents).map_err(|err| OperationError::ServiceError {
-            description: format!(
-                "Failed to read data {}. Error: {}",
-                path.to_str().unwrap(),
-                err
-            ),
-        })?;
+    let result: N = serde_json::from_str(&contents).map_err(|err| {
+        OperationError::service_error(&format!(
+            "Failed to read data {}. Error: {}",
+            path.to_str().unwrap(),
+            err
+        ))
+    })?;
 
     Ok(result)
 }
@@ -50,14 +49,13 @@ pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResul
 pub fn read_bin<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResult<N> {
     let mut file = File::open(path)?;
 
-    let result: N =
-        bincode::deserialize_from(&mut file).map_err(|err| OperationError::ServiceError {
-            description: format!(
-                "Failed to read data {}. Error: {}",
-                path.to_str().unwrap(),
-                err
-            ),
-        })?;
+    let result: N = bincode::deserialize_from(&mut file).map_err(|err| {
+        OperationError::service_error(&format!(
+            "Failed to read data {}. Error: {}",
+            path.to_str().unwrap(),
+            err
+        ))
+    })?;
 
     Ok(result)
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -29,6 +29,14 @@ pub enum OperationError {
     Cancelled { description: String },
 }
 
+impl OperationError {
+    pub fn service_error(description: &str) -> OperationError {
+        OperationError::ServiceError {
+            description: description.to_string(),
+        }
+    }
+}
+
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed
 #[derive(Debug, Clone)]
 pub struct SegmentFailedState {
@@ -41,34 +49,28 @@ impl<E> From<AtomicIoError<E>> for OperationError {
     fn from(err: AtomicIoError<E>) -> Self {
         match err {
             AtomicIoError::Internal(io_err) => OperationError::from(io_err),
-            AtomicIoError::User(_user_err) => OperationError::ServiceError {
-                description: "Unknown atomic write error".to_owned(),
-            },
+            AtomicIoError::User(_user_err) => {
+                OperationError::service_error("Unknown atomic write error")
+            }
         }
     }
 }
 
 impl From<IoError> for OperationError {
     fn from(err: IoError) -> Self {
-        OperationError::ServiceError {
-            description: format!("{}", err),
-        }
+        OperationError::service_error(&format!("IO Error: {}", err))
     }
 }
 
 impl From<Error> for OperationError {
     fn from(err: Error) -> Self {
-        OperationError::ServiceError {
-            description: format!("persistence error: {}", err),
-        }
+        OperationError::service_error(&format!("persistence error: {}", err))
     }
 }
 
 impl From<serde_json::Error> for OperationError {
     fn from(err: serde_json::Error) -> Self {
-        OperationError::ServiceError {
-            description: format!("Json error: {}", err),
-        }
+        OperationError::service_error(&format!("Json error: {}", err))
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -102,9 +102,7 @@ impl StructPayloadIndex {
             Some(indexes) => {
                 let file = File::create(&field_index_path)?;
                 serde_cbor::to_writer(file, indexes).map_err(|err| {
-                    OperationError::ServiceError {
-                        description: format!("Unable to save index: {:?}", err),
-                    }
+                    OperationError::service_error(&format!("Unable to save index: {:?}", err))
                 })?;
             }
         }
@@ -123,10 +121,9 @@ impl StructPayloadIndex {
                 field_index_path.to_str().unwrap()
             );
             let file = File::open(field_index_path)?;
-            let field_indexes: Vec<FieldIndex> =
-                serde_cbor::from_reader(file).map_err(|err| OperationError::ServiceError {
-                    description: format!("Unable to load index: {:?}", err),
-                })?;
+            let field_indexes: Vec<FieldIndex> = serde_cbor::from_reader(file).map_err(|err| {
+                OperationError::service_error(&format!("Unable to load index: {:?}", err))
+            })?;
 
             Ok(field_indexes)
         } else {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -260,20 +260,18 @@ impl SegmentEntry for Segment {
             .iter()
             .map(|&scored_point_offset| {
                 let point_offset = scored_point_offset.idx;
-                let point_id =
-                    id_tracker
-                        .external_id(point_offset)
-                        .ok_or(OperationError::service_error(&format!(
-                            "Corrupter id_tracker, no external value for {}",
-                            scored_point_offset.idx
-                        )))?;
-                let point_version =
-                    id_tracker
-                        .version(point_id)
-                        .ok_or(OperationError::service_error(&format!(
-                            "Corrupter id_tracker, no version for point {}",
-                            point_id
-                        )))?;
+                let point_id = id_tracker.external_id(point_offset).ok_or_else(|| {
+                    OperationError::service_error(&format!(
+                        "Corrupter id_tracker, no external value for {}",
+                        scored_point_offset.idx
+                    ))
+                })?;
+                let point_version = id_tracker.version(point_id).ok_or_else(|| {
+                    OperationError::service_error(&format!(
+                        "Corrupter id_tracker, no version for point {}",
+                        point_id
+                    ))
+                })?;
                 let payload = if with_payload.enable {
                     let initial_payload = self.payload_by_offset(point_offset)?;
                     let processed_payload = if let Some(i) = &with_payload.payload_selector {
@@ -574,13 +572,13 @@ impl SegmentEntry for Segment {
         let mut deleted_path = self.current_path.clone();
         deleted_path.set_extension("deleted");
         rename(&self.current_path, &deleted_path)?;
-        Ok(remove_dir_all(&deleted_path).map_err(|err| {
+        remove_dir_all(&deleted_path).map_err(|err| {
             OperationError::service_error(&format!(
                 "Can't remove segment data at {}, error: {}",
                 deleted_path.to_str().unwrap_or_default(),
                 err
             ))
-        })?)
+        })
     }
 
     fn delete_field_index(&mut self, op_num: u64, key: PayloadKeyTypeRef) -> OperationResult<bool> {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -90,9 +90,10 @@ impl Segment {
             // Failed operations should not be skipped,
             // fail if newer operation is attempted before proper recovery
             if *failed_version < op_num {
-                return Err(OperationError::ServiceError {
-                    description: format!("Not recovered from previous error: {}", error),
-                });
+                return Err(OperationError::service_error(&format!(
+                    "Not recovered from previous error: {}",
+                    error
+                )));
             } // else: Re-try operation
         }
 
@@ -262,21 +263,17 @@ impl SegmentEntry for Segment {
                 let point_id =
                     id_tracker
                         .external_id(point_offset)
-                        .ok_or(OperationError::ServiceError {
-                            description: format!(
-                                "Corrupter id_tracker, no external value for {}",
-                                scored_point_offset.idx
-                            ),
-                        })?;
+                        .ok_or(OperationError::service_error(&format!(
+                            "Corrupter id_tracker, no external value for {}",
+                            scored_point_offset.idx
+                        )))?;
                 let point_version =
                     id_tracker
                         .version(point_id)
-                        .ok_or(OperationError::ServiceError {
-                            description: format!(
-                                "Corrupter id_tracker, no version for point {}",
-                                point_id
-                            ),
-                        })?;
+                        .ok_or(OperationError::service_error(&format!(
+                            "Corrupter id_tracker, no version for point {}",
+                            point_id
+                        )))?;
                 let payload = if with_payload.enable {
                     let initial_payload = self.payload_by_offset(point_offset)?;
                     let processed_payload = if let Some(i) = &with_payload.payload_selector {
@@ -577,7 +574,13 @@ impl SegmentEntry for Segment {
         let mut deleted_path = self.current_path.clone();
         deleted_path.set_extension("deleted");
         rename(&self.current_path, &deleted_path)?;
-        Ok(remove_dir_all(&deleted_path)?)
+        Ok(remove_dir_all(&deleted_path).map_err(|err| {
+            OperationError::service_error(&format!(
+                "Can't remove segment data at {}, error: {}",
+                deleted_path.to_str().unwrap_or_default(),
+                err
+            ))
+        })?)
     }
 
     fn delete_field_index(&mut self, op_num: u64, key: PayloadKeyTypeRef) -> OperationResult<bool> {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -54,9 +54,9 @@ impl SegmentBuilder {
     ///
     pub fn update_from(&mut self, other: &Segment, stopped: &AtomicBool) -> OperationResult<bool> {
         match &mut self.segment {
-            None => Err(OperationError::ServiceError {
-                description: "Segment building error: created segment not found".to_owned(),
-            }),
+            None => Err(OperationError::service_error(
+                "Segment building error: created segment not found",
+            )),
             Some(self_segment) => {
                 self_segment.version = cmp::max(self_segment.version(), other.version());
 
@@ -124,9 +124,9 @@ impl SegmentBuilder {
 
     pub fn build(mut self, stopped: &AtomicBool) -> Result<Segment, OperationError> {
         {
-            let mut segment = self.segment.ok_or(OperationError::ServiceError {
-                description: "Segment building error: created segment not found".to_owned(),
-            })?;
+            let mut segment = self.segment.ok_or(OperationError::service_error(
+                "Segment building error: created segment not found",
+            ))?;
             self.segment = None;
 
             for field in &self.indexed_fields {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -124,9 +124,9 @@ impl SegmentBuilder {
 
     pub fn build(mut self, stopped: &AtomicBool) -> Result<Segment, OperationError> {
         {
-            let mut segment = self.segment.ok_or(OperationError::service_error(
-                "Segment building error: created segment not found",
-            ))?;
+            let mut segment = self.segment.ok_or_else(|| {
+                OperationError::service_error("Segment building error: created segment not found")
+            })?;
             self.segment = None;
 
             for field in &self.indexed_fields {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -123,14 +123,13 @@ pub fn load_segment(path: &Path, schema_storage: Arc<SchemaStorage>) -> Operatio
     let mut file = File::open(segment_config_path)?;
     file.read_to_string(&mut contents)?;
 
-    let segment_state: SegmentState =
-        serde_json::from_str(&contents).map_err(|err| OperationError::ServiceError {
-            description: format!(
-                "Failed to read segment {}. Error: {}",
-                path.to_str().unwrap(),
-                err
-            ),
-        })?;
+    let segment_state: SegmentState = serde_json::from_str(&contents).map_err(|err| {
+        OperationError::service_error(&format!(
+            "Failed to read segment {}. Error: {}",
+            path.to_str().unwrap(),
+            err
+        ))
+    })?;
 
     create_segment(
         segment_state.version,

--- a/lib/segment/tests/fail_recovery_test.rs
+++ b/lib/segment/tests/fail_recovery_test.rs
@@ -21,9 +21,7 @@ mod tests {
         segment.error_status = Some(SegmentFailedState {
             version: 2,
             point_id: Some(1.into()),
-            error: OperationError::ServiceError {
-                description: "test error".to_string(),
-            },
+            error: OperationError::service_error("test error"),
         });
 
         // op_num is greater than errored. Skip because not recovered yet


### PR DESCRIPTION
this PR includes:

- New status field for optimizer error: if optimizer fails with error - it will be displayed in collection info, status of the collection will be `Red`
- Decouple segment exclusion from the collection and actual data removing. If data removing fails - all required segment swaps will still be performed. It also allowed to make some functions pure (without Result)
- Fix behavior of the optimizer, finished worker notifies the optimization handler that it might be good to check if some segments require further optimization 


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

