### PR TITLE
[sharding] Receive shard transfer

### DIFF
--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -5,10 +5,23 @@ import "collections.proto";
 package qdrant;
 
 service CollectionsInternal {
+  /*
+  Get collection info
+  */
   rpc Get (GetCollectionInfoRequestInternal) returns (GetCollectionInfoResponse) {}
+
+  /*
+ Initiate shard transfer
+ */
+  rpc Initiate (InitiateShardTransferRequest) returns (CollectionOperationResponse) {}
 }
 
 message GetCollectionInfoRequestInternal {
   GetCollectionInfoRequest get_collectionInfoRequest = 1;
   uint32 shard_id = 2;
+}
+
+message InitiateShardTransferRequest {
+  string collection_name = 1; // Name of the collection
+  uint32 shard_id = 2; // Id of the temporary shard
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -879,6 +879,15 @@ pub struct GetCollectionInfoRequestInternal {
     #[prost(uint32, tag="2")]
     pub shard_id: u32,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InitiateShardTransferRequest {
+    /// Name of the collection
+    #[prost(string, tag="1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Id of the temporary shard
+    #[prost(uint32, tag="2")]
+    pub shard_id: u32,
+}
 /// Generated client implementations.
 pub mod collections_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -943,6 +952,8 @@ pub mod collections_internal_client {
             self.inner = self.inner.accept_gzip();
             self
         }
+        ///
+        ///Get collection info
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequestInternal>,
@@ -962,6 +973,27 @@ pub mod collections_internal_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        ///
+        ///Initiate shard transfer
+        pub async fn initiate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::InitiateShardTransferRequest>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.CollectionsInternal/Initiate",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -971,10 +1003,18 @@ pub mod collections_internal_server {
     ///Generated trait containing gRPC methods that should be implemented for use with CollectionsInternalServer.
     #[async_trait]
     pub trait CollectionsInternal: Send + Sync + 'static {
+        ///
+        ///Get collection info
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequestInternal>,
         ) -> Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
+        ///
+        ///Initiate shard transfer
+        async fn initiate(
+            &self,
+            request: tonic::Request<super::InitiateShardTransferRequest>,
+        ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct CollectionsInternalServer<T: CollectionsInternal> {
@@ -1053,6 +1093,44 @@ pub mod collections_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.CollectionsInternal/Initiate" => {
+                    #[allow(non_camel_case_types)]
+                    struct InitiateSvc<T: CollectionsInternal>(pub Arc<T>);
+                    impl<
+                        T: CollectionsInternal,
+                    > tonic::server::UnaryService<super::InitiateShardTransferRequest>
+                    for InitiateSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::InitiateShardTransferRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).initiate(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InitiateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -4,6 +4,7 @@ pub mod local_shard_operations;
 pub mod proxy_shard;
 pub mod remote_shard;
 pub mod shard_config;
+pub mod shard_transfer;
 
 use crate::shard::proxy_shard::ProxyShard;
 use crate::shard::remote_shard::RemoteShard;

--- a/lib/collection/src/shard/shard_transfer.rs
+++ b/lib/collection/src/shard/shard_transfer.rs
@@ -1,0 +1,53 @@
+use crate::{
+    CollectionConfig, CollectionError, CollectionId, CollectionResult, LocalShard, ShardId,
+};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// ShardTransfer
+///
+/// ShardTransfer holds the state an ongoing shard transfer on the receiving end.
+pub struct ShardTransfer {
+    pub shard_id: ShardId,
+    temporary_shard: LocalShard,
+}
+
+impl ShardTransfer {
+    pub async fn new(
+        shard_id: ShardId,
+        collection_id: CollectionId,
+        collection_path: &Path,
+        shared_config: Arc<RwLock<CollectionConfig>>,
+    ) -> CollectionResult<Self> {
+        let shard_path = Self::create_temporary_shard_dir(collection_path, shard_id).await?;
+        let temporary_shard =
+            LocalShard::build(shard_id, collection_id, &shard_path, shared_config).await?;
+        Ok(Self {
+            shard_id,
+            temporary_shard,
+        })
+    }
+
+    pub fn inner_shard(&self) -> &LocalShard {
+        &self.temporary_shard
+    }
+
+    /// Create directory to hold the temporary data for shard with `shard_id`
+    pub async fn create_temporary_shard_dir(
+        collection_path: &Path,
+        shard_id: ShardId,
+    ) -> CollectionResult<PathBuf> {
+        let shard_path = collection_path.join(format!("{shard_id}-temp"));
+        tokio::fs::create_dir_all(&shard_path)
+            .await
+            .map_err(|err| CollectionError::ServiceError {
+                error: format!("Can't create shard {shard_id} directory. Error: {}", err),
+            })?;
+        Ok(shard_path)
+    }
+
+    pub async fn before_drop(&mut self) {
+        self.temporary_shard.before_drop().await;
+    }
+}

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -23,7 +23,8 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
 
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
+        let mut collection =
+            simple_collection_fixture(collection_dir.path(), shard_number, 0).await;
         collection.before_drop().await;
     }
     for _i in 0..5 {
@@ -68,7 +69,8 @@ async fn test_collection_payload_reloading() {
 async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
+        let mut collection =
+            simple_collection_fixture(collection_dir.path(), shard_number, 0).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
@@ -133,7 +135,8 @@ async fn test_collection_payload_custom_payload() {
 async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
     let collection_dir = TempDir::new("collection").unwrap();
     {
-        let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
+        let mut collection =
+            simple_collection_fixture(collection_dir.path(), shard_number, 0).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
                 ids: vec![0.into(), 1.into()],

--- a/lib/collection/tests/pagination_test.rs
+++ b/lib/collection/tests/pagination_test.rs
@@ -16,7 +16,7 @@ async fn test_collection_paginated_search() {
 async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     let collection_dir = tempdir::TempDir::new("test_collection_paginated_search").unwrap();
 
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
+    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number, 0).await;
 
     // Upload 1000 random vectors to the collection
     let mut points = Vec::new();


### PR DESCRIPTION
This PR adds the receive part of the shard transfer as described in https://github.com/qdrant/qdrant/issues/789

The code change consist in tracking the ongoing transfers on a per collection basis.

Using that knowledge, we are about to reroute properly the internal upsert points API to the temporary shard.

I have tested manually that the node accepts the traffic.
<details>
  <summary>Test logs</summary>

  ```
+ QDRANT_HOST=localhost:47339
+ docker_grpcurl='docker run --rm --network=host -v /home/agourlay/Workspace/qdrant/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto'
+ docker run --rm --network=host -v /home/agourlay/Workspace/qdrant/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto -d '{
   "collection_name": "test_collection",
   "shard_id": 1
}' localhost:47339 qdrant.CollectionsInternal/Initiate
{
  "result": true,
  "time": 0.311461271
}
+ docker run --rm --network=host -v /home/agourlay/Workspace/qdrant/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto -d '{
  "upsert_points" : {
    "collection_name": "test_collection",
    "wait": true,
    "points": [
      {
        "id": { "num": 1 },
        "vector": [0.05, 0.61, 0.76, 0.74],
        "payload": {
          "city": { "string_value": "Berlin" },
          "country":  { "string_value": "Germany" },
          "population": { "integer_value":  1000000 },
          "square": { "double_value": 12.5 },
          "coords": { "struct_value": { "fields": { "lat": { "double_value": 1.0 }, "lon": { "double_value": 2.0 } } } }
        }
      },
      {"id": { "num": 2 }, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "London" }]}}}},
      {"id": { "num": 3 }, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "Moscow" }]}}}},
      {"id": { "num": 4 }, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": {"list_value": {"values": [{ "string_value": "London" }, { "string_value": "Moscow" }]}}}},
      {"id": { "num": 5 }, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count":{"list_value": {"values": [{ "integer_value": 0 }]}}}},
      {"id": { "num": 6 }, "vector": [0.35, 0.08, 0.11, 0.44]}
    ]
  },
  "shard_id": 1
}' localhost:47339 qdrant.PointsInternal/Upsert
{
  "result": {
    "status": "Acknowledged"
  },
  "time": 0.001549475
}
  ```

</details>

The next step will be to promote a transfer shard as a local shard at then end of the transfer.