### PR TITLE
Add multipeer deployment test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,12 +46,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
-        run: sudo apt-get install clang
+        run: sudo apt-get install clang python3-pytest
       - name: Install protoc
         run: .github/scripts/protoc.sh
         shell: bash
       - name: Build
         run: cargo build
-      - name: Run integration tests
+      - name: Run integration tests - 1 peer
         run: ./tests/integration-tests.sh distributed
         shell: bash
+      - name: Run integration tests - multiple peers
+        run: pytest ./tests/python_tests/multipeer_test.py

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install pytest
-        run: pip install pytest
+        run: pip install pytest requests
       - name: Install protoc
         run: .github/scripts/protoc.sh
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,9 +46,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
-        run: sudo apt-get install clang python3-pip
+        run: sudo apt-get install clang
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Install pytest
-        run: pip3 install pytest
+        run: pip install pytest
       - name: Install protoc
         run: .github/scripts/protoc.sh
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
-        run: sudo apt-get install clang python3-pytest
+        run: sudo apt-get install clang python3-pip
+      - name: Install pytest
+        run: pip3 install pytest
       - name: Install protoc
         run: .github/scripts/protoc.sh
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
 /storage
+*.log

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> std::io::Result<()> {
             toc_arc.clone().into(),
             args.bootstrap,
             args.uri.map(|uri| uri.to_string()),
-            settings.cluster.p2p.p2p_port.map(|port| port as u32),
+            settings.cluster.p2p.port.map(|port| port as u32),
             settings.cluster.consensus.clone(),
         )
         .expect("Can't initialize consensus");
@@ -118,7 +118,7 @@ fn main() -> std::io::Result<()> {
                 }
             })?;
 
-        if let Some(internal_grpc_port) = settings.cluster.p2p.p2p_port {
+        if let Some(internal_grpc_port) = settings.cluster.p2p.port {
             let toc_arc = toc_arc.clone();
             let settings = settings.clone();
             let handle = thread::Builder::new()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,7 +26,7 @@ pub struct ClusterConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct P2pConfig {
     #[serde(default)]
-    pub p2p_port: Option<u16>,
+    pub port: Option<u16>,
     #[serde(default = "default_connection_pool_size")]
     pub connection_pool_size: usize,
 }
@@ -34,7 +34,7 @@ pub struct P2pConfig {
 impl Default for P2pConfig {
     fn default() -> Self {
         P2pConfig {
-            p2p_port: None,
+            port: None,
             connection_pool_size: default_connection_pool_size(),
         }
     }

--- a/tests/python_tests/.gitignore
+++ b/tests/python_tests/.gitignore
@@ -1,0 +1,2 @@
+.pytest_cache
+__pycache__

--- a/tests/python_tests/conftest.py
+++ b/tests/python_tests/conftest.py
@@ -1,0 +1,9 @@
+# Tracks processes that need to be killed at the end of the test
+processes = []
+
+
+def pytest_sessionfinish(session, exitstatus):
+    print()
+    for p in processes:
+        print(f"Killing {p.pid}")
+        p.kill()

--- a/tests/python_tests/multipeer_test.py
+++ b/tests/python_tests/multipeer_test.py
@@ -1,0 +1,103 @@
+import os
+import pathlib
+import shutil
+import time
+
+import requests
+from . import conftest
+from subprocess import Popen
+
+N_PEERS = 2
+
+
+def get_http_port(peer_index: int) -> int:
+    return 6330 + peer_index*10
+
+
+def get_p2p_port(peer_index: int) -> int:
+    return 6330 + peer_index*10 + 1
+
+
+def get_env(p2p_port: int, http_port: int) -> dict[str, str]:
+    env = os.environ.copy()
+    env["QDRANT__CLUSTER__ENABLED"] = "true"
+    env["QDRANT__CLUSTER__P2P__PORT"] = str(p2p_port)
+    env["QDRANT__SERVICE__HTTP_PORT"] = str(http_port)
+    return env
+
+
+def get_uri(port: int) -> str:
+    return f"http://127.0.0.1:{port}"
+
+
+def assert_http_ok(response: requests.Response):
+    if response.status_code != 200:
+        raise Exception(
+            f"Http request failed with status {response.status_code} and contents: {response.json()}")
+
+
+def test_multipeer_deployment(tmp_path: pathlib.Path):
+    # Ensure current path is project root
+    directory_path = os.getcwd()
+    folder_name = os.path.basename(directory_path)
+    assert folder_name == "qdrant"
+
+    qdrant_exec = directory_path + "/target/debug/qdrant"
+
+    # Make peer folders
+    peer_dirs = []
+    for i in range(N_PEERS):
+        peer_dir = tmp_path / f"peer{i}"
+        peer_dir.mkdir()
+        peer_dirs.append(peer_dir)
+        shutil.copytree("config", peer_dir / "config")
+
+    # Gathers REST API uris
+    peer_api_uris = []
+
+    # Start bootstrap
+    p2p_port = get_p2p_port(0)
+    http_port = get_http_port(0)
+    env = get_env(p2p_port, http_port)
+    bootstrap_uri = get_uri(p2p_port)
+    peer_api_uris.append(get_uri(http_port))
+    log_file = open("peer0.log", "w")
+    conftest.processes.append(
+        Popen([qdrant_exec, "--uri", bootstrap_uri], env=env, cwd=peer_dirs[0], stderr=log_file))
+    time.sleep(5)
+
+    # Start other peers
+    for i in range(1, len(peer_dirs)):
+        p2p_port = get_p2p_port(i)
+        http_port = get_http_port(i)
+        env = get_env(p2p_port, http_port)
+        peer_api_uris.append(get_uri(http_port))
+        log_file = open(f"peer{i}.log", "w")
+        conftest.processes.append(
+            Popen([qdrant_exec, "--bootstrap", bootstrap_uri], env=env, cwd=peer_dirs[i], stderr=log_file))
+
+    # Wait
+    time.sleep(3)
+
+    # Check that there are no collections on all peers
+    for uri in peer_api_uris:
+        r = requests.get(f"{uri}/collections")
+        assert_http_ok(r)
+        assert len(r.json()["result"]["collections"]) == 0
+
+    # Create collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection", json={
+            "vector_size": 4,
+            "distance": "Dot"
+        })
+    assert_http_ok(r)
+
+    time.sleep(5)
+
+    # Check that it exists on all peers
+    for uri in peer_api_uris:
+        r = requests.get(f"{uri}/collections")
+        assert_http_ok(r)
+        assert r.json()[
+            "result"]["collections"][0]["name"] == "test_collection"

--- a/tests/python_tests/multipeer_test.py
+++ b/tests/python_tests/multipeer_test.py
@@ -7,7 +7,7 @@ import requests
 from . import conftest
 from subprocess import Popen
 
-N_PEERS = 2
+N_PEERS = 5
 
 
 def get_http_port(peer_index: int) -> int:
@@ -75,6 +75,7 @@ def test_multipeer_deployment(tmp_path: pathlib.Path):
         log_file = open(f"peer{i}.log", "w")
         conftest.processes.append(
             Popen([qdrant_exec, "--bootstrap", bootstrap_uri], env=env, cwd=peer_dirs[i], stderr=log_file))
+        time.sleep(3)
 
     # Wait
     time.sleep(3)


### PR DESCRIPTION
## Issue
Closes #582

## Fixes
Also contains fixes for snapshot and wal handling as several bugs were discovered during the test.

## Test Details
- Test is written in python as the logic seems too complex for bash script to handle it and be easy to understand
- Pytest python testing framework is used to run it
- Current number of peers is set to 5
