### PR TITLE
Wait for operation commit

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,3 +30,24 @@ jobs:
         run: |
           ./tests/integration-tests.sh
         shell: bash
+
+  test-consensus:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v1
+      - name: Install dependencies
+        run: sudo apt-get install clang
+      - name: Build
+        run: cargo build --features consensus
+      - name: Run integration tests
+        run: |
+          ./tests/integration-tests.sh
+        shell: bash

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2004,7 +2004,7 @@ pub struct UpsertPointsInternal {
     #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -2013,7 +2013,7 @@ pub mod points_internal_client {
         inner: tonic::client::Grpc<T>,
     }
     impl PointsInternalClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -2026,8 +2026,8 @@ pub mod points_internal_client {
     impl<T> PointsInternalClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
+        T::ResponseBody: Default + Body<Data = Bytes> + Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
@@ -2051,15 +2051,17 @@ pub mod points_internal_client {
         {
             PointsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
-        #[doc = r" Compress requests with `gzip`."]
-        #[doc = r""]
-        #[doc = r" This requires the server to support it otherwise it might respond with an"]
-        #[doc = r" error."]
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
         pub fn send_gzip(mut self) -> Self {
             self.inner = self.inner.send_gzip();
             self
         }
-        #[doc = r" Enable decompressing responses with `gzip`."]
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
         pub fn accept_gzip(mut self) -> Self {
             self.inner = self.inner.accept_gzip();
             self
@@ -2080,11 +2082,11 @@ pub mod points_internal_client {
         }
     }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod points_internal_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer."]
+    ///Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer.
     #[async_trait]
     pub trait PointsInternal: Send + Sync + 'static {
         async fn upsert(
@@ -2101,7 +2103,9 @@ pub mod points_internal_server {
     struct _Inner<T>(Arc<T>);
     impl<T: PointsInternal> PointsInternalServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
             let inner = _Inner(inner);
             Self {
                 inner,
@@ -2123,7 +2127,7 @@ pub mod points_internal_server {
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -22,7 +22,7 @@ pub trait DiffConfig<T: DeserializeOwned + Serialize> {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Merge)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Merge, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct HnswConfigDiff {
     /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
@@ -35,7 +35,7 @@ pub struct HnswConfigDiff {
     pub full_scan_threshold: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Merge)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Merge, PartialEq, Eq, Hash)]
 pub struct WalConfigDiff {
     /// Size of a single WAL segment in MB
     pub wal_capacity_mb: Option<usize>,
@@ -77,6 +77,37 @@ pub struct OptimizersConfigDiff {
     /// Maximum available threads for optimization workers
     pub max_optimization_threads: Option<usize>,
 }
+
+impl std::hash::Hash for OptimizersConfigDiff {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.deleted_threshold.map(f64::to_le_bytes).hash(state);
+        self.vacuum_min_vector_number.hash(state);
+        self.default_segment_number.hash(state);
+        self.max_segment_size.hash(state);
+        self.memmap_threshold.hash(state);
+        self.indexing_threshold.hash(state);
+        self.payload_indexing_threshold.hash(state);
+        self.flush_interval_sec.hash(state);
+        self.max_optimization_threads.hash(state);
+    }
+}
+
+impl PartialEq for OptimizersConfigDiff {
+    fn eq(&self, other: &Self) -> bool {
+        self.deleted_threshold.map(f64::to_le_bytes)
+            == other.deleted_threshold.map(f64::to_le_bytes)
+            && self.vacuum_min_vector_number == other.vacuum_min_vector_number
+            && self.default_segment_number == other.default_segment_number
+            && self.max_segment_size == other.max_segment_size
+            && self.memmap_threshold == other.memmap_threshold
+            && self.indexing_threshold == other.indexing_threshold
+            && self.payload_indexing_threshold == other.payload_indexing_threshold
+            && self.flush_interval_sec == other.flush_interval_sec
+            && self.max_optimization_threads == other.max_optimization_threads
+    }
+}
+
+impl Eq for OptimizersConfigDiff {}
 
 impl DiffConfig<HnswConfig> for HnswConfigDiff {}
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -72,7 +72,9 @@ impl FromStr for ExtendedPointId {
 pub type PointIdType = ExtendedPointId;
 
 /// Type of internal tags, build from payload
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, FromPrimitive, PartialEq, Eq)]
+#[derive(
+    Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, FromPrimitive, PartialEq, Eq, Hash,
+)]
 /// Distance function types used to compare vectors
 pub enum Distance {
     /// https://en.wikipedia.org/wiki/Cosine_similarity

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -9,35 +9,35 @@ use serde::{Deserialize, Serialize};
 
 /// Create alternative name for a collection.
 /// Collection will be available under both names for search, retrieve,
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateAlias {
     pub collection_name: String,
     pub alias_name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateAliasOperation {
     pub create_alias: CreateAlias,
 }
 
 /// Delete alias if exists
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct DeleteAlias {
     pub alias_name: String,
 }
 
 /// Delete alias if exists
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct DeleteAliasOperation {
     pub delete_alias: DeleteAlias,
 }
 
 /// Change alias to a new one
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct RenameAlias {
     pub old_alias_name: String,
@@ -45,14 +45,14 @@ pub struct RenameAlias {
 }
 
 /// Change alias to a new one
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct RenameAliasOperation {
     pub rename_alias: RenameAlias,
 }
 
 /// Group of all the possible operations related to collection aliases
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum AliasOperations {
@@ -80,7 +80,7 @@ impl From<RenameAlias> for AliasOperations {
 }
 
 /// Operation for creating new collection and (optionally) specify index params
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateCollection {
     pub vector_size: usize,
@@ -101,7 +101,7 @@ pub const fn default_shard_number() -> u32 {
 }
 
 /// Operation for creating new collection and (optionally) specify index params
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateCollectionOperation {
     pub collection_name: String,
@@ -110,7 +110,7 @@ pub struct CreateCollectionOperation {
 }
 
 /// Operation for updating parameters of the existing collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateCollection {
     /// Custom params for Optimizers.  If none - values from service configuration file are used.
@@ -119,7 +119,7 @@ pub struct UpdateCollection {
 }
 
 /// Operation for updating parameters of the existing collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateCollectionOperation {
     pub collection_name: String,
@@ -130,19 +130,19 @@ pub struct UpdateCollectionOperation {
 /// Operation for performing changes of collection aliases.
 /// Alias changes are atomic, meaning that no collection modifications can happen between
 /// alias operations.
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct ChangeAliasesOperation {
     pub actions: Vec<AliasOperations>,
 }
 
 /// Operation for deleting collection with given name
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct DeleteCollectionOperation(pub String);
 
 /// Enumeration of all possible collection update operations
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionMetaOperations {
     CreateCollection(CreateCollectionOperation),

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -81,6 +81,14 @@ impl<T> From<std::sync::mpsc::SendError<T>> for StorageError {
     }
 }
 
+impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
+    fn from(err: tokio::sync::oneshot::error::RecvError) -> Self {
+        StorageError::ServiceError {
+            description: format!("Channel sender dropped: {}", err),
+        }
+    }
+}
+
 #[cfg(feature = "consensus")]
 impl From<serde_cbor::Error> for StorageError {
     fn from(err: serde_cbor::Error) -> Self {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -379,6 +379,7 @@ impl TableOfContent {
                         wait_timeout.as_secs_f64()
                     ),
                 },
+                // ??? - forwards 3 possible errors: timeout, sender dropped, operation failed
             )???)
     }
 

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -55,7 +55,7 @@ mod tests {
                         shard_number: 1,
                     },
                 }),
-                true,
+                None,
             ))
             .unwrap();
 
@@ -68,7 +68,7 @@ mod tests {
                         }
                         .into()],
                 }),
-                true,
+                None,
             ))
             .unwrap();
 
@@ -92,7 +92,7 @@ mod tests {
                             .into(),
                         ],
                 }),
-                true,
+                None,
             ))
             .unwrap();
 

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -43,42 +43,39 @@ mod tests {
         let toc = TableOfContent::new(&config, runtime);
 
         handle
-            .block_on(
-                toc.submit_collection_operation(CollectionMetaOperations::CreateCollection(
-                    CreateCollectionOperation {
-                        collection_name: "test".to_string(),
-                        create_collection: CreateCollection {
-                            vector_size: 10,
-                            distance: Distance::Cosine,
-                            hnsw_config: None,
-                            wal_config: None,
-                            optimizers_config: None,
-                            shard_number: 1,
-                        },
+            .block_on(toc.submit_collection_operation(
+                CollectionMetaOperations::CreateCollection(CreateCollectionOperation {
+                    collection_name: "test".to_string(),
+                    create_collection: CreateCollection {
+                        vector_size: 10,
+                        distance: Distance::Cosine,
+                        hnsw_config: None,
+                        wal_config: None,
+                        optimizers_config: None,
+                        shard_number: 1,
                     },
-                )),
-            )
+                }),
+                true,
+            ))
             .unwrap();
 
         handle
-            .block_on(
-                toc.submit_collection_operation(CollectionMetaOperations::ChangeAliases(
-                    ChangeAliasesOperation {
-                        actions: vec![CreateAlias {
+            .block_on(toc.submit_collection_operation(
+                CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation {
+                    actions: vec![CreateAlias {
                             collection_name: "test".to_string(),
                             alias_name: "test_alias".to_string(),
                         }
                         .into()],
-                    },
-                )),
-            )
+                }),
+                true,
+            ))
             .unwrap();
 
         handle
-            .block_on(
-                toc.submit_collection_operation(CollectionMetaOperations::ChangeAliases(
-                    ChangeAliasesOperation {
-                        actions: vec![
+            .block_on(toc.submit_collection_operation(
+                CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation {
+                    actions: vec![
                             CreateAlias {
                                 collection_name: "test".to_string(),
                                 alias_name: "test_alias2".to_string(),
@@ -94,9 +91,9 @@ mod tests {
                             }
                             .into(),
                         ],
-                    },
-                )),
-            )
+                }),
+                true,
+            ))
             .unwrap();
 
         handle.block_on(toc.get_collection("test_alias3")).unwrap();

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -34,7 +34,7 @@ async fn update_collections(
     operation: web::Json<CollectionMetaOperations>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = toc.submit_collection_operation(operation.0).await;
+    let response = toc.submit_collection_operation(operation.0, true).await;
     process_response(response, timing)
 }
 
@@ -47,12 +47,13 @@ async fn create_collection(
     let timing = Instant::now();
     let name = path.into_inner();
     let response = toc
-        .submit_collection_operation(CollectionMetaOperations::CreateCollection(
-            CreateCollectionOperation {
+        .submit_collection_operation(
+            CollectionMetaOperations::CreateCollection(CreateCollectionOperation {
                 collection_name: name,
                 create_collection: operation.0,
-            },
-        ))
+            }),
+            true,
+        )
         .await;
     process_response(response, timing)
 }
@@ -66,12 +67,13 @@ async fn update_collection(
     let timing = Instant::now();
     let name = path.into_inner();
     let response = toc
-        .submit_collection_operation(CollectionMetaOperations::UpdateCollection(
-            UpdateCollectionOperation {
+        .submit_collection_operation(
+            CollectionMetaOperations::UpdateCollection(UpdateCollectionOperation {
                 collection_name: name,
                 update_collection: operation.0,
-            },
-        ))
+            }),
+            true,
+        )
         .await;
     process_response(response, timing)
 }
@@ -84,9 +86,10 @@ async fn delete_collection(
     let timing = Instant::now();
     let name = path.into_inner();
     let response = toc
-        .submit_collection_operation(CollectionMetaOperations::DeleteCollection(
-            DeleteCollectionOperation(name),
-        ))
+        .submit_collection_operation(
+            CollectionMetaOperations::DeleteCollection(DeleteCollectionOperation(name)),
+            true,
+        )
         .await;
     process_response(response, timing)
 }
@@ -98,7 +101,7 @@ async fn update_aliases(
 ) -> impl Responder {
     let timing = Instant::now();
     let response = toc
-        .submit_collection_operation(CollectionMetaOperations::ChangeAliases(operation.0))
+        .submit_collection_operation(CollectionMetaOperations::ChangeAliases(operation.0), true)
         .await;
     process_response(response, timing)
 }

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -34,7 +34,7 @@ async fn update_collections(
     operation: web::Json<CollectionMetaOperations>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = toc.submit_collection_operation(operation.0, true).await;
+    let response = toc.submit_collection_operation(operation.0, None).await;
     process_response(response, timing)
 }
 
@@ -52,7 +52,7 @@ async fn create_collection(
                 collection_name: name,
                 create_collection: operation.0,
             }),
-            true,
+            None,
         )
         .await;
     process_response(response, timing)
@@ -72,7 +72,7 @@ async fn update_collection(
                 collection_name: name,
                 update_collection: operation.0,
             }),
-            true,
+            None,
         )
         .await;
     process_response(response, timing)
@@ -88,7 +88,7 @@ async fn delete_collection(
     let response = toc
         .submit_collection_operation(
             CollectionMetaOperations::DeleteCollection(DeleteCollectionOperation(name)),
-            true,
+            None,
         )
         .await;
     process_response(response, timing)
@@ -101,7 +101,7 @@ async fn update_aliases(
 ) -> impl Responder {
     let timing = Instant::now();
     let response = toc
-        .submit_collection_operation(CollectionMetaOperations::ChangeAliases(operation.0), true)
+        .submit_collection_operation(CollectionMetaOperations::ChangeAliases(operation.0), None)
         .await;
     process_response(response, timing)
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -187,7 +187,6 @@ mod tests {
         env_logger::init();
         let runtime = crate::create_search_runtime(settings.storage.performance.max_search_threads)
             .expect("Can't create runtime.");
-        let handle = runtime.handle().clone();
         let mut toc = TableOfContent::new(&settings.storage, runtime);
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         toc.with_propose_sender(propose_sender);
@@ -215,7 +214,10 @@ mod tests {
         assert_eq!(toc_arc.all_collections_sync().len(), 0);
 
         // When
-        handle
+
+        // New runtime is used as timers need to be enabled.
+        tokio::runtime::Runtime::new()
+            .unwrap()
             .block_on(toc_arc.submit_collection_operation(
                 CollectionMetaOperations::CreateCollection(CreateCollectionOperation {
                     collection_name: "test".to_string(),
@@ -228,7 +230,7 @@ mod tests {
                         shard_number: 1,
                     },
                 }),
-                true,
+                None,
             ))
             .unwrap();
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -228,9 +228,9 @@ mod tests {
                         shard_number: 1,
                     },
                 }),
+                true,
             ))
             .unwrap();
-        thread::sleep(Duration::from_secs(5));
 
         // Then
         assert_eq!(toc_arc.hard_state().unwrap().commit, 2);

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -65,7 +65,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations, true)
+            .submit_collection_operation(operations, None)
             .await
             .map_err(error_to_status)?;
 
@@ -84,7 +84,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations, true)
+            .submit_collection_operation(operations, None)
             .await
             .map_err(error_to_status)?;
 
@@ -103,7 +103,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations, true)
+            .submit_collection_operation(operations, None)
             .await
             .map_err(error_to_status)?;
 
@@ -122,7 +122,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations, true)
+            .submit_collection_operation(operations, None)
             .await
             .map_err(error_to_status)?;
 

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -65,7 +65,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations)
+            .submit_collection_operation(operations, true)
             .await
             .map_err(error_to_status)?;
 
@@ -84,7 +84,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations)
+            .submit_collection_operation(operations, true)
             .await
             .map_err(error_to_status)?;
 
@@ -103,7 +103,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations)
+            .submit_collection_operation(operations, true)
             .await
             .map_err(error_to_status)?;
 
@@ -122,7 +122,7 @@ impl Collections for CollectionsService {
         let timing = Instant::now();
         let result = self
             .toc
-            .submit_collection_operation(operations)
+            .submit_collection_operation(operations, true)
             .await
             .map_err(error_to_status)?;
 


### PR DESCRIPTION
Relates to #429 

### Updates

After this PR all collection meta operations with consensus feature enabled will be waiting for commit before answering request.

Integration tests are also enabled for consensus feature. As now their behavior is valid (they expect that each request returns when an operation is complete)

### Out of Scope

Actually propagating changes to the API was left out for a separate PR. 

### Assumptions

- `CollectionMetaOperations` supplied by client are relatively unique and therefore can be compared by hash/eq
