### PR TITLE
Integration tests use dedicated key cache to avoid false sharing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
         run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
+      - name: Build with gRPC
+        run: cargo build --features grpc
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,8 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: gRPC-debug
       - name: Install dependencies
         run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
       - name: Build with gRPC

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -8,8 +8,6 @@ cd "$(dirname "$0")/../"
 
 QDRANT_HOST='localhost:6333'
 
-# Build
-$(cargo build --features grpc)
 # Run in background
 $(./target/debug/qdrant) &
 


### PR DESCRIPTION
In https://github.com/qdrant/qdrant/pull/320 we have added a cache to reuse various artifacts generated by cargo.

This has successfully decreased the build time of all jobs but the integration tests jobs.

The reason is that all jobs are using the same cache key BUT the integration tests job is built with the `gRPC` flag.

To avoid false sharing, the integration test job is now using a dedicated key cache for differentiation. 

This brings the run time from 17 minutes to 10 minutes.