### PR TITLE
Pool gRPC transport channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,10 +243,12 @@ version = "0.7.0"
 dependencies = [
  "prost 0.10.1",
  "prost-types 0.10.1",
+ "rand 0.8.5",
  "schemars",
  "segment",
  "serde",
  "serde_json",
+ "tokio",
  "tonic",
  "tonic-build",
  "tower",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = "~1.0"
 schemars = { version = "0.8.8", features = ["uuid"] }
 uuid = { version = "0.8", features = ["v4", "serde"] }
 tower = "0.4.12"
+tokio = "1.18.2"
+rand = "0.8.5"
 
 segment = {path = "../segment"}
 

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -3,20 +3,8 @@ pub mod models;
 #[allow(clippy::all)]
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 pub mod qdrant;
-
-use std::time::Duration;
-
-use tonic::transport::{Channel, Error, Uri};
-use tower::timeout::Timeout;
+pub mod transport_channel_pool;
 
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
-}
-
-pub async fn timeout_channel(
-    timeout: Duration,
-    peer_address: Uri,
-) -> Result<Timeout<Channel>, Error> {
-    let channel = Channel::builder(peer_address).connect().await?;
-    Ok(Timeout::new(channel, timeout))
 }

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -1,0 +1,68 @@
+use rand::seq::SliceRandom;
+use std::collections::HashMap;
+use std::time::Duration;
+use std::vec::Vec;
+use tonic::transport::{Channel, Error, Uri};
+
+/// Holds a pool of channels established for a set of URIs.
+/// Channel are shared by cloning them.
+/// Make the `pool_size` larger to increase throughput.
+#[derive(Default)]
+pub struct TransportChannelPool {
+    ip_to_pool: tokio::sync::RwLock<HashMap<Uri, Vec<Channel>>>,
+    pool_size: usize,
+    grpc_timeout: Duration,
+}
+
+impl TransportChannelPool {
+    pub fn new(p2p_grpc_timeout: Duration, pool_size: usize) -> Self {
+        Self {
+            ip_to_pool: Default::default(),
+            grpc_timeout: p2p_grpc_timeout,
+            pool_size,
+        }
+    }
+
+    pub async fn make_channel(grpc_timeout: Duration, uri: Uri) -> Result<Channel, Error> {
+        let endpoint = Channel::builder(uri)
+            .timeout(grpc_timeout)
+            .connect_timeout(grpc_timeout)
+            .keep_alive_while_idle(true);
+        // `connect` is using the `Reconnect` network service internally to handle dropped connections
+        endpoint.connect().await
+    }
+
+    /// Initialize a pool for the URI and return a clone of the first channel.
+    /// Does not fail if the pool already exist.
+    async fn init_pool_for_uri(&self, uri: Uri) -> Result<Channel, Error> {
+        let mut guard = self.ip_to_pool.write().await;
+        match guard.get(&uri) {
+            None => {
+                let mut channels = Vec::with_capacity(self.pool_size);
+                for _ in 0..self.pool_size {
+                    let channel = Self::make_channel(self.grpc_timeout, uri.clone()).await?;
+                    channels.push(channel);
+                }
+                let result = channels[0].clone();
+                guard.insert(uri.clone(), channels);
+                Ok(result)
+            }
+            Some(channels) => Ok(channels[0].clone()),
+        }
+    }
+
+    pub async fn get_pooled_channel(&self, uri: &Uri) -> Option<Channel> {
+        let guard = self.ip_to_pool.read().await;
+        guard
+            .get(uri)
+            .and_then(|channels| channels.choose(&mut rand::thread_rng()))
+            .cloned()
+    }
+
+    pub async fn get_or_create_pooled_channel(&self, uri: &Uri) -> Result<Channel, Error> {
+        match self.get_pooled_channel(uri).await {
+            None => self.init_pool_for_uri(uri.clone()).await,
+            Some(channel) => Ok(channel),
+        }
+    }
+}

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -131,3 +131,11 @@ impl<E: std::fmt::Display> From<atomicwrites::Error<E>> for StorageError {
         }
     }
 }
+
+impl From<tonic::transport::Error> for StorageError {
+    fn from(err: tonic::transport::Error) -> Self {
+        StorageError::ServiceError {
+            description: format!("Tonic transport error: {}", err),
+        }
+    }
+}

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -823,7 +823,7 @@ impl TableOfContent {
     }
 
     /// A pool will be created if no channels exist for this address.
-    pub async fn get_grpc_pooled_channel(&self, uri: &Uri) -> Result<Channel, StorageError> {
+    pub async fn get_or_create_pooled_channel(&self, uri: &Uri) -> Result<Channel, StorageError> {
         self.transport_channel_pool
             .get_or_create_pooled_channel(uri)
             .await

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -36,6 +36,7 @@ use crate::{
     },
     types::PeerAddressById,
 };
+use api::grpc::transport_channel_pool::TransportChannelPool;
 use collection::collection_manager::collection_managers::CollectionSearcher;
 use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
 use collection::shard::ShardId;
@@ -46,7 +47,7 @@ use raft::{
     RawNode,
 };
 use tokio::sync::oneshot;
-use tonic::transport::Uri;
+use tonic::transport::{Channel, Uri};
 use wal::Wal;
 
 const COLLECTIONS_DIR: &str = "collections";
@@ -56,6 +57,7 @@ const DEFAULT_META_OP_WAIT: Duration = Duration::from_secs(10);
 pub struct ConsensusEnabled {
     pub propose_sender: std::sync::mpsc::Sender<Vec<u8>>,
     pub first_peer: bool,
+    pub transport_channel_pool: TransportChannelPool,
 }
 
 /// The main object of the service. It holds all objects, required for proper functioning.
@@ -73,6 +75,7 @@ pub struct TableOfContent {
     propose_sender: Option<std::sync::Mutex<std::sync::mpsc::Sender<Vec<u8>>>>,
     on_consensus_op_apply:
         std::sync::Mutex<HashMap<ConsensusOperations, oneshot::Sender<Result<bool, StorageError>>>>,
+    transport_channel_pool: TransportChannelPool,
     this_peer_id: u64,
 }
 
@@ -129,6 +132,14 @@ impl TableOfContent {
         )
         .expect("Cannot initialize Raft persistent storage");
 
+        let (propose_sender, transport_channel_pool) = match consensus_enabled {
+            None => (None, TransportChannelPool::default()), // use a default empty pool as consensus is disabled
+            Some(ce) => (
+                Some(std::sync::Mutex::new(ce.propose_sender)),
+                ce.transport_channel_pool,
+            ),
+        };
+
         TableOfContent {
             collections: Arc::new(RwLock::new(collections)),
             storage_config: storage_config.clone(),
@@ -140,8 +151,9 @@ impl TableOfContent {
             this_peer_id: raft_state.this_peer_id(),
             collection_meta_wal,
             raft_state: Arc::new(std::sync::Mutex::new(raft_state)),
-            propose_sender: consensus_enabled.map(|ce| std::sync::Mutex::new(ce.propose_sender)),
+            propose_sender,
             on_consensus_op_apply: std::sync::Mutex::new(HashMap::new()),
+            transport_channel_pool,
         }
     }
 
@@ -808,6 +820,19 @@ impl TableOfContent {
 
     pub fn add_peer(&self, peer_id: PeerId, uri: Uri) -> Result<(), StorageError> {
         self.raft_state.lock()?.insert_peer(peer_id, uri)
+    }
+
+    /// A pool will be created if no channels exist for this address.
+    pub async fn get_grpc_pooled_channel(&self, uri: &Uri) -> Result<Channel, StorageError> {
+        self.transport_channel_pool
+            .get_or_create_pooled_channel(uri)
+            .await
+            .map_err(|err| StorageError::ServiceError {
+                description: format!(
+                    "Can't create pooled transport channel for {}. Error: {}",
+                    uri, err
+                ),
+            })
     }
 }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -9,15 +9,13 @@ use std::{
 };
 
 use anyhow::Context;
-use api::grpc::{
-    qdrant::{raft_client::RaftClient, PeerId, RaftMessage as GrpcRaftMessage},
-    timeout_channel,
-};
+use api::grpc::qdrant::{raft_client::RaftClient, PeerId, RaftMessage as GrpcRaftMessage};
 use storage::content_manager::{
     consensus_ops::ConsensusOperations, errors::StorageError, toc::TableOfContentRef,
 };
 
 use crate::settings::ConsensusConfig;
+use api::grpc::transport_channel_pool::TransportChannelPool;
 use raft::{eraftpb::Message as RaftMessage, prelude::*};
 use tokio::runtime::Runtime;
 use tonic::transport::Uri;
@@ -115,7 +113,8 @@ impl Consensus {
         p2p_port: Option<u32>,
         config: &ConsensusConfig,
     ) -> anyhow::Result<()> {
-        let channel = timeout_channel(
+        // Use dedicated transport channel for bootstrapping because of specific timeout
+        let channel = TransportChannelPool::make_channel(
             Duration::from_secs(config.bootstrap_timeout_sec),
             bootstrap_peer,
         )
@@ -309,6 +308,7 @@ fn handle_messages(
         .collect();
     let bootstrap_uri = bootstrap_uri.clone();
     let consensus_config_arc = Arc::new(config.clone());
+    let toc_arc = Arc::new(toc.clone());
     let future = async move {
         let mut send_futures = Vec::new();
         for (message, address) in messages_with_address {
@@ -331,7 +331,7 @@ fn handle_messages(
                     }
                 },
             };
-            send_futures.push(send_message(address, message, consensus_config_arc.clone()));
+            send_futures.push(send_message(toc_arc.clone(), address, message));
         }
         for result in futures::future::join_all(send_futures).await {
             if let Err(err) = result {
@@ -353,7 +353,8 @@ async fn who_is(
     let bootstrap_uri =
         bootstrap_uri.ok_or_else(|| anyhow::anyhow!("No bootstrap uri supplied"))?;
     let bootstrap_timeout = Duration::from_secs(config.bootstrap_timeout_sec);
-    let channel = timeout_channel(bootstrap_timeout, bootstrap_uri)
+    // Use dedicated transport channel for who_is because of specific timeout
+    let channel = TransportChannelPool::make_channel(bootstrap_timeout, bootstrap_uri)
         .await
         .context("Failed to create timeout channel")?;
     let mut client = RaftClient::new(channel);
@@ -366,12 +367,12 @@ async fn who_is(
 }
 
 async fn send_message(
+    toc: Arc<TableOfContentRef>,
     address: Uri,
     message: RaftMessage,
-    config: Arc<ConsensusConfig>,
 ) -> anyhow::Result<()> {
-    let message_timeout = Duration::from_millis(config.message_timeout_ms);
-    let channel = timeout_channel(message_timeout, address)
+    let channel = toc
+        .get_grpc_pooled_channel(&address)
         .await
         .context("Failed to create timeout channel")?;
     let mut client = RaftClient::new(channel);
@@ -391,6 +392,7 @@ mod tests {
     use std::{sync::Arc, thread, time::Duration};
 
     use crate::settings::ConsensusConfig;
+    use api::grpc::transport_channel_pool::TransportChannelPool;
     use segment::types::Distance;
     use slog::Drain;
     use storage::content_manager::toc::ConsensusEnabled;
@@ -418,6 +420,7 @@ mod tests {
         let consensus_enabled = ConsensusEnabled {
             propose_sender,
             first_peer: true,
+            transport_channel_pool: TransportChannelPool::default(),
         };
         let toc = TableOfContent::new(&settings.storage, runtime, Some(consensus_enabled));
         let toc_arc = Arc::new(toc);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -308,7 +308,8 @@ fn handle_messages(
         .collect();
     let bootstrap_uri = bootstrap_uri.clone();
     let consensus_config_arc = Arc::new(config.clone());
-    let toc_arc = Arc::new(toc.clone());
+    // TableOfContentRef wraps a Arc<TableOfContent>
+    let toc_clone = toc.clone();
     let future = async move {
         let mut send_futures = Vec::new();
         for (message, address) in messages_with_address {
@@ -331,7 +332,7 @@ fn handle_messages(
                     }
                 },
             };
-            send_futures.push(send_message(toc_arc.clone(), address, message));
+            send_futures.push(send_message(toc_clone.clone(), address, message));
         }
         for result in futures::future::join_all(send_futures).await {
             if let Err(err) = result {
@@ -367,7 +368,7 @@ async fn who_is(
 }
 
 async fn send_message(
-    toc: Arc<TableOfContentRef>,
+    toc: TableOfContentRef,
     address: Uri,
     message: RaftMessage,
 ) -> anyhow::Result<()> {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -373,7 +373,7 @@ async fn send_message(
     message: RaftMessage,
 ) -> anyhow::Result<()> {
     let channel = toc
-        .get_grpc_pooled_channel(&address)
+        .get_or_create_pooled_channel(&address)
         .await
         .context("Failed to create timeout channel")?;
     let mut client = RaftClient::new(channel);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,8 @@ pub struct ServiceConfig {
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ClusterConfig {
     pub enabled: bool, // disabled by default
+    #[serde(default = "default_timeout_ms")]
+    pub grpc_timeout_ms: u64,
     #[serde(default)]
     pub p2p: P2pConfig,
     #[serde(default)]
@@ -25,15 +27,15 @@ pub struct ClusterConfig {
 pub struct P2pConfig {
     #[serde(default)]
     pub p2p_port: Option<u16>,
-    #[serde(default = "default_timeout_ms")]
-    pub p2p_grpc_timeout_ms: u64,
+    #[serde(default = "default_connection_pool_size")]
+    pub connection_pool_size: usize,
 }
 
 impl Default for P2pConfig {
     fn default() -> Self {
         P2pConfig {
             p2p_port: None,
-            p2p_grpc_timeout_ms: default_timeout_ms(),
+            connection_pool_size: default_connection_pool_size(),
         }
     }
 }
@@ -44,8 +46,6 @@ pub struct ConsensusConfig {
     pub max_message_queue_size: usize, // controls the back-pressure at the Raft level
     #[serde(default = "default_tick_period_ms")]
     pub tick_period_ms: u64,
-    #[serde(default = "default_timeout_ms")]
-    pub message_timeout_ms: u64,
     #[serde(default = "default_bootstrap_timeout_sec")]
     pub bootstrap_timeout_sec: u64,
 }
@@ -55,7 +55,6 @@ impl Default for ConsensusConfig {
         ConsensusConfig {
             max_message_queue_size: default_max_message_queue_size(),
             tick_period_ms: default_tick_period_ms(),
-            message_timeout_ms: default_timeout_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
         }
     }
@@ -95,6 +94,10 @@ fn default_bootstrap_timeout_sec() -> u64 {
 
 fn default_max_message_queue_size() -> usize {
     100
+}
+
+fn default_connection_pool_size() -> usize {
+    2
 }
 
 impl Settings {


### PR DESCRIPTION
This PR adds a pooling system of gRPC transport channels #584

The pooling is used in both the Raft messaging and in the remote shards interactions to avoid having to establish network connections at each interactions with other peers.

The recommended way to pool Tonic's transport channels is to clone them.

https://github.com/hyperium/tonic/blob/de2e4ac077c076736dc451f3415ea7da1a61a560/tonic/src/transport/channel/mod.rs#L50-L67

The proposed solution is to hold in memory mappings between `URI` and a `Vec<Channel>` and to serve clones of the channels on demand.
Throughput can be increased by increasing the size of the pool of channels to clone from.

Those channels are configured with proper timeouts and will try to reconnect automatically on network errors.

I had to unify the `p2p` and `consensus` timeout into a single configuration knob to use the pool in both Raft and remote shard. (Andrey wanted a single timeout for the cluster configuration anyway :smile: )
