### PR TITLE
[real-time index] add In-mem btree numeric index

### DIFF
--- a/lib/segment/src/index/field_index/btree_index.rs
+++ b/lib/segment/src/index/field_index/btree_index.rs
@@ -1,0 +1,250 @@
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::ops::Bound::{Excluded, Included, Unbounded};
+
+use serde_json::Value;
+
+use crate::index::field_index::{
+    CardinalityEstimation, FieldIndex, PayloadBlockCondition, PayloadFieldIndex,
+    PayloadFieldIndexBuilder, ValueIndexer,
+};
+use crate::index::key_encoding::{encode_f64_key_ascending, encode_i64_key_ascending};
+use crate::types::{
+    FieldCondition, FloatPayloadType, IntPayloadType, PayloadKeyType, PointOffsetType, Range,
+};
+
+trait KeyEncoder {
+    fn encode_key(&self, id: PointOffsetType) -> Vec<u8>;
+}
+
+impl KeyEncoder for IntPayloadType {
+    fn encode_key(&self, id: PointOffsetType) -> Vec<u8> {
+        encode_i64_key_ascending(*self, id)
+    }
+}
+
+impl KeyEncoder for FloatPayloadType {
+    fn encode_key(&self, id: PointOffsetType) -> Vec<u8> {
+        encode_f64_key_ascending(*self, id)
+    }
+}
+
+#[derive(Default)]
+struct NumericIndex<T: KeyEncoder> {
+    map: BTreeMap<Vec<u8>, u32>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: KeyEncoder> NumericIndex<T> {
+    pub fn add_value(&mut self, id: PointOffsetType, value: T) {
+        let key = value.encode_key(id);
+        self.map.insert(key, id);
+    }
+
+    fn add_many_to_list(&mut self, idx: PointOffsetType, values: impl IntoIterator<Item = T>) {
+        for value in values {
+            self.add_value(idx, value);
+        }
+    }
+}
+
+impl<T: KeyEncoder + From<f64>> PayloadFieldIndex for NumericIndex<T> {
+    fn filter(
+        &self,
+        condition: &FieldCondition,
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+        let cond_range = condition.range.as_ref()?;
+
+        let start_bound = match cond_range {
+            Range { gt: Some(gt), .. } => {
+                let v: T = gt.to_owned().into();
+                Excluded(v.encode_key(u32::MAX))
+            }
+            Range { gte: Some(gte), .. } => {
+                let v: T = gte.to_owned().into();
+                Included(v.encode_key(u32::MIN))
+            }
+            _ => Unbounded,
+        };
+
+        let end_bound = match cond_range {
+            Range { lt: Some(lt), .. } => {
+                let v: T = lt.to_owned().into();
+                Excluded(v.encode_key(u32::MIN))
+            }
+            Range { lte: Some(lte), .. } => {
+                let v: T = lte.to_owned().into();
+                Included(v.encode_key(u32::MAX))
+            }
+            _ => Unbounded,
+        };
+
+        Some(Box::new(
+            self.map.range((start_bound, end_bound)).map(|(_, v)| *v),
+        ))
+    }
+
+    fn estimate_cardinality(&self, _condition: &FieldCondition) -> Option<CardinalityEstimation> {
+        //TODO(gvelo): add histogram.
+        todo!()
+    }
+
+    fn payload_blocks(
+        &self,
+        _threshold: usize,
+        _key: PayloadKeyType,
+    ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
+        todo!()
+    }
+
+    fn count_indexed_points(&self) -> usize {
+        self.map.len()
+    }
+}
+
+impl PayloadFieldIndexBuilder for NumericIndex<IntPayloadType> {
+    fn add(&mut self, id: PointOffsetType, value: &Value) {
+        self.add_point(id, value);
+    }
+
+    fn build(&mut self) -> FieldIndex {
+        //TODO(gvelo): handle this properly
+        panic!("cannot build");
+    }
+}
+
+impl PayloadFieldIndexBuilder for NumericIndex<FloatPayloadType> {
+    fn add(&mut self, id: PointOffsetType, value: &Value) {
+        self.add_point(id, value);
+    }
+
+    fn build(&mut self) -> FieldIndex {
+        //TODO(gvelo): handle this properly
+        panic!("cannot build");
+    }
+}
+
+impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<IntPayloadType>) {
+        self.add_many_to_list(id, values)
+    }
+
+    fn get_value(&self, value: &Value) -> Option<IntPayloadType> {
+        if let Value::Number(num) = value {
+            return num.as_i64();
+        }
+        None
+    }
+}
+
+impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<FloatPayloadType>) {
+        self.add_many_to_list(id, values)
+    }
+
+    fn get_value(&self, value: &Value) -> Option<FloatPayloadType> {
+        if let Value::Number(num) = value {
+            return num.as_f64();
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+
+    use super::*;
+
+    #[test]
+    fn test_numeric_index() {
+        let values = vec![
+            vec![1.0],
+            vec![1.0],
+            vec![1.0],
+            vec![1.0],
+            vec![1.0],
+            vec![2.0],
+            vec![2.5],
+            vec![2.6],
+            vec![3.0],
+        ];
+
+        let mut index: NumericIndex<_> = Default::default();
+
+        values
+            .into_iter()
+            .enumerate()
+            .for_each(|(idx, values)| index.add_many_to_list(idx as PointOffsetType + 1, values));
+
+        test_cond(
+            &index,
+            Range {
+                gt: Some(1.0),
+                gte: None,
+                lt: None,
+                lte: None,
+            },
+            vec![6, 7, 8, 9],
+        );
+
+        test_cond(
+            &index,
+            Range {
+                gt: None,
+                gte: Some(1.0),
+                lt: None,
+                lte: None,
+            },
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+        );
+
+        test_cond(
+            &index,
+            Range {
+                gt: None,
+                gte: None,
+                lt: Some(2.6),
+                lte: None,
+            },
+            vec![1, 2, 3, 4, 5, 6, 7],
+        );
+
+        test_cond(
+            &index,
+            Range {
+                gt: None,
+                gte: None,
+                lt: None,
+                lte: Some(2.6),
+            },
+            vec![1, 2, 3, 4, 5, 6, 7, 8],
+        );
+
+        test_cond(
+            &index,
+            Range {
+                gt: None,
+                gte: Some(2.0),
+                lt: None,
+                lte: Some(2.6),
+            },
+            vec![6, 7, 8],
+        );
+    }
+
+    fn test_cond<T: KeyEncoder + From<f64>>(index: &NumericIndex<T>, rng: Range, result: Vec<u32>) {
+        let condition = FieldCondition {
+            key: "".to_string(),
+            r#match: None,
+            range: Some(rng),
+            geo_bounding_box: None,
+            geo_radius: None,
+            values_count: None,
+        };
+
+        let offsets = index.filter(&condition).unwrap().collect_vec();
+
+        assert_eq!(offsets, result);
+    }
+}

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,16 +1,16 @@
 use crate::types::{FieldCondition, IsEmptyCondition, PointOffsetType};
 use std::collections::HashSet;
 
+mod btree_index;
 mod field_index_base;
 pub mod geo_hash;
 mod geo_index;
+#[allow(dead_code)]
+mod histogram;
 pub mod index_selector;
 pub mod map_index;
 pub mod numeric_index;
 mod stat_tools;
-
-#[allow(dead_code)]
-mod histogram;
 
 pub use field_index_base::*;
 

--- a/lib/segment/src/index/key_encoding.rs
+++ b/lib/segment/src/index/key_encoding.rs
@@ -75,7 +75,7 @@ pub fn decode_f64_ascending(buf: &[u8]) -> f64 {
 }
 
 /// Encode a i64 into `buf` so that is sorts ascending.
-fn encode_i64_ascending(val: i64, buf: &mut Vec<u8>) {
+pub fn encode_i64_ascending(val: i64, buf: &mut Vec<u8>) {
     let i = val ^ i64::MIN;
     buf.extend(i.to_be_bytes());
 }


### PR DESCRIPTION
Implementation of `PayloadFieldIndex` for numeric data, which should replace currently used outdated implementation.

Old implementation uses sorted array, which could not be dynamically extended.
New implementation uses BTree with some clever encoding tricks explained in https://www.notion.so/qdrant/On-flight-index-updates-d20b4606bafa4f499488bf7cd67816af

Out of scope:

- cardinality estimation
- persistance
- integration with existing payload index interface

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
