### PR TITLE
refactor `score_points` for better semantics

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -72,7 +72,6 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         })
     });
 
-    let mut scored_points_buffer = vec![ScoredPointOffset::default(); 1000];
     group.bench_function("build-n-search-hnsw-10x-score-point", |b| {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
@@ -83,7 +82,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let mut points_to_score = (0..1500)
                 .map(|_| rng.gen_range(0..(NUM_VECTORS * 10)) as u32)
                 .collect_vec();
-            scorer.score_points_to_buffer(&mut points_to_score, &mut scored_points_buffer, |_| {})
+            scorer.score_points(&mut points_to_score, 1000, |_| {})
         })
     });
 
@@ -123,7 +122,6 @@ fn scoring_vectors(c: &mut Criterion) {
     let num_vectors = base_num_vectors;
     let vector_holder = TestRawScorerProducer::new(DIM, num_vectors, metric.clone(), &mut rng);
 
-    let mut scored_points_buffer = vec![ScoredPointOffset::default(); points_per_cycle];
     group.bench_function("score-point", |b| {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
@@ -134,14 +132,13 @@ fn scoring_vectors(c: &mut Criterion) {
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points_to_buffer(&mut points_to_score, &mut scored_points_buffer, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
         })
     });
 
     let num_vectors = base_num_vectors * 10;
     let vector_holder = TestRawScorerProducer::new(DIM, num_vectors, metric.clone(), &mut rng);
 
-    let mut scored_points_buffer = vec![ScoredPointOffset::default(); points_per_cycle];
     group.bench_function("score-point-10x", |b| {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
@@ -152,14 +149,13 @@ fn scoring_vectors(c: &mut Criterion) {
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points_to_buffer(&mut points_to_score, &mut scored_points_buffer, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
         })
     });
 
     let num_vectors = base_num_vectors * 50;
     let vector_holder = TestRawScorerProducer::new(DIM, num_vectors, metric, &mut rng);
 
-    let mut scored_points_buffer = vec![ScoredPointOffset::default(); points_per_cycle];
     group.bench_function("score-point-50x", |b| {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
@@ -170,7 +166,7 @@ fn scoring_vectors(c: &mut Criterion) {
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points_to_buffer(&mut points_to_score, &mut scored_points_buffer, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
         })
     });
 }

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -47,7 +47,6 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
     let mut plain_search_range: Vec<PointOffsetType> =
         (0..NUM_VECTORS as PointOffsetType).collect();
-    let mut plain_search_points_buffer = vec![ScoredPointOffset::default(); NUM_VECTORS];
     group.bench_function("plain_search", |b| {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
@@ -56,15 +55,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut top_score = 0.;
-            scorer.score_points_to_buffer(
-                &mut plain_search_range,
-                &mut plain_search_points_buffer,
-                |score| {
-                    if score.score > top_score {
-                        top_score = score.score
-                    }
-                },
-            );
+            scorer.score_points(&mut plain_search_range, NUM_VECTORS, |score| {
+                if score.score > top_score {
+                    top_score = score.score
+                }
+            });
         })
     });
 


### PR DESCRIPTION
There is some refactoring aimed to improve semantics of the function.
As I understood, the function `score_points_to_buffer` only used the buffer as internal temporary storage and never supposed to return anything in it.

**Considered alternative**

It was also possible to remove `action` instead and use the temporary buffer for returning the values. But in this case it would be a bit more complicated for the calling side, as it would be required to create and iterate over the buffer explicitly.