### PR TITLE
also consider the corner case in test

### DIFF
--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -106,11 +106,8 @@ mod tests {
 
         assert!(
             (estimation_struct.exp as f64 - real_number as f64).abs()
-                < (estimation_plain.exp as f64 - real_number as f64).abs()
+                <= (estimation_plain.exp as f64 - real_number as f64).abs()
         );
-
-        eprintln!("estimation_struct = {:#?}", estimation_struct);
-        eprintln!("estimation_plain = {:#?}", estimation_plain);
     }
 
     #[test]


### PR DESCRIPTION
### All Submissions:

Fixes https://github.com/qdrant/qdrant/issues/472

The reason was that test expected structure cardinality estimation to be more precise than naive one, but even a broken clock gets to be right twice a day.
