### PR TITLE
add optional CORS headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414360eed71ba2d5435b185ba43ecbe281dfab5df3898286d6b7be8074372c92"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log 0.4.17",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,6 +2515,7 @@ dependencies = [
 name = "qdrant"
 version = "0.7.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "anyhow",
  "api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ config = "~0.13.1"
 tokio = { version = "~1.18", features = ["full"] }
 
 actix-web = { version = "4.0.1", optional = true }
+actix-cors = "0.6.1"
 tonic = "0.7.2"
 num-traits = "0.2.15"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,3 +87,9 @@ service:
   grpc_port: null
   # Uncomment to enable gRPC:
   # grpc_port: 6334
+
+  # Enable CORS headers in REST API.
+  # If enabled, browsers would be allowed to query REST endpoints regardless of query origin.
+  # More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+  # Default: true
+  enable_cors: true

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -4,7 +4,8 @@ pub mod helpers;
 
 use crate::actix::api::collections_api::config_collections_api;
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
-use actix_web::middleware::Logger;
+use actix_cors::Cors;
+use actix_web::middleware::{Condition, Logger};
 use actix_web::web::Data;
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use std::sync::Arc;
@@ -45,7 +46,10 @@ pub fn init(toc: Arc<TableOfContent>, settings: Settings) -> std::io::Result<()>
     actix_web::rt::System::new().block_on(async {
         let toc_data = web::Data::new(toc);
         HttpServer::new(move || {
+            let cors = Cors::default().allow_any_origin().allow_any_origin();
+
             App::new()
+                .wrap(Condition::new(settings.service.enable_cors, cors))
                 .wrap(Logger::default())
                 .app_data(toc_data.clone())
                 .app_data(Data::new(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,6 +10,8 @@ pub struct ServiceConfig {
     pub grpc_port: Option<u16>, // None means that gRPC is disabled
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,
+    #[serde(default = "default_cors")]
+    pub enable_cors: bool,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -70,6 +72,10 @@ pub struct Settings {
     pub service: ServiceConfig,
     #[serde(default)]
     pub cluster: ClusterConfig,
+}
+
+fn default_cors() -> bool {
+    true
 }
 
 fn default_debug() -> bool {


### PR DESCRIPTION
### All Submissions:

Allows to enable CORS headers in Actix web server - if configured - Actix will enable CORS (true by default)

Useful for accessing REST API with browser for debugging

Related to https://github.com/qdrant/qdrant/issues/610

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

