### PR TITLE
Remove overcomplicated iterator: no action in scorer

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -27,9 +27,9 @@ fn build_index(num_vectors: usize) -> (TestRawScorerProducer<CosineMetric>, Grap
     for idx in 0..(num_vectors as PointOffsetType) {
         let added_vector = vector_holder.vectors[idx as usize].to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
         let level = graph_layers.get_random_layer(&mut rng);
-        graph_layers.link_new_point(idx, level, &mut scorer);
+        graph_layers.link_new_point(idx, level, scorer);
     }
     (vector_holder, graph_layers)
 }
@@ -46,8 +46,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, &mut scorer);
+            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            graph_layers.search(TOP, EF, scorer);
         })
     });
 
@@ -55,8 +55,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
         let raw_scorer = vector_holder.get_raw_scorer(query);
-        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-        graph_layers.search(TOP, EF, &mut scorer);
+        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        graph_layers.search(TOP, EF, scorer);
     }
 
     let (vector_holder, graph_layers) = build_index(NUM_VECTORS * 10);
@@ -66,8 +66,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, &mut scorer);
+            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            graph_layers.search(TOP, EF, scorer);
         })
     });
 
@@ -89,8 +89,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
         let raw_scorer = vector_holder.get_raw_scorer(query);
-        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-        graph_layers.search(TOP, EF, &mut scorer);
+        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        graph_layers.search(TOP, EF, scorer);
     }
 }
 

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -9,7 +9,6 @@ use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::CosineMetric;
 use segment::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
-use segment::vector_storage::ScoredPointOffset;
 
 const NUM_VECTORS: usize = 5_000;
 const DIM: usize = 16;
@@ -28,9 +27,9 @@ fn build_index(num_vectors: usize) -> (TestRawScorerProducer<CosineMetric>, Grap
     for idx in 0..(num_vectors as PointOffsetType) {
         let added_vector = vector_holder.vectors[idx as usize].to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
         let level = graph_layers.get_random_layer(&mut rng);
-        graph_layers.link_new_point(idx, level, &scorer);
+        graph_layers.link_new_point(idx, level, &mut scorer);
     }
     (vector_holder, graph_layers)
 }
@@ -47,8 +46,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, &scorer);
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            graph_layers.search(TOP, EF, &mut scorer);
         })
     });
 
@@ -56,8 +55,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
         let raw_scorer = vector_holder.get_raw_scorer(query);
-        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-        graph_layers.search(TOP, EF, &scorer);
+        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        graph_layers.search(TOP, EF, &mut scorer);
     }
 
     let (vector_holder, graph_layers) = build_index(NUM_VECTORS * 10);
@@ -67,8 +66,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-            graph_layers.search(TOP, EF, &scorer);
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            graph_layers.search(TOP, EF, &mut scorer);
         })
     });
 
@@ -77,12 +76,12 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut points_to_score = (0..1500)
                 .map(|_| rng.gen_range(0..(NUM_VECTORS * 10)) as u32)
                 .collect_vec();
-            scorer.score_points(&mut points_to_score, 1000, |_| {})
+            scorer.score_points(&mut points_to_score, 1000);
         })
     });
 
@@ -90,8 +89,8 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
         let raw_scorer = vector_holder.get_raw_scorer(query);
-        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
-        graph_layers.search(TOP, EF, &scorer);
+        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        graph_layers.search(TOP, EF, &mut scorer);
     }
 }
 
@@ -127,12 +126,12 @@ fn scoring_vectors(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle);
         })
     });
 
@@ -144,12 +143,12 @@ fn scoring_vectors(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle);
         })
     });
 
@@ -161,12 +160,12 @@ fn scoring_vectors(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)
                 .map(|_| rng.gen_range(0..num_vectors) as u32)
                 .collect_vec();
-            scorer.score_points(&mut points_to_score, points_per_cycle, |_| {})
+            scorer.score_points(&mut points_to_score, points_per_cycle);
         })
     });
 }

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -29,9 +29,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
             for idx in 0..(NUM_VECTORS as PointOffsetType) {
                 let added_vector = vector_holder.vectors[idx as usize].to_vec();
                 let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-                let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+                let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
                 let level = graph_layers.get_random_layer(&mut rng);
-                graph_layers.link_new_point(idx, level, &mut scorer);
+                graph_layers.link_new_point(idx, level, scorer);
             }
         })
     });

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -29,9 +29,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
             for idx in 0..(NUM_VECTORS as PointOffsetType) {
                 let added_vector = vector_holder.vectors[idx as usize].to_vec();
                 let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-                let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+                let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
                 let level = graph_layers.get_random_layer(&mut rng);
-                graph_layers.link_new_point(idx, level, &scorer);
+                graph_layers.link_new_point(idx, level, &mut scorer);
             }
         })
     });

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -8,7 +8,6 @@ use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::simple::CosineMetric;
 use segment::types::PointOffsetType;
-use segment::vector_storage::ScoredPointOffset;
 
 const NUM_VECTORS: usize = 100000;
 const DIM: usize = 64;
@@ -29,9 +28,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
     for idx in 0..(NUM_VECTORS as PointOffsetType) {
         let added_vector = vector_holder.vectors[idx as usize].to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
         let level = graph_layers.get_random_layer(&mut rng);
-        graph_layers.link_new_point(idx, level, &scorer);
+        graph_layers.link_new_point(idx, level, &mut scorer);
     }
 
     group.bench_function("hnsw_search", |b| {
@@ -39,9 +38,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let query = random_vector(&mut rng, DIM);
 
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
-            graph_layers.search(TOP, EF, &scorer);
+            graph_layers.search(TOP, EF, &mut scorer);
         })
     });
 
@@ -52,10 +51,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let query = random_vector(&mut rng, DIM);
 
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
             let mut top_score = 0.;
-            scorer.score_points(&mut plain_search_range, NUM_VECTORS, |score| {
+            let scores = scorer.score_points(&mut plain_search_range, NUM_VECTORS);
+            scores.iter().copied().for_each(|score| {
                 if score.score > top_score {
                     top_score = score.score
                 }

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -28,9 +28,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
     for idx in 0..(NUM_VECTORS as PointOffsetType) {
         let added_vector = vector_holder.vectors[idx as usize].to_vec();
         let raw_scorer = vector_holder.get_raw_scorer(added_vector);
-        let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+        let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
         let level = graph_layers.get_random_layer(&mut rng);
-        graph_layers.link_new_point(idx, level, &mut scorer);
+        graph_layers.link_new_point(idx, level, scorer);
     }
 
     group.bench_function("hnsw_search", |b| {
@@ -38,9 +38,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let query = random_vector(&mut rng, DIM);
 
             let raw_scorer = vector_holder.get_raw_scorer(query);
-            let mut scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
+            let scorer = FilteredScorer::new(&raw_scorer, Some(&fake_filter_context));
 
-            graph_layers.search(TOP, EF, &mut scorer);
+            graph_layers.search(TOP, EF, scorer);
         })
     });
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -111,11 +111,11 @@ impl HNSWIndex {
             let vector = vector_storage.get_vector(block_point_id).unwrap();
             let raw_scorer = vector_storage.raw_scorer(vector);
             block_condition_checker.current_point = block_point_id;
-            let points_scorer =
+            let mut points_scorer =
                 FilteredScorer::new(raw_scorer.as_ref(), Some(block_condition_checker));
 
             let level = self.graph.point_level(block_point_id);
-            graph.link_new_point(block_point_id, level, &points_scorer);
+            graph.link_new_point(block_point_id, level, &mut points_scorer);
         }
     }
 
@@ -139,9 +139,9 @@ impl HNSWIndex {
 
         let filter_context = filter.map(|f| payload_index.filter_context(f));
 
-        let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
+        let mut points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
-        self.graph.search(top, ef, &points_scorer)
+        self.graph.search(top, ef, &mut points_scorer)
     }
 }
 
@@ -224,10 +224,11 @@ impl VectorIndex for HNSWIndex {
             }
             let vector = vector_storage.get_vector(vector_id).unwrap();
             let raw_scorer = vector_storage.raw_scorer(vector);
-            let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
+            let mut points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
 
             let level = self.graph.get_random_layer(&mut rng);
-            self.graph.link_new_point(vector_id, level, &points_scorer);
+            self.graph
+                .link_new_point(vector_id, level, &mut points_scorer);
         }
 
         debug!("finish main graph");

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -111,11 +111,11 @@ impl HNSWIndex {
             let vector = vector_storage.get_vector(block_point_id).unwrap();
             let raw_scorer = vector_storage.raw_scorer(vector);
             block_condition_checker.current_point = block_point_id;
-            let mut points_scorer =
+            let points_scorer =
                 FilteredScorer::new(raw_scorer.as_ref(), Some(block_condition_checker));
 
             let level = self.graph.point_level(block_point_id);
-            graph.link_new_point(block_point_id, level, &mut points_scorer);
+            graph.link_new_point(block_point_id, level, points_scorer);
         }
     }
 
@@ -139,9 +139,9 @@ impl HNSWIndex {
 
         let filter_context = filter.map(|f| payload_index.filter_context(f));
 
-        let mut points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
+        let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
-        self.graph.search(top, ef, &mut points_scorer)
+        self.graph.search(top, ef, points_scorer)
     }
 }
 
@@ -224,11 +224,10 @@ impl VectorIndex for HNSWIndex {
             }
             let vector = vector_storage.get_vector(vector_id).unwrap();
             let raw_scorer = vector_storage.raw_scorer(vector);
-            let mut points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
+            let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
 
             let level = self.graph.get_random_layer(&mut rng);
-            self.graph
-                .link_new_point(vector_id, level, &mut points_scorer);
+            self.graph.link_new_point(vector_id, level, points_scorer);
         }
 
         debug!("finish main graph");

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -28,17 +28,14 @@ impl<'a> FilteredScorer<'a> {
     }
 
     /// Method filters and calculates scores for the given slice of points
-    /// and yields obtained scores into the callback.
     ///
-    /// For performance reasons:
-    /// - This function uses callback instead of iterator
-    /// - This function mutates input values
+    /// For performance reasons this function mutates input values.
+    /// For result slice allocation this function mutates self.
     ///
     /// # Arguments
     ///
     /// * `point_ids` - list of points to score. *Warn*: This input will be wrecked during the execution.
     /// * `limit` - limits the number of points to process after filtering.
-    /// * `action` - callback. This function is called for each scored point (not more than `limit` times)
     ///
     pub fn score_points(
         &mut self,

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,13 +1,11 @@
 use crate::payload_storage::FilterContext;
 use crate::types::{PointOffsetType, ScoreType};
 use crate::vector_storage::{RawScorer, ScoredPointOffset};
-use std::cell::RefCell;
-use std::ops::DerefMut;
 
 pub struct FilteredScorer<'a> {
     pub raw_scorer: &'a dyn RawScorer,
     pub filter_context: Option<&'a dyn FilterContext>,
-    points_buffer: RefCell<Vec<ScoredPointOffset>>,
+    points_buffer: Vec<ScoredPointOffset>,
 }
 
 impl<'a> FilteredScorer<'a> {
@@ -18,7 +16,7 @@ impl<'a> FilteredScorer<'a> {
         FilteredScorer {
             raw_scorer,
             filter_context,
-            points_buffer: RefCell::new(vec![]),
+            points_buffer: Vec::new(),
         }
     }
 
@@ -42,10 +40,11 @@ impl<'a> FilteredScorer<'a> {
     /// * `limit` - limits the number of points to process after filtering.
     /// * `action` - callback. This function is called for each scored point (not more than `limit` times)
     ///
-    pub fn score_points<F>(&self, point_ids: &mut [PointOffsetType], limit: usize, action: F)
-    where
-        F: FnMut(ScoredPointOffset),
-    {
+    pub fn score_points(
+        &mut self,
+        point_ids: &mut [PointOffsetType],
+        limit: usize,
+    ) -> &[ScoredPointOffset] {
         // apply filter and store filtered ids to source slice memory
         let filtered_point_ids = match self.filter_context {
             None => point_ids,
@@ -63,17 +62,12 @@ impl<'a> FilteredScorer<'a> {
             }
         };
 
-        let mut scored_points_buffer = self.points_buffer.borrow_mut();
-        scored_points_buffer.resize(limit, ScoredPointOffset::default());
-
+        self.points_buffer
+            .resize(limit, ScoredPointOffset::default());
         let count = self
             .raw_scorer
-            .score_points(filtered_point_ids, scored_points_buffer.deref_mut());
-        scored_points_buffer
-            .iter()
-            .take(count)
-            .copied()
-            .for_each(action);
+            .score_points(filtered_point_ids, &mut self.points_buffer);
+        &self.points_buffer[0..count]
     }
 
     pub fn score_point(&self, point_id: PointOffsetType) -> ScoreType {


### PR DESCRIPTION
Method `FilteredScorer.score_points` does only one thing: score points and return a slice of the scores result. I propose these changes because filtered scorer api is simpler (as an advantage). As a disadvantage, we have to use mutable references because FilteredScorer contains a buffer for results.