### PR TITLE
fix new clippy lints in 1.59

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -181,7 +181,7 @@ mod tests {
                 .set_payload(
                     102,
                     point_id,
-                    &"color".to_string(),
+                    "color",
                     PayloadType::Keyword(vec!["red".to_string()]),
                 )
                 .unwrap();
@@ -191,12 +191,7 @@ mod tests {
             segment
                 .get()
                 .write()
-                .set_payload(
-                    102,
-                    point_id,
-                    &"size".to_string(),
-                    PayloadType::Float(vec![0.42]),
-                )
+                .set_payload(102, point_id, "size", PayloadType::Float(vec![0.42]))
                 .unwrap();
         }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -651,10 +651,10 @@ mod tests {
             build_segment(dir.path(), &config, Arc::new(SchemaStorage::new())).unwrap();
         segment.upsert_point(0, 0.into(), &[1.0, 1.0]).unwrap();
 
-        let result1 = segment.set_full_payload_with_json(0, 0.into(), &data1.to_string());
+        let result1 = segment.set_full_payload_with_json(0, 0.into(), data1);
         assert!(result1.is_err());
 
-        let result2 = segment.set_full_payload_with_json(0, 0.into(), &data2.to_string());
+        let result2 = segment.set_full_payload_with_json(0, 0.into(), data2);
         assert!(result2.is_err());
     }
 
@@ -684,7 +684,7 @@ mod tests {
             build_segment(dir.path(), &config, Arc::new(SchemaStorage::new())).unwrap();
         segment.upsert_point(0, 0.into(), &[1.0, 1.0]).unwrap();
         segment
-            .set_full_payload_with_json(0, 0.into(), &data.to_string())
+            .set_full_payload_with_json(0, 0.into(), data)
             .unwrap();
 
         let filter_valid_str = r#"

--- a/lib/segment/tests/fail_recovery_test.rs
+++ b/lib/segment/tests/fail_recovery_test.rs
@@ -28,7 +28,7 @@ mod tests {
         let fail_res = segment.set_payload(
             3,
             1.into(),
-            &"color".to_string(),
+            "color",
             PayloadType::Keyword(vec!["red".to_string()]),
         );
         assert!(fail_res.is_err());
@@ -37,7 +37,7 @@ mod tests {
         let fail_res = segment.set_payload(
             3,
             2.into(),
-            &"color".to_string(),
+            "color",
             PayloadType::Keyword(vec!["red".to_string()]),
         );
         assert!(fail_res.is_err());
@@ -46,7 +46,7 @@ mod tests {
         let ok_res = segment.set_payload(
             2,
             2.into(),
-            &"color".to_string(),
+            "color",
             PayloadType::Keyword(vec!["red".to_string()]),
         );
         assert!(ok_res.is_ok());
@@ -56,7 +56,7 @@ mod tests {
         let recover_res = segment.set_payload(
             2,
             1.into(),
-            &"color".to_string(),
+            "color",
             PayloadType::Keyword(vec!["red".to_string()]),
         );
 

--- a/lib/segment/tests/set_payload_test.rs
+++ b/lib/segment/tests/set_payload_test.rs
@@ -48,7 +48,7 @@ mod tests {
             build_segment(dir.path(), &config, Arc::new(SchemaStorage::new())).unwrap();
         segment.upsert_point(0, 0.into(), &[1.0, 1.0]).unwrap();
         segment
-            .set_full_payload_with_json(0, 0.into(), &data.to_string())
+            .set_full_payload_with_json(0, 0.into(), data)
             .unwrap();
         let payload = segment.payload(0.into()).unwrap();
         let keys: Vec<PayloadKeyType> = payload.keys().cloned().collect();


### PR DESCRIPTION
Updating to Rust 1.59 and using the latest [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-159) version locally yields some errors.

This PR fixes those issues right away to avoid blocking the CI pipeline in the near future.