### PR TITLE
SegmentHolder snapshot all segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "tonic",
  "tower",
  "wal",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,8 +791,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tower",
+ "uuid",
  "wal",
- "walkdir",
 ]
 
 [[package]]
@@ -1265,6 +1265,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fsio"
@@ -3093,6 +3099,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "criterion",
+ "fs_extra",
  "geo",
  "geohash",
  "itertools",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dev-dependencies]
 tempdir = "0.3.7"
 criterion = "0.3"
-
+walkdir = "2.3.2"
 
 [dependencies]
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 [dev-dependencies]
 tempdir = "0.3.7"
 criterion = "0.3"
-walkdir = "2.3.2"
 
 [dependencies]
 
@@ -35,6 +34,7 @@ async-trait = "0.1.56"
 arc-swap = "1.5.0"
 tonic = "0.7.2"
 tower = "0.4.13"
+uuid = { version = "1.1", features = ["v4", "serde"] }
 
 segment = {path = "../segment"}
 api = {path = "../api"}

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -542,6 +542,8 @@ impl SegmentEntry for ProxySegment {
             in_memory_wrapped_segment.delete_point(segment_version, deleted_point)?;
         }
         in_memory_wrapped_segment.take_snapshot(snapshot_dir_path)?;
+        // release segment resources
+        drop(in_memory_wrapped_segment);
         // delete temporary copy
         remove_dir_all(copy_target_dir)?;
         Ok(())

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -8,7 +8,7 @@ use segment::types::{
 };
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -498,6 +498,13 @@ impl SegmentEntry for ProxySegment {
 
     fn vector_dim(&self) -> usize {
         self.write_segment.get().read().vector_dim()
+    }
+
+    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()> {
+        self.wrapped_segment
+            .get()
+            .read()
+            .take_snapshot(snapshot_dir_path)
     }
 }
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1,6 +1,7 @@
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::entry::entry_point::{OperationResult, SegmentEntry, SegmentFailedState};
+use segment::segment_constructor::load_segment;
 use segment::types::{
     Condition, Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
@@ -8,9 +9,11 @@ use segment::types::{
 };
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
+use std::fs::{create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use uuid::Uuid;
 
 type LockedRmSet = Arc<RwLock<HashSet<PointIdType>>>;
 type LockedFieldsSet = Arc<RwLock<HashSet<PayloadKeyType>>>;
@@ -501,10 +504,56 @@ impl SegmentEntry for ProxySegment {
     }
 
     fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()> {
+        log::info!(
+            "Taking a snapshot of a proxy segment into {:?}",
+            snapshot_dir_path
+        );
+        // extra care is needed to capture outstanding deleted points
+        let deleted_points_guard = self.deleted_points.read();
+        let wrapped_segment_arc = self.wrapped_segment.get();
+        let wrapped_segment_guard = wrapped_segment_arc.read();
+
+        // stable copy of the deleted points at the time of the snapshot
+        let deleted_points_copy = deleted_points_guard.clone();
+
+        // create unique dir. to hold data copy of wrapped segment
+        let copy_target_dir = snapshot_dir_path.join(format!("segment_copy_{}", Uuid::new_v4()));
+        create_dir_all(&copy_target_dir)?;
+
+        // copy proxy segment current wrapped data
+        let full_copy_path = self.copy_segment_directory(&copy_target_dir)?;
+        // snapshot write_segment
+        self.write_segment
+            .get()
+            .read()
+            .take_snapshot(snapshot_dir_path)?;
+
+        // unlock deleted_points as we have a stable copy
+        drop(wrapped_segment_guard);
+        drop(deleted_points_guard);
+
+        // load copy of wrapped segment in memory
+        let mut in_memory_wrapped_segment = load_segment(&full_copy_path)?;
+        let mut segment_version = in_memory_wrapped_segment.version;
+
+        // remove potentially deleted points from wrapped_segment
+        for deleted_point in deleted_points_copy {
+            segment_version += 1;
+            in_memory_wrapped_segment.delete_point(segment_version, deleted_point)?;
+        }
+        in_memory_wrapped_segment.take_snapshot(snapshot_dir_path)?;
+        // delete temporary copy
+        remove_dir_all(copy_target_dir)?;
+        Ok(())
+    }
+
+    /// This implementation delegates to the `wrapped_segment` copy directory
+    /// Other members from the proxy segment won't be copied!
+    fn copy_segment_directory(&self, target_dir_path: &Path) -> OperationResult<PathBuf> {
         self.wrapped_segment
             .get()
             .read()
-            .take_snapshot(snapshot_dir_path)
+            .copy_segment_directory(target_dir_path)
     }
 }
 
@@ -513,6 +562,7 @@ mod tests {
     use super::*;
     use crate::collection_manager::fixtures::{build_segment_1, empty_segment};
     use segment::types::FieldCondition;
+    use std::fs::read_dir;
     use tempdir::TempDir;
 
     #[test]
@@ -618,5 +668,48 @@ mod tests {
 
         assert_eq!(original_points_filtered.len() - 1, proxy_res_filtered.len());
         assert_eq!(original_points.len() - 1, proxy_res.len());
+    }
+
+    #[test]
+    fn test_take_snapshot() {
+        let dir = TempDir::new("segment_dir").unwrap();
+        let original_segment = LockedSegment::new(build_segment_1(dir.path()));
+        let write_segment = LockedSegment::new(empty_segment(dir.path()));
+        let deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
+
+        let deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
+        let created_indexes = Arc::new(RwLock::new(
+            HashMap::<PayloadKeyType, PayloadSchemaType>::new(),
+        ));
+
+        let mut proxy_segment = ProxySegment::new(
+            original_segment,
+            write_segment,
+            deleted_points,
+            created_indexes,
+            deleted_indexes,
+        );
+
+        let vec4 = vec![1.1, 1.0, 0.0, 1.0];
+        proxy_segment.upsert_point(100, 4.into(), &vec4).unwrap();
+        let vec6 = vec![1.0, 1.0, 0.5, 1.0];
+        proxy_segment.upsert_point(101, 6.into(), &vec6).unwrap();
+        proxy_segment.delete_point(102, 1.into()).unwrap();
+
+        let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
+        eprintln!("Snapshot into {:?}", snapshot_dir.path());
+
+        proxy_segment.take_snapshot(snapshot_dir.path()).unwrap();
+
+        // validate that two archives were created (wrapped_segment & write_segment)
+        let archive_count = read_dir(&snapshot_dir).unwrap().into_iter().count();
+        assert_eq!(archive_count, 2);
+
+        for archive in read_dir(&snapshot_dir).unwrap() {
+            let archive_path = archive.unwrap().path();
+            let archive_extension = archive_path.extension().unwrap();
+            // correct file extension
+            assert_eq!(archive_extension, "tar");
+        }
     }
 }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -439,8 +439,8 @@ mod tests {
     use crate::collection_manager::fixtures::{build_segment_1, build_segment_2};
 
     use super::*;
+    use std::fs::read_dir;
     use std::{thread, time};
-    use walkdir::WalkDir;
 
     #[test]
     fn test_add_and_swap() {
@@ -553,7 +553,8 @@ mod tests {
         let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
         holder.snapshot_all(snapshot_dir.path()).unwrap();
 
-        let archive_count = WalkDir::new(snapshot_dir.path()).into_iter().count();
-        assert_eq!(archive_count, 2 + 1); // If the path is a directory, then it is the first item yielded by the iterator.
+        let archive_count = read_dir(&snapshot_dir).unwrap().into_iter().count();
+        // one archive produced per concrete segment in the SegmentHolder
+        assert_eq!(archive_count, 2);
     }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -40,6 +40,7 @@ bitvec = "1.0.0"
 seahash = "4.1.0"
 json-patch = "0.2.6"
 tar = "0.4.38"
+fs_extra = "1.2.0"
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -104,6 +104,12 @@ impl From<serde_json::Error> for OperationError {
     }
 }
 
+impl From<fs_extra::error::Error> for OperationError {
+    fn from(err: fs_extra::error::Error) -> Self {
+        OperationError::service_error(&format!("File system error: {}", err))
+    }
+}
+
 pub type OperationResult<T> = result::Result<T, OperationError>;
 
 pub fn get_service_error<T>(err: &OperationResult<T>) -> Option<OperationError> {
@@ -255,4 +261,9 @@ pub trait SegmentEntry {
     ///
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
     fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()>;
+
+    /// Copy the segment directory structure into `target_dir_path`
+    ///
+    /// Return the `Path` of the copy
+    fn copy_segment_directory(&self, target_dir_path: &Path) -> OperationResult<PathBuf>;
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -8,7 +8,7 @@ use atomicwrites::Error as AtomicIoError;
 use rocksdb::Error;
 use std::collections::HashMap;
 use std::io::Error as IoError;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::result;
 use thiserror::Error;
 
@@ -250,4 +250,9 @@ pub trait SegmentEntry {
         op_num: SeqNumberType,
         filter: &'a Filter,
     ) -> OperationResult<usize>;
+
+    /// Take a snapshot of the segment.
+    ///
+    /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
+    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()>;
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -14,6 +14,7 @@ use crate::types::{
 use crate::vector_storage::VectorStorageSS;
 use atomic_refcell::AtomicRefCell;
 use atomicwrites::{AllowOverwrite, AtomicFile};
+use fs_extra::dir::{copy_with_progress, CopyOptions, TransitProcess};
 use rocksdb::DB;
 use std::collections::HashMap;
 use std::fs::{remove_dir_all, rename, File};
@@ -664,8 +665,12 @@ impl SegmentEntry for Segment {
         self.segment_config.vector_size
     }
 
-    #[allow(dead_code)]
     fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()> {
+        log::info!(
+            "Taking snapshot of segment {:?} into {:?}",
+            self.current_path,
+            snapshot_dir_path
+        );
         if !snapshot_dir_path.exists() {
             return Err(OperationError::service_error(&format!(
                 "the snapshot path provided {:?} does not exist",
@@ -700,6 +705,50 @@ impl SegmentEntry for Segment {
         builder.append_dir_all(".", &self.current_path)?;
         builder.finish()?;
         Ok(())
+    }
+
+    fn copy_segment_directory(&self, target_dir_path: &Path) -> OperationResult<PathBuf> {
+        log::info!(
+            "Copying segment {:?} into {:?}",
+            self.current_path,
+            target_dir_path
+        );
+        if !target_dir_path.exists() {
+            return Err(OperationError::service_error(&format!(
+                "the copy path provided {:?} does not exist",
+                target_dir_path
+            )));
+        }
+        if !target_dir_path.is_dir() {
+            return Err(OperationError::service_error(&format!(
+                "the copy path provided {:?} is not a directory",
+                target_dir_path
+            )));
+        }
+
+        // flush segment to capture latest state
+        self.flush()?;
+
+        let segment_id = self
+            .current_path
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .unwrap();
+
+        let handle = |process_info: TransitProcess| {
+            log::debug!(
+                "Copying segment {} {}/{}",
+                segment_id,
+                process_info.copied_bytes,
+                process_info.total_bytes
+            );
+            fs_extra::dir::TransitProcessResult::ContinueOrAbort
+        };
+
+        let options = CopyOptions::new();
+        copy_with_progress(&self.current_path, target_dir_path, &options, handle)?;
+
+        Ok(target_dir_path.join(segment_id))
     }
 }
 
@@ -899,5 +948,50 @@ mod tests {
             .into_iter()
             .count();
         assert_eq!(decompressed_file_count, segment_file_count);
+    }
+
+    #[test]
+    fn test_copy_segment_directory() {
+        let data = r#"
+        {
+            "name": "John Doe",
+            "age": 43,
+            "metadata": {
+                "height": 50,
+                "width": 60
+            }
+        }"#;
+
+        let segment_base_dir = TempDir::new("segment_dir").unwrap();
+        let config = SegmentConfig {
+            vector_size: 2,
+            index: Indexes::Plain {},
+            storage_type: StorageType::InMemory,
+            distance: Distance::Dot,
+            payload_storage_type: Default::default(),
+        };
+
+        let mut segment = build_segment(segment_base_dir.path(), &config).unwrap();
+        segment.upsert_point(0, 0.into(), &[1.0, 1.0]).unwrap();
+
+        let payload: Payload = serde_json::from_str(data).unwrap();
+        segment.set_full_payload(0, 0.into(), &payload).unwrap();
+        segment.flush().unwrap();
+
+        // Recursively count all files and folders in directory and subdirectories.
+        let segment_file_count = WalkDir::new(segment.current_path.clone())
+            .into_iter()
+            .count();
+        assert_eq!(segment_file_count, 20);
+
+        let segment_copy_dir = TempDir::new("segment_copy_dir").unwrap();
+        let full_copy_path = segment
+            .copy_segment_directory(segment_copy_dir.path())
+            .unwrap();
+
+        // Recursively count all files and folders in directory and subdirectories.
+        let copy_segment_file_count = WalkDir::new(full_copy_path).into_iter().count();
+
+        assert_eq!(copy_segment_file_count, segment_file_count);
     }
 }


### PR DESCRIPTION
Context: issue https://github.com/qdrant/qdrant/issues/744 follow up on https://github.com/qdrant/qdrant/pull/751

This PR introduces `snapshot_all` at the `SegmentHolder` level.

I had to move the implementation of `take_snapshot` to `SegmentEntry`.

I have one concern regarding the lack of synchronization while we iterate over the segments, the operation is not viewing all the segments at the same time. Not sure if it could be an issue in practice.