### PR TITLE
clean collection stress

### DIFF
--- a/benches/service/collection_stress.js
+++ b/benches/service/collection_stress.js
@@ -2,8 +2,8 @@ import http from "k6/http";
 import { check } from 'k6';
 
 let host = 'http://localhost:6333'
-
 let collection_name = 'stress_collection';
+let upsert_url = `${host}/collections/${collection_name}/points`;
 
 let vector_length = 128;
 let vectors_per_batch = 32;
@@ -110,13 +110,11 @@ export function setup() {
 }
 
 export default function () {
-    var url = `${host}/collections/${collection_name}/points`;
-
     var payload = JSON.stringify({
         "points": Array.from({ length: vectors_per_batch }, () => generate_point()),
     });
 
-    let res_upsert = http.put(url, payload, params);
+    let res_upsert = http.put(upsert_url, payload, params);
     check(res_upsert, {
         'upsert_points is status 200': (r) => r.status === 200,
     });

--- a/benches/service/run.sh
+++ b/benches/service/run.sh
@@ -4,6 +4,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 
-docker run --network=host --rm -i loadimpact/k6 run -u 10 -i 500000 - <"$DIR/collection_stress.js"
+docker run --network=host --rm -i loadimpact/k6 run -u 10 -i 500000 --duration 30m - <"$DIR/collection_stress.js"
 
 


### PR DESCRIPTION
This PR performs a tiny cleanup of the `collection_stress` benchmark.

I got confused by the default 10m0s default max duration for `k6` which makes the bench stop way too early.

```
  scenarios: (100.00%) 1 scenario, 10 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 500000 iterations shared among 10 VUs (maxDuration: 10m0s, gracefulStop: 30s)
```

Making the `duration` parameter explicit enables us to easily shoot for longer period of times.

```
  scenarios: (100.00%) 1 scenario, 10 max VUs, 30m30s max duration (incl. graceful stop):
           * default: 500000 iterations shared among 10 VUs (maxDuration: 30m0s, gracefulStop: 30s)
```

As a bonus I have added the extraction of a constant in the script.
