### PR TITLE
Fix gRPC port for consensus tests

### DIFF
--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -31,12 +31,12 @@ def get_port() -> int:
         return s.getsockname()[1]
 
 
-def get_env(p2p_port: int, gRPC_port: int, http_port: int) -> dict[str, str]:
+def get_env(p2p_port: int, grpc_port: int, http_port: int) -> dict[str, str]:
     env = os.environ.copy()
     env["QDRANT__CLUSTER__ENABLED"] = "true"
     env["QDRANT__CLUSTER__P2P__PORT"] = str(p2p_port)
     env["QDRANT__SERVICE__HTTP_PORT"] = str(http_port)
-    env["QDRANT__SERVICE__GRPC_PORT"] = str(gRPC_port)
+    env["QDRANT__SERVICE__GRPC_PORT"] = str(grpc_port)
     return env
 
 
@@ -65,9 +65,9 @@ def get_qdrant_exec() -> str:
 # Starts a peer and returns its api_uri
 def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str) -> str:
     p2p_port = get_port()
-    gRPC_port = get_port()
+    grpc_port = get_port()
     http_port = get_port()
-    env = get_env(p2p_port, gRPC_port, http_port)
+    env = get_env(p2p_port, grpc_port, http_port)
     log_file = open(log_file, "w")
     processes.append(
         Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri], env=env, cwd=peer_dir, stderr=log_file))
@@ -77,9 +77,9 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str) -> str:
 # Starts a peer and returns its api_uri and p2p_uri
 def start_first_peer(peer_dir: Path, log_file: str) -> Tuple[str, str]:
     p2p_port = get_port()
-    gRPC_port = get_port()
+    grpc_port = get_port()
     http_port = get_port()
-    env = get_env(p2p_port, gRPC_port, http_port)
+    env = get_env(p2p_port, grpc_port, http_port)
     log_file = open(log_file, "w")
     bootstrap_uri = get_uri(p2p_port)
     processes.append(

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -31,11 +31,12 @@ def get_port() -> int:
         return s.getsockname()[1]
 
 
-def get_env(p2p_port: int, http_port: int) -> dict[str, str]:
+def get_env(p2p_port: int, gRPC_port: int, http_port: int) -> dict[str, str]:
     env = os.environ.copy()
     env["QDRANT__CLUSTER__ENABLED"] = "true"
     env["QDRANT__CLUSTER__P2P__PORT"] = str(p2p_port)
     env["QDRANT__SERVICE__HTTP_PORT"] = str(http_port)
+    env["QDRANT__SERVICE__GRPC_PORT"] = str(gRPC_port)
     return env
 
 
@@ -64,8 +65,9 @@ def get_qdrant_exec() -> str:
 # Starts a peer and returns its api_uri
 def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str) -> str:
     p2p_port = get_port()
+    gRPC_port = get_port()
     http_port = get_port()
-    env = get_env(p2p_port, http_port)
+    env = get_env(p2p_port, gRPC_port, http_port)
     log_file = open(log_file, "w")
     processes.append(
         Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri], env=env, cwd=peer_dir, stderr=log_file))
@@ -75,8 +77,9 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str) -> str:
 # Starts a peer and returns its api_uri and p2p_uri
 def start_first_peer(peer_dir: Path, log_file: str) -> Tuple[str, str]:
     p2p_port = get_port()
+    gRPC_port = get_port()
     http_port = get_port()
-    env = get_env(p2p_port, http_port)
+    env = get_env(p2p_port, gRPC_port, http_port)
     log_file = open(log_file, "w")
     bootstrap_uri = get_uri(p2p_port)
     processes.append(


### PR DESCRIPTION
This PR gives a unique `gRPC` port to every qdrant process in the consensus test.

It is necessary because since this [change](https://github.com/qdrant/qdrant/commit/8ac3eef4c7e1519d78c0036b779b192cab482c94#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR96) enabled the gRPC endpoint by defaultt.
 We get noisy errors during consensus tests in logs because all process try to bind on the same port.

```
[2022-07-11T16:00:26.882Z INFO  qdrant::tonic] Qdrant gRPC listening on 6334
thread 'grpc' panicked at 'called `Result::unwrap()` on an `Err` value: tonic::transport::Error(Transport, hyper::Error(Listen, Os { code: 98, kind: AddrInUse, message: "Address already in use" }))', src/tonic/mod.rs:68:10
stack backtrace:
```
