### PR TITLE
use condwar instead of channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = [ "web" ]
+default = [ "web", "parking_lot" ]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
@@ -19,7 +19,7 @@ rusty-hook = "^0.11.2"
 
 [dependencies]
 
-parking_lot = { version = "0.12", features=["deadlock_detection"], optional = true }
+parking_lot = { version = "0.12.1", features=["deadlock_detection"], optional = true }
 
 num_cpus = "1.13"
 thiserror = "1.0"

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,3 +1,4 @@
+use parking_lot::{Condvar, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::runtime;
 use tokio::runtime::Runtime;
@@ -18,4 +19,71 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
             format!("search-{}", id)
         })
         .build()
+}
+
+pub struct IsReady {
+    condvar: Condvar,
+    value: Mutex<bool>,
+}
+
+impl Default for IsReady {
+    fn default() -> Self {
+        Self {
+            condvar: Condvar::new(),
+            value: Mutex::new(false),
+        }
+    }
+}
+
+impl IsReady {
+    pub fn make_ready(&self) {
+        let mut is_ready = self.value.lock();
+        if !*is_ready {
+            *is_ready = true;
+            self.condvar.notify_all();
+        }
+    }
+
+    pub fn make_not_ready(&self) {
+        *self.value.lock() = false;
+    }
+
+    pub fn check_ready(&self) -> bool {
+        *self.value.lock()
+    }
+
+    pub fn await_ready(&self) {
+        let mut is_ready = self.value.lock();
+        if !*is_ready {
+            self.condvar.wait(&mut is_ready);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn test_is_ready() {
+        let is_ready = Arc::new(IsReady::default());
+        let is_ready_clone = is_ready.clone();
+        let join = thread::spawn(move || {
+            is_ready_clone.await_ready();
+            eprintln!(
+                "is_ready_clone.check_ready() = {:#?}",
+                is_ready_clone.check_ready()
+            );
+        });
+
+        sleep(Duration::from_millis(500));
+        eprintln!("Making ready");
+        is_ready.make_ready();
+        sleep(Duration::from_millis(500));
+        join.join().unwrap()
+    }
 }


### PR DESCRIPTION
### All Submissions:

- Use condition variable instead of channel
- rename `notify_when_leader` into `notify_when_leader`, which is more general and could be reused in other places
- simplifies a code a bit
