### PR TITLE
Add consistent hashing library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "criterion",
  "env_logger 0.9.0",
  "futures",
+ "hashring",
  "indicatif",
  "itertools",
  "log 0.4.14",
@@ -1286,6 +1287,14 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashring"
+version = "0.2.0"
+source = "git+https://github.com/qdrant/hashring-rs#36477e847213054db7eae7677a5b4652aef96655"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "heapless"
@@ -2783,6 +2792,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "slab"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,6 +23,7 @@ serde_cbor = "0.11.2"
 rmp-serde = "~1.0"
 wal = { git = "https://github.com/generall/wal.git" }
 ordered-float = "2.10"
+hashring = { git = "https://github.com/qdrant/hashring-rs" }
 
 tokio = {version = "~1.17", features = ["full"]}
 futures = "0.3.21"


### PR DESCRIPTION
Consistent hashing is used for shard selection based on point id.

## Library Selection

Choice: https://github.com/jeromefroe/hashring-rs

Pros:
+ Default hash function is ok, can be swapped
+ Uses `Hash` trait
+ Updated in 2020
+ Uses binary search to find shard

Cons:
- Weird transformation at key generation, seems unneeded

Alt: https://github.com/mattnenterprise/rust-hash-ring

Pros:
+ Default hash function is ok, can be swapped
+ Updated in 2020

Cons:
- Needs `ToString` instead of `Hash`
- Uses linear search to find shard

Others have few downloads and are long forgotten or unfinished.
Generally it would not be difficult to write our own lib if we wanted to swap.

## Fork

The selected library was forked to [fix](https://github.com/qdrant/hashring-rs/commit/36477e847213054db7eae7677a5b4652aef96655) minor issue with unnecessary `mut` reference on `get`. Hopefully [this](https://github.com/jeromefroe/hashring-rs/pull/7) will be merged into original repo.
