### PR TITLE
Use latest raft-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
  "futures",
  "hashring",
  "indicatif",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "merge",
  "num_cpus",
@@ -913,7 +913,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.3",
+ "itertools",
 ]
 
 [[package]]
@@ -1195,12 +1195,6 @@ name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
@@ -1713,15 +1707,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -2229,7 +2214,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "libc",
- "petgraph 0.6.0",
+ "petgraph",
  "redox_syscall",
  "smallvec",
  "thread-id",
@@ -2305,21 +2290,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.1",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2470,12 +2445,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.7.0",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -2490,18 +2465,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools 0.9.0",
+ "itertools",
+ "lazy_static",
  "log 0.4.17",
  "multimap",
- "petgraph 0.5.1",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "petgraph",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
  "tempfile",
  "which",
 ]
@@ -2516,11 +2493,11 @@ dependencies = [
  "cfg-if",
  "cmake",
  "heck 0.4.0",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "log 0.4.17",
  "multimap",
- "petgraph 0.6.0",
+ "petgraph",
  "prost 0.10.1",
  "prost-types 0.10.1",
  "regex",
@@ -2530,12 +2507,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2548,7 +2525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2556,12 +2533,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.7.0",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -2582,13 +2559,13 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "protobuf-build"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7266835d38c38c73b091a24412de1f4b4382a5195fab1ec038161582b03b78"
+checksum = "4b2be70fa994657539e3c872cc54363c9bf28b0d7a7f774df70e9fd760df3bc4"
 dependencies = [
  "bitflags",
  "proc-macro2",
- "prost-build 0.7.0",
+ "prost-build 0.9.0",
  "quote",
  "syn",
 ]
@@ -2608,12 +2585,12 @@ dependencies = [
  "config",
  "env_logger",
  "futures",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "num-traits",
  "num_cpus",
  "parking_lot",
- "prost 0.7.0",
+ "prost 0.9.0",
  "raft",
  "raft-proto",
  "rusty-hook",
@@ -2653,9 +2630,8 @@ dependencies = [
 
 [[package]]
 name = "raft"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08aa642fc2067062af4d4a3a3b8b909cd80e810b994af44c5a60253fc673f934"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs?rev=52d84aac8734369d81c2d77413ea3ab8e58e0af9#52d84aac8734369d81c2d77413ea3ab8e58e0af9"
 dependencies = [
  "fxhash",
  "getset",
@@ -2668,12 +2644,11 @@ dependencies = [
 
 [[package]]
 name = "raft-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b74f65f886af112d6046c131def44849404757d22f835a0b7ef1aa473e4c96f"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs?rev=52d84aac8734369d81c2d77413ea3ab8e58e0af9#52d84aac8734369d81c2d77413ea3ab8e58e0af9"
 dependencies = [
  "lazy_static",
- "prost 0.7.0",
+ "prost 0.9.0",
  "protobuf",
  "protobuf-build",
 ]
@@ -3117,7 +3092,7 @@ dependencies = [
  "criterion",
  "geo",
  "geohash",
- "itertools 0.10.3",
+ "itertools",
  "json-patch",
  "log 0.4.17",
  "memmap 0.7.0",
@@ -3416,11 +3391,11 @@ dependencies = [
  "atomicwrites",
  "collection",
  "http",
- "itertools 0.10.3",
+ "itertools",
  "log 0.4.17",
  "num_cpus",
  "parking_lot",
- "prost 0.7.0",
+ "prost 0.9.0",
  "raft",
  "rand 0.8.5",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,11 @@ tonic = "0.7.2"
 num-traits = "0.2.15"
 
 # Consensus related crates
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false }
+raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
-prost = "=0.7.0"
-raft-proto = { version = "=0.6.0", features = ["prost-codec"], default-features = false}
+prost = "=0.9.0"
+raft-proto = {  git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false}
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -26,8 +26,8 @@ parking_lot = { version = "0.12.1", features=["deadlock_detection", "serde"]}
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }
-raft = { version = "=0.6.0", features = ["prost-codec"], default-features = false}
-prost = { version = "=0.7.0" } # version of prost used by raft
+raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
+prost = { version = "=0.9.0" } # version of prost used by raft
 serde_cbor = { version = "0.11.2" }
 
 segment = {path = "../segment"}


### PR DESCRIPTION
This PR uses the commit https://github.com/tikv/raft-rs/commit/52d84aac8734369d81c2d77413ea3ab8e58e0af9 as dependency version for raft-rs.

Some arguments for this:
- raft-rs has not published a release in more than a year
- there are some [unreleased bug fixes](https://github.com/tikv/raft-rs/compare/v0.6.0...master)
- it updated to `prost` 0.9.0 which would enable us to close https://github.com/qdrant/qdrant/issues/521 