### PR TITLE
Fix entry reapplication on restart

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -198,7 +198,7 @@ impl Consensus {
             match self.receiver.recv_timeout(timeout) {
                 Ok(Message::FromPeer(message)) => {
                     log::trace!(
-                        "Recieved a message from peer with progress: {:?}. Message: {:?}",
+                        "Received a message from peer with progress: {:?}. Message: {:?}",
                         self.node.raft.prs().get(message.from),
                         message
                     );

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -375,6 +375,9 @@ fn handle_committed_entries(
     state: &ConsensusStateRef,
     raw_node: &mut RawNode<ConsensusStateRef>,
 ) -> raft::Result<()> {
+    if state.persistent.read().unapplied_entities_count() > 0 {
+        panic!("Preconditon broken - all committed entries must be applied before this fn call")
+    }
     let last_applied = state.persistent.read().last_applied_entry();
     if let Some(last_applied) = last_applied {
         entries = entries

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -197,10 +197,10 @@ impl Consensus {
         loop {
             match self.receiver.recv_timeout(timeout) {
                 Ok(Message::FromPeer(message)) => {
-                    log::debug!(
-                        "Proposing entry from peer {} with progress {:?}",
-                        message.from,
-                        self.node.raft.prs().get(message.from)
+                    log::trace!(
+                        "Recieved a message from peer with progress: {:?}. Message: {:?}",
+                        self.node.raft.prs().get(message.from),
+                        message
                     );
                     self.node.step(*message)?
                 }
@@ -241,7 +241,7 @@ impl Consensus {
         // Get the `Ready` with `RawNode::ready` interface.
         let mut ready = self.node.ready();
         if !ready.messages().is_empty() {
-            log::debug!("Handling {} messages", ready.messages().len());
+            log::trace!("Handling {} messages", ready.messages().len());
             if let Err(err) = self.handle_messages(ready.take_messages(), &store) {
                 log::error!("Failed to send messages: {err}")
             }
@@ -277,7 +277,7 @@ impl Consensus {
             self.handle_soft_state(ss);
         }
         if !ready.persisted_messages().is_empty() {
-            log::debug!(
+            log::trace!(
                 "Handling {} persisted messages",
                 ready.persisted_messages().len()
             );
@@ -371,10 +371,17 @@ impl Consensus {
 }
 
 fn handle_committed_entries(
-    entries: Vec<Entry>,
+    mut entries: Vec<Entry>,
     state: &ConsensusStateRef,
     raw_node: &mut RawNode<ConsensusStateRef>,
 ) -> raft::Result<()> {
+    let last_applied = state.persistent.read().last_applied_entry();
+    if let Some(last_applied) = last_applied {
+        entries = entries
+            .into_iter()
+            .filter(|entry| entry.index > last_applied)
+            .collect();
+    }
     if let (Some(first), Some(last)) = (entries.first(), entries.last()) {
         state.set_unapplied_entries(first.index, last.index)?;
         state.apply_entries(raw_node)?;

--- a/tests/consensus_tests/create_collection_and_check.py
+++ b/tests/consensus_tests/create_collection_and_check.py
@@ -15,8 +15,6 @@ r = requests.put(
         "distance": "Dot",
         "shard_number": 6
     })
-print(r)
-print(r.json())
 assert r.status_code == 200
 
 # Wait

--- a/tests/consensus_tests/create_collection_and_check.py
+++ b/tests/consensus_tests/create_collection_and_check.py
@@ -15,6 +15,8 @@ r = requests.put(
         "distance": "Dot",
         "shard_number": 6
     })
+print(r)
+print(r.json())
 assert r.status_code == 200
 
 # Wait


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/711

Raft library returns all committed entries after restart - which was not well documented or expected :smile: 
