### PR TITLE
gRPC int payload

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -8,7 +8,7 @@ use crate::grpc::qdrant::{
     GeoBoundingBox, GeoPoint, GeoRadius, HasIdCondition, HealthCheckReply, HnswConfigDiff,
     IsEmptyCondition, ListCollectionsResponse, ListValue, Match, PayloadExcludeSelector,
     PayloadIncludeSelector, PayloadSchemaInfo, PayloadSchemaType, PointId, Range, ScoredPoint,
-    SearchParams, Value, Struct, ValuesCount, WithPayloadSelector,
+    SearchParams, Struct, Value, ValuesCount, WithPayloadSelector,
 };
 
 use crate::grpc::qdrant::value::Kind;
@@ -58,9 +58,7 @@ fn json_to_proto(json_value: serde_json::Value) -> Value {
     }
 }
 
-pub fn proto_to_payloads(
-    proto: HashMap<String, Value>,
-) -> Result<segment::types::Payload, Status> {
+pub fn proto_to_payloads(proto: HashMap<String, Value>) -> Result<segment::types::Payload, Status> {
     let mut map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
     for (k, v) in proto.into_iter() {
         map.insert(k, proto_to_json(v)?);

--- a/lib/api/src/grpc/proto/json_with_int.proto
+++ b/lib/api/src/grpc/proto/json_with_int.proto
@@ -1,0 +1,61 @@
+// Fork of the google.protobuf.Value with explicit support for integer values
+
+syntax = "proto3";
+
+package qdrant;
+
+// `Struct` represents a structured data value, consisting of fields
+// which map to dynamically typed values. In some languages, `Struct`
+// might be supported by a native representation. For example, in
+// scripting languages like JS a struct is represented as an
+// object. The details of that representation are described together
+// with the proto support for the language.
+//
+// The JSON representation for `Struct` is JSON object.
+message Struct {
+  // Unordered map of dynamically typed values.
+  map<string, Value> fields = 1;
+}
+
+// `Value` represents a dynamically typed value which can be either
+// null, a number, a string, a boolean, a recursive struct value, or a
+// list of values. A producer of value is expected to set one of that
+// variants, absence of any variant indicates an error.
+//
+// The JSON representation for `Value` is JSON value.
+message Value {
+  // The kind of value.
+  oneof kind {
+    // Represents a null value.
+    NullValue null_value = 1;
+    // Represents a double value.
+    double double_value = 2;
+    // Represents an integer value
+    int64 integer_value = 3;
+    // Represents a string value.
+    string string_value = 4;
+    // Represents a boolean value.
+    bool bool_value = 5;
+    // Represents a structured value.
+    Struct struct_value = 6;
+    // Represents a repeated `Value`.
+    ListValue list_value = 7;
+  }
+}
+
+// `NullValue` is a singleton enumeration to represent the null value for the
+// `Value` type union.
+//
+//  The JSON representation for `NullValue` is JSON `null`.
+enum NullValue {
+  // Null value.
+  NULL_VALUE = 0;
+}
+
+// `ListValue` is a wrapper around a repeated field of values.
+//
+// The JSON representation for `ListValue` is JSON array.
+message ListValue {
+  // Repeated field of dynamically typed values.
+  repeated Value values = 1;
+}

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package qdrant;
 
-import "google/protobuf/struct.proto";
+import "json_with_int.proto";
 
 // ---------------------------------------------
 // ------------- Point Id Requests -------------
@@ -42,7 +42,7 @@ message GetPoints {
 message SetPayloadPoints {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
-  map<string, google.protobuf.Value> payload = 3; // New payload values
+  map<string, Value> payload = 3; // New payload values
   repeated PointId points = 4; // List of point to modify
 }
 
@@ -80,11 +80,11 @@ message DeleteFieldIndexCollection {
 }
 
 message PayloadIncludeSelector {
-  repeated string include = 1; // List of payload keys to include into result
+  repeated string fields = 1; // List of payload keys to include into result
 }
 
 message PayloadExcludeSelector {
-  repeated string exclude = 1; // List of payload keys to exclude from the result
+  repeated string fields = 1; // List of payload keys to exclude from the result
 }
 
 message WithPayloadSelector {
@@ -157,7 +157,7 @@ enum UpdateStatus {
 
 message ScoredPoint {
   PointId id = 1; // Point id
-  map<string, google.protobuf.Value> payload = 2; // Payload
+  map<string, Value> payload = 2; // Payload
   float score = 3; // Similarity score
   repeated float vector = 4; // Vector
   uint64 version = 5; // Last update operation applied to this point
@@ -176,7 +176,7 @@ message ScrollResponse {
 
 message RetrievedPoint {
   PointId id = 1;
-  map<string, google.protobuf.Value> payload = 2;
+  map<string, Value> payload = 2;
   repeated float vector = 3;
 }
 
@@ -281,7 +281,7 @@ message PointsIdsList {
 message PointStruct {
   PointId id = 1;
   repeated float vector = 2;
-  map<string, google.protobuf.Value> payload = 3;
+  map<string, Value> payload = 3;
 }
 
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1090,6 +1090,79 @@ pub mod collections_internal_server {
         const NAME: &'static str = "qdrant.CollectionsInternal";
     }
 }
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Struct {
+    /// Unordered map of dynamically typed values.
+    #[prost(map="string, message", tag="1")]
+    pub fields: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+}
+/// `Value` represents a dynamically typed value which can be either
+/// null, a number, a string, a boolean, a recursive struct value, or a
+/// list of values. A producer of value is expected to set one of that
+/// variants, absence of any variant indicates an error.
+///
+/// The JSON representation for `Value` is JSON value.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Value {
+    /// The kind of value.
+    #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6, 7")]
+    pub kind: ::core::option::Option<value::Kind>,
+}
+/// Nested message and enum types in `Value`.
+pub mod value {
+    /// The kind of value.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        /// Represents a null value.
+        #[prost(enumeration="super::NullValue", tag="1")]
+        NullValue(i32),
+        /// Represents a double value.
+        #[prost(double, tag="2")]
+        DoubleValue(f64),
+        /// Represents an integer value
+        #[prost(int64, tag="3")]
+        IntegerValue(i64),
+        /// Represents a string value.
+        #[prost(string, tag="4")]
+        StringValue(::prost::alloc::string::String),
+        /// Represents a boolean value.
+        #[prost(bool, tag="5")]
+        BoolValue(bool),
+        /// Represents a structured value.
+        #[prost(message, tag="6")]
+        StructValue(super::Struct),
+        /// Represents a repeated `Value`.
+        #[prost(message, tag="7")]
+        ListValue(super::ListValue),
+    }
+}
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListValue {
+    /// Repeated field of dynamically typed values.
+    #[prost(message, repeated, tag="1")]
+    pub values: ::prost::alloc::vec::Vec<Value>,
+}
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+///  The JSON representation for `NullValue` is JSON `null`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NullValue {
+    /// Null value.
+    NullValue = 0,
+}
 // ---------------------------------------------
 // ------------- Point Id Requests -------------
 // ---------------------------------------------
@@ -1163,7 +1236,7 @@ pub struct SetPayloadPoints {
     pub wait: ::core::option::Option<bool>,
     /// New payload values
     #[prost(map="string, message", tag="3")]
-    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     /// List of point to modify
     #[prost(message, repeated, tag="4")]
     pub points: ::prost::alloc::vec::Vec<PointId>,
@@ -1226,13 +1299,13 @@ pub struct DeleteFieldIndexCollection {
 pub struct PayloadIncludeSelector {
     /// List of payload keys to include into result
     #[prost(string, repeated, tag="1")]
-    pub include: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PayloadExcludeSelector {
     /// List of payload keys to exclude from the result
     #[prost(string, repeated, tag="1")]
-    pub exclude: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WithPayloadSelector {
@@ -1359,7 +1432,7 @@ pub struct ScoredPoint {
     pub id: ::core::option::Option<PointId>,
     /// Payload
     #[prost(map="string, message", tag="2")]
-    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     /// Similarity score
     #[prost(float, tag="3")]
     pub score: f32,
@@ -1394,7 +1467,7 @@ pub struct RetrievedPoint {
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<PointId>,
     #[prost(map="string, message", tag="2")]
-    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     #[prost(float, repeated, tag="3")]
     pub vector: ::prost::alloc::vec::Vec<f32>,
 }
@@ -1574,7 +1647,7 @@ pub struct PointStruct {
     #[prost(float, repeated, tag="2")]
     pub vector: ::prost::alloc::vec::Vec<f32>,
     #[prost(map="string, message", tag="3")]
-    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPoint {

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -31,17 +31,17 @@ $docker_grpcurl -d '{
       "id": { "num": 1 },
       "vector": [0.05, 0.61, 0.76, 0.74],
       "payload": {
-        "city": "Berlin",
-        "country": "Germany",
-        "population": 1000000,
-        "square": 12.5,
-        "coords": { "lat": 1.0, "lon": 2.0 }
+        "city": { "string_value": "Berlin" },
+        "country":  { "string_value": "Germany" },
+        "population": { "integer_value":  1000000 },
+        "square": { "double_value": 12.5 },
+        "coords": { "struct_value": { "fields": { "lat": { "double_value": 1.0 }, "lon": { "double_value": 2.0 } } } }
       }
     },
-    {"id": { "num": 2 }, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"] }},
-    {"id": { "num": 3 }, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": ["Berlin", "Moscow"] }},
-    {"id": { "num": 4 }, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": ["London", "Moscow"] }},
-    {"id": { "num": 5 }, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count":[0]}},
+    {"id": { "num": 2 }, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "London" }]}}}},
+    {"id": { "num": 3 }, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "Moscow" }]}}}},
+    {"id": { "num": 4 }, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": {"list_value": {"values": [{ "string_value": "London" }, { "string_value": "Moscow" }]}}}},
+    {"id": { "num": 5 }, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count":{"list_value": {"values": [{ "integer_value": 0 }]}}}},
     {"id": { "num": 6 }, "vector": [0.35, 0.08, 0.11, 0.44]}
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
@@ -151,6 +151,15 @@ $docker_grpcurl -d '{
   ]
 }' $QDRANT_HOST qdrant.Collections/UpdateAliases
 
+
+$docker_grpcurl -d '{
+  "collection_name": "test_collection",
+  "with_vector": false,
+  "with_payload": {
+    "include": {"fields": ["population"]}
+  },
+  "ids": [{ "num": 1 }]
+}' $QDRANT_HOST qdrant.Points/Get
 
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
 #[[ "$SAVED_VECTORS_COUNT" == "6" ]] || {


### PR DESCRIPTION
### All Submissions:

related to https://github.com/qdrant/qdrant/issues/545

A bit controversial approach, from one point of view - `google.protobuf.Value` is a default way represent JSON in protobuf.
However, this implementation breaks integer representation pretty actively, e.g. it replaces `1` with `1.0` so that the returned data is not equivalent to uploaded.

Some tools like `grpcurl` have a special processing for "well-known-types" of google, that is why the test is so heavily modified.
On the other hand - python grpc client does not have this tricks and it is required to convert json into protobuf explicitly.
So on the client side it should be possible to support the change transparently.

In light of our assumption that grpc is a low-level tool, I think it would be acceptable to implement custom structures for it, allowing to control the process with more precision at the expense of some convenience.

Would like to hear other opinions.


* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?
