### PR TITLE
[Sharding] Shard operations are executed concurrently

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -435,11 +435,12 @@ impl Collection {
 
         let mut points = Vec::new();
 
-        let target_shards = self
+        let target_shards: Vec<_> = self
             .target_shards(shard_selection)?
-            .map(|shard| shard.get());
+            .map(|shard| shard.get())
+            .collect();
         let futures = FuturesUnordered::new();
-        for shard in target_shards {
+        for shard in &target_shards {
             let result = shard.scroll_by(
                 segment_searcher,
                 offset,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -23,7 +23,9 @@ use std::collections::HashMap;
 pub type VectorType = Vec<VectorElementType>;
 
 /// Current state of the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Copy, Clone,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionStatus {
     /// Collection if completely ready for requests
@@ -36,7 +38,7 @@ pub enum CollectionStatus {
 }
 
 /// Current state of the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum OptimizersStatus {
     /// Optimizers are reporting as expected


### PR DESCRIPTION
This PR is part of #467 and adds the concurrent execution of shard operations for:
- `search`
- `retrieve`
- `scroll_by`
- `recommend_by` (transitively)
- `info`

It tries to apply the same pattern using `FuturesUnordered` at every call sites to setup a convention.

Some methods are still performing the shard operations sequentially and could be tackled in another PR:
- `update_from_client` (tried to migrate it but more changes are required)
- `update_optimizer_params_from_diff`
- `update_optimizer_params`


I had some problems a long the way with rustc, thank to @e-ivkov for the help!