### PR TITLE
enable gRPC via a runtime config

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,12 +22,10 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
-        with:
-          key: gRPC-debug
       - name: Install dependencies
         run: sudo apt-get install clang libopenblas-dev libgfortran-10-dev gfortran
-      - name: Build with gRPC
-        run: cargo build --features grpc
+      - name: Build
+        run: cargo build
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ doctest = false
 [features]
 default = [ "web" ]
 web = ["actix-web"]
-grpc = ["tonic", "tonic-build", "prost", "num-traits"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
 
@@ -39,16 +38,16 @@ config = "~0.12.0"
 tokio = { version = "~1.17", features = ["full"] }
 
 actix-web = { version = "4.0.1", optional = true }
-tonic =  { version = "0.6.2", optional = true }
-num-traits = { version = "0.2.14", optional = true }
-prost = { version = "0.9", optional = true }
+tonic = "0.6.2"
+num-traits = "0.2.14"
+prost = "0.9"
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }
 storage = { path = "lib/storage" }
 
 [build-dependencies]
-tonic-build = { version = "0.6.2", features = ["prost"], optional = true }
+tonic-build = { version = "0.6.2", features = ["prost"] }
 
 [patch.crates-io]
 # Env flag OPENBLAS_DYNAMIC_ARCH is implemented in this custom fork

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -82,5 +82,8 @@ service:
   # HTTP port to bind the service on
   http_port: 6333
 
-  # GRPC port to bind the service on
-  grpc_port: 6334
+  # gRPC port to bind the service on.
+  # If `null` - gRPC is disabed. Default: null
+  grpc_port: null
+  # Uncomment to enable gRPC:
+  # grpc_port: 6334

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,7 +80,7 @@ service:
   host: 0.0.0.0
 
   # HTTP port to bind the service on
-  rest_port: 6333
+  http_port: 6333
 
   # GRPC port to bind the service on
   grpc_port: 6334

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,7 +80,7 @@ service:
   host: 0.0.0.0
 
   # HTTP port to bind the service on
-  port: 6333
+  rest_port: 6333
 
   # GRPC port to bind the service on
   grpc_port: 6334

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -4,7 +4,7 @@ log_level: DEBUG,sled=INFO
 
 service:
   host: 127.0.0.1
-  rest_port: 6333
+  http_port: 6333
   grpc_port: 6334
 
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -5,7 +5,8 @@ log_level: DEBUG,sled=INFO
 service:
   host: 127.0.0.1
   http_port: 6333
-  grpc_port: 6334
+  # Uncomment to enable gRPC:
+  #grpc_port: 6334
 
 
 storage:

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -4,7 +4,7 @@ log_level: DEBUG,sled=INFO
 
 service:
   host: 127.0.0.1
-  port: 6333
+  rest_port: 6333
   grpc_port: 6334
 
 

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -4,5 +4,5 @@ log_level: INFO
 
 service:
   host: 0.0.0.0
-  port: 6333
+  rest_port: 6333
   grpc_port: 6334

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -4,5 +4,5 @@ log_level: INFO
 
 service:
   host: 0.0.0.0
-  rest_port: 6333
+  http_port: 6333
   grpc_port: 6334

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -5,4 +5,5 @@ log_level: INFO
 service:
   host: 0.0.0.0
   http_port: 6333
-  grpc_port: 6334
+  # Uncomment to enable gRPC:
+  #grpc_port: 6334

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,9 +84,9 @@ Our protocol buffers are defined in `src/tonic/proto/*.proto`
 
 1. define request and response types using protocol buffers (use [oneOf](https://developers.google.com/protocol-buffers/docs/proto3#oneof) for enums payloads)
 2. specify RPC methods inside the service definition using protocol buffers
-3. `cargo build --features grpc` will generate the struct definitions and a service trait
+3. `cargo build` will generate the struct definitions and a service trait
 4. implement the service trait in Rust
-5. start server `cargo run --bin qdrant --features grpc`
+5. start server `cargo run --bin qdrant`
 6. run integration test `./tests/basic_grpc_test.sh`
 
 Here is a good [tonic tutorial](https://github.com/hyperium/tonic/blob/master/examples/routeguide-tutorial.md#defining-the-service) for reference.

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -60,7 +60,7 @@ pub fn init(toc: Arc<TableOfContent>, settings: Settings) -> std::io::Result<()>
         .workers(max_web_workers(&settings))
         .bind(format!(
             "{}:{}",
-            settings.service.host, settings.service.rest_port
+            settings.service.host, settings.service.http_port
         ))?
         .run()
         .await

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -60,7 +60,7 @@ pub fn init(toc: Arc<TableOfContent>, settings: Settings) -> std::io::Result<()>
         .workers(max_web_workers(&settings))
         .bind(format!(
             "{}:{}",
-            settings.service.host, settings.service.port
+            settings.service.host, settings.service.rest_port
         ))?
         .run()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 mod actix;
 pub mod common;
 mod settings;
-#[cfg(feature = "grpc")]
 mod tonic;
 
 use std::io::Error;
@@ -47,15 +46,17 @@ fn main() -> std::io::Result<()> {
             .unwrap();
         handles.push(handle);
     }
-    #[cfg(feature = "grpc")]
-    {
+
+    if let Some(grpc_port) = settings.service.grpc_port {
         let toc_arc = toc_arc.clone();
         let settings = settings.clone();
         let handle = thread::Builder::new()
             .name("grpc".to_string())
-            .spawn(move || tonic::init(toc_arc, settings))
+            .spawn(move || tonic::init(toc_arc, settings.service.host, grpc_port))
             .unwrap();
         handles.push(handle);
+    } else {
+        log::info!("gRPC endpoint disabled");
     }
 
     #[cfg(feature = "service_debug")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use storage::types::StorageConfig;
 pub struct ServiceConfig {
     pub host: String,
     pub port: u16,
-    pub grpc_port: u16,
+    pub grpc_port: Option<u16>,
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,8 +6,8 @@ use storage::types::StorageConfig;
 #[derive(Debug, Deserialize, Clone)]
 pub struct ServiceConfig {
     pub host: String,
-    pub port: u16,
-    pub grpc_port: Option<u16>,
+    pub rest_port: u16,
+    pub grpc_port: Option<u16>, // None means that gRPC is disabled
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -37,7 +37,7 @@ impl Settings {
             .add_source(File::with_name("config/local").required(false))
             // Add in settings from the environment (with a prefix of APP)
             // Eg.. `QDRANT_DEBUG=1 ./target/app` would set the `debug` key
-            .add_source(Environment::with_prefix("QDRANT"))
+            .add_source(Environment::with_prefix("QDRANT").separator("__"))
             .build()?;
 
         // You can deserialize (and thus freeze) the entire configuration as

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use storage::types::StorageConfig;
 #[derive(Debug, Deserialize, Clone)]
 pub struct ServiceConfig {
     pub host: String,
-    pub rest_port: u16,
+    pub http_port: u16,
     pub grpc_port: Option<u16>, // None means that gRPC is disabled
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -7,6 +7,7 @@ set -ex
 cd "$(dirname "$0")/../"
 
 QDRANT_HOST='localhost:6333'
+export QDRANT__SERVICE__GRPC_PORT="6334"
 
 # Run in background
 $(./target/debug/qdrant) &


### PR DESCRIPTION
This PR enables the gRPC endpoint via runtime configuration instead of a build feature https://github.com/qdrant/qdrant/issues/350

This is done by changing the `grpc_port` settings to be an `Option` which is not a breaking change for the serialization of the configuration.