### PR TITLE
Remove sled for alias mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
  "merge",
  "num_cpus",
  "ordered-float",
- "parking_lot 0.12.0",
+ "parking_lot",
  "rand 0.8.5",
  "rmp-serde",
  "schemars",
@@ -1037,16 +1037,6 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1485,15 +1475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,7 +1709,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f20f72ed93291a72e22e8b16bb18762183bb4943f0f483da5b8be1a9e8192752"
 dependencies = [
- "fs2 0.2.5",
+ "fs2",
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
@@ -1964,37 +1945,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2186,7 +2142,7 @@ dependencies = [
  "log 0.4.16",
  "nix",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "prost-derive 0.9.0",
@@ -2370,7 +2326,7 @@ dependencies = [
  "log 0.4.16",
  "num-traits",
  "num_cpus",
- "parking_lot 0.12.0",
+ "parking_lot",
  "prost 0.9.0",
  "prost-types 0.9.0",
  "raft",
@@ -2786,7 +2742,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "ordered-float",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pprof",
  "rand 0.8.5",
  "rmp-serde",
@@ -2934,22 +2890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2 0.4.3",
- "fxhash",
- "libc",
- "log 0.4.16",
- "parking_lot 0.11.2",
-]
-
-[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,7 +2954,6 @@ dependencies = [
  "segment",
  "serde",
  "serde_cbor",
- "sled",
  "tempdir",
  "thiserror",
  "tokio",
@@ -3243,7 +3182,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3551,7 +3490,7 @@ dependencies = [
  "docopt",
  "env_logger 0.3.5",
  "eventual",
- "fs2 0.2.5",
+ "fs2",
  "log 0.3.9",
  "memmap 0.2.3",
  "rand 0.3.23",

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,6 +1,6 @@
 
 debug: true
-log_level: DEBUG,sled=INFO
+log_level: DEBUG
 
 service:
   host: 127.0.0.1

--- a/lib/segment/src/common/file_operations.rs
+++ b/lib/segment/src/common/file_operations.rs
@@ -1,16 +1,59 @@
-use crate::entry::entry_point::{OperationError, OperationResult};
 use atomicwrites::AtomicFile;
+use atomicwrites::Error as AtomicIoError;
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fs::File;
+use std::io::Error as IoError;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
+use std::result;
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+#[error("{0}")]
+pub enum FileStorageError {
+    #[error("File storage IO error {description} found")]
+    IoError { description: String },
+    #[error("File storage AtomicIO user error found")]
+    UserAtomicIoError,
+    #[error("Generic file storage error {description} found")]
+    GenericError { description: String },
+}
+
+impl FileStorageError {
+    pub fn generic_error(description: &str) -> FileStorageError {
+        FileStorageError::GenericError {
+            description: description.to_string(),
+        }
+    }
+}
+
+impl<E> From<AtomicIoError<E>> for FileStorageError {
+    fn from(err: AtomicIoError<E>) -> Self {
+        match err {
+            AtomicIoError::Internal(io_err) => FileStorageError::IoError {
+                description: format!("{}", io_err),
+            },
+            AtomicIoError::User(_atomic_io_err) => FileStorageError::UserAtomicIoError,
+        }
+    }
+}
+
+impl From<IoError> for FileStorageError {
+    fn from(io_err: IoError) -> Self {
+        FileStorageError::IoError {
+            description: io_err.to_string(),
+        }
+    }
+}
+
+pub type FileOperationResult<T> = result::Result<T, FileStorageError>;
 
 pub fn atomic_save_bin<N: DeserializeOwned + Serialize>(
     path: &Path,
     object: &N,
-) -> OperationResult<()> {
+) -> FileOperationResult<()> {
     let af = AtomicFile::new(path, AllowOverwrite);
     af.write(|f| {
         let mut writer = BufWriter::new(f);
@@ -22,21 +65,21 @@ pub fn atomic_save_bin<N: DeserializeOwned + Serialize>(
 pub fn atomic_save_json<N: DeserializeOwned + Serialize>(
     path: &Path,
     object: &N,
-) -> OperationResult<()> {
+) -> FileOperationResult<()> {
     let af = AtomicFile::new(path, AllowOverwrite);
     let state_bytes = serde_json::to_vec(object).unwrap();
     af.write(|f| f.write_all(&state_bytes))?;
     Ok(())
 }
 
-pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResult<N> {
+pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> FileOperationResult<N> {
     let mut contents = String::new();
 
     let mut file = File::open(path)?;
     file.read_to_string(&mut contents)?;
 
     let result: N = serde_json::from_str(&contents).map_err(|err| {
-        OperationError::service_error(&format!(
+        FileStorageError::generic_error(&format!(
             "Failed to read data {}. Error: {}",
             path.to_str().unwrap(),
             err
@@ -46,11 +89,11 @@ pub fn read_json<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResul
     Ok(result)
 }
 
-pub fn read_bin<N: DeserializeOwned + Serialize>(path: &Path) -> OperationResult<N> {
+pub fn read_bin<N: DeserializeOwned + Serialize>(path: &Path) -> FileOperationResult<N> {
     let mut file = File::open(path)?;
 
     let result: N = bincode::deserialize_from(&mut file).map_err(|err| {
-        OperationError::service_error(&format!(
+        FileStorageError::generic_error(&format!(
             "Failed to read data {}. Error: {}",
             path.to_str().unwrap(),
             err

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -1,3 +1,4 @@
+use crate::common::file_operations::FileStorageError;
 use crate::types::{
     Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
@@ -49,6 +50,22 @@ pub struct SegmentFailedState {
     pub version: SeqNumberType,
     pub point_id: Option<PointIdType>,
     pub error: OperationError,
+}
+
+impl From<FileStorageError> for OperationError {
+    fn from(err: FileStorageError) -> Self {
+        match err {
+            FileStorageError::IoError { description } => {
+                OperationError::service_error(&format!("IO Error: {}", description))
+            }
+            FileStorageError::UserAtomicIoError => {
+                OperationError::service_error("Unknown atomic write error")
+            }
+            FileStorageError::GenericError { description } => {
+                OperationError::service_error(&description)
+            }
+        }
+    }
 }
 
 impl<E> From<AtomicIoError<E>> for OperationError {

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -46,7 +46,6 @@ fn external_to_stored_id(point_id: &PointIdType) -> StoredPointId {
     point_id.into()
 }
 
-/// Since sled is used for reading only during the initialization, large read cache is not required
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 
 const MAPPING_CF: &str = "mapping";

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -34,10 +34,10 @@ impl HnswGraphConfig {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_json(path)
+        read_json(path).map_err(|err| err.into())
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_json(path, self)
+        atomic_save_json(path, self).map_err(|err| err.into())
     }
 }

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -34,10 +34,10 @@ impl HnswGraphConfig {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_json(path).map_err(|err| err.into())
+        Ok(read_json(path)?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_json(path, self).map_err(|err| err.into())
+        Ok(atomic_save_json(path, self)?)
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -474,11 +474,11 @@ impl GraphLayers {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_bin(path).map_err(|err| err.into())
+        Ok(read_bin(path)?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_bin(path, self).map_err(|err| err.into())
+        Ok(atomic_save_bin(path, self)?)
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -474,11 +474,11 @@ impl GraphLayers {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_bin(path)
+        read_bin(path).map_err(|err| err.into())
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_bin(path, self)
+        atomic_save_bin(path, self).map_err(|err| err.into())
     }
 }
 

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -19,10 +19,10 @@ impl PayloadConfig {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_json(path)
+        read_json(path).map_err(|err| err.into())
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_json(path, self)
+        atomic_save_json(path, self).map_err(|err| err.into())
     }
 }

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -19,10 +19,10 @@ impl PayloadConfig {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        read_json(path).map_err(|err| err.into())
+        Ok(read_json(path)?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        atomic_save_json(path, self).map_err(|err| err.into())
+        Ok(atomic_save_json(path, self)?)
     }
 }

--- a/lib/segment/src/lib.rs
+++ b/lib/segment/src/lib.rs
@@ -1,4 +1,4 @@
-mod common;
+pub mod common;
 pub mod entry;
 pub mod fixtures;
 mod id_tracker;

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::PayloadStorage;
 
-/// Since sled is used for reading only during the initialization, large read cache is not required
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 const DB_NAME: &str = "payload";
 

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -18,7 +18,6 @@ use bit_vec::BitVec;
 use std::mem::size_of;
 use std::sync::Arc;
 
-/// Since sled is used for reading only during the initialization, large read cache is not required
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 
 /// In-memory vector storage with on-update persistence using `store`

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -13,7 +13,6 @@ tempdir = "0.3.7"
 
 [dependencies]
 
-sled = "0.34"
 num_cpus = "1.13"
 thiserror = "1.0"
 rand = "0.8.5"

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -12,24 +12,12 @@ pub const ALIAS_MAPPING_CONFIG_FILE: &str = "data.json";
 struct AliasMapping(HashMap<String, String>);
 
 impl AliasMapping {
-    // TODO error type conversion
     pub fn load(path: &Path) -> Result<Self, StorageError> {
-        read_json(path).map_err(|err| {
-            println!("failed to read_json {:?}", err);
-            StorageError::ServiceError {
-                description: "something bad happened".to_string(),
-            }
-        })
+        read_json(path).map_err(|err| err.into())
     }
 
-    // TODO error type conversion
     pub fn save(&self, path: &Path) -> Result<(), StorageError> {
-        atomic_save_json(path, self).map_err(|err| {
-            println!("failed to save_json {:?}", err);
-            StorageError::ServiceError {
-                description: "something bad happened".to_string(),
-            }
-        })
+        atomic_save_json(path, self).map_err(|err| err.into())
     }
 }
 

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -15,11 +15,11 @@ struct AliasMapping(HashMap<Alias, collection::CollectionId>);
 
 impl AliasMapping {
     pub fn load(path: &Path) -> Result<Self, StorageError> {
-        read_json(path).map_err(|err| err.into())
+        Ok(read_json(path)?)
     }
 
     pub fn save(&self, path: &Path) -> Result<(), StorageError> {
-        atomic_save_json(path, self).map_err(|err| err.into())
+        Ok(atomic_save_json(path, self)?)
     }
 }
 

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -9,10 +9,9 @@ use std::path::{Path, PathBuf};
 pub const ALIAS_MAPPING_CONFIG_FILE: &str = "data.json";
 
 type Alias = String;
-type CollectionName = String;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-struct AliasMapping(HashMap<Alias, CollectionName>);
+struct AliasMapping(HashMap<Alias, collection::CollectionId>);
 
 impl AliasMapping {
     pub fn load(path: &Path) -> Result<Self, StorageError> {
@@ -24,7 +23,7 @@ impl AliasMapping {
     }
 }
 
-/// Not thread-safe, accesses must be synchronized by an exclusive lock at the call site
+/// Persists mapping between alias and collection name. The data is assumed to be relatively small.
 /// - Reads are served from memory.
 /// - Writes are durably saved.
 pub struct AliasPersistence {

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -1,0 +1,100 @@
+use crate::content_manager::errors::StorageError;
+use segment::common::file_operations::{atomic_save_json, read_json};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub const ALIAS_MAPPING_CONFIG_FILE: &str = "data.json";
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+struct AliasMapping(HashMap<String, String>);
+
+impl AliasMapping {
+    // TODO error type conversion
+    pub fn load(path: &Path) -> Result<Self, StorageError> {
+        read_json(path).map_err(|err| {
+            println!("failed to read_json {:?}", err);
+            StorageError::ServiceError {
+                description: "something bad happened".to_string(),
+            }
+        })
+    }
+
+    // TODO error type conversion
+    pub fn save(&self, path: &Path) -> Result<(), StorageError> {
+        atomic_save_json(path, self).map_err(|err| {
+            println!("failed to save_json {:?}", err);
+            StorageError::ServiceError {
+                description: "something bad happened".to_string(),
+            }
+        })
+    }
+}
+
+/// Not thread-safe, accesses must be synchronized by an exclusive lock at the call site
+pub struct AliasPersistence {
+    data_path: PathBuf,
+}
+
+impl AliasPersistence {
+    pub fn get_config_path(path: &Path) -> PathBuf {
+        path.join(ALIAS_MAPPING_CONFIG_FILE)
+    }
+
+    fn init_file(dir_path: &Path) -> Result<PathBuf, StorageError> {
+        let data_path = Self::get_config_path(dir_path);
+        if !data_path.exists() {
+            let mut file = fs::File::create(&data_path)?;
+            let empty_json = "{}";
+            file.write_all(empty_json.as_bytes())?;
+        }
+        Ok(data_path)
+    }
+
+    pub fn open(dir_path: PathBuf) -> Result<Self, StorageError> {
+        if !dir_path.exists() {
+            fs::create_dir_all(&dir_path)?;
+        }
+        let data_path = Self::init_file(&dir_path)?;
+        Ok(AliasPersistence { data_path })
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>, StorageError> {
+        let alias = AliasMapping::load(&self.data_path)?;
+        Ok(alias.0.get(key).cloned())
+    }
+
+    pub fn contains_alias(&self, key: &str) -> Result<bool, StorageError> {
+        let alias = AliasMapping::load(&self.data_path)?;
+        Ok(alias.0.contains_key(key))
+    }
+
+    pub fn insert(&self, key: String, value: String) -> Result<(), StorageError> {
+        let mut alias = AliasMapping::load(&self.data_path)?;
+        println!("inserting {} {}", &key, &value);
+        // not checking if it already existed
+        alias.0.insert(key, value);
+        alias.save(&self.data_path)?;
+        Ok(())
+    }
+
+    pub fn remove(&self, key: &str) -> Result<Option<String>, StorageError> {
+        let mut alias = AliasMapping::load(&self.data_path)?;
+        let res = alias.0.remove(key);
+        alias.save(&self.data_path)?;
+        Ok(res)
+    }
+
+    pub fn collection_aliases(&self, collection_name: &str) -> Result<Vec<String>, StorageError> {
+        let mut result = vec![];
+        let alias = AliasMapping::load(&self.data_path)?;
+        for (alias, target_collection) in alias.0.into_iter() {
+            if collection_name == target_collection {
+                result.push(alias);
+            }
+        }
+        Ok(result)
+    }
+}

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -1,6 +1,4 @@
 use collection::operations::types::CollectionError;
-use sled::transaction::TransactionError;
-use sled::Error;
 use std::io::Error as IoError;
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -35,22 +33,6 @@ impl From<CollectionError> for StorageError {
             err @ CollectionError::InconsistentFailure { .. } => StorageError::ServiceError {
                 description: format!("{err}"),
             },
-        }
-    }
-}
-
-impl From<Error> for StorageError {
-    fn from(err: Error) -> Self {
-        StorageError::ServiceError {
-            description: format!("Persistence error: {:?}", err),
-        }
-    }
-}
-
-impl From<TransactionError> for StorageError {
-    fn from(err: TransactionError) -> Self {
-        StorageError::ServiceError {
-            description: format!("Persistence error: {}", err),
         }
     }
 }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,5 +1,5 @@
-pub mod collection_meta_ops;
 mod alias_mapping;
+pub mod collection_meta_ops;
 mod collections_ops;
 pub mod errors;
 pub mod toc;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,4 +1,5 @@
 pub mod collection_meta_ops;
+mod alias_mapping;
 mod collections_ops;
 pub mod errors;
 pub mod toc;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -295,16 +295,7 @@ impl TableOfContent {
                             new_alias_name,
                         },
                 }) => {
-                    if !alias_lock.contains_alias(&old_alias_name) {
-                        return Err(StorageError::NotFound {
-                            description: format!("Alias {} does not exists!", old_alias_name),
-                        });
-                    }
-
-                    // safe Option.unwrap as the alias mapping is currently locked exclusively
-                    let collection = alias_lock.remove(&old_alias_name)?.unwrap();
-                    // remove + insert is not transactional
-                    alias_lock.insert(new_alias_name, collection)?
+                    alias_lock.rename_alias(&old_alias_name, new_alias_name)?;
                 }
             };
         }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -2,11 +2,8 @@ use std::collections::HashMap;
 use std::fs::{create_dir_all, read_dir, remove_dir_all};
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
-use std::str::from_utf8;
 use std::sync::Arc;
 
-use sled::transaction::UnabortableTransactionError;
-use sled::{Config, Db};
 use tokio::runtime::Runtime;
 use tokio::sync::{RwLock, RwLockReadGuard};
 
@@ -25,6 +22,7 @@ use crate::content_manager::collection_meta_ops::{
     CreateAliasOperation, CreateCollection, DeleteAlias, DeleteAliasOperation, RenameAlias,
     RenameAliasOperation, UpdateCollection,
 };
+use crate::content_manager::alias_mapping::AliasPersistence;
 use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::errors::StorageError;
 use crate::types::StorageConfig;
@@ -36,10 +34,6 @@ use raft::{eraftpb::Entry as RaftEntry, RaftState};
 use std::ops::Deref;
 #[cfg(feature = "consensus")]
 use wal::Wal;
-
-/// Since sled is used for reading only during the initialization, large read cache is not required
-#[allow(clippy::identity_op)]
-const SLED_CACHE_SIZE: u64 = 1 * 1024 * 1024; // 1 mb
 
 const COLLECTIONS_DIR: &str = "collections";
 #[cfg(feature = "consensus")]
@@ -53,7 +47,7 @@ pub struct TableOfContent {
     storage_config: StorageConfig,
     search_runtime: Runtime,
     collection_management_runtime: Runtime,
-    alias_persistence: Db,
+    alias_persistence: AliasPersistence,
     segment_searcher: Box<dyn CollectionSearcher + Sync + Send>,
 
     #[cfg(feature = "consensus")]
@@ -91,13 +85,10 @@ impl TableOfContent {
             collections.insert(collection_name, collection);
         }
 
-        let alias_path = Path::new(&storage_config.storage_path).join("aliases.sled");
+        let alias_path = Path::new(&storage_config.storage_path).join("aliases");
 
-        let alias_persistence = Config::new()
-            .cache_capacity(SLED_CACHE_SIZE)
-            .path(alias_path)
-            .open()
-            .expect("Can't open database by the provided config");
+        let alias_persistence =
+            AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
 
         #[cfg(feature = "consensus")]
         let collection_meta_wal = {
@@ -155,11 +146,11 @@ impl TableOfContent {
     /// If alias exists - returns the original collection name
     /// If neither exists - returns [`StorageError`]
     async fn resolve_name(&self, collection_name: &str) -> Result<String, StorageError> {
-        let alias_collection_name = self.alias_persistence.get(collection_name.as_bytes())?;
+        let alias_collection_name = self.alias_persistence.get(collection_name)?;
 
         let resolved_name = match alias_collection_name {
             None => collection_name.to_string(),
-            Some(resolved_alias) => from_utf8(&resolved_alias).unwrap().to_string(),
+            Some(resolved_alias) => resolved_alias,
         };
         self.collections
             .read()
@@ -289,13 +280,12 @@ impl TableOfContent {
                         .validate_collection_not_exists(&alias_name)
                         .await?;
 
-                    self.alias_persistence
-                        .insert(alias_name.as_bytes(), collection_name.as_bytes())?;
+                    self.alias_persistence.insert(alias_name, collection_name)?;
                 }
                 AliasOperations::DeleteAlias(DeleteAliasOperation {
                     delete_alias: DeleteAlias { alias_name },
                 }) => {
-                    self.alias_persistence.remove(alias_name.as_bytes())?;
+                    self.alias_persistence.remove(&alias_name)?;
                 }
                 AliasOperations::RenameAlias(RenameAliasOperation {
                     rename_alias:
@@ -304,28 +294,19 @@ impl TableOfContent {
                             new_alias_name,
                         },
                 }) => {
-                    if !self
-                        .alias_persistence
-                        .contains_key(old_alias_name.as_bytes())?
-                    {
+                    if !self.alias_persistence.contains_alias(&old_alias_name)? {
                         return Err(StorageError::NotFound {
                             description: format!("Alias {} does not exists!", old_alias_name),
                         });
                     }
 
-                    let transaction_res = self.alias_persistence.transaction(|tx_db| {
-                        let collection = tx_db
-                            .remove(old_alias_name.as_bytes())?
-                            .ok_or(UnabortableTransactionError::Conflict)?;
-
-                        tx_db.insert(new_alias_name.as_bytes(), collection)?;
-                        Ok(())
-                    });
-                    transaction_res?;
+                    // safe Option.unwrap as the alias mapping is currently locked exclusively
+                    let collection = self.alias_persistence.remove(&old_alias_name)?.unwrap();
+                    // remove + insert is not transactional
+                    self.alias_persistence.insert(new_alias_name, collection)?
                 }
             };
         }
-        self.alias_persistence.flush()?;
         Ok(true)
     }
 
@@ -445,15 +426,7 @@ impl TableOfContent {
 
     /// List of all aliases for a given collection
     pub fn collection_aliases(&self, collection_name: &str) -> Result<Vec<String>, StorageError> {
-        let mut result = vec![];
-        for pair in self.alias_persistence.iter() {
-            let (alias_bt, target_collection_bt) = pair?;
-            let alias = from_utf8(&alias_bt).unwrap().to_string();
-            let target_collection = from_utf8(&target_collection_bt).unwrap();
-            if collection_name == target_collection {
-                result.push(alias);
-            }
-        }
+        let result = self.alias_persistence.collection_aliases(collection_name)?;
         Ok(result)
     }
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -17,12 +17,12 @@ use collection::operations::CollectionUpdateOperations;
 use collection::Collection;
 use segment::types::ScoredPoint;
 
+use crate::content_manager::alias_mapping::AliasPersistence;
 use crate::content_manager::collection_meta_ops::{
     AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
     CreateAliasOperation, CreateCollection, DeleteAlias, DeleteAliasOperation, RenameAlias,
     RenameAliasOperation, UpdateCollection,
 };
-use crate::content_manager::alias_mapping::AliasPersistence;
 use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::errors::StorageError;
 use crate::types::StorageConfig;

--- a/openapi/tests/openapi_integration/test_alias.py
+++ b/openapi/tests/openapi_integration/test_alias.py
@@ -33,6 +33,18 @@ def test_alias_operations():
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
         method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "top": 3
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 3
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
         path_params={'collection_name': "test_alias"},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
@@ -41,3 +53,29 @@ def test_alias_operations():
     )
     assert response.ok
     assert len(response.json()['result']) == 3
+
+    response = request_with_validation(
+        api='/collections/aliases',
+        method="POST",
+        body={
+            "actions": [
+                {
+                    "delete_alias": {
+                        "alias_name": "test_alias"
+                    }
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': "test_alias"},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "top": 3
+        }
+    )
+    assert response.status_code == 404

--- a/openapi/tests/run_docker.sh
+++ b/openapi/tests/run_docker.sh
@@ -14,4 +14,4 @@ cd "$(dirname "$0")"
 
 trap clear_after_tests EXIT
 
-pytest
+pytest -s


### PR DESCRIPTION
This PR tackles #204 by migrating the persistence for alias mappings from [Sled](https://github.com/spacejam/sled) to a simple json file.

## Notes for the reviewers

- The content of the mapping is kept in memory and sync. to disk when modified.
- In order to reuse the utilities in [file_operations](https://github.com/qdrant/qdrant/blob/e45379e4384062e92ee1c9be82c250047464c9ef/lib/segment/src/common/file_operations.rs#L22), a new error representation was introduced to cleanly separate `OperationError` and `StorageError`.
- Alias renaming is kept atomic as the previous implementation.
