### PR TITLE
alias gRPC endpoint

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -257,6 +257,7 @@ impl TableOfContent {
         }
     }
 
+    /// performs several alias changes in an atomic fashion
     pub async fn update_aliases(
         &self,
         operation: ChangeAliasesOperation,

--- a/src/tonic/proto/collections.proto
+++ b/src/tonic/proto/collections.proto
@@ -27,6 +27,10 @@ service Collections {
   Drop collection and all associated data
    */
   rpc Delete (DeleteCollection) returns (CollectionOperationResponse) {}
+  /*
+  Update Aliases of the existing collection
+  */
+  rpc UpdateAliases (ChangeAliases) returns (CollectionOperationResponse) {}
 }
 
 message GetCollectionInfoRequest {
@@ -202,4 +206,30 @@ message CollectionInfo {
   uint64 ram_data_size = 6; // Used RAM (not implemented)
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
+}
+
+message ChangeAliases {
+  repeated AliasOperations actions = 1; // List of actions
+}
+
+message AliasOperations {
+  oneof action {
+    CreateAlias create_alias = 1;
+    RenameAlias rename_alias = 2;
+    DeleteAlias delete_alias = 3;
+  }
+}
+
+message CreateAlias {
+  string collection_name = 1; // Name of the collection
+  string alias_name = 2; // New name of the alias
+}
+
+message RenameAlias {
+  string old_alias_name = 1; // Name of the alias to rename
+  string new_alias_name = 2; // Name of the alias
+}
+
+message DeleteAlias {
+  string alias_name = 1; // Name of the alias
 }

--- a/src/tonic/qdrant.rs
+++ b/src/tonic/qdrant.rs
@@ -223,6 +223,52 @@ pub struct CollectionInfo {
     pub payload_schema:
         ::std::collections::HashMap<::prost::alloc::string::String, PayloadSchemaInfo>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChangeAliases {
+    #[prost(message, repeated, tag = "1")]
+    pub actions: ::prost::alloc::vec::Vec<AliasOperations>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AliasOperations {
+    #[prost(oneof = "alias_operations::Action", tags = "1, 2, 3")]
+    pub action: ::core::option::Option<alias_operations::Action>,
+}
+/// Nested message and enum types in `AliasOperations`.
+pub mod alias_operations {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Action {
+        #[prost(message, tag = "1")]
+        CreateAlias(super::CreateAlias),
+        #[prost(message, tag = "2")]
+        RenameAlias(super::RenameAlias),
+        #[prost(message, tag = "3")]
+        DeleteAlias(super::DeleteAlias),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateAlias {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Name of the alias
+    #[prost(string, tag = "2")]
+    pub alias_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenameAlias {
+    /// Name of the alias to rename
+    #[prost(string, tag = "1")]
+    pub old_alias_name: ::prost::alloc::string::String,
+    /// Name of the alias
+    #[prost(string, tag = "2")]
+    pub new_alias_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteAlias {
+    /// Name of the alias
+    #[prost(string, tag = "1")]
+    pub alias_name: ::prost::alloc::string::String,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Distance {
@@ -391,6 +437,22 @@ pub mod collections_client {
             let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Delete");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        #[doc = ""]
+        #[doc = "Update Aliases of the existing collection"]
+        pub async fn update_aliases(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ChangeAliases>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/UpdateAliases");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 #[doc = r" Generated server implementations."]
@@ -429,6 +491,12 @@ pub mod collections_server {
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteCollection>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        #[doc = ""]
+        #[doc = "Update Aliases of the existing collection"]
+        async fn update_aliases(
+            &self,
+            request: tonic::Request<super::ChangeAliases>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -617,6 +685,37 @@ pub mod collections_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/UpdateAliases" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateAliasesSvc<T: Collections>(pub Arc<T>);
+                    impl<T: Collections> tonic::server::UnaryService<super::ChangeAliases> for UpdateAliasesSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ChangeAliases>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).update_aliases(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateAliasesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -102,7 +102,54 @@ $docker_grpcurl -d '{
   "negative": [{ "num": 2 }]
 }' $QDRANT_HOST qdrant.Points/Recommend
 
+# create alias
+$docker_grpcurl -d '{
+  "actions": [
+    {
+      "create_alias": {
+        "alias_name": "test_alias",
+        "collection_name": "test_collection"
+      }
+    }
+  ]
+}' $QDRANT_HOST qdrant.Collections/UpdateAliases
 
+# search via alias
+$docker_grpcurl -d '{
+  "collection_name": "test_alias",
+  "vector": [0.2,0.1,0.9,0.7],
+  "top": 3
+}' $QDRANT_HOST qdrant.Points/Search
+
+# rename alias
+$docker_grpcurl -d '{
+  "actions": [
+    {
+      "rename_alias": {
+        "old_alias_name": "test_alias",
+        "new_alias_name": "new_test_alias"
+      }
+    }
+  ]
+}' $QDRANT_HOST qdrant.Collections/UpdateAliases
+
+# search via renamed alias
+$docker_grpcurl -d '{
+  "collection_name": "new_test_alias",
+  "vector": [0.2,0.1,0.9,0.7],
+  "top": 3
+}' $QDRANT_HOST qdrant.Points/Search
+
+# delete alias
+$docker_grpcurl -d '{
+  "actions": [
+    {
+      "delete_alias": {
+        "alias_name": "new_test_alias"
+      }
+    }
+  ]
+}' $QDRANT_HOST qdrant.Collections/UpdateAliases
 
 
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
@@ -136,29 +183,3 @@ $docker_grpcurl -d '{
 #      "vector": [0.2, 0.1, 0.9, 0.7],
 #      "top": 3
 #  }' | jq
-#
-#
-#
-#curl -L -X POST "http://$QDRANT_HOST/collections" \
-#  --fail -s \
-#  -H 'Content-Type: application/json' \
-#  --data-raw '{
-#      "change_aliases": {
-#          "actions": [
-#              {
-#                  "create_alias": {
-#                      "alias_name": "test_alias",
-#                      "collection_name": "test_collection"
-#                  }
-#              }
-#          ]
-#      }
-#  }' | jq
-#
-#curl -L -X POST "http://$QDRANT_HOST/collections/test_alias/points/search" \
-#  -H 'Content-Type: application/json' \
-#  --fail -s \
-#  --data-raw '{
-#        "vector": [0.2,0.1,0.9,0.7],
-#        "top": 3
-#    }' | jq


### PR DESCRIPTION
This PR exposes the collection alias management feature as a gRPC endpoint https://github.com/qdrant/qdrant/issues/398

It follows closely the REST implementation as we need to preserve the atomicity property when applying several update operations sequentially.