### PR TITLE
Smarter defaults

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,8 +34,9 @@ storage:
     #  - Current write RPS
     #
     # It is recommended to select default number of segments as a factor of the number of search threads,
-    # so that each segment would be handled evenly by one of the threads
-    default_segment_number: 5
+    # so that each segment would be handled evenly by one of the threads.
+    # If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
+    default_segment_number: 0
 
     # Do not create segments larger this number of points.
     # Large segments might require disproportionately long indexation times,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,21 +38,25 @@ storage:
     # If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     default_segment_number: 0
 
-    # Do not create segments larger this number of points.
+    # Do not create segments larger this size (in KiloBytes).
     # Large segments might require disproportionately long indexation times,
     # therefore it makes sense to limit the size of segments.
     #
     # If indexation speed have more priority for your - make this parameter lower.
     # If search speed is more important - make this parameter higher.
-    max_segment_size: 200000
+    # Note: 1Kb = 1 vector of size 256
+    max_segment_size_kb: 200000
 
-    # Maximum number of vectors to store in-memory per segment.
+    # Maximum size (in KiloBytes) of vectors to store in-memory per segment.
     # Segments larger than this threshold will be stored as read-only memmaped file.
-    memmap_threshold: 50000
+    # To enable memmap storage, lower the threshold
+    # Note: 1Kb = 1 vector of size 256
+    memmap_threshold_kb: 200000
 
-    # Maximum number of vectors allowed for plain index.
+    # Maximum size (in KiloBytes) of vectors allowed for plain index.
     # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
-    indexing_threshold: 20000
+    # Note: 1Kb = 1 vector of size 256
+    indexing_threshold_kb: 20000
 
     # Starting from this amount of vectors per-segment the engine will start building index for payload.
     payload_indexing_threshold: 10000
@@ -69,10 +73,11 @@ storage:
     m: 16
     # Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.
     ef_construct: 100
-    # Minimal amount of points for additional payload-based indexing.
-    # If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    # Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    # If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used -
     # in this case full-scan search should be preferred by query planner and additional indexing is not required.
-    full_scan_threshold: 10000
+    # Note: 1Kb = 1 vector of size 256
+    full_scan_threshold_kb: 10000
 
 service:
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -672,7 +672,7 @@
             "type": "integer"
           },
           "full_scan_threshold": {
-            "description": "Minimal amount of points for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required.",
+            "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "type": "integer"
@@ -701,7 +701,7 @@
             "type": "integer"
           },
           "full_scan_threshold": {
-            "description": "Minimal amount of points for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required.",
+            "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "nullable": true,
@@ -788,7 +788,7 @@
       "OptimizersConfig": {
         "properties": {
           "default_segment_number": {
-            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads",
+            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads If `default_segment_number = 0`, will be automatically selected by the number of available CPUs",
             "format": "uint",
             "minimum": 0,
             "type": "integer"
@@ -805,7 +805,7 @@
             "type": "integer"
           },
           "indexing_threshold": {
-            "description": "Maximum number of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md",
+            "description": "Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "type": "integer"
@@ -817,13 +817,13 @@
             "type": "integer"
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this number of points. Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher.",
+            "description": "Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "type": "integer"
           },
           "memmap_threshold": {
-            "description": "Maximum number of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.",
+            "description": "Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "type": "integer"
@@ -857,7 +857,7 @@
       "OptimizersConfigDiff": {
         "properties": {
           "default_segment_number": {
-            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads",
+            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads If `default_segment_number = 0`, will be automatically selected by the number of available CPUs",
             "format": "uint",
             "minimum": 0,
             "nullable": true,
@@ -877,7 +877,7 @@
             "type": "integer"
           },
           "indexing_threshold": {
-            "description": "Maximum number of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md",
+            "description": "Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "nullable": true,
@@ -891,14 +891,14 @@
             "type": "integer"
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this number of points. Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher.",
+            "description": "Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "nullable": true,
             "type": "integer"
           },
           "memmap_threshold": {
-            "description": "Maximum number of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.",
+            "description": "Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256",
             "format": "uint",
             "minimum": 0,
             "nullable": true,

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -59,9 +59,10 @@ message HnswConfigDiff {
   */
   optional uint64 ef_construct = 2;
   /*
-  Minimal amount of points for additional payload-based indexing.
+  Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
   If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
   in this case full-scan search should be preferred by query planner and additional indexing is not required.
+  Note: 1Kb = 1 vector of size 256
   */
   optional uint64 full_scan_threshold = 3;
 }
@@ -92,22 +93,26 @@ message OptimizersConfigDiff {
   */
   optional uint64 default_segment_number = 3;
   /*
-  Do not create segments larger this number of points.
+  Do not create segments larger this size (in KiloBytes).
   Large segments might require disproportionately long indexation times,
   therefore it makes sense to limit the size of segments.
 
   If indexation speed have more priority for your - make this parameter lower.
   If search speed is more important - make this parameter higher.
+  Note: 1Kb = 1 vector of size 256
   */
   optional uint64 max_segment_size = 4;
   /*
-  Maximum number of vectors to store in-memory per segment.
+  Maximum size (in KiloBytes) of vectors to store in-memory per segment.
   Segments larger than this threshold will be stored as read-only memmaped file.
+  To enable memmap storage, lower the threshold
+  Note: 1Kb = 1 vector of size 256
   */
   optional uint64 memmap_threshold = 5;
   /*
-  Maximum number of vectors allowed for plain index.
+  Maximum size (in KiloBytes) of vectors allowed for plain index.
   Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+  Note: 1Kb = 1 vector of size 256
   */
   optional uint64 indexing_threshold = 6;
   /*

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -107,6 +107,7 @@ pub fn build_test_holder(path: &Path) -> RwLock<SegmentHolder> {
 pub(crate) fn get_merge_optimizer(
     segment_path: &Path,
     collection_temp_dir: &Path,
+    dim: usize,
 ) -> MergeOptimizer {
     MergeOptimizer::new(
         5,
@@ -119,7 +120,7 @@ pub(crate) fn get_merge_optimizer(
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {
-            vector_size: 4,
+            vector_size: dim,
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
             on_disk_payload: false,
@@ -131,6 +132,7 @@ pub(crate) fn get_merge_optimizer(
 pub(crate) fn get_indexing_optimizer(
     segment_path: &Path,
     collection_temp_dir: &Path,
+    dim: usize
 ) -> IndexingOptimizer {
     IndexingOptimizer::new(
         OptimizerThresholds {
@@ -141,7 +143,7 @@ pub(crate) fn get_indexing_optimizer(
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {
-            vector_size: 4,
+            vector_size: dim,
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
             on_disk_payload: false,

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -132,7 +132,7 @@ pub(crate) fn get_merge_optimizer(
 pub(crate) fn get_indexing_optimizer(
     segment_path: &Path,
     collection_temp_dir: &Path,
-    dim: usize
+    dim: usize,
 ) -> IndexingOptimizer {
     IndexingOptimizer::new(
         OptimizerThresholds {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -468,6 +468,10 @@ impl SegmentEntry for ProxySegment {
             .write()
             .delete_filtered(op_num, filter)
     }
+
+    fn vector_dim(&self) -> usize {
+        self.write_segment.get().read().vector_dim()
+    }
 }
 
 #[cfg(test)]

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use segment::types::{HnswConfig, Indexes, PayloadIndexType, SegmentType, StorageType, VECTOR_ELEMENT_SIZE};
+use segment::types::{
+    HnswConfig, Indexes, PayloadIndexType, SegmentType, StorageType, VECTOR_ELEMENT_SIZE,
+};
 
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
@@ -83,8 +85,10 @@ impl IndexingOptimizer {
                     StorageType::Mmap => true,
                 };
 
-                let big_for_mmap = vector_size >= self.thresholds_config.memmap_threshold * BYTES_IN_KB;
-                let big_for_index = vector_size >= self.thresholds_config.indexing_threshold * BYTES_IN_KB;
+                let big_for_mmap =
+                    vector_size >= self.thresholds_config.memmap_threshold * BYTES_IN_KB;
+                let big_for_index =
+                    vector_size >= self.thresholds_config.indexing_threshold * BYTES_IN_KB;
 
                 // ToDo: remove deprecated
                 let big_for_payload_index =
@@ -149,9 +153,9 @@ mod tests {
     use itertools::Itertools;
     use parking_lot::lock_api::RwLock;
     use rand::thread_rng;
+    use segment::fixtures::index_fixtures::random_vector;
     use serde_json::json;
     use tempdir::TempDir;
-    use segment::fixtures::index_fixtures::random_vector;
 
     use segment::types::{Payload, PayloadSchemaType, StorageType};
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use segment::types::{HnswConfig, Indexes, PayloadIndexType, SegmentType, StorageType};
+use segment::types::{HnswConfig, Indexes, PayloadIndexType, SegmentType, StorageType, VECTOR_ELEMENT_SIZE};
 
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
@@ -10,6 +10,8 @@ use crate::collection_manager::optimizers::segment_optimizer::{
     OptimizerThresholds, SegmentOptimizer,
 };
 use crate::config::CollectionParams;
+
+const BYTES_IN_KB: usize = 1024;
 
 /// Looks for the segments, which require to be indexed.
 /// If segment is too large, but still does not have indexes - it is time to create some indexes.
@@ -57,6 +59,7 @@ impl IndexingOptimizer {
                 let segment_entry = segment.get();
                 let read_segment = segment_entry.read();
                 let vector_count = read_segment.vectors_count();
+                let vector_size = vector_count * read_segment.vector_dim() * VECTOR_ELEMENT_SIZE;
 
                 let segment_config = read_segment.config();
 
@@ -80,10 +83,12 @@ impl IndexingOptimizer {
                     StorageType::Mmap => true,
                 };
 
-                let big_for_mmap = vector_count >= self.thresholds_config.memmap_threshold;
-                let big_for_index = vector_count >= self.thresholds_config.indexing_threshold;
+                let big_for_mmap = vector_size >= self.thresholds_config.memmap_threshold * BYTES_IN_KB;
+                let big_for_index = vector_size >= self.thresholds_config.indexing_threshold * BYTES_IN_KB;
+
+                // ToDo: remove deprecated
                 let big_for_payload_index =
-                    vector_count >= self.thresholds_config.payload_indexing_threshold;
+                    vector_size >= self.thresholds_config.payload_indexing_threshold * BYTES_IN_KB;
 
                 let has_payload = !read_segment.get_indexed_fields().is_empty();
 
@@ -92,11 +97,11 @@ impl IndexingOptimizer {
                     || (has_payload && big_for_payload_index && !is_payload_indexed);
 
                 match require_indexing {
-                    true => Some((*idx, vector_count)),
+                    true => Some((*idx, vector_size)),
                     false => None,
                 }
             })
-            .max_by_key(|(_, num_vectors)| *num_vectors)
+            .max_by_key(|(_, vector_size)| *vector_size)
             .map(|(idx, _)| (idx, segments_read_guard.get(idx).unwrap().clone()))
     }
 }
@@ -143,8 +148,10 @@ mod tests {
 
     use itertools::Itertools;
     use parking_lot::lock_api::RwLock;
+    use rand::thread_rng;
     use serde_json::json;
     use tempdir::TempDir;
+    use segment::fixtures::index_fixtures::random_vector;
 
     use segment::types::{Payload, PayloadSchemaType, StorageType};
 
@@ -166,12 +173,13 @@ mod tests {
     fn test_indexing_optimizer() {
         init();
 
+        let mut rng = thread_rng();
         let mut holder = SegmentHolder::default();
 
         let payload_field = "number".to_owned();
 
         let stopped = AtomicBool::new(false);
-        let dim = 4;
+        let dim = 256;
 
         let segments_dir = TempDir::new("segments_dir").unwrap();
         let segments_temp_dir = TempDir::new("segments_temp_dir").unwrap();
@@ -313,9 +321,9 @@ mod tests {
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
                 ids: vec![501.into(), 502.into(), 503.into()],
                 vectors: vec![
-                    vec![1.0, 0.0, 0.5, 0.0],
-                    vec![1.0, 0.0, 0.5, 0.5],
-                    vec![1.0, 0.0, 0.5, 1.0],
+                    random_vector(&mut rng, dim),
+                    random_vector(&mut rng, dim),
+                    random_vector(&mut rng, dim),
                 ],
                 payloads: Some(vec![
                     Some(point_payload.clone()),
@@ -380,9 +388,9 @@ mod tests {
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
                 ids: vec![601.into(), 602.into(), 603.into()],
                 vectors: vec![
-                    vec![0.0, 1.0, 0.5, 0.0],
-                    vec![0.0, 1.0, 0.5, 0.5],
-                    vec![0.0, 1.0, 0.5, 1.0],
+                    random_vector(&mut rng, dim),
+                    random_vector(&mut rng, dim),
+                    random_vector(&mut rng, dim),
                 ],
                 payloads: None,
             }));

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -6,9 +6,11 @@ use crate::collection_manager::optimizers::segment_optimizer::{
 };
 use crate::config::CollectionParams;
 use itertools::Itertools;
-use segment::types::{HnswConfig, SegmentType};
+use segment::types::{HnswConfig, SegmentType, VECTOR_ELEMENT_SIZE};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+
+const BYTES_IN_KB: usize = 1024;
 
 /// Optimizer that tries to reduce number of segments until it fits configured value.
 /// It merges 3 smallest segments into a single large segment.
@@ -96,7 +98,10 @@ impl SegmentOptimizer for MergeOptimizer {
                 let segment_entry = segment.get();
                 let read_segment = segment_entry.read();
                 match read_segment.segment_type() != SegmentType::Special {
-                    true => Some((*idx, read_segment.vectors_count())),
+                    true => Some((
+                        *idx,
+                        read_segment.vectors_count() * read_segment.vector_dim() * VECTOR_ELEMENT_SIZE
+                    )),
                     false => None,
                 }
             })
@@ -105,7 +110,7 @@ impl SegmentOptimizer for MergeOptimizer {
                 *size_sum += size; // produce a cumulative sum of segment sizes starting from smallest
                 Some((sid, *size_sum))
             })
-            .take_while(|(_, size)| *size < self.max_segment_size)
+            .take_while(|(_, size)| *size < self.max_segment_size * BYTES_IN_KB)
             .take(3)
             .map(|x| x.0)
             .collect();
@@ -134,14 +139,15 @@ mod tests {
         let temp_dir = TempDir::new("segment_temp_dir").unwrap();
 
         let mut holder = SegmentHolder::default();
+        let dim = 256;
 
         let _segments_to_merge = vec![
-            holder.add(random_segment(dir.path(), 100, 40, 4)),
-            holder.add(random_segment(dir.path(), 100, 50, 4)),
-            holder.add(random_segment(dir.path(), 100, 60, 4)),
+            holder.add(random_segment(dir.path(), 100, 40, dim)),
+            holder.add(random_segment(dir.path(), 100, 50, dim)),
+            holder.add(random_segment(dir.path(), 100, 60, dim)),
         ];
 
-        let mut merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path());
+        let mut merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);
 
         let locked_holder = Arc::new(RwLock::new(holder));
 
@@ -167,23 +173,24 @@ mod tests {
         let temp_dir = TempDir::new("segment_temp_dir").unwrap();
 
         let mut holder = SegmentHolder::default();
+        let dim = 256;
 
         let segments_to_merge = vec![
-            holder.add(random_segment(dir.path(), 100, 3, 4)),
-            holder.add(random_segment(dir.path(), 100, 3, 4)),
-            holder.add(random_segment(dir.path(), 100, 3, 4)),
+            holder.add(random_segment(dir.path(), 100, 3, dim)),
+            holder.add(random_segment(dir.path(), 100, 3, dim)),
+            holder.add(random_segment(dir.path(), 100, 3, dim)),
         ];
 
         let other_segment_ids: Vec<SegmentId> = vec![
-            holder.add(random_segment(dir.path(), 100, 20, 4)),
-            holder.add(random_segment(dir.path(), 100, 20, 4)),
-            holder.add(random_segment(dir.path(), 100, 20, 4)),
-            holder.add(random_segment(dir.path(), 100, 20, 4)),
+            holder.add(random_segment(dir.path(), 100, 20, dim)),
+            holder.add(random_segment(dir.path(), 100, 20, dim)),
+            holder.add(random_segment(dir.path(), 100, 20, dim)),
+            holder.add(random_segment(dir.path(), 100, 20, dim)),
         ];
 
-        let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path());
+        let merge_optimizer = get_merge_optimizer(dir.path(), temp_dir.path(), dim);
 
-        let locked_holder = Arc::new(RwLock::new(holder));
+        let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
 
         let suggested_for_merge =
             merge_optimizer.check_condition(locked_holder.clone(), &Default::default());

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -100,7 +100,9 @@ impl SegmentOptimizer for MergeOptimizer {
                 match read_segment.segment_type() != SegmentType::Special {
                     true => Some((
                         *idx,
-                        read_segment.vectors_count() * read_segment.vector_dim() * VECTOR_ELEMENT_SIZE
+                        read_segment.vectors_count()
+                            * read_segment.vector_dim()
+                            * VECTOR_ELEMENT_SIZE,
                     )),
                     false => None,
                 }

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -29,9 +29,11 @@ pub struct HnswConfigDiff {
     pub m: Option<usize>,
     /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.
     pub ef_construct: Option<usize>,
-    /// Minimal amount of points for additional payload-based indexing.
-    /// If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used -
     /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "full_scan_threshold_kb")]
     pub full_scan_threshold: Option<usize>,
 }
 
@@ -56,19 +58,27 @@ pub struct OptimizersConfigDiff {
     ///
     /// It is recommended to select default number of segments as a factor of the number of search threads,
     /// so that each segment would be handled evenly by one of the threads
+    /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: Option<usize>,
-    /// Do not create segments larger this number of points.
+    /// Do not create segments larger this size (in KiloBytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///
     /// If indexation speed have more priority for your - make this parameter lower.
     /// If search speed is more important - make this parameter higher.
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "max_segment_size_kb")]
     pub max_segment_size: Option<usize>,
-    /// Maximum number of vectors to store in-memory per segment.
+    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
+    /// To enable memmap storage, lower the threshold
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "memmap_threshold_kb")]
     pub memmap_threshold: Option<usize>,
-    /// Maximum number of vectors allowed for plain index.
+    /// Maximum size (in KiloBytes) of vectors allowed for plain index.
     /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "indexing_threshold_kb")]
     pub indexing_threshold: Option<usize>,
     /// Starting from this amount of vectors per-segment the engine will start building index for payload.
     pub payload_indexing_threshold: Option<usize>,

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -26,18 +26,25 @@ pub struct OptimizersConfig {
     /// so that each segment would be handled evenly by one of the threads
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: usize,
-    /// Do not create segments larger this number of points.
+    /// Do not create segments larger this size (in KiloBytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///
     /// If indexation speed have more priority for your - make this parameter lower.
     /// If search speed is more important - make this parameter higher.
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "max_segment_size_kb")]
     pub max_segment_size: usize,
-    /// Maximum number of vectors to store in-memory per segment.
+    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
+    /// To enable memmap storage, lower the threshold
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "memmap_threshold_kb")]
     pub memmap_threshold: usize,
-    /// Maximum number of vectors allowed for plain index.
+    /// Maximum size (in KiloBytes) of vectors allowed for plain index.
     /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "indexing_threshold_kb")]
     pub indexing_threshold: usize,
     /// Starting from this amount of vectors per-segment the engine will start building index for payload.
     pub payload_indexing_threshold: usize,

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -24,6 +24,7 @@ pub struct OptimizersConfig {
     ///
     /// It is recommended to select default number of segments as a factor of the number of search threads,
     /// so that each segment would be handled evenly by one of the threads
+    /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: usize,
     /// Do not create segments larger this number of points.
     /// Large segments might require disproportionately long indexation times,

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,4 +1,3 @@
-use std::cmp::{max, min};
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 use crate::collection_manager::optimizers::merge_optimizer::MergeOptimizer;
 use crate::collection_manager::optimizers::segment_optimizer::OptimizerThresholds;
@@ -8,6 +7,7 @@ use crate::update_handler::Optimizer;
 use schemars::JsonSchema;
 use segment::types::HnswConfig;
 use serde::{Deserialize, Serialize};
+use std::cmp::{max, min};
 use std::path::Path;
 use std::sync::Arc;
 

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -224,7 +224,9 @@ impl LocalShard {
 
         let vector_size = config.params.vector_size;
         let distance = config.params.distance;
-        for _sid in 0..config.optimizer_config.default_segment_number {
+        let segment_number = config.optimizer_config.get_number_segments();
+
+        for _sid in 0..segment_number {
             let path_clone = segments_path.clone();
             let segment_config = SegmentConfig {
                 vector_size,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -195,6 +195,8 @@ pub trait SegmentEntry {
     /// Return number of vectors in this segment
     fn vectors_count(&self) -> usize;
 
+    fn vector_dim(&self) -> usize;
+
     /// Number of vectors, marked as deleted
     fn deleted_count(&self) -> usize;
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -6,7 +6,9 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::{PayloadIndexSS, VectorIndex};
 use crate::types::Condition::Field;
-use crate::types::{FieldCondition, Filter, HnswConfig, SearchParams, VECTOR_ELEMENT_SIZE, VectorElementType};
+use crate::types::{
+    FieldCondition, Filter, HnswConfig, SearchParams, VectorElementType, VECTOR_ELEMENT_SIZE,
+};
 use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 use atomic_refcell::AtomicRefCell;
 use log::debug;
@@ -45,11 +47,7 @@ impl HNSWIndex {
             let indexing_threshold = hnsw_config.full_scan_threshold * BYTES_IN_KB
                 / (vector_storage.borrow().vector_dim() * VECTOR_ELEMENT_SIZE);
 
-            HnswGraphConfig::new(
-                hnsw_config.m,
-                hnsw_config.ef_construct,
-                indexing_threshold,
-            )
+            HnswGraphConfig::new(hnsw_config.m, hnsw_config.ef_construct, indexing_threshold)
         };
 
         let graph_path = GraphLayers::get_path(path);

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -637,6 +637,10 @@ impl SegmentEntry for Segment {
 
         Ok(deleted_points)
     }
+
+    fn vector_dim(&self) -> usize {
+        self.segment_config.vector_size
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -11,6 +11,7 @@ use serde_json::{Map, Value};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Formatter;
+use std::mem::size_of;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -31,6 +32,8 @@ pub type VectorElementType = f32;
 pub type FloatPayloadType = f64;
 /// Type of integer point payload
 pub type IntPayloadType = i64;
+
+pub const VECTOR_ELEMENT_SIZE: usize = size_of::<VectorElementType>();
 
 /// Type, used for specifying point ID in user interface
 #[derive(
@@ -245,9 +248,11 @@ pub struct HnswConfig {
     pub m: usize,
     /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.
     pub ef_construct: usize,
-    /// Minimal amount of points for additional payload-based indexing.
-    /// If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used -
     /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
+    /// Note: 1Kb = 1 vector of size 256
+    #[serde(alias = "full_scan_threshold_kb")]
     pub full_scan_threshold: usize,
 }
 

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -30,7 +30,8 @@ mod tests {
         let ef = 32;
         let ef_construct = 16;
         let distance = Distance::Cosine;
-        let indexing_threshold = 500;
+        let full_scan_threshold = 16; // KB
+        let indexing_threshold = 500; // num vectors
         let num_payload_values = 2;
 
         let mut rnd = thread_rng();
@@ -82,7 +83,7 @@ mod tests {
         let hnsw_config = HnswConfig {
             m,
             ef_construct,
-            full_scan_threshold: indexing_threshold,
+            full_scan_threshold,
         };
 
         let mut hnsw_index = HNSWIndex::open(

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -16,7 +16,10 @@ curl -X PUT "http://$QDRANT_HOST/collections/test_collection" \
   --fail -s \
   --data-raw '{
       "vector_size": 4,
-      "distance": "Dot"
+      "distance": "Dot",
+      "optimizers_config": {
+        "default_segment_number": 2
+      }
     }' | jq
 
 # fail to decode payload


### PR DESCRIPTION
### All Submissions:

related Issue: https://github.com/qdrant/qdrant/issues/635

Changes:

- `default_segment_number` can now be auto-selected sing amount of CPUs
- `memmap_threshold` is now set to `max_segment_size` by default, to prevent usage of mmap by default
- thresholds are now configured in KiloBytes instead of number of vectors, it should better reflect the performance of large and small vectors

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?
