### PR TITLE
Fixes `test_alias_operation`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       run: .github/scripts/protoc.sh
       shell: bash
     - name: Test with consensus feature
-      run: cargo test --package qdrant --bin qdrant --features consensus -- consensus::tests
+      run: cargo test --all --features consensus
 
 #   build:
 #     runs-on: ubuntu-latest

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -26,6 +26,7 @@ impl AliasMapping {
 /// Persists mapping between alias and collection name. The data is assumed to be relatively small.
 /// - Reads are served from memory.
 /// - Writes are durably saved.
+#[derive(Debug)]
 pub struct AliasPersistence {
     data_path: PathBuf,
     alias_mapping: AliasMapping,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -362,10 +362,7 @@ impl TableOfContent {
         let propose_sender = match &self.propose_sender {
             Some(sender) => sender,
             None => {
-                log::error!(
-                    "Cannot submit collection meta operation proposal: no sender supplied to ToC"
-                );
-                return Ok(true);
+                return Err(StorageError::ServiceError { description: "Cannot submit collection meta operation proposal: no sender supplied to ToC".to_string() });
             }
         };
         let serialized = serde_cbor::to_vec(&operation)?;

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -1,17 +1,19 @@
-use collection::optimizers_builder::OptimizersConfig;
-use storage::content_manager::toc::TableOfContent;
-use storage::types::{PerformanceConfig, StorageConfig};
-use tempdir::TempDir;
-use tokio::runtime::Runtime;
-
-#[cfg(test)]
+#[cfg(all(test, not(feature = "consensus")))]
 mod tests {
-    use super::*;
+    use collection::optimizers_builder::OptimizersConfig;
     use segment::types::Distance;
-    use storage::content_manager::collection_meta_ops::{
-        ChangeAliasesOperation, CollectionMetaOperations, CreateAlias, CreateCollection,
-        CreateCollectionOperation, DeleteAlias, RenameAlias,
+    use storage::{
+        content_manager::{
+            collection_meta_ops::{
+                ChangeAliasesOperation, CollectionMetaOperations, CreateAlias, CreateCollection,
+                CreateCollectionOperation, DeleteAlias, RenameAlias,
+            },
+            toc::TableOfContent,
+        },
+        types::{PerformanceConfig, StorageConfig},
     };
+    use tempdir::TempDir;
+    use tokio::runtime::Runtime;
 
     #[test]
     fn test_alias_operation() {


### PR DESCRIPTION
Closes #491 

## Cause
Alias test uses `submit_collection_operation` which behavior differs based on `consensus` feature.
With this feature enabled it requires Raft to finalize the operation, but in this test Raft is not started.

## Fix
1. Limit the test to work only without consensus feature
    (We already have a specific case which checks collection operations with consensus)
2. Improve error reporting for cases when Raft was not started but ToC tries to access it.
3. Run with `--all` consensus tests to detect such cases faster