### PR TITLE
Fix deadlock in cluster status.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: .github/scripts/protoc.sh
         shell: bash
       - name: Build
-        run: cargo build
+        run: cargo build --features service_debug
       - name: Run integration tests
         run: ./tests/integration-tests.sh
         shell: bash
@@ -56,7 +56,7 @@ jobs:
         run: .github/scripts/protoc.sh
         shell: bash
       - name: Build
-        run: cargo build
+        run: cargo build --features service_debug
       - name: Run integration tests - 1 peer
         run: ./tests/integration-tests.sh distributed
         shell: bash

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -175,15 +175,18 @@ impl ConsensusState {
             .collect();
         let pending_operations = persistent.unapplied_entities_count();
         let soft_state = self.soft_state.read();
+        let leader = soft_state.as_ref().map(|state| state.leader_id);
+        let role = soft_state.as_ref().map(|state| state.raft_state.into());
+        let peer_id = persistent.this_peer_id;
         ClusterStatus::Enabled(ClusterInfo {
-            peer_id: self.this_peer_id(),
+            peer_id,
             peers,
             raft_info: RaftInfo {
                 term: hard_state.term,
                 commit: hard_state.commit,
                 pending_operations,
-                leader: soft_state.as_ref().map(|state| state.leader_id),
-                role: soft_state.as_ref().map(|state| state.raft_state.into()),
+                leader,
+                role,
             },
         })
     }


### PR DESCRIPTION
This PR fixes a deadlock in the cluster status. (found in the context of https://github.com/qdrant/qdrant/issues/709)

Here is the deadlock detection report.

```
[2022-06-17T15:53:02.855Z ERROR qdrant] 1 deadlocks detected
    Deadlock #0
    Thread Id 140401950271040
       0:     0x55e2e05bea4a - backtrace::backtrace::libunwind::trace::h48399522ee083924
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.65/src/backtrace/libunwind.rs:93:5
                               backtrace::backtrace::trace_unsynchronized::h4499f1decc2119c3
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.65/src/backtrace/mod.rs:66:5
       1:     0x55e2e05be9c2 - backtrace::backtrace::trace::h40e7832466c0123d
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.65/src/backtrace/mod.rs:53:14
       2:     0x55e2e061df56 - backtrace::capture::Backtrace::create::hc9687f6b7ef6261b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.65/src/capture.rs:176:9
       3:     0x55e2e061de9d - backtrace::capture::Backtrace::new::h1ee45e25e70ffb31
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.65/src/capture.rs:140:22
       4:     0x55e2e0582ec9 - parking_lot_core::parking_lot::deadlock_impl::on_unpark::h0b5ec0771432db83
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.3/src/parking_lot.rs:1203:32
       5:     0x55e2e0546fab - parking_lot_core::parking_lot::deadlock::on_unpark::h75f5f123992805e7
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.3/src/parking_lot.rs:1136:9
       6:     0x55e2e05546df - parking_lot_core::parking_lot::park::{{closure}}::habf2e4618474516c
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.3/src/parking_lot.rs:637:17
       7:     0x55e2e0551e28 - parking_lot_core::parking_lot::with_thread_data::h5eb7ea2dbf01fb62
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.3/src/parking_lot.rs:207:5
                               parking_lot_core::parking_lot::park::h34e17314b20ce15d
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.3/src/parking_lot.rs:600:5
       8:     0x55e2e0546894 - parking_lot::raw_rwlock::RawRwLock::lock_common::h350f02072f30069f
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/src/raw_rwlock.rs:1115:17
       9:     0x55e2e0544ed4 - parking_lot::raw_rwlock::RawRwLock::lock_shared_slow::h9ab696aa98e7c75b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/src/raw_rwlock.rs:719:9
      10:     0x55e2deeb48a4 - <parking_lot::raw_rwlock::RawRwLock as lock_api::rwlock::RawRwLock>::lock_shared::h3f8efdb77f0b7ca6
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/src/raw_rwlock.rs:109:26
      11:     0x55e2deeb2143 - lock_api::rwlock::RwLock<R,T>::read::h42ec4242177988a1
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.7/src/rwlock.rs:448:9
      12:     0x55e2dec5e97f - storage::content_manager::consensus_state::ConsensusState::this_peer_id::hc9caea33d8dbd210
                                   at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus_state.rs:158:9
      13:     0x55e2de6c7302 - storage::content_manager::consensus_state::ConsensusState::cluster_status::{{closure}}::h0d6281ad07298171
                                   at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus_state.rs:188:23
      14:     0x55e2de2d9aa9 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::heec32e849af56268
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      15:     0x55e2de2e48b9 - storage::Dispatcher::cluster_status::{{closure}}::hf3d5336072014736
                                   at /home/agourlay/Workspace/qdrant/lib/storage/src/lib.rs:106:50
      16:     0x55e2de2cd489 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h7479e9728b6d6f79
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      17:     0x55e2de2e6690 - <qdrant::actix::api::cluster_api::cluster_status as actix_web::service::HttpServiceFactory>::register::cluster_status::{{closure}}::h54c756af06cd99f1
                                   at /home/agourlay/Workspace/qdrant/src/actix/api/cluster_api.rs:11:47
      18:     0x55e2de2c2269 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h1abfa45806f6af96
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      19:     0x55e2de629a57 - actix_web::handler::handler_service::{{closure}}::{{closure}}::hb22f3010b8cfdb13
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.1.0/src/handler.rs:105:32
      20:     0x55e2de2c0409 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h0879e184101fb624
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      21:     0x55e2dff3955f - <core::pin::Pin<P> as core::future::future::Future>::poll::hed38f4af485e5dfe
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/future.rs:124:9
      22:     0x55e2dff25539 - <actix_web::resource::Resource<T> as actix_web::service::HttpServiceFactory>::register::{{closure}}::{{closure}}::h4ab8cb6c99029938
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.1.0/src/resource.rs:383:27
      23:     0x55e2dfef5aaa - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h38059c79609ed16c
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      24:     0x55e2dff3955f - <core::pin::Pin<P> as core::future::future::Future>::poll::hed38f4af485e5dfe
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/future.rs:124:9
      25:     0x55e2de706ba0 - <actix_cors::middleware::CorsMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}::h8e2131abaf67a041
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-cors-0.6.1/src/middleware.rs:203:26
      26:     0x55e2de2c0737 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h0b663f874b9788c4
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      27:     0x55e2de26396b - <core::pin::Pin<P> as core::future::future::Future>::poll::hc816a00a0c93d7b0
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/future.rs:124:9
      28:     0x55e2de37b65b - <actix_web::middleware::condition::ConditionMiddlewareFuture<E,D> as core::future::future::Future>::poll::hfc8d6bf1c0b33237
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.1.0/src/middleware/condition.rs:123:54
      29:     0x55e2de1b4059 - <actix_web::middleware::logger::LoggerResponse<S,B> as core::future::future::Future>::poll::h43e896827aa06a78
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.1.0/src/middleware/logger.rs:302:32
      30:     0x55e2de50fae4 - <actix_service::map_err::MapErrFuture<A,Req,F,E> as core::future::future::Future>::poll::ha73d558f09067eef
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-service-2.0.2/src/map_err.rs:99:9
      31:     0x55e2de469b92 - actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::handle_request::h12f2941888db304c
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-http-3.0.4/src/h1/dispatcher.rs:652:34
      32:     0x55e2de4655f9 - actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::poll_request::hbcf99928bc4bddbe
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-http-3.0.4/src/h1/dispatcher.rs:805:33
      33:     0x55e2de46d6a7 - <actix_http::h1::dispatcher::Dispatcher<T,S,B,X,U> as core::future::future::Future>::poll::ha31b1c1d0870295c
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-http-3.0.4/src/h1/dispatcher.rs:1190:21
      34:     0x55e2de44162c - <actix_http::service::HttpServiceHandlerResponse<T,S,B,X,U> as core::future::future::Future>::poll::h5d8ffdfb48143837
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-http-3.0.4/src/service.rs:650:45
      35:     0x55e2de20afdd - <actix_service::and_then::AndThenServiceResponse<A,B,Req> as core::future::future::Future>::poll::h7424980d66b55f3b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-service-2.0.2/src/and_then.rs:114:37
      36:     0x55e2de613b70 - <actix_server::service::StreamService<S,I> as actix_service::Service<(actix_server::worker::WorkerCounterGuard,actix_server::socket::MioStream)>>::call::{{closure}}::h1252d42ee41cbbe2
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-server-2.1.1/src/service.rs:75:30
      37:     0x55e2de2d04bb - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h925c7e706e0ae23c
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      38:     0x55e2de3dc8f4 - tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}::he87396000cfb842e
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/core.rs:165:17
      39:     0x55e2de1cccc0 - tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut::hcb099da3d5a90dda
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/loom/std/unsafe_cell.rs:14:9
      40:     0x55e2de3dc277 - tokio::runtime::task::core::CoreStage<T>::poll::hccaf06d0f0135744
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/core.rs:155:13
      41:     0x55e2de3e932a - tokio::runtime::task::harness::poll_future::{{closure}}::hd2b1fa29fac15f0a
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/harness.rs:470:19
      42:     0x55e2de26de53 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hdac2a87d049655dd
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panic/unwind_safe.rs:271:9
      43:     0x55e2de41f7f0 - std::panicking::try::do_call::h76fec48e91c77ea7
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
      44:     0x55e2de4229cb - __rust_try
      45:     0x55e2de41da80 - std::panicking::try::hb3e4b5aaf218f2c7
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
      46:     0x55e2de6c04fa - std::panic::catch_unwind::h48334af7a83e7b64
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
      47:     0x55e2de3e8368 - tokio::runtime::task::harness::poll_future::h730991cd57efefe6
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/harness.rs:458:18
      48:     0x55e2de3ea197 - tokio::runtime::task::harness::Harness<T,S>::poll_inner::h9486918a14138764
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/harness.rs:104:27
      49:     0x55e2de3f1383 - tokio::runtime::task::harness::Harness<T,S>::poll::he2c6628d26baaa1b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/harness.rs:57:15
      50:     0x55e2de533b00 - tokio::runtime::task::raw::poll::hd7c0f38f10561495
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/raw.rs:144:5
      51:     0x55e2e0493d6f - tokio::runtime::task::raw::RawTask::poll::hd086c89ae1143f20
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/raw.rs:84:18
      52:     0x55e2e04944c2 - tokio::runtime::task::LocalNotified<S>::run::h39e5cd5c78c999c4
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/task/mod.rs:376:9
      53:     0x55e2e04d4fdb - tokio::task::local::LocalSet::tick::{{closure}}::hb3354e177f4d278a
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:528:54
      54:     0x55e2e0470e9c - tokio::coop::with_budget::{{closure}}::h0e4f463a159ee2d7
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:102:9
      55:     0x55e2e04d915d - std::thread::local::LocalKey<T>::try_with::h00b88529c4ff40c2
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:442:16
      56:     0x55e2e04d9045 - std::thread::local::LocalKey<T>::with::hfc58b804a5a194e9
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:418:9
      57:     0x55e2e04d4f8a - tokio::coop::with_budget::h5a60f084c5b59e4b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:95:5
                               tokio::coop::budget::h85dd0acf6d103dcd
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:72:5
                               tokio::task::local::LocalSet::tick::h1abb13175f963490
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:528:31
      58:     0x55e2e043d4df - <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll::{{closure}}::h7a93a4e930e784de
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:675:16
      59:     0x55e2e042a78f - tokio::macros::scoped_tls::ScopedKey<T>::set::hbe06da548c114d3f
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/macros/scoped_tls.rs:61:9
      60:     0x55e2e043c42b - tokio::task::local::LocalSet::with::hd456babb099f8ede
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:566:9
      61:     0x55e2e043d2c4 - <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll::hc4fd70a0017d021f
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:661:9
      62:     0x55e2e043c736 - tokio::task::local::LocalSet::run_until::{{closure}}::h4685e358ca1c45cf
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:491:18
      63:     0x55e2e042ae0d - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h1788e21606acdbe0
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
      64:     0x55e2e0427dac - <core::pin::Pin<P> as core::future::future::Future>::poll::h9892f42117c166c3
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/future.rs:124:9
      65:     0x55e2e04344f2 - tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}::h3fc8448cc8a58cc3
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:508:48
      66:     0x55e2e0439304 - tokio::coop::with_budget::{{closure}}::heda2f2407205c7ef
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:102:9
      67:     0x55e2e0446a7a - std::thread::local::LocalKey<T>::try_with::h4d5e27729f783e1b
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:442:16
      68:     0x55e2e044613e - std::thread::local::LocalKey<T>::with::hc98e475f4fbb34e7
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:418:9
      69:     0x55e2e04343a0 - tokio::coop::with_budget::h255789933be8a5ea
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:95:5
                               tokio::coop::budget::hc5f98ebbebecbef8
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/coop.rs:72:5
                               tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}::{{closure}}::h6d31a7fe5726d782
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:508:25
      70:     0x55e2e0431b26 - tokio::runtime::basic_scheduler::Context::enter::h3cc29d65246e046f
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:362:19
      71:     0x55e2e0433492 - tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}::h07eaf022dc4dfca9
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:507:36
      72:     0x55e2e043315c - tokio::runtime::basic_scheduler::CoreGuard::enter::{{closure}}::hba2a1340dd80306b
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:565:57
      73:     0x55e2e042a89f - tokio::macros::scoped_tls::ScopedKey<T>::set::hd91999ddeac417d5
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/macros/scoped_tls.rs:61:9
      74:     0x55e2e0432ecb - tokio::runtime::basic_scheduler::CoreGuard::enter::hfd595012b3a1fa43
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:565:27
      75:     0x55e2e0433201 - tokio::runtime::basic_scheduler::CoreGuard::block_on::h3378f41a3fa1c942
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:498:9
      76:     0x55e2e0430efb - tokio::runtime::basic_scheduler::BasicScheduler::block_on::h1454d89e9219acab
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/basic_scheduler.rs:174:24
      77:     0x55e2e041ba4c - tokio::runtime::Runtime::block_on::h559e0adde24df143
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/mod.rs:480:46
      78:     0x55e2e043c4ee - tokio::task::local::LocalSet::block_on::hb7fb945b6d6ec3ce
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/task/local.rs:452:9
      79:     0x55e2e042b161 - actix_rt::runtime::Runtime::block_on::hb0f80e1f9aff5c86
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-rt-2.7.0/src/runtime.rs:80:9
      80:     0x55e2dffadd8f - actix_rt::arbiter::Arbiter::with_tokio_rt::{{closure}}::h31aa1299bc6840c2
                                   at /home/agourlay/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-rt-2.7.0/src/arbiter.rs:144:21
      81:     0x55e2dff8b13d - std::sys_common::backtrace::__rust_begin_short_backtrace::hce537c22c5497df4
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:122:18
      82:     0x55e2dffcbcf1 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::hfdc66d9003440ba6
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/mod.rs:498:17
      83:     0x55e2e0002661 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hc5c4d4f10fd71371
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panic/unwind_safe.rs:271:9
      84:     0x55e2e000863c - std::panicking::try::do_call::h11a2a72fbe7731be
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
      85:     0x55e2e000d92b - __rust_try
      86:     0x55e2e0008317 - std::panicking::try::heb0e6c882d8d478c
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
      87:     0x55e2dffbae61 - std::panic::catch_unwind::h1c46c4e11e8669f7
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
      88:     0x55e2dffcb19f - std::thread::Builder::spawn_unchecked_::{{closure}}::h1f89ae99ec258a03
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/mod.rs:497:30
      89:     0x55e2dff9633f - core::ops::function::FnOnce::call_once{{vtable.shim}}::h7602d5c70f6c45b2
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
      90:     0x55e2e070bfb3 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::ha99802c2c52ada61
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/alloc/src/boxed.rs:1861:9
                               <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::ha39aea1c57e28a15
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/alloc/src/boxed.rs:1861:9
                               std::sys::unix::thread::Thread::new::thread_start::h9f8e3d72b1f7662f
                                   at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys/unix/thread.rs:108:17
      91:     0x7fb21d394b43 - start_thread
                                   at ./nptl/./nptl/pthread_create.c:442:8
      92:     0x7fb21d426a00 - clone3
                                   at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
      93:                0x0 - <unknown>

```

The interesting part being

```
  12:     0x55e2dec5e97f - storage::content_manager::consensus_state::ConsensusState::this_peer_id::hc9caea33d8dbd210
                                   at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus_state.rs:158:9
```

The problem occurs when trying to access `self.this_peer_id` which performs a read lock.

```rust
    pub fn this_peer_id(&self) -> PeerId {
        self.persistent.read().this_peer_id
    }
```

We already have a `LockGuard` in scope for `persistent` a few lines above and the docs of `parking_lot` are mentioning.

```text
This lock uses a task-fair locking policy which avoids both reader and writer starvation.
This means that readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock. 
Because of this, attempts to recursively acquire a read lock within a single thread may result in a deadlock.
```

The solution is to not acquire twice the `persistent` read lock on the cluster status thread.