### PR TITLE
add rustfmt to build docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM rust:1.59 as builder
 
+RUN apt-get update ; apt-get install -y clang ; rustup component add rustfmt
+
 COPY . ./qdrant
 WORKDIR ./qdrant
 
-RUN apt-get update ; apt-get install -y clang
 
 # Build actual target here
 RUN cargo build --release --bin qdrant


### PR DESCRIPTION
Fixes

```
   Compiling qdrant v0.6.0 (/qdrant)
error: failed to run custom build command for `qdrant v0.6.0 (/qdrant)`

Caused by:
  process didn't exit successfully: `/qdrant/target/release/build/qdrant-8318c117d38401e4/build-script-build` (exit status: 1)
  --- stderr
  error: 'rustfmt' is not installed for the toolchain '1.59.0-x86_64-unknown-linux-gnu'
  To install, run `rustup component add rustfmt`
warning: build failed, waiting for other jobs to finish...
error: build failed
```