### PR TITLE
Fix propagation of 'wait' flag to remote shard operations

### DIFF
--- a/lib/collection/src/shard/conversions.rs
+++ b/lib/collection/src/shard/conversions.rs
@@ -18,12 +18,13 @@ use tonic::Status;
 pub fn internal_upsert_points(
     point_insert_operations: PointInsertOperations,
     shard: &RemoteShard,
+    wait: bool,
 ) -> CollectionResult<UpsertPointsInternal> {
     Ok(UpsertPointsInternal {
         shard_id: shard.id,
         upsert_points: Some(UpsertPoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             points: match point_insert_operations {
                 PointInsertOperations::PointsBatch(batch) => batch.try_into()?,
                 PointInsertOperations::PointsList(list) => list
@@ -35,12 +36,16 @@ pub fn internal_upsert_points(
     })
 }
 
-pub fn internal_delete_points(ids: Vec<PointIdType>, shard: &RemoteShard) -> DeletePointsInternal {
+pub fn internal_delete_points(
+    ids: Vec<PointIdType>,
+    shard: &RemoteShard,
+    wait: bool,
+) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id: shard.id,
         delete_points: Some(DeletePoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
                     ids: ids.into_iter().map(|id| id.into()).collect(),
@@ -53,12 +58,13 @@ pub fn internal_delete_points(ids: Vec<PointIdType>, shard: &RemoteShard) -> Del
 pub fn internal_delete_points_by_filter(
     filter: Filter,
     shard: &RemoteShard,
+    wait: bool,
 ) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id: shard.id,
         delete_points: Some(DeletePoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
@@ -69,12 +75,13 @@ pub fn internal_delete_points_by_filter(
 pub fn internal_set_payload(
     set_payload: SetPayload,
     shard: &RemoteShard,
+    wait: bool,
 ) -> SetPayloadPointsInternal {
     SetPayloadPointsInternal {
         shard_id: shard.id,
         set_payload_points: Some(SetPayloadPoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             payload: payload_to_proto(set_payload.payload),
             points: set_payload.points.into_iter().map(|id| id.into()).collect(),
         }),
@@ -84,12 +91,13 @@ pub fn internal_set_payload(
 pub fn internal_delete_payload(
     delete_payload: DeletePayload,
     shard: &RemoteShard,
+    wait: bool,
 ) -> DeletePayloadPointsInternal {
     DeletePayloadPointsInternal {
         shard_id: shard.id,
         delete_payload_points: Some(DeletePayloadPoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             keys: delete_payload.keys,
             points: delete_payload
                 .points
@@ -103,12 +111,13 @@ pub fn internal_delete_payload(
 pub fn internal_clear_payload(
     points: Vec<PointIdType>,
     shard: &RemoteShard,
+    wait: bool,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id: shard.id,
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
                     ids: points.into_iter().map(|id| id.into()).collect(),
@@ -121,12 +130,13 @@ pub fn internal_clear_payload(
 pub fn internal_clear_payload_by_filter(
     filter: Filter,
     shard: &RemoteShard,
+    wait: bool,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id: shard.id,
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
@@ -137,12 +147,13 @@ pub fn internal_clear_payload_by_filter(
 pub fn internal_create_index(
     create_index: CreateIndex,
     shard: &RemoteShard,
+    wait: bool,
 ) -> CreateFieldIndexCollectionInternal {
     CreateFieldIndexCollectionInternal {
         shard_id: shard.id,
         create_field_index_collection: Some(CreateFieldIndexCollection {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             field_name: create_index.field_name,
             field_type: create_index.field_type.map(|ft| ft.index()),
         }),
@@ -152,12 +163,13 @@ pub fn internal_create_index(
 pub fn internal_delete_index(
     delete_index: String,
     shard: &RemoteShard,
+    wait: bool,
 ) -> DeleteFieldIndexCollectionInternal {
     DeleteFieldIndexCollectionInternal {
         shard_id: shard.id,
         delete_field_index_collection: Some(DeleteFieldIndexCollection {
             collection_name: shard.collection_id.clone(),
-            wait: Some(true),
+            wait: Some(wait),
             field_name: delete_index,
         }),
     }

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -129,48 +129,54 @@ impl ShardOperation for &RemoteShard {
         let response = match operation {
             CollectionUpdateOperations::PointOperation(point_ops) => match point_ops {
                 PointOperations::UpsertPoints(point_insert_operations) => {
-                    let request =
-                        tonic::Request::new(internal_upsert_points(point_insert_operations, self)?);
+                    let request = tonic::Request::new(internal_upsert_points(
+                        point_insert_operations,
+                        self,
+                        wait,
+                    )?);
                     client.upsert(request).await?
                 }
                 PointOperations::DeletePoints { ids } => {
-                    let request = tonic::Request::new(internal_delete_points(ids, self));
+                    let request = tonic::Request::new(internal_delete_points(ids, self, wait));
                     client.delete(request).await?
                 }
                 PointOperations::DeletePointsByFilter(filter) => {
                     let request =
-                        tonic::Request::new(internal_delete_points_by_filter(filter, self));
+                        tonic::Request::new(internal_delete_points_by_filter(filter, self, wait));
                     client.delete(request).await?
                 }
             },
             CollectionUpdateOperations::PayloadOperation(payload_ops) => match payload_ops {
                 PayloadOps::SetPayload(set_payload) => {
-                    let request = tonic::Request::new(internal_set_payload(set_payload, self));
+                    let request =
+                        tonic::Request::new(internal_set_payload(set_payload, self, wait));
                     client.set_payload(request).await?
                 }
                 PayloadOps::DeletePayload(delete_payload) => {
                     let request =
-                        tonic::Request::new(internal_delete_payload(delete_payload, self));
+                        tonic::Request::new(internal_delete_payload(delete_payload, self, wait));
                     client.delete_payload(request).await?
                 }
                 PayloadOps::ClearPayload { points } => {
-                    let request = tonic::Request::new(internal_clear_payload(points, self));
+                    let request = tonic::Request::new(internal_clear_payload(points, self, wait));
                     client.clear_payload(request).await?
                 }
                 PayloadOps::ClearPayloadByFilter(filter) => {
                     let request =
-                        tonic::Request::new(internal_clear_payload_by_filter(filter, self));
+                        tonic::Request::new(internal_clear_payload_by_filter(filter, self, wait));
                     client.clear_payload(request).await?
                 }
             },
             CollectionUpdateOperations::FieldIndexOperation(field_index_op) => match field_index_op
             {
                 FieldIndexOperations::CreateIndex(create_index) => {
-                    let request = tonic::Request::new(internal_create_index(create_index, self));
+                    let request =
+                        tonic::Request::new(internal_create_index(create_index, self, wait));
                     client.create_field_index(request).await?
                 }
                 FieldIndexOperations::DeleteIndex(delete_index) => {
-                    let request = tonic::Request::new(internal_delete_index(delete_index, self));
+                    let request =
+                        tonic::Request::new(internal_delete_index(delete_index, self, wait));
                     client.delete_field_index(request).await?
                 }
             },


### PR DESCRIPTION
This PR is a bug fix to propagate properly the user's `wait` flag to the remote shard operations.

Currently we are always waiting for remote shards which is not correct.