### PR TITLE
Return a JSON body in case of JSON decoding error

### DIFF
--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -19,6 +19,20 @@ curl -X PUT "http://$QDRANT_HOST/collections/test_collection" \
       "distance": "Dot"
     }' | jq
 
+# fail to decode payload
+JSON_ERROR=$(curl -X PUT "http://$QDRANT_HOST/collections/test_collection" \
+  -H 'Content-Type: application/json' \
+  -s \
+  --data-raw '{
+      "vector_size": 4,
+      "distance": "Dots"
+    }' | jq '.status.error')
+JSON_ERROR_EXPECTED='"Json deserialize error: unknown variant `Dots`, expected one of `Cosine`, `Euclid`, `Dot` at line 3 column 24"'
+[[ "$JSON_ERROR" == "$JSON_ERROR_EXPECTED" ]] || {
+  echo 'check failed - unexpected error'
+  exit 1
+}
+
 curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq
 
 # insert points


### PR DESCRIPTION
This PR tackles the issue #555 

The JSON decoding of input payload takes place in the Actix infrastructure in order to enable endpoints to handle directly the deserialized objects.

However this infra. does not follow the same convention as the errors created by the endpoints directly, in this case it returns error as plain text.

This PR fixes our `json_error_handler` called by Actix in order to serve a JSON error payload in those cases as well.