### PR TITLE
Allows bootstrapping peer on addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,8 +652,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static 1.4.0",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -792,7 +831,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools 0.10.3",
@@ -953,7 +992,7 @@ dependencies = [
  "lazy_static 0.2.11",
  "regex 0.1.80",
  "rustc-serialize",
- "strsim",
+ "strsim 0.5.2",
 ]
 
 [[package]]
@@ -2077,6 +2116,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2511,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "api",
+ "clap 3.1.12",
  "collection",
  "config",
  "env_logger 0.9.0",
@@ -3110,6 +3156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "symbolic-common"
 version = "8.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3262,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ schemars = { version = "0.8.8", features = ["uuid"] }
 itertools = "0.10"
 anyhow = "1.0.57"
 futures = "0.3.21"
+clap = { version = "3.1.12", features = ["derive"] }
 
 config = "~0.13.1"
 

--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -5,12 +5,36 @@ package qdrant;
 import "google/protobuf/empty.proto";
 
 service Raft {
-  /*
-  Send Raft message to another peer
-   */
-  rpc Send (RaftMessage) returns (google.protobuf.Empty) {}
+  // Send Raft message to another peer
+  rpc Send (RaftMessage) returns (google.protobuf.Empty);
+  // Send to bootstrap
+  rpc WhoIs (PeerId) returns (Uri);
+  // Send to bootstrap
+  // Proposes to add to known_peers list
+  // Returns all peers
+  rpc AddPeerToKnown (Peer) returns (AllPeers);
+  // Send to bootstrap
+  // Proposes to add to consensus as learner peer
+  rpc AddPeerAsParticipant (Peer) returns (google.protobuf.Empty);
 }
 
 message RaftMessage {
     bytes message = 1;
+}
+
+message AllPeers {
+    repeated Peer all_peers = 1;
+}
+
+message Peer {
+    string uri = 1;
+    uint64 id = 2;
+}
+
+message PeerId {
+  uint64 id = 1;
+}
+
+message Uri {
+  string uri = 1;
 }

--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -7,14 +7,15 @@ import "google/protobuf/empty.proto";
 service Raft {
   // Send Raft message to another peer
   rpc Send (RaftMessage) returns (google.protobuf.Empty);
-  // Send to bootstrap
+  // Send to bootstrap peer
+  // Returns uri by id if bootstrap knows this peer
   rpc WhoIs (PeerId) returns (Uri);
-  // Send to bootstrap
-  // Proposes to add to known_peers list
+  // Send to bootstrap peer
+  // Proposes to add this peer Uri and ID to a map of all peers
   // Returns all peers
   rpc AddPeerToKnown (Peer) returns (AllPeers);
-  // Send to bootstrap
-  // Proposes to add to consensus as learner peer
+  // Send to bootstrap peer
+  // Proposes to add this peer as participant of consensus
   rpc AddPeerAsParticipant (Peer) returns (google.protobuf.Empty);
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3382,6 +3382,28 @@ pub struct RaftMessage {
     #[prost(bytes="vec", tag="1")]
     pub message: ::prost::alloc::vec::Vec<u8>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AllPeers {
+    #[prost(message, repeated, tag="1")]
+    pub all_peers: ::prost::alloc::vec::Vec<Peer>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Peer {
+    #[prost(string, tag="1")]
+    pub uri: ::prost::alloc::string::String,
+    #[prost(uint64, tag="2")]
+    pub id: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PeerId {
+    #[prost(uint64, tag="1")]
+    pub id: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Uri {
+    #[prost(string, tag="1")]
+    pub uri: ::prost::alloc::string::String,
+}
 /// Generated client implementations.
 pub mod raft_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -3446,8 +3468,7 @@ pub mod raft_client {
             self.inner = self.inner.accept_gzip();
             self
         }
-        ///
-        ///Send Raft message to another peer
+        /// Send Raft message to another peer
         pub async fn send(
             &mut self,
             request: impl tonic::IntoRequest<super::RaftMessage>,
@@ -3465,6 +3486,67 @@ pub mod raft_client {
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/Send");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        /// Send to bootstrap
+        pub async fn who_is(
+            &mut self,
+            request: impl tonic::IntoRequest<super::PeerId>,
+        ) -> Result<tonic::Response<super::Uri>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/WhoIs");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Send to bootstrap
+        /// Proposes to add to known_peers list
+        /// Returns all peers
+        pub async fn add_peer_to_known(
+            &mut self,
+            request: impl tonic::IntoRequest<super::Peer>,
+        ) -> Result<tonic::Response<super::AllPeers>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Raft/AddPeerToKnown",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Send to bootstrap
+        /// Proposes to add to consensus as learner peer
+        pub async fn add_peer_as_participant(
+            &mut self,
+            request: impl tonic::IntoRequest<super::Peer>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Raft/AddPeerAsParticipant",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -3474,11 +3556,28 @@ pub mod raft_server {
     ///Generated trait containing gRPC methods that should be implemented for use with RaftServer.
     #[async_trait]
     pub trait Raft: Send + Sync + 'static {
-        ///
-        ///Send Raft message to another peer
+        /// Send Raft message to another peer
         async fn send(
             &self,
             request: tonic::Request<super::RaftMessage>,
+        ) -> Result<tonic::Response<()>, tonic::Status>;
+        /// Send to bootstrap
+        async fn who_is(
+            &self,
+            request: tonic::Request<super::PeerId>,
+        ) -> Result<tonic::Response<super::Uri>, tonic::Status>;
+        /// Send to bootstrap
+        /// Proposes to add to known_peers list
+        /// Returns all peers
+        async fn add_peer_to_known(
+            &self,
+            request: tonic::Request<super::Peer>,
+        ) -> Result<tonic::Response<super::AllPeers>, tonic::Status>;
+        /// Send to bootstrap
+        /// Proposes to add to consensus as learner peer
+        async fn add_peer_as_participant(
+            &self,
+            request: tonic::Request<super::Peer>,
         ) -> Result<tonic::Response<()>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -3553,6 +3652,118 @@ pub mod raft_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = SendSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Raft/WhoIs" => {
+                    #[allow(non_camel_case_types)]
+                    struct WhoIsSvc<T: Raft>(pub Arc<T>);
+                    impl<T: Raft> tonic::server::UnaryService<super::PeerId>
+                    for WhoIsSvc<T> {
+                        type Response = super::Uri;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::PeerId>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).who_is(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = WhoIsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Raft/AddPeerToKnown" => {
+                    #[allow(non_camel_case_types)]
+                    struct AddPeerToKnownSvc<T: Raft>(pub Arc<T>);
+                    impl<T: Raft> tonic::server::UnaryService<super::Peer>
+                    for AddPeerToKnownSvc<T> {
+                        type Response = super::AllPeers;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Peer>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).add_peer_to_known(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = AddPeerToKnownSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Raft/AddPeerAsParticipant" => {
+                    #[allow(non_camel_case_types)]
+                    struct AddPeerAsParticipantSvc<T: Raft>(pub Arc<T>);
+                    impl<T: Raft> tonic::server::UnaryService<super::Peer>
+                    for AddPeerAsParticipantSvc<T> {
+                        type Response = ();
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Peer>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).add_peer_as_participant(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = AddPeerAsParticipantSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3486,7 +3486,8 @@ pub mod raft_client {
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/Send");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Send to bootstrap
+        /// Send to bootstrap peer
+        /// Returns uri by id if bootstrap knows this peer
         pub async fn who_is(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerId>,
@@ -3504,8 +3505,8 @@ pub mod raft_client {
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/WhoIs");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Send to bootstrap
-        /// Proposes to add to known_peers list
+        /// Send to bootstrap peer
+        /// Proposes to add this peer Uri and ID to a map of all peers
         /// Returns all peers
         pub async fn add_peer_to_known(
             &mut self,
@@ -3526,8 +3527,8 @@ pub mod raft_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Send to bootstrap
-        /// Proposes to add to consensus as learner peer
+        /// Send to bootstrap peer
+        /// Proposes to add this peer as participant of consensus
         pub async fn add_peer_as_participant(
             &mut self,
             request: impl tonic::IntoRequest<super::Peer>,
@@ -3561,20 +3562,21 @@ pub mod raft_server {
             &self,
             request: tonic::Request<super::RaftMessage>,
         ) -> Result<tonic::Response<()>, tonic::Status>;
-        /// Send to bootstrap
+        /// Send to bootstrap peer
+        /// Returns uri by id if bootstrap knows this peer
         async fn who_is(
             &self,
             request: tonic::Request<super::PeerId>,
         ) -> Result<tonic::Response<super::Uri>, tonic::Status>;
-        /// Send to bootstrap
-        /// Proposes to add to known_peers list
+        /// Send to bootstrap peer
+        /// Proposes to add this peer Uri and ID to a map of all peers
         /// Returns all peers
         async fn add_peer_to_known(
             &self,
             request: tonic::Request<super::Peer>,
         ) -> Result<tonic::Response<super::AllPeers>, tonic::Status>;
-        /// Send to bootstrap
-        /// Proposes to add to consensus as learner peer
+        /// Send to bootstrap peer
+        /// Proposes to add this peer as participant of consensus
         async fn add_peer_as_participant(
             &self,
             request: tonic::Request<super::Peer>,

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,6 +1,4 @@
 use collection::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
-#[cfg(feature = "consensus")]
-use raft::eraftpb::Entry as RaftEntry;
 use schemars::JsonSchema;
 use segment::types::Distance;
 use serde::{Deserialize, Serialize};
@@ -149,13 +147,4 @@ pub enum CollectionMetaOperations {
     UpdateCollection(UpdateCollectionOperation),
     DeleteCollection(DeleteCollectionOperation),
     ChangeAliases(ChangeAliasesOperation),
-}
-
-#[cfg(feature = "consensus")]
-impl TryFrom<&RaftEntry> for CollectionMetaOperations {
-    type Error = serde_cbor::Error;
-
-    fn try_from(entry: &RaftEntry) -> Result<Self, Self::Error> {
-        serde_cbor::from_slice(entry.get_data())
-    }
 }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -6,3 +6,27 @@ pub mod errors;
 #[cfg(feature = "consensus")]
 pub mod raft_state;
 pub mod toc;
+
+#[cfg(feature = "consensus")]
+pub mod consensus_ops {
+    use collection::PeerId;
+    use raft::eraftpb::Entry as RaftEntry;
+    use serde::{Deserialize, Serialize};
+
+    use super::collection_meta_ops::CollectionMetaOperations;
+
+    /// Operation that should pass consensus
+    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+    pub enum ConsensusOperations {
+        CollectionMeta(Box<CollectionMetaOperations>),
+        AddPeer(PeerId, String),
+    }
+
+    impl TryFrom<&RaftEntry> for ConsensusOperations {
+        type Error = serde_cbor::Error;
+
+        fn try_from(entry: &RaftEntry) -> Result<Self, Self::Error> {
+            serde_cbor::from_slice(entry.get_data())
+        }
+    }
+}

--- a/lib/storage/src/content_manager/raft_state.rs
+++ b/lib/storage/src/content_manager/raft_state.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use atomicwrites::{AtomicFile, OverwriteBehavior::AllowOverwrite};
+use collection::PeerId;
 use itertools::Itertools;
 use prost::Message;
 use raft::{
@@ -14,6 +15,7 @@ use raft::{
     RaftState,
 };
 use serde::{Deserialize, Serialize};
+use tonic::transport::Uri;
 
 use crate::types::PeerAddressById;
 
@@ -110,6 +112,19 @@ impl Persistent {
         self.save()
     }
 
+    pub fn set_peer_address_by_id(
+        &mut self,
+        peer_address_by_id: PeerAddressById,
+    ) -> Result<(), StorageError> {
+        *self.peer_address_by_id.write()? = PeerAddressByIdWrapper(peer_address_by_id);
+        self.save()
+    }
+
+    pub fn insert_peer(&mut self, peer_id: PeerId, address: Uri) -> Result<(), StorageError> {
+        self.peer_address_by_id.write()?.0.insert(peer_id, address);
+        self.save()
+    }
+
     pub fn peer_address_by_id(&self) -> Result<PeerAddressById, StorageError> {
         let peer_address_by_id = &self.peer_address_by_id.read()?;
         Ok(peer_address_by_id.0.clone())
@@ -151,10 +166,11 @@ impl Persistent {
     }
 }
 
+/// Serializable [`PeerAddressById`]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(try_from = "HashMap<u64, String>")]
 #[serde(into = "HashMap<u64, String>")]
-struct PeerAddressByIdWrapper(PeerAddressById);
+pub struct PeerAddressByIdWrapper(pub PeerAddressById);
 
 impl From<PeerAddressByIdWrapper> for HashMap<u64, String> {
     fn from(wrapper: PeerAddressByIdWrapper) -> Self {

--- a/lib/storage/src/content_manager/raft_state.rs
+++ b/lib/storage/src/content_manager/raft_state.rs
@@ -121,7 +121,14 @@ impl Persistent {
     }
 
     pub fn insert_peer(&mut self, peer_id: PeerId, address: Uri) -> Result<(), StorageError> {
-        self.peer_address_by_id.write()?.0.insert(peer_id, address);
+        if let Some(prev_peer_address) = self
+            .peer_address_by_id
+            .write()?
+            .0
+            .insert(peer_id, address.clone())
+        {
+            log::warn!("Replaced address of peer {peer_id} from {prev_peer_address} to {address}");
+        }
         self.save()
     }
 

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -1,14 +1,23 @@
 use crate::consensus;
-use api::grpc::qdrant::{raft_server::Raft, RaftMessage as RaftMessageBytes};
+use api::grpc::qdrant::{
+    raft_server::Raft, AllPeers, Peer, PeerId, RaftMessage as RaftMessageBytes, Uri as UriStr,
+};
 use raft::eraftpb::Message as RaftMessage;
-use std::sync::{mpsc::SyncSender, Mutex};
+use std::sync::{mpsc::SyncSender, Arc, Mutex};
+use storage::content_manager::{consensus_ops::ConsensusOperations, toc::TableOfContent};
 use tonic::{async_trait, Request, Response, Status};
 
-pub struct RaftService(Mutex<SyncSender<consensus::Message>>);
+pub struct RaftService {
+    message_sender: Mutex<SyncSender<consensus::Message>>,
+    toc: Arc<TableOfContent>,
+}
 
 impl RaftService {
-    pub fn new(sender: SyncSender<consensus::Message>) -> Self {
-        Self(Mutex::new(sender))
+    pub fn new(sender: SyncSender<consensus::Message>, toc: Arc<TableOfContent>) -> Self {
+        Self {
+            message_sender: Mutex::new(sender),
+            toc,
+        }
     }
 }
 
@@ -19,11 +28,58 @@ impl Raft for RaftService {
             .map_err(|err| {
                 Status::invalid_argument(format!("Failed to parse raft message: {err}"))
             })?;
-        self.0
+        self.message_sender
             .lock()
             .map_err(|_| Status::internal("Can't capture the Raft message sender lock"))?
             .send(consensus::Message::FromPeer(Box::new(message)))
             .map_err(|_| Status::internal("Can't send Raft message over channel"))?;
         Ok(Response::new(()))
+    }
+
+    async fn who_is(
+        &self,
+        request: tonic::Request<PeerId>,
+    ) -> Result<tonic::Response<UriStr>, tonic::Status> {
+        let addresses = self
+            .toc
+            .peer_address_by_id()
+            .map_err(|err| Status::internal(format!("Can't get peer addresses: {err}")))?;
+        let uri = addresses
+            .get(&request.get_ref().id)
+            .ok_or_else(|| Status::internal("Peer not found"))?;
+        Ok(Response::new(UriStr {
+            uri: uri.to_string(),
+        }))
+    }
+
+    async fn add_peer_to_known(
+        &self,
+        request: tonic::Request<Peer>,
+    ) -> Result<tonic::Response<AllPeers>, tonic::Status> {
+        let peer = request.into_inner();
+        self.toc
+            .propose_consensus_op(ConsensusOperations::AddPeer(peer.id, peer.uri), None)
+            .await
+            .map_err(|err| Status::internal(format!("Failed to add peer: {err}")))?;
+        let addresses = self
+            .toc
+            .peer_address_by_id()
+            .map_err(|err| Status::internal(format!("Can't get peer addresses: {err}")))?;
+        Ok(Response::new(AllPeers {
+            all_peers: addresses
+                .into_iter()
+                .map(|(id, uri)| Peer {
+                    id,
+                    uri: uri.to_string(),
+                })
+                .collect(),
+        }))
+    }
+
+    async fn add_peer_as_participant(
+        &self,
+        _request: tonic::Request<Peer>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        todo!();
     }
 }

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -95,7 +95,7 @@ pub fn init_internal(
             let service = QdrantService::default();
             let collections_internal_service = CollectionsInternalService::new(toc.clone());
             let points_internal_service = PointsInternalService::new(toc.clone());
-            let raft_service = RaftService::new(to_consensus);
+            let raft_service = RaftService::new(to_consensus, toc.clone());
 
             log::info!("Qdrant internal gRPC listening on {}", internal_grpc_port);
 


### PR DESCRIPTION
## Changes
1. Peer address to id map is synced with consensus
2. New peers still have to pre-fetch the addresses as otherwise they will not be able to answer during sync (consequently failing sync)
3. For pre-fetching addresses and requesting peer addition bootstrap logic is introduced (CLI args, API, logic in consensus module)

## Issue
Closes https://github.com/qdrant/qdrant/issues/514

## Out of scope
1. Adding peer to consensus https://github.com/qdrant/qdrant/issues/530
2. Tests? 
At this stage they might not be very useful for bootstrap logic. After we implement https://github.com/qdrant/qdrant/issues/530 though we will be able to test the whole peer addresses sync.
