### PR TITLE
ensure lib/api version is same as main package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "api"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "prost 0.10.1",
  "prost-types 0.10.1",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -3,3 +3,7 @@ pub mod models;
 #[allow(clippy::all)]
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 pub mod qdrant;
+
+pub const fn api_crate_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -66,3 +66,17 @@ pub fn init(toc: Arc<TableOfContent>, settings: Settings) -> std::io::Result<()>
         .await
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use ::api::grpc::api_crate_version;
+
+    #[test]
+    fn test_version() {
+        assert_eq!(
+            api_crate_version(),
+            env!("CARGO_PKG_VERSION"),
+            "Qdrant and lib/api crate versions are not same"
+        );
+    }
+}


### PR DESCRIPTION
There is a problem with version returned from `/` API. Data structure relies on compile-time variable in `lib/api` crate which might be different from main crate. 
I didn't find an easy way to ensure single source of truth for the version in both crates, so I decided to ensure equivalence instead.

Alternatives:
I considered using https://github.com/nvzqz/static-assertions-rs, but didn't succeed in making it work.