### PR TITLE
Fix clippy 1.62

### DIFF
--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -394,7 +394,7 @@ mod tests {
 
         assert_eq!(raw_res1, raw_res2);
 
-        let _top_idx = match closest.get(0) {
+        match closest.get(0) {
             Some(scored_point) => {
                 assert_ne!(scored_point.idx, 2);
                 assert_eq!(&raw_res1[scored_point.idx as usize], scored_point);

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,7 @@ fn main() -> anyhow::Result<()> {
     #[cfg(feature = "service_debug")]
     {
         use parking_lot::deadlock;
+        use std::fmt::Write;
 
         const DEADLOCK_CHECK_PERIOD: Duration = Duration::from_secs(10);
 
@@ -221,13 +222,15 @@ fn main() -> anyhow::Result<()> {
 
                 let mut error = format!("{} deadlocks detected\n", deadlocks.len());
                 for (i, threads) in deadlocks.iter().enumerate() {
-                    error.push_str(&format!("Deadlock #{}\n", i));
+                    writeln!(error, "Deadlock #{}", i).expect("fail to writeln!");
                     for t in threads {
-                        error.push_str(&format!(
-                            "Thread Id {:#?}\n{:#?}\n",
+                        writeln!(
+                            error,
+                            "Thread Id {:#?}\n{:#?}",
                             t.thread_id(),
                             t.backtrace()
-                        ));
+                        )
+                        .expect("fail to writeln!");
                     }
                 }
                 log::error!("{}", error);


### PR DESCRIPTION
As always, new Rust release can break our pipeline as it uses the latest version.

This PR fixes the new issue reported by Clippy.