### PR TITLE
Introduce ProxyShard

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -426,6 +426,7 @@ impl Collection {
                 id
             ))),
             Some(shard @ Shard::Local(_)) => Ok(shard),
+            Some(shard @ Shard::Proxy(_)) => Ok(shard),
         }
     }
 
@@ -953,6 +954,9 @@ impl Collection {
             match shard {
                 Shard::Local(local_shard) => {
                     local_shard.create_snapshot(&shard_snapshot_path).await?;
+                }
+                Shard::Proxy(proxy_shard) => {
+                    proxy_shard.create_snapshot(&shard_snapshot_path).await?;
                 }
                 Shard::Remote(remote_shard) => {
                     // copy shard directory to snapshot directory

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -1,9 +1,11 @@
 mod conversions;
 pub mod local_shard;
 pub mod local_shard_operations;
+pub mod proxy_shard;
 pub mod remote_shard;
 pub mod shard_config;
 
+use crate::shard::proxy_shard::ProxyShard;
 use crate::shard::remote_shard::RemoteShard;
 use crate::{
     CollectionInfo, CollectionResult, CollectionUpdateOperations, CountRequest, CountResult,
@@ -24,6 +26,7 @@ pub type ShardId = u32;
 pub enum Shard {
     Local(LocalShard),
     Remote(RemoteShard),
+    Proxy(ProxyShard),
 }
 
 impl Shard {
@@ -31,6 +34,7 @@ impl Shard {
         match self {
             Shard::Local(local_shard) => Arc::new(local_shard),
             Shard::Remote(remote_shard) => Arc::new(remote_shard),
+            Shard::Proxy(proxy_shard) => Arc::new(proxy_shard),
         }
     }
 
@@ -38,6 +42,7 @@ impl Shard {
         match self {
             Shard::Local(local_shard) => local_shard.before_drop().await,
             Shard::Remote(_) => (),
+            Shard::Proxy(proxy_shard) => proxy_shard.before_drop().await,
         }
     }
 
@@ -45,6 +50,7 @@ impl Shard {
         match self {
             Shard::Local(_) => this_peer_id,
             Shard::Remote(remote) => remote.peer_id,
+            Shard::Proxy(_) => this_peer_id,
         }
     }
 }

--- a/lib/collection/src/shard/proxy_shard.rs
+++ b/lib/collection/src/shard/proxy_shard.rs
@@ -1,0 +1,145 @@
+use crate::operations::operation_effect::{EstimateOperationEffectArea, OperationEffectArea};
+use crate::{
+    CollectionError, CollectionInfo, CollectionResult, CollectionUpdateOperations, CountRequest,
+    CountResult, LocalShard, PointRequest, Record, SearchRequest, ShardOperation, UpdateResult,
+};
+use async_trait::async_trait;
+use segment::types::{
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
+};
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+type ChangedPointsSet = Arc<RwLock<HashSet<PointIdType>>>;
+
+/// ProxyShard
+///
+/// ProxyShard is a wrapper type for a LocalShard.
+///
+/// It can be used to provide all read and write operations while the wrapped shard is being transferred to another node.
+/// It keeps track of changed points during the shard transfer to assure consistency.
+pub struct ProxyShard {
+    wrapped_shard: LocalShard,
+    changed_points: ChangedPointsSet,
+}
+
+/// Max number of updates tracked to synchronize after the transfer.
+const MAX_CHANGES_TRACKED_COUNT: usize = 10_000;
+
+impl ProxyShard {
+    // TODO: In order for the tracking system to be correct, the wrapped shard update queue operation should be empty at this moment.
+    #[allow(unused)]
+    fn new(wrapped_shard: LocalShard) -> Self {
+        Self {
+            wrapped_shard,
+            changed_points: Default::default(),
+        }
+    }
+
+    async fn check_changed_points_limit(&self, next: usize) -> CollectionResult<()> {
+        if self.changed_points.read().await.len() + next > MAX_CHANGES_TRACKED_COUNT {
+            Err(CollectionError::service_error(
+                "Too many points changed during the proxy shard lifetime".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Forward `create_snapshot` to `wrapped_shard`
+    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+        self.wrapped_shard.create_snapshot(target_path).await
+    }
+
+    /// Forward `before_drop` to `wrapped_shard`
+    pub async fn before_drop(&mut self) {
+        self.wrapped_shard.before_drop().await
+    }
+}
+
+#[async_trait]
+impl ShardOperation for &ProxyShard {
+    /// Update `wrapped_shard` while keeping track of the changed points
+    async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        let local_shard = &self.wrapped_shard;
+        let estimate_effect = operation.estimate_effect_area();
+        match estimate_effect {
+            OperationEffectArea::Empty => {}
+            OperationEffectArea::Points(points) => {
+                self.check_changed_points_limit(points.len()).await?;
+                let mut changed_points_guard = self.changed_points.write().await;
+                for point in points {
+                    changed_points_guard.insert(point);
+                }
+            }
+            OperationEffectArea::Filter(filter) => {
+                let cardinality = local_shard.estimate_cardinality(Some(&filter)).await?;
+                // validate the size of the change set before retrieving it
+                self.check_changed_points_limit(cardinality.max).await?;
+                let points = local_shard.read_filtered(Some(&filter)).await?;
+                let mut changed_points_guard = self.changed_points.write().await;
+                for point in points {
+                    changed_points_guard.insert(point);
+                }
+            }
+        }
+        local_shard.update(operation, wait).await
+    }
+
+    /// Forward read-only `scroll_by` to `wrapped_shard`
+    async fn scroll_by(
+        &self,
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: bool,
+        filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .scroll_by(offset, limit, with_payload_interface, with_vector, filter)
+            .await
+    }
+
+    /// Forward read-only `info` to `wrapped_shard`
+    async fn info(&self) -> CollectionResult<CollectionInfo> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.info().await
+    }
+
+    /// Forward read-only `search` to `wrapped_shard`
+    async fn search(
+        &self,
+        request: Arc<SearchRequest>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.search(request, search_runtime_handle).await
+    }
+
+    /// Forward read-only `count` to `wrapped_shard`
+    async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.count(request).await
+    }
+
+    /// Forward read-only `retrieve` to `wrapped_shard`
+    async fn retrieve(
+        &self,
+        request: Arc<PointRequest>,
+        with_payload: &WithPayload,
+        with_vector: bool,
+    ) -> CollectionResult<Vec<Record>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .retrieve(request, with_payload, with_vector)
+            .await
+    }
+}


### PR DESCRIPTION
This PR introduce a basic structure for the `ProxyShard`.

A `ProxyShard` wraps a `LocalShard` and captures all the points id changed during its lifetime up to a limit.

It is intentionally small to get the ball rolling and make further refactoring easier to review in the near future.