### PR TITLE
Switch consensus to a runtime configuration

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: .github/scripts/protoc.sh
         shell: bash
       - name: Build
-        run: cargo build --features consensus
+        run: cargo build
       - name: Run integration tests
-        run: ./tests/integration-tests.sh
+        run: ./tests/integration-tests.sh distributed
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,25 +30,6 @@ jobs:
     - name: Run tests
       run: cargo test --all
 
-  test-consensus:
-
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install minimal stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
-    - name: Install dependencies
-      run: sudo apt-get install clang
-    - name: Install protoc
-      run: .github/scripts/protoc.sh
-      shell: bash
-    - name: Test with consensus feature
-      run: cargo test --all --features consensus
-
 #   build:
 #     runs-on: ubuntu-latest
 #     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ doctest = false
 default = [ "web" ]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
-consensus = ["raft", "slog", "slog-stdlog", "storage/consensus", "prost"]
-
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -44,10 +42,10 @@ tonic = "0.7.1"
 num-traits = "0.2.15"
 
 # Consensus related crates
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false, optional = true }
-slog =  { version = "2.7.0", optional = true }
-slog-stdlog = { version = "4.1.1", optional = true }
-prost = { version = "=0.7.0", optional = true }
+raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false }
+slog =  { version = "2.7.0" }
+slog-stdlog = { version = "4.1.1" }
+prost = { version = "=0.7.0" }
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.2.0"
 authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
 edition = "2021"
 
-[features]
-consensus = ["raft", "prost", "serde_cbor", "atomicwrites"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -27,10 +24,10 @@ tonic = "0.7.1"
 http = "0.2"
 
 # Consensus related
-atomicwrites = { version = "0.3.1", optional = true }
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false, optional = true }
-prost = { version = "=0.7.0", optional = true } # version of prost used by raft
-serde_cbor = { version = "0.11.2", optional = true }
+atomicwrites = { version = "0.3.1" }
+raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false}
+prost = { version = "=0.7.0" } # version of prost used by raft
+serde_cbor = { version = "0.11.2" }
 
 segment = {path = "../segment"}
 collection = {path = "../collection"}

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -106,12 +106,10 @@ impl AliasPersistence {
         result
     }
 
-    #[cfg(feature = "consensus")]
     pub fn state(&self) -> &AliasMapping {
         &self.alias_mapping
     }
 
-    #[cfg(feature = "consensus")]
     pub fn apply_state(&mut self, alias_mapping: AliasMapping) -> Result<(), StorageError> {
         self.alias_mapping = alias_mapping;
         self.alias_mapping.save(&self.data_path)?;

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -92,7 +92,6 @@ impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
     }
 }
 
-#[cfg(feature = "consensus")]
 impl From<serde_cbor::Error> for StorageError {
     fn from(err: serde_cbor::Error) -> Self {
         StorageError::ServiceError {
@@ -101,7 +100,6 @@ impl From<serde_cbor::Error> for StorageError {
     }
 }
 
-#[cfg(feature = "consensus")]
 impl From<prost::EncodeError> for StorageError {
     fn from(err: prost::EncodeError) -> Self {
         StorageError::ServiceError {
@@ -110,7 +108,6 @@ impl From<prost::EncodeError> for StorageError {
     }
 }
 
-#[cfg(feature = "consensus")]
 impl From<prost::DecodeError> for StorageError {
     fn from(err: prost::DecodeError) -> Self {
         StorageError::ServiceError {
@@ -119,7 +116,6 @@ impl From<prost::DecodeError> for StorageError {
     }
 }
 
-#[cfg(feature = "consensus")]
 impl<E: std::fmt::Display> From<atomicwrites::Error<E>> for StorageError {
     fn from(err: atomicwrites::Error<E>) -> Self {
         StorageError::ServiceError {

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -3,11 +3,9 @@ pub mod collection_meta_ops;
 mod collections_ops;
 pub mod conversions;
 pub mod errors;
-#[cfg(feature = "consensus")]
 pub mod raft_state;
 pub mod toc;
 
-#[cfg(feature = "consensus")]
 pub mod consensus_ops {
     use collection::PeerId;
     use raft::eraftpb::Entry as RaftEntry;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -30,35 +30,24 @@ use crate::content_manager::{
     errors::StorageError,
 };
 use crate::types::StorageConfig;
-use collection::collection_manager::collection_managers::CollectionSearcher;
-use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
-use collection::shard::ShardId;
-
-#[cfg(feature = "consensus")]
 use crate::{
     content_manager::{
         consensus_ops::ConsensusOperations, raft_state::Persistent as PersistentRaftState,
     },
     types::PeerAddressById,
 };
-#[cfg(feature = "consensus")]
+use collection::collection_manager::collection_managers::CollectionSearcher;
+use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
+use collection::shard::ShardId;
 use collection::PeerId;
-#[cfg(feature = "consensus")]
+pub use consensus::TableOfContentRef;
 use raft::eraftpb::{Entry as RaftEntry, Snapshot as RaftSnapshot};
-#[cfg(feature = "consensus")]
 use tokio::sync::oneshot;
-#[cfg(feature = "consensus")]
 use tonic::transport::Uri;
-#[cfg(feature = "consensus")]
 use wal::Wal;
 
-#[cfg(feature = "consensus")]
-pub use consensus::TableOfContentRef;
-
 const COLLECTIONS_DIR: &str = "collections";
-#[cfg(feature = "consensus")]
 const COLLECTIONS_META_WAL_DIR: &str = "collections_meta_wal";
-#[cfg(feature = "consensus")]
 const DEFAULT_META_OP_WAIT: Duration = Duration::from_secs(10);
 
 /// The main object of the service. It holds all objects, required for proper functioning.
@@ -71,22 +60,21 @@ pub struct TableOfContent {
     collection_management_runtime: Runtime,
     alias_persistence: RwLock<AliasPersistence>,
     segment_searcher: Box<dyn CollectionSearcher + Sync + Send>,
-
-    #[cfg(feature = "consensus")]
     collection_meta_wal: Arc<std::sync::Mutex<Wal>>,
-    #[cfg(feature = "consensus")]
     raft_state: Arc<std::sync::Mutex<PersistentRaftState>>,
-    #[cfg(feature = "consensus")]
     propose_sender: Option<std::sync::Mutex<std::sync::mpsc::Sender<Vec<u8>>>>,
-    #[cfg(feature = "consensus")]
     on_consensus_op_apply:
         std::sync::Mutex<HashMap<ConsensusOperations, oneshot::Sender<Result<bool, StorageError>>>>,
-    #[cfg(feature = "consensus")]
+    distributed_mode: bool,
     this_peer_id: u64,
 }
 
 impl TableOfContent {
-    pub fn new(storage_config: &StorageConfig, search_runtime: Runtime) -> Self {
+    pub fn new(
+        storage_config: &StorageConfig,
+        search_runtime: Runtime,
+        distributed_mode: bool,
+    ) -> Self {
         let collections_path = Path::new(&storage_config.storage_path).join(&COLLECTIONS_DIR);
         let collection_management_runtime = Runtime::new().unwrap();
 
@@ -119,7 +107,6 @@ impl TableOfContent {
         let alias_persistence =
             AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
 
-        #[cfg(feature = "consensus")]
         let collection_meta_wal = {
             let collections_meta_wal_path =
                 Path::new(&storage_config.storage_path).join(&COLLECTIONS_META_WAL_DIR);
@@ -129,7 +116,7 @@ impl TableOfContent {
                 Wal::open(collections_meta_wal_path).unwrap(),
             ))
         };
-        #[cfg(feature = "consensus")]
+
         let raft_state = PersistentRaftState::load_or_init(&storage_config.storage_path)
             .expect("Cannot initialize Raft persistent storage");
 
@@ -141,20 +128,15 @@ impl TableOfContent {
             segment_searcher: Box::new(SimpleCollectionSearcher::new()),
             collection_management_runtime,
             // PeerId does not change during execution so it is ok to copy it here.
-            #[cfg(feature = "consensus")]
             this_peer_id: raft_state.this_peer_id(),
-            #[cfg(feature = "consensus")]
             collection_meta_wal,
-            #[cfg(feature = "consensus")]
             raft_state: Arc::new(std::sync::Mutex::new(raft_state)),
-            #[cfg(feature = "consensus")]
             propose_sender: None,
-            #[cfg(feature = "consensus")]
             on_consensus_op_apply: std::sync::Mutex::new(HashMap::new()),
+            distributed_mode,
         }
     }
 
-    #[cfg(feature = "consensus")]
     pub fn with_propose_sender(&mut self, sender: std::sync::mpsc::Sender<Vec<u8>>) {
         self.propose_sender = Some(std::sync::Mutex::new(sender))
     }
@@ -355,21 +337,17 @@ impl TableOfContent {
         operation: CollectionMetaOperations,
         wait_timeout: Option<Duration>,
     ) -> Result<bool, StorageError> {
-        #[cfg(feature = "consensus")]
-        {
+        if self.distributed_mode {
             self.propose_consensus_op(
                 ConsensusOperations::CollectionMeta(Box::new(operation)),
                 wait_timeout,
             )
             .await
-        }
-        #[cfg(not(feature = "consensus"))]
-        {
+        } else {
             self.perform_collection_meta_op(operation).await
         }
     }
 
-    #[cfg(feature = "consensus")]
     pub async fn propose_consensus_op(
         &self,
         operation: ConsensusOperations,
@@ -588,7 +566,6 @@ impl TableOfContent {
         result.map_err(|err| err.into())
     }
 
-    #[cfg(feature = "consensus")]
     pub fn collection_wal_entry(&self, id: u64) -> raft::Result<RaftEntry> {
         <RaftEntry as prost::Message>::decode(
             self.collection_meta_wal
@@ -601,12 +578,10 @@ impl TableOfContent {
         .map_err(consensus::raft_error_other)
     }
 
-    #[cfg(feature = "consensus")]
     pub fn this_peer_id(&self) -> u64 {
         self.this_peer_id
     }
 
-    #[cfg(feature = "consensus")]
     async fn collection_meta_snapshot(&self) -> raft::Result<consensus::CollectionMetaSnapshot> {
         use super::raft_state::PeerAddressByIdWrapper;
 
@@ -630,7 +605,6 @@ impl TableOfContent {
         })
     }
 
-    #[cfg(feature = "consensus")]
     pub fn apply_entry(&self, entry: &RaftEntry) -> Result<bool, StorageError> {
         let operation: ConsensusOperations = entry.try_into()?;
         let on_apply = self.on_consensus_op_apply.lock()?.remove(&operation);
@@ -655,7 +629,6 @@ impl TableOfContent {
         result
     }
 
-    #[cfg(feature = "consensus")]
     pub fn set_unapplied_entries(
         &self,
         first_index: u64,
@@ -668,7 +641,6 @@ impl TableOfContent {
             .map_err(consensus::raft_error_other)
     }
 
-    #[cfg(feature = "consensus")]
     pub fn apply_entries(&self) -> Result<(), raft::Error> {
         use raft::eraftpb::EntryType;
 
@@ -703,7 +675,6 @@ impl TableOfContent {
         Ok(())
     }
 
-    #[cfg(feature = "consensus")]
     pub fn append_entries(&self, entries: Vec<RaftEntry>) -> Result<(), StorageError> {
         use prost::Message;
 
@@ -718,7 +689,6 @@ impl TableOfContent {
         Ok(())
     }
 
-    #[cfg(feature = "consensus")]
     pub fn apply_snapshot(&self, snapshot: &RaftSnapshot) -> Result<(), StorageError> {
         let snapshot: consensus::CollectionMetaSnapshot = snapshot.try_into()?;
 
@@ -773,31 +743,26 @@ impl TableOfContent {
         })
     }
 
-    #[cfg(feature = "consensus")]
     pub fn set_hard_state(&self, hard_state: raft::eraftpb::HardState) -> Result<(), StorageError> {
         self.raft_state
             .lock()?
             .apply_state_update(|state| state.hard_state = hard_state)
     }
 
-    #[cfg(feature = "consensus")]
     pub fn hard_state(&self) -> Result<raft::eraftpb::HardState, StorageError> {
         Ok(self.raft_state.lock()?.state().hard_state.clone())
     }
 
-    #[cfg(feature = "consensus")]
     pub fn set_commit_index(&self, index: u64) -> Result<(), StorageError> {
         self.raft_state
             .lock()?
             .apply_state_update(|state| state.hard_state.commit = index)
     }
 
-    #[cfg(feature = "consensus")]
     pub fn peer_address_by_id(&self) -> Result<PeerAddressById, StorageError> {
         self.raft_state.lock()?.peer_address_by_id()
     }
 
-    #[cfg(feature = "consensus")]
     pub fn add_peer(&self, peer_id: PeerId, uri: Uri) -> Result<(), StorageError> {
         self.raft_state.lock()?.insert_peer(peer_id, uri)
     }
@@ -814,7 +779,6 @@ impl Drop for TableOfContent {
     }
 }
 
-#[cfg(feature = "consensus")]
 mod consensus {
     use std::{collections::HashMap, ops::Deref, sync::Arc};
 

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(all(test, not(feature = "consensus")))]
+#[cfg(all(test))]
 mod tests {
     use collection::optimizers_builder::OptimizersConfig;
     use segment::types::Distance;
@@ -42,7 +42,7 @@ mod tests {
         let runtime = Runtime::new().unwrap();
         let handle = runtime.handle().clone();
 
-        let toc = TableOfContent::new(&config, runtime);
+        let toc = TableOfContent::new(&config, runtime, false);
 
         handle
             .block_on(toc.submit_collection_operation(

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -42,7 +42,8 @@ mod tests {
         let runtime = Runtime::new().unwrap();
         let handle = runtime.handle().clone();
 
-        let toc = TableOfContent::new(&config, runtime, false);
+        let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
+        let toc = TableOfContent::new(&config, runtime, propose_sender, false);
 
         handle
             .block_on(toc.submit_collection_operation(

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -42,8 +42,7 @@ mod tests {
         let runtime = Runtime::new().unwrap();
         let handle = runtime.handle().clone();
 
-        let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
-        let toc = TableOfContent::new(&config, runtime, propose_sender, false);
+        let toc = TableOfContent::new(&config, runtime, None);
 
         handle
             .block_on(toc.submit_collection_operation(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -380,9 +380,8 @@ mod tests {
         env_logger::init();
         let runtime = crate::create_search_runtime(settings.storage.performance.max_search_threads)
             .expect("Can't create runtime.");
-        let mut toc = TableOfContent::new(&settings.storage, runtime, true);
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
-        toc.with_propose_sender(propose_sender);
+        let toc = TableOfContent::new(&settings.storage, runtime, propose_sender, true);
         let toc_arc = Arc::new(toc);
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
         let (mut consensus, message_sender) = Consensus::new(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -380,7 +380,7 @@ mod tests {
         env_logger::init();
         let runtime = crate::create_search_runtime(settings.storage.performance.max_search_threads)
             .expect("Can't create runtime.");
-        let mut toc = TableOfContent::new(&settings.storage, runtime);
+        let mut toc = TableOfContent::new(&settings.storage, runtime, true);
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         toc.with_propose_sender(propose_sender);
         let toc_arc = Arc::new(toc);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -360,6 +360,7 @@ mod tests {
     use crate::settings::ConsensusConfig;
     use segment::types::Distance;
     use slog::Drain;
+    use storage::content_manager::toc::ConsensusEnabled;
     use storage::content_manager::{
         collection_meta_ops::{
             CollectionMetaOperations, CreateCollection, CreateCollectionOperation,
@@ -381,7 +382,8 @@ mod tests {
         let runtime = crate::create_search_runtime(settings.storage.performance.max_search_threads)
             .expect("Can't create runtime.");
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
-        let toc = TableOfContent::new(&settings.storage, runtime, propose_sender, true);
+        let consensus_enabled = ConsensusEnabled { propose_sender };
+        let toc = TableOfContent::new(&settings.storage, runtime, Some(consensus_enabled));
         let toc_arc = Arc::new(toc);
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
         let (mut consensus, message_sender) = Consensus::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 #[cfg(feature = "web")]
 mod actix;
 pub mod common;
-#[cfg(feature = "consensus")]
 mod consensus;
 mod settings;
 mod tonic;
 
-#[cfg(feature = "consensus")]
 use consensus::Consensus;
-#[cfg(feature = "consensus")]
 use slog::Drain;
 use std::io::Error;
 use std::sync::Arc;
@@ -43,8 +40,6 @@ struct Args {
 }
 
 fn main() -> std::io::Result<()> {
-    #[cfg(feature = "consensus")]
-    let args = Args::parse();
     let settings = Settings::new().expect("Can't read config.");
     std::env::set_var("RUST_LOG", &settings.log_level);
     env_logger::init();
@@ -55,24 +50,21 @@ fn main() -> std::io::Result<()> {
         .expect("Can't create runtime.");
     let runtime_handle = runtime.handle().clone();
 
-    #[allow(unused_mut)]
-    let mut toc = TableOfContent::new(&settings.storage, runtime);
+    let mut toc = TableOfContent::new(&settings.storage, runtime, settings.cluster.enabled);
     runtime_handle.block_on(async {
         for collection in toc.all_collections().await {
             log::info!("Loaded collection: {}", collection);
         }
     });
 
-    #[cfg(feature = "consensus")]
     let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
-    #[cfg(feature = "consensus")]
     toc.with_propose_sender(propose_sender);
 
     let toc_arc = Arc::new(toc);
     let mut handles: Vec<JoinHandle<Result<(), Error>>> = vec![];
 
-    #[cfg(feature = "consensus")]
-    {
+    if settings.cluster.enabled {
+        let args = Args::parse();
         // `raft` crate uses `slog` crate so it is needed to use `slog_stdlog::StdLog` to forward
         // logs from it to `log` crate
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
@@ -127,6 +119,8 @@ fn main() -> std::io::Result<()> {
         } else {
             log::info!("gRPC internal endpoint disabled");
         }
+    } else {
+        log::info!("Distributed mode disabled");
     }
 
     #[cfg(feature = "web")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,7 @@ pub struct ServiceConfig {
 
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ClusterConfig {
-    pub enabled: bool, // disabled by default - TODO use with https://github.com/qdrant/qdrant/issues/511
+    pub enabled: bool, // disabled by default
     #[serde(default)]
     pub p2p: P2pConfig,
     #[serde(default)]

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -1,10 +1,7 @@
 pub mod collections_api;
 mod collections_common;
-#[cfg(feature = "consensus")]
 pub mod collections_internal_api;
 pub mod points_api;
 mod points_common;
-#[cfg(feature = "consensus")]
 pub mod points_internal_api;
-#[cfg(feature = "consensus")]
 pub mod raft_api;

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -1,16 +1,12 @@
 mod api;
 
 use crate::tonic::api::collections_api::CollectionsService;
-#[cfg(feature = "consensus")]
 use crate::tonic::api::collections_internal_api::CollectionsInternalService;
 use crate::tonic::api::points_api::PointsService;
-#[cfg(feature = "consensus")]
 use crate::tonic::api::points_internal_api::PointsInternalService;
 use ::api::grpc::models::VersionInfo;
-#[cfg(feature = "consensus")]
 use ::api::grpc::qdrant::collections_internal_server::CollectionsInternalServer;
 use ::api::grpc::qdrant::collections_server::CollectionsServer;
-#[cfg(feature = "consensus")]
 use ::api::grpc::qdrant::points_internal_server::PointsInternalServer;
 use ::api::grpc::qdrant::points_server::PointsServer;
 use ::api::grpc::qdrant::qdrant_server::{Qdrant, QdrantServer};
@@ -69,7 +65,6 @@ pub fn init(toc: Arc<TableOfContent>, host: String, grpc_port: u16) -> std::io::
     Ok(())
 }
 
-#[cfg(feature = "consensus")]
 pub fn init_internal(
     toc: Arc<TableOfContent>,
     host: String,

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -9,6 +9,12 @@ cd "$(dirname "$0")/../"
 QDRANT_HOST='localhost:6333'
 export QDRANT__SERVICE__GRPC_PORT="6334"
 
+MODE=$1
+# Enable distributed mode on demand
+if [ $1 == "distributed" ]; then
+  export QDRANT__CLUSTER__ENABLED="true"
+fi
+
 # Run in background
 $(./target/debug/qdrant) &
 


### PR DESCRIPTION
This PR switch the consensus from a conditional compilation cargo feature to a runtime configuration https://github.com/qdrant/qdrant/issues/511

This means:
- the consensus code is now compiled by default
- the consensus unit tests are executed by default
- the distributed deployment toggle is the `cluster.enabled` configuration field (false by default)
- the integration test bash script has a new parameter to toggle the distributed mode
- the `toc` is aware of the distribution mode 
