### PR TITLE
Promote learner

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3264,6 +3264,7 @@
         "type": "object",
         "required": [
           "commit",
+          "is_voter",
           "pending_operations",
           "term"
         ],
@@ -3303,6 +3304,10 @@
                 "nullable": true
               }
             ]
+          },
+          "is_voter": {
+            "description": "Is this peer a voter or a learner",
+            "type": "boolean"
           }
         }
       },

--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -25,6 +25,7 @@ message RaftMessage {
 
 message AllPeers {
     repeated Peer all_peers = 1;
+    uint64 first_peer_id = 2;
 }
 
 message Peer {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3472,6 +3472,8 @@ pub struct RaftMessage {
 pub struct AllPeers {
     #[prost(message, repeated, tag="1")]
     pub all_peers: ::prost::alloc::vec::Vec<Peer>,
+    #[prost(uint64, tag="2")]
+    pub first_peer_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Peer {

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -136,6 +136,7 @@ pub struct ConsensusState {
     on_consensus_op_apply:
         Mutex<HashMap<ConsensusOperations, oneshot::Sender<Result<bool, StorageError>>>>,
     propose_sender: Mutex<Sender<Vec<u8>>>,
+    first_voter: RwLock<Option<PeerId>>,
 }
 
 impl ConsensusState {
@@ -151,6 +152,7 @@ impl ConsensusState {
             toc,
             on_consensus_op_apply: Default::default(),
             propose_sender: Mutex::new(propose_sender),
+            first_voter: Default::default(),
         }
     }
 
@@ -160,6 +162,17 @@ impl ConsensusState {
 
     pub fn this_peer_id(&self) -> PeerId {
         self.persistent.read().this_peer_id
+    }
+
+    pub fn first_voter(&self) -> PeerId {
+        match self.first_voter.read().as_ref() {
+            Some(id) => *id,
+            None => self.this_peer_id(),
+        }
+    }
+
+    pub fn set_first_voter(&self, id: PeerId) {
+        *self.first_voter.write() = Some(id);
     }
 
     pub fn cluster_status(&self) -> ClusterStatus {
@@ -182,6 +195,7 @@ impl ConsensusState {
         let leader = soft_state.as_ref().map(|state| state.leader_id);
         let role = soft_state.as_ref().map(|state| state.raft_state.into());
         let peer_id = persistent.this_peer_id;
+        let is_voter = persistent.state.conf_state.get_voters().contains(&peer_id);
         ClusterStatus::Enabled(ClusterInfo {
             peer_id,
             peers,
@@ -191,6 +205,7 @@ impl ConsensusState {
                 pending_operations,
                 leader,
                 role,
+                is_voter,
             },
         })
     }
@@ -317,8 +332,18 @@ impl ConsensusState {
             .apply_state_update(move |state| state.hard_state = hard_state)
     }
 
+    pub fn set_conf_state(&self, conf_state: raft::eraftpb::ConfState) -> Result<(), StorageError> {
+        self.persistent
+            .write()
+            .apply_state_update(move |state| state.conf_state = conf_state)
+    }
+
     pub fn hard_state(&self) -> raft::eraftpb::HardState {
         self.persistent.read().state().hard_state.clone()
+    }
+
+    pub fn conf_state(&self) -> raft::eraftpb::ConfState {
+        self.persistent.read().state().conf_state.clone()
     }
 
     pub fn set_commit_index(&self, index: u64) -> Result<(), StorageError> {
@@ -665,7 +690,7 @@ impl Persistent {
     /// It is `None` if distributed deployment is disabled
     fn init(path: PathBuf, first_peer: bool) -> Result<Self, StorageError> {
         let this_peer_id = rand::random();
-        let learners = if first_peer {
+        let voters = if first_peer {
             vec![this_peer_id]
         } else {
             // `Some(false)` - Leave empty the network topology for the peer, if it is not starting a network itself.
@@ -678,7 +703,7 @@ impl Persistent {
                 hard_state: HardState::default(),
                 // For network with 1 node, set it as voter.
                 // First vec is voters, second is learners.
-                conf_state: ConfState::from((learners, vec![])),
+                conf_state: ConfState::from((voters, vec![])),
             },
             apply_progress_queue: Default::default(),
             peer_address_by_id: Default::default(),

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -55,6 +55,8 @@ pub struct RaftInfo {
     pub leader: Option<u64>,
     /// Role of this peer in the current term
     pub role: Option<StateRole>,
+    /// Is this peer a voter or a learner
+    pub is_voter: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, JsonSchema, Deserialize)]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -162,7 +162,6 @@ impl Consensus {
         .context("Failed to create timeout channel")?;
         let mut client = RaftClient::new(channel);
         let id = state_ref.this_peer_id();
-        // TODO: here ask who the first peer was and add it as the first voter
         let all_peers = client
             .add_peer_to_known(tonic::Request::new(
                 api::grpc::qdrant::AddPeerToKnownMessage {
@@ -202,7 +201,10 @@ impl Consensus {
         let mut timeout = Duration::from_millis(self.config.tick_period_ms);
 
         loop {
-            if !self.try_promote_learner()? {
+            if !self
+                .try_promote_learner()
+                .context("Failed to promote learner")?
+            {
                 // If learner promotion was proposed - do not add other proposals.
                 self.propose_updates(timeout)?;
             }


### PR DESCRIPTION
## Changes
- leader promotes learners when possible
- Fixes ERROR voters not found

## Bug
Error `voters not found` relates to the fact that first peer is started with different conf_state that contains itself as a voter. Other peers are started with empty conf_state and did not get the appropriate conf_state through sync, because it was not represented in any entry.

## Fix
We manually fetch the first_peer and inject it into the conf_state on bootstrap


Relates to #733 