### PR TITLE
document flaky test and add more info in case of failure

### DIFF
--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -200,11 +200,12 @@ mod tests {
                 estimation
             );
 
+            // warning: report flakiness at https://github.com/qdrant/qdrant/issues/534
             plain_result
                 .iter()
                 .zip(struct_result.iter())
                 .for_each(|(r1, r2)| {
-                    assert_eq!(r1.id, r2.id);
+                    assert_eq!(r1.id, r2.id, "got different ScoredPoint {:?} and {:?} for\nquery vector {:?}\nquery filter {:?}\nplain result {:?}\nstruct result{:?}", r1, r2, query_vector, query_filter, plain_result, struct_result);
                     assert!((r1.score - r2.score) < 0.0001)
                 });
         }


### PR DESCRIPTION
This PR documents and improve the error reporting for #534 

I have tried different strategies to reproduce the bug locally but none worked out:
- repeating the whole test many times
- increasing the number of `attempts`
- repeating the whole test many times with a different `StdRng::seed_from_u64`

Hopefully we will get more info next time it fails.
