### PR TITLE
vector storage chunk autoscaling

### DIFF
--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -5,7 +5,7 @@ use std::mem;
 type Chunk = Vec<VectorElementType>;
 
 // chunk size in bytes
-const CHUNK_SIZE: usize = 1024 * 1024;
+const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 
 // if dimension is too high, use this capacity
 const MIN_CHUNK_CAPACITY: usize = 16;
@@ -13,8 +13,7 @@ const MIN_CHUNK_CAPACITY: usize = 16;
 pub struct ChunkedVectors {
     dim: usize,
     len: usize,            // amount of stored vectors
-    chunk_capacity: usize, // amount of vectors in each chunk
-    chunk_size: usize,     // allocated size for chunk. chunk could be larger than needed
+    chunk_capacity: usize, // max amount of vectors in each chunk
     chunks: Vec<Chunk>,
 }
 
@@ -23,12 +22,10 @@ impl ChunkedVectors {
         let vector_size = dim * mem::size_of::<VectorElementType>();
         let chunk_capacity = max(MIN_CHUNK_CAPACITY, CHUNK_SIZE / vector_size);
         // allocate power of two sized chunks to reduce fragmentation
-        let chunk_size = usize::next_power_of_two(chunk_capacity * dim);
         ChunkedVectors {
             dim,
             len: 0,
             chunk_capacity,
-            chunk_size,
             chunks: Vec::new(),
         }
     }
@@ -58,11 +55,14 @@ impl ChunkedVectors {
         let key = key as usize;
         self.len = max(self.len, key + 1);
         while self.chunks.len() * self.chunk_capacity < self.len {
-            self.chunks.push(vec![0.; self.chunk_size]);
+            self.chunks.push(vec![]);
         }
 
         let chunk_data = &mut self.chunks[key / self.chunk_capacity];
         let idx = (key % self.chunk_capacity) * self.dim;
+        if chunk_data.len() < idx + self.dim {
+            chunk_data.resize(idx + self.dim, 0.);
+        }
         let data = &mut chunk_data[idx..idx + self.dim];
         data.clone_from_slice(vector);
     }

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -21,7 +21,6 @@ impl ChunkedVectors {
     pub fn new(dim: usize) -> ChunkedVectors {
         let vector_size = dim * mem::size_of::<VectorElementType>();
         let chunk_capacity = max(MIN_CHUNK_CAPACITY, CHUNK_SIZE / vector_size);
-        // allocate power of two sized chunks to reduce fragmentation
         ChunkedVectors {
             dim,
             len: 0,


### PR DESCRIPTION

According to benchmark, `CHUNK_SIZE` have a great impact on the HNSW search performance:

* 9% speedup for 1Mb  `CHUNK_SIZE` 
* 11% speedup for 10Mb  `CHUNK_SIZE` 
* 14% speedup for 20Mb  `CHUNK_SIZE`

At the same time allocating 20Mb of RAM for each segment for an empty collection might be too wasteful (100Mb of zeros).
The compromise solution I see here is to allow dynamic scaling within each chunk. We are avoiding large re-allocations - copying 16Mb of RAM  should be within the noise threshold. At the same time we achieve better memory locality and smaller starting memory consumption.