### PR TITLE
[WIP] reproduction for cluster stuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
  "futures",
  "hashring",
  "indicatif",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "merge",
  "num_cpus",
@@ -913,7 +913,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.3",
+ "itertools",
 ]
 
 [[package]]
@@ -1195,12 +1195,6 @@ name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
@@ -1713,15 +1707,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -2228,7 +2213,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "libc",
- "petgraph 0.6.0",
+ "petgraph",
  "redox_syscall",
  "smallvec",
  "thread-id",
@@ -2304,21 +2289,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.1",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2469,12 +2444,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.7.0",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -2489,18 +2464,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools 0.9.0",
+ "itertools",
+ "lazy_static",
  "log 0.4.17",
  "multimap",
- "petgraph 0.5.1",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "petgraph",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
  "tempfile",
  "which",
 ]
@@ -2515,11 +2492,11 @@ dependencies = [
  "cfg-if",
  "cmake",
  "heck 0.4.0",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "log 0.4.17",
  "multimap",
- "petgraph 0.6.0",
+ "petgraph",
  "prost 0.10.1",
  "prost-types 0.10.1",
  "regex",
@@ -2529,12 +2506,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2547,7 +2524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2555,12 +2532,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.7.0",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -2581,13 +2558,13 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "protobuf-build"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7266835d38c38c73b091a24412de1f4b4382a5195fab1ec038161582b03b78"
+checksum = "4b2be70fa994657539e3c872cc54363c9bf28b0d7a7f774df70e9fd760df3bc4"
 dependencies = [
  "bitflags",
  "proc-macro2",
- "prost-build 0.7.0",
+ "prost-build 0.9.0",
  "quote",
  "syn",
 ]
@@ -2607,12 +2584,12 @@ dependencies = [
  "config",
  "env_logger",
  "futures",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "num-traits",
  "num_cpus",
  "parking_lot",
- "prost 0.7.0",
+ "prost 0.9.0",
  "raft",
  "raft-proto",
  "rusty-hook",
@@ -2650,9 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "raft"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08aa642fc2067062af4d4a3a3b8b909cd80e810b994af44c5a60253fc673f934"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs#2357cb22760719bcd107a90d1e64ef505bdb1e15"
 dependencies = [
  "fxhash",
  "getset",
@@ -2665,12 +2641,11 @@ dependencies = [
 
 [[package]]
 name = "raft-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b74f65f886af112d6046c131def44849404757d22f835a0b7ef1aa473e4c96f"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs#2357cb22760719bcd107a90d1e64ef505bdb1e15"
 dependencies = [
  "lazy_static",
- "prost 0.7.0",
+ "prost 0.9.0",
  "protobuf",
  "protobuf-build",
 ]
@@ -3114,7 +3089,7 @@ dependencies = [
  "criterion",
  "geo",
  "geohash",
- "itertools 0.10.3",
+ "itertools",
  "json-patch",
  "log 0.4.17",
  "memmap 0.7.0",
@@ -3413,11 +3388,11 @@ dependencies = [
  "atomicwrites",
  "collection",
  "http",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "num_cpus",
  "parking_lot",
- "prost 0.7.0",
+ "prost 0.9.0",
  "raft",
  "rand 0.8.5",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ tonic = "0.7.2"
 num-traits = "0.2.15"
 
 # Consensus related crates
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false }
+raft = { git = "https://github.com/tikv/raft-rs", features = ["prost-codec"], default-features = false }
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
-prost = "=0.7.0"
-raft-proto = { version = "=0.6.0", features = ["prost-codec"], default-features = false}
+prost = "=0.9.0"
+raft-proto = { git = "https://github.com/tikv/raft-rs", features = ["prost-codec"], default-features = false}
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -26,8 +26,8 @@ parking_lot = { version = "0.12.1", features=["deadlock_detection"]}
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false}
-prost = { version = "=0.7.0" } # version of prost used by raft
+raft = { git = "https://github.com/tikv/raft-rs", features = ["prost-codec"], default-features = false}
+prost = { version = "=0.9.0" } # version of prost used by raft
 serde_cbor = { version = "0.11.2" }
 
 segment = {path = "../segment"}

--- a/lib/storage/src/content_manager/raft_state.rs
+++ b/lib/storage/src/content_manager/raft_state.rs
@@ -44,6 +44,7 @@ impl UnappliedEntries {
         match &mut self.0 {
             Some((current_index, _)) => {
                 *current_index += 1;
+                log::debug!("UnappliedEntries applied {:?}", self);
             }
             None => (),
         }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -49,6 +49,7 @@ pub struct RaftInfo {
     pub term: u64,
     /// The index of the latest committed (finalized) operation that this peer is aware of.
     pub commit: u64,
+    pub vote: u64,
     /// Number of consensus operations pending to be applied on this peer
     pub pending_operations: usize,
     /// Leader of the current term

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -269,6 +269,7 @@ impl Consensus {
             }
         }
         if let Some(ss) = ready.ss() {
+            log::info!("Changing soft state. New soft state: {ss:?}");
             self.handle_soft_state(ss);
         }
         if !ready.persisted_messages().is_empty() {
@@ -279,7 +280,7 @@ impl Consensus {
                 &self.bootstrap_uri,
                 &self.config,
             ) {
-                log::error!("Failed to send messages: {err}")
+                log::error!("Failed to send persisted messages: {err}")
             }
         }
 
@@ -393,6 +394,7 @@ async fn who_is(
     bootstrap_uri: Option<Uri>,
     config: Arc<ConsensusConfig>,
 ) -> anyhow::Result<Uri> {
+    log::info!("who_is {}", peer_id);
     let bootstrap_uri =
         bootstrap_uri.ok_or_else(|| anyhow::anyhow!("No bootstrap uri supplied"))?;
     let bootstrap_timeout = Duration::from_secs(config.bootstrap_timeout_sec);

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -27,6 +27,7 @@ impl RaftService {
 #[async_trait]
 impl Raft for RaftService {
     async fn send(&self, mut request: Request<RaftMessageBytes>) -> Result<Response<()>, Status> {
+        log::debug!("RaftService sent message");
         let message = <RaftMessage as prost::Message>::decode(&request.get_mut().message[..])
             .map_err(|err| {
                 Status::invalid_argument(format!("Failed to parse raft message: {err}"))
@@ -43,6 +44,7 @@ impl Raft for RaftService {
         &self,
         request: tonic::Request<PeerId>,
     ) -> Result<tonic::Response<UriStr>, tonic::Status> {
+        log::debug!("RaftService who_is");
         let addresses = self
             .toc
             .peer_address_by_id()

--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -17,7 +17,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_for_leader_setup(bootstrap_api_uri)
+    leader = wait_for_leader_setup(bootstrap_api_uri)
 
     for i in range(1, len(peer_dirs)):
         peer_api_uris.append(start_peer(
@@ -26,7 +26,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         wait_for_leader_setup(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -18,7 +18,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_for_leader_setup(bootstrap_api_uri)
+    leader = wait_for_leader_setup(bootstrap_api_uri)
 
     # Create collection
     r = requests.put(
@@ -37,7 +37,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
         wait_for_leader_setup(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that it exists on all peers
     assert_collection_exists_on_all_peers("test_collection", peer_api_uris)

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -2,7 +2,7 @@ import pathlib
 
 from .utils import *
 
-N_PEERS = 5
+N_PEERS = 3
 N_SHARDS = 6
 
 
@@ -19,17 +19,17 @@ def test_collection_sharding(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_for_leader_setup(bootstrap_api_uri)
+    leader = wait_for_leader_setup(bootstrap_api_uri)
 
     # Start other peers
     for i in range(1, len(peer_dirs)):
         peer_api_uris.append(start_peer(
             peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
         # Add peers one by one sequentially
-        wait_for_leader_setup(peer_api_uris[i])
+        # wait_for_leader_setup(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from subprocess import Popen
@@ -78,6 +79,14 @@ def make_peer_folders(base_path: Path, n_peers: int) -> list[Path]:
         peer_dirs.append(peer_dir)
         shutil.copytree("config", peer_dir / "config")
     return peer_dirs
+
+
+def print_cluster_info(peer_api_uris: [str]):
+    for uri in peer_api_uris:
+        r = requests.get(f"{uri}/cluster")
+        assert_http_ok(r)
+        res = r.json()["result"]
+        print(json.dumps(res, indent=4))
 
 
 def get_leader(peer_api_uri: str) -> str:
@@ -186,6 +195,8 @@ def wait_for_uniform_cluster_status(peer_api_uris: [str], expected_leader: str):
         elapsed = time.time() - start
         # do not wait more than WAIT_TIME_SEC
         if elapsed > WAIT_TIME_SEC:
+            # print cluster for debug
+            print_cluster_info(peer_api_uris)
             raise Exception(f"Cluster info was not uniform in time ({WAIT_TIME_SEC} sec)")
         else:
             time.sleep(RETRY_INTERVAL_SEC)


### PR DESCRIPTION
This branch contains code to reproduce the issue https://github.com/qdrant/qdrant/issues/676

To reproduce locally:
- `cargo build`
- `rm peer_0_*; pytest ./tests/consensus_tests/test_collection_sharding.py -s`

It will create a 3 nodes cluster with one node failing to fully join. It never receives the updates from the leader.

My understanding of the issue is that:

1. bootstrap leader
2. bootstrap node `foo` and `bar` concurrently
3. node `foo` joins the cluster first without problem
4. node `bar` tries to join the cluster
5. the leader receives the demand to join from `bar`
6. the leader appends it to the Raft log as a `EntryConfChangeV2`
7. the leader persists it locally
8. but the leader never commit it

It seems that the node `foo` is not even receiving this information which blocks the leader from making progress.
