### PR TITLE
Count api

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -46,6 +46,9 @@
 - [points.proto](#points-proto)
     - [ClearPayloadPoints](#qdrant-ClearPayloadPoints)
     - [Condition](#qdrant-Condition)
+    - [CountPoints](#qdrant-CountPoints)
+    - [CountResponse](#qdrant-CountResponse)
+    - [CountResult](#qdrant-CountResult)
     - [CreateFieldIndexCollection](#qdrant-CreateFieldIndexCollection)
     - [DeleteFieldIndexCollection](#qdrant-DeleteFieldIndexCollection)
     - [DeletePayloadPoints](#qdrant-DeletePayloadPoints)
@@ -192,6 +195,7 @@
 | ram_data_size | [uint64](#uint64) |  | Used RAM (not implemented) |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
+| points_count | [uint64](#uint64) |  | number of vectors in the collection |
 
 
 
@@ -360,6 +364,7 @@
 | m | [uint64](#uint64) | optional | Number of edges per node in the index graph. Larger the value - more accurate the search, more space required. |
 | ef_construct | [uint64](#uint64) | optional | Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index. |
 | full_scan_threshold | [uint64](#uint64) | optional | Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won&#39;t be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256 |
+| max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
 
 
 
@@ -730,6 +735,54 @@ The JSON representation for `Value` is JSON value.
 | isEmpty | [IsEmptyCondition](#qdrant-IsEmptyCondition) |  |  |
 | hasId | [HasIdCondition](#qdrant-HasIdCondition) |  |  |
 | filter | [Filter](#qdrant-Filter) |  |  |
+
+
+
+
+
+
+<a name="qdrant-CountPoints"></a>
+
+### CountPoints
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | name of the collection |
+| filter | [Filter](#qdrant-Filter) |  | Filter conditions - return only those points that satisfy the specified conditions |
+| exact | [bool](#bool) | optional | If `true` - return exact count, if `false` - return approximate count |
+
+
+
+
+
+
+<a name="qdrant-CountResponse"></a>
+
+### CountResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| result | [CountResult](#qdrant-CountResult) |  |  |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
+<a name="qdrant-CountResult"></a>
+
+### CountResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [uint64](#uint64) |  |  |
 
 
 
@@ -1484,6 +1537,7 @@ The JSON representation for `Value` is JSON value.
 | Search | [SearchPoints](#qdrant-SearchPoints) | [SearchResponse](#qdrant-SearchResponse) | Retrieve closest points based on vector similarity and given filtering conditions |
 | Scroll | [ScrollPoints](#qdrant-ScrollPoints) | [ScrollResponse](#qdrant-ScrollResponse) | Iterate over all or filtered points points |
 | Recommend | [RecommendPoints](#qdrant-RecommendPoints) | [RecommendResponse](#qdrant-RecommendResponse) | Look for the points which are closer to stored positive examples and at the same time further to negative examples. |
+| Count | [CountPoints](#qdrant-CountPoints) | [CountResponse](#qdrant-CountResponse) | Count points in collection with given filtering conditions |
 
  
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -694,7 +694,7 @@
           {
             "name": "collection_name",
             "in": "path",
-            "description": "Name of the collection to retrieve",
+            "description": "Name of the collection",
             "required": true,
             "schema": {
               "type": "string"
@@ -764,7 +764,7 @@
           {
             "name": "collection_name",
             "in": "path",
-            "description": "Name of the collection to retrieve",
+            "description": "Name of the collection for which to create a snapshot",
             "required": true,
             "schema": {
               "type": "string"
@@ -1724,6 +1724,85 @@
           }
         }
       }
+    },
+    "/collections/{collection_name}/points/count": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Count points",
+        "description": "Count points which matches given filtering condition",
+        "operationId": "count_points",
+        "requestBody": {
+          "description": "Request counts of points which matches given filtering condition",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to count in",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CountResult"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "openapi": "3.0.1",
@@ -2008,6 +2087,13 @@
           },
           "full_scan_threshold": {
             "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "max_indexing_threads": {
+            "description": "Number of parallel threads used for background index building. If 0 - auto selection.",
+            "default": 0,
             "type": "integer",
             "format": "uint",
             "minimum": 0
@@ -3561,6 +3647,42 @@
           "size": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0
+          }
+        }
+      },
+      "CountRequest": {
+        "description": "Count Request Counts the number of points which satisfy the given filter. If filter is not provided, the count of all points in the collection will be returned.",
+        "type": "object",
+        "properties": {
+          "filter": {
+            "description": "Look only for points which satisfies this conditions",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "exact": {
+            "description": "If true, count exact number of points. If false, count approximate number of points faster.",
+            "default": true,
+            "type": "boolean"
+          }
+        }
+      },
+      "CountResult": {
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "description": "Number of points which satisfy the conditions",
+            "type": "integer",
+            "format": "uint",
             "minimum": 0
           }
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -139,6 +139,12 @@ message RecommendPoints {
   optional uint64 offset = 10; // Offset of the result
 }
 
+message CountPoints {
+  string collection_name = 1; // name of the collection
+  Filter filter = 2; // Filter conditions - return only those points that satisfy the specified conditions
+  optional bool exact = 3; // If `true` - return exact count, if `false` - return approximate count
+}
+
 // ---------------------------------------------
 // ---------------- RPC Response ---------------
 // ---------------------------------------------
@@ -172,10 +178,19 @@ message SearchResponse {
   double time = 2; // Time spent to process
 }
 
+message CountResponse {
+  CountResult result = 1;
+  double time = 2; // Time spent to process
+}
+
 message ScrollResponse {
   optional PointId next_page_offset = 1; // Use this offset for the next query
   repeated RetrievedPoint result = 2;
   double time = 3; // Time spent to process
+}
+
+message CountResult {
+  uint64 count = 1;
 }
 
 message RetrievedPoint {

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -16,6 +16,7 @@ service PointsInternal {
   rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
   rpc Search (SearchPointsInternal) returns (SearchResponse) {}
   rpc Scroll (ScrollPointsInternal) returns (ScrollResponse) {}
+  rpc Count (CountPointsInternal) returns (CountResponse) {}
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
   rpc Get (GetPointsInternal) returns (GetResponse) {}
 }
@@ -72,5 +73,10 @@ message RecommendPointsInternal {
 
 message GetPointsInternal {
   GetPoints get_points = 1;
+  uint32 shard_id = 2;
+}
+
+message CountPointsInternal {
+  CountPoints count_points = 1;
   uint32 shard_id = 2;
 }

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -51,6 +51,8 @@ service Points {
   Look for the points which are closer to stored positive examples and at the same time further to negative examples.
    */
   rpc Recommend (RecommendPoints) returns (RecommendResponse) {}
-
-
+  /*
+   Count points in collection with given filtering conditions
+   */
+  rpc Count (CountPoints) returns (CountResponse) {}
 }

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -11,7 +11,7 @@ use crate::operations::config_diff::DiffConfig;
 use crate::operations::snapshot_ops::{
     get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
 };
-use crate::operations::types::PointRequest;
+use crate::operations::types::{CountRequest, CountResult, PointRequest};
 use crate::operations::OperationToShard;
 use crate::shard::remote_shard::RemoteShard;
 use crate::shard::shard_config::{ShardConfig, ShardType};
@@ -770,6 +770,24 @@ impl Collection {
             points,
             next_page_offset,
         })
+    }
+
+    pub async fn count(&self, request: CountRequest, shard_selection: Option<ShardId>) -> CollectionResult<CountResult> {
+        let request = Arc::new(request);
+        let target_shards = self.target_shards(shard_selection)?;
+        let count_futures = target_shards.iter().map(|shard| {
+            shard.count(request.clone())
+        });
+        let counts: Vec<_> = try_join_all(count_futures)
+            .await?
+            .into_iter()
+            .collect();
+
+        let total_count = counts.iter().map(|x| x.count).sum::<usize>();
+        let aggregated_count = CountResult {
+            count: total_count,
+        };
+        Ok(aggregated_count)
     }
 
     pub async fn retrieve(

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -772,21 +772,20 @@ impl Collection {
         })
     }
 
-    pub async fn count(&self, request: CountRequest, shard_selection: Option<ShardId>) -> CollectionResult<CountResult> {
+    pub async fn count(
+        &self,
+        request: CountRequest,
+        shard_selection: Option<ShardId>,
+    ) -> CollectionResult<CountResult> {
         let request = Arc::new(request);
         let target_shards = self.target_shards(shard_selection)?;
-        let count_futures = target_shards.iter().map(|shard| {
-            shard.count(request.clone())
-        });
-        let counts: Vec<_> = try_join_all(count_futures)
-            .await?
-            .into_iter()
-            .collect();
+        let count_futures = target_shards
+            .iter()
+            .map(|shard| shard.count(request.clone()));
+        let counts: Vec<_> = try_join_all(count_futures).await?.into_iter().collect();
 
         let total_count = counts.iter().map(|x| x.count).sum::<usize>();
-        let aggregated_count = CountResult {
-            count: total_count,
-        };
+        let aggregated_count = CountResult { count: total_count };
         Ok(aggregated_count)
     }
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -5,9 +5,7 @@ use crate::operations::point_ops::{
     Batch, FilterSelector, PointIdsList, PointStruct, PointsSelector,
 };
 use crate::operations::types::{CollectionStatus, OptimizersStatus, UpdateStatus};
-use crate::{
-    CollectionConfig, CollectionInfo, OptimizersConfig, OptimizersConfigDiff, Record, UpdateResult,
-};
+use crate::{CollectionConfig, CollectionInfo, CountResult, OptimizersConfig, OptimizersConfigDiff, Record, UpdateResult};
 use api::grpc::conversions::{payload_to_proto, proto_to_payloads};
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -388,5 +386,21 @@ impl TryFrom<api::grpc::qdrant::UpdateResult> for UpdateResult {
                 _ => return Err(Status::invalid_argument("Malformed UpdateStatus type")),
             },
         })
+    }
+}
+
+impl From<api::grpc::qdrant::CountResult> for CountResult {
+    fn from(value: api::grpc::qdrant::CountResult) -> Self {
+        Self {
+            count: value.count as usize,
+        }
+    }
+}
+
+impl From<CountResult> for api::grpc::qdrant::CountResult {
+    fn from(value: CountResult) -> Self {
+        Self {
+            count: value.count as u64,
+        }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -5,7 +5,10 @@ use crate::operations::point_ops::{
     Batch, FilterSelector, PointIdsList, PointStruct, PointsSelector,
 };
 use crate::operations::types::{CollectionStatus, OptimizersStatus, UpdateStatus};
-use crate::{CollectionConfig, CollectionInfo, CountResult, OptimizersConfig, OptimizersConfigDiff, Record, UpdateResult};
+use crate::{
+    CollectionConfig, CollectionInfo, CountResult, OptimizersConfig, OptimizersConfigDiff, Record,
+    UpdateResult,
+};
 use api::grpc::conversions::{payload_to_proto, proto_to_payloads};
 use itertools::Itertools;
 use std::collections::HashMap;

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -237,7 +237,9 @@ pub struct CountRequest {
     pub exact: bool,
 }
 
-pub fn default_exact_count() -> bool { true }
+pub fn default_exact_count() -> bool {
+    true
+}
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -224,6 +224,28 @@ pub struct RecommendRequest {
     pub score_threshold: Option<ScoreType>,
 }
 
+/// Count Request
+/// Counts the number of points which satisfy the given filter.
+/// If filter is not provided, the count of all points in the collection will be returned.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CountRequest {
+    /// Look only for points which satisfies this conditions
+    pub filter: Option<Filter>,
+    /// If true, count exact number of points. If false, count approximate number of points faster.
+    #[serde(default = "default_exact_count")]
+    pub exact: bool,
+}
+
+pub fn default_exact_count() -> bool { true }
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CountResult {
+    /// Number of points which satisfy the conditions
+    pub count: usize,
+}
+
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]
 pub enum CollectionError {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -233,6 +233,7 @@ pub struct CountRequest {
     /// Look only for points which satisfies this conditions
     pub filter: Option<Filter>,
     /// If true, count exact number of points. If false, count approximate number of points faster.
+    /// Approximate count might be unreliable during the indexing process. Default: true
     #[serde(default = "default_exact_count")]
     pub exact: bool,
 }

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -588,18 +588,30 @@ impl ShardOperation for &LocalShard {
         let some_segment = segments.iter().next();
 
         if some_segment.is_none() {
-            return Ok(CountResult { count: 0});
+            return Ok(CountResult { count: 0 });
         }
 
         let total_count = if request.exact {
-            let all_points: HashSet<_> = segments.iter()
-                .map(|(_id, segment)| segment.get().read().read_filtered(None, usize::MAX, request.filter.as_ref()))
-                .flatten()
+            let all_points: HashSet<_> = segments
+                .iter()
+                .flat_map(|(_id, segment)| {
+                    segment
+                        .get()
+                        .read()
+                        .read_filtered(None, usize::MAX, request.filter.as_ref())
+                })
                 .collect();
             all_points.len()
         } else {
-            segments.iter()
-                .map(|(_id, segment)| segment.get().read().estimate_points_count(request.filter.as_ref()).exp)
+            segments
+                .iter()
+                .map(|(_id, segment)| {
+                    segment
+                        .get()
+                        .read()
+                        .estimate_points_count(request.filter.as_ref())
+                        .exp
+                })
                 .sum()
         };
         Ok(CountResult { count: total_count })

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -1,5 +1,5 @@
 use arc_swap::ArcSwap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -35,7 +35,7 @@ use crate::shard::shard_config::{ShardConfig, SHARD_CONFIG_FILE};
 use crate::shard::ShardOperation;
 use crate::update_handler::{OperationData, Optimizer, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
-use crate::{CollectionId, PointRequest, SearchRequest, ShardId};
+use crate::{CollectionId, CountRequest, CountResult, PointRequest, SearchRequest, ShardId};
 use segment::segment::Segment;
 use segment::segment_constructor::{build_segment, load_segment};
 
@@ -581,6 +581,28 @@ impl ShardOperation for &LocalShard {
             processed_res.collect()
         };
         Ok(top_result)
+    }
+
+    async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
+        let segments = self.segments().read();
+        let some_segment = segments.iter().next();
+
+        if some_segment.is_none() {
+            return Ok(CountResult { count: 0});
+        }
+
+        let total_count = if request.exact {
+            let all_points: HashSet<_> = segments.iter()
+                .map(|(_id, segment)| segment.get().read().read_filtered(None, usize::MAX, request.filter.as_ref()))
+                .flatten()
+                .collect();
+            all_points.len()
+        } else {
+            segments.iter()
+                .map(|(_id, segment)| segment.get().read().estimate_points_count(request.filter.as_ref()).exp)
+                .sum()
+        };
+        Ok(CountResult { count: total_count })
     }
 
     async fn retrieve(

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -5,8 +5,8 @@ pub mod shard_config;
 
 use crate::shard::remote_shard::RemoteShard;
 use crate::{
-    CollectionInfo, CollectionResult, CollectionUpdateOperations, LocalShard, PeerId, PointRequest,
-    Record, SearchRequest, UpdateResult,
+    CollectionInfo, CollectionResult, CollectionUpdateOperations, CountRequest, CountResult,
+    LocalShard, PeerId, PointRequest, Record, SearchRequest, UpdateResult,
 };
 use async_trait::async_trait;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
@@ -73,6 +73,8 @@ pub trait ShardOperation {
         request: Arc<SearchRequest>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<ScoredPoint>>;
+
+    async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult>;
 
     async fn retrieve(
         &self,

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -8,8 +8,17 @@ use crate::shard::conversions::{
 };
 use crate::shard::shard_config::ShardConfig;
 use crate::shard::{PeerId, ShardId, ShardOperation};
-use crate::{ChannelService, CollectionError, CollectionId, CollectionInfo, CollectionResult, CollectionUpdateOperations, CountRequest, CountResult, PointRequest, Record, SearchRequest, UpdateResult};
-use api::grpc::qdrant::{collections_internal_client::CollectionsInternalClient, points_internal_client::PointsInternalClient, GetCollectionInfoRequest, GetCollectionInfoRequestInternal, GetPoints, GetPointsInternal, ScrollPoints, ScrollPointsInternal, SearchPoints, SearchPointsInternal, CountPoints, CountPointsInternal};
+use crate::{
+    ChannelService, CollectionError, CollectionId, CollectionInfo, CollectionResult,
+    CollectionUpdateOperations, CountRequest, CountResult, PointRequest, Record, SearchRequest,
+    UpdateResult,
+};
+use api::grpc::qdrant::{
+    collections_internal_client::CollectionsInternalClient,
+    points_internal_client::PointsInternalClient, CountPoints, CountPointsInternal,
+    GetCollectionInfoRequest, GetCollectionInfoRequestInternal, GetPoints, GetPointsInternal,
+    ScrollPoints, ScrollPointsInternal, SearchPoints, SearchPointsInternal,
+};
 use async_trait::async_trait;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
 use std::path::{Path, PathBuf};
@@ -272,7 +281,11 @@ impl ShardOperation for &RemoteShard {
         let response = client.count(request).await?;
         let count_response = response.into_inner();
         count_response.result.map_or_else(
-            || Err(CollectionError::service_error("Unexpected empty CountResult".to_string())),
+            || {
+                Err(CollectionError::service_error(
+                    "Unexpected empty CountResult".to_string(),
+                ))
+            },
             |count_result| Ok(count_result.into()),
         )
     }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -1,4 +1,5 @@
 use crate::common::file_operations::FileStorageError;
+use crate::index::field_index::CardinalityEstimation;
 use crate::types::{
     Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
@@ -12,7 +13,6 @@ use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::result;
 use thiserror::Error;
-use crate::index::field_index::CardinalityEstimation;
 
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -12,6 +12,7 @@ use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::result;
 use thiserror::Error;
+use crate::index::field_index::CardinalityEstimation;
 
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]
@@ -210,6 +211,9 @@ pub trait SegmentEntry {
 
     /// Return number of vectors in this segment
     fn points_count(&self) -> usize;
+
+    /// Estimate points count in this segment for given filter.
+    fn estimate_points_count<'a>(&'a self, filter: Option<&'a Filter>) -> CardinalityEstimation;
 
     fn vector_dim(&self) -> usize;
 

--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -1,4 +1,4 @@
-mod field_index;
+pub mod field_index;
 pub mod hnsw_index;
 mod index_base;
 mod key_encoding;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -4,6 +4,7 @@ use crate::entry::entry_point::{
     get_service_error, OperationError, OperationResult, SegmentEntry, SegmentFailedState,
 };
 use crate::id_tracker::IdTrackerSS;
+use crate::index::field_index::CardinalityEstimation;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndexSS};
 use crate::types::{
@@ -22,7 +23,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tar::Builder;
-use crate::index::field_index::CardinalityEstimation;
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 
@@ -513,13 +513,13 @@ impl SegmentEntry for Segment {
         match filter {
             None => {
                 let total_count = self.points_count();
-                    CardinalityEstimation {
-                primary_clauses: vec![],
-                min: total_count,
-                exp: total_count,
-                max: total_count
+                CardinalityEstimation {
+                    primary_clauses: vec![],
+                    min: total_count,
+                    exp: total_count,
+                    max: total_count,
+                }
             }
-            },
             Some(filter) => {
                 let payload_index = self.payload_index.borrow();
                 payload_index.estimate_cardinality(filter)

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -10,7 +10,10 @@ use tokio::sync::{RwLock, RwLockReadGuard};
 use collection::config::{CollectionConfig, CollectionParams};
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
-use collection::operations::types::{CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
+use collection::operations::types::{
+    CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult,
+    SearchRequest, UpdateResult,
+};
 use collection::operations::CollectionUpdateOperations;
 use collection::{ChannelService, Collection, CollectionShardDistribution};
 use segment::types::ScoredPoint;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -10,10 +10,7 @@ use tokio::sync::{RwLock, RwLockReadGuard};
 use collection::config::{CollectionConfig, CollectionParams};
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
-use collection::operations::types::{
-    PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest,
-    UpdateResult,
-};
+use collection::operations::types::{CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
 use collection::operations::CollectionUpdateOperations;
 use collection::{ChannelService, Collection, CollectionShardDistribution};
 use segment::types::ScoredPoint;
@@ -436,6 +433,31 @@ impl TableOfContent {
         let collection = self.get_collection(collection_name).await?;
         collection
             .search(request, self.search_runtime.handle(), shard_selection)
+            .await
+            .map_err(|err| err.into())
+    }
+
+    /// Count points in the collection.
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - in what collection do we count
+    /// * `request` - [`CountRequest`]
+    /// * `shard_selection` - which local shard to use
+    ///
+    /// # Result
+    ///
+    /// Number of points in the collection.
+    ///
+    pub async fn count(
+        &self,
+        collection_name: &str,
+        request: CountRequest,
+        shard_selection: Option<ShardId>,
+    ) -> Result<CountResult, StorageError> {
+        let collection = self.get_collection(collection_name).await?;
+        collection
+            .count(request, shard_selection)
             .await
             .map_err(|err| err.into())
     }

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -301,6 +301,29 @@ paths:
             type: string
       responses: #@ response(array(reference("ScoredPoint")))
 
+  /collections/{collection_name}/points/count:
+    post:
+      tags:
+        - points
+      summary: Count points
+      description: Count points which matches given filtering condition
+      operationId: count_points
+      requestBody:
+        description: Request counts of points which matches given filtering condition
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CountRequest"
+
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to count in
+          required: true
+          schema:
+            type: string
+      responses: #@ response(reference("CountResult"))
+
 components:
   schemas:
     ErrorResponse:

--- a/openapi/tests/openapi_integration/test_count.py
+++ b/openapi/tests/openapi_integration/test_count.py
@@ -1,0 +1,41 @@
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_collection_threshold'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    basic_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_exact_count_search():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/count',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "should": [
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": "London"
+                        }
+                    },
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": "Berlin"
+                        }
+                    }
+                ]
+            }
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['count'] == 4

--- a/openapi/tests/openapi_integration/test_count.py
+++ b/openapi/tests/openapi_integration/test_count.py
@@ -39,3 +39,34 @@ def test_exact_count_search():
     )
     assert response.ok
     assert response.json()['result']['count'] == 4
+
+
+def test_approx_count_search():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/count',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "should": [
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": "London"
+                        }
+                    },
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": "Berlin"
+                        }
+                    }
+                ]
+            },
+            "exact": False
+        }
+    )
+    assert response.ok
+    print(response.json())
+    assert response.json()['result']['count'] < 6
+    assert response.json()['result']['count'] > 0

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -24,7 +24,7 @@ pub async fn count_points(
         request.into_inner(),
         None,
     )
-        .await;
+    .await;
 
     process_response(response, timing)
 }

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use actix_web::rt::time::Instant;
+use actix_web::{post, web, Responder};
+
+use collection::operations::types::CountRequest;
+use storage::content_manager::toc::TableOfContent;
+
+use crate::actix::helpers::process_response;
+use crate::common::points::do_count_points;
+
+#[post("/collections/{name}/points/count")]
+pub async fn count_points(
+    toc: web::Data<Arc<TableOfContent>>,
+    path: web::Path<String>,
+    request: web::Json<CountRequest>,
+) -> impl Responder {
+    let collection_name = path.into_inner();
+    let timing = Instant::now();
+
+    let response = do_count_points(
+        &toc.into_inner(),
+        &collection_name,
+        request.into_inner(),
+        None,
+    )
+        .await;
+
+    process_response(response, timing)
+}

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -1,8 +1,8 @@
 pub mod cluster_api;
 pub mod collections_api;
+pub mod count_api;
 pub mod recommend_api;
 pub mod retrieve_api;
 pub mod search_api;
 pub mod snapshot_api;
 pub mod update_api;
-pub mod count_api;

--- a/src/actix/api/mod.rs
+++ b/src/actix/api/mod.rs
@@ -5,3 +5,4 @@ pub mod retrieve_api;
 pub mod search_api;
 pub mod snapshot_api;
 pub mod update_api;
+pub mod count_api;

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -88,12 +88,8 @@ pub fn init(dispatcher: Arc<Dispatcher>, settings: Settings) -> std::io::Result<
 }
 
 #[cfg(test)]
-mod tests {}
-struct Record {
-    id: Option<Id>,
-}
-
-use ::api::grpc::api_crate_version;
+mod tests {
+    use ::api::grpc::api_crate_version;
 
     #[test]
     fn test_version() {

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -12,6 +12,7 @@ use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Res
 use std::sync::Arc;
 use storage::Dispatcher;
 
+use crate::actix::api::count_api::count_points;
 use crate::actix::api::recommend_api::recommend_points;
 use crate::actix::api::retrieve_api::{get_point, get_points, scroll_points};
 use crate::actix::api::search_api::search_points;
@@ -74,6 +75,7 @@ pub fn init(dispatcher: Arc<Dispatcher>, settings: Settings) -> std::io::Result<
                 .service(scroll_points)
                 .service(search_points)
                 .service(recommend_points)
+                .service(count_points)
         })
         .workers(max_web_workers(&settings))
         .bind(format!(
@@ -86,8 +88,12 @@ pub fn init(dispatcher: Arc<Dispatcher>, settings: Settings) -> std::io::Result<
 }
 
 #[cfg(test)]
-mod tests {
-    use ::api::grpc::api_crate_version;
+mod tests {}
+struct Record {
+    id: Option<Id>,
+}
+
+use ::api::grpc::api_crate_version;
 
     #[test]
     fn test_version() {

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -1,8 +1,6 @@
 use collection::operations::payload_ops::{DeletePayload, PayloadOps, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointsSelector};
-use collection::operations::types::{
-    PointRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
-};
+use collection::operations::types::{CountRequest, CountResult, PointRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use collection::shard::ShardId;
 use schemars::JsonSchema;
@@ -148,6 +146,16 @@ pub async fn do_search_points(
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     toc.search(collection_name, request, shard_selection).await
 }
+
+pub async fn do_count_points(
+    toc: &TableOfContent,
+    collection_name: &str,
+    request: CountRequest,
+    shard_selection: Option<ShardId>,
+) -> Result<CountResult, StorageError> {
+    toc.count(collection_name, request, shard_selection).await
+}
+
 
 pub async fn do_get_points(
     toc: &TableOfContent,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -1,6 +1,9 @@
 use collection::operations::payload_ops::{DeletePayload, PayloadOps, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointsSelector};
-use collection::operations::types::{CountRequest, CountResult, PointRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
+use collection::operations::types::{
+    CountRequest, CountResult, PointRequest, Record, ScrollRequest, ScrollResult, SearchRequest,
+    UpdateResult,
+};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use collection::shard::ShardId;
 use schemars::JsonSchema;
@@ -155,7 +158,6 @@ pub async fn do_count_points(
 ) -> Result<CountResult, StorageError> {
     toc.count(collection_name, request, shard_selection).await
 }
-
 
 pub async fn do_get_points(
     toc: &TableOfContent,

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -2,10 +2,7 @@ use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
-use collection::operations::types::{
-    CollectionInfo, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult,
-    SearchRequest, UpdateResult,
-};
+use collection::operations::types::{CollectionInfo, CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
 use segment::types::ScoredPoint;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CreateCollection, UpdateCollection,
@@ -45,6 +42,8 @@ struct AllDefinitions {
     ak: DeletePayload,
     al: ClusterStatus,
     am: SnapshotDescription,
+    an: CountRequest,
+    ao: CountResult,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -2,7 +2,10 @@ use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
-use collection::operations::types::{CollectionInfo, CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult};
+use collection::operations::types::{
+    CollectionInfo, CountRequest, CountResult, PointRequest, RecommendRequest, Record,
+    ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
+};
 use segment::types::ScoredPoint;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CreateCollection, UpdateCollection,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -2,16 +2,8 @@ use tonic::{Request, Response, Status};
 
 use api::grpc::qdrant::points_server::Points;
 
-use crate::tonic::api::points_common::{
-    clear_payload, create_field_index, delete, delete_field_index, delete_payload, get, recommend,
-    scroll, search, set_payload, upsert,
-};
-use api::grpc::qdrant::{
-    ClearPayloadPoints, CreateFieldIndexCollection, DeleteFieldIndexCollection,
-    DeletePayloadPoints, DeletePoints, GetPoints, GetResponse, PointsOperationResponse,
-    RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse,
-    SetPayloadPoints, UpsertPoints,
-};
+use crate::tonic::api::points_common::{clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get, recommend, scroll, search, set_payload, upsert};
+use api::grpc::qdrant::{ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse, PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints};
 use std::sync::Arc;
 
 use storage::content_manager::toc::TableOfContent;
@@ -100,6 +92,10 @@ impl Points for PointsService {
         request: Request<RecommendPoints>,
     ) -> Result<Response<RecommendResponse>, Status> {
         recommend(self.toc.as_ref(), request.into_inner(), None).await
+    }
+
+    async fn count(&self, request: Request<CountPoints>) -> Result<Response<CountResponse>, Status> {
+        count(self.toc.as_ref(), request.into_inner(), None).await
     }
 }
 

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -2,8 +2,16 @@ use tonic::{Request, Response, Status};
 
 use api::grpc::qdrant::points_server::Points;
 
-use crate::tonic::api::points_common::{clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get, recommend, scroll, search, set_payload, upsert};
-use api::grpc::qdrant::{ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse, PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints};
+use crate::tonic::api::points_common::{
+    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
+    recommend, scroll, search, set_payload, upsert,
+};
+use api::grpc::qdrant::{
+    ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
+    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse,
+    PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse,
+    SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints,
+};
 use std::sync::Arc;
 
 use storage::content_manager::toc::TableOfContent;
@@ -94,7 +102,10 @@ impl Points for PointsService {
         recommend(self.toc.as_ref(), request.into_inner(), None).await
     }
 
-    async fn count(&self, request: Request<CountPoints>) -> Result<Response<CountResponse>, Status> {
+    async fn count(
+        &self,
+        request: Request<CountPoints>,
+    ) -> Result<Response<CountResponse>, Status> {
         count(self.toc.as_ref(), request.into_inner(), None).await
     }
 }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1,18 +1,9 @@
-use crate::common::points::{
-    do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points,
-    do_get_points, do_scroll_points, do_search_points, do_set_payload, do_update_points,
-    CreateFieldIndex,
-};
+use crate::common::points::{do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points, do_get_points, do_scroll_points, do_search_points, do_set_payload, do_update_points, CreateFieldIndex, do_count_points};
 use api::grpc::conversions::proto_to_payloads;
-use api::grpc::qdrant::{
-    ClearPayloadPoints, CreateFieldIndexCollection, DeleteFieldIndexCollection,
-    DeletePayloadPoints, DeletePoints, FieldType, GetPoints, GetResponse, PointsOperationResponse,
-    RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse,
-    SetPayloadPoints, UpsertPoints,
-};
+use api::grpc::qdrant::{ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, FieldType, GetPoints, GetResponse, PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints};
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{PointInsertOperations, PointOperations};
-use collection::operations::types::{PointRequest, ScrollRequest, SearchRequest};
+use collection::operations::types::{default_exact_count, PointRequest, ScrollRequest, SearchRequest};
 use collection::operations::CollectionUpdateOperations;
 use collection::shard::ShardId;
 use segment::types::PayloadSchemaType;
@@ -400,6 +391,35 @@ pub async fn scroll(
             .into_iter()
             .map(|point| point.into())
             .collect(),
+        time: timing.elapsed().as_secs_f64(),
+    };
+
+    Ok(Response::new(response))
+}
+
+pub async fn count(
+    toc: &TableOfContent,
+    count_points: CountPoints,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<CountResponse>, Status> {
+    let CountPoints {
+        collection_name,
+        filter,
+        exact,
+    } = count_points;
+
+    let count_request = collection::operations::types::CountRequest {
+        filter: filter.map(|f| f.try_into()).transpose()?,
+        exact: exact.unwrap_or_else(default_exact_count),
+    };
+
+    let timing = Instant::now();
+    let count_result = do_count_points(toc, &collection_name, count_request, shard_selection)
+        .await
+        .map_err(error_to_status)?;
+
+    let response = CountResponse {
+        result: Some(count_result.into()),
         time: timing.elapsed().as_secs_f64(),
     };
 

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1,9 +1,20 @@
-use crate::common::points::{do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points, do_get_points, do_scroll_points, do_search_points, do_set_payload, do_update_points, CreateFieldIndex, do_count_points};
+use crate::common::points::{
+    do_clear_payload, do_count_points, do_create_index, do_delete_index, do_delete_payload,
+    do_delete_points, do_get_points, do_scroll_points, do_search_points, do_set_payload,
+    do_update_points, CreateFieldIndex,
+};
 use api::grpc::conversions::proto_to_payloads;
-use api::grpc::qdrant::{ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, FieldType, GetPoints, GetResponse, PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints};
+use api::grpc::qdrant::{
+    ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
+    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, FieldType, GetPoints,
+    GetResponse, PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints,
+    ScrollResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints,
+};
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{PointInsertOperations, PointOperations};
-use collection::operations::types::{default_exact_count, PointRequest, ScrollRequest, SearchRequest};
+use collection::operations::types::{
+    default_exact_count, PointRequest, ScrollRequest, SearchRequest,
+};
 use collection::operations::CollectionUpdateOperations;
 use collection::shard::ShardId;
 use segment::types::PayloadSchemaType;

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -1,16 +1,17 @@
 use tonic::{Request, Response, Status};
 
 use crate::tonic::api::points_common::{
-    clear_payload, create_field_index, delete, delete_field_index, delete_payload, get, recommend,
-    scroll, search, set_payload, upsert,
+    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
+    recommend, scroll, search, set_payload, upsert,
 };
 use api::grpc::qdrant::points_internal_server::PointsInternal;
 use api::grpc::qdrant::{
-    ClearPayloadPointsInternal, CreateFieldIndexCollectionInternal,
-    DeleteFieldIndexCollectionInternal, DeletePayloadPointsInternal, DeletePointsInternal,
-    GetPointsInternal, GetResponse, PointsOperationResponse, RecommendPointsInternal,
-    RecommendResponse, ScrollPointsInternal, ScrollResponse, SearchPointsInternal, SearchResponse,
-    SetPayloadPointsInternal, UpsertPointsInternal,
+    ClearPayloadPointsInternal, CountPointsInternal, CountResponse,
+    CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
+    DeletePayloadPointsInternal, DeletePointsInternal, GetPointsInternal, GetResponse,
+    PointsOperationResponse, RecommendPointsInternal, RecommendResponse, ScrollPointsInternal,
+    ScrollResponse, SearchPointsInternal, SearchResponse, SetPayloadPointsInternal,
+    UpsertPointsInternal,
 };
 use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
@@ -201,6 +202,20 @@ impl PointsInternal for PointsInternalService {
             get_points.ok_or_else(|| Status::invalid_argument("GetPoints is missing"))?;
 
         get(self.toc.as_ref(), get_points, Some(shard_id)).await
+    }
+
+    async fn count(
+        &self,
+        request: Request<CountPointsInternal>,
+    ) -> Result<Response<CountResponse>, Status> {
+        let CountPointsInternal {
+            count_points,
+            shard_id,
+        } = request.into_inner();
+
+        let count_points =
+            count_points.ok_or_else(|| Status::invalid_argument("CountPoints is missing"))?;
+        count(self.toc.as_ref(), count_points, Some(shard_id)).await
     }
 }
 


### PR DESCRIPTION
### All Submissions:

Count API - provides a way to estimate number of points for a given filtering condition.
Works in two modes - exact - the default one. Guarantees the accurate number of points, but will retrieve and unique ids on shard level.
Not exact - will use carnality estimation and might be unreliable during optimization.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

