### PR TITLE
introduce segment-level snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,9 +3122,11 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "tar",
  "tempdir",
  "thiserror",
  "uuid 1.1.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3479,6 +3493,17 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4207,6 +4232,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,6 +12,7 @@ tempdir = "0.3.7"
 criterion = "0.3"
 rmp-serde = "~1.1"
 rand_distr = "0.4.3"
+walkdir = "2.3.2"
 
 [dependencies]
 
@@ -38,6 +39,7 @@ rand = "0.8"
 bit-vec = "0.6"
 seahash = "4.1.0"
 json-patch = "0.2.6"
+tar = "0.4.38"
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -16,10 +16,11 @@ use atomic_refcell::AtomicRefCell;
 use atomicwrites::{AllowOverwrite, AtomicFile};
 use rocksdb::DB;
 use std::collections::HashMap;
-use std::fs::{remove_dir_all, rename};
+use std::fs::{remove_dir_all, rename, File};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tar::Builder;
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 
@@ -233,6 +234,47 @@ impl Segment {
     ) -> OperationResult<Option<PayloadSchemaType>> {
         let payload_index = self.payload_index.borrow();
         payload_index.infer_payload_type(key)
+    }
+
+    /// Take a snapshot of the segment.
+    ///
+    /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
+    #[allow(dead_code)]
+    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()> {
+        if !snapshot_dir_path.exists() {
+            return Err(OperationError::service_error(&format!(
+                "the snapshot path provided {:?} does not exist",
+                snapshot_dir_path
+            )));
+        }
+        if !snapshot_dir_path.is_dir() {
+            return Err(OperationError::service_error(&format!(
+                "the snapshot path provided {:?} is not a directory",
+                snapshot_dir_path
+            )));
+        }
+        // flush segment to capture latest state
+        self.flush()?;
+        // extract segment id from current path
+        let segment_id = self
+            .current_path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap();
+        let file_name = format!("{}.tar", segment_id);
+        let archive_path = snapshot_dir_path.join(file_name);
+        if archive_path.exists() {
+            return Err(OperationError::service_error(&format!(
+                "the snapshot path directory already contains an archive for the segment {}",
+                segment_id
+            )));
+        }
+        let file = File::create(archive_path)?;
+        let mut builder = Builder::new(file);
+        // archive recursively segment directory `current_path` into `archive_path`.
+        builder.append_dir_all(".", &self.current_path)?;
+        builder.finish()?;
+        Ok(())
     }
 }
 
@@ -646,7 +688,10 @@ mod tests {
     use crate::entry::entry_point::SegmentEntry;
     use crate::segment_constructor::build_segment;
     use crate::types::{Distance, Indexes, SegmentConfig, StorageType};
+    use std::fs;
+    use tar::Archive;
     use tempdir::TempDir;
+    use walkdir::WalkDir;
 
     // no longer valid since users are now allowed to store arbitrary json objects.
     // TODO(gvelo): add tests for invalid payload types on indexed fields.
@@ -760,5 +805,79 @@ mod tests {
             )
             .unwrap();
         assert!(results_with_invalid_filter.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot() {
+        let data = r#"
+        {
+            "name": "John Doe",
+            "age": 43,
+            "metadata": {
+                "height": 50,
+                "width": 60
+            }
+        }"#;
+
+        let segment_base_dir = TempDir::new("segment_dir").unwrap();
+        let config = SegmentConfig {
+            vector_size: 2,
+            index: Indexes::Plain {},
+            storage_type: StorageType::InMemory,
+            distance: Distance::Dot,
+            payload_storage_type: Default::default(),
+        };
+
+        let mut segment = build_segment(segment_base_dir.path(), &config).unwrap();
+        segment.upsert_point(0, 0.into(), &[1.0, 1.0]).unwrap();
+
+        let payload: Payload = serde_json::from_str(data).unwrap();
+        segment.set_full_payload(0, 0.into(), &payload).unwrap();
+        segment.flush().unwrap();
+
+        // Recursively count all files and folders in directory and subdirectories:
+        let segment_file_count = WalkDir::new(segment.current_path.clone())
+            .into_iter()
+            .count();
+        assert_eq!(segment_file_count, 20);
+
+        let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
+        println!("{:?}", snapshot_dir);
+
+        // snapshotting!
+        segment.take_snapshot(snapshot_dir.path()).unwrap();
+
+        // validate that single file has been created
+        let archive = fs::read_dir(snapshot_dir.path())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let archive_extension = archive.extension().unwrap();
+        let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
+
+        // correct file extension
+        assert_eq!(archive_extension, "tar");
+
+        // archive name contains segment id
+        let segment_id = segment
+            .current_path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap();
+        assert!(archive_name.starts_with(segment_id));
+
+        // decompress archive
+        let snapshot_decompress_dir = TempDir::new("snapshot_decompress_dir").unwrap();
+        let archive_file = File::open(archive).unwrap();
+        let mut ar = Archive::new(archive_file);
+        ar.unpack(snapshot_decompress_dir.path()).unwrap();
+
+        // validate the decompressed archive the same number of files as in the segment
+        let decompressed_file_count = WalkDir::new(snapshot_decompress_dir.path())
+            .into_iter()
+            .count();
+        assert_eq!(decompressed_file_count, segment_file_count);
     }
 }


### PR DESCRIPTION
This PR implement a basic snapshot capability at the segment level (#744)

A new function archived the whole segment directory as a tar file.

It is supposed to be called while holding a read lock on the segment.