### PR TITLE
fix: gRPC bootstrap timeout needs to be higher than DEFAULT_META_OP_WAIT

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -94,8 +94,9 @@ fn default_tick_period_ms() -> u64 {
     100
 }
 
+// Should not be less than `DEFAULT_META_OP_WAIT` as bootstrapping perform sync. consensus meta operations.
 fn default_bootstrap_timeout_sec() -> u64 {
-    5
+    15
 }
 
 fn default_max_message_queue_size() -> usize {


### PR DESCRIPTION
This PR fixes the timeout which can appear during the bootstrapping phase of a node.

```
thread 'main' panicked at 'Can't initialize consensus: Failed to initialize Consensus for new Raft state

Caused by:
    0: Failed to add peer to known
    1: status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
    2: transport error
    3: Timeout expired', src/main.rs:103:10
```

During the bootstrap phase, the node performs a gRPC call to add itself as a known peer.

The node receiving this command needs to perform a synchronous meta operation on the consensus layer which can take up to 10 sec (`DEFAULT_META_OP_WAIT`).

However the gRPC client uses a timeout that is lower than 10 seconds.

This PR contains the following changes:
- increases the gRPC bootstrap timeout so that is higher than `DEFAULT_META_OP_WAIT`
- document the relation between the two timeouts
- validate the invariant following the addition of the peer