### PR TITLE
[Sharding] Internal gRPC API for get collection info

### DIFF
--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+import "collections.proto";
+
+option java_multiple_files = true;
+option java_package = "tech.qdrant.grpc";
+option java_outer_classname = "QdrantProto";
+
+package qdrant;
+
+service CollectionsInternal {
+  rpc Get (GetCollectionInfoRequestInternal) returns (GetCollectionInfoResponse) {}
+}
+
+message GetCollectionInfoRequestInternal {
+  GetCollectionInfoRequest get_collectionInfoRequest = 1;
+  uint32 shard_id = 2;
+}

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "collections_service.proto";
+import "collections_internal_service.proto";
 import "points_service.proto";
 import "points_internal_service.proto";
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -857,6 +857,237 @@ pub mod collections_server {
         const NAME: &'static str = "qdrant.Collections";
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetCollectionInfoRequestInternal {
+    #[prost(message, optional, tag="1")]
+    pub get_collection_info_request: ::core::option::Option<GetCollectionInfoRequest>,
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
+/// Generated client implementations.
+pub mod collections_internal_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct CollectionsInternalClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CollectionsInternalClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CollectionsInternalClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Default + Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CollectionsInternalClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            CollectionsInternalClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn get(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetCollectionInfoRequestInternal>,
+        ) -> Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.CollectionsInternal/Get",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod collections_internal_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with CollectionsInternalServer.
+    #[async_trait]
+    pub trait CollectionsInternal: Send + Sync + 'static {
+        async fn get(
+            &self,
+            request: tonic::Request<super::GetCollectionInfoRequestInternal>,
+        ) -> Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct CollectionsInternalServer<T: CollectionsInternal> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: CollectionsInternal> CollectionsInternalServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for CollectionsInternalServer<T>
+    where
+        T: CollectionsInternal,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.CollectionsInternal/Get" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSvc<T: CollectionsInternal>(pub Arc<T>);
+                    impl<
+                        T: CollectionsInternal,
+                    > tonic::server::UnaryService<
+                        super::GetCollectionInfoRequestInternal,
+                    > for GetSvc<T> {
+                        type Response = super::GetCollectionInfoResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::GetCollectionInfoRequestInternal,
+                            >,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).get(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: CollectionsInternal> Clone for CollectionsInternalServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: CollectionsInternal> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: CollectionsInternal> tonic::transport::NamedService
+    for CollectionsInternalServer<T> {
+        const NAME: &'static str = "qdrant.CollectionsInternal";
+    }
+}
 // ---------------------------------------------
 // ------------- Point Id Requests -------------
 // ---------------------------------------------

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -530,8 +530,8 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn info(&self) -> CollectionResult<CollectionInfo> {
-        let mut shards = self.all_shards();
+    pub async fn info(&self, shard_selection: Option<ShardId>) -> CollectionResult<CollectionInfo> {
+        let mut shards = self.target_shards(shard_selection)?;
         let mut info = shards
             .next()
             .expect("At least 1 shard expected")

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -49,7 +49,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
     }
 
     let mut collection = Collection::load("test".to_string(), collection_dir.path()).await;
-    assert_eq!(collection.info().await.unwrap().vectors_count, 2);
+    assert_eq!(collection.info(None).await.unwrap().vectors_count, 2);
     collection.before_drop().await;
 }
 

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -36,7 +36,7 @@ async fn get_collection(
 ) -> impl Responder {
     let name = path.into_inner();
     let timing = Instant::now();
-    let response = do_get_collection(&toc.into_inner(), &name).await;
+    let response = do_get_collection(&toc.into_inner(), &name, None).await;
     process_response(response, timing)
 }
 

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -1,5 +1,6 @@
 use api::grpc::models::{CollectionDescription, CollectionsResponse};
 use collection::operations::types::CollectionInfo;
+use collection::shard::ShardId;
 use itertools::Itertools;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
@@ -7,9 +8,10 @@ use storage::content_manager::toc::TableOfContent;
 pub async fn do_get_collection(
     toc: &TableOfContent,
     name: &str,
+    shard_selection: Option<ShardId>,
 ) -> Result<CollectionInfo, StorageError> {
     let collection = toc.get_collection(name).await?;
-    Ok(collection.info().await?)
+    Ok(collection.info(shard_selection).await?)
 }
 
 pub async fn do_list_collections(toc: &TableOfContent) -> CollectionsResponse {

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -10,6 +10,7 @@ use api::grpc::qdrant::{
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::tonic::api::collections_common::get;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 
@@ -53,17 +54,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<GetCollectionInfoRequest>,
     ) -> Result<Response<GetCollectionInfoResponse>, Status> {
-        let timing = Instant::now();
-        let collection_name = request.into_inner().collection_name;
-        let result = do_get_collection(&self.toc, &collection_name)
-            .await
-            .map_err(error_to_status)?;
-        let response = GetCollectionInfoResponse {
-            result: Some(result.into()),
-            time: timing.elapsed().as_secs_f64(),
-        };
-
-        Ok(Response::new(response))
+        get(self.toc.as_ref(), request.into_inner(), None).await
     }
 
     async fn list(

--- a/src/tonic/api/collections_common.rs
+++ b/src/tonic/api/collections_common.rs
@@ -1,0 +1,25 @@
+use crate::common::collections::do_get_collection;
+use api::grpc::qdrant::{GetCollectionInfoRequest, GetCollectionInfoResponse};
+use collection::shard::ShardId;
+use std::time::Instant;
+use storage::content_manager::conversions::error_to_status;
+use storage::content_manager::toc::TableOfContent;
+use tonic::{Response, Status};
+
+pub async fn get(
+    toc: &TableOfContent,
+    get_collection_info_request: GetCollectionInfoRequest,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<GetCollectionInfoResponse>, Status> {
+    let timing = Instant::now();
+    let collection_name = get_collection_info_request.collection_name;
+    let result = do_get_collection(toc, &collection_name, shard_selection)
+        .await
+        .map_err(error_to_status)?;
+    let response = GetCollectionInfoResponse {
+        result: Some(result.into()),
+        time: timing.elapsed().as_secs_f64(),
+    };
+
+    Ok(Response::new(response))
+}

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -1,0 +1,39 @@
+use crate::tonic::api::collections_common::get;
+use api::grpc::qdrant::collections_internal_server::CollectionsInternal;
+use api::grpc::qdrant::{GetCollectionInfoRequestInternal, GetCollectionInfoResponse};
+use std::sync::Arc;
+use storage::content_manager::toc::TableOfContent;
+use tonic::{Request, Response, Status};
+
+pub struct CollectionsInternalService {
+    toc: Arc<TableOfContent>,
+}
+
+impl CollectionsInternalService {
+    pub fn new(toc: Arc<TableOfContent>) -> Self {
+        Self { toc }
+    }
+}
+
+#[tonic::async_trait]
+impl CollectionsInternal for CollectionsInternalService {
+    async fn get(
+        &self,
+        request: Request<GetCollectionInfoRequestInternal>,
+    ) -> Result<Response<GetCollectionInfoResponse>, Status> {
+        let GetCollectionInfoRequestInternal {
+            get_collection_info_request,
+            shard_id,
+        } = request.into_inner();
+
+        let get_collection_info_request = get_collection_info_request
+            .ok_or_else(|| Status::invalid_argument("GetCollectionInfoRequest is missing"))?;
+
+        get(
+            self.toc.as_ref(),
+            get_collection_info_request,
+            Some(shard_id),
+        )
+        .await
+    }
+}

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -1,4 +1,7 @@
 pub mod collections_api;
+mod collections_common;
+#[cfg(feature = "consensus")]
+pub mod collections_internal_api;
 pub mod points_api;
 mod points_common;
 #[cfg(feature = "consensus")]


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/475 (https://github.com/qdrant/qdrant/issues/433).

This PR adds the method get collection info to the internal gRPC API for p2p communication.

This was the last method necessary to enable the implementation of `ShardOperation` for remote shards.