### PR TITLE
Log only h2 errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod settings;
 mod tonic;
 
 use consensus::Consensus;
+use log::LevelFilter;
 use slog::Drain;
 use std::io::Error;
 use std::sync::Arc;
@@ -45,8 +46,13 @@ struct Args {
 
 fn main() -> std::io::Result<()> {
     let settings = Settings::new().expect("Can't read config.");
-    std::env::set_var("RUST_LOG", &settings.log_level);
-    env_logger::init();
+    env_logger::Builder::new()
+        // Parse user defined log level configuration
+        .parse_filters(&settings.log_level)
+        // h2 is very verbose and we have many network operations,
+        // so it is limited to only errors
+        .filter_module("h2", LevelFilter::Error)
+        .init();
 
     // Create and own search runtime out of the scope of async context to ensure correct
     // destruction of it


### PR DESCRIPTION
- Proper setup of custom filter without env var
- Sets h2 logging to error only. During debugging consensus h2 logs are a pain as they are everywhere.
