### PR TITLE
[sharding] Materialize remote shards

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -117,7 +117,7 @@ pub enum CollectionShardDistribution {
 
 impl CollectionShardDistribution {
     /// Unpack the distribution into separate local and remote peers.
-    /// If `AllLocal`, it default to assigning `config_shard_number` locally.
+    /// If `AllLocal`, it defaults to assigning `config_shard_number` locally.
     fn unpack_or_default(self, config_shard_number: u32) -> (Vec<ShardId>, Vec<(ShardId, PeerId)>) {
         match self {
             CollectionShardDistribution::AllLocal => (
@@ -208,7 +208,7 @@ impl Collection {
         }
 
         for (shard_id, peer_id) in remote_shards {
-            let shard = RemoteShard::build(
+            let shard = RemoteShard::new(
                 shard_id,
                 id.clone(),
                 peer_id,
@@ -259,7 +259,7 @@ impl Collection {
         }
 
         for (shard_id, peer_id) in remote_shards {
-            let shard = RemoteShard::build(
+            let shard = RemoteShard::new(
                 shard_id,
                 id.clone(),
                 peer_id,

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -41,6 +41,22 @@ pub struct RemoteShard {
 }
 
 impl RemoteShard {
+    pub fn build(
+        id: ShardId,
+        collection_id: CollectionId,
+        peer_id: PeerId,
+        ip_to_address: Arc<std::sync::RwLock<HashMap<u64, Uri>>>,
+        channel_pool: Arc<TransportChannelPool>,
+    ) -> Self {
+        Self {
+            id,
+            collection_id,
+            peer_id,
+            ip_to_address,
+            channel_pool,
+        }
+    }
+
     fn current_address(&self) -> CollectionResult<Uri> {
         let guard_peer_address = self.ip_to_address.read()?;
         let peer_address = guard_peer_address.get(&self.peer_id).cloned();

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -41,7 +41,7 @@ pub struct RemoteShard {
 }
 
 impl RemoteShard {
-    pub fn build(
+    pub fn new(
         id: ShardId,
         collection_id: CollectionId,
         peer_id: PeerId,

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -9,11 +9,10 @@ use collection::{
         types::ScrollRequest,
         CollectionUpdateOperations,
     },
-    Collection,
 };
 use segment::types::{PayloadSelectorExclude, WithPayloadInterface};
 
-use crate::common::{simple_collection_fixture, N_SHARDS};
+use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
 
 mod common;
 
@@ -31,7 +30,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
         collection.before_drop().await;
     }
     for _i in 0..5 {
-        let mut collection = Collection::load("test".to_string(), collection_dir.path()).await;
+        let mut collection = load_local_collection("test".to_string(), collection_dir.path()).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
@@ -46,7 +45,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
         collection.before_drop().await;
     }
 
-    let mut collection = Collection::load("test".to_string(), collection_dir.path()).await;
+    let mut collection = load_local_collection("test".to_string(), collection_dir.path()).await;
     assert_eq!(collection.info(None).await.unwrap().vectors_count, 2);
     collection.before_drop().await;
 }
@@ -75,7 +74,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
         collection.before_drop().await;
     }
 
-    let mut collection = Collection::load("test".to_string(), collection_dir.path()).await;
+    let mut collection = load_local_collection("test".to_string(), collection_dir.path()).await;
 
     let searcher = SimpleCollectionSearcher::new();
     let res = collection
@@ -140,7 +139,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
         collection.before_drop().await;
     }
 
-    let mut collection = Collection::load("test".to_string(), collection_dir.path()).await;
+    let mut collection = load_local_collection("test".to_string(), collection_dir.path()).await;
 
     let searcher = SimpleCollectionSearcher::new();
     // Test res with filter payload

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -4,18 +4,15 @@ use std::collections::HashSet;
 use tempdir::TempDir;
 use tokio::runtime::Handle;
 
-use collection::{
-    operations::{
-        payload_ops::{PayloadOps, SetPayload},
-        point_ops::{PointOperations, PointStruct},
-        types::{RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus},
-        CollectionUpdateOperations,
-    },
-    Collection,
+use collection::operations::{
+    payload_ops::{PayloadOps, SetPayload},
+    point_ops::{PointOperations, PointStruct},
+    types::{RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus},
+    CollectionUpdateOperations,
 };
 use segment::types::{Condition, HasIdCondition, Payload, PointIdType, WithPayloadInterface};
 
-use crate::common::{simple_collection_fixture, N_SHARDS};
+use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
 use collection::collection_manager::simple_collection_searcher::SimpleCollectionSearcher;
 use collection::operations::point_ops::Batch;
 use collection::operations::types::PointRequest;
@@ -195,7 +192,8 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
         collection.before_drop().await;
     }
 
-    let mut loaded_collection = Collection::load("test".to_string(), collection_dir.path()).await;
+    let mut loaded_collection =
+        load_local_collection("test".to_string(), collection_dir.path()).await;
     let segment_searcher = SimpleCollectionSearcher::new();
     let request = PointRequest {
         ids: vec![1.into(), 2.into()],

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -1,9 +1,11 @@
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::operations::types::CollectionError;
 use collection::optimizers_builder::OptimizersConfig;
-use collection::Collection;
+use collection::{Collection, CollectionId, CollectionShardDistribution};
 use segment::types::Distance;
 use std::num::NonZeroU32;
 use std::path::Path;
+use std::sync::Arc;
 
 /// Test collections for this upper bound of shards.
 /// Testing with more shards is problematic due to `number of open files problem`
@@ -36,16 +38,44 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
         shard_number: NonZeroU32::new(shard_number).expect("Shard number can not be zero"),
     };
 
+    let collection_config = CollectionConfig {
+        params: collection_params,
+        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        wal_config,
+        hnsw_config: Default::default(),
+    };
+
+    // Default to a collection with all the shards local
+    new_local_collection("test".to_string(), collection_path, &collection_config)
+        .await
+        .unwrap()
+}
+
+/// Default to a collection with all the shards local
+pub async fn new_local_collection(
+    id: CollectionId,
+    path: &Path,
+    config: &CollectionConfig,
+) -> Result<Collection, CollectionError> {
     Collection::new(
-        "test".to_string(),
-        collection_path,
-        &CollectionConfig {
-            params: collection_params,
-            optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
-            wal_config,
-            hnsw_config: Default::default(),
-        },
+        id,
+        path,
+        config,
+        CollectionShardDistribution::AllLocal,
+        Arc::new(Default::default()),
+        Arc::new(Default::default()),
     )
     .await
-    .unwrap()
+}
+
+/// Default to a collection with all the shards local
+pub async fn load_local_collection(id: CollectionId, path: &Path) -> Collection {
+    Collection::load(
+        id,
+        path,
+        CollectionShardDistribution::AllLocal,
+        Arc::new(Default::default()),
+        Arc::new(Default::default()),
+    )
+    .await
 }

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -1,11 +1,10 @@
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::types::CollectionError;
 use collection::optimizers_builder::OptimizersConfig;
-use collection::{Collection, CollectionId, CollectionShardDistribution};
+use collection::{ChannelService, Collection, CollectionId, CollectionShardDistribution};
 use segment::types::Distance;
 use std::num::NonZeroU32;
 use std::path::Path;
-use std::sync::Arc;
 
 /// Test collections for this upper bound of shards.
 /// Testing with more shards is problematic due to `number of open files problem`
@@ -62,8 +61,7 @@ pub async fn new_local_collection(
         path,
         config,
         CollectionShardDistribution::AllLocal,
-        Arc::new(Default::default()),
-        Arc::new(Default::default()),
+        ChannelService::default(),
     )
     .await
 }
@@ -74,8 +72,7 @@ pub async fn load_local_collection(id: CollectionId, path: &Path) -> Collection 
         id,
         path,
         CollectionShardDistribution::AllLocal,
-        Arc::new(Default::default()),
-        Arc::new(Default::default()),
+        ChannelService::default(),
     )
     .await
 }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,3 +1,4 @@
+use crate::content_manager::shard_distribution::ShardDistributionProposal;
 use collection::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
 use schemars::JsonSchema;
 use segment::types::Distance;
@@ -144,6 +145,7 @@ pub struct DeleteCollectionOperation(pub String);
 #[serde(rename_all = "snake_case")]
 pub enum CollectionMetaOperations {
     CreateCollection(CreateCollectionOperation),
+    CreateCollectionDistributed(CreateCollectionOperation, ShardDistributionProposal),
     UpdateCollection(UpdateCollectionOperation),
     DeleteCollection(DeleteCollectionOperation),
     ChangeAliases(ChangeAliasesOperation),

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -4,19 +4,23 @@ mod collections_ops;
 pub mod conversions;
 pub mod errors;
 pub mod raft_state;
+mod shard_distribution;
 pub mod toc;
 
 pub mod consensus_ops {
+    use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
+    use crate::content_manager::shard_distribution::ShardDistributionProposal;
     use collection::PeerId;
     use raft::eraftpb::Entry as RaftEntry;
     use serde::{Deserialize, Serialize};
 
-    use super::collection_meta_ops::CollectionMetaOperations;
-
     /// Operation that should pass consensus
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
     pub enum ConsensusOperations {
-        CollectionMeta(Box<CollectionMetaOperations>),
+        CollectionMeta(
+            Box<CollectionMetaOperations>,
+            Option<ShardDistributionProposal>,
+        ),
         AddPeer(PeerId, String),
     }
 

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -9,7 +9,6 @@ pub mod toc;
 
 pub mod consensus_ops {
     use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
-    use crate::content_manager::shard_distribution::ShardDistributionProposal;
     use collection::PeerId;
     use raft::eraftpb::Entry as RaftEntry;
     use serde::{Deserialize, Serialize};
@@ -17,10 +16,7 @@ pub mod consensus_ops {
     /// Operation that should pass consensus
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
     pub enum ConsensusOperations {
-        CollectionMeta(
-            Box<CollectionMetaOperations>,
-            Option<ShardDistributionProposal>,
-        ),
+        CollectionMeta(Box<CollectionMetaOperations>),
         AddPeer(PeerId, String),
     }
 

--- a/lib/storage/src/content_manager/raft_state.rs
+++ b/lib/storage/src/content_manager/raft_state.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::types::PeerAddressById;
 use atomicwrites::{AtomicFile, OverwriteBehavior::AllowOverwrite};
 use collection::PeerId;
 use raft::{
@@ -13,8 +14,6 @@ use raft::{
 };
 use serde::{Deserialize, Serialize};
 use tonic::transport::Uri;
-
-use crate::types::PeerAddressById;
 
 use super::errors::StorageError;
 
@@ -57,7 +56,7 @@ pub struct Persistent {
     state: RaftState,
     unapplied_entries: UnappliedEntries,
     #[serde(with = "serialize_peer_addresses")]
-    peer_address_by_id: Arc<std::sync::RwLock<PeerAddressById>>,
+    pub peer_address_by_id: Arc<std::sync::RwLock<PeerAddressById>>,
     this_peer_id: u64,
     #[serde(skip)]
     path: PathBuf,

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -1,0 +1,98 @@
+use collection::shard::{Shard, ShardId};
+use collection::PeerId;
+use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PeerShardCount {
+    shard_count: usize, // self.shard_count and other.shard_count are compared first to determine eq & ord
+    peer_id: PeerId,
+}
+
+impl PeerShardCount {
+    fn new(shard_count: usize, peer_id: PeerId) -> Self {
+        Self {
+            shard_count,
+            peer_id,
+        }
+    }
+
+    fn inc_shard_count(&mut self) {
+        self.shard_count += 1;
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+pub struct ShardDistributionProposal {
+    pub distribution: Vec<(ShardId, PeerId)>,
+}
+
+impl ShardDistributionProposal {
+    /// Builds a proposal for the distribution of shards.
+    /// It will propose to allocate shards so that all peers have the same number of shards at the end.
+    pub fn build(
+        config_shard_number: u32,
+        this_peer_id: PeerId,
+        known_peers: &[PeerId],
+        known_shards: Vec<&Shard>,
+    ) -> Self {
+        // min number of shard_count on top to make this a min-heap
+        let mut min_heap: BinaryHeap<Reverse<PeerShardCount>> =
+            BinaryHeap::with_capacity(known_peers.len());
+
+        // count number of existing shards per peers
+        for &peer in known_peers {
+            let shard_count_on_peer = known_shards
+                .iter()
+                .filter(|shard| match shard {
+                    Shard::Remote(remote_shard) if remote_shard.peer_id == peer => true,
+                    Shard::Local(_) if this_peer_id == peer => true,
+                    _ => false,
+                })
+                .count();
+            min_heap.push(Reverse(PeerShardCount::new(shard_count_on_peer, peer)))
+        }
+
+        // no known peers with shards - add minimal entry for this peer so it gets all the shards
+        if min_heap.is_empty() {
+            min_heap.push(Reverse(PeerShardCount::new(1, this_peer_id)))
+        }
+
+        let mut distribution: Vec<(ShardId, PeerId)> =
+            Vec::with_capacity(config_shard_number as usize);
+
+        // propose the peer with the least amount of existing shards to host the next shard
+        for shard_id in 0..config_shard_number {
+            let mut least_loaded_peer = min_heap.peek_mut().unwrap();
+            let selected_peer = least_loaded_peer.0.peer_id;
+            least_loaded_peer.0.inc_shard_count();
+            distribution.push((shard_id, selected_peer));
+        }
+
+        Self { distribution }
+    }
+
+    pub fn local_shards_for_peer(&self, peer_id: PeerId) -> Vec<ShardId> {
+        self.distribution
+            .iter()
+            .filter_map(
+                |(shard, peer)| {
+                    if peer == &peer_id {
+                        Some(*shard)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect()
+    }
+
+    pub fn remote_shards_for_peer(&self, peer_id: PeerId) -> Vec<(ShardId, PeerId)> {
+        self.distribution
+            .iter()
+            .filter(|(_shard, peer)| peer != &peer_id)
+            .copied()
+            .collect()
+    }
+}

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -1,5 +1,6 @@
 use collection::shard::{Shard, ShardId};
 use collection::PeerId;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
@@ -23,7 +24,7 @@ impl PeerShardCount {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct ShardDistributionProposal {
     pub distribution: Vec<(ShardId, PeerId)>,
 }

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -31,7 +31,7 @@ pub struct ShardDistributionProposal {
 impl ShardDistributionProposal {
     /// Builds a proposal for the distribution of shards.
     /// It will propose to allocate shards so that all peers have the same number of shards at the end.
-    pub fn build(
+    pub fn new(
         config_shard_number: u32,
         this_peer_id: PeerId,
         known_peers: &[PeerId],
@@ -73,7 +73,7 @@ impl ShardDistributionProposal {
         Self { distribution }
     }
 
-    pub fn local_shards_for_peer(&self, peer_id: PeerId) -> Vec<ShardId> {
+    pub fn local_shards_for(&self, peer_id: PeerId) -> Vec<ShardId> {
         self.distribution
             .iter()
             .filter_map(
@@ -88,7 +88,7 @@ impl ShardDistributionProposal {
             .collect()
     }
 
-    pub fn remote_shards_for_peer(&self, peer_id: PeerId) -> Vec<(ShardId, PeerId)> {
+    pub fn remote_shards_for(&self, peer_id: PeerId) -> Vec<(ShardId, PeerId)> {
         self.distribution
             .iter()
             .filter(|(_shard, peer)| peer != &peer_id)

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -394,7 +394,7 @@ impl TableOfContent {
                         .iter()
                         .flat_map(|(_, col)| col.all_shards())
                         .collect();
-                    let shard_distribution = ShardDistributionProposal::build(
+                    let shard_distribution = ShardDistributionProposal::new(
                         shard_number,
                         self.this_peer_id,
                         &known_peers,
@@ -458,8 +458,8 @@ impl TableOfContent {
                 let collection_shard_distribution = match shard_distribution_proposal {
                     None => CollectionShardDistribution::AllLocal,
                     Some(distribution) => {
-                        let local = distribution.local_shards_for_peer(self.this_peer_id);
-                        let remote = distribution.remote_shards_for_peer(self.this_peer_id);
+                        let local = distribution.local_shards_for(self.this_peer_id);
+                        let remote = distribution.remote_shards_for(self.this_peer_id);
                         CollectionShardDistribution::Distribution { local, remote }
                     }
                 };

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -469,7 +469,7 @@ mod tests {
                         hnsw_config: None,
                         wal_config: None,
                         optimizers_config: None,
-                        shard_number: 1,
+                        shard_number: 2,
                     },
                 }),
                 None,

--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -10,7 +10,7 @@ from . import conftest
 from subprocess import Popen
 
 N_PEERS = 5
-
+N_SHARDS = 6
 
 def test_collection_after_peers_added(tmp_path: pathlib.Path):
     # Ensure current path is project root
@@ -62,11 +62,12 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         assert_http_ok(r)
         assert len(r.json()["result"]["collections"]) == 0
 
-    # Create collection
+    # Create collection in first peer
     r = requests.put(
         f"{peer_api_uris[0]}/collections/test_collection", json={
             "vector_size": 4,
-            "distance": "Dot"
+            "distance": "Dot",
+            "shard_number": N_SHARDS,
         })
     assert_http_ok(r)
 
@@ -78,3 +79,40 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         assert_http_ok(r)
         assert r.json()[
             "result"]["collections"][0]["name"] == "test_collection"
+
+    # Create points in first peer's collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                      "city": "Berlin",
+                      "country": "Germany" ,
+                      "count": 1000000,
+                      "square": 12.5,
+                      "coords": { "lat": 1.0, "lon": 2.0 }
+                    }
+                },
+                {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"]}},
+                {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": ["Berlin", "Moscow"]}},
+                {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": ["London", "Moscow"]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count": [0]}},
+                {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
+            ]
+        })
+    assert_http_ok(r)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+         r = requests.post(
+             f"{uri}/collections/test_collection/points/search", json={
+                 "vector": [0.2, 0.1, 0.9, 0.7],
+                 "top": 3,
+             }
+         )
+         assert_http_ok(r)
+         assert r.json()["result"][0]["id"] == 4
+         assert r.json()["result"][1]["id"] == 1
+         assert r.json()["result"][2]["id"] == 3

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -10,7 +10,7 @@ from . import conftest
 from subprocess import Popen
 
 N_PEERS = 5
-
+N_SHARDS = 6
 
 def test_collection_before_peers_added(tmp_path: pathlib.Path):
     # Ensure current path is project root
@@ -46,7 +46,8 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
     r = requests.put(
         f"{peer_api_uris[0]}/collections/test_collection", json={
             "vector_size": 4,
-            "distance": "Dot"
+            "distance": "Dot",
+            "shard_number": N_SHARDS
         })
     assert_http_ok(r)
 

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -12,7 +12,7 @@ from subprocess import Popen
 N_PEERS = 5
 N_SHARDS = 6
 
-def test_collection_after_peers_added(tmp_path: pathlib.Path):
+def test_collection_sharding(tmp_path: pathlib.Path):
     # Ensure current path is project root
     directory_path = os.getcwd()
     folder_name = os.path.basename(directory_path)

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -10,6 +10,7 @@ from . import conftest
 from subprocess import Popen
 
 N_PEERS = 5
+N_SHARDS = 6
 
 def test_collection_after_peers_added(tmp_path: pathlib.Path):
     # Ensure current path is project root
@@ -61,11 +62,12 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         assert_http_ok(r)
         assert len(r.json()["result"]["collections"]) == 0
 
-    # Create collection
+    # Create collection in first peer
     r = requests.put(
         f"{peer_api_uris[0]}/collections/test_collection", json={
             "vector_size": 4,
             "distance": "Dot",
+            "shard_number": N_SHARDS,
         })
     assert_http_ok(r)
 
@@ -77,3 +79,40 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         assert_http_ok(r)
         assert r.json()[
             "result"]["collections"][0]["name"] == "test_collection"
+
+    # Create points in first peer's collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                      "city": "Berlin",
+                      "country": "Germany" ,
+                      "count": 1000000,
+                      "square": 12.5,
+                      "coords": { "lat": 1.0, "lon": 2.0 }
+                    }
+                },
+                {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"]}},
+                {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": ["Berlin", "Moscow"]}},
+                {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": ["London", "Moscow"]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count": [0]}},
+                {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
+            ]
+        })
+    assert_http_ok(r)
+
+    # Check that 'search' returns the same results on all peers
+    for uri in peer_api_uris:
+         r = requests.post(
+             f"{uri}/collections/test_collection/points/search", json={
+                 "vector": [0.2, 0.1, 0.9, 0.7],
+                 "top": 3,
+             }
+         )
+         assert_http_ok(r)
+         assert r.json()["result"][0]["id"] == 4
+         assert r.json()["result"][1]["id"] == 1
+         assert r.json()["result"][2]["id"] == 3


### PR DESCRIPTION
This PR handles remote shards during collection creation https://github.com/qdrant/qdrant/issues/519

## How it works.

When a peer receives a `create_collection` command, it generates a proposal to allocate the new collection's shards among all peers available.

The current strategy is to aim for having the same number of shards on all peers which should be good enough for the time being.

This proposal is bundled with the `create_collection` command and sent down the Raft consensus pipeline.

Once the bundle is committed, all peers will apply the `create_collection` command and respect the proposal regarding the shards that they have been attributed.

## Testing

There is an integration test that inserts points and search works with several peers and several shards.

## Next task

An important piece is left out of this PR in order to smooth the review.

We discovered during the implementation that the remote shard topology is not available at startup time.

This means the booting peer will assume it owns all shards of the collections it found locally on its file system.
Its view of the world will be adjusted once it receives a `SnapshotData` via Raft which contains the full shard topology.
A possible solution is to persist the topology on each peer. 
