### PR TITLE
[sharding] Persist shard information

### DIFF
--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -32,6 +32,7 @@ use crate::operations::types::{
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::{build_optimizers, OptimizersConfig};
+use crate::shard::shard_config::ShardConfig;
 use crate::shard::ShardOperation;
 use crate::update_handler::{OperationData, Optimizer, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
@@ -198,6 +199,11 @@ impl LocalShard {
         shard_path: &Path,
         config: &CollectionConfig,
     ) -> CollectionResult<LocalShard> {
+        // initialize local shard config file
+        ShardConfig::init_file(shard_path)?;
+        let shard_config = ShardConfig::new_local();
+        shard_config.save(shard_path)?;
+
         let wal_path = shard_path.join("wal");
 
         create_dir_all(&wal_path)

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -1,6 +1,7 @@
 mod conversions;
 pub mod local_shard;
 pub mod remote_shard;
+pub mod shard_config;
 
 use crate::shard::remote_shard::RemoteShard;
 use crate::{

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -1,0 +1,58 @@
+use crate::{CollectionError, CollectionResult, PeerId};
+use std::path::{Path, PathBuf};
+
+use segment::common::file_operations::{atomic_save_json, read_json};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+
+pub const SHARD_CONFIG_FILE: &str = "config.json";
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub enum ShardType {
+    Local,
+    Remote { peer_id: PeerId },
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ShardConfig {
+    pub r#type: ShardType,
+}
+
+impl ShardConfig {
+    fn get_config_path(path: &Path) -> PathBuf {
+        path.join(SHARD_CONFIG_FILE)
+    }
+
+    /// Initialize an empty config. file if it does not already exist.
+    pub fn init_file(dir_path: &Path) -> Result<(), CollectionError> {
+        let file_path = Self::get_config_path(dir_path);
+        log::info!("Initialize shard config in {:?}", file_path);
+        if !file_path.exists() {
+            let mut file = fs::File::create(&file_path)?;
+            let empty_json = "{}";
+            file.write_all(empty_json.as_bytes())?;
+        }
+        Ok(())
+    }
+
+    pub fn new_remote(peer_id: PeerId) -> Self {
+        let r#type = ShardType::Remote { peer_id };
+        Self { r#type }
+    }
+
+    pub fn new_local() -> Self {
+        let r#type = ShardType::Local;
+        Self { r#type }
+    }
+
+    pub fn load(shard_path: &Path) -> CollectionResult<Self> {
+        let config_path = Self::get_config_path(shard_path);
+        Ok(read_json(&config_path)?)
+    }
+
+    pub fn save(&self, shard_path: &Path) -> CollectionResult<()> {
+        let config_path = Self::get_config_path(shard_path);
+        Ok(atomic_save_json(&config_path, self)?)
+    }
+}

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -20,8 +20,8 @@ pub struct ShardConfig {
 }
 
 impl ShardConfig {
-    fn get_config_path(path: &Path) -> PathBuf {
-        path.join(SHARD_CONFIG_FILE)
+    fn get_config_path(shard_path: &Path) -> PathBuf {
+        shard_path.join(SHARD_CONFIG_FILE)
     }
 
     /// Initialize an empty config. file if it does not already exist.
@@ -48,6 +48,14 @@ impl ShardConfig {
 
     pub fn load(shard_path: &Path) -> CollectionResult<Self> {
         let config_path = Self::get_config_path(shard_path);
+        // shard config was introduced in 0.8.0
+        // therefore we need to generate a shard config for existing local shards
+        if !config_path.exists() {
+            log::info!("Detected missing shard config file in {:?}", shard_path);
+            Self::init_file(shard_path)?;
+            let shard_config = Self::new_local();
+            shard_config.save(shard_path)?;
+        }
         Ok(read_json(&config_path)?)
     }
 

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -68,10 +68,5 @@ pub async fn new_local_collection(
 
 /// Default to a collection with all the shards local
 pub async fn load_local_collection(id: CollectionId, path: &Path) -> Collection {
-    Collection::load(
-        id,
-        path,
-        ChannelService::default(),
-    )
-    .await
+    Collection::load(id, path, ChannelService::default()).await
 }

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -71,7 +71,6 @@ pub async fn load_local_collection(id: CollectionId, path: &Path) -> Collection 
     Collection::load(
         id,
         path,
-        CollectionShardDistribution::AllLocal,
         ChannelService::default(),
     )
     .await

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -126,14 +126,9 @@ impl TableOfContent {
                 .expect("A filename of one of the collection files is not a valid UTF-8")
                 .to_string();
 
-            let shard_distribution =
-                CollectionShardDistribution::from_local_state(&collection_path)
-                    .expect("Can't infer shard distribution from local shard configurations");
-
             let collection = collection_management_runtime.block_on(Collection::load(
                 collection_name.clone(),
                 &collection_path,
-                shard_distribution,
                 channel_service.clone(),
             ));
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -126,10 +126,14 @@ impl TableOfContent {
                 .expect("A filename of one of the collection files is not a valid UTF-8")
                 .to_string();
 
+            let shard_distribution =
+                CollectionShardDistribution::from_local_state(&collection_path)
+                    .expect("Can't infer shard distribution from local shard configurations");
+
             let collection = collection_management_runtime.block_on(Collection::load(
                 collection_name.clone(),
                 &collection_path,
-                CollectionShardDistribution::AllLocal, //TODO read remote info from local file system
+                shard_distribution,
                 channel_service.clone(),
             ));
 
@@ -916,6 +920,7 @@ impl TableOfContent {
                                 .apply_state(
                                     state.clone(),
                                     self.this_peer_id(),
+                                    &self.get_collection_path(&collection.name()),
                                     channel_service.clone(),
                                 )
                                 .await?;


### PR DESCRIPTION
This PR adds persistence of the shard information https://github.com/qdrant/qdrant/issues/618

The information is required at startup time in order to keep track of the remote shards.

The solution proposed is to have a `config.json` file in **every** shard folder which will indicate:
- the shard type: local vs remote
- the peer_id which owns the shard in case of a remote shard

Some information about the file:
- it uses the JSON format as it is preferable to have something human readable
- it is created by default for existing local shards

This PR still misses an integration test where peers in a cluster are restarted.