### PR TITLE
Multiple shards in collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,8 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "hashring"
-version = "0.2.0"
-source = "git+https://github.com/qdrant/hashring-rs#36477e847213054db7eae7677a5b4652aef96655"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a4b4f3c339ede20e4dbdee1bb18c40ec138bb28f0658ba3c3d9294805ca931"
 dependencies = [
  "siphasher",
 ]

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "grpc")]
-    {
-        tonic_build::configure()
-            .out_dir("src/tonic/") // saves generated structures at this location
-            .compile(
-                &["src/tonic/proto/qdrant.proto"], // proto entry point
-                &["src/tonic/proto"], // specify the root location to search proto dependencies
-            )
-            .unwrap();
-    }
+    tonic_build::configure()
+        .out_dir("src/tonic/") // saves generated structures at this location
+        .compile(
+            &["src/tonic/proto/qdrant.proto"], // proto entry point
+            &["src/tonic/proto"], // specify the root location to search proto dependencies
+        )
+        .unwrap();
+
     Ok(())
 }

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -194,6 +194,7 @@
 | ----- | ---- | ----- | ----------- |
 | vector_size | [uint64](#uint64) |  | Size of the vectors |
 | distance | [Distance](#qdrant-Distance) |  | Distance function used for comparing vectors |
+| shard_number | [uint32](#uint32) |  | Number of shards in collection |
 
 
 
@@ -605,7 +606,7 @@ If indexation speed have more priority for your - make this parameter lower. If 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| should | [Condition](#qdrant-Condition) | repeated | At least one of thous conditions should match |
+| should | [Condition](#qdrant-Condition) | repeated | At least one of those conditions should match |
 | must | [Condition](#qdrant-Condition) | repeated | All conditions must match |
 | must_not | [Condition](#qdrant-Condition) | repeated | All conditions must NOT match |
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -161,6 +161,13 @@
           "distance": {
             "$ref": "#/components/schemas/Distance"
           },
+          "shard_number": {
+            "default": 1,
+            "description": "Number of shards the collection has",
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
           "vector_size": {
             "description": "Size of a vectors used",
             "format": "uint",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,7 +23,7 @@ serde_cbor = "0.11.2"
 rmp-serde = "~1.0"
 wal = { git = "https://github.com/generall/wal.git" }
 ordered-float = "2.10"
-hashring = { git = "https://github.com/qdrant/hashring-rs" }
+hashring = "0.2.1"
 
 tokio = {version = "~1.17", features = ["full"]}
 futures = "0.3.21"

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -137,6 +137,7 @@ pub(crate) fn get_merge_optimizer(
         CollectionParams {
             vector_size: 4,
             distance: Distance::Dot,
+            shard_number: 1,
         },
         Default::default(),
         Arc::new(SchemaStorage::new()),
@@ -158,6 +159,7 @@ pub(crate) fn get_indexing_optimizer(
         CollectionParams {
             vector_size: 4,
             distance: Distance::Dot,
+            shard_number: 1,
         },
         Default::default(),
         Arc::new(SchemaStorage::new()),

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -207,6 +207,7 @@ mod tests {
             CollectionParams {
                 vector_size: segment_config.vector_size,
                 distance: segment_config.distance,
+                shard_number: 1,
             },
             Default::default(),
             Arc::new(SchemaStorage::new()),

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -210,6 +210,7 @@ mod tests {
             CollectionParams {
                 vector_size: 4,
                 distance: Distance::Dot,
+                shard_number: 1,
             },
             Default::default(),
             Arc::new(SchemaStorage::new()),

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -48,6 +48,13 @@ pub struct CollectionParams {
     pub vector_size: usize,
     /// Type of distance function used for measuring distance between vectors
     pub distance: Distance,
+    /// Number of shards the collection has
+    #[serde(default = "default_shard_number")]
+    pub shard_number: u32,
+}
+
+fn default_shard_number() -> u32 {
+    1
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -1,11 +1,17 @@
 //! Crate, which implements all functions required for operations with a single collection
 
-use std::{path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    fs::create_dir_all,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::operations::types::PointRequest;
 use collection_manager::collection_managers::CollectionSearcher;
 use config::CollectionConfig;
 use hashring::HashRing;
+use itertools::Itertools;
 use operations::{
     config_diff::OptimizersConfigDiff,
     types::{
@@ -14,7 +20,13 @@ use operations::{
     },
     CollectionUpdateOperations, SplitByShard, Validate,
 };
-use segment::types::{ScoredPoint, VectorElementType, WithPayload, WithPayloadInterface};
+use segment::{
+    spaces::tools::peek_top_scores_iterable,
+    types::{
+        Condition, ExtendedPointId, Filter, HasIdCondition, ScoredPoint, VectorElementType,
+        WithPayload, WithPayloadInterface,
+    },
+};
 use shard::{Shard, ShardId};
 use tokio::runtime::Handle;
 
@@ -36,7 +48,7 @@ type CollectionId = String;
 
 /// Collection's data is split into several shards.
 pub struct Collection {
-    shard: Shard,
+    shards: HashMap<ShardId, Shard>,
     ring: HashRing<ShardId>,
 }
 
@@ -46,29 +58,73 @@ impl Collection {
         path: &Path,
         config: &CollectionConfig,
     ) -> Result<Self, CollectionError> {
+        config.save(path)?;
         let mut ring = HashRing::new();
-        ring.add(0);
-        Ok(Self {
-            shard: Shard::build(0, id, path, config)?,
-            ring,
-        })
+        let mut shards = HashMap::new();
+        for shard_id in 0..config.params.shard_number {
+            let shard_path = shard_path(path, shard_id);
+            create_dir_all(&shard_path).map_err(|err| CollectionError::ServiceError {
+                error: format!("Can't create shard {shard_id} directory. Error: {}", err),
+            })?;
+            shards.insert(
+                shard_id,
+                Shard::build(shard_id, id.clone(), &shard_path, config)?,
+            );
+            ring.add(shard_id);
+        }
+        Ok(Self { shards, ring })
     }
 
     pub fn load(id: CollectionId, path: &Path) -> Self {
+        let config = CollectionConfig::load(path).unwrap_or_else(|err| {
+            panic!(
+                "Can't read collection config due to {}\nat {}",
+                err,
+                path.to_str().unwrap()
+            )
+        });
         let mut ring = HashRing::new();
-        ring.add(0);
-        Self {
-            shard: Shard::load(0, id, path),
-            ring,
+        let mut shards = HashMap::new();
+
+        // TODO: Migrate previous format to new one
+        if let Some(shard) = Self::try_load_legacy_one_shard(id.clone(), path, &config) {
+            log::warn!("Loading legacy collection storage as 1 shard.");
+            shards.insert(0, shard);
+            ring.add(0);
+            return Self { shards, ring };
+        }
+
+        for shard_id in 0..config.params.shard_number {
+            let shard_path = shard_path(path, shard_id);
+            shards.insert(
+                shard_id,
+                Shard::load(shard_id, id.clone(), &shard_path, &config),
+            );
+            ring.add(shard_id);
+        }
+        Self { shards, ring }
+    }
+
+    fn try_load_legacy_one_shard(
+        id: CollectionId,
+        collection_path: &Path,
+        config: &CollectionConfig,
+    ) -> Option<Shard> {
+        if Shard::segments_path(collection_path).is_dir() {
+            Some(Shard::load(0, id, collection_path, config))
+        } else {
+            None
         }
     }
 
-    fn shard_by_id(&self, _id: ShardId) -> &Shard {
-        &self.shard
+    fn shard_by_id(&self, id: ShardId) -> &Shard {
+        self.shards
+            .get(&id)
+            .expect("Shard is guaranteed to be added when id is added to the ring.")
     }
 
-    fn all_shards(&self) -> Vec<&Shard> {
-        vec![&self.shard]
+    fn all_shards(&self) -> impl Iterator<Item = &Shard> {
+        self.shards.values()
     }
 
     pub async fn update(
@@ -102,8 +158,86 @@ impl Collection {
         segment_searcher: &(dyn CollectionSearcher + Sync),
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<ScoredPoint>> {
-        self.shard
-            .recommend_by(request, segment_searcher, search_runtime_handle)
+        if request.positive.is_empty() {
+            return Err(CollectionError::BadRequest {
+                description: "At least one positive vector ID required".to_owned(),
+            });
+        }
+
+        let reference_vectors_ids = request
+            .positive
+            .iter()
+            .chain(&request.negative)
+            .cloned()
+            .collect_vec();
+
+        let vectors = self
+            .retrieve(
+                PointRequest {
+                    ids: reference_vectors_ids.clone(),
+                    with_payload: Some(WithPayloadInterface::Bool(true)),
+                    with_vector: true,
+                },
+                segment_searcher,
+            )
+            .await?;
+        let vectors_map: HashMap<ExtendedPointId, Vec<VectorElementType>> = vectors
+            .into_iter()
+            .map(|rec| (rec.id, rec.vector.unwrap()))
+            .collect();
+
+        for &point_id in &reference_vectors_ids {
+            if !vectors_map.contains_key(&point_id) {
+                return Err(CollectionError::NotFound {
+                    missed_point_id: point_id,
+                });
+            }
+        }
+
+        let avg_positive = avg_vectors(
+            request
+                .positive
+                .iter()
+                .map(|vid| vectors_map.get(vid).unwrap()),
+        );
+
+        let search_vector = if request.negative.is_empty() {
+            avg_positive
+        } else {
+            let avg_negative = avg_vectors(
+                request
+                    .negative
+                    .iter()
+                    .map(|vid| vectors_map.get(vid).unwrap()),
+            );
+
+            avg_positive
+                .iter()
+                .cloned()
+                .zip(avg_negative.iter().cloned())
+                .map(|(pos, neg)| pos + pos - neg)
+                .collect()
+        };
+
+        let search_request = SearchRequest {
+            vector: search_vector,
+            filter: Some(Filter {
+                should: None,
+                must: request
+                    .filter
+                    .clone()
+                    .map(|filter| vec![Condition::Filter(filter)]),
+                must_not: Some(vec![Condition::HasId(HasIdCondition {
+                    has_id: reference_vectors_ids.iter().cloned().collect(),
+                })]),
+            }),
+            with_payload: request.with_payload.clone(),
+            with_vector: request.with_vector,
+            params: request.params,
+            top: request.top,
+        };
+
+        self.search(search_request, segment_searcher, search_runtime_handle)
             .await
     }
 
@@ -113,13 +247,15 @@ impl Collection {
         segment_searcher: &(dyn CollectionSearcher + Sync),
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<ScoredPoint>> {
-        segment_searcher
-            .search(
-                self.shard.segments(),
-                Arc::new(request),
-                search_runtime_handle,
-            )
-            .await
+        let mut points = Vec::new();
+        let request = Arc::new(request);
+        for shard in self.all_shards() {
+            let mut shard_points = segment_searcher
+                .search(shard.segments(), request.clone(), search_runtime_handle)
+                .await?;
+            points.append(&mut shard_points);
+        }
+        Ok(peek_top_scores_iterable(points, request.top))
     }
 
     pub async fn scroll_by(
@@ -127,7 +263,54 @@ impl Collection {
         request: ScrollRequest,
         segment_searcher: &(dyn CollectionSearcher + Sync),
     ) -> CollectionResult<ScrollResult> {
-        self.shard.scroll_by(request, segment_searcher).await
+        let default_request = ScrollRequest::default();
+
+        let offset = request.offset;
+        let limit = request
+            .limit
+            .unwrap_or_else(|| default_request.limit.unwrap());
+        let with_payload_interface = request
+            .with_payload
+            .clone()
+            .unwrap_or_else(|| default_request.with_payload.clone().unwrap());
+        let with_vector = request.with_vector;
+
+        if limit == 0 {
+            return Err(CollectionError::BadRequest {
+                description: "Limit cannot be 0".to_string(),
+            });
+        }
+
+        // Needed to return next page offset.
+        let limit = limit + 1;
+
+        let mut points = Vec::new();
+        for shard in self.all_shards() {
+            let mut shard_points = shard
+                .scroll_by(
+                    segment_searcher,
+                    offset,
+                    limit,
+                    &with_payload_interface,
+                    with_vector,
+                    request.filter.as_ref(),
+                )
+                .await?;
+            points.append(&mut shard_points);
+        }
+        points.sort_by_key(|point| point.id);
+        let mut points: Vec<_> = points.into_iter().take(limit).collect();
+        let next_page_offset = if points.len() < limit {
+            // This was the last page
+            None
+        } else {
+            // remove extra point, it would be a first point of the next page
+            Some(points.pop().unwrap().id)
+        };
+        Ok(ScrollResult {
+            points,
+            next_page_offset,
+        })
     }
 
     pub async fn retrieve(
@@ -142,14 +325,14 @@ impl Collection {
         let with_payload = WithPayload::from(with_payload_interface);
         let with_vector = request.with_vector;
 
-        segment_searcher
-            .retrieve(
-                self.shard.segments(),
-                &request.ids,
-                &with_payload,
-                with_vector,
-            )
-            .await
+        let mut points = Vec::new();
+        for shard in self.all_shards() {
+            let mut shard_points = segment_searcher
+                .retrieve(shard.segments(), &request.ids, &with_payload, with_vector)
+                .await?;
+            points.append(&mut shard_points);
+        }
+        Ok(points)
     }
 
     /// Updates shard optimization params:
@@ -160,14 +343,26 @@ impl Collection {
         &self,
         optimizer_config_diff: OptimizersConfigDiff,
     ) -> CollectionResult<()> {
-        self.shard
-            .update_optimizer_params(optimizer_config_diff)
-            .await
+        for shard in self.all_shards() {
+            shard
+                .update_optimizer_params(optimizer_config_diff.clone())
+                .await?;
+        }
+        Ok(())
     }
 
     pub async fn info(&self) -> CollectionResult<CollectionInfo> {
-        self.shard.info().await
+        // TODO: get info from all shards - change API
+        self.shards
+            .get(&0)
+            .expect("At least 1 shard expected")
+            .info()
+            .await
     }
+}
+
+pub fn shard_path(collection_path: &Path, shard_id: ShardId) -> PathBuf {
+    collection_path.join(format!("{shard_id}"))
 }
 
 pub fn avg_vectors<'a>(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 pub type VectorType = Vec<VectorElementType>;
 
 /// Current state of the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionStatus {
     /// Collection if completely ready for requests
@@ -37,7 +37,7 @@ pub enum CollectionStatus {
 }
 
 /// Current state of the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum OptimizersStatus {
     /// Optimizers are reporting as expected

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -47,14 +47,14 @@ pub struct OptimizersConfig {
 }
 
 pub fn build_optimizers(
-    collection_path: &Path,
+    shard_path: &Path,
     collection_params: &CollectionParams,
     optimizers_config: &OptimizersConfig,
     hnsw_config: &HnswConfig,
     schema_store: Arc<SchemaStorage>,
 ) -> Arc<Vec<Arc<Optimizer>>> {
-    let segments_path = collection_path.join("segments");
-    let temp_segments_path = collection_path.join("temp_segments");
+    let segments_path = shard_path.join("segments");
+    let temp_segments_path = shard_path.join("temp_segments");
 
     let threshold_config = OptimizerThresholds {
         memmap_threshold: optimizers_config.memmap_threshold,

--- a/lib/collection/src/shard.rs
+++ b/lib/collection/src/shard.rs
@@ -12,12 +12,12 @@ use segment::segment_constructor::simple_segment_constructor::build_simple_segme
 use std::cmp::max;
 use std::fs::create_dir_all;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::runtime::{self, Handle, Runtime};
+use tokio::runtime::{self, Runtime};
 use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot, Mutex, RwLock as TokioRwLock};
 
 use segment::types::{
-    Condition, Filter, HasIdCondition, PayloadKeyType, PayloadSchemaInfo, PointIdType, ScoredPoint,
-    SegmentType, VectorElementType, WithPayload,
+    ExtendedPointId, Filter, PayloadKeyType, PayloadSchemaInfo, SegmentType, WithPayload,
+    WithPayloadInterface,
 };
 
 use crate::collection_manager::collection_managers::CollectionSearcher;
@@ -26,8 +26,8 @@ use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::config::CollectionConfig;
 use crate::operations::config_diff::{DiffConfig, OptimizersConfigDiff};
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CollectionStatus, OptimizersStatus,
-    RecommendRequest, ScrollRequest, ScrollResult, SearchRequest, UpdateResult, UpdateStatus,
+    CollectionError, CollectionInfo, CollectionResult, CollectionStatus, OptimizersStatus, Record,
+    UpdateResult, UpdateStatus,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::build_optimizers;
@@ -56,6 +56,7 @@ pub struct Shard {
     update_sender: ArcSwap<UnboundedSender<UpdateSignal>>,
     path: PathBuf,
     schema_store: Arc<SchemaStorage>,
+    id: ShardId,
 }
 
 /// Shard holds information about segments and WAL.
@@ -112,21 +113,19 @@ impl Shard {
             update_sender: ArcSwap::from_pointee(update_sender),
             path: collection_path.to_owned(),
             schema_store,
+            id,
         }
     }
 
-    pub fn load(id: ShardId, collection_id: CollectionId, collection_path: &Path) -> Shard {
-        let wal_path = collection_path.join("wal");
-        let segments_path = collection_path.join("segments");
+    pub fn load(
+        id: ShardId,
+        collection_id: CollectionId,
+        shard_path: &Path,
+        collection_config: &CollectionConfig,
+    ) -> Shard {
+        let wal_path = Self::wal_path(shard_path);
+        let segments_path = Self::segments_path(shard_path);
         let mut segment_holder = SegmentHolder::default();
-
-        let collection_config = CollectionConfig::load(collection_path).unwrap_or_else(|err| {
-            panic!(
-                "Can't read collection config due to {}\nat {}",
-                err,
-                collection_path.to_str().unwrap()
-            )
-        });
 
         let wal: SerdeWal<CollectionUpdateOperations> = SerdeWal::new(
             wal_path.to_str().unwrap(),
@@ -167,7 +166,7 @@ impl Shard {
         }
 
         let optimizers = build_optimizers(
-            collection_path,
+            shard_path,
             &collection_config.params,
             &collection_config.optimizer_config,
             &collection_config.hnsw_config,
@@ -178,10 +177,10 @@ impl Shard {
             id,
             collection_id,
             segment_holder,
-            collection_config,
+            collection_config.clone(),
             wal,
             optimizers,
-            collection_path,
+            shard_path,
             schema_storage,
         );
 
@@ -190,23 +189,31 @@ impl Shard {
         collection
     }
 
+    pub fn wal_path(shard_path: &Path) -> PathBuf {
+        shard_path.join("wal")
+    }
+
+    pub fn segments_path(shard_path: &Path) -> PathBuf {
+        shard_path.join("segments")
+    }
+
     /// Creates new empty shard with given configuration, initializing all storages, optimizers and directories.
     pub fn build(
         id: ShardId,
         collection_id: CollectionId,
-        collection_path: &Path,
+        shard_path: &Path,
         config: &CollectionConfig,
     ) -> CollectionResult<Shard> {
-        let wal_path = collection_path.join("wal");
+        let wal_path = shard_path.join("wal");
 
         create_dir_all(&wal_path).map_err(|err| CollectionError::ServiceError {
-            error: format!("Can't create collection directory. Error: {}", err),
+            error: format!("Can't create shard wal directory. Error: {}", err),
         })?;
 
-        let segments_path = collection_path.join("segments");
+        let segments_path = shard_path.join("segments");
 
         create_dir_all(&segments_path).map_err(|err| CollectionError::ServiceError {
-            error: format!("Can't create collection directory. Error: {}", err),
+            error: format!("Can't create shard segments directory. Error: {}", err),
         })?;
 
         let mut segment_holder = SegmentHolder::default();
@@ -226,20 +233,11 @@ impl Shard {
         let wal: SerdeWal<CollectionUpdateOperations> =
             SerdeWal::new(wal_path.to_str().unwrap(), &(&config.wal_config).into())?;
 
-        let collection_config = CollectionConfig {
-            params: config.params.clone(),
-            hnsw_config: config.hnsw_config,
-            optimizer_config: config.optimizer_config.clone(),
-            wal_config: config.wal_config.clone(),
-        };
-
-        collection_config.save(collection_path)?;
-
         let optimizers = build_optimizers(
-            collection_path,
+            shard_path,
             &config.params,
             &config.optimizer_config,
-            &collection_config.hnsw_config,
+            &config.hnsw_config,
             schema_storage.clone(),
         );
 
@@ -247,10 +245,10 @@ impl Shard {
             id,
             collection_id,
             segment_holder,
-            collection_config,
+            config.clone(),
             wal,
             optimizers,
-            collection_path,
+            shard_path,
             schema_storage,
         );
 
@@ -305,53 +303,23 @@ impl Shard {
 
     pub async fn scroll_by(
         &self,
-        request: ScrollRequest,
         segment_searcher: &(dyn CollectionSearcher + Sync),
-    ) -> CollectionResult<ScrollResult> {
-        let default_request = ScrollRequest::default();
-
-        let offset = request.offset;
-        let limit = request
-            .limit
-            .unwrap_or_else(|| default_request.limit.unwrap());
-        let with_payload_interface = &request
-            .with_payload
-            .clone()
-            .unwrap_or_else(|| default_request.with_payload.clone().unwrap());
-        let with_vector = request.with_vector;
-
-        if limit == 0 {
-            return Err(CollectionError::BadRequest {
-                description: "Limit cannot be 0".to_string(),
-            });
-        }
-
-        // Retrieve 1 extra point to determine proper `next_page_offset`
-        let retrieve_limit = limit + 1;
-
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: bool,
+        filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
         // ToDo: Make faster points selection with a set
         let segments = self.segments();
-        let mut point_ids = segments
+        let point_ids = segments
             .read()
             .iter()
-            .flat_map(|(_, segment)| {
-                segment
-                    .get()
-                    .read()
-                    .read_filtered(offset, retrieve_limit, request.filter.as_ref())
-            })
+            .flat_map(|(_, segment)| segment.get().read().read_filtered(offset, limit, filter))
             .sorted()
             .dedup()
-            .take(retrieve_limit)
+            .take(limit)
             .collect_vec();
-
-        let next_page_offset = if point_ids.len() < retrieve_limit {
-            // This was the last page
-            None
-        } else {
-            // remove extra point, it would be a first point of the next page
-            Some(point_ids.pop().unwrap())
-        };
 
         let with_payload = WithPayload::from(with_payload_interface);
         let mut points = segment_searcher
@@ -359,99 +327,7 @@ impl Shard {
             .await?;
         points.sort_by_key(|point| point.id);
 
-        Ok(ScrollResult {
-            points,
-            next_page_offset,
-        })
-    }
-
-    pub async fn recommend_by(
-        &self,
-        request: RecommendRequest,
-        segment_searcher: &(dyn CollectionSearcher + Sync),
-        search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
-        let segments = self.segments();
-        if request.positive.is_empty() {
-            return Err(CollectionError::BadRequest {
-                description: "At least one positive vector ID required".to_owned(),
-            });
-        }
-
-        let reference_vectors_ids = request
-            .positive
-            .iter()
-            .chain(&request.negative)
-            .cloned()
-            .collect_vec();
-
-        let vectors = segment_searcher
-            .retrieve(
-                segments,
-                &reference_vectors_ids,
-                &WithPayload::from(true),
-                true,
-            )
-            .await?;
-        let vectors_map: HashMap<PointIdType, Vec<VectorElementType>> = vectors
-            .into_iter()
-            .map(|rec| (rec.id, rec.vector.unwrap()))
-            .collect();
-
-        for &point_id in &reference_vectors_ids {
-            if !vectors_map.contains_key(&point_id) {
-                return Err(CollectionError::NotFound {
-                    missed_point_id: point_id,
-                });
-            }
-        }
-
-        let avg_positive = crate::avg_vectors(
-            request
-                .positive
-                .iter()
-                .map(|vid| vectors_map.get(vid).unwrap()),
-        );
-
-        let search_vector = if request.negative.is_empty() {
-            avg_positive
-        } else {
-            let avg_negative = crate::avg_vectors(
-                request
-                    .negative
-                    .iter()
-                    .map(|vid| vectors_map.get(vid).unwrap()),
-            );
-
-            avg_positive
-                .iter()
-                .cloned()
-                .zip(avg_negative.iter().cloned())
-                .map(|(pos, neg)| pos + pos - neg)
-                .collect()
-        };
-
-        let search_request = SearchRequest {
-            vector: search_vector,
-            filter: Some(Filter {
-                should: None,
-                must: request
-                    .filter
-                    .clone()
-                    .map(|filter| vec![Condition::Filter(filter)]),
-                must_not: Some(vec![Condition::HasId(HasIdCondition {
-                    has_id: reference_vectors_ids.iter().cloned().collect(),
-                })]),
-            }),
-            with_payload: request.with_payload,
-            with_vector: request.with_vector,
-            params: request.params,
-            top: request.top,
-        };
-
-        segment_searcher
-            .search(segments, Arc::new(search_request), search_runtime_handle)
-            .await
+        Ok(points)
     }
 
     /// Collect overview information about the collection
@@ -571,15 +447,21 @@ impl Shard {
 
 impl Drop for Shard {
     fn drop(&mut self) {
+        println!("Dropping shard {}", self.id);
         // Finishes update tasks right before destructor stuck to do so with runtime
         self.update_sender.load().send(UpdateSignal::Stop).unwrap();
+        println!("Sent stop signal {}", self.id);
+
         block_on(self.stop_flush_worker());
+        println!("Sent stop flush worker {}", self.id);
 
         block_on(self.wait_update_workers_stop()).unwrap();
+        println!("Stopped update workers {}", self.id);
 
         match self.runtime_handle.take() {
             None => {}
             Some(handle) => {
+                println!("Dropping runtime handle {}", self.id);
                 // The drop could be called from the tokio context, e.g. from perform_collection_operation method.
                 // Calling remove from there would lead to the following error in a new version of tokio:
                 // "Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context."
@@ -593,5 +475,7 @@ impl Drop for Shard {
                 thread_handler.join().unwrap();
             }
         }
+
+        println!("Dropped shard {}", self.id)
     }
 }

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -18,10 +18,15 @@ mod common;
 
 #[tokio::test]
 async fn test_collection_reloading() {
+    test_collection_reloading_with_shards(1).await;
+    test_collection_reloading_with_shards(10).await;
+}
+
+async fn test_collection_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
     {
-        let _collection = simple_collection_fixture(collection_dir.path()).await;
+        let _collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
     }
     for _i in 0..5 {
         let collection = Collection::load("test".to_string(), collection_dir.path());
@@ -43,9 +48,14 @@ async fn test_collection_reloading() {
 
 #[tokio::test]
 async fn test_collection_payload_reloading() {
+    test_collection_payload_reloading_with_shards(1).await;
+    test_collection_payload_reloading_with_shards(10).await;
+}
+
+async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let collection = simple_collection_fixture(collection_dir.path()).await;
+        let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(PointsBatch {
                 batch: Batch {
@@ -99,9 +109,14 @@ async fn test_collection_payload_reloading() {
 
 #[tokio::test]
 async fn test_collection_payload_custom_payload() {
+    test_collection_payload_custom_payload_with_shards(1).await;
+    test_collection_payload_custom_payload_with_shards(10).await;
+}
+
+async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let collection = simple_collection_fixture(collection_dir.path()).await;
+        let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(PointsBatch {
                 batch: Batch {

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -26,9 +26,14 @@ mod common;
 
 #[tokio::test]
 async fn test_collection_updater() {
+    test_collection_updater_with_shards(1).await;
+    test_collection_updater_with_shards(10).await;
+}
+
+async fn test_collection_updater_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let collection = simple_collection_fixture(collection_dir.path()).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -83,9 +88,14 @@ async fn test_collection_updater() {
 
 #[tokio::test]
 async fn test_collection_search_with_payload_and_vector() {
+    test_collection_search_with_payload_and_vector_with_shards(1).await;
+    test_collection_search_with_payload_and_vector_with_shards(10).await;
+}
+
+async fn test_collection_search_with_payload_and_vector_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let collection = simple_collection_fixture(collection_dir.path()).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -133,12 +143,18 @@ async fn test_collection_search_with_payload_and_vector() {
     }
 }
 
+// FIXME: dos not work
 #[tokio::test]
 async fn test_collection_loading() {
+    test_collection_loading_with_shards(10).await;
+    //test_collection_loading_with_shards(10).await;
+}
+
+async fn test_collection_loading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
     {
-        let collection = simple_collection_fixture(collection_dir.path()).await;
+        let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             Batch {
                 ids: vec![0, 1, 2, 3, 4]
@@ -244,10 +260,16 @@ fn test_deserialization2() {
     let _read_obj2: CollectionUpdateOperations = rmp_serde::from_read_ref(&raw_bytes).unwrap();
 }
 
+// Request to find points sent to all shards but they might not have a particular id, so they will return an error
 #[tokio::test]
 async fn test_recommendation_api() {
+    test_recommendation_api_with_shards(1).await;
+    test_recommendation_api_with_shards(10).await;
+}
+
+async fn test_recommendation_api_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
-    let collection = simple_collection_fixture(collection_dir.path()).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -297,8 +319,13 @@ async fn test_recommendation_api() {
 
 #[tokio::test]
 async fn test_read_api() {
+    test_read_api_with_shards(1).await;
+    test_read_api_with_shards(10).await;
+}
+
+async fn test_read_api_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
-    let collection = simple_collection_fixture(collection_dir.path()).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
         Batch {
@@ -345,9 +372,14 @@ async fn test_read_api() {
 
 #[tokio::test]
 async fn test_collection_delete_points_by_filter() {
+    test_collection_delete_points_by_filter_with_shards(1).await;
+    test_collection_delete_points_by_filter_with_shards(10).await;
+}
+
+async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let collection = simple_collection_fixture(collection_dir.path()).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
 };
 
 #[allow(dead_code)]
-pub async fn simple_collection_fixture(collection_path: &Path) -> Collection {
+pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
         wal_segments_ahead: 0,
@@ -26,6 +26,7 @@ pub async fn simple_collection_fixture(collection_path: &Path) -> Collection {
     let collection_params = CollectionParams {
         vector_size: 4,
         distance: Distance::Dot,
+        shard_number,
     };
 
     Collection::new(

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
 };
 
 #[allow(dead_code)]
-pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
+pub fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
         wal_segments_ahead: 0,

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -2,9 +2,8 @@ use crate::content_manager::errors::StorageError;
 use async_trait::async_trait;
 use collection::Collection;
 use std::collections::HashMap;
-use std::sync::Arc;
 
-pub type Collections = HashMap<String, Arc<Collection>>;
+pub type Collections = HashMap<String, Collection>;
 
 #[async_trait]
 pub trait Checker {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -161,6 +161,7 @@ impl TableOfContent {
         let collection_params = CollectionParams {
             vector_size,
             distance,
+            shard_number: 1,
         };
         let wal_config = match wal_config_diff {
             None => self.storage_config.wal.clone(),

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use sled::transaction::UnabortableTransactionError;
 use sled::{Config, Db};
 use tokio::runtime::Runtime;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, RwLockReadGuard};
 
 use collection::config::{CollectionConfig, CollectionParams};
 use collection::operations::config_diff::DiffConfig;
@@ -44,6 +44,7 @@ pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: StorageConfig,
     search_runtime: Runtime,
+    collection_management_runtime: Runtime,
     alias_persistence: Db,
     segment_searcher: Box<dyn CollectionSearcher + Sync + Send>,
 }
@@ -51,13 +52,14 @@ pub struct TableOfContent {
 impl TableOfContent {
     pub fn new(storage_config: &StorageConfig, search_runtime: Runtime) -> Self {
         let collections_path = Path::new(&storage_config.storage_path).join(&COLLECTIONS_DIR);
+        let collection_management_runtime = Runtime::new().unwrap();
 
         create_dir_all(&collections_path).expect("Can't create Collections directory");
 
         let collection_paths =
             read_dir(&collections_path).expect("Can't read Collections directory");
 
-        let mut collections: HashMap<String, Arc<Collection>> = Default::default();
+        let mut collections: HashMap<String, Collection> = Default::default();
 
         for entry in collection_paths {
             let collection_path = entry
@@ -70,9 +72,10 @@ impl TableOfContent {
                 .expect("A filename of one of the collection files is not a valid UTF-8")
                 .to_string();
 
-            let collection = Collection::load(collection_name.clone(), &collection_path);
+            let collection = collection_management_runtime
+                .block_on(Collection::load(collection_name.clone(), &collection_path));
 
-            collections.insert(collection_name, Arc::new(collection));
+            collections.insert(collection_name, collection);
         }
 
         let alias_path = Path::new(&storage_config.storage_path).join("aliases.sled");
@@ -89,6 +92,7 @@ impl TableOfContent {
             search_runtime,
             alias_persistence,
             segment_searcher: Box::new(SimpleCollectionSearcher::new()),
+            collection_management_runtime,
         }
     }
 
@@ -193,7 +197,7 @@ impl TableOfContent {
         write_collections
             .validate_collection_not_exists(collection_name)
             .await?;
-        write_collections.insert(collection_name.to_string(), Arc::new(collection));
+        write_collections.insert(collection_name.to_string(), collection);
         Ok(true)
     }
 
@@ -215,8 +219,8 @@ impl TableOfContent {
     }
 
     pub async fn delete_collection(&self, collection_name: &str) -> Result<bool, StorageError> {
-        if let Some(removed) = self.collections.write().await.remove(collection_name) {
-            tokio::task::spawn_blocking(move || drop(removed)).await?;
+        if let Some(mut removed) = self.collections.write().await.remove(collection_name) {
+            removed.before_drop().await;
             let path = self.get_collection_path(collection_name);
             remove_dir_all(path).map_err(|err| StorageError::ServiceError {
                 description: format!(
@@ -313,14 +317,16 @@ impl TableOfContent {
         }
     }
 
-    pub async fn get_collection(
-        &self,
+    pub async fn get_collection<'a>(
+        &'a self,
         collection_name: &str,
-    ) -> Result<Arc<Collection>, StorageError> {
+    ) -> Result<RwLockReadGuard<'a, Collection>, StorageError> {
         let read_collection = self.collections.read().await;
         let real_collection_name = self.resolve_name(collection_name).await?;
         // resolve_name already checked collection existence, unwrap is safe here
-        Ok(read_collection.get(&real_collection_name).unwrap().clone())
+        Ok(RwLockReadGuard::map(read_collection, |collection| {
+            collection.get(&real_collection_name).unwrap()
+        }))
     }
 
     /// Recommend points using positive and negative example from the request
@@ -450,5 +456,16 @@ impl TableOfContent {
             .update(operation, wait)
             .await
             .map_err(|err| err.into())
+    }
+}
+
+// `TableOfContent` should not be dropped from async context.
+impl Drop for TableOfContent {
+    fn drop(&mut self) {
+        self.collection_management_runtime.block_on(async {
+            for (_, mut collection) in self.collections.write().await.drain() {
+                collection.before_drop().await;
+            }
+        });
     }
 }

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -235,6 +235,7 @@ impl From<(Instant, collection::operations::types::CollectionInfo)> for GetColle
                             segment::types::Distance::Dot => Distance::Dot,
                         }
                         .into(),
+                        shard_number: config.params.shard_number,
                     }),
                     hnsw_config: Some(HnswConfigDiff {
                         m: Some(config.hnsw_config.m as u64),

--- a/src/tonic/proto/collections.proto
+++ b/src/tonic/proto/collections.proto
@@ -178,6 +178,7 @@ message CollectionOperationResponse {
 message CollectionParams {
   uint64 vector_size = 1; // Size of the vectors
   Distance distance = 2; // Distance function used for comparing vectors
+  uint32 shard_number = 3; // Number of shards in collection
 }
 
 message CollectionConfig {

--- a/src/tonic/qdrant.rs
+++ b/src/tonic/qdrant.rs
@@ -167,6 +167,9 @@ pub struct CollectionParams {
     /// Distance function used for comparing vectors
     #[prost(enumeration = "Distance", tag = "2")]
     pub distance: i32,
+    /// Number of shards in collection
+    #[prost(uint32, tag = "3")]
+    pub shard_number: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionConfig {
@@ -985,7 +988,7 @@ pub struct RecommendResponse {
 
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Filter {
-    /// At least one of thous conditions should match
+    /// At least one of those conditions should match
     #[prost(message, repeated, tag = "1")]
     pub should: ::prost::alloc::vec::Vec<Condition>,
     /// All conditions must match


### PR DESCRIPTION
Closes #323 

## Changes

- Introduces option to have multiple shards in a collection
- Sets default number of shards to 1
- Read legacy format with 1 shard
- Async drop update for collection
- Collection tests for 1 and 10 shards 
- Hashring set to updated `0.2.1` version (our PR was merged)
- Fix tonic API generation problem

## Async Drop

During tests it was noticed that with 10 or more shards, futures in Drop were stuck on await though technically ready. Upon closer investigation I found that `futures::block_on` is used in Drop, but `Drop` happens in tokio context - this probably leads to some wakers being lost.

Generally tokio does not allow spawning a new runtime inside another runtime. And with external runtimes (like `futures`) it is considered to be an undefined behavior AFAIK.

Therefore I introduce async `before_drop` function, which needs to be called manually. It does not need to spawn and block a new runtime. This is less convenient for development, but I believe currently it is the only solution.

## Test time

As you can see in CI tests length have increased by approximately 3 minutes. This is due to all collection tests being executed also with 10 shards. Mostly file operations take this time. I am currently not sure if we should leave it at 10 or decrease to 5 or less, to save test time.
