### PR TITLE
[Sharding] Shard aware updates for internal API

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "points.proto";
+
+option java_multiple_files = true;
+option java_package = "tech.qdrant.grpc";
+option java_outer_classname = "QdrantProto";
+
+package qdrant;
+
+import "google/protobuf/struct.proto";
+
+service PointsInternal {
+  rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}
+}
+
+message UpsertPointsInternal {
+  UpsertPoints upsert_points = 1;
+  uint32 shard_id = 2;
+}

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "collections_service.proto";
 import "points_service.proto";
+import "points_internal_service.proto";
 
 option java_multiple_files = true;
 option java_package = "tech.qdrant.grpc";

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1979,6 +1979,206 @@ pub mod points_server {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpsertPointsInternal {
+    #[prost(message, optional, tag = "1")]
+    pub upsert_points: ::core::option::Option<UpsertPoints>,
+    #[prost(uint32, tag = "2")]
+    pub shard_id: u32,
+}
+#[doc = r" Generated client implementations."]
+pub mod points_internal_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct PointsInternalClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl PointsInternalClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> PointsInternalClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> PointsInternalClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            PointsInternalClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn upsert(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Upsert");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+#[doc = r" Generated server implementations."]
+pub mod points_internal_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer."]
+    #[async_trait]
+    pub trait PointsInternal: Send + Sync + 'static {
+        async fn upsert(
+            &self,
+            request: tonic::Request<super::UpsertPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct PointsInternalServer<T: PointsInternal> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: PointsInternal> PointsInternalServer<T> {
+        pub fn new(inner: T) -> Self {
+            let inner = Arc::new(inner);
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for PointsInternalServer<T>
+    where
+        T: PointsInternal,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Never;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.PointsInternal/Upsert" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpsertSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::UpsertPointsInternal> for UpsertSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpsertPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).upsert(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: PointsInternal> Clone for PointsInternalServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: PointsInternal> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: PointsInternal> tonic::transport::NamedService for PointsInternalServer<T> {
+        const NAME: &'static str = "qdrant.PointsInternal";
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckReply {

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 
 use crate::operations::types::PointRequest;
 use crate::operations::OperationToShard;
+use crate::shard::ShardOperation;
 use collection_manager::collection_managers::CollectionSearcher;
 use config::CollectionConfig;
 use futures::{stream::futures_unordered::FuturesUnordered, StreamExt};
@@ -205,6 +206,43 @@ impl Collection {
     }
 
     pub async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        shard_selection: Option<ShardId>,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        match shard_selection {
+            Some(shard_selection) => {
+                self.update_from_peer(operation, shard_selection, wait)
+                    .await
+            }
+            None => self.update_from_client(operation, wait).await,
+        }
+    }
+
+    pub async fn update_from_peer(
+        &self,
+        operation: CollectionUpdateOperations,
+        shard_selection: ShardId,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        match self.shards.get(&shard_selection) {
+            None => Err(CollectionError::service_error(format!(
+                "Shard {} does not exist",
+                shard_selection
+            ))),
+            Some(Shard::Remote(_)) => Err(CollectionError::service_error(format!(
+                "Shard {} is not local on peer",
+                shard_selection
+            ))),
+            Some(Shard::Local(local_shard)) => {
+                let res = local_shard.update(operation.clone(), wait).await;
+                res
+            }
+        }
+    }
+
+    pub async fn update_from_client(
         &self,
         operation: CollectionUpdateOperations,
         wait: bool,

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -205,21 +205,6 @@ impl Collection {
         self.shards.values()
     }
 
-    pub async fn update(
-        &self,
-        operation: CollectionUpdateOperations,
-        shard_selection: Option<ShardId>,
-        wait: bool,
-    ) -> CollectionResult<UpdateResult> {
-        match shard_selection {
-            Some(shard_selection) => {
-                self.update_from_peer(operation, shard_selection, wait)
-                    .await
-            }
-            None => self.update_from_client(operation, wait).await,
-        }
-    }
-
     pub async fn update_from_peer(
         &self,
         operation: CollectionUpdateOperations,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -218,6 +218,12 @@ pub enum CollectionError {
     },
 }
 
+impl CollectionError {
+    pub fn service_error(error: String) -> CollectionError {
+        CollectionError::ServiceError { error }
+    }
+}
+
 impl From<OperationError> for CollectionError {
     fn from(err: OperationError) -> Self {
         match err {

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -41,7 +41,10 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
                 },
             })),
         );
-        collection.update(insert_points, true).await.unwrap();
+        collection
+            .update_from_client(insert_points, true)
+            .await
+            .unwrap();
         collection.before_drop().await;
     }
 
@@ -69,7 +72,10 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
                 },
             })),
         );
-        collection.update(insert_points, true).await.unwrap();
+        collection
+            .update_from_client(insert_points, true)
+            .await
+            .unwrap();
         collection.before_drop().await;
     }
 
@@ -132,7 +138,10 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
                 },
             })),
         );
-        collection.update(insert_points, true).await.unwrap();
+        collection
+            .update_from_client(insert_points, true)
+            .await
+            .unwrap();
         collection.before_drop().await;
     }
 

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -50,7 +50,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
         .into(),
     );
 
-    let insert_result = collection.update(insert_points, true).await;
+    let insert_result = collection.update_from_client(insert_points, true).await;
 
     match insert_result {
         Ok(res) => {
@@ -107,7 +107,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
         .into(),
     );
 
-    let insert_result = collection.update(insert_points, true).await;
+    let insert_result = collection.update_from_client(insert_points, true).await;
 
     match insert_result {
         Ok(res) => {
@@ -172,7 +172,10 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
             .into(),
         );
 
-        collection.update(insert_points, true).await.unwrap();
+        collection
+            .update_from_client(insert_points, true)
+            .await
+            .unwrap();
 
         let payload: Payload = serde_json::from_str(r#"{"color":"red"}"#).unwrap();
 
@@ -182,7 +185,10 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
                 points: vec![2.into(), 3.into()],
             }));
 
-        collection.update(assign_payload, true).await.unwrap();
+        collection
+            .update_from_client(assign_payload, true)
+            .await
+            .unwrap();
         collection.before_drop().await;
     }
 
@@ -290,7 +296,10 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
         .into(),
     );
 
-    collection.update(insert_points, true).await.unwrap();
+    collection
+        .update_from_client(insert_points, true)
+        .await
+        .unwrap();
     let segment_searcher = SimpleCollectionSearcher::new();
     let result = collection
         .recommend_by(
@@ -347,7 +356,10 @@ async fn test_read_api_with_shards(shard_number: u32) {
         .into(),
     ));
 
-    collection.update(insert_points, true).await.unwrap();
+    collection
+        .update_from_client(insert_points, true)
+        .await
+        .unwrap();
 
     let segment_searcher = SimpleCollectionSearcher::new();
     let result = collection
@@ -398,7 +410,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         .into(),
     );
 
-    let insert_result = collection.update(insert_points, true).await;
+    let insert_result = collection.update_from_client(insert_points, true).await;
 
     match insert_result {
         Ok(res) => {
@@ -419,7 +431,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         PointOperations::DeletePointsByFilter(delete_filter),
     );
 
-    let delete_result = collection.update(delete_points, true).await;
+    let delete_result = collection.update_from_client(delete_points, true).await;
 
     match delete_result {
         Ok(res) => {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -29,6 +29,7 @@ use crate::types::StorageConfig;
 use collection::collection_manager::collection_managers::CollectionSearcher;
 use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
 
+use collection::shard::ShardId;
 #[cfg(feature = "consensus")]
 use raft::{
     eraftpb::{Entry as RaftEntry, Snapshot as RaftSnapshot},
@@ -508,11 +509,12 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         operation: CollectionUpdateOperations,
+        shard_selection: Option<ShardId>,
         wait: bool,
     ) -> Result<UpdateResult, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
-            .update(operation, wait)
+            .update(operation, shard_selection, wait)
             .await
             .map_err(|err| err.into())
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -513,10 +513,15 @@ impl TableOfContent {
         wait: bool,
     ) -> Result<UpdateResult, StorageError> {
         let collection = self.get_collection(collection_name).await?;
-        collection
-            .update(operation, shard_selection, wait)
-            .await
-            .map_err(|err| err.into())
+        let result = match shard_selection {
+            Some(shard_selection) => {
+                collection
+                    .update_from_peer(operation, shard_selection, wait)
+                    .await
+            }
+            None => collection.update_from_client(operation, wait).await,
+        };
+        result.map_err(|err| err.into())
     }
 
     #[cfg(feature = "consensus")]

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -32,7 +32,8 @@ pub async fn update_points(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_update_points(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_update_points(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -48,7 +49,8 @@ pub async fn upsert_points(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_upsert_points(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_upsert_points(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -64,7 +66,8 @@ pub async fn delete_points(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_delete_points(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_delete_points(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -80,7 +83,7 @@ pub async fn set_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_set_payload(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response = do_set_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -96,7 +99,8 @@ pub async fn delete_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_delete_payload(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_delete_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -112,7 +116,8 @@ pub async fn clear_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_clear_payload(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_clear_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -128,7 +133,8 @@ pub async fn create_field_index(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_create_index(&toc.into_inner(), &collection_name, operation, wait).await;
+    let response =
+        do_create_index(&toc.into_inner(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
@@ -142,7 +148,8 @@ pub async fn delete_field_index(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_delete_index(&toc.into_inner(), &collection_name, field_name, wait).await;
+    let response =
+        do_delete_index(&toc.into_inner(), &collection_name, field_name, None, wait).await;
     process_response(response, timing)
 }
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -4,6 +4,7 @@ use collection::operations::types::{
     PointRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
 };
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
+use collection::shard::ShardId;
 use schemars::JsonSchema;
 use segment::types::{PayloadSchemaType, ScoredPoint};
 use serde::{Deserialize, Serialize};
@@ -21,20 +22,23 @@ pub async fn do_update_points(
     toc: &TableOfContent,
     collection_name: &str,
     operation: CollectionUpdateOperations,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
-    toc.update(collection_name, operation, wait).await
+    toc.update(collection_name, operation, shard_selection, wait)
+        .await
 }
 
 pub async fn do_upsert_points(
     toc: &TableOfContent,
     collection_name: &str,
     operation: PointInsertOperations,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(operation));
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -42,6 +46,7 @@ pub async fn do_delete_points(
     toc: &TableOfContent,
     collection_name: &str,
     points: PointsSelector,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let point_operation = match points {
@@ -53,7 +58,7 @@ pub async fn do_delete_points(
         }
     };
     let collection_operation = CollectionUpdateOperations::PointOperation(point_operation);
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -61,11 +66,12 @@ pub async fn do_set_payload(
     toc: &TableOfContent,
     collection_name: &str,
     operation: SetPayload,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(operation));
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -73,11 +79,12 @@ pub async fn do_delete_payload(
     toc: &TableOfContent,
     collection_name: &str,
     operation: DeletePayload,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PayloadOperation(PayloadOps::DeletePayload(operation));
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -85,6 +92,7 @@ pub async fn do_clear_payload(
     toc: &TableOfContent,
     collection_name: &str,
     points: PointsSelector,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let points_operation = match points {
@@ -97,7 +105,7 @@ pub async fn do_clear_payload(
     };
 
     let collection_operation = CollectionUpdateOperations::PayloadOperation(points_operation);
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -105,6 +113,7 @@ pub async fn do_create_index(
     toc: &TableOfContent,
     collection_name: &str,
     operation: CreateFieldIndex,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
@@ -113,7 +122,7 @@ pub async fn do_create_index(
             field_type: operation.field_type,
         }),
     );
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 
@@ -121,12 +130,13 @@ pub async fn do_delete_index(
     toc: &TableOfContent,
     collection_name: &str,
     index_name: String,
+    shard_selection: Option<ShardId>,
     wait: bool,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::DeleteIndex(index_name),
     );
-    toc.update(collection_name, collection_operation, wait)
+    toc.update(collection_name, collection_operation, shard_selection, wait)
         .await
 }
 

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -1,2 +1,4 @@
 pub mod collections_api;
 pub mod points_api;
+mod points_common;
+pub mod points_internal_api;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1,0 +1,54 @@
+use crate::common::points::do_update_points;
+use api::grpc::qdrant::{PointsOperationResponse, UpsertPoints};
+use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointsList};
+use collection::operations::CollectionUpdateOperations;
+use collection::shard::ShardId;
+use std::time::Instant;
+use storage::content_manager::conversions::error_to_status;
+use storage::content_manager::toc::TableOfContent;
+use tonic::{Response, Status};
+
+pub fn points_operation_response(
+    timing: Instant,
+    update_result: collection::operations::types::UpdateResult,
+) -> PointsOperationResponse {
+    PointsOperationResponse {
+        result: Some(update_result.into()),
+        time: timing.elapsed().as_secs_f64(),
+    }
+}
+
+pub async fn upsert(
+    toc: &TableOfContent,
+    upsert_points: UpsertPoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let UpsertPoints {
+        collection_name,
+        wait,
+        points,
+    } = upsert_points;
+
+    let points = points
+        .into_iter()
+        .map(|point| point.try_into())
+        .collect::<Result<_, _>>()?;
+
+    let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperations::PointsList(PointsList { points }),
+    ));
+
+    let timing = Instant::now();
+    let result = do_update_points(
+        toc,
+        &collection_name,
+        operation,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -1,0 +1,44 @@
+use tonic::{Request, Response, Status};
+
+use crate::tonic::api::points_common::upsert;
+use api::grpc::qdrant::points_internal_server::PointsInternal;
+use api::grpc::qdrant::{PointsOperationResponse, UpsertPointsInternal};
+use std::sync::Arc;
+use storage::content_manager::toc::TableOfContent;
+
+pub struct PointsInternalService {
+    toc: Arc<TableOfContent>,
+}
+
+impl PointsInternalService {
+    pub fn new(toc: Arc<TableOfContent>) -> Self {
+        Self { toc }
+    }
+}
+
+#[tonic::async_trait]
+impl PointsInternal for PointsInternalService {
+    async fn upsert(
+        &self,
+        request: Request<UpsertPointsInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let UpsertPointsInternal {
+            upsert_points,
+            shard_id,
+        } = request.into_inner();
+
+        let upsert_points =
+            upsert_points.ok_or_else(|| Status::invalid_argument("UpsertPoints is missing"))?;
+
+        upsert(self.toc.as_ref(), upsert_points, Some(shard_id)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_grpc() {
+        // For running build from IDE
+        eprintln!("hello");
+    }
+}

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -6,6 +6,7 @@ use api::grpc::qdrant::{PointsOperationResponse, UpsertPointsInternal};
 use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
 
+/// This API is intended for P2P communication within a distributed deployment.
 pub struct PointsInternalService {
     toc: Arc<TableOfContent>,
 }

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -2,8 +2,10 @@ mod api;
 
 use crate::tonic::api::collections_api::CollectionsService;
 use crate::tonic::api::points_api::PointsService;
+use crate::tonic::api::points_internal_api::PointsInternalService;
 use ::api::grpc::models::VersionInfo;
 use ::api::grpc::qdrant::collections_server::CollectionsServer;
+use ::api::grpc::qdrant::points_internal_server::PointsInternalServer;
 use ::api::grpc::qdrant::points_server::PointsServer;
 use ::api::grpc::qdrant::qdrant_server::{Qdrant, QdrantServer};
 use ::api::grpc::qdrant::{HealthCheckReply, HealthCheckRequest};
@@ -44,6 +46,7 @@ pub fn init(toc: Arc<TableOfContent>, host: String, grpc_port: u16) -> std::io::
             let service = QdrantService::default();
             let collections_service = CollectionsService::new(toc.clone());
             let points_service = PointsService::new(toc.clone());
+            let points_internal_service = PointsInternalService::new(toc.clone());
 
             log::info!("Qdrant gRPC listening on {}", grpc_port);
 
@@ -51,6 +54,7 @@ pub fn init(toc: Arc<TableOfContent>, host: String, grpc_port: u16) -> std::io::
                 .add_service(QdrantServer::new(service))
                 .add_service(CollectionsServer::new(collections_service))
                 .add_service(PointsServer::new(points_service))
+                .add_service(PointsInternalServer::new(points_internal_service)) // TODO serve from different port
                 .serve_with_shutdown(socket, async {
                     signal::ctrl_c().await.unwrap();
                     log::info!("Stopping gRPC");


### PR DESCRIPTION
This PR adds a shard aware update API. https://github.com/qdrant/qdrant/issues/419

A new optional `shard_selection` parameter is propagated down the stack to choose how to handle the update:
- `update_from_client` is the current public API which splits batches by shards for redistribution
- `update_from_peer` is the new API which expects the `shard_selection` to be one of the peer's local shard (the error handling needs to be revised) 

In order to validate the current direction I have implemented a single method on a newly introduced internal gRPC API to get a feel for the complete integration.

I tried to mitigate code duplication by introducing a common API layer `points_common.rs`.