### PR TITLE
add more error context for consenus init

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -73,7 +73,8 @@ impl Consensus {
                 &runtime,
                 sender.clone(),
                 is_leader_established.clone(),
-            )?;
+            )
+            .context("Failed to initialize Consensus for new Raft state")?;
         } else {
             if bootstrap_peer.is_some() || uri.is_some() {
                 log::info!("Local raft state found - bootstrap and uri cli arguments were ignored")
@@ -163,7 +164,8 @@ impl Consensus {
                     id,
                 },
             ))
-            .await?
+            .await
+            .context("Failed to add peer to known")?
             .into_inner();
         // Although peer addresses are synchronized with consensus, addresses need to be pre-fetched in the case of a new peer
         // or it will not know how to answer the Raft leader
@@ -179,7 +181,8 @@ impl Consensus {
         }
         client
             .add_peer_as_participant(tonic::Request::new(api::grpc::qdrant::PeerId { id }))
-            .await?;
+            .await
+            .context("Failed to add peer as participant")?;
         Ok(())
     }
 


### PR DESCRIPTION
Tiny PR to add more context to the possible errors happening during consensus initialization. (related to https://github.com/qdrant/qdrant/issues/676)

This helped me chase the source of a timeout.

```
thread 'main' panicked at 'Can't initialize consensus: Failed to initialize Consensus for new Raft state

Caused by:
    0: Failed to add peer to known participant
    1: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
    2: transport error
    3: Timeout expired', src/main.rs:103:10
```    