### PR TITLE
Add leader_id and role to cluster API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,6 +3305,7 @@ dependencies = [
  "itertools 0.10.3",
  "log 0.4.17",
  "num_cpus",
+ "parking_lot",
  "prost 0.7.0",
  "raft",
  "rand 0.8.5",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3273,6 +3273,7 @@
             "minimum": 0
           },
           "commit": {
+            "description": "The index of the latest committed (finalized) operation that this peer is aware of.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
@@ -3282,8 +3283,35 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          },
+          "leader": {
+            "description": "Leader of the current term",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
+          },
+          "role": {
+            "description": "Role of this peer in the current term",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StateRole"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
+      },
+      "StateRole": {
+        "type": "string",
+        "enum": [
+          "Follower",
+          "Candidate",
+          "Leader",
+          "PreCandidate"
+        ]
       }
     }
   }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.53"
 log = "0.4"
 tonic = "0.7.2"
 http = "0.2"
+parking_lot = { version = "0.12.1", features=["deadlock_detection"]}
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -47,12 +47,37 @@ pub struct RaftInfo {
     /// The term number increases monotonically.
     /// Each server stores the current term number which is also exchanged in every communication.
     pub term: u64,
-    // ToDo: What does this mean?
+    /// The index of the latest committed (finalized) operation that this peer is aware of.
     pub commit: u64,
     /// Number of consensus operations pending to be applied on this peer
     pub pending_operations: usize,
-    // ToDo: Who is the current leader?
-    // pub leader: u64
+    /// Leader of the current term
+    pub leader: Option<u64>,
+    /// Role of this peer in the current term
+    pub role: Option<StateRole>,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, JsonSchema, Deserialize)]
+pub enum StateRole {
+    /// The node is a follower of the leader.
+    Follower,
+    /// The node could become a leader.
+    Candidate,
+    /// The node is a leader.
+    Leader,
+    /// The node could become a candidate, if `prevote` is enabled.
+    PreCandidate,
+}
+
+impl From<raft::StateRole> for StateRole {
+    fn from(role: raft::StateRole) -> Self {
+        match role {
+            raft::StateRole::Follower => Self::Follower,
+            raft::StateRole::Candidate => Self::Candidate,
+            raft::StateRole::Leader => Self::Leader,
+            raft::StateRole::PreCandidate => Self::PreCandidate,
+        }
+    }
 }
 
 /// Description of enabled cluster

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -307,6 +307,7 @@ impl Consensus {
     }
 
     fn handle_soft_state(&self, state: &SoftState) {
+        self.node.raft.raft_log.store.set_raft_soft_state(state);
         if state.raft_state == StateRole::Leader || state.raft_state == StateRole::Follower {
             self.is_leader_established.make_ready()
         } else {


### PR DESCRIPTION
Fixes TODOs from https://github.com/qdrant/qdrant/pull/631

Looks like this now:
```json
{
  "result": {
    "status": "enabled",
    "peer_id": 11532566549086892000,
    "peers": {
      "9834046559507417430": {
        "uri": "http://172.18.0.3:6335/"
      },
      "11532566549086892528": {
        "uri": "http://qdrant_node_1:6335/"
      }
    },
    "raft_info": {
      "term": 1,
      "commit": 4,
      "pending_operations": 1,
      "leader": 11532566549086892000,
      "role": "Leader"
    }
  },
  "status": "ok",
  "time": 5.731e-06
}
```