### PR TITLE
Cifs dir delete

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,6 +8,7 @@ use segment::types::{
 };
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 type LockedRmSet = Arc<RwLock<HashSet<PointIdType>>>;
@@ -394,9 +395,12 @@ impl SegmentEntry for ProxySegment {
         }
     }
 
-    fn drop_data(&mut self) -> OperationResult<()> {
-        self.wrapped_segment.get().write().drop_data()?;
-        Ok(())
+    fn drop_data(self) -> OperationResult<()> {
+        self.wrapped_segment.drop_data()
+    }
+
+    fn data_path(&self) -> PathBuf {
+        self.wrapped_segment.get().read().data_path()
     }
 
     fn delete_field_index(&mut self, op_num: u64, key: PayloadKeyTypeRef) -> OperationResult<bool> {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -33,15 +33,10 @@ impl LockedSegment {
     }
 
     pub fn get(&self) -> Arc<RwLock<dyn SegmentEntry>> {
-        let res: Arc<RwLock<dyn SegmentEntry>> = match self {
+        match self {
             LockedSegment::Original(segment) => segment.clone(),
             LockedSegment::Proxy(proxy) => proxy.clone(),
-        };
-        eprintln!(
-            "giving SegmentEntry from LockedSegment: {:?}",
-            res.read().data_path()
-        );
-        res
+        }
     }
 
     pub fn drop_data(self) -> OperationResult<()> {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -37,7 +37,10 @@ impl LockedSegment {
             LockedSegment::Original(segment) => segment.clone(),
             LockedSegment::Proxy(proxy) => proxy.clone(),
         };
-        eprintln!("giving SegmentEntry from LockedSegment: {:?}", res.read().data_path());
+        eprintln!(
+            "giving SegmentEntry from LockedSegment: {:?}",
+            res.read().data_path()
+        );
         res
     }
 
@@ -45,15 +48,17 @@ impl LockedSegment {
         match self {
             LockedSegment::Original(segment) => match Arc::try_unwrap(segment) {
                 Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                Err(locked_segment) => Err(OperationError::service_error(
-                    &format!("Removing segment which is still in use: {:?}", locked_segment.read().data_path()),
-                )),
+                Err(locked_segment) => Err(OperationError::service_error(&format!(
+                    "Removing segment which is still in use: {:?}",
+                    locked_segment.read().data_path()
+                ))),
             },
             LockedSegment::Proxy(proxy) => match Arc::try_unwrap(proxy) {
                 Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                Err(locked_segment) => Err(OperationError::service_error(
-                    &format!("Removing segment which is still in use: {:?}", locked_segment.read().data_path()),
-                )),
+                Err(locked_segment) => Err(OperationError::service_error(&format!(
+                    "Removing segment which is still in use: {:?}",
+                    locked_segment.read().data_path()
+                ))),
             },
         }
     }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -421,18 +421,24 @@ pub trait SegmentOptimizer {
 
             let has_appendable_segments = write_segments.random_appendable_segment().is_some();
 
+            // Release reference counter of the optimized segments
+            drop(optimizing_segments);
             // Append a temp segment to a collection if it is not empty or there is no other appendable segment
             if tmp_segment.get().read().vectors_count() > 0 || !has_appendable_segments {
                 write_segments.add_locked(tmp_segment);
+                // Only remove data after we ensure the consistency of the collection.
+                // If remove fails - we will still have operational collection with reported error.
+                for proxy in proxies {
+                    proxy.drop_data()?;
+                }
             } else {
+                // Proxy contains pointer to the `tmp_segment`, so they should be removed first
+                for proxy in proxies {
+                    proxy.drop_data()?;
+                }
                 tmp_segment.drop_data()?;
             }
 
-            // Only remove data after we ensure the consistency of the collection.
-            // If remove fails - we will till have operational collection with reported error.
-            for proxy in proxies {
-                proxy.drop_data()?;
-            }
         }
         Ok(true)
     }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -438,7 +438,6 @@ pub trait SegmentOptimizer {
                 }
                 tmp_segment.drop_data()?;
             }
-
         }
         Ok(true)
     }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -8,6 +8,7 @@ use atomicwrites::Error as AtomicIoError;
 use rocksdb::Error;
 use std::collections::HashMap;
 use std::io::Error as IoError;
+use std::path::PathBuf;
 use std::result;
 use thiserror::Error;
 
@@ -217,7 +218,10 @@ pub trait SegmentEntry {
     fn flush(&self) -> OperationResult<SeqNumberType>;
 
     /// Removes all persisted data and forces to destroy segment
-    fn drop_data(&mut self) -> OperationResult<()>;
+    fn drop_data(self) -> OperationResult<()>;
+
+    /// Path to data, owned by segment
+    fn data_path(&self) -> PathBuf;
 
     /// Delete field index, if exists
     fn delete_field_index(

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -559,10 +559,12 @@ impl SegmentEntry for Segment {
         Ok(state.version)
     }
 
-    fn drop_data(&mut self) -> OperationResult<()> {
-        let mut deleted_path = self.current_path.clone();
+    fn drop_data(self) -> OperationResult<()> {
+        let current_path = self.current_path.clone();
+        drop(self);
+        let mut deleted_path = current_path.clone();
         deleted_path.set_extension("deleted");
-        rename(&self.current_path, &deleted_path)?;
+        rename(&current_path, &deleted_path)?;
         remove_dir_all(&deleted_path).map_err(|err| {
             OperationError::service_error(&format!(
                 "Can't remove segment data at {}, error: {}",
@@ -570,6 +572,10 @@ impl SegmentEntry for Segment {
                 err
             ))
         })
+    }
+
+    fn data_path(&self) -> PathBuf {
+        self.current_path.clone()
     }
 
     fn delete_field_index(&mut self, op_num: u64, key: PayloadKeyTypeRef) -> OperationResult<bool> {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -319,6 +319,7 @@ impl TableOfContent {
         if let Some(mut removed) = self.collections.write().await.remove(collection_name) {
             removed.before_drop().await;
             let path = self.get_collection_path(collection_name);
+            drop(removed);
             remove_dir_all(path).map_err(|err| StorageError::ServiceError {
                 description: format!(
                     "Can't delete collection {}, error: {}",


### PR DESCRIPTION
### All Submissions:

Issue: https://github.com/qdrant/qdrant/issues/701

Overall problem is related to the unconventional behavior of the CIFS (samba) remote file system.
Being developed for windows, it has inherited some of the vices of the file systems of this family.
In particular, the file deletion procedure deviates from unix standards.

Instead of deleting the "used" file, CIFT considers it deleted, but does not release the so-called hard link.

As a result, you can observe funny visual effects:

![image](https://user-images.githubusercontent.com/1935623/173963661-863aaa2f-d4a7-426f-92b4-0e675eeb3209.png)

This disregard for the standard was not initially considered in Qdrant.
Therefore, files could be deleted while still in use, which is perfectly normal in linux.

This PR changes that behavior. Objects must now be consumed before deleting files, which frees up file descriptors and makes deletion compatible with the CIFT snags.



* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?
