### PR TITLE
Introduces consensus with Raft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
  "futures",
  "hashring",
  "indicatif",
- "itertools",
+ "itertools 0.10.3",
  "log 0.4.14",
  "merge",
  "num_cpus",
@@ -749,7 +749,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static 1.4.0",
  "num-traits",
  "oorandom",
@@ -771,7 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.3",
 ]
 
 [[package]]
@@ -1290,6 +1290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2255,9 +2276,9 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot 0.12.0",
- "prost",
- "prost-build",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "prost-derive 0.9.0",
  "smallvec",
  "symbolic-demangle",
  "tempfile",
@@ -2305,12 +2326,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.9.0",
+ "log 0.4.14",
+ "multimap",
+ "petgraph 0.5.1",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -2321,16 +2370,29 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static 1.4.0",
  "log 0.4.14",
  "multimap",
  "petgraph 0.6.0",
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "regex 1.5.4",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2340,10 +2402,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.3",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes",
+ "prost 0.7.0",
 ]
 
 [[package]]
@@ -2353,7 +2425,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
+name = "protobuf-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7266835d38c38c73b091a24412de1f4b4382a5195fab1ec038161582b03b78"
+dependencies = [
+ "bitflags",
+ "proc-macro2",
+ "prost-build 0.7.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2364,18 +2455,21 @@ dependencies = [
  "collection",
  "config",
  "env_logger 0.9.0",
- "itertools",
+ "itertools 0.10.3",
  "log 0.4.14",
  "num-traits",
  "num_cpus",
  "parking_lot 0.12.0",
- "prost",
+ "prost 0.9.0",
+ "raft",
  "rand 0.8.5",
  "rusty-hook",
  "schemars",
  "segment",
  "serde",
  "serde_json",
+ "slog",
+ "slog-stdlog",
  "storage",
  "tempdir",
  "thiserror",
@@ -2401,6 +2495,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raft"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08aa642fc2067062af4d4a3a3b8b909cd80e810b994af44c5a60253fc673f934"
+dependencies = [
+ "fxhash",
+ "getset",
+ "protobuf",
+ "raft-proto",
+ "rand 0.8.5",
+ "slog",
+ "thiserror",
+]
+
+[[package]]
+name = "raft-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b74f65f886af112d6046c131def44849404757d22f835a0b7ef1aa473e4c96f"
+dependencies = [
+ "lazy_static 1.4.0",
+ "prost 0.7.0",
+ "protobuf",
+ "protobuf-build",
 ]
 
 [[package]]
@@ -2763,7 +2884,7 @@ dependencies = [
  "criterion",
  "geo",
  "geohash",
- "itertools",
+ "itertools 0.10.3",
  "log 0.4.14",
  "memmap 0.7.0",
  "ndarray",
@@ -2935,6 +3056,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static 1.4.0",
+ "slog",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
+dependencies = [
+ "log 0.4.14",
+ "slog",
+ "slog-scope",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,7 +3111,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "collection",
- "itertools",
+ "itertools 0.10.3",
  "num_cpus",
  "rand 0.8.5",
  "schemars",
@@ -3293,8 +3442,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.7",
@@ -3312,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.9.0",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 default = [ "web" ]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
+consensus = ["raft", "slog", "slog-stdlog"]
 
 
 [dev-dependencies]
@@ -41,6 +42,10 @@ actix-web = { version = "4.0.1", optional = true }
 tonic = "0.6.2"
 num-traits = "0.2.14"
 prost = "0.9"
+
+raft = { version = "0.6.0", features = ["prost-codec"], default-features = false, optional = true }
+slog =  { version = "2.7.0", optional = true }
+slog-stdlog = { version = "4.1.0", optional = true }
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -47,7 +47,7 @@ mod wal;
 #[cfg(test)]
 mod tests;
 
-type CollectionId = String;
+pub type CollectionId = String;
 
 /// Collection's data is split into several shards.
 pub struct Collection {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,0 +1,130 @@
+use std::{
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    time::{Duration, Instant},
+};
+
+use raft::{prelude::*, storage::MemStorage};
+
+const TICK_PERIOD_MS: u64 = 100;
+
+pub struct Consensus {
+    node: RawNode<MemStorage>,
+    receiver: Receiver<Message>,
+}
+
+impl Consensus {
+    pub fn new(logger: &slog::Logger) -> (Self, Sender<Message>) {
+        let config = Config {
+            id: 1,
+            ..Default::default()
+        };
+        config.validate().unwrap();
+        let storage = MemStorage::new_with_conf_state((vec![1], vec![]));
+        let node = RawNode::new(&config, storage, logger).unwrap();
+        let (sender, receiver) = mpsc::channel();
+        (Self { node, receiver }, sender)
+    }
+
+    pub fn start(&mut self) {
+        let mut t = Instant::now();
+        let mut timeout = Duration::from_millis(TICK_PERIOD_MS);
+
+        loop {
+            match self.receiver.recv_timeout(timeout) {
+                Ok(message) => self.node.step(message).unwrap(),
+                Err(RecvTimeoutError::Timeout) => (),
+                Err(RecvTimeoutError::Disconnected) => {
+                    log::warn!("Stopping Raft as message sender was dropped");
+                    return;
+                }
+            }
+
+            let d = t.elapsed();
+            t = Instant::now();
+            if d >= timeout {
+                timeout = Duration::from_millis(TICK_PERIOD_MS);
+                // We drive Raft every 100ms.
+                self.node.tick();
+            } else {
+                timeout -= d;
+            }
+            Consensus::on_ready(&mut self.node);
+        }
+    }
+
+    fn on_ready(raft_group: &mut RawNode<MemStorage>) {
+        if !raft_group.has_ready() {
+            return;
+        }
+        let store = raft_group.raft.raft_log.store.clone();
+
+        // Get the `Ready` with `RawNode::ready` interface.
+        let mut ready = raft_group.ready();
+
+        let handle_messages = |msgs: Vec<Message>| {
+            for _msg in msgs {
+                // Send messages to other peers.
+            }
+        };
+
+        if !ready.messages().is_empty() {
+            // Send out the messages come from the node.
+            handle_messages(ready.take_messages());
+        }
+
+        if !ready.snapshot().is_empty() {
+            // This is a snapshot, we need to apply the snapshot at first.
+            store.wl().apply_snapshot(ready.snapshot().clone()).unwrap();
+        }
+
+        let mut _last_apply_index = 0;
+        let mut handle_committed_entries = |committed_entries: Vec<Entry>| {
+            for entry in committed_entries {
+                // Mostly, you need to save the last apply index to resume applying
+                // after restart. Here we just ignore this because we use a Memory storage.
+                _last_apply_index = entry.index;
+
+                if entry.data.is_empty() {
+                    // Emtpy entry, when the peer becomes Leader it will send an empty entry.
+                    continue;
+                }
+
+                if entry.get_entry_type() == EntryType::EntryNormal {
+                    // TODO: Manipulate data
+                    // entry.data.get(0).unwrap());
+                }
+
+                // TODO: handle EntryConfChange
+            }
+        };
+        handle_committed_entries(ready.take_committed_entries());
+
+        if !ready.entries().is_empty() {
+            // Append entries to the Raft log.
+            store.wl().append(ready.entries()).unwrap();
+        }
+
+        if let Some(hs) = ready.hs() {
+            // Raft HardState changed, and we need to persist it.
+            store.wl().set_hardstate(hs.clone());
+        }
+
+        if !ready.persisted_messages().is_empty() {
+            // Send out the persisted messages come from the node.
+            handle_messages(ready.take_persisted_messages());
+        }
+
+        // Advance the Raft.
+        let mut light_rd = raft_group.advance(ready);
+        // Update commit index.
+        if let Some(commit) = light_rd.commit_index() {
+            store.wl().mut_hard_state().set_commit(commit);
+        }
+        // Send out the messages.
+        handle_messages(light_rd.take_messages());
+        // Apply all committed entries.
+        handle_committed_entries(light_rd.take_committed_entries());
+        // Advance the apply index.
+        raft_group.advance_apply();
+    }
+}


### PR DESCRIPTION
Closes #386 

Consensus will be used to synchronize global state which is:
- Collection meta
- Shard to Peer mapping

Most of this pull request is based on:
- Raft 1 peer example - https://github.com/tikv/raft-rs/blob/master/examples/single_mem_node/main.rs
- Raft snippets in https://docs.rs/raft/latest/raft/index.html

Consensus start is behind a feature gate to not worsen performance for users as consensus in 1 peer case is basically useless. It is only for development for now.

### Library Comparison

1. https://github.com/tikv/raft-rs
    1. Pros: 
        1. Used in production
        2. Highly configurable/customizable
    2. Cons: 
        1. Slightly complicated to setup
    4. Stars: 2k
    5. Conclusion: Suggested to use
2. https://github.com/async-raft/async-raft
    1. Pros:
        1. Simple interface
        2. Good documentation
    2. Cons:
        1. Limited customizability
        2. Not certain if it is used in production
    3. Stars: 800
    4. Conclusion: Might be too limiting, as we need custom logic on top of Raft
3. https://github.com/andreev-io/little-raft
    1. Stars: 280
    2. Conclusion: Personal project - doesn't seem like a good option for such a critical part of the system
