### PR TITLE
parallel segments loading

### DIFF
--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -144,6 +144,8 @@ impl LocalShard {
             )
         });
 
+        let mut load_handlers = vec![];
+
         for entry in segment_dirs {
             let segments_path = entry.unwrap().path();
             if segments_path.ends_with("deleted") {
@@ -155,14 +157,19 @@ impl LocalShard {
                 });
                 continue;
             }
-            let segment = match load_segment(&segments_path) {
-                Ok(x) => x,
-                Err(err) => panic!(
-                    "Can't load segments from {}, error: {}",
-                    segments_path.to_str().unwrap(),
-                    err
-                ),
-            };
+            load_handlers.push(thread::spawn(move || load_segment(&segments_path)));
+        }
+
+        for handler in load_handlers {
+            let res = handler.join();
+            if let Err(err) = res {
+                panic!("Can't load segment {:?}", err);
+            }
+            let res = res.unwrap();
+            if let Err(res) = res {
+                panic!("Can't load segment {:?}", res);
+            }
+            let segment = res.unwrap();
             segment_holder.add(segment);
         }
 


### PR DESCRIPTION
### All Submissions:

Issue: https://github.com/qdrant/qdrant/issues/774

Benchmarks:

loading of 200k vectors collection of 4 segments (50k + 50k + 100k + 0): 

- before change: 5s
- after change: 3s 

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?
