### PR TITLE
Remove last sleep consensus test

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -1,11 +1,8 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::io::Result<()> {
     tonic_build::configure()
         .out_dir("src/grpc/") // saves generated structures at this location
         .compile(
             &["src/grpc/proto/qdrant.proto"], // proto entry point
             &["src/grpc/proto"], // specify the root location to search proto dependencies
         )
-        .unwrap();
-
-    Ok(())
 }

--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -23,7 +23,7 @@ def test_collection_after_peers_added(tmp_path: pathlib.Path):
         peer_api_uris.append(start_peer(
             peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
         # Add peers one by one sequentially
-        wait_peer_added(peer_api_uris[i])
+        wait_peer_added(peer_api_uris[i], i + 1)
 
     # Wait for cluster
     wait_for_uniform_cluster_status(peer_api_uris, leader)

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -34,7 +34,7 @@ def test_collection_before_peers_added(tmp_path: pathlib.Path):
         peer_api_uris.append(start_peer(
             peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
         # Add peers one by one sequentially
-        wait_peer_added(peer_api_uris[i])
+        wait_peer_added(peer_api_uris[i], i + 1)
 
     # Wait for cluster
     wait_for_uniform_cluster_status(peer_api_uris, leader)

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -26,7 +26,7 @@ def test_collection_sharding(tmp_path: pathlib.Path):
         peer_api_uris.append(start_peer(
             peer_dirs[i], f"peer_0_{i}.log", bootstrap_uri))
         # Add peers one by one sequentially
-        wait_peer_added(peer_api_uris[i])
+        wait_peer_added(peer_api_uris[i], i + 1)
 
     # Wait for cluster
     wait_for_uniform_cluster_status(peer_api_uris, leader)


### PR DESCRIPTION
This PR removes the last sleep in the consensus test.

The insight is that having a non null `leader` field does not mean that the peer joined the cluster successfully.
The peer fully joined when its list of `peers` has the right size.

