### PR TITLE
Disable simd on small dimensions

### DIFF
--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -11,6 +11,12 @@ use super::simple_avx::*;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::simple_neon::*;
 
+#[cfg(target_arch = "x86_64")]
+const MIN_DIM_SIZE_AVX: usize = 32;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+const MIN_DIM_SIZE_SIMD: usize = 16;
+
 #[derive(Clone)]
 pub struct DotProductMetric {}
 
@@ -28,7 +34,9 @@ impl Metric for EuclidMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
             {
                 return unsafe { euclid_similarity_avx(v1, v2) };
             }
@@ -36,14 +44,14 @@ impl Metric for EuclidMetric {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { euclid_similarity_sse(v1, v2) };
             }
         }
 
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { euclid_similarity_neon(v1, v2) };
             }
         }
@@ -64,7 +72,9 @@ impl Metric for DotProductMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
             {
                 return unsafe { dot_similarity_avx(v1, v2) };
             }
@@ -72,14 +82,14 @@ impl Metric for DotProductMetric {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_sse(v1, v2) };
             }
         }
 
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_neon(v1, v2) };
             }
         }
@@ -100,7 +110,9 @@ impl Metric for CosineMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
             {
                 return unsafe { dot_similarity_avx(v1, v2) };
             }
@@ -108,14 +120,14 @@ impl Metric for CosineMetric {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_sse(v1, v2) };
             }
         }
 
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_neon(v1, v2) };
             }
         }
@@ -128,7 +140,7 @@ impl Metric for CosineMetric {
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
-                && vector.len() >= 32
+                && vector.len() >= MIN_DIM_SIZE_AVX
             {
                 return Some(unsafe { cosine_preprocess_avx(vector) });
             }
@@ -136,14 +148,15 @@ impl Metric for CosineMetric {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("sse") && vector.len() >= 16 {
+            if is_x86_feature_detected!("sse") && vector.len() >= MIN_DIM_SIZE_SIMD {
                 return Some(unsafe { cosine_preprocess_sse(vector) });
             }
         }
 
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= 16 {
+            if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= MIN_DIM_SIZE_SIMD
+            {
                 return Some(unsafe { cosine_preprocess_neon(vector) });
             }
         }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -28,7 +28,8 @@ impl Metric for EuclidMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            {
                 return unsafe { euclid_similarity_avx(v1, v2) };
             }
         }
@@ -63,7 +64,8 @@ impl Metric for DotProductMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            {
                 return unsafe { dot_similarity_avx(v1, v2) };
             }
         }
@@ -98,7 +100,8 @@ impl Metric for CosineMetric {
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32
+            {
                 return unsafe { dot_similarity_avx(v1, v2) };
             }
         }
@@ -123,7 +126,10 @@ impl Metric for CosineMetric {
     fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && vector.len() >= 32 {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && vector.len() >= 32
+            {
                 return Some(unsafe { cosine_preprocess_avx(vector) });
             }
         }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -26,27 +26,6 @@ impl Metric for EuclidMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") {
-                return unsafe { euclid_similarity_avx(v1, v2) };
-            }
-        }
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            if is_x86_feature_detected!("sse") {
-                return unsafe { euclid_similarity_sse(v1, v2) };
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { euclid_similarity_neon(v1, v2) };
-            }
-        }
-
         euclid_similarity(v1, v2)
     }
 
@@ -61,27 +40,6 @@ impl Metric for DotProductMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") {
-                return unsafe { dot_similarity_avx(v1, v2) };
-            }
-        }
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            if is_x86_feature_detected!("sse") {
-                return unsafe { dot_similarity_sse(v1, v2) };
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { dot_similarity_neon(v1, v2) };
-            }
-        }
-
         dot_similarity(v1, v2)
     }
 
@@ -96,52 +54,10 @@ impl Metric for CosineMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") {
-                return unsafe { dot_similarity_avx(v1, v2) };
-            }
-        }
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            if is_x86_feature_detected!("sse") {
-                return unsafe { dot_similarity_sse(v1, v2) };
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { dot_similarity_neon(v1, v2) };
-            }
-        }
-
         dot_similarity(v1, v2)
     }
 
     fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") {
-                return Some(unsafe { cosine_preprocess_avx(vector) });
-            }
-        }
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            if is_x86_feature_detected!("sse") {
-                return Some(unsafe { cosine_preprocess_sse(vector) });
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return Some(unsafe { cosine_preprocess_neon(vector) });
-            }
-        }
-
         Some(cosine_preprocess(vector))
     }
 }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -26,6 +26,27 @@ impl Metric for EuclidMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+                return unsafe { euclid_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+                return unsafe { euclid_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+                return unsafe { euclid_similarity_neon(v1, v2) };
+            }
+        }
+
         euclid_similarity(v1, v2)
     }
 
@@ -40,6 +61,27 @@ impl Metric for DotProductMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+                return unsafe { dot_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+                return unsafe { dot_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+                return unsafe { dot_similarity_neon(v1, v2) };
+            }
+        }
+
         dot_similarity(v1, v2)
     }
 
@@ -54,10 +96,52 @@ impl Metric for CosineMetric {
     }
 
     fn similarity(&self, v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && v1.len() >= 32 {
+                return unsafe { dot_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= 16 {
+                return unsafe { dot_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= 16 {
+                return unsafe { dot_similarity_neon(v1, v2) };
+            }
+        }
+
         dot_similarity(v1, v2)
     }
 
     fn preprocess(&self, vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx") && is_x86_feature_detected!("fma") && vector.len() >= 32 {
+                return Some(unsafe { cosine_preprocess_avx(vector) });
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && vector.len() >= 16 {
+                return Some(unsafe { cosine_preprocess_sse(vector) });
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= 16 {
+                return Some(unsafe { cosine_preprocess_neon(vector) });
+            }
+        }
+
         Some(cosine_preprocess(vector))
     }
 }


### PR DESCRIPTION
When the dimension is lower than simd processing stride, it is faster to use regular functions instead of simd