### PR TITLE
[sharding] Introduce local & remote shards

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -30,12 +30,12 @@ use segment::{
         WithPayload, WithPayloadInterface,
     },
 };
-use shard::{LocalShard, ShardId};
 use tokio::runtime::Handle;
 
 use crate::operations::OperationToShard;
+use crate::shard::local_shard::LocalShard;
+use crate::shard::{Shard, ShardId};
 use crate::Shard::Local;
-use crate::shard::Shard;
 
 pub mod collection_manager;
 mod common;
@@ -133,7 +133,10 @@ impl Collection {
             let new_wal_path = LocalShard::wal_path(&shard_path);
             create_dir_all(&new_segmnents_path)?;
             create_dir_all(&new_wal_path)?;
-            rename(LocalShard::segments_path(collection_path), &new_segmnents_path)?;
+            rename(
+                LocalShard::segments_path(collection_path),
+                &new_segmnents_path,
+            )?;
             rename(LocalShard::wal_path(collection_path), &new_wal_path)?;
             log::info!("Migration finished.");
         }

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -301,12 +301,9 @@ impl Collection {
         let mut points = Vec::new();
         let request = Arc::new(request);
         for shard in self.all_shards() {
-            let mut shard_points = segment_searcher
-                .search(
-                    shard.get().segments(),
-                    request.clone(),
-                    search_runtime_handle,
-                )
+            let mut shard_points = shard
+                .get()
+                .search(request.clone(), segment_searcher, search_runtime_handle)
                 .await?;
             points.append(&mut shard_points);
         }
@@ -380,13 +377,14 @@ impl Collection {
             .unwrap_or(&WithPayloadInterface::Bool(false));
         let with_payload = WithPayload::from(with_payload_interface);
         let with_vector = request.with_vector;
-
+        let request = Arc::new(request);
         let mut points = Vec::new();
         for shard in self.all_shards() {
-            let mut shard_points = segment_searcher
+            let mut shard_points = shard
+                .get()
                 .retrieve(
-                    shard.get().segments(),
-                    &request.ids,
+                    request.clone(),
+                    segment_searcher,
                     &with_payload,
                     with_vector,
                 )

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -5,12 +5,11 @@ pub mod types;
 
 use std::collections::HashMap;
 
+use crate::ShardId;
 use hashring::HashRing;
 use schemars::JsonSchema;
 use segment::types::ExtendedPointId;
 use serde::{Deserialize, Serialize};
-
-use crate::shard::ShardId;
 
 use self::types::CollectionResult;
 

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -5,7 +5,7 @@ use serde;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::shard::ShardId;
+use crate::ShardId;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
 

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -1,4 +1,5 @@
-use crate::{operations::types::VectorType, shard::ShardId};
+use crate::operations::types::VectorType;
+use crate::ShardId;
 use hashring::HashRing;
 use schemars::JsonSchema;
 use segment::types::{Filter, PayloadInterface, PayloadKeyType, PointIdType};

--- a/lib/collection/src/shard.rs
+++ b/lib/collection/src/shard.rs
@@ -46,15 +46,75 @@ pub type PeerId = u32;
 ///
 /// A shard can either be local or remote
 ///
-enum Shard {
+pub enum Shard {
     Local(LocalShard),
     Remote(RemoteShard)
+}
+
+impl Shard {
+    pub async fn before_drop(&mut self) {
+        match self {
+            Shard::Local(local_shard) => local_shard.before_drop().await,
+            Shard::Remote(_) => (),
+        }
+    }
+
+    pub async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        match self {
+            Shard::Local(local_shard) => local_shard.update(operation, wait).await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub fn segments(&self) -> &RwLock<SegmentHolder> {
+        match self {
+            Shard::Local(local_shard) => local_shard.segments(),
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn scroll_by(
+        &self,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: bool,
+        filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
+        match self {
+            Shard::Local(local_shard) => local_shard.scroll_by(segment_searcher, offset, limit, with_payload_interface, with_vector, filter).await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn update_optimizer_params(
+        &self,
+        optimizer_config_diff: OptimizersConfigDiff,
+    ) -> CollectionResult<()> {
+        match self {
+            Shard::Local(local_shard) => local_shard.update_optimizer_params(optimizer_config_diff).await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn info(&self) -> CollectionResult<CollectionInfo> {
+        match self {
+            Shard::Local(local_shard) => local_shard.info().await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
 }
 
 /// RemoteShard
 ///
 /// Remote Shard is a representation of a shard that is located on a remote peer.
-///
+/// Currently a placeholder implementation for later work.
+#[allow(dead_code)]
 pub struct RemoteShard {
     id: ShardId,
     collection_id: CollectionId,

--- a/lib/collection/src/shard.rs
+++ b/lib/collection/src/shard.rs
@@ -40,9 +40,30 @@ use std::fs::{read_dir, remove_dir_all};
 
 pub type ShardId = u32;
 
+pub type PeerId = u32;
+
 /// Shard
 ///
-/// Shard is an entity that can be moved between peers and contains some part of one collections data.
+/// A shard can either be local or remote
+///
+enum Shard {
+    Local(LocalShard),
+    Remote(RemoteShard)
+}
+
+/// RemoteShard
+///
+/// Remote Shard is a representation of a shard that is located on a remote peer.
+///
+pub struct RemoteShard {
+    id: ShardId,
+    collection_id: CollectionId,
+    peer_id: PeerId,
+}
+
+/// LocalShard
+///
+/// LocalShard is an entity that can be moved between peers and contains some part of one collections data.
 ///
 /// Holds all object, required for collection functioning
 pub struct LocalShard {

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -116,6 +116,10 @@ impl LocalShard {
         }
     }
 
+    fn segments(&self) -> &RwLock<SegmentHolder> {
+        self.segments.deref()
+    }
+
     pub async fn load(
         id: ShardId,
         collection_id: CollectionId,
@@ -356,10 +360,6 @@ impl ShardOperation for &LocalShard {
                 status: UpdateStatus::Acknowledged,
             })
         }
-    }
-
-    fn segments(&self) -> &RwLock<SegmentHolder> {
-        self.segments.deref()
     }
 
     async fn scroll_by(

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -33,93 +33,10 @@ use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::build_optimizers;
 use crate::update_handler::{OperationData, Optimizer, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
-use crate::CollectionId;
+use crate::{CollectionId, ShardId};
 use segment::payload_storage::schema_storage::SchemaStorage;
 use segment::segment_constructor::load_segment;
 use std::fs::{read_dir, remove_dir_all};
-
-pub type ShardId = u32;
-
-pub type PeerId = u32;
-
-/// Shard
-///
-/// A shard can either be local or remote
-///
-pub enum Shard {
-    Local(LocalShard),
-    Remote(RemoteShard)
-}
-
-impl Shard {
-    pub async fn before_drop(&mut self) {
-        match self {
-            Shard::Local(local_shard) => local_shard.before_drop().await,
-            Shard::Remote(_) => (),
-        }
-    }
-
-    pub async fn update(
-        &self,
-        operation: CollectionUpdateOperations,
-        wait: bool,
-    ) -> CollectionResult<UpdateResult> {
-        match self {
-            Shard::Local(local_shard) => local_shard.update(operation, wait).await,
-            Shard::Remote(_) => todo!(),
-        }
-    }
-
-    pub fn segments(&self) -> &RwLock<SegmentHolder> {
-        match self {
-            Shard::Local(local_shard) => local_shard.segments(),
-            Shard::Remote(_) => todo!(),
-        }
-    }
-
-    pub async fn scroll_by(
-        &self,
-        segment_searcher: &(dyn CollectionSearcher + Sync),
-        offset: Option<ExtendedPointId>,
-        limit: usize,
-        with_payload_interface: &WithPayloadInterface,
-        with_vector: bool,
-        filter: Option<&Filter>,
-    ) -> CollectionResult<Vec<Record>> {
-        match self {
-            Shard::Local(local_shard) => local_shard.scroll_by(segment_searcher, offset, limit, with_payload_interface, with_vector, filter).await,
-            Shard::Remote(_) => todo!(),
-        }
-    }
-
-    pub async fn update_optimizer_params(
-        &self,
-        optimizer_config_diff: OptimizersConfigDiff,
-    ) -> CollectionResult<()> {
-        match self {
-            Shard::Local(local_shard) => local_shard.update_optimizer_params(optimizer_config_diff).await,
-            Shard::Remote(_) => todo!(),
-        }
-    }
-
-    pub async fn info(&self) -> CollectionResult<CollectionInfo> {
-        match self {
-            Shard::Local(local_shard) => local_shard.info().await,
-            Shard::Remote(_) => todo!(),
-        }
-    }
-}
-
-/// RemoteShard
-///
-/// Remote Shard is a representation of a shard that is located on a remote peer.
-/// Currently a placeholder implementation for later work.
-#[allow(dead_code)]
-pub struct RemoteShard {
-    id: ShardId,
-    collection_id: CollectionId,
-    peer_id: PeerId,
-}
 
 /// LocalShard
 ///

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -284,11 +284,8 @@ impl LocalShard {
         self.segments.read().flush_all().unwrap();
         bar.finish();
     }
-}
 
-#[async_trait]
-impl ShardOperation for LocalShard {
-    async fn before_drop(&mut self) {
+    pub async fn before_drop(&mut self) {
         // Finishes update tasks right before destructor stuck to do so with runtime
         self.update_sender.load().send(UpdateSignal::Stop).unwrap();
 
@@ -315,7 +312,10 @@ impl ShardOperation for LocalShard {
 
         self.before_drop_called = true;
     }
+}
 
+#[async_trait]
+impl ShardOperation for &LocalShard {
     /// Imply interior mutability.
     /// Performs update operation on this collection asynchronously.
     /// Explicitly waits for result to be updated.

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -5,12 +5,13 @@ use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::shard::remote_shard::RemoteShard;
 use crate::{
     CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations, LocalShard,
-    OptimizersConfigDiff, Record, UpdateResult,
+    OptimizersConfigDiff, PointRequest, Record, SearchRequest, UpdateResult,
 };
 use async_trait::async_trait;
 use parking_lot::RwLock;
-use segment::types::{ExtendedPointId, Filter, WithPayloadInterface};
+use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
 use std::sync::Arc;
+use tokio::runtime::Handle;
 
 pub type ShardId = u32;
 
@@ -68,4 +69,19 @@ pub trait ShardOperation {
     ) -> CollectionResult<()>;
 
     async fn info(&self) -> CollectionResult<CollectionInfo>;
+
+    async fn search(
+        &self,
+        request: Arc<SearchRequest>,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>>;
+
+    async fn retrieve(
+        &self,
+        request: Arc<PointRequest>,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        with_payload: &WithPayload,
+        with_vector: bool,
+    ) -> CollectionResult<Vec<Record>>;
 }

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -1,14 +1,12 @@
 pub mod local_shard;
 pub mod remote_shard;
 
-use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::shard::remote_shard::RemoteShard;
 use crate::{
     CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations, LocalShard,
     OptimizersConfigDiff, PointRequest, Record, SearchRequest, UpdateResult,
 };
 use async_trait::async_trait;
-use parking_lot::RwLock;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -50,8 +48,6 @@ pub trait ShardOperation {
         operation: CollectionUpdateOperations,
         wait: bool,
     ) -> CollectionResult<UpdateResult>;
-
-    fn segments(&self) -> &RwLock<SegmentHolder>;
 
     async fn scroll_by(
         &self,

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -1,0 +1,99 @@
+pub mod local_shard;
+pub mod remote_shard;
+
+use crate::collection_manager::holders::segment_holder::SegmentHolder;
+use crate::shard::remote_shard::RemoteShard;
+use crate::{
+    CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations, LocalShard,
+    OptimizersConfigDiff, Record, UpdateResult,
+};
+use parking_lot::RwLock;
+use segment::types::{ExtendedPointId, Filter, WithPayloadInterface};
+
+pub type ShardId = u32;
+
+pub type PeerId = u32;
+
+/// Shard
+///
+/// A shard can either be local or remote
+///
+#[allow(clippy::large_enum_variant)]
+pub enum Shard {
+    Local(LocalShard),
+    Remote(RemoteShard),
+}
+
+impl Shard {
+    pub async fn before_drop(&mut self) {
+        match self {
+            Shard::Local(local_shard) => local_shard.before_drop().await,
+            Shard::Remote(_) => (),
+        }
+    }
+
+    pub async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        match self {
+            Shard::Local(local_shard) => local_shard.update(operation, wait).await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub fn segments(&self) -> &RwLock<SegmentHolder> {
+        match self {
+            Shard::Local(local_shard) => local_shard.segments(),
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn scroll_by(
+        &self,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: bool,
+        filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
+        match self {
+            Shard::Local(local_shard) => {
+                local_shard
+                    .scroll_by(
+                        segment_searcher,
+                        offset,
+                        limit,
+                        with_payload_interface,
+                        with_vector,
+                        filter,
+                    )
+                    .await
+            }
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn update_optimizer_params(
+        &self,
+        optimizer_config_diff: OptimizersConfigDiff,
+    ) -> CollectionResult<()> {
+        match self {
+            Shard::Local(local_shard) => {
+                local_shard
+                    .update_optimizer_params(optimizer_config_diff)
+                    .await
+            }
+            Shard::Remote(_) => todo!(),
+        }
+    }
+
+    pub async fn info(&self) -> CollectionResult<CollectionInfo> {
+        match self {
+            Shard::Local(local_shard) => local_shard.info().await,
+            Shard::Remote(_) => todo!(),
+        }
+    }
+}

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -21,11 +21,7 @@ pub struct RemoteShard {
 
 #[async_trait]
 #[allow(unused_variables)]
-impl ShardOperation for RemoteShard {
-    async fn before_drop(&mut self) {
-        todo!()
-    }
-
+impl ShardOperation for &RemoteShard {
     async fn update(
         &self,
         operation: CollectionUpdateOperations,

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -1,5 +1,12 @@
-use crate::shard::{PeerId, ShardId};
-use crate::CollectionId;
+use crate::collection_manager::holders::segment_holder::SegmentHolder;
+use crate::shard::{PeerId, ShardId, ShardOperation};
+use crate::{
+    CollectionId, CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations,
+    OptimizersConfigDiff, Record, UpdateResult,
+};
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use segment::types::{ExtendedPointId, Filter, WithPayloadInterface};
 
 /// RemoteShard
 ///
@@ -10,4 +17,47 @@ pub struct RemoteShard {
     id: ShardId,
     collection_id: CollectionId,
     peer_id: PeerId,
+}
+
+#[async_trait]
+#[allow(unused_variables)]
+impl ShardOperation for RemoteShard {
+    async fn before_drop(&mut self) {
+        todo!()
+    }
+
+    async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        todo!()
+    }
+
+    fn segments(&self) -> &RwLock<SegmentHolder> {
+        todo!()
+    }
+
+    async fn scroll_by(
+        &self,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: bool,
+        filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
+        todo!()
+    }
+
+    async fn update_optimizer_params(
+        &self,
+        optimizer_config_diff: OptimizersConfigDiff,
+    ) -> CollectionResult<()> {
+        todo!()
+    }
+
+    async fn info(&self) -> CollectionResult<CollectionInfo> {
+        todo!()
+    }
 }

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -2,11 +2,13 @@ use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::shard::{PeerId, ShardId, ShardOperation};
 use crate::{
     CollectionId, CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations,
-    OptimizersConfigDiff, Record, UpdateResult,
+    OptimizersConfigDiff, PointRequest, Record, SearchRequest, UpdateResult,
 };
 use async_trait::async_trait;
 use parking_lot::RwLock;
-use segment::types::{ExtendedPointId, Filter, WithPayloadInterface};
+use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
+use std::sync::Arc;
+use tokio::runtime::Handle;
 
 /// RemoteShard
 ///
@@ -54,6 +56,25 @@ impl ShardOperation for &RemoteShard {
     }
 
     async fn info(&self) -> CollectionResult<CollectionInfo> {
+        todo!()
+    }
+
+    async fn search(
+        &self,
+        request: Arc<SearchRequest>,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        todo!()
+    }
+
+    async fn retrieve(
+        &self,
+        request: Arc<PointRequest>,
+        segment_searcher: &(dyn CollectionSearcher + Sync),
+        with_payload: &WithPayload,
+        with_vector: bool,
+    ) -> CollectionResult<Vec<Record>> {
         todo!()
     }
 }

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -1,0 +1,13 @@
+use crate::shard::{PeerId, ShardId};
+use crate::CollectionId;
+
+/// RemoteShard
+///
+/// Remote Shard is a representation of a shard that is located on a remote peer.
+/// Currently a placeholder implementation for later work.
+#[allow(dead_code)]
+pub struct RemoteShard {
+    id: ShardId,
+    collection_id: CollectionId,
+    peer_id: PeerId,
+}

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -1,11 +1,9 @@
-use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::shard::{PeerId, ShardId, ShardOperation};
 use crate::{
     CollectionId, CollectionInfo, CollectionResult, CollectionSearcher, CollectionUpdateOperations,
     OptimizersConfigDiff, PointRequest, Record, SearchRequest, UpdateResult,
 };
 use async_trait::async_trait;
-use parking_lot::RwLock;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -29,10 +27,6 @@ impl ShardOperation for &RemoteShard {
         operation: CollectionUpdateOperations,
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
-        todo!()
-    }
-
-    fn segments(&self) -> &RwLock<SegmentHolder> {
         todo!()
     }
 


### PR DESCRIPTION
This PR introduces the possibility to have local and remote shards #373 

As a result the shard operations are abstracted behind a `ShardOperations` trait which will enable us to implement the remote shard later on.

The code regarding shards has been split and gathered under a new `shard` module.

The polymorphism has been implemented following the style found in `LockedSegment` for consistency.

It is easier to review commit by commit as some files moved.