### PR TITLE
Remove serialization wrappers

### DIFF
--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -5,3 +5,35 @@
 
 pub mod content_manager;
 pub mod types;
+
+pub mod serialize_peer_addresses {
+    use itertools::Itertools;
+    use serde::{self, de, Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::HashMap;
+
+    use crate::types::PeerAddressById;
+
+    pub fn serialize<S>(addresses: &PeerAddressById, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let addresses: HashMap<u64, String> = addresses
+            .clone()
+            .into_iter()
+            .map(|(id, address)| (id, format!("{address}")))
+            .collect();
+        addresses.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<PeerAddressById, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let addresses: HashMap<u64, String> = HashMap::deserialize(deserializer)?;
+        addresses
+            .into_iter()
+            .map(|(id, address)| address.parse().map(|address| (id, address)))
+            .try_collect()
+            .map_err(|err| de::Error::custom(format!("Failed to parse uri: {err}")))
+    }
+}


### PR DESCRIPTION
- Removes `RaftStateWrapper` and `PeerAddressByIdWrapper` which helped with serde serialization.
- Uses alternative way through serde attributes

This should help with limiting propagation of wrapper types to the outer code.