### PR TITLE
Fix conversion for UpdateStatus from the gRPC layer

### DIFF
--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -387,8 +387,12 @@ impl TryFrom<api::grpc::qdrant::UpdateResult> for UpdateResult {
         Ok(Self {
             operation_id: value.operation_id,
             status: match value.status {
-                1 => UpdateStatus::Acknowledged,
-                2 => UpdateStatus::Completed,
+                status if status == api::grpc::qdrant::UpdateStatus::Acknowledged as i32 => {
+                    UpdateStatus::Acknowledged
+                }
+                status if status == api::grpc::qdrant::UpdateStatus::Completed as i32 => {
+                    UpdateStatus::Completed
+                }
                 _ => return Err(Status::invalid_argument("Malformed UpdateStatus type")),
             },
         })

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -372,7 +372,10 @@ impl From<UpdateResult> for api::grpc::qdrant::UpdateResult {
     fn from(value: UpdateResult) -> Self {
         Self {
             operation_id: value.operation_id,
-            status: value.status as i32,
+            status: match value.status {
+                UpdateStatus::Acknowledged => api::grpc::qdrant::UpdateStatus::Acknowledged as i32,
+                UpdateStatus::Completed => api::grpc::qdrant::UpdateStatus::Completed as i32,
+            },
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -88,8 +88,6 @@ pub struct CollectionInfo {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
-    /// Unknown update status
-    Unknown,
     /// Request is saved to WAL and will be process in a queue
     Acknowledged,
     /// Request is completed, changes are actual

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -88,6 +88,8 @@ pub struct CollectionInfo {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
+    /// Unknown update status
+    Unknown,
     /// Request is saved to WAL and will be process in a queue
     Acknowledged,
     /// Request is completed, changes are actual
@@ -385,13 +387,13 @@ impl From<tonic::Status> for CollectionError {
     fn from(err: tonic::Status) -> Self {
         match err.code() {
             tonic::Code::InvalidArgument => CollectionError::BadInput {
-                description: "InvalidArgument".to_string(),
+                description: format!("InvalidArgument: {}", err),
             },
             tonic::Code::NotFound => CollectionError::BadRequest {
-                description: "NotFound".to_string(),
+                description: format!("NotFound: {}", err),
             },
             tonic::Code::Internal => CollectionError::ServiceError {
-                error: "Internal error".to_string(),
+                error: format!("Internal error: {}", err),
             },
             other => CollectionError::ServiceError {
                 error: format!("Tonic status error: {}", other),


### PR DESCRIPTION
This PR fixes a nasty bug happening when remote shards use the wait flag to `false`.

It is due to an incomplete mapping of the gRPC `UpdateStatus` to the operations `UpdateStatus`.

Here is the mapping code.

```rust
impl From<UpdateResult> for api::grpc::qdrant::UpdateResult {
    fn from(value: UpdateResult) -> Self {
        Self {
            operation_id: value.operation_id,
            status: value.status as i32,
        }
    }
}

impl TryFrom<api::grpc::qdrant::UpdateResult> for UpdateResult {
    type Error = Status;

    fn try_from(value: api::grpc::qdrant::UpdateResult) -> Result<Self, Self::Error> {
        Ok(Self {
            operation_id: value.operation_id,
            status: match value.status {
                1 => UpdateStatus::Acknowledged,
                2 => UpdateStatus::Completed,
                _ => return Err(Status::invalid_argument("Malformed UpdateStatus type")),
            },
        })
    }
}
```

The first conversion relies on the C-style enum however, the enum is missing the `0` entry.

I have improved the logging as it was difficult to find this error.