### PR TITLE
Kill qdrant processes after each python test

### DIFF
--- a/tests/consensus_tests/conftest.py
+++ b/tests/consensus_tests/conftest.py
@@ -1,9 +1,0 @@
-# Tracks processes that need to be killed at the end of the test
-processes = []
-
-
-def pytest_sessionfinish(session, exitstatus):
-    print()
-    for p in processes:
-        print(f"Killing {p.pid}")
-        p.kill()


### PR DESCRIPTION
Currently all processes are killed only after all tests are completed. This unnecessarily increases both disk and CPU load.
