### PR TITLE
Split operation by shard

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -173,31 +173,6 @@ pub(crate) fn upsert_points(
     vectors: &[VectorType],
     payloads: &Option<Vec<Option<HashMap<PayloadKeyType, PayloadInterface>>>>,
 ) -> CollectionResult<usize> {
-    if ids.len() != vectors.len() {
-        return Err(CollectionError::BadInput {
-            description: format!(
-                "Amount of ids ({}) and vectors ({}) does not match",
-                ids.len(),
-                vectors.len()
-            ),
-        });
-    }
-
-    match payloads {
-        None => {}
-        Some(payload_vector) => {
-            if payload_vector.len() != ids.len() {
-                return Err(CollectionError::BadInput {
-                    description: format!(
-                        "Amount of ids ({}) and payloads ({}) does not match",
-                        ids.len(),
-                        payload_vector.len()
-                    ),
-                });
-            }
-        }
-    }
-
     let vectors_map: HashMap<PointIdType, &VectorType> = ids.iter().cloned().zip(vectors).collect();
     let payloads_map: HashMap<PointIdType, &HashMap<PayloadKeyType, PayloadInterface>> =
         match payloads {

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -3,10 +3,17 @@ pub mod payload_ops;
 pub mod point_ops;
 pub mod types;
 
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
+use segment::types::ExtendedPointId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+use crate::shard::ShardId;
+
+use self::types::CollectionResult;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum FieldIndexOperations {
     /// Create index for payload field
@@ -15,13 +22,103 @@ pub enum FieldIndexOperations {
     DeleteIndex(String),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum CollectionUpdateOperations {
     PointOperation(point_ops::PointOperations),
     PayloadOperation(payload_ops::PayloadOps),
     FieldIndexOperation(FieldIndexOperations),
+}
+
+/// A mapping of operation to shard.
+/// Is a result of splitting one operation into several shards by corresponding PointIds
+pub enum OperationToShard<O> {
+    ByShard(Vec<(ShardId, O)>),
+    ToAll(O),
+}
+
+impl<O> OperationToShard<O> {
+    pub fn by_shard(operations: impl IntoIterator<Item = (ShardId, O)>) -> Self {
+        Self::ByShard(operations.into_iter().collect())
+    }
+
+    pub fn to_all(operation: O) -> Self {
+        Self::ToAll(operation)
+    }
+
+    pub fn map<O2>(self, f: impl Fn(O) -> O2) -> OperationToShard<O2> {
+        match self {
+            OperationToShard::ByShard(operation_to_shard) => OperationToShard::ByShard(
+                operation_to_shard
+                    .into_iter()
+                    .map(|(id, operation)| (id, f(operation)))
+                    .collect(),
+            ),
+            OperationToShard::ToAll(to_all) => OperationToShard::ToAll(f(to_all)),
+        }
+    }
+}
+
+/// Stateless validation of operation content.
+/// Checks for `CollectionError::BadInput`
+pub trait Validate {
+    fn validate(&self) -> CollectionResult<()>;
+}
+
+impl Validate for CollectionUpdateOperations {
+    fn validate(&self) -> CollectionResult<()> {
+        match self {
+            CollectionUpdateOperations::PointOperation(operation) => operation.validate(),
+            CollectionUpdateOperations::PayloadOperation(_) => Ok(()),
+            CollectionUpdateOperations::FieldIndexOperation(_) => Ok(()),
+        }
+    }
+}
+
+fn point_to_shard(_point_id: ExtendedPointId) -> ShardId {
+    // TODO: use consistent hashing here
+    0
+}
+
+/// Split iterator of items that have point ids by shard
+fn split_iter_by_shard<I, F, O>(iter: I, id_extractor: F) -> OperationToShard<Vec<O>>
+where
+    I: IntoIterator<Item = O>,
+    F: Fn(&O) -> ExtendedPointId,
+{
+    let mut op_vec_by_shard: HashMap<ShardId, Vec<O>> = HashMap::new();
+    for operation in iter {
+        let shard_id = point_to_shard(id_extractor(&operation));
+        op_vec_by_shard
+            .entry(shard_id)
+            .or_insert_with(Vec::new)
+            .push(operation);
+    }
+    OperationToShard::by_shard(op_vec_by_shard)
+}
+
+/// Trait for Operation enums to split them by shard.
+pub trait SplitByShard {
+    fn split_by_shard(self) -> OperationToShard<Self>
+    where
+        Self: Sized;
+}
+
+impl SplitByShard for CollectionUpdateOperations {
+    fn split_by_shard(self) -> OperationToShard<Self> {
+        match self {
+            CollectionUpdateOperations::PointOperation(operation) => operation
+                .split_by_shard()
+                .map(CollectionUpdateOperations::PointOperation),
+            CollectionUpdateOperations::PayloadOperation(operation) => operation
+                .split_by_shard()
+                .map(CollectionUpdateOperations::PayloadOperation),
+            operation @ CollectionUpdateOperations::FieldIndexOperation(_) => {
+                OperationToShard::to_all(operation)
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -1,10 +1,16 @@
-use crate::operations::types::VectorType;
+use crate::{operations::types::VectorType, shard::ShardId};
 use schemars::JsonSchema;
 use segment::types::{Filter, PayloadInterface, PayloadKeyType, PointIdType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+use super::{
+    point_to_shard, split_iter_by_shard,
+    types::{CollectionError, CollectionResult},
+    OperationToShard, SplitByShard, Validate,
+};
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct PointStruct {
     /// Point id
@@ -15,7 +21,7 @@ pub struct PointStruct {
     pub payload: Option<HashMap<PayloadKeyType, PayloadInterface>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Batch {
     pub ids: Vec<PointIdType>,
@@ -23,13 +29,13 @@ pub struct Batch {
     pub payloads: Option<Vec<Option<HashMap<PayloadKeyType, PayloadInterface>>>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct PointsBatch {
     pub batch: Batch,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct PointsList {
     pub points: Vec<PointStruct>,
@@ -57,7 +63,7 @@ pub enum PointsSelector {
     FilterSelector(FilterSelector),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum PointInsertOperations {
@@ -67,7 +73,7 @@ pub enum PointInsertOperations {
     PointsList(PointsList),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum PointOperations {
     /// Insert or update points
@@ -76,6 +82,105 @@ pub enum PointOperations {
     DeletePoints { ids: Vec<PointIdType> },
     /// Delete points by given filter criteria
     DeletePointsByFilter(Filter),
+}
+
+impl Validate for PointOperations {
+    fn validate(&self) -> CollectionResult<()> {
+        match self {
+            PointOperations::UpsertPoints(upsert_points) => upsert_points.validate(),
+            PointOperations::DeletePoints { ids: _ } => Ok(()),
+            PointOperations::DeletePointsByFilter(_) => Ok(()),
+        }
+    }
+}
+
+impl Validate for PointInsertOperations {
+    fn validate(&self) -> CollectionResult<()> {
+        match self {
+            PointInsertOperations::PointsList(_) => Ok(()),
+            PointInsertOperations::PointsBatch(PointsBatch { batch }) => {
+                if batch.ids.len() != batch.vectors.len() {
+                    return Err(CollectionError::BadInput {
+                        description: format!(
+                            "Amount of ids ({}) and vectors ({}) does not match",
+                            batch.ids.len(),
+                            batch.vectors.len()
+                        ),
+                    });
+                }
+                if let Some(payload_vector) = &batch.payloads {
+                    if payload_vector.len() != batch.ids.len() {
+                        return Err(CollectionError::BadInput {
+                            description: format!(
+                                "Amount of ids ({}) and payloads ({}) does not match",
+                                batch.ids.len(),
+                                payload_vector.len()
+                            ),
+                        });
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl SplitByShard for PointsBatch {
+    fn split_by_shard(self) -> OperationToShard<Self> {
+        let PointsBatch { batch } = self;
+        let mut batch_by_shard: HashMap<ShardId, PointsBatch> = HashMap::new();
+        for i in 0..batch.ids.len() {
+            let shard_id = point_to_shard(batch.ids[i]);
+            let shard_batch = batch_by_shard
+                .entry(shard_id)
+                .or_insert_with(PointsBatch::default);
+            shard_batch.batch.ids.push(batch.ids[i]);
+            shard_batch.batch.vectors.push(batch.vectors[i].clone());
+            if let Some(payloads) = &batch.payloads {
+                shard_batch
+                    .batch
+                    .payloads
+                    .get_or_insert(Vec::new())
+                    .push(payloads[i].clone())
+            }
+        }
+        OperationToShard::by_shard(batch_by_shard)
+    }
+}
+
+impl SplitByShard for PointsList {
+    fn split_by_shard(self) -> OperationToShard<Self> {
+        split_iter_by_shard(self.points, |point| point.id).map(|points| PointsList { points })
+    }
+}
+
+impl SplitByShard for PointOperations {
+    fn split_by_shard(self) -> OperationToShard<Self> {
+        match self {
+            PointOperations::UpsertPoints(upsert_points) => upsert_points
+                .split_by_shard()
+                .map(PointOperations::UpsertPoints),
+            PointOperations::DeletePoints { ids } => {
+                split_iter_by_shard(ids, |id| *id).map(|ids| PointOperations::DeletePoints { ids })
+            }
+            by_filter @ PointOperations::DeletePointsByFilter(_) => {
+                OperationToShard::to_all(by_filter)
+            }
+        }
+    }
+}
+
+impl SplitByShard for PointInsertOperations {
+    fn split_by_shard(self) -> OperationToShard<Self> {
+        match self {
+            PointInsertOperations::PointsBatch(batch) => batch
+                .split_by_shard()
+                .map(PointInsertOperations::PointsBatch),
+            PointInsertOperations::PointsList(list) => {
+                list.split_by_shard().map(PointInsertOperations::PointsList)
+            }
+        }
+    }
 }
 
 impl From<Batch> for PointInsertOperations {
@@ -99,5 +204,46 @@ impl From<Batch> for PointOperations {
 impl From<Vec<PointStruct>> for PointOperations {
     fn from(points: Vec<PointStruct>) -> Self {
         PointOperations::UpsertPoints(PointInsertOperations::PointsList(PointsList { points }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_batch() {
+        let batch = PointInsertOperations::PointsBatch(PointsBatch {
+            batch: Batch {
+                ids: vec![PointIdType::NumId(0)],
+                vectors: vec![],
+                payloads: None,
+            },
+        });
+        assert!(matches!(
+            batch.validate(),
+            Err(CollectionError::BadInput { description: _ })
+        ));
+
+        let batch = PointInsertOperations::PointsBatch(PointsBatch {
+            batch: Batch {
+                ids: vec![PointIdType::NumId(0)],
+                vectors: vec![vec![0.1]],
+                payloads: None,
+            },
+        });
+        assert!(matches!(batch.validate(), Ok(())));
+
+        let batch = PointInsertOperations::PointsBatch(PointsBatch {
+            batch: Batch {
+                ids: vec![PointIdType::NumId(0)],
+                vectors: vec![vec![0.1]],
+                payloads: Some(vec![]),
+            },
+        });
+        assert!(matches!(
+            batch.validate(),
+            Err(CollectionError::BadInput { description: _ })
+        ));
     }
 }


### PR DESCRIPTION
Introduces traits and their implementations for update operations:
- `SplitByShard`
- `Validate`

In future PRs:
- consistent hashing will replace the `point_to_shard` stub
- Multiple shards will be added