### PR TITLE
Increase gRPC timeout to 1 minute

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,7 +87,7 @@ fn default_log_level() -> String {
 }
 
 fn default_timeout_ms() -> u64 {
-    1000
+    1000 * 60
 }
 
 fn default_tick_period_ms() -> u64 {


### PR DESCRIPTION
This PR increases the default timeout used for the itnernal gRPC calls from 1 second to 1 minute.

```rust
 #[serde(default = "default_timeout_ms")]
    pub grpc_timeout_ms: u64,
```

This is the only call site for this function.

The current value is too aggressive and can prevent clients from using the `wait` flag properly.
Under high throughput, it is normal for a request using the `wait` flag to take more than 1 second.
     