### PR TITLE
Format timestamps with millis precision in log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ fn main() -> anyhow::Result<()> {
     let mut log_builder = env_logger::Builder::new();
 
     log_builder
+        // Timestamp in millis
+        .format_timestamp_millis()
         // Parse user defined log level configuration
         .parse_filters(&settings.log_level)
         // h2 is very verbose and we have many network operations,


### PR DESCRIPTION
Tiny PR to format the timestamp with milliseconds in the logs.

This helps to disambiguate certain operations in the logs during debugs. 

- Before

```
[2022-06-16T10:19:47Z DEBUG hyper::client::connect::http] connecting to 127.0.0.1:53377
[2022-06-16T10:19:47Z DEBUG hyper::client::connect::http] connected to 127.0.0.1:53377
[2022-06-16T10:19:47Z DEBUG hyper::client::connect::http] connecting to 127.0.0.1:53377
[2022-06-16T10:19:47Z DEBUG hyper::client::connect::http] connected to 127.0.0.1:53377
```
- After

```
[2022-06-16T10:21:15.723Z DEBUG hyper::client::connect::http] connecting to 127.0.0.1:43983
[2022-06-16T10:21:15.724Z DEBUG hyper::client::connect::http] connected to 127.0.0.1:43983
[2022-06-16T10:21:15.725Z DEBUG hyper::client::connect::http] connecting to 127.0.0.1:43983
[2022-06-16T10:21:15.726Z DEBUG hyper::client::connect::http] connected to 127.0.0.1:43983
```
