### PR TITLE
Dedicated cache key for Clippy build

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -24,6 +24,8 @@ jobs:
         components: rustfmt, clippy
     - uses: actions/checkout@v2
     - uses: Swatinem/rust-cache@v1
+      with:
+        key: clippy
     - name: Install dependencies
       run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
     - name: Check code formatting


### PR DESCRIPTION
Same logic as in https://github.com/qdrant/qdrant/pull/335 but for Clippy this time.