### PR TITLE
[Sharding] internal API for shard-aware points retrieval

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -21,6 +21,7 @@ service PointsInternal {
   rpc Search (SearchPointsInternal) returns (SearchResponse) {}
   rpc Scroll (ScrollPointsInternal) returns (ScrollResponse) {}
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
+  rpc Get (GetPointsInternal) returns (GetResponse) {}
 }
 
 message UpsertPointsInternal {
@@ -70,5 +71,10 @@ message ScrollPointsInternal {
 
 message RecommendPointsInternal {
   RecommendPoints recommend_points = 1;
+  uint32 shard_id = 2;
+}
+
+message GetPointsInternal {
+  GetPoints get_points = 1;
   uint32 shard_id = 2;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2291,6 +2291,13 @@ pub struct RecommendPointsInternal {
     #[prost(uint32, tag="2")]
     pub shard_id: u32,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPointsInternal {
+    #[prost(message, optional, tag="1")]
+    pub get_points: ::core::option::Option<GetPoints>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -2544,6 +2551,25 @@ pub mod points_internal_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn get(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetPointsInternal>,
+        ) -> Result<tonic::Response<super::GetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Get",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2593,6 +2619,10 @@ pub mod points_internal_server {
             &self,
             request: tonic::Request<super::RecommendPointsInternal>,
         ) -> Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
+        async fn get(
+            &self,
+            request: tonic::Request<super::GetPointsInternal>,
+        ) -> Result<tonic::Response<super::GetResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct PointsInternalServer<T: PointsInternal> {
@@ -3024,6 +3054,44 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = RecommendSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Get" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::GetPointsInternal>
+                    for GetSvc<T> {
+                        type Response = super::GetResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).get(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -482,6 +482,7 @@ impl TableOfContent {
     ///
     /// * `collection_name` - select from this collection
     /// * `request` - [`PointRequest`]
+    /// * `shard_selection` - which local shard to use
     ///
     /// # Result
     ///
@@ -490,10 +491,11 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         request: PointRequest,
+        shard_selection: Option<ShardId>,
     ) -> Result<Vec<Record>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         collection
-            .retrieve(request, self.segment_searcher.as_ref(), None)
+            .retrieve(request, self.segment_searcher.as_ref(), shard_selection)
             .await
             .map_err(|err| err.into())
     }

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -21,7 +21,7 @@ async fn do_get_point(
         with_payload: Some(WithPayloadInterface::Bool(true)),
         with_vector: true,
     };
-    toc.retrieve(collection_name, request)
+    toc.retrieve(collection_name, request, None)
         .await
         .map(|points| points.into_iter().next())
 }
@@ -78,7 +78,13 @@ pub async fn get_points(
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response = do_get_points(&toc.into_inner(), &collection_name, request.into_inner()).await;
+    let response = do_get_points(
+        &toc.into_inner(),
+        &collection_name,
+        request.into_inner(),
+        None,
+    )
+    .await;
     process_response(response, timing)
 }
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -153,8 +153,10 @@ pub async fn do_get_points(
     toc: &TableOfContent,
     collection_name: &str,
     request: PointRequest,
+    shard_selection: Option<ShardId>,
 ) -> Result<Vec<Record>, StorageError> {
-    toc.retrieve(collection_name, request).await
+    toc.retrieve(collection_name, request, shard_selection)
+        .await
 }
 
 pub async fn do_scroll_points(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -1,16 +1,16 @@
 use tonic::{Request, Response, Status};
 
 use crate::tonic::api::points_common::{
-    clear_payload, create_field_index, delete, delete_field_index, delete_payload, recommend,
+    clear_payload, create_field_index, delete, delete_field_index, delete_payload, get, recommend,
     scroll, search, set_payload, upsert,
 };
 use api::grpc::qdrant::points_internal_server::PointsInternal;
 use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CreateFieldIndexCollectionInternal,
     DeleteFieldIndexCollectionInternal, DeletePayloadPointsInternal, DeletePointsInternal,
-    PointsOperationResponse, RecommendPointsInternal, RecommendResponse, ScrollPointsInternal,
-    ScrollResponse, SearchPointsInternal, SearchResponse, SetPayloadPointsInternal,
-    UpsertPointsInternal,
+    GetPointsInternal, GetResponse, PointsOperationResponse, RecommendPointsInternal,
+    RecommendResponse, ScrollPointsInternal, ScrollResponse, SearchPointsInternal, SearchResponse,
+    SetPayloadPointsInternal, UpsertPointsInternal,
 };
 use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
@@ -186,6 +186,21 @@ impl PointsInternal for PointsInternalService {
             scroll_points.ok_or_else(|| Status::invalid_argument("ScrollPoints is missing"))?;
 
         scroll(self.toc.as_ref(), scroll_points, Some(shard_id)).await
+    }
+
+    async fn get(
+        &self,
+        request: Request<GetPointsInternal>,
+    ) -> Result<Response<GetResponse>, Status> {
+        let GetPointsInternal {
+            get_points,
+            shard_id,
+        } = request.into_inner();
+
+        let get_points =
+            get_points.ok_or_else(|| Status::invalid_argument("GetPoints is missing"))?;
+
+        get(self.toc.as_ref(), get_points, Some(shard_id)).await
     }
 }
 


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/463 (https://github.com/qdrant/qdrant/issues/433).

This PR adds the `retrieve` method to the internal gRPC API for p2p communication.