### PR TITLE
[Sharding] Introduce cluster configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,21 +87,3 @@ service:
   grpc_port: null
   # Uncomment to enable gRPC:
   # grpc_port: 6334
-
-cluster:
-  p2p:
-    # gRPC port to bind the internal p2p service on.
-    p2p_port: 6335
-    # gRPC timeout to apply for p2p communication.
-    p2p_grpc_timeout_ms: 1000
-
-  # consensus related configuration
-  consensus:
-    # max number of Raft messages in-flight
-    max_in_flight_messages: 100
-    # ticking period to drive Raft
-    tick_period_ms: 100
-    # timeout to send Raft messages
-    message_timeout_ms: 1000
-    # timeout to retrieve existing peers
-    bootstrap_timeout_sec: 5

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,3 +87,21 @@ service:
   grpc_port: null
   # Uncomment to enable gRPC:
   # grpc_port: 6334
+
+cluster:
+  p2p:
+    # gRPC port to bind the internal p2p service on.
+    p2p_port: 6335
+    # gRPC timeout to apply for p2p communication.
+    p2p_grpc_timeout_ms: 1000
+
+  # consensus related configuration
+  consensus:
+    # max number of Raft messages in-flight
+    max_in_flight_messages: 100
+    # ticking period to drive Raft
+    tick_period_ms: 100
+    # timeout to send Raft messages
+    message_timeout_ms: 1000
+    # timeout to retrieve existing peers
+    bootstrap_timeout_sec: 5

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -7,8 +7,6 @@ service:
   http_port: 6333
   # Uncomment to enable gRPC:
   #grpc_port: 6334
-  # Uncomment to enable internal gRPC:
-  #internal_grpc_port: 6335
 
 
 storage:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -7,5 +7,3 @@ service:
   http_port: 6333
   # Uncomment to enable gRPC:
   #grpc_port: 6334
-  # Uncomment to enable internal gRPC:
-  #internal_grpc_port: 6335

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -39,10 +39,8 @@ pub struct RemoteShard {
     pub(crate) collection_id: CollectionId,
     pub peer_id: PeerId,
     ip_to_address: Arc<std::sync::RwLock<HashMap<u64, Uri>>>,
+    p2p_grpc_timeout: Duration,
 }
-
-// TODO add to consensus config
-const GRPC_TIMEOUT: Duration = Duration::from_millis(1000);
 
 // TODO pool channels
 impl RemoteShard {
@@ -60,7 +58,7 @@ impl RemoteShard {
 
     async fn points_client(&self) -> CollectionResult<PointsInternalClient<Timeout<Channel>>> {
         let current_address = self.current_address()?;
-        let timeout_channel = timeout_channel(GRPC_TIMEOUT, current_address).await?;
+        let timeout_channel = timeout_channel(self.p2p_grpc_timeout, current_address).await?;
         Ok(PointsInternalClient::new(timeout_channel))
     }
 
@@ -68,7 +66,7 @@ impl RemoteShard {
         &self,
     ) -> CollectionResult<CollectionsInternalClient<Timeout<Channel>>> {
         let current_address = self.current_address()?;
-        let timeout_channel = timeout_channel(GRPC_TIMEOUT, current_address).await?;
+        let timeout_channel = timeout_channel(self.p2p_grpc_timeout, current_address).await?;
         Ok(CollectionsInternalClient::new(timeout_channel))
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -13,14 +14,10 @@ use api::grpc::{
 };
 use storage::content_manager::{errors::StorageError, toc::TableOfContentRef};
 
+use crate::settings::ConsensusConfig;
 use raft::{eraftpb::Message as RaftMessage, prelude::*};
 use tokio::runtime::Runtime;
 use tonic::transport::Uri;
-
-const CHANNEL_CAPACITY: usize = 100;
-const TICK_PERIOD_MS: u64 = 100;
-const MESSAGE_TIMEOUT: Duration = Duration::from_millis(1000);
-const BOOTSTRAP_TIMEOUT: Duration = Duration::from_millis(5000);
 
 type Node = RawNode<TableOfContentRef>;
 
@@ -34,6 +31,7 @@ pub struct Consensus {
     receiver: Receiver<Message>,
     runtime: Runtime,
     bootstrap_uri: Option<Uri>,
+    config: ConsensusConfig,
 }
 
 impl Consensus {
@@ -44,12 +42,13 @@ impl Consensus {
         bootstrap_peer: Option<Uri>,
         uri: Option<String>,
         p2p_port: Option<u32>,
+        config: ConsensusConfig,
     ) -> anyhow::Result<(Self, SyncSender<Message>)> {
-        let config = Config {
+        let raft_config = Config {
             id: toc_ref.this_peer_id(),
             ..Default::default()
         };
-        config.validate()?;
+        raft_config.validate()?;
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .thread_name_fn(|| {
                 static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
@@ -63,21 +62,28 @@ impl Consensus {
             if uri.is_none() && p2p_port.is_none() {
                 return Err(anyhow::anyhow!("Failed to bootstrap peer as neither `internal rpc port` was configured nor `this peer uri` was supplied"));
             }
-            runtime.block_on(Self::bootstrap(&toc_ref, bootstrap_peer, uri, p2p_port))?;
+            runtime.block_on(Self::bootstrap(
+                &toc_ref,
+                bootstrap_peer,
+                uri,
+                p2p_port,
+                &config,
+            ))?;
         } else {
             log::info!("Bootstrapping is disabled. Assuming this peer is the first in the network")
         }
         // Before consensus has started apply any unapplied committed entries
         // They might have not been applied due to unplanned Qdrant shutdown
         toc_ref.apply_entries()?;
-        let node = Node::new(&config, toc_ref, logger)?;
-        let (sender, receiver) = mpsc::sync_channel(CHANNEL_CAPACITY);
+        let node = Node::new(&raft_config, toc_ref, logger)?;
+        let (sender, receiver) = mpsc::sync_channel(config.max_in_flight_messages);
         Ok((
             Self {
                 node,
                 receiver,
                 runtime,
                 bootstrap_uri: bootstrap_peer,
+                config,
             },
             sender,
         ))
@@ -88,10 +94,14 @@ impl Consensus {
         bootstrap_peer: Uri,
         uri: Option<String>,
         p2p_port: Option<u32>,
+        config: &ConsensusConfig,
     ) -> anyhow::Result<()> {
-        let channel = timeout_channel(BOOTSTRAP_TIMEOUT, bootstrap_peer)
-            .await
-            .context("Failed to create timeout channel")?;
+        let channel = timeout_channel(
+            Duration::from_secs(config.bootstrap_timeout_sec),
+            bootstrap_peer,
+        )
+        .await
+        .context("Failed to create timeout channel")?;
         let mut client = RaftClient::new(channel);
         let all_peers = client
             .add_peer_to_known(tonic::Request::new(
@@ -120,7 +130,7 @@ impl Consensus {
 
     pub fn start(&mut self) -> anyhow::Result<()> {
         let mut t = Instant::now();
-        let mut timeout = Duration::from_millis(TICK_PERIOD_MS);
+        let mut timeout = Duration::from_millis(self.config.tick_period_ms);
 
         loop {
             match self.receiver.recv_timeout(timeout) {
@@ -139,18 +149,28 @@ impl Consensus {
             let d = t.elapsed();
             t = Instant::now();
             if d >= timeout {
-                timeout = Duration::from_millis(TICK_PERIOD_MS);
-                // We drive Raft every 100ms.
+                timeout = Duration::from_millis(self.config.tick_period_ms);
+                // We drive Raft every `tick_period_ms`.
                 self.node.tick();
             } else {
                 timeout -= d;
             }
-            on_ready(&mut self.node, &self.runtime, &self.bootstrap_uri);
+            on_ready(
+                &mut self.node,
+                &self.runtime,
+                &self.bootstrap_uri,
+                &self.config,
+            );
         }
     }
 }
 
-fn on_ready(raft_group: &mut Node, runtime: &Runtime, bootstrap_uri: &Option<Uri>) {
+fn on_ready(
+    raft_group: &mut Node,
+    runtime: &Runtime,
+    bootstrap_uri: &Option<Uri>,
+    config: &ConsensusConfig,
+) {
     if !raft_group.has_ready() {
         return;
     }
@@ -159,7 +179,13 @@ fn on_ready(raft_group: &mut Node, runtime: &Runtime, bootstrap_uri: &Option<Uri
     // Get the `Ready` with `RawNode::ready` interface.
     let mut ready = raft_group.ready();
     if !ready.messages().is_empty() {
-        if let Err(err) = handle_messages(ready.take_messages(), &store, runtime, bootstrap_uri) {
+        if let Err(err) = handle_messages(
+            ready.take_messages(),
+            &store,
+            runtime,
+            bootstrap_uri,
+            config,
+        ) {
             log::error!("Failed to send messages: {err}")
         }
     }
@@ -193,6 +219,7 @@ fn on_ready(raft_group: &mut Node, runtime: &Runtime, bootstrap_uri: &Option<Uri
             &store,
             runtime,
             bootstrap_uri,
+            config,
         ) {
             log::error!("Failed to send messages: {err}")
         }
@@ -207,7 +234,13 @@ fn on_ready(raft_group: &mut Node, runtime: &Runtime, bootstrap_uri: &Option<Uri
             log::error!("Failed to set commit index: {err}")
         }
     }
-    if let Err(err) = handle_messages(light_rd.take_messages(), &store, runtime, bootstrap_uri) {
+    if let Err(err) = handle_messages(
+        light_rd.take_messages(),
+        &store,
+        runtime,
+        bootstrap_uri,
+        config,
+    ) {
         log::error!("Failed to send messages: {err}")
     }
     // Apply all committed entries.
@@ -231,6 +264,7 @@ fn handle_messages(
     toc: &TableOfContentRef,
     runtime: &Runtime,
     bootstrap_uri: &Option<Uri>,
+    config: &ConsensusConfig,
 ) -> Result<(), StorageError> {
     let peer_address_by_id = toc.peer_address_by_id()?;
     let messages_with_address: Vec<_> = messages
@@ -241,12 +275,19 @@ fn handle_messages(
         })
         .collect();
     let bootstrap_uri = bootstrap_uri.clone();
+    let consensus_config_arc = Arc::new(config.clone());
     let future = async move {
         let mut send_futures = Vec::new();
         for (message, address) in messages_with_address {
             let address = match address {
                 Some(address) => address,
-                None => match who_is(message.to, bootstrap_uri.clone()).await {
+                None => match who_is(
+                    message.to,
+                    bootstrap_uri.clone(),
+                    consensus_config_arc.clone(),
+                )
+                .await
+                {
                     Ok(address) => address,
                     Err(_) => {
                         log::warn!(
@@ -257,7 +298,7 @@ fn handle_messages(
                     }
                 },
             };
-            send_futures.push(send_message(address, message));
+            send_futures.push(send_message(address, message, consensus_config_arc.clone()));
         }
         for result in futures::future::join_all(send_futures).await {
             if let Err(err) = result {
@@ -271,10 +312,15 @@ fn handle_messages(
     Ok(())
 }
 
-async fn who_is(peer_id: collection::PeerId, bootstrap_uri: Option<Uri>) -> anyhow::Result<Uri> {
+async fn who_is(
+    peer_id: collection::PeerId,
+    bootstrap_uri: Option<Uri>,
+    config: Arc<ConsensusConfig>,
+) -> anyhow::Result<Uri> {
     let bootstrap_uri =
         bootstrap_uri.ok_or_else(|| anyhow::anyhow!("No bootstrap uri supplied"))?;
-    let channel = timeout_channel(BOOTSTRAP_TIMEOUT, bootstrap_uri)
+    let bootstrap_timeout = Duration::from_secs(config.bootstrap_timeout_sec);
+    let channel = timeout_channel(bootstrap_timeout, bootstrap_uri)
         .await
         .context("Failed to create timeout channel")?;
     let mut client = RaftClient::new(channel);
@@ -286,8 +332,13 @@ async fn who_is(peer_id: collection::PeerId, bootstrap_uri: Option<Uri>) -> anyh
         .parse()?)
 }
 
-async fn send_message(address: Uri, message: RaftMessage) -> anyhow::Result<()> {
-    let channel = timeout_channel(MESSAGE_TIMEOUT, address)
+async fn send_message(
+    address: Uri,
+    message: RaftMessage,
+    config: Arc<ConsensusConfig>,
+) -> anyhow::Result<()> {
+    let message_timeout = Duration::from_millis(config.message_timeout_ms);
+    let channel = timeout_channel(message_timeout, address)
         .await
         .context("Failed to create timeout channel")?;
     let mut client = RaftClient::new(channel);
@@ -306,6 +357,7 @@ async fn send_message(address: Uri, message: RaftMessage) -> anyhow::Result<()> 
 mod tests {
     use std::{sync::Arc, thread, time::Duration};
 
+    use crate::settings::ConsensusConfig;
     use segment::types::Distance;
     use slog::Drain;
     use storage::content_manager::{
@@ -333,8 +385,15 @@ mod tests {
         toc.with_propose_sender(propose_sender);
         let toc_arc = Arc::new(toc);
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
-        let (mut consensus, message_sender) =
-            Consensus::new(&slog_logger, toc_arc.clone().into(), None, None, None).unwrap();
+        let (mut consensus, message_sender) = Consensus::new(
+            &slog_logger,
+            toc_arc.clone().into(),
+            None,
+            None,
+            None,
+            ConsensusConfig::default(),
+        )
+        .unwrap();
         thread::spawn(move || consensus.start().unwrap());
         thread::spawn(move || {
             while let Ok(entry) = propose_receiver.recv() {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -76,7 +76,7 @@ impl Consensus {
         // They might have not been applied due to unplanned Qdrant shutdown
         toc_ref.apply_entries()?;
         let node = Node::new(&raft_config, toc_ref, logger)?;
-        let (sender, receiver) = mpsc::sync_channel(config.max_in_flight_messages);
+        let (sender, receiver) = mpsc::sync_channel(config.max_message_queue_size);
         Ok((
             Self {
                 node,

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ fn main() -> std::io::Result<()> {
             toc_arc.clone().into(),
             args.bootstrap,
             args.uri.map(|uri| uri.to_string()),
-            settings.service.internal_grpc_port.map(|port| port as u32),
+            settings.cluster.p2p.p2p_port.map(|port| port as u32),
+            settings.cluster.consensus.clone(),
         )
         .expect("Can't initialize consensus");
         thread::Builder::new()
@@ -108,7 +109,7 @@ fn main() -> std::io::Result<()> {
                 }
             })?;
 
-        if let Some(internal_grpc_port) = settings.service.internal_grpc_port {
+        if let Some(internal_grpc_port) = settings.cluster.p2p.p2p_port {
             let toc_arc = toc_arc.clone();
             let settings = settings.clone();
             let handle = thread::Builder::new()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,31 +14,49 @@ pub struct ServiceConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClusterConfig {
+    pub enabled: bool, // TODO use with https://github.com/qdrant/qdrant/issues/511
+    #[serde(default)]
     pub p2p: P2pConfig,
+    #[serde(default)]
     pub consensus: ConsensusConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct P2pConfig {
+    #[serde(default)]
     pub p2p_port: Option<u16>,
+    #[serde(default = "default_timeout_ms")]
     pub p2p_grpc_timeout_ms: u64,
+}
+
+impl Default for P2pConfig {
+    fn default() -> Self {
+        P2pConfig {
+            p2p_port: None,
+            p2p_grpc_timeout_ms: default_timeout_ms(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ConsensusConfig {
+    #[serde(default = "default_max_in_flight_messages")]
     pub max_in_flight_messages: usize,
+    #[serde(default = "default_tick_period_ms")]
     pub tick_period_ms: u64,
+    #[serde(default = "default_timeout_ms")]
     pub message_timeout_ms: u64,
+    #[serde(default = "default_bootstrap_timeout_sec")]
     pub bootstrap_timeout_sec: u64,
 }
 
 impl Default for ConsensusConfig {
     fn default() -> Self {
         ConsensusConfig {
-            max_in_flight_messages: 100,
-            tick_period_ms: 100,
-            message_timeout_ms: 1000,
-            bootstrap_timeout_sec: 5,
+            max_in_flight_messages: default_max_in_flight_messages(),
+            tick_period_ms: default_tick_period_ms(),
+            message_timeout_ms: default_timeout_ms(),
+            bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
         }
     }
 }
@@ -49,7 +67,32 @@ pub struct Settings {
     pub log_level: String,
     pub storage: StorageConfig,
     pub service: ServiceConfig,
+    #[serde(default = "default_cluster_config")]
     pub cluster: ClusterConfig,
+}
+
+fn default_cluster_config() -> ClusterConfig {
+    ClusterConfig {
+        enabled: false, //disabled by default
+        p2p: P2pConfig::default(),
+        consensus: ConsensusConfig::default(),
+    }
+}
+
+fn default_timeout_ms() -> u64 {
+    1000
+}
+
+fn default_tick_period_ms() -> u64 {
+    100
+}
+
+fn default_bootstrap_timeout_sec() -> u64 {
+    5
+}
+
+fn default_max_in_flight_messages() -> usize {
+    100
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,23 +12,13 @@ pub struct ServiceConfig {
     pub max_workers: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct ClusterConfig {
-    pub enabled: bool, // TODO use with https://github.com/qdrant/qdrant/issues/511
+    pub enabled: bool, // disabled by default - TODO use with https://github.com/qdrant/qdrant/issues/511
     #[serde(default)]
     pub p2p: P2pConfig,
     #[serde(default)]
     pub consensus: ConsensusConfig,
-}
-
-impl Default for ClusterConfig {
-    fn default() -> Self {
-        ClusterConfig {
-            enabled: false, //disabled by default
-            p2p: P2pConfig::default(),
-            consensus: ConsensusConfig::default(),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,9 +8,39 @@ pub struct ServiceConfig {
     pub host: String,
     pub http_port: u16,
     pub grpc_port: Option<u16>, // None means that gRPC is disabled
-    pub internal_grpc_port: Option<u16>, // None means that the internal gRPC is disabled
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ClusterConfig {
+    pub p2p: P2pConfig,
+    pub consensus: ConsensusConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct P2pConfig {
+    pub p2p_port: Option<u16>,
+    pub p2p_grpc_timeout_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ConsensusConfig {
+    pub max_in_flight_messages: usize,
+    pub tick_period_ms: u64,
+    pub message_timeout_ms: u64,
+    pub bootstrap_timeout_sec: u64,
+}
+
+impl Default for ConsensusConfig {
+    fn default() -> Self {
+        ConsensusConfig {
+            max_in_flight_messages: 100,
+            tick_period_ms: 100,
+            message_timeout_ms: 1000,
+            bootstrap_timeout_sec: 5,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -19,6 +49,7 @@ pub struct Settings {
     pub log_level: String,
     pub storage: StorageConfig,
     pub service: ServiceConfig,
+    pub cluster: ClusterConfig,
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,16 @@ pub struct ClusterConfig {
     pub consensus: ConsensusConfig,
 }
 
+impl Default for ClusterConfig {
+    fn default() -> Self {
+        ClusterConfig {
+            enabled: false, //disabled by default
+            p2p: P2pConfig::default(),
+            consensus: ConsensusConfig::default(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct P2pConfig {
     #[serde(default)]
@@ -40,8 +50,8 @@ impl Default for P2pConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ConsensusConfig {
-    #[serde(default = "default_max_in_flight_messages")]
-    pub max_in_flight_messages: usize,
+    #[serde(default = "default_max_message_queue_size")]
+    pub max_message_queue_size: usize, // controls the back-pressure at the Raft level
     #[serde(default = "default_tick_period_ms")]
     pub tick_period_ms: u64,
     #[serde(default = "default_timeout_ms")]
@@ -53,7 +63,7 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> Self {
         ConsensusConfig {
-            max_in_flight_messages: default_max_in_flight_messages(),
+            max_message_queue_size: default_max_message_queue_size(),
             tick_period_ms: default_tick_period_ms(),
             message_timeout_ms: default_timeout_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
@@ -67,16 +77,8 @@ pub struct Settings {
     pub log_level: String,
     pub storage: StorageConfig,
     pub service: ServiceConfig,
-    #[serde(default = "default_cluster_config")]
+    #[serde(default)]
     pub cluster: ClusterConfig,
-}
-
-fn default_cluster_config() -> ClusterConfig {
-    ClusterConfig {
-        enabled: false, //disabled by default
-        p2p: P2pConfig::default(),
-        consensus: ConsensusConfig::default(),
-    }
 }
 
 fn default_timeout_ms() -> u64 {
@@ -91,7 +93,7 @@ fn default_bootstrap_timeout_sec() -> u64 {
     5
 }
 
-fn default_max_in_flight_messages() -> usize {
+fn default_max_message_queue_size() -> usize {
     100
 }
 


### PR DESCRIPTION
This PR introduce a proper configuration for the distributed deployment. #495

One decision I took is to separate the `consensus` configuration from the strictly `p2p` configuration as there are kind of orthogonal.

The cluster deployment is still hidden behind the compile time flag `--features consensus`, it will be addressed later on in #511.