### PR TITLE
Property tests for Storage trait impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2455,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2642,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,7 +2730,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
 
@@ -2812,6 +2859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3016,6 +3072,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.10",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -3399,6 +3467,7 @@ dependencies = [
  "log 0.4.17",
  "num_cpus",
  "parking_lot",
+ "proptest",
  "prost 0.9.0",
  "raft",
  "rand 0.8.5",
@@ -4010,6 +4079,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 tempdir = "0.3.7"
+proptest = "1.0.0"
 
 [dependencies]
-
 num_cpus = "1.13"
 thiserror = "1.0"
 rand = "0.8.5"

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -10,7 +10,7 @@ pub const ALIAS_MAPPING_CONFIG_FILE: &str = "data.json";
 
 type Alias = String;
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
 pub struct AliasMapping(HashMap<Alias, collection::CollectionId>);
 
 impl AliasMapping {

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -32,10 +32,16 @@ use wal::Wal;
 use super::alias_mapping::AliasMapping;
 use super::consensus_ops::ConsensusOperations;
 use super::errors::StorageError;
-use super::toc::TableOfContent;
+use super::CollectionContainer;
 
 const COLLECTIONS_META_WAL_DIR: &str = "collections_meta_wal";
 const DEFAULT_META_OP_WAIT: Duration = Duration::from_secs(10);
+
+pub mod prelude {
+    use crate::content_manager::toc::TableOfContent;
+
+    pub type ConsensusState = super::ConsensusState<TableOfContent>;
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SnapshotData {
@@ -44,7 +50,7 @@ pub struct SnapshotData {
     pub address_by_id: PeerAddressById,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct CollectionsSnapshot {
     pub collections: HashMap<CollectionId, collection::State>,
     pub aliases: AliasMapping,
@@ -128,26 +134,27 @@ impl ConsensusOpWal {
     }
 }
 
-pub struct ConsensusState {
+pub struct ConsensusState<C: CollectionContainer> {
     pub persistent: RwLock<Persistent>,
     wal: Mutex<ConsensusOpWal>,
     soft_state: RwLock<Option<SoftState>>,
-    toc: Arc<TableOfContent>,
+    toc: Arc<C>,
     on_consensus_op_apply:
         Mutex<HashMap<ConsensusOperations, oneshot::Sender<Result<bool, StorageError>>>>,
     propose_sender: Mutex<Sender<Vec<u8>>>,
     first_voter: RwLock<Option<PeerId>>,
 }
 
-impl ConsensusState {
+impl<C: CollectionContainer> ConsensusState<C> {
     pub fn new(
         persistent_state: Persistent,
-        toc: Arc<TableOfContent>,
+        toc: Arc<C>,
         propose_sender: Sender<Vec<u8>>,
+        storage_path: &str,
     ) -> Self {
         Self {
             persistent: RwLock::new(persistent_state),
-            wal: Mutex::new(ConsensusOpWal::new(toc.storage_path())),
+            wal: Mutex::new(ConsensusOpWal::new(storage_path)),
             soft_state: RwLock::new(None),
             toc,
             on_consensus_op_apply: Default::default(),
@@ -291,7 +298,7 @@ impl ConsensusState {
         let on_apply = self.on_consensus_op_apply.lock().remove(&operation);
         let result = match operation {
             ConsensusOperations::CollectionMeta(operation) => {
-                self.toc.perform_collection_meta_op_sync(*operation)
+                self.toc.perform_collection_meta_op(*operation)
             }
             ConsensusOperations::AddPeer(peer_id, uri) => self
                 .add_peer(
@@ -396,7 +403,7 @@ impl ConsensusState {
     }
 }
 
-impl Storage for ConsensusState {
+impl<C: CollectionContainer> Storage for ConsensusState<C> {
     fn initial_state(&self) -> raft::Result<RaftState> {
         Ok(self.persistent.read().state.clone())
     }
@@ -409,6 +416,17 @@ impl Storage for ConsensusState {
         _context: GetEntriesContext,
     ) -> raft::Result<Vec<RaftEntry>> {
         let max_size: Option<_> = max_size.into();
+        if low < self.first_index()? {
+            return Err(raft::Error::Store(raft::StorageError::Compacted));
+        }
+
+        if high > self.last_index()? + 1 {
+            panic!(
+                "index out of bound (last: {}, high: {})",
+                self.last_index()? + 1,
+                high
+            );
+        }
         self.wal.lock().entries(low, high, max_size)
     }
 
@@ -438,7 +456,7 @@ impl Storage for ConsensusState {
     }
 
     fn snapshot(&self, request_index: u64, _to: u64) -> raft::Result<raft::eraftpb::Snapshot> {
-        let collections_data = self.toc.collections_snapshot_sync();
+        let collections_data = self.toc.collections_snapshot();
         let persistent = self.persistent.read();
         let raft_state = persistent.state().clone();
         if raft_state.hard_state.commit >= request_index {
@@ -463,18 +481,18 @@ impl Storage for ConsensusState {
 }
 
 #[derive(Clone)]
-pub struct ConsensusStateRef(pub Arc<ConsensusState>);
+pub struct ConsensusStateRef(pub Arc<prelude::ConsensusState>);
 
 impl Deref for ConsensusStateRef {
-    type Target = ConsensusState;
+    type Target = prelude::ConsensusState;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
 
-impl From<ConsensusState> for ConsensusStateRef {
-    fn from(state: ConsensusState) -> Self {
+impl From<prelude::ConsensusState> for ConsensusStateRef {
+    fn from(state: prelude::ConsensusState) -> Self {
         Self(Arc::new(state))
     }
 }
@@ -822,9 +840,16 @@ pub fn raft_error_other(e: impl std::error::Error) -> raft::Error {
 
 #[cfg(test)]
 mod tests {
-    use raft::eraftpb::Entry;
+    use proptest::prelude::*;
+    use raft::{
+        eraftpb::Entry,
+        storage::{MemStorage, Storage},
+    };
 
-    use super::{ConsensusOpWal, EntryApplyProgressQueue, Persistent};
+    use std::sync::{mpsc, Arc};
+
+    use super::{ConsensusOpWal, ConsensusState, EntryApplyProgressQueue, Persistent};
+    use crate::content_manager::CollectionContainer;
 
     #[test]
     fn update_is_applied() {
@@ -916,5 +941,90 @@ mod tests {
         .unwrap();
         // Even when `max_size` is `0` this fn should return at least 1 entry
         assert_eq!(wal.entries(4, 5, Some(0)).unwrap().len(), 1)
+    }
+
+    struct NoCollections;
+
+    impl CollectionContainer for NoCollections {
+        fn perform_collection_meta_op(
+            &self,
+            _operation: crate::content_manager::collection_meta_ops::CollectionMetaOperations,
+        ) -> Result<bool, crate::content_manager::errors::StorageError> {
+            Ok(true)
+        }
+
+        fn collections_snapshot(&self) -> super::CollectionsSnapshot {
+            super::CollectionsSnapshot::default()
+        }
+
+        fn apply_collections_snapshot(
+            &self,
+            _data: super::CollectionsSnapshot,
+        ) -> Result<(), crate::content_manager::errors::StorageError> {
+            Ok(())
+        }
+    }
+
+    fn setup_storages(
+        entries: Vec<Entry>,
+        path: &std::path::Path,
+    ) -> (ConsensusState<NoCollections>, MemStorage) {
+        let persistent = Persistent::load_or_init(path, true).unwrap();
+        let (sender, _) = mpsc::channel();
+        let consensus_state = ConsensusState::new(
+            persistent,
+            Arc::new(NoCollections),
+            sender,
+            path.to_str().unwrap(),
+        );
+        let mem_storage = MemStorage::new();
+        mem_storage.wl().append(entries.as_ref()).unwrap();
+        consensus_state.append_entries(entries).unwrap();
+        (consensus_state, mem_storage)
+    }
+
+    prop_compose! {
+        fn gen_entries(min_entries: u64, max_entries: u64)(n in min_entries..max_entries, inc_term_every in 1u64..max_entries) -> Vec<Entry> {
+            (1..(n+1)).into_iter().map(|index| Entry {index, term: 1 + index/inc_term_every, ..Default::default()}).collect::<Vec<Entry>>()
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn check_first_and_last_indexes(entries in gen_entries(0, 100)) {
+            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
+            prop_assert_eq!(mem_storage.last_index(), consensus_state.last_index());
+            prop_assert_eq!(mem_storage.first_index(), consensus_state.first_index());
+        }
+
+        #[test]
+        fn check_term(entries in gen_entries(0, 100), id in 0u64..100) {
+            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
+            prop_assert_eq!(mem_storage.term(id), consensus_state.term(id))
+        }
+
+        #[test]
+        fn check_entries(entries in gen_entries(1, 100),
+                low in 0u64..100,
+                len in 1u64..100,
+                max_size in proptest::option::of(proptest::num::u64::ANY)
+            ) {
+            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
+            let mut high = low + len;
+            let last_index = mem_storage.last_index().unwrap();
+            if high > last_index + 1 {
+                high = last_index + 1;
+            }
+            let mut low = low;
+            if low > last_index {
+                low = last_index;
+            }
+            let context_1 = raft::storage::GetEntriesContext::empty(false);
+            let context_2 = raft::storage::GetEntriesContext::empty(false);
+            prop_assert_eq!(mem_storage.entries(low, high, max_size, context_1), consensus_state.entries(low, high, max_size, context_2));
+        }
     }
 }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,3 +1,8 @@
+use self::{
+    collection_meta_ops::CollectionMetaOperations, consensus_state::CollectionsSnapshot,
+    errors::StorageError,
+};
+
 mod alias_mapping;
 pub mod collection_meta_ops;
 mod collections_ops;
@@ -27,4 +32,15 @@ pub mod consensus_ops {
             serde_cbor::from_slice(entry.get_data())
         }
     }
+}
+
+pub trait CollectionContainer {
+    fn perform_collection_meta_op(
+        &self,
+        operation: CollectionMetaOperations,
+    ) -> Result<bool, StorageError>;
+
+    fn collections_snapshot(&self) -> CollectionsSnapshot;
+
+    fn apply_collections_snapshot(&self, data: CollectionsSnapshot) -> Result<(), StorageError>;
 }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -34,6 +34,8 @@ pub mod consensus_ops {
     }
 }
 
+/// Collection container abstraction for consensus
+/// Used to mock ToC in consensus state tests
 pub trait CollectionContainer {
     fn perform_collection_meta_op(
         &self,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -18,7 +18,7 @@ use collection::{ChannelService, Collection, CollectionShardDistribution};
 use segment::types::ScoredPoint;
 
 use super::collection_meta_ops::CreateCollectionOperation;
-use super::consensus_state;
+use super::{consensus_state, CollectionContainer};
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
 use crate::content_manager::{
     alias_mapping::AliasPersistence,
@@ -616,6 +616,26 @@ impl TableOfContent {
             shard_distribution.distribution
         );
         shard_distribution
+    }
+}
+
+impl CollectionContainer for TableOfContent {
+    fn perform_collection_meta_op(
+        &self,
+        operation: CollectionMetaOperations,
+    ) -> Result<bool, StorageError> {
+        self.perform_collection_meta_op_sync(operation)
+    }
+
+    fn collections_snapshot(&self) -> consensus_state::CollectionsSnapshot {
+        self.collections_snapshot_sync()
+    }
+
+    fn apply_collections_snapshot(
+        &self,
+        data: consensus_state::CollectionsSnapshot,
+    ) -> Result<(), StorageError> {
+        self.apply_collections_snapshot(data)
     }
 }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -542,8 +542,14 @@ mod tests {
             persistent_state.this_peer_id(),
         );
         let toc_arc = Arc::new(toc);
-        let consensus_state: ConsensusStateRef =
-            ConsensusState::new(persistent_state, toc_arc.clone(), propose_sender).into();
+        let storage_path = toc_arc.storage_path();
+        let consensus_state: ConsensusStateRef = ConsensusState::new(
+            persistent_state,
+            toc_arc.clone(),
+            propose_sender,
+            storage_path,
+        )
+        .into();
         let dispatcher = Dispatcher::new(toc_arc.clone()).with_consensus(consensus_state.clone());
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
         let (mut consensus, message_sender) = Consensus::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,10 +113,16 @@ fn main() -> anyhow::Result<()> {
     });
 
     let toc_arc = Arc::new(toc);
+    let storage_path = toc_arc.storage_path();
     let mut handles: Vec<JoinHandle<Result<(), Error>>> = vec![];
     let mut dispatcher = Dispatcher::new(toc_arc.clone());
-    let consensus_state: ConsensusStateRef =
-        ConsensusState::new(persistent_consensus_state, toc_arc.clone(), propose_sender).into();
+    let consensus_state: ConsensusStateRef = ConsensusState::new(
+        persistent_consensus_state,
+        toc_arc.clone(),
+        propose_sender,
+        storage_path,
+    )
+    .into();
     if settings.cluster.enabled {
         dispatcher = dispatcher.with_consensus(consensus_state.clone());
     }


### PR DESCRIPTION
Closes #730 

`Storage::initial_state` and `Storage::snapshot` are not tested as they are not good targets for property testing and are rather straightforward.