### PR TITLE
gRPC API for snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 name = "api"
 version = "0.8.3"
 dependencies = [
+ "chrono",
  "prost 0.10.4",
  "prost-types 0.10.1",
  "rand 0.8.5",

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -99,6 +99,15 @@
   
     - [Qdrant](#qdrant-Qdrant)
   
+- [snapshots_service.proto](#snapshots_service-proto)
+    - [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest)
+    - [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse)
+    - [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest)
+    - [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse)
+    - [SnapshotDescription](#qdrant-SnapshotDescription)
+  
+    - [Snapshots](#qdrant-Snapshots)
+  
 - [Scalar Value Types](#scalar-value-types)
 
 
@@ -192,6 +201,7 @@
 | ram_data_size | [uint64](#uint64) |  | Used RAM (not implemented) |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
+| points_count | [uint64](#uint64) |  | number of vectors in the collection |
 
 
 
@@ -360,6 +370,7 @@
 | m | [uint64](#uint64) | optional | Number of edges per node in the index graph. Larger the value - more accurate the search, more space required. |
 | ef_construct | [uint64](#uint64) | optional | Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index. |
 | full_scan_threshold | [uint64](#uint64) | optional | Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won&#39;t be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256 |
+| max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
 
 
 
@@ -1536,6 +1547,112 @@ The JSON representation for `Value` is JSON value.
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | HealthCheck | [HealthCheckRequest](#qdrant-HealthCheckRequest) | [HealthCheckReply](#qdrant-HealthCheckReply) |  |
+
+ 
+
+
+
+<a name="snapshots_service-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## snapshots_service.proto
+
+
+
+<a name="qdrant-CreateSnapshotRequest"></a>
+
+### CreateSnapshotRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+
+
+
+
+
+
+<a name="qdrant-CreateSnapshotResponse"></a>
+
+### CreateSnapshotResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| snapshot_description | [SnapshotDescription](#qdrant-SnapshotDescription) |  |  |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
+<a name="qdrant-ListSnapshotsRequest"></a>
+
+### ListSnapshotsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+
+
+
+
+
+
+<a name="qdrant-ListSnapshotsResponse"></a>
+
+### ListSnapshotsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| snapshot_descriptions | [SnapshotDescription](#qdrant-SnapshotDescription) | repeated |  |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
+<a name="qdrant-SnapshotDescription"></a>
+
+### SnapshotDescription
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Name of the snapshot |
+| creation_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Creation time of the snapshot |
+| size | [int64](#int64) |  | Size of the snapshot in bytes |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="qdrant-Snapshots"></a>
+
+### Snapshots
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Create | [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest) | [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse) | Create snapshot |
+| List | [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest) | [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse) | List snapshots |
 
  
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { version = "1.1", features = ["v4", "serde"] }
 tower = "0.4.13"
 tokio = "1.19.2"
 rand = "0.8.5"
+chrono = { version = "~0.4", features = ["serde"] }
 
 segment = {path = "../segment"}
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -12,6 +12,7 @@ use crate::grpc::qdrant::{
 };
 
 use crate::grpc::qdrant::value::Kind;
+use chrono::{NaiveDateTime, Timelike};
 use segment::types::{PayloadSelector, WithPayloadInterface};
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -607,5 +608,12 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             full_scan_threshold: hnsw_config.full_scan_threshold.unwrap_or_default() as usize,
             max_indexing_threads: hnsw_config.max_indexing_threads.unwrap_or_default() as usize,
         }
+    }
+}
+
+pub fn date_time_to_proto(date_time: NaiveDateTime) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: date_time.timestamp(), // number of non-leap seconds since the midnight on January 1, 1970.
+        nanos: date_time.nanosecond() as i32,
     }
 }

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -5,6 +5,7 @@ import "collections_internal_service.proto";
 import "points_service.proto";
 import "points_internal_service.proto";
 import "raft_service.proto";
+import "snapshots_service.proto";
 
 package qdrant;
 

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package qdrant;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+service Snapshots {
+  /*
+ Create snapshot
+  */
+  rpc Create (CreateSnapshotRequest) returns (CreateSnapshotResponse) {}
+  /*
+  List snapshots
+   */
+  rpc List (ListSnapshotsRequest) returns (ListSnapshotsResponse) {}
+}
+
+message CreateSnapshotRequest {
+  string collection_name = 1; // Name of the collection
+}
+
+message ListSnapshotsRequest {
+  string collection_name = 1; // Name of the collection
+}
+
+
+message SnapshotDescription {
+  string name = 1; // Name of the snapshot
+  google.protobuf.Timestamp creation_time = 2; // Creation time of the snapshot
+  int64 size = 3; // Size of the snapshot in bytes
+}
+
+message CreateSnapshotResponse {
+  SnapshotDescription snapshot_description = 1;
+  double time = 2; // Time spent to process
+}
+
+message ListSnapshotsResponse {
+  repeated SnapshotDescription snapshot_descriptions = 1;
+  double time = 2; // Time spent to process
+}

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3929,6 +3929,332 @@ pub mod raft_server {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateSnapshotRequest {
+    /// Name of the collection
+    #[prost(string, tag="1")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSnapshotsRequest {
+    /// Name of the collection
+    #[prost(string, tag="1")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotDescription {
+    /// Name of the snapshot
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Creation time of the snapshot
+    #[prost(message, optional, tag="2")]
+    pub creation_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// Size of the snapshot in bytes
+    #[prost(int64, tag="3")]
+    pub size: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateSnapshotResponse {
+    #[prost(message, optional, tag="1")]
+    pub snapshot_description: ::core::option::Option<SnapshotDescription>,
+    /// Time spent to process
+    #[prost(double, tag="2")]
+    pub time: f64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSnapshotsResponse {
+    #[prost(message, repeated, tag="1")]
+    pub snapshot_descriptions: ::prost::alloc::vec::Vec<SnapshotDescription>,
+    /// Time spent to process
+    #[prost(double, tag="2")]
+    pub time: f64,
+}
+/// Generated client implementations.
+pub mod snapshots_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct SnapshotsClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl SnapshotsClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> SnapshotsClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SnapshotsClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            SnapshotsClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        ///
+        ///Create snapshot
+        pub async fn create(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
+        ) -> Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Create");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        ///
+        ///List snapshots
+        pub async fn list(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/List");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod snapshots_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with SnapshotsServer.
+    #[async_trait]
+    pub trait Snapshots: Send + Sync + 'static {
+        ///
+        ///Create snapshot
+        async fn create(
+            &self,
+            request: tonic::Request<super::CreateSnapshotRequest>,
+        ) -> Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
+        ///
+        ///List snapshots
+        async fn list(
+            &self,
+            request: tonic::Request<super::ListSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct SnapshotsServer<T: Snapshots> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Snapshots> SnapshotsServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for SnapshotsServer<T>
+    where
+        T: Snapshots,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.Snapshots/Create" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateSvc<T: Snapshots>(pub Arc<T>);
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::CreateSnapshotRequest>
+                    for CreateSvc<T> {
+                        type Response = super::CreateSnapshotResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateSnapshotRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).create(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Snapshots/List" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListSvc<T: Snapshots>(pub Arc<T>);
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::ListSnapshotsRequest>
+                    for ListSvc<T> {
+                        type Response = super::ListSnapshotsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListSnapshotsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).list(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ListSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Snapshots> Clone for SnapshotsServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Snapshots> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Snapshots> tonic::transport::NamedService for SnapshotsServer<T> {
+        const NAME: &'static str = "qdrant.Snapshots";
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -1,4 +1,5 @@
 use crate::CollectionResult;
+use api::grpc::conversions::date_time_to_proto;
 use chrono::NaiveDateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,16 @@ pub struct SnapshotDescription {
     pub name: String,
     pub creation_time: NaiveDateTime,
     pub size: u64,
+}
+
+impl From<SnapshotDescription> for api::grpc::qdrant::SnapshotDescription {
+    fn from(value: SnapshotDescription) -> Self {
+        Self {
+            name: value.name,
+            creation_time: Some(date_time_to_proto(value.creation_time)),
+            size: value.size as i64,
+        }
+    }
 }
 
 pub async fn get_snapshot_description(path: &Path) -> CollectionResult<SnapshotDescription> {

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -5,3 +5,4 @@ pub mod points_api;
 mod points_common;
 pub mod points_internal_api;
 pub mod raft_api;
+pub mod snapshots_api;

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -1,0 +1,54 @@
+use crate::common::collections::{do_create_snapshot, do_list_snapshots};
+use api::grpc::qdrant::snapshots_server::Snapshots;
+use api::grpc::qdrant::{
+    CreateSnapshotRequest, CreateSnapshotResponse, ListSnapshotsRequest, ListSnapshotsResponse,
+};
+use std::sync::Arc;
+use std::time::Instant;
+use storage::content_manager::conversions::error_to_status;
+use storage::content_manager::toc::TableOfContent;
+use tonic::{async_trait, Request, Response, Status};
+
+pub struct SnapshotsService {
+    toc: Arc<TableOfContent>,
+}
+
+impl SnapshotsService {
+    pub fn new(toc: Arc<TableOfContent>) -> Self {
+        Self { toc }
+    }
+}
+
+#[async_trait]
+impl Snapshots for SnapshotsService {
+    async fn create(
+        &self,
+        request: Request<CreateSnapshotRequest>,
+    ) -> Result<Response<CreateSnapshotResponse>, Status> {
+        let collection_name = request.into_inner().collection_name;
+        let timing = Instant::now();
+        let response = do_create_snapshot(&self.toc, &collection_name)
+            .await
+            .map_err(error_to_status)?;
+        Ok(Response::new(CreateSnapshotResponse {
+            snapshot_description: Some(response.into()),
+            time: timing.elapsed().as_secs_f64(),
+        }))
+    }
+
+    async fn list(
+        &self,
+        request: Request<ListSnapshotsRequest>,
+    ) -> Result<Response<ListSnapshotsResponse>, Status> {
+        let collection_name = request.into_inner().collection_name;
+
+        let timing = Instant::now();
+        let snapshots = do_list_snapshots(&self.toc, &collection_name)
+            .await
+            .map_err(error_to_status)?;
+        Ok(Response::new(ListSnapshotsResponse {
+            snapshot_descriptions: snapshots.into_iter().map(|s| s.into()).collect(),
+            time: timing.elapsed().as_secs_f64(),
+        }))
+    }
+}

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -4,12 +4,14 @@ use crate::tonic::api::collections_api::CollectionsService;
 use crate::tonic::api::collections_internal_api::CollectionsInternalService;
 use crate::tonic::api::points_api::PointsService;
 use crate::tonic::api::points_internal_api::PointsInternalService;
+use crate::tonic::api::snapshots_api::SnapshotsService;
 use ::api::grpc::models::VersionInfo;
 use ::api::grpc::qdrant::collections_internal_server::CollectionsInternalServer;
 use ::api::grpc::qdrant::collections_server::CollectionsServer;
 use ::api::grpc::qdrant::points_internal_server::PointsInternalServer;
 use ::api::grpc::qdrant::points_server::PointsServer;
 use ::api::grpc::qdrant::qdrant_server::{Qdrant, QdrantServer};
+use ::api::grpc::qdrant::snapshots_server::SnapshotsServer;
 use ::api::grpc::qdrant::{HealthCheckReply, HealthCheckRequest};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -48,6 +50,7 @@ pub fn init(dispatcher: Arc<Dispatcher>, host: String, grpc_port: u16) -> std::i
             let service = QdrantService::default();
             let collections_service = CollectionsService::new(dispatcher.clone());
             let points_service = PointsService::new(dispatcher.toc().clone());
+            let snapshot_service = SnapshotsService::new(dispatcher.toc().clone());
 
             log::info!("Qdrant gRPC listening on {}", grpc_port);
 
@@ -55,6 +58,7 @@ pub fn init(dispatcher: Arc<Dispatcher>, host: String, grpc_port: u16) -> std::i
                 .add_service(QdrantServer::new(service))
                 .add_service(CollectionsServer::new(collections_service))
                 .add_service(PointsServer::new(points_service))
+                .add_service(SnapshotsServer::new(snapshot_service))
                 .serve_with_shutdown(socket, async {
                     signal::ctrl_c().await.unwrap();
                     log::debug!("Stopping gRPC");


### PR DESCRIPTION
This PR introduces a gRPC API for the snapshot feature.

I have not been able to implement a `Get` API to stream the snapshot file to the users because of an impedance mismatch with the protocol buffer goals.

According to the [official doc](https://developers.google.com/protocol-buffers/docs/techniques#large-data) it is not made to stream large data set.

