### PR TITLE
gitignore __pycache__/

### DIFF
--- a/openapi/.gitignore
+++ b/openapi/.gitignore
@@ -6,3 +6,4 @@
 /openapi-merged.yaml
 /openapi-merged.json
 /openapi-points.yaml
+__pycache__/


### PR DESCRIPTION
This PR adds the `__pycache__/` directories to the `.gitignore`.

Two of those are left behind after running `./tests/openapi_integration_test.sh`

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	openapi/tests/openapi_integration/__pycache__/
	openapi/tests/openapi_integration/helpers/__pycache__/
```