### PR TITLE
Init. Raft config with last applied entry

### DIFF
--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -365,6 +365,10 @@ impl ConsensusState {
     pub fn append_entries(&self, entries: Vec<RaftEntry>) -> Result<(), StorageError> {
         self.wal.lock().append_entries(entries)
     }
+
+    pub fn last_applied_entry(&self) -> Option<u64> {
+        self.persistent.read().last_applied_entry()
+    }
 }
 
 impl Storage for ConsensusState {


### PR DESCRIPTION
This PR initialize properly the `applied` field for the Raft config.

The raft library will not return entries to the application smaller or equal to `applied` on restart.

This enables us to clean the filtering logic in the handling of committed entries introduced in https://github.com/qdrant/qdrant/pull/715 
