### PR TITLE
[sharding] Add internal gRPC API for search recommend & scroll

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -18,6 +18,9 @@ service PointsInternal {
   rpc ClearPayload (ClearPayloadPointsInternal) returns (PointsOperationResponse) {}
   rpc CreateFieldIndex (CreateFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
   rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
+  rpc Search (SearchPointsInternal) returns (SearchResponse) {}
+  rpc Scroll (ScrollPointsInternal) returns (ScrollResponse) {}
+  rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
 }
 
 message UpsertPointsInternal {
@@ -52,5 +55,20 @@ message CreateFieldIndexCollectionInternal {
 
 message DeleteFieldIndexCollectionInternal {
   DeleteFieldIndexCollection delete_field_index_collection = 1;
+  uint32 shard_id = 2;
+}
+
+message SearchPointsInternal {
+  SearchPoints search_points = 1;
+  uint32 shard_id = 2;
+}
+
+message ScrollPointsInternal {
+  ScrollPoints scroll_points = 1;
+  uint32 shard_id = 2;
+}
+
+message RecommendPointsInternal {
+  RecommendPoints recommend_points = 1;
   uint32 shard_id = 2;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2270,6 +2270,27 @@ pub struct DeleteFieldIndexCollectionInternal {
     #[prost(uint32, tag="2")]
     pub shard_id: u32,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SearchPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub search_points: ::core::option::Option<SearchPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ScrollPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub scroll_points: ::core::option::Option<ScrollPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RecommendPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub recommend_points: ::core::option::Option<RecommendPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -2466,6 +2487,63 @@ pub mod points_internal_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn search(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SearchPointsInternal>,
+        ) -> Result<tonic::Response<super::SearchResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Search",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn scroll(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ScrollPointsInternal>,
+        ) -> Result<tonic::Response<super::ScrollResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Scroll",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn recommend(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RecommendPointsInternal>,
+        ) -> Result<tonic::Response<super::RecommendResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Recommend",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2503,6 +2581,18 @@ pub mod points_internal_server {
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        async fn search(
+            &self,
+            request: tonic::Request<super::SearchPointsInternal>,
+        ) -> Result<tonic::Response<super::SearchResponse>, tonic::Status>;
+        async fn scroll(
+            &self,
+            request: tonic::Request<super::ScrollPointsInternal>,
+        ) -> Result<tonic::Response<super::ScrollResponse>, tonic::Status>;
+        async fn recommend(
+            &self,
+            request: tonic::Request<super::RecommendPointsInternal>,
+        ) -> Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct PointsInternalServer<T: PointsInternal> {
@@ -2820,6 +2910,120 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = DeleteFieldIndexSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Search" => {
+                    #[allow(non_camel_case_types)]
+                    struct SearchSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SearchPointsInternal>
+                    for SearchSvc<T> {
+                        type Response = super::SearchResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SearchPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).search(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SearchSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Scroll" => {
+                    #[allow(non_camel_case_types)]
+                    struct ScrollSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::ScrollPointsInternal>
+                    for ScrollSvc<T> {
+                        type Response = super::ScrollResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ScrollPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).scroll(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ScrollSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Recommend" => {
+                    #[allow(non_camel_case_types)]
+                    struct RecommendSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::RecommendPointsInternal>
+                    for RecommendSvc<T> {
+                        type Response = super::RecommendResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RecommendPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).recommend(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = RecommendSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -203,11 +203,11 @@ impl Collection {
 
     fn local_shard_by_id(&self, id: ShardId) -> CollectionResult<&LocalShard> {
         match self.shards.get(&id) {
-            None => Err(CollectionError::service_error(format!(
+            None => Err(CollectionError::bad_shard_selection(format!(
                 "Shard {} does not exist",
                 id
             ))),
-            Some(Shard::Remote(_)) => Err(CollectionError::service_error(format!(
+            Some(Shard::Remote(_)) => Err(CollectionError::bad_shard_selection(format!(
                 "Shard {} is not local on peer",
                 id
             ))),

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -319,6 +319,7 @@ impl Collection {
                     with_vector: true,
                 },
                 segment_searcher,
+                shard_selection,
             )
             .await?;
         let vectors_map: HashMap<ExtendedPointId, Vec<VectorElementType>> = vectors
@@ -468,6 +469,7 @@ impl Collection {
         &self,
         request: PointRequest,
         segment_searcher: &(dyn CollectionSearcher + Sync),
+        shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Record>> {
         let with_payload_interface = request
             .with_payload
@@ -477,7 +479,7 @@ impl Collection {
         let with_vector = request.with_vector;
         let request = Arc::new(request);
         let mut points = Vec::new();
-        for shard in self.all_shards() {
+        for shard in self.target_shards(shard_selection)? {
             let mut shard_points = shard
                 .get()
                 .retrieve(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -208,6 +208,8 @@ pub enum CollectionError {
     BadRequest { description: String },
     #[error("Operation Cancelled: {description}")]
     Cancelled { description: String },
+    #[error("Bad shard selection: {description}")]
+    BadShardSelection { description: String },
     #[error(
     "{shards_failed} out of {shards_total} shards failed to apply operation. First error captured: {first_err}"
     )]
@@ -221,6 +223,10 @@ pub enum CollectionError {
 impl CollectionError {
     pub fn service_error(error: String) -> CollectionError {
         CollectionError::ServiceError { error }
+    }
+
+    pub fn bad_shard_selection(description: String) -> CollectionError {
+        CollectionError::BadShardSelection { description }
     }
 }
 

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -92,6 +92,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
                 with_vector: true,
             },
             &searcher,
+            None,
         )
         .await
         .unwrap();
@@ -159,6 +160,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
                 with_vector: true,
             },
             &searcher,
+            None,
         )
         .await
         .unwrap();
@@ -190,6 +192,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
                 with_vector: false,
             },
             &searcher,
+            None,
         )
         .await
         .unwrap();

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -200,7 +200,7 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
         with_vector: true,
     };
     let retrieved = loaded_collection
-        .retrieve(request, &segment_searcher)
+        .retrieve(request, &segment_searcher, None)
         .await
         .unwrap();
 

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -70,7 +70,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
 
     let segment_searcher = SimpleCollectionSearcher::new();
     let search_res = collection
-        .search(search_request, &segment_searcher, &Handle::current())
+        .search(search_request, &segment_searcher, &Handle::current(), None)
         .await;
 
     match search_res {
@@ -127,7 +127,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
 
     let segment_searcher = SimpleCollectionSearcher::new();
     let search_res = collection
-        .search(search_request, &segment_searcher, &Handle::current())
+        .search(search_request, &segment_searcher, &Handle::current(), None)
         .await;
 
     match search_res {
@@ -314,6 +314,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
             },
             &segment_searcher,
             &Handle::current(),
+            None,
         )
         .await
         .unwrap();
@@ -372,6 +373,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
                 with_vector: false,
             },
             &segment_searcher,
+            None,
         )
         .await
         .unwrap();
@@ -451,6 +453,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
                 with_vector: false,
             },
             &segment_searcher,
+            None,
         )
         .await
         .unwrap();

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -41,6 +41,9 @@ impl From<CollectionError> for StorageError {
             err @ CollectionError::InconsistentFailure { .. } => StorageError::ServiceError {
                 description: format!("{err}"),
             },
+            CollectionError::BadShardSelection { description } => {
+                StorageError::BadRequest { description }
+            }
         }
     }
 }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -493,7 +493,7 @@ impl TableOfContent {
     ) -> Result<Vec<Record>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
-            .retrieve(request, self.segment_searcher.as_ref())
+            .retrieve(request, self.segment_searcher.as_ref(), None)
             .await
             .map_err(|err| err.into())
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -433,6 +433,7 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         request: RecommendRequest,
+        shard_selection: Option<ShardId>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
@@ -440,6 +441,7 @@ impl TableOfContent {
                 request,
                 self.segment_searcher.deref(),
                 self.search_runtime.handle(),
+                shard_selection,
             )
             .await
             .map_err(|err| err.into())
@@ -452,7 +454,7 @@ impl TableOfContent {
     ///
     /// * `collection_name` - in what collection do we search
     /// * `request` - [`SearchRequest`]
-    ///
+    /// * `shard_selection` - which local shard to use
     /// # Result
     ///
     /// Points with search score
@@ -460,6 +462,7 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         request: SearchRequest,
+        shard_selection: Option<ShardId>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
@@ -467,6 +470,7 @@ impl TableOfContent {
                 request,
                 self.segment_searcher.as_ref(),
                 self.search_runtime.handle(),
+                shard_selection,
             )
             .await
             .map_err(|err| err.into())
@@ -527,6 +531,7 @@ impl TableOfContent {
     ///
     /// * `collection_name` - which collection to use
     /// * `request` - [`ScrollRequest`]
+    /// * `shard_selection` - which local shard to use
     ///
     /// # Result
     ///
@@ -535,10 +540,11 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         request: ScrollRequest,
+        shard_selection: Option<ShardId>,
     ) -> Result<ScrollResult, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
-            .scroll_by(request, self.segment_searcher.deref())
+            .scroll_by(request, self.segment_searcher.deref(), shard_selection)
             .await
             .map_err(|err| err.into())
     }

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -15,7 +15,7 @@ async fn do_recommend_points(
     collection_name: &str,
     request: RecommendRequest,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
-    toc.recommend(collection_name, request).await
+    toc.recommend(collection_name, request, None).await
 }
 
 #[post("/collections/{name}/points/recommend")]

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -31,7 +31,7 @@ async fn scroll_get_points(
     collection_name: &str,
     request: ScrollRequest,
 ) -> Result<ScrollResult, StorageError> {
-    toc.scroll(collection_name, request).await
+    toc.scroll(collection_name, request, None).await
 }
 
 #[get("/collections/{name}/points/{id}")]

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -18,8 +18,13 @@ pub async fn search_points(
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response =
-        do_search_points(&toc.into_inner(), &collection_name, request.into_inner()).await;
+    let response = do_search_points(
+        &toc.into_inner(),
+        &collection_name,
+        request.into_inner(),
+        None,
+    )
+    .await;
 
     process_response(response, timing)
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -144,8 +144,9 @@ pub async fn do_search_points(
     toc: &TableOfContent,
     collection_name: &str,
     request: SearchRequest,
+    shard_selection: Option<ShardId>,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
-    toc.search(collection_name, request).await
+    toc.search(collection_name, request, shard_selection).await
 }
 
 pub async fn do_get_points(
@@ -160,6 +161,7 @@ pub async fn do_scroll_points(
     toc: &TableOfContent,
     collection_name: &str,
     request: ScrollRequest,
+    shard_selection: Option<ShardId>,
 ) -> Result<ScrollResult, StorageError> {
-    toc.scroll(collection_name, request).await
+    toc.scroll(collection_name, request, shard_selection).await
 }


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/445 (https://github.com/qdrant/qdrant/issues/433) for the methods:
- search
- recommend
- scroll

This PR uses the same approach regarding sharing code via `points_common.rs`.

I have decided to introduce at the collection level `local_shard_by_id` to unify the shard selection error handling.

After this PR, the only method left on `ShardOperation` to implement is `info(&self) -> CollectionResult<CollectionInfo>`