### PR TITLE
Move out consensus test setup into util

### DIFF
--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -1,59 +1,28 @@
-import os
 import pathlib
-import shutil
 import time
-
 import requests
-
 from .utils import *
-from . import conftest
-from subprocess import Popen
 
 N_PEERS = 5
 
+
 def test_collection_after_peers_added(tmp_path: pathlib.Path):
-    # Ensure current path is project root
-    directory_path = os.getcwd()
-    folder_name = os.path.basename(directory_path)
-    assert folder_name == "qdrant"
-
-    qdrant_exec = directory_path + "/target/debug/qdrant"
-
-    # Make peer folders
-    peer_dirs = []
-    for i in range(N_PEERS):
-        peer_dir = tmp_path / f"peer{i}"
-        peer_dir.mkdir()
-        peer_dirs.append(peer_dir)
-        shutil.copytree("config", peer_dir / "config")
+    assert_project_root()
+    peer_dirs = make_peer_folders(tmp_path, N_PEERS)
 
     # Gathers REST API uris
     peer_api_uris = []
 
-    # Start bootstrap
-    p2p_port = get_port()
-    http_port = get_port()
-    env = get_env(p2p_port, http_port)
-    bootstrap_uri = get_uri(p2p_port)
-    peer_api_uris.append(get_uri(http_port))
-    log_file = open("peer_0_0.log", "w")
-    conftest.processes.append(
-        Popen([qdrant_exec, "--uri", bootstrap_uri], env=env, cwd=peer_dirs[0], stderr=log_file))
-    time.sleep(5)
+    (bootstrap_api_uri, bootstrap_uri) = start_first_peer(
+        peer_dirs[0], "peer_0_0.log")
+    peer_api_uris.append(bootstrap_api_uri)
 
-    # Start other peers
     for i in range(1, len(peer_dirs)):
-        p2p_port = get_port()
-        http_port = get_port()
-        env = get_env(p2p_port, http_port)
-        peer_api_uris.append(get_uri(http_port))
-        log_file = open(f"peer_0_{i}.log", "w")
-        conftest.processes.append(
-            Popen([qdrant_exec, "--bootstrap", bootstrap_uri], env=env, cwd=peer_dirs[i], stderr=log_file))
-        time.sleep(3)
+        peer_api_uris.append(start_peer(
+            peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
 
     # Wait
-    time.sleep(3)
+    time.sleep(5)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -12,35 +12,17 @@ from subprocess import Popen
 N_PEERS = 5
 N_SHARDS = 6
 
+
 def test_collection_before_peers_added(tmp_path: pathlib.Path):
-    # Ensure current path is project root
-    directory_path = os.getcwd()
-    folder_name = os.path.basename(directory_path)
-    assert folder_name == "qdrant"
-
-    qdrant_exec = directory_path + "/target/debug/qdrant"
-
-    # Make peer folders
-    peer_dirs = []
-    for i in range(N_PEERS):
-        peer_dir = tmp_path / f"peer{i}"
-        peer_dir.mkdir()
-        peer_dirs.append(peer_dir)
-        shutil.copytree("config", peer_dir / "config")
+    assert_project_root()
+    peer_dirs = make_peer_folders(tmp_path, N_PEERS)
 
     # Gathers REST API uris
     peer_api_uris = []
 
-    # Start bootstrap
-    p2p_port = get_port()
-    http_port = get_port()
-    env = get_env(p2p_port, http_port)
-    bootstrap_uri = get_uri(p2p_port)
-    peer_api_uris.append(get_uri(http_port))
-    log_file = open("peer_1_0.log", "w")
-    conftest.processes.append(
-        Popen([qdrant_exec, "--uri", bootstrap_uri], env=env, cwd=peer_dirs[0], stderr=log_file))
-    time.sleep(5)
+    (bootstrap_api_uri, bootstrap_uri) = start_first_peer(
+        peer_dirs[0], "peer_0_0.log")
+    peer_api_uris.append(bootstrap_api_uri)
 
     # Create collection
     r = requests.put(
@@ -55,17 +37,12 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
 
     # Start other peers
     for i in range(1, len(peer_dirs)):
-        p2p_port = get_port()
-        http_port = get_port()
-        env = get_env(p2p_port, http_port)
-        peer_api_uris.append(get_uri(http_port))
-        log_file = open(f"peer_1_{i}.log", "w")
-        conftest.processes.append(
-            Popen([qdrant_exec, "--bootstrap", bootstrap_uri], env=env, cwd=peer_dirs[i], stderr=log_file))
+        peer_api_uris.append(start_peer(
+            peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
         time.sleep(3)
 
     # Wait
-    time.sleep(3)
+    time.sleep(5)
 
     # Check that it exists on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -12,49 +12,26 @@ from subprocess import Popen
 N_PEERS = 5
 N_SHARDS = 6
 
+
 def test_collection_sharding(tmp_path: pathlib.Path):
-    # Ensure current path is project root
-    directory_path = os.getcwd()
-    folder_name = os.path.basename(directory_path)
-    assert folder_name == "qdrant"
-
-    qdrant_exec = directory_path + "/target/debug/qdrant"
-
-    # Make peer folders
-    peer_dirs = []
-    for i in range(N_PEERS):
-        peer_dir = tmp_path / f"peer{i}"
-        peer_dir.mkdir()
-        peer_dirs.append(peer_dir)
-        shutil.copytree("config", peer_dir / "config")
+    assert_project_root()
+    peer_dirs = make_peer_folders(tmp_path, N_PEERS)
 
     # Gathers REST API uris
     peer_api_uris = []
 
     # Start bootstrap
-    p2p_port = get_port()
-    http_port = get_port()
-    env = get_env(p2p_port, http_port)
-    bootstrap_uri = get_uri(p2p_port)
-    peer_api_uris.append(get_uri(http_port))
-    log_file = open("peer_0_0.log", "w")
-    conftest.processes.append(
-        Popen([qdrant_exec, "--uri", bootstrap_uri], env=env, cwd=peer_dirs[0], stderr=log_file))
-    time.sleep(5)
+    (bootstrap_api_uri, bootstrap_uri) = start_first_peer(
+        peer_dirs[0], "peer_0_0.log")
+    peer_api_uris.append(bootstrap_api_uri)
 
     # Start other peers
     for i in range(1, len(peer_dirs)):
-        p2p_port = get_port()
-        http_port = get_port()
-        env = get_env(p2p_port, http_port)
-        peer_api_uris.append(get_uri(http_port))
-        log_file = open(f"peer_0_{i}.log", "w")
-        conftest.processes.append(
-            Popen([qdrant_exec, "--bootstrap", bootstrap_uri], env=env, cwd=peer_dirs[i], stderr=log_file))
-        time.sleep(3)
+        peer_api_uris.append(start_peer(
+            peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
 
     # Wait
-    time.sleep(3)
+    time.sleep(5)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:
@@ -88,17 +65,21 @@ def test_collection_sharding(tmp_path: pathlib.Path):
                     "id": 1,
                     "vector": [0.05, 0.61, 0.76, 0.74],
                     "payload": {
-                      "city": "Berlin",
-                      "country": "Germany" ,
-                      "count": 1000000,
-                      "square": 12.5,
-                      "coords": { "lat": 1.0, "lon": 2.0 }
+                        "city": "Berlin",
+                        "country": "Germany",
+                        "count": 1000000,
+                        "square": 12.5,
+                        "coords": {"lat": 1.0, "lon": 2.0}
                     }
                 },
-                {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"]}},
-                {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": ["Berlin", "Moscow"]}},
-                {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": ["London", "Moscow"]}},
-                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count": [0]}},
+                {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11],
+                    "payload": {"city": ["Berlin", "London"]}},
+                {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94],
+                    "payload": {"city": ["Berlin", "Moscow"]}},
+                {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
+                    "payload": {"city": ["London", "Moscow"]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22,
+                                     0.44], "payload": {"count": [0]}},
                 {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
             ]
         })
@@ -106,13 +87,13 @@ def test_collection_sharding(tmp_path: pathlib.Path):
 
     # Check that 'search' returns the same results on all peers
     for uri in peer_api_uris:
-         r = requests.post(
-             f"{uri}/collections/test_collection/points/search", json={
-                 "vector": [0.2, 0.1, 0.9, 0.7],
-                 "top": 3,
-             }
-         )
-         assert_http_ok(r)
-         assert r.json()["result"][0]["id"] == 4
-         assert r.json()["result"][1]["id"] == 1
-         assert r.json()["result"][2]["id"] == 3
+        r = requests.post(
+            f"{uri}/collections/test_collection/points/search", json={
+                "vector": [0.2, 0.1, 0.9, 0.7],
+                "top": 3,
+            }
+        )
+        assert_http_ok(r)
+        assert r.json()["result"][0]["id"] == 4
+        assert r.json()["result"][1]["id"] == 1
+        assert r.json()["result"][2]["id"] == 3

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -1,7 +1,13 @@
 import os
+import shutil
+from subprocess import Popen
+import time
+from typing import Tuple
 import requests
 import socket
 from contextlib import closing
+from . import conftest
+from pathlib import Path
 
 
 def get_port() -> int:
@@ -27,3 +33,50 @@ def assert_http_ok(response: requests.Response):
     if response.status_code != 200:
         raise Exception(
             f"Http request failed with status {response.status_code} and contents: {response.json()}")
+
+
+def assert_project_root():
+    directory_path = os.getcwd()
+    folder_name = os.path.basename(directory_path)
+    assert folder_name == "qdrant"
+
+
+def get_qdrant_exec() -> str:
+    directory_path = os.getcwd()
+    qdrant_exec = directory_path + "/target/debug/qdrant"
+    return qdrant_exec
+
+
+# Starts a peer and returns its api_uri
+def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str) -> str:
+    p2p_port = get_port()
+    http_port = get_port()
+    env = get_env(p2p_port, http_port)
+    log_file = open(log_file, "w")
+    conftest.processes.append(
+        Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri], env=env, cwd=peer_dir, stderr=log_file))
+    time.sleep(3)
+    return get_uri(http_port)
+
+
+# Starts a peer and returns its api_uri and p2p_uri
+def start_first_peer(peer_dir: Path, log_file: str) -> Tuple[str, str]:
+    p2p_port = get_port()
+    http_port = get_port()
+    env = get_env(p2p_port, http_port)
+    log_file = open(log_file, "w")
+    bootstrap_uri = get_uri(p2p_port)
+    conftest.processes.append(
+        Popen([get_qdrant_exec(), "--uri", bootstrap_uri], env=env, cwd=peer_dir, stderr=log_file))
+    time.sleep(5)
+    return (get_uri(http_port), bootstrap_uri)
+
+
+def make_peer_folders(base_path: Path, n_peers: int) -> list[Path]:
+    peer_dirs = []
+    for i in range(n_peers):
+        peer_dir = base_path / f"peer{i}"
+        peer_dir.mkdir()
+        peer_dirs.append(peer_dir)
+        shutil.copytree("config", peer_dir / "config")
+    return peer_dirs


### PR DESCRIPTION
Simplifies tests before we fully switch to docker-compose.

There are also some formatting changes - they are from `autopep8`
