### PR TITLE
Remove unecessary async fn on cluster status

### DIFF
--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -158,7 +158,7 @@ impl ConsensusState {
         self.persistent.read().this_peer_id
     }
 
-    pub async fn cluster_status(&self) -> ClusterStatus {
+    pub fn cluster_status(&self) -> ClusterStatus {
         let persistent = self.persistent.read();
         let hard_state = &persistent.state.hard_state;
         let peers = persistent

--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -101,9 +101,9 @@ impl Dispatcher {
         }
     }
 
-    pub async fn cluster_status(&self) -> ClusterStatus {
+    pub fn cluster_status(&self) -> ClusterStatus {
         match self.consensus_state.as_ref() {
-            Some(state) => state.cluster_status().await,
+            Some(state) => state.cluster_status(),
             None => ClusterStatus::Disabled,
         }
     }

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -7,7 +7,7 @@ use storage::Dispatcher;
 #[get("/cluster")]
 async fn cluster_status(dispatcher: web::Data<Arc<Dispatcher>>) -> impl Responder {
     let timing = Instant::now();
-    let response = dispatcher.cluster_status().await;
+    let response = dispatcher.cluster_status();
     process_response(Ok(response), timing)
 }
 


### PR DESCRIPTION
The `cluster_status` does not perform any async. operations.