### PR TITLE
Fixes shard drop on collection creation

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -68,10 +68,12 @@ impl Collection {
         let mut shards: HashMap<ShardId, Shard> = HashMap::new();
         for shard_id in 0..config.params.shard_number {
             let shard_path = shard_path(path, shard_id);
-            create_dir_all(&shard_path).map_err(|err| CollectionError::ServiceError {
-                error: format!("Can't create shard {shard_id} directory. Error: {}", err),
-            })?;
-            let shard = match Shard::build(shard_id, id.clone(), &shard_path, config) {
+            let shard = create_dir_all(&shard_path)
+                .map_err(|err| CollectionError::ServiceError {
+                    error: format!("Can't create shard {shard_id} directory. Error: {}", err),
+                })
+                .and_then(|()| Shard::build(shard_id, id.clone(), &shard_path, config));
+            let shard = match shard {
                 Ok(shard) => shard,
                 Err(err) => {
                     let futures: FuturesUnordered<_> = shards

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -12,21 +12,21 @@ use collection::{
 };
 use segment::types::{PayloadSelectorExclude, PayloadType, WithPayloadInterface};
 
-use crate::common::simple_collection_fixture;
+use crate::common::{simple_collection_fixture, N_SHARDS};
 
 mod common;
 
 #[tokio::test]
 async fn test_collection_reloading() {
     test_collection_reloading_with_shards(1).await;
-    test_collection_reloading_with_shards(10).await;
+    test_collection_reloading_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         collection.before_drop().await;
     }
     for _i in 0..5 {
@@ -52,13 +52,13 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
 #[tokio::test]
 async fn test_collection_payload_reloading() {
     test_collection_payload_reloading_with_shards(1).await;
-    test_collection_payload_reloading_with_shards(10).await;
+    test_collection_payload_reloading_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(PointsBatch {
                 batch: Batch {
@@ -115,13 +115,13 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
 #[tokio::test]
 async fn test_collection_payload_custom_payload() {
     test_collection_payload_custom_payload_with_shards(1).await;
-    test_collection_payload_custom_payload_with_shards(10).await;
+    test_collection_payload_custom_payload_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(PointsBatch {
                 batch: Batch {

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -18,7 +18,7 @@ use segment::types::{
     WithPayloadInterface,
 };
 
-use crate::common::simple_collection_fixture;
+use crate::common::{simple_collection_fixture, N_SHARDS};
 use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
 use collection::operations::types::PointRequest;
 
@@ -27,13 +27,13 @@ mod common;
 #[tokio::test]
 async fn test_collection_updater() {
     test_collection_updater_with_shards(1).await;
-    test_collection_updater_with_shards(10).await;
+    test_collection_updater_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_updater_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -90,13 +90,13 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
 #[tokio::test]
 async fn test_collection_search_with_payload_and_vector() {
     test_collection_search_with_payload_and_vector_with_shards(1).await;
-    test_collection_search_with_payload_and_vector_with_shards(10).await;
+    test_collection_search_with_payload_and_vector_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_search_with_payload_and_vector_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -149,14 +149,14 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
 #[tokio::test]
 async fn test_collection_loading() {
     test_collection_loading_with_shards(1).await;
-    test_collection_loading_with_shards(10).await;
+    test_collection_loading_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_loading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             Batch {
                 ids: vec![0, 1, 2, 3, 4]
@@ -269,12 +269,12 @@ fn test_deserialization2() {
 #[tokio::test]
 async fn test_recommendation_api() {
     test_recommendation_api_with_shards(1).await;
-    test_recommendation_api_with_shards(10).await;
+    test_recommendation_api_with_shards(N_SHARDS).await;
 }
 
 async fn test_recommendation_api_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
@@ -326,12 +326,12 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
 #[tokio::test]
 async fn test_read_api() {
     test_read_api_with_shards(1).await;
-    test_read_api_with_shards(10).await;
+    test_read_api_with_shards(N_SHARDS).await;
 }
 
 async fn test_read_api_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
         Batch {
@@ -380,13 +380,13 @@ async fn test_read_api_with_shards(shard_number: u32) {
 #[tokio::test]
 async fn test_collection_delete_points_by_filter() {
     test_collection_delete_points_by_filter_with_shards(1).await;
-    test_collection_delete_points_by_filter_with_shards(10).await;
+    test_collection_delete_points_by_filter_with_shards(N_SHARDS).await;
 }
 
 async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number);
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -5,15 +5,15 @@ use segment::types::Distance;
 use std::path::Path;
 
 /// Test collections for this upper bound of shards.
-/// Testing with 10+ shards is problematic due to `number of open files problem`
+/// Testing with more shards is problematic due to `number of open files problem`
 /// See https://github.com/qdrant/qdrant/issues/379
 #[allow(dead_code)]
-pub const N_SHARDS: u32 = 5;
+pub const N_SHARDS: u32 = 3;
 
 pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     deleted_threshold: 0.9,
     vacuum_min_vector_number: 1000,
-    default_segment_number: 5,
+    default_segment_number: 2,
     max_segment_size: 100_000,
     memmap_threshold: 100_000,
     indexing_threshold: 50_000,

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -4,6 +4,12 @@ use collection::Collection;
 use segment::types::Distance;
 use std::path::Path;
 
+/// Test collections for this upper bound of shards.
+/// Testing with 10+ shards is problematic due to `number of open files problem`
+/// See https://github.com/qdrant/qdrant/issues/379
+#[allow(dead_code)]
+pub const N_SHARDS: u32 = 5;
+
 pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     deleted_threshold: 0.9,
     vacuum_min_vector_number: 1000,
@@ -17,7 +23,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
 };
 
 #[allow(dead_code)]
-pub fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
+pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
         wal_segments_ahead: 0,
@@ -39,5 +45,6 @@ pub fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> C
             hnsw_config: Default::default(),
         },
     )
+    .await
     .unwrap()
 }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -191,7 +191,8 @@ impl TableOfContent {
                 optimizer_config: optimizers_config,
                 hnsw_config,
             },
-        )?;
+        )
+        .await?;
 
         let mut write_collections = self.collections.write().await;
         write_collections


### PR DESCRIPTION
1. Fixes shard drop on collection creation (Closes #379 )
2. Fixes collection info method - 
previously info method could count same segment's info twice.
3. Concurrent waiting for the shard drop
4. Decreased number of shards per collection in tests to 3, number of segments to 2