### PR TITLE
Grpc int payload str

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -98,7 +98,7 @@ fn proto_to_json(proto: prost_types::Value) -> Result<Value, Status> {
             Kind::StringValue(s) => match parse_int(&s) {
                 Some(int) => Ok(Value::Number(int.into())),
                 None => Ok(Value::String(s)),
-            }
+            },
             Kind::BoolValue(b) => Ok(Value::Bool(b)),
             Kind::StructValue(s) => {
                 let mut map = Map::new();

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -33,7 +33,7 @@ $docker_grpcurl -d '{
       "payload": {
         "city": "Berlin",
         "country": "Germany",
-        "population": 1000000,
+        "population": "1000000i",
         "square": 12.5,
         "coords": { "lat": 1.0, "lon": 2.0 }
       }


### PR DESCRIPTION
alternative to 
https://github.com/qdrant/qdrant/pull/564

pros:
- better support from grpcurl

cons:
- impossible to distinguish `123i` as string vs `123i` as integer
- would require explicit documentation

