### PR TITLE
Consensus tests use cluster API instead of sleep

### DIFF
--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -1,13 +1,6 @@
-import os
 import pathlib
-import shutil
-import time
-
-import requests
 
 from .utils import *
-from . import conftest
-from subprocess import Popen
 
 N_PEERS = 5
 N_SHARDS = 6
@@ -25,13 +18,18 @@ def test_collection_sharding(tmp_path: pathlib.Path):
         peer_dirs[0], "peer_0_0.log")
     peer_api_uris.append(bootstrap_api_uri)
 
+    # Wait for leader
+    wait_for_leader_setup(bootstrap_api_uri)
+
     # Start other peers
     for i in range(1, len(peer_dirs)):
         peer_api_uris.append(start_peer(
             peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
+        # Add peers one by one sequentially
+        wait_for_leader_setup(peer_api_uris[i])
 
-    # Wait
-    time.sleep(5)
+    # Wait for cluster
+    wait_for_uniform_cluster_size(peer_api_uris)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:
@@ -48,14 +46,8 @@ def test_collection_sharding(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    time.sleep(5)
-
     # Check that it exists on all peers
-    for uri in peer_api_uris:
-        r = requests.get(f"{uri}/collections")
-        assert_http_ok(r)
-        assert r.json()[
-            "result"]["collections"][0]["name"] == "test_collection"
+    wait_for_uniform_collection_existence("test_collection", peer_api_uris)
 
     # Create points in first peer's collection
     r = requests.put(


### PR DESCRIPTION
This PR tackles https://github.com/qdrant/qdrant/issues/673 by removing as many `sleep` instructions as possible.

Those sleep instructions were necessary to give time to the node to startup & join the cluster.

With this PR the cluster state is validated by repeatedly polling the cluster and collection API with an upper bound timeout.

I have created a bunch of utility functions for testing the eventually consistent interactions which I have moved into `utils.py`.

For example we can check that:
- the `/cluster` leader field is not null
- that all nodes see the same cluster size

A follow up work will be to have additional nodes join the cluster concurrently to execute the tests even faster by fixing #676. 