### PR TITLE
On disk payload storage

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,12 @@ storage:
   # Where to store all the data
   storage_path: ./storage
 
+  # If true - point's payload will not be stored in memory.
+  # It will be read from the disk every time it is requested.
+  # This setting saves RAM by (slightly) increasing the response time.
+  # Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+  on_disk_payload: false
+
   # Write-ahead-log related configuration
   wal:
     # Size of a single WAL segment

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -233,6 +233,7 @@
 | vector_size | [uint64](#uint64) |  | Size of the vectors |
 | distance | [Distance](#qdrant-Distance) |  | Distance function used for comparing vectors |
 | shard_number | [uint32](#uint32) |  | Number of shards in collection |
+| on_disk_payload | [bool](#bool) |  | Read payload directly from disk? |
 
 
 
@@ -270,6 +271,7 @@
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) | optional | Configuration of the Write-Ahead-Log |
 | optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | Configuration of the optimizers |
 | shard_number | [uint32](#uint32) | optional | Number of shards in the collection, default = 1 |
+| on_disk_payload | [bool](#bool) | optional | If `true` keep payload on disk, if `false` - in RAM |
 | timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds, if not specified - default value will be supplied |
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -76,7 +76,7 @@
             "properties": {
               "status": {
                 "enum": [
-                  "ClusterStatusDisabled"
+                  "disabled"
                 ],
                 "type": "string"
               }
@@ -217,6 +217,11 @@
           "distance": {
             "$ref": "#/components/schemas/Distance"
           },
+          "on_disk_payload": {
+            "default": false,
+            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
+            "type": "boolean"
+          },
           "shard_number": {
             "default": 1,
             "description": "Number of shards the collection has",
@@ -319,6 +324,12 @@
               }
             ],
             "description": "Custom params for HNSW index. If none - values from service configuration file are used."
+          },
+          "on_disk_payload": {
+            "default": null,
+            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
+            "nullable": true,
+            "type": "boolean"
           },
           "optimizers_config": {
             "anyOf": [

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -132,7 +132,8 @@ message CreateCollection {
   optional WalConfigDiff wal_config = 5; // Configuration of the Write-Ahead-Log
   optional OptimizersConfigDiff optimizers_config = 6; // Configuration of the optimizers
   optional uint32 shard_number = 7; // Number of shards in the collection, default = 1
-  optional uint64 timeout = 8; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+  optional bool on_disk_payload = 8; // If `true` keep payload on disk, if `false` - in RAM
+  optional uint64 timeout = 9; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
 }
 
 message UpdateCollection {
@@ -155,6 +156,7 @@ message CollectionParams {
   uint64 vector_size = 1; // Size of the vectors
   Distance distance = 2; // Distance function used for comparing vectors
   uint32 shard_number = 3; // Number of shards in collection
+  bool on_disk_payload = 4; // Read payload directly from disk?
 }
 
 message CollectionConfig {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -132,7 +132,7 @@ message CreateCollection {
   optional WalConfigDiff wal_config = 5; // Configuration of the Write-Ahead-Log
   optional OptimizersConfigDiff optimizers_config = 6; // Configuration of the optimizers
   optional uint32 shard_number = 7; // Number of shards in the collection, default = 1
-  optional bool on_disk_payload = 8; // If `true` keep payload on disk, if `false` - in RAM
+  optional bool on_disk_payload = 8; // If true - point's payload will not be stored in memory
   optional uint64 timeout = 9; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
 }
 
@@ -156,7 +156,7 @@ message CollectionParams {
   uint64 vector_size = 1; // Size of the vectors
   Distance distance = 2; // Distance function used for comparing vectors
   uint32 shard_number = 3; // Number of shards in collection
-  bool on_disk_payload = 4; // Read payload directly from disk?
+  bool on_disk_payload = 4; // If true - point's payload will not be stored in memory
 }
 
 message CollectionConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -138,8 +138,11 @@ pub struct CreateCollection {
     /// Number of shards in the collection, default = 1
     #[prost(uint32, optional, tag="7")]
     pub shard_number: ::core::option::Option<u32>,
+    /// If `true` keep payload on disk, if `false` - in RAM
+    #[prost(bool, optional, tag="8")]
+    pub on_disk_payload: ::core::option::Option<bool>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-    #[prost(uint64, optional, tag="8")]
+    #[prost(uint64, optional, tag="9")]
     pub timeout: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -183,6 +186,9 @@ pub struct CollectionParams {
     /// Number of shards in collection
     #[prost(uint32, tag="3")]
     pub shard_number: u32,
+    /// Read payload directly from disk?
+    #[prost(bool, tag="4")]
+    pub on_disk_payload: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionConfig {

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -122,6 +122,7 @@ pub(crate) fn get_merge_optimizer(
             vector_size: 4,
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
+            on_disk_payload: false,
         },
         Default::default(),
     )
@@ -143,6 +144,7 @@ pub(crate) fn get_indexing_optimizer(
             vector_size: 4,
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
+            on_disk_payload: false,
         },
         Default::default(),
     )

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -199,6 +199,7 @@ mod tests {
                 vector_size: segment_config.vector_size,
                 distance: segment_config.distance,
                 shard_number: NonZeroU32::new(1).unwrap(),
+                on_disk_payload: false,
             },
             Default::default(),
         );

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -184,7 +184,7 @@ mod tests {
                 .unwrap();
         }
 
-        let locked_holder = Arc::new(RwLock::new(holder));
+        let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let vacuum_optimizer = VacuumOptimizer::new(
             0.2,
@@ -200,6 +200,7 @@ mod tests {
                 vector_size: 4,
                 distance: Distance::Dot,
                 shard_number: NonZeroU32::new(1).unwrap(),
+                on_disk_payload: false,
             },
             Default::default(),
         );

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -52,10 +52,19 @@ pub struct CollectionParams {
     /// Number of shards the collection has
     #[serde(default = "default_shard_number")]
     pub shard_number: NonZeroU32,
+    /// If true - point's payload will not be stored in memory.
+    /// It will be read from the disk every time it is requested.
+    /// This setting saves RAM by (slightly) increasing the response time.
+    /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    #[serde(default = "default_on_disk_payload")]
+    pub on_disk_payload: bool,
 }
 
 fn default_shard_number() -> NonZeroU32 {
     NonZeroU32::new(1).unwrap()
+}
+fn default_on_disk_payload() -> bool {
+    false
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -90,6 +90,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     }
                     .into(),
                     shard_number: config.params.shard_number.get(),
+                    on_disk_payload: config.params.on_disk_payload,
                 }),
                 hnsw_config: Some(api::grpc::qdrant::HnswConfigDiff {
                     m: Some(config.hnsw_config.m as u64),
@@ -213,6 +214,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                         Some(distance) => distance,
                     },
                     shard_number: NonZeroU32::new(params.shard_number).unwrap(),
+                    on_disk_payload: params.on_disk_payload,
                 },
             },
             hnsw_config: match config.hnsw_config {

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use parking_lot::RwLock;
-use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use std::cmp::max;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::fs::create_dir_all;
@@ -17,8 +16,8 @@ use tokio::runtime::{self, Handle, Runtime};
 use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot, Mutex, RwLock as TokioRwLock};
 
 use segment::types::{
-    ExtendedPointId, Filter, PayloadIndexInfo, PayloadKeyType, ScoredPoint, SegmentType,
-    WithPayload, WithPayloadInterface,
+    ExtendedPointId, Filter, PayloadIndexInfo, PayloadKeyType, PayloadStorageType, ScoredPoint,
+    SegmentConfig, SegmentType, WithPayload, WithPayloadInterface,
 };
 
 use crate::collection_manager::collection_managers::CollectionSearcher;
@@ -36,7 +35,7 @@ use crate::shard::ShardOperation;
 use crate::update_handler::{OperationData, Optimizer, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
 use crate::{CollectionId, PointRequest, SearchRequest, ShardId};
-use segment::segment_constructor::load_segment;
+use segment::segment_constructor::{build_segment, load_segment};
 use std::fs::{read_dir, remove_dir_all};
 
 /// LocalShard
@@ -221,8 +220,18 @@ impl LocalShard {
         let distance = config.params.distance;
         for _sid in 0..config.optimizer_config.default_segment_number {
             let path_clone = segments_path.clone();
-            let segment =
-                thread::spawn(move || build_simple_segment(&path_clone, vector_size, distance));
+            let segment_config = SegmentConfig {
+                vector_size,
+                distance,
+                index: Default::default(),
+                payload_index: Default::default(),
+                storage_type: Default::default(),
+                payload_storage_type: match config.params.on_disk_payload {
+                    true => PayloadStorageType::OnDisk,
+                    false => PayloadStorageType::InMemory,
+                },
+            };
+            let segment = thread::spawn(move || build_segment(&path_clone, &segment_config));
             build_handlers.push(segment);
         }
 

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -35,6 +35,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
         vector_size: 4,
         distance: Distance::Dot,
         shard_number: NonZeroU32::new(shard_number).expect("Shard number can not be zero"),
+        on_disk_payload: false,
     };
 
     let collection_config = CollectionConfig {

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -4,7 +4,10 @@ pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {
     (b + 1..=a).rev()
 }
 
-pub fn get_value_from_json_map<'a>(path: &str, value: &'a serde_json::Map<String, Value>) -> Option<&'a Value> {
+pub fn get_value_from_json_map<'a>(
+    path: &str,
+    value: &'a serde_json::Map<String, Value>,
+) -> Option<&'a Value> {
     match path.split_once('.') {
         Some((element, path)) => match value.get(element) {
             Some(Value::Object(map)) => get_value_from_json_map(path, map),
@@ -18,7 +21,10 @@ pub fn get_value_from_json_map<'a>(path: &str, value: &'a serde_json::Map<String
     }
 }
 
-pub fn remove_value_from_json_map(path: &str, value: &mut serde_json::Map<String, Value>) -> Option<Value> {
+pub fn remove_value_from_json_map(
+    path: &str,
+    value: &mut serde_json::Map<String, Value>,
+) -> Option<Value> {
     match path.split_once('.') {
         Some((element, new_path)) => {
             if new_path.is_empty() {

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -1,3 +1,36 @@
+use serde_json::Value;
+
 pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {
     (b + 1..=a).rev()
+}
+
+pub fn get_value_from_json_map<'a>(path: &str, value: &'a serde_json::Map<String, Value>) -> Option<&'a Value> {
+    match path.split_once('.') {
+        Some((element, path)) => match value.get(element) {
+            Some(Value::Object(map)) => get_value_from_json_map(path, map),
+            Some(value) => match path.is_empty() {
+                true => Some(value),
+                false => None,
+            },
+            None => None,
+        },
+        None => value.get(path),
+    }
+}
+
+pub fn remove_value_from_json_map(path: &str, value: &mut serde_json::Map<String, Value>) -> Option<Value> {
+    match path.split_once('.') {
+        Some((element, new_path)) => {
+            if new_path.is_empty() {
+                value.remove(element)
+            } else {
+                match value.get_mut(element) {
+                    None => None,
+                    Some(Value::Object(map)) => remove_value_from_json_map(new_path, map),
+                    Some(_value) => None,
+                }
+            }
+        }
+        None => value.remove(path),
+    }
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -70,7 +70,7 @@ impl From<FileStorageError> for OperationError {
 
 impl From<serde_cbor::Error> for OperationError {
     fn from(err: serde_cbor::Error) -> Self {
-        OperationError::service_error(&format!("Failed to parse stored data: {}", err))
+        OperationError::service_error(&format!("Failed to parse data: {}", err))
     }
 }
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -68,6 +68,12 @@ impl From<FileStorageError> for OperationError {
     }
 }
 
+impl From<serde_cbor::Error> for OperationError {
+    fn from(err: serde_cbor::Error) -> Self {
+        OperationError::service_error(&format!("Failed to parse stored data: {}", err))
+    }
+}
+
 impl<E> From<AtomicIoError<E>> for OperationError {
     fn from(err: AtomicIoError<E>) -> Self {
         match err {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -28,7 +28,7 @@ pub fn condition_converter<'a>(
             .unwrap_or_else(|| {
                 Box::new(move |point_id| {
                     payload_provider.with_payload(point_id, |payload| {
-                        check_field_condition(field_condition, payload)
+                        check_field_condition(field_condition, &payload)
                     })
                 })
             }),
@@ -37,7 +37,7 @@ pub fn condition_converter<'a>(
         //       it does not mean that there are no values in payload
         Condition::IsEmpty(is_empty) => Box::new(move |point_id| {
             payload_provider.with_payload(point_id, |payload| {
-                check_is_empty_condition(is_empty, payload)
+                check_is_empty_condition(is_empty, &payload)
             })
         }),
         // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet

--- a/lib/segment/src/index/query_optimization/payload_provider.rs
+++ b/lib/segment/src/index/query_optimization/payload_provider.rs
@@ -24,8 +24,12 @@ impl PayloadProvider {
     {
         let payload_storage_guard = self.payload_storage.borrow();
         let payload_ptr_opt = match payload_storage_guard.deref() {
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.payload_ptr(point_id).map(|x| x.into()),
-            PayloadStorageEnum::SimplePayloadStorage(s) => s.payload_ptr(point_id).map(|x| x.into()),
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                s.payload_ptr(point_id).map(|x| x.into())
+            }
+            PayloadStorageEnum::SimplePayloadStorage(s) => {
+                s.payload_ptr(point_id).map(|x| x.into())
+            }
             // Warn: Possible panic here
             // Currently, it is possible that `read_payload` fails with Err,
             // but it seems like a very rare possibility which might only happen

--- a/lib/segment/src/index/query_optimization/payload_provider.rs
+++ b/lib/segment/src/index/query_optimization/payload_provider.rs
@@ -1,5 +1,5 @@
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::types::{Payload, PointOffsetType};
+use crate::types::{OwnedPayloadRef, Payload, PointOffsetType};
 use atomic_refcell::AtomicRefCell;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -20,17 +20,35 @@ impl PayloadProvider {
 
     pub fn with_payload<F, G>(&self, point_id: PointOffsetType, callback: F) -> G
     where
-        F: FnOnce(&Payload) -> G,
+        F: FnOnce(OwnedPayloadRef) -> G,
     {
         let payload_storage_guard = self.payload_storage.borrow();
         let payload_ptr_opt = match payload_storage_guard.deref() {
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.payload_ptr(point_id),
-            PayloadStorageEnum::SimplePayloadStorage(s) => s.payload_ptr(point_id),
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.payload_ptr(point_id).map(|x| x.into()),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.payload_ptr(point_id).map(|x| x.into()),
+            // Warn: Possible panic here
+            // Currently, it is possible that `read_payload` fails with Err,
+            // but it seems like a very rare possibility which might only happen
+            // if something is wrong with disk or storage is corrupted.
+            //
+            // In both cases it means that service can't be of use any longer.
+            // It is as good as dead. Therefore it is tolerable to just panic here.
+            // Downside is - API user won't be notified of the failure.
+            // It will just timeout.
+            //
+            // The alternative:
+            // Rewrite condition checking code to support error reporting.
+            // Which may lead to slowdown and assumes a lot of changes.
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s
+                .read_payload(point_id)
+                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {}", err))
+                .map(|x| x.into()),
         };
+
         let payload = if let Some(payload_ptr) = payload_ptr_opt {
             payload_ptr
         } else {
-            &self.empty_payload
+            (&self.empty_payload).into()
         };
 
         callback(payload)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -24,7 +24,7 @@ use crate::index::struct_filter_context::StructFilterContext;
 use crate::index::visited_pool::VisitedPool;
 use crate::index::PayloadIndex;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::payload_storage::{FilterContext, PayloadStorage};
+use crate::payload_storage::FilterContext;
 use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, PayloadKeyType, PayloadKeyTypeRef,
     PayloadSchemaType, PointOffsetType,
@@ -196,15 +196,15 @@ impl StructPayloadIndex {
         let payload_storage = self.payload.borrow();
 
         let mut builders = index_selector(&field_type);
-        for point_id in payload_storage.iter_ids() {
-            let point_payload = payload_storage.payload(point_id);
+        payload_storage.iter(|point_id, point_payload| {
             let field_value_opt = point_payload.get_value(field);
             if let Some(field_value) = field_value_opt {
                 for builder in &mut builders {
                     builder.add(point_id, field_value);
                 }
             }
-        }
+            true
+        })?;
 
         let field_indexes = builders
             .iter_mut()

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -1,6 +1,6 @@
+use crate::entry::entry_point::OperationResult;
 use crate::types::{Payload, PointOffsetType};
 use std::collections::HashMap;
-use crate::entry::entry_point::OperationResult;
 
 /// Same as `SimplePayloadStorage` but without persistence
 /// Warn: for tests only
@@ -15,7 +15,8 @@ impl InMemoryPayloadStorage {
     }
 
     pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
-        where F: FnMut(PointOffsetType, &Payload) -> bool
+    where
+        F: FnMut(PointOffsetType, &Payload) -> bool,
     {
         for (key, val) in self.payload.iter() {
             let do_continue = callback(*key, val);

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -1,5 +1,6 @@
 use crate::types::{Payload, PointOffsetType};
 use std::collections::HashMap;
+use crate::entry::entry_point::OperationResult;
 
 /// Same as `SimplePayloadStorage` but without persistence
 /// Warn: for tests only
@@ -11,5 +12,17 @@ pub struct InMemoryPayloadStorage {
 impl InMemoryPayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
+    }
+
+    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+        where F: FnMut(PointOffsetType, &Payload) -> bool
+    {
+        for (key, val) in self.payload.iter() {
+            let do_continue = callback(*key, val);
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -18,10 +18,10 @@ impl PayloadStorage for InMemoryPayloadStorage {
         Ok(())
     }
 
-    fn payload(&self, point_id: PointOffsetType) -> Payload {
+    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         match self.payload.get(&point_id) {
-            Some(payload) => payload.to_owned(),
-            None => Default::default(),
+            Some(payload) => Ok(payload.to_owned()),
+            None => Ok(Default::default()),
         }
     }
 
@@ -52,10 +52,6 @@ impl PayloadStorage for InMemoryPayloadStorage {
     fn flush(&self) -> OperationResult<()> {
         Ok(())
     }
-
-    fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
-        Box::new(self.payload.keys().copied())
-    }
 }
 
 #[cfg(test)]
@@ -63,7 +59,7 @@ mod tests {
     use super::*;
     use crate::fixtures::payload_context_fixture::IdsIterator;
     use crate::payload_storage::query_checker::check_payload;
-    use crate::types::{Condition, FieldCondition, Filter};
+    use crate::types::{Condition, FieldCondition, Filter, OwnedPayloadRef};
     use serde_json::json;
     use std::cell::RefCell;
 
@@ -101,14 +97,14 @@ mod tests {
         // How to check for payload in case if Payload is stored on disk
         // and it is preferred to only load the Payload once and if it is strictly required.
 
-        let payload: RefCell<Option<Payload>> = RefCell::new(None);
+        let payload: RefCell<Option<OwnedPayloadRef>> = RefCell::new(None);
         check_payload(
             || {
                 eprintln!("request payload");
                 if payload.borrow().is_none() {
-                    payload.replace(Some(get_payload()));
+                    payload.replace(Some(get_payload().into()));
                 }
-                unsafe { payload.try_borrow_unguarded().unwrap().as_ref().unwrap() }
+                payload.borrow().as_ref().map(|x| x.clone()).unwrap()
             },
             &id_tracker,
             &query,
@@ -125,9 +121,9 @@ mod tests {
         storage.assign(100, &payload).unwrap();
         storage.wipe().unwrap();
         storage.assign(100, &payload).unwrap();
-        assert!(!storage.payload(100).is_empty());
+        assert!(!storage.payload(100).unwrap().is_empty());
         storage.wipe().unwrap();
-        assert_eq!(storage.payload(100), Default::default());
+        assert_eq!(storage.payload(100).unwrap(), Default::default());
     }
 
     #[test]
@@ -157,7 +153,7 @@ mod tests {
         let payload: Payload = serde_json::from_str(data).unwrap();
         let mut storage = InMemoryPayloadStorage::default();
         storage.assign(100, &payload).unwrap();
-        let pload = storage.payload(100);
+        let pload = storage.payload(100).unwrap();
         assert_eq!(pload, payload);
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -104,7 +104,7 @@ mod tests {
                 if payload.borrow().is_none() {
                     payload.replace(Some(get_payload().into()));
                 }
-                payload.borrow().as_ref().map(|x| x.clone()).unwrap()
+                payload.borrow().as_ref().cloned().unwrap()
             },
             &id_tracker,
             &query,

--- a/lib/segment/src/payload_storage/mod.rs
+++ b/lib/segment/src/payload_storage/mod.rs
@@ -6,5 +6,6 @@ pub mod payload_storage_enum;
 pub mod query_checker;
 pub mod simple_payload_storage;
 pub mod simple_payload_storage_impl;
+pub mod on_disk_payload_storage;
 
 pub use payload_storage_base::*;

--- a/lib/segment/src/payload_storage/mod.rs
+++ b/lib/segment/src/payload_storage/mod.rs
@@ -1,11 +1,11 @@
 pub mod condition_checker;
 pub mod in_memory_payload_storage;
 pub mod in_memory_payload_storage_impl;
+pub mod on_disk_payload_storage;
 mod payload_storage_base;
 pub mod payload_storage_enum;
 pub mod query_checker;
 pub mod simple_payload_storage;
 pub mod simple_payload_storage_impl;
-pub mod on_disk_payload_storage;
 
 pub use payload_storage_base::*;

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -55,7 +55,8 @@ impl OnDiskPayloadStorage {
             .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
         let payload = store_ref
             .get_pinned_cf(cf_handle, key)?
-            .map(|raw| serde_cbor::from_slice(raw.as_ref())).transpose()?;
+            .map(|raw| serde_cbor::from_slice(raw.as_ref()))
+            .transpose()?;
         Ok(payload)
     }
 
@@ -101,7 +102,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
     fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         let payload = self.read_payload(point_id)?;
         match payload {
-            Some(payload) => Ok(payload.to_owned()),
+            Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
     }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -1,0 +1,148 @@
+use crate::common::rocksdb_operations::{db_options, db_write_options, DB_PAYLOAD_CF};
+use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
+use atomic_refcell::AtomicRefCell;
+use std::sync::Arc;
+
+use rocksdb::{IteratorMode, DB};
+use serde_json::Value;
+
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::payload_storage::PayloadStorage;
+
+/// On-disk implementation of `PayloadStorage`.
+/// Persists all changes to disk using `store`, does not keep payload in memory
+pub struct OnDiskPayloadStorage {
+    store: Arc<AtomicRefCell<DB>>,
+}
+
+impl OnDiskPayloadStorage {
+    pub fn open(store: Arc<AtomicRefCell<DB>>) -> OperationResult<Self> {
+        Ok(OnDiskPayloadStorage { store })
+    }
+
+    pub fn remove_from_storage(&self, point_id: PointOffsetType) -> OperationResult<()> {
+        let store_ref = self.store.borrow();
+        let cf_handle = store_ref
+            .cf_handle(DB_PAYLOAD_CF)
+            .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
+        store_ref.delete_cf(cf_handle, serde_cbor::to_vec(&point_id).unwrap())?;
+        Ok(())
+    }
+
+    pub fn update_storage(
+        &self,
+        point_id: PointOffsetType,
+        payload: &Payload,
+    ) -> OperationResult<()> {
+        let store_ref = self.store.borrow();
+        let cf_handle = store_ref
+            .cf_handle(DB_PAYLOAD_CF)
+            .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
+        store_ref.put_cf_opt(
+            cf_handle,
+            serde_cbor::to_vec(&point_id).unwrap(),
+            serde_cbor::to_vec(payload).unwrap(),
+            &db_write_options(),
+        )?;
+        Ok(())
+    }
+
+    pub fn read_payload(&self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+        let key = serde_cbor::to_vec(&point_id).unwrap();
+        let store_ref = self.store.borrow();
+        let cf_handle = store_ref
+            .cf_handle(DB_PAYLOAD_CF)
+            .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
+        let payload = store_ref
+            .get_pinned_cf(cf_handle, key)?
+            .map(|raw| serde_cbor::from_slice(raw.as_ref())).transpose()?;
+        Ok(payload)
+    }
+
+    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> bool,
+    {
+        let store_ref = self.store.borrow();
+        let cf_handle = store_ref
+            .cf_handle(DB_PAYLOAD_CF)
+            .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
+        let iterator = store_ref.iterator_cf(cf_handle, IteratorMode::Start);
+        for (key, val) in iterator {
+            let do_continue = callback(
+                serde_cbor::from_slice(&key)?,
+                &serde_cbor::from_slice(&val)?,
+            );
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PayloadStorage for OnDiskPayloadStorage {
+    fn assign_all(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        self.update_storage(point_id, payload)
+    }
+
+    fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
+        let stored_payload = self.read_payload(point_id)?;
+        match stored_payload {
+            Some(mut point_payload) => {
+                point_payload.merge(payload);
+                self.update_storage(point_id, &point_payload)?
+            }
+            None => self.update_storage(point_id, payload)?,
+        }
+        Ok(())
+    }
+
+    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
+        let payload = self.read_payload(point_id)?;
+        match payload {
+            Some(payload) => Ok(payload.to_owned()),
+            None => Ok(Default::default()),
+        }
+    }
+
+    fn delete(
+        &mut self,
+        point_id: PointOffsetType,
+        key: PayloadKeyTypeRef,
+    ) -> OperationResult<Option<Value>> {
+        let stored_payload = self.read_payload(point_id)?;
+
+        match stored_payload {
+            Some(mut payload) => {
+                let res = payload.remove(key);
+                if res.is_some() {
+                    self.update_storage(point_id, &payload)?;
+                }
+                Ok(res)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>> {
+        let payload = self.read_payload(point_id)?;
+        self.remove_from_storage(point_id)?;
+        Ok(payload)
+    }
+
+    fn wipe(&mut self) -> OperationResult<()> {
+        let mut store_ref = self.store.borrow_mut();
+        store_ref.drop_cf(DB_PAYLOAD_CF)?;
+        store_ref.create_cf(DB_PAYLOAD_CF, &db_options())?;
+        Ok(())
+    }
+
+    fn flush(&self) -> OperationResult<()> {
+        let store_ref = self.store.borrow();
+        let cf_handle = store_ref
+            .cf_handle(DB_PAYLOAD_CF)
+            .ok_or_else(|| OperationError::service_error("Payload storage column not found"))?;
+        Ok(store_ref.flush_cf(cf_handle)?)
+    }
+}

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -15,7 +15,7 @@ pub trait PayloadStorage {
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()>;
 
     /// Get payload for point
-    fn payload(&self, point_id: PointOffsetType) -> Payload;
+    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
 
     /// Delete payload by key
     fn delete(
@@ -32,9 +32,6 @@ pub trait PayloadStorage {
 
     /// Force persistence of current storage state.
     fn flush(&self) -> OperationResult<()>;
-
-    /// Iterate all point ids with payload
-    fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 }
 
 pub trait ConditionChecker {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -121,15 +121,16 @@ mod tests {
         assert_eq!(storage.payload(100).unwrap(), Default::default());
     }
 
-
     #[test]
     fn test_on_disk_storage() {
         let dir = TempDir::new("storage_dir").unwrap();
         let db = open_db(dir.path()).unwrap();
 
         {
-            let mut storage: PayloadStorageEnum = SimplePayloadStorage::open(db.clone()).unwrap().into();
-            let payload: Payload = serde_json::from_str(r#"{
+            let mut storage: PayloadStorageEnum =
+                SimplePayloadStorage::open(db.clone()).unwrap().into();
+            let payload: Payload = serde_json::from_str(
+                r#"{
                 "name": "John Doe",
                 "age": 52,
                 "location": {
@@ -139,7 +140,9 @@ mod tests {
                         "lat": 37.8136
                     }
                 }
-            }"#).unwrap();
+            }"#,
+            )
+            .unwrap();
 
             storage.assign_all(100, &payload).unwrap();
 
@@ -166,7 +169,8 @@ mod tests {
 
             eprintln!("res = {:#?}", res);
 
-            let partial_payload: Payload = serde_json::from_str(r#"{ "hobby": "vector search" }"#).unwrap();
+            let partial_payload: Payload =
+                serde_json::from_str(r#"{ "hobby": "vector search" }"#).unwrap();
             storage.assign(100, &partial_payload).unwrap();
 
             storage.delete(100, "location.city").unwrap();

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,5 +1,6 @@
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use crate::payload_storage::on_disk_payload_storage::OnDiskPayloadStorage;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::payload_storage::PayloadStorage;
 use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
@@ -8,6 +9,7 @@ use serde_json::Value;
 pub enum PayloadStorageEnum {
     InMemoryPayloadStorage(InMemoryPayloadStorage),
     SimplePayloadStorage(SimplePayloadStorage),
+    OnDiskPayloadStorage(OnDiskPayloadStorage),
 }
 
 impl From<InMemoryPayloadStorage> for PayloadStorageEnum {
@@ -22,18 +24,39 @@ impl From<SimplePayloadStorage> for PayloadStorageEnum {
     }
 }
 
+impl From<OnDiskPayloadStorage> for PayloadStorageEnum {
+    fn from(a: OnDiskPayloadStorage) -> Self {
+        PayloadStorageEnum::OnDiskPayloadStorage(a)
+    }
+}
+
+impl PayloadStorageEnum {
+    pub fn iter<F>(&self, callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> bool,
+    {
+        match self {
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.iter(callback),
+            PayloadStorageEnum::SimplePayloadStorage(s) => s.iter(callback),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.iter(callback),
+        }
+    }
+}
+
 impl PayloadStorage for PayloadStorageEnum {
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.assign(point_id, payload),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.assign(point_id, payload),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.assign(point_id, payload),
         }
     }
 
-    fn payload(&self, point_id: PointOffsetType) -> Payload {
+    fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload> {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.payload(point_id),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.payload(point_id),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.payload(point_id),
         }
     }
 
@@ -45,6 +68,7 @@ impl PayloadStorage for PayloadStorageEnum {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.delete(point_id, key),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.delete(point_id, key),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.delete(point_id, key),
         }
     }
 
@@ -52,6 +76,7 @@ impl PayloadStorage for PayloadStorageEnum {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.drop(point_id),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.drop(point_id),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.drop(point_id),
         }
     }
 
@@ -59,6 +84,7 @@ impl PayloadStorage for PayloadStorageEnum {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.wipe(),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.wipe(),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.wipe(),
         }
     }
 
@@ -66,13 +92,7 @@ impl PayloadStorage for PayloadStorageEnum {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.flush(),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.flush(),
-        }
-    }
-
-    fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
-        match self {
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.iter_ids(),
-            PayloadStorageEnum::SimplePayloadStorage(s) => s.iter_ids(),
+            PayloadStorageEnum::OnDiskPayloadStorage(s) => s.flush(),
         }
     }
 }
@@ -96,8 +116,69 @@ mod tests {
         storage.assign(100, &payload).unwrap();
         storage.wipe().unwrap();
         storage.assign(100, &payload).unwrap();
-        assert!(!storage.payload(100).is_empty());
+        assert!(!storage.payload(100).unwrap().is_empty());
         storage.wipe().unwrap();
-        assert_eq!(storage.payload(100), Default::default());
+        assert_eq!(storage.payload(100).unwrap(), Default::default());
+    }
+
+
+    #[test]
+    fn test_on_disk_storage() {
+        let dir = TempDir::new("storage_dir").unwrap();
+        let db = open_db(dir.path()).unwrap();
+
+        {
+            let mut storage: PayloadStorageEnum = SimplePayloadStorage::open(db.clone()).unwrap().into();
+            let payload: Payload = serde_json::from_str(r#"{
+                "name": "John Doe",
+                "age": 52,
+                "location": {
+                    "city": "Melbourne",
+                    "geo": {
+                        "lon": 144.9631,
+                        "lat": 37.8136
+                    }
+                }
+            }"#).unwrap();
+
+            storage.assign_all(100, &payload).unwrap();
+
+            let partial_payload: Payload = serde_json::from_str(r#"{ "age": 53 }"#).unwrap();
+            storage.assign(100, &partial_payload).unwrap();
+
+            storage.delete(100, "location.geo").unwrap();
+
+            let res = storage.payload(100).unwrap();
+
+            assert!(res.0.contains_key("age"));
+            assert!(res.0.contains_key("location"));
+            assert!(res.0.contains_key("name"));
+        }
+
+        {
+            let mut storage: PayloadStorageEnum = OnDiskPayloadStorage::open(db).unwrap().into();
+
+            let res = storage.payload(100).unwrap();
+
+            assert!(res.0.contains_key("age"));
+            assert!(res.0.contains_key("location"));
+            assert!(res.0.contains_key("name"));
+
+            eprintln!("res = {:#?}", res);
+
+            let partial_payload: Payload = serde_json::from_str(r#"{ "hobby": "vector search" }"#).unwrap();
+            storage.assign(100, &partial_payload).unwrap();
+
+            storage.delete(100, "location.city").unwrap();
+            storage.delete(100, "location").unwrap();
+
+            let res = storage.payload(100).unwrap();
+
+            assert!(res.0.contains_key("age"));
+            assert!(res.0.contains_key("hobby"));
+            assert!(res.0.contains_key("name"));
+
+            eprintln!("res = {:#?}", res);
+        }
     }
 }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -185,7 +185,9 @@ impl ConditionChecker for SimpleConditionChecker {
                             // Rewrite condition checking code to support error reporting.
                             // Which may lead to slowdown and assumes a lot of changes.
                             s.read_payload(point_id)
-                                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {}", err))
+                                .unwrap_or_else(|err| {
+                                    panic!("Payload storage is corrupted: {}", err)
+                                })
                                 .map(|x| x.into())
                         }
                     };
@@ -195,11 +197,7 @@ impl ConditionChecker for SimpleConditionChecker {
                         Some(x) => x,
                     }));
                 }
-                payload_ref_cell
-                    .borrow()
-                    .as_ref()
-                    .map(|x| x.clone())
-                    .unwrap()
+                payload_ref_cell.borrow().as_ref().cloned().unwrap()
             },
             self.id_tracker.borrow().deref(),
             query,

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -9,7 +9,9 @@ use crate::id_tracker::IdTrackerSS;
 use crate::payload_storage::condition_checker::ValueChecker;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::ConditionChecker;
-use crate::types::{Condition, FieldCondition, Filter, IsEmptyCondition, Payload, PointOffsetType};
+use crate::types::{
+    Condition, FieldCondition, Filter, IsEmptyCondition, OwnedPayloadRef, Payload, PointOffsetType,
+};
 
 fn check_condition<F>(checker: &F, condition: &Condition) -> bool
 where
@@ -70,11 +72,13 @@ pub fn check_payload<'a, F>(
     point_id: PointOffsetType,
 ) -> bool
 where
-    F: Fn() -> &'a Payload,
+    F: Fn() -> OwnedPayloadRef<'a>,
 {
     let checker = |condition: &Condition| match condition {
-        Condition::Field(field_condition) => check_field_condition(field_condition, get_payload()),
-        Condition::IsEmpty(is_empty) => check_is_empty_condition(is_empty, get_payload()),
+        Condition::Field(field_condition) => {
+            check_field_condition(field_condition, get_payload().deref())
+        }
+        Condition::IsEmpty(is_empty) => check_is_empty_condition(is_empty, get_payload().deref()),
         Condition::HasId(has_id) => {
             let external_id = match id_tracker.external_id(point_id) {
                 None => return false,
@@ -155,21 +159,47 @@ impl ConditionChecker for SimpleConditionChecker {
     fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool {
         let payload_storage_guard = self.payload_storage.borrow();
 
-        let payload_cell: RefCell<Option<&Payload>> = RefCell::new(None);
+        let payload_ref_cell: RefCell<Option<OwnedPayloadRef>> = RefCell::new(None);
         check_payload(
             || {
-                if payload_cell.borrow().is_none() {
+                if payload_ref_cell.borrow().is_none() {
                     let payload_ptr = match payload_storage_guard.deref() {
-                        PayloadStorageEnum::InMemoryPayloadStorage(s) => s.payload_ptr(point_id),
-                        PayloadStorageEnum::SimplePayloadStorage(s) => s.payload_ptr(point_id),
+                        PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                            s.payload_ptr(point_id).map(|x| x.into())
+                        }
+                        PayloadStorageEnum::SimplePayloadStorage(s) => {
+                            s.payload_ptr(point_id).map(|x| x.into())
+                        }
+                        PayloadStorageEnum::OnDiskPayloadStorage(s) => {
+                            // Warn: Possible panic here
+                            // Currently, it is possible that `read_payload` fails with Err,
+                            // but it seems like a very rare possibility which might only happen
+                            // if something is wrong with disk or storage is corrupted.
+                            //
+                            // In both cases it means that service can't be of use any longer.
+                            // It is as good as dead. Therefore it is tolerable to just panic here.
+                            // Downside is - API user won't be notified of the failure.
+                            // It will just timeout.
+                            //
+                            // The alternative:
+                            // Rewrite condition checking code to support error reporting.
+                            // Which may lead to slowdown and assumes a lot of changes.
+                            s.read_payload(point_id)
+                                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {}", err))
+                                .map(|x| x.into())
+                        }
                     };
 
-                    payload_cell.replace(Some(match payload_ptr {
-                        None => &self.empty_payload,
+                    payload_ref_cell.replace(Some(match payload_ptr {
+                        None => (&self.empty_payload).into(),
                         Some(x) => x,
                     }));
                 }
-                payload_cell.borrow().unwrap()
+                payload_ref_cell
+                    .borrow()
+                    .as_ref()
+                    .map(|x| x.clone())
+                    .unwrap()
             },
             self.id_tracker.borrow().deref(),
             query,

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -53,4 +53,17 @@ impl SimplePayloadStorage {
     pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
         self.payload.get(&point_id)
     }
+
+    pub fn iter<F>(&self, mut callback: F) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> bool,
+    {
+        for (key, val) in self.payload.iter() {
+            let do_continue = callback(*key, val);
+            if !do_continue {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -214,24 +214,23 @@ impl Segment {
     /// Retrieve payload by internal ID
     #[inline]
     fn payload_by_offset(&self, point_offset: PointOffsetType) -> OperationResult<Payload> {
-        Ok(self.payload_storage.borrow().payload(point_offset))
+        Ok(self.payload_storage.borrow().payload(point_offset)?)
     }
 
     pub fn save_current_state(&self) -> OperationResult<()> {
         self.save_state(&self.get_state())
     }
 
-    fn infer_from_payload_data(&self, key: PayloadKeyTypeRef) -> Option<PayloadSchemaType> {
+    fn infer_from_payload_data(&self, key: PayloadKeyTypeRef) -> OperationResult<Option<PayloadSchemaType>> {
         let payload_store = self.payload_storage.borrow();
-        let id = payload_store.iter_ids().next();
-        match id {
-            Some(id) => {
-                let payload = payload_store.payload(id);
-                let field_value = payload.get_value(key);
-                field_value.and_then(infer_value_type)
-            }
-            None => None,
-        }
+
+        let mut schema = None;
+        payload_store.iter(|_id, payload| {
+            let field_value = payload.get_value(key);
+            schema = field_value.and_then(infer_value_type);
+            false
+        })?;
+        Ok(schema)
     }
 }
 
@@ -591,7 +590,7 @@ impl SegmentEntry for Segment {
                     .set_indexed(key, *schema_type)?;
                 Ok(true)
             }
-            None => match segment.infer_from_payload_data(key) {
+            None => match segment.infer_from_payload_data(key)? {
                 None => Err(ServiceError {
                     description: "cannot infer field data type".to_string(),
                 }),

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -214,14 +214,17 @@ impl Segment {
     /// Retrieve payload by internal ID
     #[inline]
     fn payload_by_offset(&self, point_offset: PointOffsetType) -> OperationResult<Payload> {
-        Ok(self.payload_storage.borrow().payload(point_offset)?)
+        self.payload_storage.borrow().payload(point_offset)
     }
 
     pub fn save_current_state(&self) -> OperationResult<()> {
         self.save_state(&self.get_state())
     }
 
-    fn infer_from_payload_data(&self, key: PayloadKeyTypeRef) -> OperationResult<Option<PayloadSchemaType>> {
+    fn infer_from_payload_data(
+        &self,
+        key: PayloadKeyTypeRef,
+    ) -> OperationResult<Option<PayloadSchemaType>> {
         let payload_store = self.payload_storage.borrow();
 
         let mut schema = None;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -692,6 +692,7 @@ mod tests {
             payload_index: Some(PayloadIndexType::Plain),
             storage_type: StorageType::InMemory,
             distance: Distance::Dot,
+            payload_storage_type: Default::default(),
         };
 
         let mut segment = build_segment(dir.path(), &config).unwrap();

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -84,7 +84,7 @@ impl SegmentBuilder {
                             id_tracker.set_version(external_id, other_version)?;
                             payload_storage.assign(
                                 new_internal_id,
-                                &other_payload_storage.payload(old_internal_id),
+                                &other_payload_storage.payload(old_internal_id)?,
                             )?;
                         }
                         Some(existing_version) => {
@@ -98,7 +98,7 @@ impl SegmentBuilder {
                                 id_tracker.set_version(external_id, other_version)?;
                                 payload_storage.assign(
                                     new_internal_id,
-                                    &other_payload_storage.payload(old_internal_id),
+                                    &other_payload_storage.payload(old_internal_id)?,
                                 )?;
                             } else {
                                 // Old version is still good, do not move anything else

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -5,11 +5,13 @@ use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::{PlainIndex, PlainPayloadIndex};
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndexSS, VectorIndexSS};
+use crate::payload_storage::on_disk_payload_storage::OnDiskPayloadStorage;
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::segment::{Segment, SEGMENT_STATE_FILE};
 use crate::types::{
-    Indexes, PayloadIndexType, SegmentConfig, SegmentState, SegmentType, SeqNumberType, StorageType,
+    Indexes, PayloadIndexType, PayloadStorageType, SegmentConfig, SegmentState, SegmentType,
+    SeqNumberType, StorageType,
 };
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
@@ -47,7 +49,10 @@ fn create_segment(
         }
     };
 
-    let payload_storage = sp(SimplePayloadStorage::open(database.clone())?.into());
+    let payload_storage = match config.payload_storage_type {
+        PayloadStorageType::InMemory => sp(SimplePayloadStorage::open(database.clone())?.into()),
+        PayloadStorageType::OnDisk => sp(OnDiskPayloadStorage::open(database.clone())?.into()),
+    };
 
     let condition_checker = Arc::new(SimpleConditionChecker::new(
         payload_storage.clone(),

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -25,6 +25,7 @@ pub fn build_simple_segment(
             payload_index: None,
             distance,
             storage_type: Default::default(),
+            payload_storage_type: Default::default(),
         },
     )
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -306,6 +306,23 @@ impl Default for StorageType {
     }
 }
 
+/// Type of payload storage
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type", content = "options")]
+pub enum PayloadStorageType {
+    /// Store payload in memory and use persistence storage only if vectors are changed
+    InMemory,
+    /// Store payload on disk only, read each time it is requested
+    OnDisk,
+}
+
+impl Default for PayloadStorageType {
+    fn default() -> Self {
+        PayloadStorageType::InMemory
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentConfig {
@@ -319,6 +336,9 @@ pub struct SegmentConfig {
     pub payload_index: Option<PayloadIndexType>,
     /// Type of vector storage
     pub storage_type: StorageType,
+    /// Defines payload storage type
+    #[serde(default)]
+    pub payload_storage_type: PayloadStorageType,
 }
 
 /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1290,7 +1290,8 @@ mod tests {
 
     #[test]
     fn test_remove_key() {
-        let mut payload: Payload = serde_json::from_str(r#"
+        let mut payload: Payload = serde_json::from_str(
+            r#"
         {
             "a": 1,
             "b": {
@@ -1302,7 +1303,9 @@ mod tests {
                 }
             }
         }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         remove_value("b.c", &mut payload.0);
         assert_ne!(payload, Default::default());
         remove_value("b.e.f", &mut payload.0);
@@ -1320,7 +1323,6 @@ mod tests {
         remove_value("b", &mut payload.0);
         assert_eq!(payload, Default::default());
     }
-
 }
 
 pub type TheMap<K, V> = BTreeMap<K, V>;

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,3 +1,4 @@
+use crate::common::utils;
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use geo::prelude::HaversineDistance;
@@ -14,7 +15,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
 use uuid::Uuid;
-use crate::common::utils;
 
 /// Type of point index inside a segment
 pub type PointOffsetType = u32;
@@ -1076,10 +1076,10 @@ impl Filter {
 mod tests {
     use super::*;
 
+    use crate::common::utils::remove_value_from_json_map;
     use serde::de::DeserializeOwned;
     use serde_json;
     use serde_json::json;
-    use crate::common::utils::remove_value_from_json_map;
 
     #[allow(dead_code)]
     fn check_rms_serialization<T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug>(

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -45,6 +45,7 @@ mod tests {
             payload_index: Some(PayloadIndexType::Plain),
             storage_type: StorageType::InMemory,
             distance,
+            payload_storage_type: Default::default(),
         };
 
         let int_key = "int";

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -27,6 +27,7 @@ mod tests {
             payload_index: Some(PayloadIndexType::Plain),
             storage_type: StorageType::InMemory,
             distance: Distance::Dot,
+            payload_storage_type: Default::default(),
         };
 
         let mut plain_segment = build_segment(path_plain, &config).unwrap();

--- a/lib/segment/tests/segment_builder_test.rs
+++ b/lib/segment/tests/segment_builder_test.rs
@@ -80,6 +80,7 @@ mod tests {
             index: Indexes::Hnsw(Default::default()),
             payload_index: None,
             storage_type: Default::default(),
+            payload_storage_type: Default::default(),
         };
 
         let mut builder =

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -87,6 +87,12 @@ pub struct CreateCollection {
     /// Number of shards in collection. Default is 1, minimum is 1.
     #[serde(default = "default_shard_number")]
     pub shard_number: u32,
+    /// If true - point's payload will not be stored in memory.
+    /// It will be read from the disk every time it is requested.
+    /// This setting saves RAM by (slightly) increasing the response time.
+    /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    #[serde(default = "default_on_disk_payload")]
+    pub on_disk_payload: Option<bool>,
     /// Custom params for HNSW index. If none - values from service configuration file are used.
     pub hnsw_config: Option<HnswConfigDiff>,
     /// Custom params for WAL. If none - values from service configuration file are used.
@@ -97,6 +103,10 @@ pub struct CreateCollection {
 
 pub const fn default_shard_number() -> u32 {
     1
+}
+
+pub const fn default_on_disk_payload() -> Option<bool> {
+    None
 }
 
 /// Operation for creating new collection and (optionally) specify index params

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -38,6 +38,7 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                 wal_config: value.wal_config.map(|v| v.into()),
                 optimizers_config: value.optimizers_config.map(|v| v.into()),
                 shard_number: value.shard_number.unwrap_or_else(default_shard_number),
+                on_disk_payload: value.on_disk_payload,
             },
         }))
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -232,6 +232,7 @@ impl TableOfContent {
             vector_size,
             distance,
             shard_number,
+            on_disk_payload,
             hnsw_config: hnsw_config_diff,
             wal_config: wal_config_diff,
             optimizers_config: optimizers_config_diff,
@@ -251,6 +252,7 @@ impl TableOfContent {
             shard_number: NonZeroU32::new(shard_number).ok_or(StorageError::BadInput {
                 description: "`shard_number` cannot be 0".to_string(),
             })?,
+            on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
         };
         let wal_config = match wal_config_diff {
             None => self.storage_config.wal.clone(),

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -19,10 +19,16 @@ pub struct PerformanceConfig {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct StorageConfig {
     pub storage_path: String,
+    #[serde(default = "default_on_disk_payload")]
+    pub on_disk_payload: bool,
     pub optimizers: OptimizersConfig,
     pub wal: WalConfig,
     pub performance: PerformanceConfig,
     pub hnsw_index: HnswConfig,
+}
+
+fn default_on_disk_payload() -> bool {
+    false
 }
 
 /// Information of a peer in the cluster

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -21,6 +21,7 @@ mod tests {
 
         let config = StorageConfig {
             storage_path: storage_dir.path().to_str().unwrap().to_string(),
+            on_disk_payload: false,
             optimizers: OptimizersConfig {
                 deleted_threshold: 0.5,
                 vacuum_min_vector_number: 100,
@@ -55,6 +56,7 @@ mod tests {
                         wal_config: None,
                         optimizers_config: None,
                         shard_number: 1,
+                        on_disk_payload: None,
                     },
                 }),
                 None,

--- a/openapi/tests/openapi_integration/helpers/collection_setup.py
+++ b/openapi/tests/openapi_integration/helpers/collection_setup.py
@@ -10,7 +10,7 @@ def drop_collection(collection_name='test_collection'):
     assert response.ok
 
 
-def basic_collection_setup(collection_name='test_collection'):
+def basic_collection_setup(collection_name='test_collection', on_disk_payload=False):
     response = request_with_validation(
         api='/collections/{collection_name}',
         method="DELETE",
@@ -24,7 +24,8 @@ def basic_collection_setup(collection_name='test_collection'):
         path_params={'collection_name': collection_name},
         body={
             "vector_size": 4,
-            "distance": "Dot"
+            "distance": "Dot",
+            "on_disk_payload": on_disk_payload
         }
     )
     assert response.ok

--- a/openapi/tests/openapi_integration/test_basic_retrieve_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api.py
@@ -14,6 +14,10 @@ def setup():
 
 
 def test_points_retrieve():
+    points_retrieve()
+
+
+def points_retrieve():
     response = request_with_validation(
         api='/collections/{collection_name}/points/{id}',
         method="GET",
@@ -85,6 +89,10 @@ def test_points_retrieve():
 
 
 def test_exclude_payload():
+    exclude_payload()
+
+
+def exclude_payload():
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
         method="POST",
@@ -114,6 +122,10 @@ def test_exclude_payload():
 
 
 def test_is_empty_condition():
+    is_empty_condition()
+
+
+def is_empty_condition():
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
         method="POST",
@@ -141,6 +153,10 @@ def test_is_empty_condition():
 
 
 def test_recommendation():
+    recommendation()
+
+
+def recommendation():
     response = request_with_validation(
         api='/collections/{collection_name}/points/recommend',
         method="POST",
@@ -159,6 +175,10 @@ def test_recommendation():
 
 
 def test_query_nested():
+    query_nested()
+
+
+def query_nested():
     response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="PUT",

--- a/openapi/tests/openapi_integration/test_basic_retrieve_api_on_disk.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api_on_disk.py
@@ -1,0 +1,35 @@
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+from .test_basic_retrieve_api import points_retrieve, exclude_payload, is_empty_condition, \
+    recommendation, query_nested
+
+collection_name = 'test_collection'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    basic_collection_setup(collection_name=collection_name, on_disk_payload=True)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_points_retrieve_on_disk():
+    points_retrieve()
+
+
+def test_exclude_payload_on_disk():
+    exclude_payload()
+
+
+def test_is_empty_condition_on_disk():
+    is_empty_condition()
+
+
+def test_recommendation_on_disk():
+    recommendation()
+
+
+def test_query_nested_on_disk():
+    query_nested()

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -470,6 +470,7 @@ mod tests {
                         wal_config: None,
                         optimizers_config: None,
                         shard_number: 2,
+                        on_disk_payload: None,
                     },
                 }),
                 None,


### PR DESCRIPTION
### All Submissions:

Related to https://github.com/qdrant/qdrant/issues/406

Adds an OnDisk payload storage, which could be optionally enabled.
New storage is compatible with the regular one and could be enabled without collection re-creation (manually).

Reading payload from disk makes it theoretically possible to fail during the read operation, so that is why payload interface have `OperationResult` type now. There are also a tricky place where I decided to keep `unwrap` instead of changing a lot of signatures everywhere - see the attached commentary.

Additional modifications:

- Payload remove method now understands nested path: `field.subfield.subsubfield`
- Replaced ID iterator with callback function due to typical rust problems with iterators and borrowed values.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
