### PR TITLE
Graph edges container suggestion

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -61,3 +61,8 @@ harness = false
 [[bench]]
 name = "id_type_benchmark"
 harness = false
+
+[[bench]]
+name = "links_container"
+harness = false
+

--- a/lib/segment/benches/links_container.rs
+++ b/lib/segment/benches/links_container.rs
@@ -1,0 +1,142 @@
+mod prof;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use rand::rngs::StdRng;
+use rand::{thread_rng, SeedableRng, Rng};
+use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
+use segment::index::hnsw_index::base_links_container::BaseLinksContainer;
+use segment::index::hnsw_index::graph_layers::GraphLayers;
+use segment::index::hnsw_index::links_container::LinksContainer;
+use segment::index::hnsw_index::point_scorer::FilteredScorer;
+use segment::index::hnsw_index::simple_links_container::SimpleLinksContainer;
+use segment::spaces::simple::DotProductMetric;
+use segment::types::PointOffsetType;
+
+const NUM_VECTORS: usize = 200_000;
+const DIM: usize = 16;
+const M: usize = 32;
+const SAMPLE: usize = 100;
+
+
+fn links_container_bench_base(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
+    let mut group = c.benchmark_group("links-container-bench");
+
+    let mut link_container = BaseLinksContainer::new(M, NUM_VECTORS);
+
+    for i in 0..NUM_VECTORS {
+        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        link_container.set_links(i as PointOffsetType, &links);
+    }
+
+    group.bench_function("base-level", |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rng, DIM);
+            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let mut scorer = FilteredScorer::new(&raw_scorer, None);
+
+            let mut top_score = 0.;
+            let mut buffer = vec![];
+            for _ in 0..SAMPLE {
+                buffer.clear();
+                let point_id = rng.gen_range(0..NUM_VECTORS) as PointOffsetType;
+                buffer.extend_from_slice(link_container.get_links(point_id));
+                let scores = scorer.score_points(&mut buffer, M);
+                scores.iter().copied().for_each(|score| {
+                    if score.score > top_score {
+                        top_score = score.score
+                    }
+                });
+            }
+        })
+    });
+
+    group.finish();
+}
+
+fn links_container_bench_simple(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
+    let mut group = c.benchmark_group("links-container-bench");
+
+    let mut link_container = SimpleLinksContainer::new(NUM_VECTORS);
+
+    for i in 0..NUM_VECTORS {
+        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        link_container.set_links(i as PointOffsetType, 0, &links);
+    }
+
+    group.bench_function("simple", |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rng, DIM);
+            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let mut scorer = FilteredScorer::new(&raw_scorer, None);
+
+            let mut top_score = 0.;
+            let mut buffer = vec![];
+            for _ in 0..SAMPLE {
+                buffer.clear();
+                let point_id = rng.gen_range(0..NUM_VECTORS) as PointOffsetType;
+                buffer.extend_from_slice(link_container.get_links(point_id, 0));
+                let scores = scorer.score_points(&mut buffer, M);
+                scores.iter().copied().for_each(|score| {
+                    if score.score > top_score {
+                        top_score = score.score
+                    }
+                });
+            }
+        })
+    });
+
+    group.finish();
+}
+
+
+fn links_container_bench_with_levels(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
+    let mut group = c.benchmark_group("links-container-bench");
+
+    let mut link_container = LinksContainer::new();
+
+    link_container.reserve(NUM_VECTORS, M);
+
+    for i in 0..NUM_VECTORS {
+        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        link_container.set_links(i as PointOffsetType, 0, &links);
+    }
+
+    group.bench_function("full-levels", |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rng, DIM);
+            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let mut scorer = FilteredScorer::new(&raw_scorer, None);
+
+            let mut top_score = 0.;
+            let mut buffer = vec![];
+            for _ in 0..SAMPLE {
+                buffer.clear();
+                let point_id = rng.gen_range(0..NUM_VECTORS) as PointOffsetType;
+                buffer.extend_from_slice(link_container.get_links(point_id, 0));
+                let scores = scorer.score_points(&mut buffer, M);
+                scores.iter().copied().for_each(|score| {
+                    if score.score > top_score {
+                        top_score = score.score
+                    }
+                });
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = links_container_bench_base, links_container_bench_simple, links_container_bench_with_levels
+}
+
+criterion_main!(benches);

--- a/lib/segment/benches/links_container.rs
+++ b/lib/segment/benches/links_container.rs
@@ -3,7 +3,7 @@ mod prof;
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use rand::rngs::StdRng;
-use rand::{thread_rng, SeedableRng, Rng};
+use rand::{thread_rng, Rng, SeedableRng};
 use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
 use segment::index::hnsw_index::base_links_container::BaseLinksContainer;
 use segment::index::hnsw_index::graph_layers::GraphLayers;
@@ -18,7 +18,6 @@ const DIM: usize = 16;
 const M: usize = 32;
 const SAMPLE: usize = 100;
 
-
 fn links_container_bench_base(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
@@ -27,7 +26,9 @@ fn links_container_bench_base(c: &mut Criterion) {
     let mut link_container = BaseLinksContainer::new(M, NUM_VECTORS);
 
     for i in 0..NUM_VECTORS {
-        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        let links = (0..M)
+            .map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType)
+            .collect_vec();
         link_container.set_links(i as PointOffsetType, &links);
     }
 
@@ -64,7 +65,9 @@ fn links_container_bench_simple(c: &mut Criterion) {
     let mut link_container = SimpleLinksContainer::new(NUM_VECTORS);
 
     for i in 0..NUM_VECTORS {
-        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        let links = (0..M)
+            .map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType)
+            .collect_vec();
         link_container.set_links(i as PointOffsetType, 0, &links);
     }
 
@@ -93,7 +96,6 @@ fn links_container_bench_simple(c: &mut Criterion) {
     group.finish();
 }
 
-
 fn links_container_bench_with_levels(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
@@ -104,7 +106,9 @@ fn links_container_bench_with_levels(c: &mut Criterion) {
     link_container.reserve(NUM_VECTORS, M);
 
     for i in 0..NUM_VECTORS {
-        let links = (0..M).map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType).collect_vec();
+        let links = (0..M)
+            .map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType)
+            .collect_vec();
         link_container.set_links(i as PointOffsetType, 0, &links);
     }
 

--- a/lib/segment/benches/links_container.rs
+++ b/lib/segment/benches/links_container.rs
@@ -10,6 +10,7 @@ use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::links_container::LinksContainer;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::index::hnsw_index::simple_links_container::SimpleLinksContainer;
+use segment::index::hnsw_index::simple_links_container_no_level::SimpleLinksContainerNoLevel;
 use segment::spaces::simple::DotProductMetric;
 use segment::types::PointOffsetType;
 
@@ -96,6 +97,45 @@ fn links_container_bench_simple(c: &mut Criterion) {
     group.finish();
 }
 
+fn links_container_bench_simple_no_levels(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
+    let mut group = c.benchmark_group("links-container-bench");
+
+    let mut link_container = SimpleLinksContainerNoLevel::new(NUM_VECTORS);
+
+    for i in 0..NUM_VECTORS {
+        let links = (0..M)
+            .map(|_| rng.gen_range(0..NUM_VECTORS) as PointOffsetType)
+            .collect_vec();
+        link_container.set_links(i as PointOffsetType, &links);
+    }
+
+    group.bench_function("simple-no-levels", |b| {
+        b.iter(|| {
+            let query = random_vector(&mut rng, DIM);
+            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let mut scorer = FilteredScorer::new(&raw_scorer, None);
+
+            let mut top_score = 0.;
+            let mut buffer = vec![];
+            for _ in 0..SAMPLE {
+                buffer.clear();
+                let point_id = rng.gen_range(0..NUM_VECTORS) as PointOffsetType;
+                buffer.extend_from_slice(link_container.get_links(point_id));
+                let scores = scorer.score_points(&mut buffer, M);
+                scores.iter().copied().for_each(|score| {
+                    if score.score > top_score {
+                        top_score = score.score
+                    }
+                });
+            }
+        })
+    });
+
+    group.finish();
+}
+
 fn links_container_bench_with_levels(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let vector_holder = TestRawScorerProducer::new(DIM, NUM_VECTORS, DotProductMetric {}, &mut rng);
@@ -140,7 +180,7 @@ fn links_container_bench_with_levels(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
-    targets = links_container_bench_base, links_container_bench_simple, links_container_bench_with_levels
+    targets = links_container_bench_base, links_container_bench_simple, links_container_bench_simple_no_levels, links_container_bench_with_levels
 }
 
 criterion_main!(benches);

--- a/lib/segment/src/index/hnsw_index/base_links_container.rs
+++ b/lib/segment/src/index/hnsw_index/base_links_container.rs
@@ -4,7 +4,7 @@ use crate::types::PointOffsetType;
 pub struct BaseLinksContainer {
     links_data: Vec<PointOffsetType>,
     links_per_record: usize,
-    num_records: usize
+    num_records: usize,
 }
 
 impl BaseLinksContainer {
@@ -21,7 +21,7 @@ impl BaseLinksContainer {
         BaseLinksContainer {
             links_data,
             links_per_record,
-            num_records
+            num_records,
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/base_links_container.rs
+++ b/lib/segment/src/index/hnsw_index/base_links_container.rs
@@ -1,0 +1,43 @@
+use crate::types::PointOffsetType;
+
+#[derive(Debug, Default)]
+pub struct BaseLinksContainer {
+    links_data: Vec<PointOffsetType>,
+    links_per_record: usize,
+    num_records: usize
+}
+
+impl BaseLinksContainer {
+    #[inline]
+    fn links_offset(&self, point_id: PointOffsetType) -> usize {
+        point_id as usize * self.links_per_record
+    }
+
+    pub fn new(links_per_record: usize, num_records: usize) -> BaseLinksContainer {
+        let mut links_data: Vec<PointOffsetType> = Default::default();
+
+        links_data.resize(num_records * (links_per_record + 1), 0);
+
+        BaseLinksContainer {
+            links_data,
+            links_per_record,
+            num_records
+        }
+    }
+
+    pub fn set_links(&mut self, point_id: PointOffsetType, links: &[PointOffsetType]) {
+        let mut offset = self.links_offset(point_id);
+        self.links_data[offset] = links.len() as PointOffsetType;
+        offset += 1;
+        for link in links {
+            self.links_data[offset] = *link;
+            offset += 1;
+        }
+    }
+
+    pub fn get_links(&self, point_id: PointOffsetType) -> &[PointOffsetType] {
+        let offset = self.links_offset(point_id);
+        let num_links = self.links_data[offset] as usize;
+        &self.links_data[(offset + 1)..(offset + 1 + num_links)]
+    }
+}

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -9,6 +9,7 @@ pub mod links_container;
 pub mod point_scorer;
 mod search_context;
 pub mod simple_links_container;
+pub mod simple_links_container_no_level;
 
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -1,3 +1,4 @@
+pub mod base_links_container;
 mod build_cache;
 pub mod build_condition_checker;
 mod config;
@@ -7,7 +8,6 @@ pub mod hnsw;
 pub mod links_container;
 pub mod point_scorer;
 mod search_context;
-pub mod base_links_container;
 pub mod simple_links_container;
 
 #[cfg(test)]

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -7,6 +7,8 @@ pub mod hnsw;
 pub mod links_container;
 pub mod point_scorer;
 mod search_context;
+pub mod base_links_container;
+pub mod simple_links_container;
 
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/index/hnsw_index/simple_links_container.rs
+++ b/lib/segment/src/index/hnsw_index/simple_links_container.rs
@@ -1,0 +1,30 @@
+use crate::types::PointOffsetType;
+
+#[derive(Debug, Default)]
+pub struct SimpleLinksContainer {
+    links_data: Vec<Vec<Vec<PointOffsetType>>>,
+}
+
+impl SimpleLinksContainer {
+    pub fn new(num_points: usize) -> Self {
+        let mut links_data: Vec<Vec<Vec<PointOffsetType>>> = vec![];
+        let empty_level = vec![];
+        links_data.resize(num_points, vec![empty_level]);
+
+        Self { links_data }
+    }
+
+    pub fn set_links(
+        &mut self,
+        point_id: PointOffsetType,
+        level: usize,
+        links: &[PointOffsetType],
+    ) {
+        self.links_data[point_id as usize][level].clear();
+        self.links_data[point_id as usize][level].extend_from_slice(links);
+    }
+
+    pub fn get_links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
+        &self.links_data[point_id as usize][level]
+    }
+}

--- a/lib/segment/src/index/hnsw_index/simple_links_container_no_level.rs
+++ b/lib/segment/src/index/hnsw_index/simple_links_container_no_level.rs
@@ -1,0 +1,24 @@
+use crate::types::PointOffsetType;
+
+#[derive(Debug, Default)]
+pub struct SimpleLinksContainerNoLevel {
+    links_data: Vec<Vec<PointOffsetType>>,
+}
+
+impl SimpleLinksContainerNoLevel {
+    pub fn new(num_points: usize) -> Self {
+        let mut links_data: Vec<Vec<PointOffsetType>> = vec![];
+        links_data.resize(num_points, vec![]);
+
+        Self { links_data }
+    }
+
+    pub fn set_links(&mut self, point_id: PointOffsetType, links: &[PointOffsetType]) {
+        self.links_data[point_id as usize].clear();
+        self.links_data[point_id as usize].extend_from_slice(links);
+    }
+
+    pub fn get_links(&self, point_id: PointOffsetType) -> &[PointOffsetType] {
+        &self.links_data[point_id as usize]
+    }
+}


### PR DESCRIPTION
I was trying to reproduce the impact of links storage in a simple benchmark to identify the maximal optimization potential. The setup is similar to what happens in actual HNSW, but without any candidates processing:

- create random links graph
- score neighbors of a random node with some random query (vector scoring component is for proper scale)

There are 3 implementations of the link container in the benchmark:

- `base-level` - similar to hnsw, separate implementation for level-0.
- `simple` - mimics the current master version - vec of vec of vec
- `full-levels` - the one proposed in PR

Results of the bench on my machine:

![Screenshot from 2022-04-16 20-13-06](https://user-images.githubusercontent.com/1935623/163687013-f8e9a21f-d57b-4e2f-a841-cc6a1a79a46c.png)

Which indicates that current implementation is indeed performs almost the same as proposed. At the same time it might be worth trying to split containers and search implementation for level-0 and all the others.

Potential speed-up is `~15%`
