### PR TITLE
Adds `PeerAddressById` to `StorageConfig`

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -29,7 +29,7 @@ use crate::content_manager::{
     collections_ops::{Checker, Collections},
     errors::StorageError,
 };
-use crate::types::StorageConfig;
+use crate::types::{PeerAddressById, StorageConfig};
 use collection::collection_manager::collection_managers::CollectionSearcher;
 use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
 use collection::shard::ShardId;
@@ -744,6 +744,10 @@ impl TableOfContent {
         self.raft_state
             .lock()?
             .apply_state_update(|state| state.hard_state.commit = index)
+    }
+
+    pub fn peer_address_by_id(&self) -> &PeerAddressById {
+        &self.storage_config.peer_address_by_id
     }
 }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -1,8 +1,12 @@
+use std::{collections::HashMap, net::SocketAddr};
+
 use collection::config::WalConfig;
 use collection::optimizers_builder::OptimizersConfig;
 use schemars::JsonSchema;
 use segment::types::HnswConfig;
 use serde::{Deserialize, Serialize};
+
+pub type PeerAddressById = HashMap<u64, SocketAddr>;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct PerformanceConfig {
@@ -17,4 +21,6 @@ pub struct StorageConfig {
     pub wal: WalConfig,
     pub performance: PerformanceConfig,
     pub hnsw_index: HnswConfig,
+    #[serde(default)]
+    pub peer_address_by_id: PeerAddressById,
 }

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -37,6 +37,7 @@ mod tests {
                 max_search_threads: 1,
             },
             hnsw_index: Default::default(),
+            peer_address_by_id: Default::default(),
         };
 
         let runtime = Runtime::new().unwrap();


### PR DESCRIPTION
It is done with `serde(default)` instead of feature as having features for config is usually ugly, it would force us to have 2 configs at this stage for example.
