### PR TITLE
Harden consensus test and debugging

### DIFF
--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -17,7 +17,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_peer_added(bootstrap_api_uri)
+    leader = wait_peer_added(bootstrap_api_uri)
 
     for i in range(1, len(peer_dirs)):
         peer_api_uris.append(start_peer(
@@ -26,7 +26,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         wait_peer_added(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -18,7 +18,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_peer_added(bootstrap_api_uri)
+    leader = wait_peer_added(bootstrap_api_uri)
 
     # Create collection
     r = requests.put(
@@ -37,7 +37,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
         wait_peer_added(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that it exists on all peers
     assert_collection_exists_on_all_peers("test_collection", peer_api_uris)

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -19,7 +19,7 @@ def test_collection_sharding(tmp_path: pathlib.Path):
     peer_api_uris.append(bootstrap_api_uri)
 
     # Wait for leader
-    wait_peer_added(bootstrap_api_uri)
+    leader = wait_peer_added(bootstrap_api_uri)
 
     # Start other peers
     for i in range(1, len(peer_dirs)):
@@ -29,7 +29,7 @@ def test_collection_sharding(tmp_path: pathlib.Path):
         wait_peer_added(peer_api_uris[i])
 
     # Wait for cluster
-    wait_for_uniform_cluster_size(peer_api_uris)
+    wait_for_uniform_cluster_status(peer_api_uris, leader)
 
     # Check that there are no collections on all peers
     for uri in peer_api_uris:

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from subprocess import Popen
@@ -80,6 +81,35 @@ def make_peer_folders(base_path: Path, n_peers: int) -> list[Path]:
     return peer_dirs
 
 
+def print_cluster_info(peer_api_uris: [str]):
+    for uri in peer_api_uris:
+        r = requests.get(f"{uri}/cluster")
+        assert_http_ok(r)
+        res = r.json()["result"]
+        print(json.dumps(res, indent=4))
+
+
+def get_leader(peer_api_uri: str) -> str:
+    r = requests.get(f"{peer_api_uri}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["raft_info"]["leader"]
+
+
+def check_leader(peer_api_uri: str, expected_leader: str) -> bool:
+    try:
+        r = requests.get(f"{peer_api_uri}/cluster")
+        assert_http_ok(r)
+        leader = r.json()["result"]["raft_info"]["leader"]
+        correct_leader = leader == expected_leader
+        if not correct_leader:
+            print(f"Cluster leader invalid for peer {peer_api_uri} {leader}/{expected_leader}")
+        return correct_leader
+    except requests.exceptions.ConnectionError:
+        # the api is not yet available - caller needs to retry
+        print(f"Could not contact peer {peer_api_uri} to fetch cluster leader")
+        return False
+
+
 def leader_is_defined(peer_api_uri: str) -> bool:
     try:
         r = requests.get(f"{peer_api_uri}/cluster")
@@ -92,24 +122,25 @@ def leader_is_defined(peer_api_uri: str) -> bool:
         return False
 
 
-def cluster_size(peer_api_uri: str, expected_size: int) -> bool:
+def check_cluster_size(peer_api_uri: str, expected_size: int) -> bool:
     try:
         r = requests.get(f"{peer_api_uri}/cluster")
         assert_http_ok(r)
         peers = r.json()["result"]["peers"]
-        if not len(peers) == expected_size:
+        correct_size = len(peers) == expected_size
+        if not correct_size:
             print(f"Cluster size invalid for peer {peer_api_uri} {len(peers)}/{expected_size}")
-        return len(peers) == expected_size
+        return correct_size
     except requests.exceptions.ConnectionError:
         # the api is not yet available - caller needs to retry
         print(f"Could not contact peer {peer_api_uri} to fetch cluster size")
         return False
 
 
-def all_cluster_size_consistent(peer_api_uris: [str]) -> bool:
+def all_nodes_cluster_info_consistent(peer_api_uris: [str], expected_leader: str) -> bool:
     expected_size = len(peer_api_uris)
     for uri in peer_api_uris:
-        if cluster_size(uri, expected_size):
+        if check_leader(uri, expected_leader) and check_cluster_size(uri, expected_size):
             continue
         else:
             return False
@@ -146,7 +177,7 @@ WAIT_TIME_SEC = 30
 RETRY_INTERVAL_SEC = 0.2
 
 
-def wait_peer_added(peer_api_uri: str):
+def wait_peer_added(peer_api_uri: str) -> str:
     start = time.time()
     while not leader_is_defined(peer_api_uri):
         elapsed = time.time() - start
@@ -155,16 +186,19 @@ def wait_peer_added(peer_api_uri: str):
             raise Exception(f"Leader was not established in time ({WAIT_TIME_SEC} sec)")
         else:
             time.sleep(RETRY_INTERVAL_SEC)
-    # It seems that waiting for leader to be recognised is not enough
+    # FIXME It seems that waiting for leader to be recognised is not enough
     time.sleep(3)
+    return get_leader(peer_api_uri)
 
 
-def wait_for_uniform_cluster_size(peer_api_uris: [str]):
+def wait_for_uniform_cluster_status(peer_api_uris: [str], expected_leader: str):
     start = time.time()
-    while not all_cluster_size_consistent(peer_api_uris):
+    while not all_nodes_cluster_info_consistent(peer_api_uris, expected_leader):
         elapsed = time.time() - start
         # do not wait more than WAIT_TIME_SEC
         if elapsed > WAIT_TIME_SEC:
+            # print cluster for debug
+            print_cluster_info(peer_api_uris)
             raise Exception(f"Cluster size was not uniform in time ({WAIT_TIME_SEC} sec)")
         else:
             time.sleep(RETRY_INTERVAL_SEC)


### PR DESCRIPTION
This PR harden the consensus tests and adds new debug logs to help the operators (context: https://github.com/qdrant/qdrant/issues/676)

The tests now check that all the nodes report the same leader and cluster size.