### PR TITLE
Hot fix to ensure bin compat. of RaftState

### DIFF
--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -538,6 +538,7 @@ impl EntryApplyProgressQueue {
 pub struct Persistent {
     #[serde(with = "RaftStateDef")]
     state: RaftState,
+    #[serde(default)] // TODO quick fix to avoid breaking the compat. with 0.8.1
     latest_snapshot_meta: SnapshotMetadataSer,
     apply_progress_queue: EntryApplyProgressQueue,
     #[serde(with = "serialize_peer_addresses")]


### PR DESCRIPTION
This PR introduces a hot-fix to ensure that the current raft state is compatible with previous versions (0.8.1).

We want to avoid the following error 

```
Error: Service internal error: cbor (de)serialization error: missing field `latest_snapshot_meta
```

A follow up PR will also make sure that the Raft state is not materialized in a single node setup.
