### PR TITLE
Periodic flushing

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -50,8 +50,8 @@ storage:
     # Starting from this amount of vectors per-segment the engine will start building index for payload.
     payload_indexing_threshold: 10000
 
-    # Minimum interval between forced flushes.
-    flush_interval_sec: 10
+    # Interval between forced flushes.
+    flush_interval_sec: 1
     
     # Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
     max_optimization_threads: 0

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -371,6 +371,12 @@ impl<'s> SegmentHolder {
             Ok(max_persisted_version)
         }
     }
+
+    pub fn report_optimizer_error<E: Into<CollectionError>>(&mut self, error: E) {
+        if self.optimizer_errors.is_none() {
+            self.optimizer_errors = Some(error.into());
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes a problem with not removed WAL files.

Ideally there should remain (after some time) at maximum 1 closed WAL files and 2 open. Before this fix there were situations when there would be multiple closed files and they were never removed as the time progressed. The problem seemed to be that at the time of flush requests (on update) not all segments have saved all updates yet.

With periodic flushing this problem is fixed and the system always comes to a state when there is at most 1 closed wal file if there are no more updates for some time. Additionally this introduces an advantage of decreased CPU and disk load.
