### PR TITLE
upd naming in api

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2278,7 +2278,7 @@
         ]
       }
     },
-    "/collections/{name}": {
+    "/collections/{collection_name}": {
       "delete": {
         "description": "Drop collection and all associated data",
         "operationId": "delete_collection",
@@ -2286,7 +2286,7 @@
           {
             "description": "Name of the collection to delete",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2353,7 +2353,7 @@
           {
             "description": "Name of the collection to retrieve",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2420,7 +2420,7 @@
           {
             "description": "Name of the collection to update",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2498,7 +2498,7 @@
           {
             "description": "Name of the collection to search in",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2584,7 +2584,7 @@
           {
             "description": "Name of the new collection",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2655,7 +2655,7 @@
         ]
       }
     },
-    "/collections/{name}/index": {
+    "/collections/{collection_name}/index": {
       "put": {
         "description": "Create index for field in collection",
         "operationId": "create_field_index",
@@ -2663,7 +2663,7 @@
           {
             "description": "Name of the collection",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2743,7 +2743,7 @@
         ]
       }
     },
-    "/collections/{name}/index/{field_name}": {
+    "/collections/{collection_name}/index/{field_name}": {
       "delete": {
         "description": "Delete field index for collection",
         "operationId": "delete_field_index",
@@ -2751,7 +2751,7 @@
           {
             "description": "Name of the collection",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2830,7 +2830,7 @@
         ]
       }
     },
-    "/collections/{name}/points": {
+    "/collections/{collection_name}/points": {
       "post": {
         "description": "Retrieve multiple points by specified IDs",
         "operationId": "get_points",
@@ -2838,7 +2838,7 @@
           {
             "description": "Name of the collection to retrieve from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2918,7 +2918,7 @@
           {
             "description": "Name of the collection to update from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -2998,7 +2998,7 @@
         ]
       }
     },
-    "/collections/{name}/points/delete": {
+    "/collections/{collection_name}/points/delete": {
       "post": {
         "description": "Delete points",
         "operationId": "delete_points",
@@ -3006,7 +3006,7 @@
           {
             "description": "Name of the collection to delete from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3086,7 +3086,7 @@
         ]
       }
     },
-    "/collections/{name}/points/payload": {
+    "/collections/{collection_name}/points/payload": {
       "post": {
         "description": "Set payload for points",
         "operationId": "set_payload",
@@ -3094,7 +3094,7 @@
           {
             "description": "Name of the collection to set from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3174,7 +3174,7 @@
         ]
       }
     },
-    "/collections/{name}/points/payload/clear": {
+    "/collections/{collection_name}/points/payload/clear": {
       "post": {
         "description": "Remove all payload for specified points",
         "operationId": "clear_payload",
@@ -3182,7 +3182,7 @@
           {
             "description": "Name of the collection to clear payload from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3262,7 +3262,7 @@
         ]
       }
     },
-    "/collections/{name}/points/payload/delete": {
+    "/collections/{collection_name}/points/payload/delete": {
       "post": {
         "description": "Delete specified key payload for points",
         "operationId": "delete_payload",
@@ -3270,7 +3270,7 @@
           {
             "description": "Name of the collection to delete from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3350,7 +3350,7 @@
         ]
       }
     },
-    "/collections/{name}/points/recommend": {
+    "/collections/{collection_name}/points/recommend": {
       "post": {
         "description": "Look for the points which are closer to stored positive examples and at the same time further to negative examples.",
         "operationId": "recommend_points",
@@ -3358,7 +3358,7 @@
           {
             "description": "Name of the collection to search in",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3432,7 +3432,7 @@
         ]
       }
     },
-    "/collections/{name}/points/scroll": {
+    "/collections/{collection_name}/points/scroll": {
       "post": {
         "description": "Scroll request - paginate over all points which matches given filtering condition",
         "operationId": "scroll_points",
@@ -3440,7 +3440,7 @@
           {
             "description": "Name of the collection to retrieve from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3511,7 +3511,7 @@
         ]
       }
     },
-    "/collections/{name}/points/search": {
+    "/collections/{collection_name}/points/search": {
       "post": {
         "description": "Retrieve closest points based on vector similarity and given filtering conditions",
         "operationId": "search_points",
@@ -3519,7 +3519,7 @@
           {
             "description": "Name of the collection to search in",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"
@@ -3593,7 +3593,7 @@
         ]
       }
     },
-    "/collections/{name}/points/{id}": {
+    "/collections/{collection_name}/points/{id}": {
       "get": {
         "description": "Retrieve full information of single point by id",
         "operationId": "get_point",
@@ -3601,7 +3601,7 @@
           {
             "description": "Name of the collection to retrieve from",
             "in": "path",
-            "name": "name",
+            "name": "collection_name",
             "required": true,
             "schema": {
               "type": "string"

--- a/openapi/openapi-collections.ytt.yaml
+++ b/openapi/openapi-collections.ytt.yaml
@@ -25,7 +25,7 @@ paths:
               $ref: "#/components/schemas/StorageOperations"
       responses: #@ response(type("boolean"))
 
-  /collections/{name}:
+  /collections/{collection_name}:
     get:
       tags:
         - collections
@@ -33,7 +33,7 @@ paths:
       description: Get detailed information about specified existing collection
       operationId: get_collection
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to retrieve
           required: true
@@ -55,7 +55,7 @@ paths:
               $ref: "#/components/schemas/CreateCollection"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the new collection
           required: true
@@ -77,7 +77,7 @@ paths:
               $ref: "#/components/schemas/UpdateCollection"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to update
           required: true
@@ -92,7 +92,7 @@ paths:
       description: Drop collection and all associated data
       operationId: delete_collection
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to delete
           required: true
@@ -115,7 +115,7 @@ paths:
 
       responses: #@ response(type("boolean"))
 
-  /collections/{name}/index:
+  /collections/{collection_name}/index:
     put:
       tags:
         - collections
@@ -123,7 +123,7 @@ paths:
       description: Create index for field in collection
       operationId: create_field_index
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection
           required: true
@@ -144,7 +144,7 @@ paths:
 
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/index/{field_name}:
+  /collections/{collection_name}/index/{field_name}:
     delete:
       tags:
         - collections
@@ -152,7 +152,7 @@ paths:
       description: Delete field index for collection
       operationId: delete_field_index
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection
           required: true

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -221,7 +221,7 @@ tags:
 
 paths:
 
-  /collections/{name}/points/scroll:
+  /collections/{collection_name}/points/scroll:
     post:
       tags:
         - points
@@ -236,7 +236,7 @@ paths:
               $ref: "#/components/schemas/ScrollRequest"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to retrieve from
           required: true
@@ -244,7 +244,7 @@ paths:
             type: string
       responses: #@ response(reference("ScrollResult"))
 
-  /collections/{name}/points/search:
+  /collections/{collection_name}/points/search:
     post:
       tags:
         - points
@@ -259,7 +259,7 @@ paths:
               $ref: "#/components/schemas/SearchRequest"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to search in
           required: true
@@ -267,7 +267,7 @@ paths:
             type: string
       responses: #@ response(array(reference("ScoredPoint")))
 
-  /collections/{name}/points/recommend:
+  /collections/{collection_name}/points/recommend:
     post:
       tags:
         - points
@@ -282,7 +282,7 @@ paths:
               $ref: "#/components/schemas/RecommendRequest"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to search in
           required: true

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -1,7 +1,7 @@
 #@ load("openapi.lib.yml", "response", "reference", "type", "array")
 
 paths:
-  /collections/{name}:
+  /collections/{collection_name}:
     post:
       tags:
         - points
@@ -17,7 +17,7 @@ paths:
               $ref: "#/components/schemas/CollectionUpdateOperations"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to search in
           required: true
@@ -31,7 +31,7 @@ paths:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/points/{id}:
+  /collections/{collection_name}/points/{id}:
     get:
       tags:
         - points
@@ -39,7 +39,7 @@ paths:
       description: Retrieve full information of single point by id
       operationId: get_point
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to retrieve from
           required: true
@@ -53,7 +53,7 @@ paths:
             $ref: "#/components/schemas/ExtendedPointId"
       responses: #@ response(reference("Record"))
 
-  /collections/{name}/points:
+  /collections/{collection_name}/points:
     post:
       tags:
         - points
@@ -68,7 +68,7 @@ paths:
               $ref: "#/components/schemas/PointRequest"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to retrieve from
           required: true
@@ -90,7 +90,7 @@ paths:
               $ref: "#/components/schemas/PointInsertOperations"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to update from
           required: true
@@ -104,7 +104,7 @@ paths:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/points/delete:
+  /collections/{collection_name}/points/delete:
     post:
       tags:
         - points
@@ -119,7 +119,7 @@ paths:
               $ref: "#/components/schemas/PointsSelector"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to delete from
           required: true
@@ -133,7 +133,7 @@ paths:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/points/payload:
+  /collections/{collection_name}/points/payload:
     post:
       tags:
         - points
@@ -148,7 +148,7 @@ paths:
               $ref: "#/components/schemas/SetPayload"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to set from
           required: true
@@ -162,7 +162,7 @@ paths:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/points/payload/delete:
+  /collections/{collection_name}/points/payload/delete:
     post:
       tags:
         - points
@@ -177,7 +177,7 @@ paths:
               $ref: "#/components/schemas/DeletePayload"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to delete from
           required: true
@@ -191,7 +191,7 @@ paths:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
 
-  /collections/{name}/points/payload/clear:
+  /collections/{collection_name}/points/payload/clear:
     post:
       tags:
         - points
@@ -206,7 +206,7 @@ paths:
               $ref: "#/components/schemas/PointsSelector"
 
       parameters:
-        - name: name
+        - name: collection_name
           in: path
           description: Name of the collection to clear payload from
           required: true

--- a/openapi/tests/openapi_integration/helpers/collection_setup.py
+++ b/openapi/tests/openapi_integration/helpers/collection_setup.py
@@ -3,25 +3,25 @@ from openapi_integration.helpers.helpers import request_with_validation
 
 def drop_collection(collection_name='test_collection'):
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="DELETE",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
 
 
 def basic_collection_setup(collection_name='test_collection'):
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="DELETE",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "vector_size": 4,
             "distance": "Dot"
@@ -30,16 +30,16 @@ def basic_collection_setup(collection_name='test_collection'):
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [

--- a/openapi/tests/openapi_integration/test_alias.py
+++ b/openapi/tests/openapi_integration/test_alias.py
@@ -31,9 +31,9 @@ def test_alias_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points/search',
+        api='/collections/{collection_name}/points/search',
         method="POST",
-        path_params={'name': "test_alias"},
+        path_params={'collection_name': "test_alias"},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
             "top": 3

--- a/openapi/tests/openapi_integration/test_basic_retrieve_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api.py
@@ -15,16 +15,16 @@ def setup():
 
 def test_points_retrieve():
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': 2},
+        path_params={'collection_name': collection_name, 'id': 2},
     )
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "ids": [1, 2]
         }
@@ -33,17 +33,17 @@ def test_points_retrieve():
     assert len(response.json()['result']) == 2
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert response.json()['result']['vectors_count'] == 6
 
     response = request_with_validation(
-        api='/collections/{name}/points/search',
+        api='/collections/{collection_name}/points/search',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
             "top": 3
@@ -53,9 +53,9 @@ def test_points_retrieve():
     assert len(response.json()['result']) == 3
 
     response = request_with_validation(
-        api='/collections/{name}/points/search',
+        api='/collections/{collection_name}/points/search',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "filter": {
                 "should": [
@@ -75,9 +75,9 @@ def test_points_retrieve():
     assert len(response.json()['result']) == 2  # only 2 London records in collection
 
     response = request_with_validation(
-        api='/collections/{name}/points/scroll',
+        api='/collections/{collection_name}/points/scroll',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={"offset": 2, "limit": 2, "with_vector": True}
     )
     assert response.ok
@@ -86,9 +86,9 @@ def test_points_retrieve():
 
 def test_exclude_payload():
     response = request_with_validation(
-        api='/collections/{name}/points/search',
+        api='/collections/{collection_name}/points/search',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
             "top": 5,
@@ -115,9 +115,9 @@ def test_exclude_payload():
 
 def test_recommendation():
     response = request_with_validation(
-        api='/collections/{name}/points/recommend',
+        api='/collections/{collection_name}/points/recommend',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "top": 3,
             "negative": [],

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -15,9 +15,9 @@ def setup():
 
 def test_collection_update():
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="PATCH",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "optimizers_config": {
                 "default_segment_number": 6,
@@ -28,9 +28,9 @@ def test_collection_update():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [
@@ -45,8 +45,8 @@ def test_collection_update():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': 7},
+        path_params={'collection_name': collection_name, 'id': 7},
     )
     assert response.ok

--- a/openapi/tests/openapi_integration/test_delete_points.py
+++ b/openapi/tests/openapi_integration/test_delete_points.py
@@ -16,9 +16,9 @@ def setup():
 def test_delete_points():
     # delete point by filter (has_id)
     response = request_with_validation(
-        api='/collections/{name}/points/delete',
+        api='/collections/{collection_name}/points/delete',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "filter": {
@@ -32,17 +32,17 @@ def test_delete_points():
 
     # quantity check if the above point id was deleted
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert response.json()['result']['vectors_count'] == 5
 
     response = request_with_validation(
-        api='/collections/{name}/points/delete',
+        api='/collections/{collection_name}/points/delete',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [1, 2, 3, 4]
@@ -52,9 +52,9 @@ def test_delete_points():
 
     # quantity check if the above point id was deleted
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert response.json()['result']['vectors_count'] == 1

--- a/openapi/tests/openapi_integration/test_payload_indexing.py
+++ b/openapi/tests/openapi_integration/test_payload_indexing.py
@@ -16,9 +16,9 @@ def setup():
 def test_payload_indexing_operations():
     # create payload
     response = request_with_validation(
-        api='/collections/{name}/points/payload',
+        api='/collections/{collection_name}/points/payload',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "payload": {"test_payload": "keyword"},
@@ -28,18 +28,18 @@ def test_payload_indexing_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert not response.json()['result']['payload_schema']['test_payload']['indexed']
 
     # Create index
     response = request_with_validation(
-        api='/collections/{name}/index',
+        api='/collections/{collection_name}/index',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "field_name": "test_payload"
@@ -48,26 +48,26 @@ def test_payload_indexing_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert response.json()['result']['payload_schema']['test_payload']['indexed']
 
     # Delete index
     response = request_with_validation(
-        api='/collections/{name}/index/{field_name}',
+        api='/collections/{collection_name}/index/{field_name}',
         method="DELETE",
-        path_params={'name': collection_name, 'field_name': 'test_payload'},
+        path_params={'collection_name': collection_name, 'field_name': 'test_payload'},
         query_params={'wait': 'true'},
     )
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="GET",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
     assert not response.json()['result']['payload_schema']['test_payload']['indexed']

--- a/openapi/tests/openapi_integration/test_payload_operations.py
+++ b/openapi/tests/openapi_integration/test_payload_operations.py
@@ -16,9 +16,9 @@ def setup():
 def test_payload_operations():
     # create payload
     response = request_with_validation(
-        api='/collections/{name}/points/payload',
+        api='/collections/{collection_name}/points/payload',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "payload": {"test_payload": "keyword"},
@@ -29,18 +29,18 @@ def test_payload_operations():
 
     # check payload
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': 6},
+        path_params={'collection_name': collection_name, 'id': 6},
     )
     assert response.ok
     assert len(response.json()['result']['payload']) == 1
 
     # clean payload by filter
     response = request_with_validation(
-        api='/collections/{name}/points/payload/clear',
+        api='/collections/{collection_name}/points/payload/clear',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "filter": {
@@ -54,18 +54,18 @@ def test_payload_operations():
 
     # check payload
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': 6},
+        path_params={'collection_name': collection_name, 'id': 6},
     )
     assert response.ok
     assert len(response.json()['result']['payload']) == 0
 
     # create payload
     response = request_with_validation(
-        api='/collections/{name}/points/payload',
+        api='/collections/{collection_name}/points/payload',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "payload": {"test_payload": "keyword"},
@@ -76,9 +76,9 @@ def test_payload_operations():
 
     # delete payload by id
     response = request_with_validation(
-        api='/collections/{name}/points/payload/delete',
+        api='/collections/{collection_name}/points/payload/delete',
         method="POST",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "keys": ["test_payload"],
@@ -89,9 +89,9 @@ def test_payload_operations():
 
     # check payload
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': 6},
+        path_params={'collection_name': collection_name, 'id': 6},
     )
     assert response.ok
     assert len(response.json()['result']['payload']) == 0

--- a/openapi/tests/openapi_integration/test_schema_consistency.py
+++ b/openapi/tests/openapi_integration/test_schema_consistency.py
@@ -8,16 +8,16 @@ collection_name = 'test_collection_schema_consistency'
 
 def test_uuid_operations():
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="DELETE",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         body={
             "vector_size": 3,
             "distance": "Cosine"
@@ -26,9 +26,9 @@ def test_uuid_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [
@@ -45,9 +45,9 @@ def test_uuid_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [
@@ -64,8 +64,8 @@ def test_uuid_operations():
     assert not response.ok
 
     response = request_with_validation(
-        api='/collections/{name}',
+        api='/collections/{collection_name}',
         method="DELETE",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
     )
     assert response.ok

--- a/openapi/tests/openapi_integration/test_uuid_ops.py
+++ b/openapi/tests/openapi_integration/test_uuid_ops.py
@@ -15,9 +15,9 @@ def setup():
 
 def test_uuid_operations():
     response = request_with_validation(
-        api='/collections/{name}/points',
+        api='/collections/{collection_name}/points',
         method="PUT",
-        path_params={'name': collection_name},
+        path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
             "points": [
@@ -37,8 +37,8 @@ def test_uuid_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/{name}/points/{id}',
+        api='/collections/{collection_name}/points/{id}',
         method="GET",
-        path_params={'name': collection_name, 'id': "b524a3c4-c568-4383-8019-c9ca08243d6a"},
+        path_params={'collection_name': collection_name, 'id': "b524a3c4-c568-4383-8019-c9ca08243d6a"},
     )
     assert response.ok


### PR DESCRIPTION
* Unifies naming of the path parameter `collection_name`

There were a problem with un-update python client which, which used `collection_name` instead of `name` in some places. It was impossible to update consistently without loosing backward compatibility, unfortunately.

This will require 0.6.0 release

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?
