### PR TITLE
Increase sleep in consensus tests

### DIFF
--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -54,7 +54,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         time.sleep(3)
 
     # Wait
-    time.sleep(3)
+    time.sleep(5)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -64,7 +64,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
         time.sleep(3)
 
     # Wait
-    time.sleep(3)
+    time.sleep(5)
 
     # Check that it exists on all peers
     for uri in peer_api_uris:


### PR DESCRIPTION
Related to this error in tests: https://github.com/qdrant/qdrant/runs/6569724438?check_suite_focus=true

The cause is probably that peers were not started yet. I tested locally with Rust 1.61 and it works - so this change should not have influenced this.
