### PR TITLE
fix duplicate bench group

### DIFF
--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -22,7 +22,7 @@ const USE_HEURISTIC: bool = true;
 fn hnsw_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, CosineMetric {}, &mut rng);
-    let mut group = c.benchmark_group("hnsw-index-build-group");
+    let mut group = c.benchmark_group("hnsw-index-search-group");
     let mut rng = thread_rng();
     let fake_condition_checker = FakeConditionChecker {};
 


### PR DESCRIPTION
Found with the following log

```
16:35:27 [WARN] Benchmark group hnsw-index-build-group encountered again. Benchmark group IDs must be unique. First seen in the benchmark target 'hnsw_build_graph'
```