### PR TITLE
update tokio 1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log 0.4.14",
- "mio 0.8.0",
+ "mio",
  "num_cpus",
  "socket2",
  "tokio",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.111"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libloading"
@@ -1733,19 +1733,6 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
-dependencies = [
- "libc",
- "log 0.4.14",
- "miow",
- "ntapi",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2826,9 +2813,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -3077,19 +3064,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr 2.4.0",
- "mio 0.7.11",
+ "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 
 config = "~0.11.0"
 
-tokio = { version = "~1.16", features = ["full"] }
+tokio = { version = "~1.17", features = ["full"] }
 
 actix-web = { version = "4.0.0-rc.3", optional = true }
 tonic =  { version = "0.6.2", optional = true }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = "~1.0"
 wal = { git = "https://github.com/generall/wal.git" }
 ordered-float = "2.10"
 
-tokio = {version = "~1.16", features = ["full"]}
+tokio = {version = "~1.17", features = ["full"]}
 futures = "0.3.21"
 atomicwrites = "0.3.1"
 log = "0.4"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -15,7 +15,7 @@ num_cpus = "1.13"
 thiserror = "1.0"
 rand = "0.8.5"
 wal = { git = "https://github.com/generall/wal.git" }
-tokio = {version = "~1.16", features = ["rt-multi-thread"]}
+tokio = {version = "~1.17", features = ["rt-multi-thread"]}
 serde = { version = "~1.0", features = ["derive"] }
 schemars = { version = "0.8.8", features = ["uuid"] }
 itertools = "0.10"


### PR DESCRIPTION
I was wondering why Dependabot did not propose this update as it is already 8 days old.

So this PR updates Tokio to 1.17 https://github.com/tokio-rs/tokio/releases/tag/tokio-1.17.0 as it contains interesting fixes.