### PR TITLE
[sharding] add internal API for CollectionUpdateOperations

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -12,9 +12,45 @@ import "google/protobuf/struct.proto";
 
 service PointsInternal {
   rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}
+  rpc Delete (DeletePointsInternal) returns (PointsOperationResponse) {}
+  rpc SetPayload (SetPayloadPointsInternal) returns (PointsOperationResponse) {}
+  rpc DeletePayload (DeletePayloadPointsInternal) returns (PointsOperationResponse) {}
+  rpc ClearPayload (ClearPayloadPointsInternal) returns (PointsOperationResponse) {}
+  rpc CreateFieldIndex (CreateFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
+  rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
 }
 
 message UpsertPointsInternal {
   UpsertPoints upsert_points = 1;
+  uint32 shard_id = 2;
+}
+
+message DeletePointsInternal {
+  DeletePoints delete_points = 1;
+  uint32 shard_id = 2;
+}
+
+message SetPayloadPointsInternal {
+  SetPayloadPoints set_payload_points = 1;
+  uint32 shard_id = 2;
+}
+
+message DeletePayloadPointsInternal {
+  DeletePayloadPoints delete_payload_points = 1;
+  uint32 shard_id = 2;
+}
+
+message ClearPayloadPointsInternal {
+  ClearPayloadPoints clear_payload_points = 1;
+  uint32 shard_id = 2;
+}
+
+message CreateFieldIndexCollectionInternal {
+  CreateFieldIndexCollection create_field_index_collection = 1;
+  uint32 shard_id = 2;
+}
+
+message DeleteFieldIndexCollectionInternal {
+  DeleteFieldIndexCollection delete_field_index_collection = 1;
   uint32 shard_id = 2;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2216,6 +2216,48 @@ pub struct UpsertPointsInternal {
     #[prost(uint32, tag="2")]
     pub shard_id: u32,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub delete_points: ::core::option::Option<DeletePoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPayloadPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePayloadPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub delete_payload_points: ::core::option::Option<DeletePayloadPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClearPayloadPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub clear_payload_points: ::core::option::Option<ClearPayloadPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateFieldIndexCollectionInternal {
+    #[prost(message, optional, tag="1")]
+    pub create_field_index_collection: ::core::option::Option<CreateFieldIndexCollection>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteFieldIndexCollectionInternal {
+    #[prost(message, optional, tag="1")]
+    pub delete_field_index_collection: ::core::option::Option<DeleteFieldIndexCollection>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -2298,6 +2340,120 @@ pub mod points_internal_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn delete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeletePointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Delete",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn set_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/SetPayload",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeletePayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/DeletePayload",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn clear_payload(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ClearPayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/ClearPayload",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn create_field_index(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateFieldIndexCollectionInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/CreateFieldIndex",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_field_index(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteFieldIndexCollectionInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/DeleteFieldIndex",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2310,6 +2466,30 @@ pub mod points_internal_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete(
+            &self,
+            request: tonic::Request<super::DeletePointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn set_payload(
+            &self,
+            request: tonic::Request<super::SetPayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete_payload(
+            &self,
+            request: tonic::Request<super::DeletePayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn clear_payload(
+            &self,
+            request: tonic::Request<super::ClearPayloadPointsInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn create_field_index(
+            &self,
+            request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
+        ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn delete_field_index(
+            &self,
+            request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -2386,6 +2566,248 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UpsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Delete" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::DeletePointsInternal>
+                    for DeleteSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeletePointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/SetPayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct SetPayloadSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SetPayloadPointsInternal>
+                    for SetPayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SetPayloadPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).set_payload(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SetPayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/DeletePayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeletePayloadSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::DeletePayloadPointsInternal>
+                    for DeletePayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeletePayloadPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).delete_payload(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeletePayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/ClearPayload" => {
+                    #[allow(non_camel_case_types)]
+                    struct ClearPayloadSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::ClearPayloadPointsInternal>
+                    for ClearPayloadSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ClearPayloadPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).clear_payload(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ClearPayloadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/CreateFieldIndex" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<
+                        super::CreateFieldIndexCollectionInternal,
+                    > for CreateFieldIndexSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::CreateFieldIndexCollectionInternal,
+                            >,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).create_field_index(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateFieldIndexSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/DeleteFieldIndex" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<
+                        super::DeleteFieldIndexCollectionInternal,
+                    > for DeleteFieldIndexSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::DeleteFieldIndexCollectionInternal,
+                            >,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).delete_field_index(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteFieldIndexSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1,8 +1,18 @@
-use crate::common::points::do_update_points;
-use api::grpc::qdrant::{PointsOperationResponse, UpsertPoints};
+use crate::common::points::{
+    do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points,
+    do_set_payload, do_update_points, CreateFieldIndex,
+};
+use api::grpc::conversions::proto_to_payloads;
+use api::grpc::qdrant::{
+    ClearPayloadPoints, CreateFieldIndexCollection, DeleteFieldIndexCollection,
+    DeletePayloadPoints, DeletePoints, FieldType, PointsOperationResponse, SetPayloadPoints,
+    UpsertPoints,
+};
+use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointsList};
 use collection::operations::CollectionUpdateOperations;
 use collection::shard::ShardId;
+use segment::types::PayloadSchemaType;
 use std::time::Instant;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
@@ -43,6 +53,209 @@ pub async fn upsert(
         toc,
         &collection_name,
         operation,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn delete(
+    toc: &TableOfContent,
+    delete_points: DeletePoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let DeletePoints {
+        collection_name,
+        wait,
+        points,
+    } = delete_points;
+
+    let points_selector = match points {
+        None => return Err(Status::invalid_argument("PointSelector is missing")),
+        Some(p) => p.try_into()?,
+    };
+
+    let timing = Instant::now();
+    let result = do_delete_points(
+        toc,
+        &collection_name,
+        points_selector,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn set_payload(
+    toc: &TableOfContent,
+    set_payload_points: SetPayloadPoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let SetPayloadPoints {
+        collection_name,
+        wait,
+        payload,
+        points,
+    } = set_payload_points;
+
+    let operation = collection::operations::payload_ops::SetPayload {
+        payload: proto_to_payloads(payload)?,
+        points: points
+            .into_iter()
+            .map(|p| p.try_into())
+            .collect::<Result<_, _>>()?,
+    };
+
+    let timing = Instant::now();
+    let result = do_set_payload(
+        toc,
+        &collection_name,
+        operation,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn delete_payload(
+    toc: &TableOfContent,
+    delete_payload_points: DeletePayloadPoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let DeletePayloadPoints {
+        collection_name,
+        wait,
+        keys,
+        points,
+    } = delete_payload_points;
+
+    let operation = DeletePayload {
+        keys,
+        points: points
+            .into_iter()
+            .map(|p| p.try_into())
+            .collect::<Result<_, _>>()?,
+    };
+
+    let timing = Instant::now();
+    let result = do_delete_payload(
+        toc,
+        &collection_name,
+        operation,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn clear_payload(
+    toc: &TableOfContent,
+    clear_payload_points: ClearPayloadPoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let ClearPayloadPoints {
+        collection_name,
+        wait,
+        points,
+    } = clear_payload_points;
+
+    let points_selector = match points {
+        None => return Err(Status::invalid_argument("PointSelector is missing")),
+        Some(p) => p.try_into()?,
+    };
+
+    let timing = Instant::now();
+    let result = do_clear_payload(
+        toc,
+        &collection_name,
+        points_selector,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn create_field_index(
+    toc: &TableOfContent,
+    create_field_index_collection: CreateFieldIndexCollection,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let CreateFieldIndexCollection {
+        collection_name,
+        wait,
+        field_name,
+        field_type,
+    } = create_field_index_collection;
+
+    let field_type = match field_type {
+        None => None,
+        Some(f) => match FieldType::from_i32(f) {
+            None => return Err(Status::invalid_argument("cannot convert field_type")),
+            Some(v) => match v {
+                FieldType::Keyword => Some(PayloadSchemaType::Keyword),
+                FieldType::Integer => Some(PayloadSchemaType::Integer),
+                FieldType::Float => Some(PayloadSchemaType::Float),
+                FieldType::Geo => Some(PayloadSchemaType::Geo),
+            },
+        },
+    };
+
+    let operation = CreateFieldIndex {
+        field_name,
+        field_type,
+    };
+
+    let timing = Instant::now();
+    let result = do_create_index(
+        toc,
+        &collection_name,
+        operation,
+        shard_selection,
+        wait.unwrap_or(false),
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn delete_field_index(
+    toc: &TableOfContent,
+    delete_field_index_collection: DeleteFieldIndexCollection,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let DeleteFieldIndexCollection {
+        collection_name,
+        wait,
+        field_name,
+    } = delete_field_index_collection;
+
+    let timing = Instant::now();
+    let result = do_delete_index(
+        toc,
+        &collection_name,
+        field_name,
         shard_selection,
         wait.unwrap_or(false),
     )

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -1,8 +1,15 @@
 use tonic::{Request, Response, Status};
 
-use crate::tonic::api::points_common::upsert;
+use crate::tonic::api::points_common::{
+    clear_payload, create_field_index, delete, delete_field_index, delete_payload, set_payload,
+    upsert,
+};
 use api::grpc::qdrant::points_internal_server::PointsInternal;
-use api::grpc::qdrant::{PointsOperationResponse, UpsertPointsInternal};
+use api::grpc::qdrant::{
+    ClearPayloadPointsInternal, CreateFieldIndexCollectionInternal,
+    DeleteFieldIndexCollectionInternal, DeletePayloadPointsInternal, DeletePointsInternal,
+    PointsOperationResponse, SetPayloadPointsInternal, UpsertPointsInternal,
+};
 use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
 
@@ -32,6 +39,106 @@ impl PointsInternal for PointsInternalService {
             upsert_points.ok_or_else(|| Status::invalid_argument("UpsertPoints is missing"))?;
 
         upsert(self.toc.as_ref(), upsert_points, Some(shard_id)).await
+    }
+
+    async fn delete(
+        &self,
+        request: Request<DeletePointsInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeletePointsInternal {
+            delete_points,
+            shard_id,
+        } = request.into_inner();
+
+        let delete_points =
+            delete_points.ok_or_else(|| Status::invalid_argument("DeletePoints is missing"))?;
+
+        delete(self.toc.as_ref(), delete_points, Some(shard_id)).await
+    }
+
+    async fn set_payload(
+        &self,
+        request: Request<SetPayloadPointsInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let SetPayloadPointsInternal {
+            set_payload_points,
+            shard_id,
+        } = request.into_inner();
+
+        let set_payload_points = set_payload_points
+            .ok_or_else(|| Status::invalid_argument("SetPayloadPoints is missing"))?;
+
+        set_payload(self.toc.as_ref(), set_payload_points, Some(shard_id)).await
+    }
+
+    async fn delete_payload(
+        &self,
+        request: Request<DeletePayloadPointsInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeletePayloadPointsInternal {
+            delete_payload_points,
+            shard_id,
+        } = request.into_inner();
+
+        let delete_payload_points = delete_payload_points
+            .ok_or_else(|| Status::invalid_argument("DeletePayloadPoints is missing"))?;
+
+        delete_payload(self.toc.as_ref(), delete_payload_points, Some(shard_id)).await
+    }
+
+    async fn clear_payload(
+        &self,
+        request: Request<ClearPayloadPointsInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let ClearPayloadPointsInternal {
+            clear_payload_points,
+            shard_id,
+        } = request.into_inner();
+
+        let clear_payload_points = clear_payload_points
+            .ok_or_else(|| Status::invalid_argument("ClearPayloadPoints is missing"))?;
+
+        clear_payload(self.toc.as_ref(), clear_payload_points, Some(shard_id)).await
+    }
+
+    async fn create_field_index(
+        &self,
+        request: Request<CreateFieldIndexCollectionInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let CreateFieldIndexCollectionInternal {
+            create_field_index_collection,
+            shard_id,
+        } = request.into_inner();
+
+        let create_field_index_collection = create_field_index_collection
+            .ok_or_else(|| Status::invalid_argument("CreateFieldIndexCollection is missing"))?;
+
+        create_field_index(
+            self.toc.as_ref(),
+            create_field_index_collection,
+            Some(shard_id),
+        )
+        .await
+    }
+
+    async fn delete_field_index(
+        &self,
+        request: Request<DeleteFieldIndexCollectionInternal>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        let DeleteFieldIndexCollectionInternal {
+            delete_field_index_collection,
+            shard_id,
+        } = request.into_inner();
+
+        let delete_field_index_collection = delete_field_index_collection
+            .ok_or_else(|| Status::invalid_argument("DeleteFieldIndexCollection is missing"))?;
+
+        delete_field_index(
+            self.toc.as_ref(),
+            delete_field_index_collection,
+            Some(shard_id),
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
This PR addresses partially https://github.com/qdrant/qdrant/issues/433 by tackling first the `CollectionUpdateOperations`.

Others operations required broader change which would made a single PR difficult to review.

The approach is to exposed an API that looks like the existing one adding an extra argument to select the target shard.

The change ends up being rather mechanical as the between public and internal API is shared in `points_common`.
