### PR TITLE
Add import formatting rules

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install miniml nightly (only for fmt)
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rustfmt
     - name: Install minimal stable
       uses: actions-rs/toolchain@v1
       with:
@@ -32,6 +38,6 @@ jobs:
       run: .github/scripts/protoc.sh
       shell: bash
     - name: Check code formatting
-      run: cargo fmt --all -- --check
+      run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-push = "cargo fmt --all -- --check"
+pre-push = "cargo +nightly fmt --all -- --check"
 
 [logging]
 verbose = true

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1,7 +1,16 @@
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use chrono::{NaiveDateTime, Timelike};
+use segment::types::{PayloadSelector, WithPayloadInterface};
+use tonic::Status;
+use uuid::Uuid;
+
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
 use crate::grpc::qdrant::point_id::PointIdOptions;
 use crate::grpc::qdrant::r#match::MatchValue;
+use crate::grpc::qdrant::value::Kind;
 use crate::grpc::qdrant::with_payload_selector::SelectorOptions;
 use crate::grpc::qdrant::{
     CollectionDescription, CollectionOperationResponse, Condition, FieldCondition, Filter,
@@ -10,14 +19,6 @@ use crate::grpc::qdrant::{
     PayloadIncludeSelector, PayloadSchemaInfo, PayloadSchemaType, PointId, Range, ScoredPoint,
     SearchParams, Struct, Value, ValuesCount, WithPayloadSelector,
 };
-
-use crate::grpc::qdrant::value::Kind;
-use chrono::{NaiveDateTime, Timelike};
-use segment::types::{PayloadSelector, WithPayloadInterface};
-use std::collections::{HashMap, HashSet};
-use std::time::Instant;
-use tonic::Status;
-use uuid::Uuid;
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {
     payload

--- a/lib/api/src/grpc/models.rs
+++ b/lib/api/src/grpc/models.rs
@@ -1,7 +1,8 @@
+use std::fmt::Debug;
+
 use schemars::JsonSchema;
 use serde;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 #[derive(Serialize, Deserialize)]
 pub struct VersionInfo {

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -1,7 +1,8 @@
-use rand::seq::SliceRandom;
 use std::collections::HashMap;
 use std::time::Duration;
 use std::vec::Vec;
+
+use rand::seq::SliceRandom;
 use tonic::transport::{Channel, Error, Uri};
 
 /// Holds a pool of channels established for a set of URIs.

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1,3 +1,24 @@
+use std::cmp::max;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use futures::future::{join_all, try_join_all};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use itertools::Itertools;
+use segment::common::version::StorageVersion;
+use segment::spaces::tools::{peek_top_largest_scores_iterable, peek_top_smallest_scores_iterable};
+use segment::types::{
+    Condition, ExtendedPointId, Filter, HasIdCondition, Order, ScoredPoint, VectorElementType,
+    WithPayload, WithPayloadInterface,
+};
+use semver::{Version, VersionReq};
+use tar::Builder as TarBuilder;
+use tokio::fs::{copy, create_dir_all, remove_dir_all, remove_file, rename};
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
 use crate::collection_state::State;
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
@@ -20,25 +41,6 @@ use crate::shard::{
     ShardOperation, ShardTransfer, HASH_RING_SHARD_SCALE,
 };
 use crate::telemetry::CollectionTelemetry;
-use futures::future::{join_all, try_join_all};
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
-use itertools::Itertools;
-use segment::common::version::StorageVersion;
-use segment::spaces::tools::{peek_top_largest_scores_iterable, peek_top_smallest_scores_iterable};
-use segment::types::{
-    Condition, ExtendedPointId, Filter, HasIdCondition, Order, ScoredPoint, VectorElementType,
-    WithPayload, WithPayloadInterface,
-};
-use semver::{Version, VersionReq};
-use std::cmp::max;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tar::Builder as TarBuilder;
-use tokio::fs::{copy, create_dir_all, remove_dir_all, remove_file, rename};
-use tokio::runtime::Handle;
-use tokio::sync::RwLock;
 
 struct CollectionVersion;
 

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -1,9 +1,7 @@
 use parking_lot::RwLock;
-
 use segment::types::SeqNumberType;
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
-
 use crate::collection_manager::segments_updater::*;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
@@ -72,15 +70,13 @@ impl CollectionUpdater {
 
 #[cfg(test)]
 mod tests {
+    use segment::types::{Payload, WithPayload};
     use tempdir::TempDir;
 
-    use segment::types::{Payload, WithPayload};
-
+    use super::*;
     use crate::collection_manager::fixtures::build_test_holder;
     use crate::collection_manager::segments_searcher::SegmentsSearcher;
     use crate::collection_manager::segments_updater::upsert_points;
-
-    use super::*;
     use crate::operations::payload_ops::{DeletePayload, PayloadOps, SetPayload};
     use crate::operations::point_ops::PointOperations;
 

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -3,12 +3,11 @@ use std::path::Path;
 
 use parking_lot::RwLock;
 use rand::Rng;
-use serde_json::json;
-
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{Distance, Payload, PointIdType, SeqNumberType};
+use serde_json::json;
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1,4 +1,10 @@
-use crate::collection_manager::holders::segment_holder::LockedSegment;
+use std::cmp::max;
+use std::collections::{HashMap, HashSet};
+use std::fs::{create_dir_all, remove_dir_all};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::entry::entry_point::{OperationResult, SegmentEntry, SegmentFailedState};
 use segment::index::field_index::CardinalityEstimation;
@@ -8,13 +14,9 @@ use segment::types::{
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
     VectorElementType, WithPayload,
 };
-use std::cmp::max;
-use std::collections::{HashMap, HashSet};
-use std::fs::{create_dir_all, remove_dir_all};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use uuid::Uuid;
+
+use crate::collection_manager::holders::segment_holder::LockedSegment;
 
 type LockedRmSet = Arc<RwLock<HashSet<PointIdType>>>;
 type LockedFieldsSet = Arc<RwLock<HashSet<PayloadKeyType>>>;
@@ -584,11 +586,13 @@ impl SegmentEntry for ProxySegment {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::read_dir;
+
+    use segment::types::FieldCondition;
+    use tempdir::TempDir;
+
     use super::*;
     use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
-    use segment::types::FieldCondition;
-    use std::fs::read_dir;
-    use tempdir::TempDir;
 
     #[test]
     fn test_writing() {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1,21 +1,20 @@
 use std::cmp::{max, min};
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::ops::Mul;
+use std::path::Path;
 use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
-
 use segment::entry::entry_point::{OperationError, OperationResult, SegmentEntry};
 use segment::segment::Segment;
 use segment::types::{PointIdType, SeqNumberType};
 
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::operations::types::CollectionError;
-use std::ops::Mul;
-use std::path::Path;
-use std::thread::sleep;
-use std::time::Duration;
 
 pub type SegmentId = usize;
 
@@ -431,16 +430,15 @@ impl<'s> SegmentHolder {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use std::fs::read_dir;
+    use std::{thread, time};
 
     use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
     use segment::types::Distance;
-
-    use crate::collection_manager::fixtures::{build_segment_1, build_segment_2};
+    use tempdir::TempDir;
 
     use super::*;
-    use std::fs::read_dir;
-    use std::{thread, time};
+    use crate::collection_manager::fixtures::{build_segment_1, build_segment_2};
 
     #[test]
     fn test_add_and_swap() {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -215,11 +215,11 @@ mod tests {
     use parking_lot::lock_api::RwLock;
     use rand::thread_rng;
     use segment::fixtures::index_fixtures::random_vector;
+    use segment::types::{Payload, PayloadSchemaType, StorageType};
     use serde_json::json;
     use tempdir::TempDir;
 
-    use segment::types::{Payload, PayloadSchemaType, StorageType};
-
+    use super::*;
     use crate::collection_manager::fixtures::random_segment;
     use crate::collection_manager::holders::segment_holder::SegmentHolder;
     use crate::collection_manager::segments_updater::{
@@ -227,8 +227,6 @@ mod tests {
     };
     use crate::operations::point_ops::{Batch, PointInsertOperations, PointOperations};
     use crate::operations::{CreateIndex, FieldIndexOperations};
-
-    use super::*;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -1,3 +1,9 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use itertools::Itertools;
+use segment::types::{HnswConfig, SegmentType, VECTOR_ELEMENT_SIZE};
+
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
 };
@@ -5,10 +11,6 @@ use crate::collection_manager::optimizers::segment_optimizer::{
     OptimizerThresholds, SegmentOptimizer,
 };
 use crate::config::CollectionParams;
-use itertools::Itertools;
-use segment::types::{HnswConfig, SegmentType, VECTOR_ELEMENT_SIZE};
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
 
 const BYTES_IN_KB: usize = 1024;
 
@@ -125,13 +127,15 @@ impl SegmentOptimizer for MergeOptimizer {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use tempdir::TempDir;
+
     use super::*;
     use crate::collection_manager::fixtures::{get_merge_optimizer, random_segment};
     use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
-    use parking_lot::RwLock;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
-    use tempdir::TempDir;
 
     #[test]
     fn test_max_merge_size() {

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
-
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -1,3 +1,9 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use ordered_float::OrderedFloat;
+use segment::types::{HnswConfig, SegmentType};
+
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentId,
 };
@@ -5,10 +11,6 @@ use crate::collection_manager::optimizers::segment_optimizer::{
     OptimizerThresholds, SegmentOptimizer,
 };
 use crate::config::CollectionParams;
-use ordered_float::OrderedFloat;
-use segment::types::{HnswConfig, SegmentType};
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
 
 /// Optimizer which looks for segments with hig amount of soft-deleted points.
 /// Used to free up space.
@@ -113,19 +115,20 @@ impl SegmentOptimizer for VacuumOptimizer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::collection_manager::fixtures::random_segment;
-    use crate::collection_manager::holders::segment_holder::SegmentHolder;
+    use std::num::NonZeroU32;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
     use itertools::Itertools;
     use parking_lot::RwLock;
     use rand::Rng;
     use segment::types::Distance;
-    use serde_json::json;
-    use serde_json::Value;
-    use std::num::NonZeroU32;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
+    use serde_json::{json, Value};
     use tempdir::TempDir;
+
+    use super::*;
+    use crate::collection_manager::fixtures::random_segment;
+    use crate::collection_manager::holders::segment_holder::SegmentHolder;
 
     #[test]
     fn test_vacuum_conditions() {

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -5,14 +5,12 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::entry::entry_point::OperationError;
-use tokio::runtime::Handle;
-
 use segment::spaces::tools::peek_top_largest_scores_iterable;
 use segment::types::{PointIdType, ScoredPoint, SeqNumberType, WithPayload, WithPayloadInterface};
+use tokio::runtime::Handle;
 
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
-use crate::operations::types::CollectionResult;
-use crate::operations::types::{Record, SearchRequest};
+use crate::operations::types::{CollectionResult, Record, SearchRequest};
 
 /// Simple implementation of segment manager
 ///  - rebuild segment for memory optimization purposes
@@ -145,9 +143,8 @@ async fn search_in_segment(
 mod tests {
     use tempdir::TempDir;
 
-    use crate::collection_manager::fixtures::build_test_holder;
-
     use super::*;
+    use crate::collection_manager::fixtures::build_test_holder;
 
     #[tokio::test]
     async fn test_segments_search() {

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
+use itertools::Itertools;
 use parking_lot::{RwLock, RwLockWriteGuard};
-
+use segment::entry::entry_point::{OperationResult, SegmentEntry};
 use segment::types::{
     Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointIdType,
     SeqNumberType, VectorElementType,
@@ -12,8 +13,6 @@ use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{Batch, PointInsertOperations, PointOperations};
 use crate::operations::types::{CollectionError, CollectionResult, VectorType};
 use crate::operations::FieldIndexOperations;
-use itertools::Itertools;
-use segment::entry::entry_point::{OperationResult, SegmentEntry};
 
 /// A collection of functions for updating points and payloads stored in segments
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -1,17 +1,19 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use parking_lot::RwLock;
+use segment::entry::entry_point::SegmentEntry;
+use segment::types::{PayloadKeyType, PayloadSchemaType, PointIdType};
+use tempdir::TempDir;
+
 use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
 use crate::collection_manager::segments_updater::upsert_points;
-use itertools::Itertools;
-use parking_lot::RwLock;
-use segment::entry::entry_point::SegmentEntry;
-use segment::types::{PayloadKeyType, PayloadSchemaType, PointIdType};
-use std::collections::{HashMap, HashSet};
-use std::path::Path;
-use std::sync::Arc;
-use tempdir::TempDir;
 
 fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> SegmentId {
     let mut write_segments = segments.write();

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use crate::collection::Collection;
 use crate::config::CollectionConfig;
 use crate::operations::types::CollectionResult;
 use crate::shard::remote_shard::RemoteShard;
 use crate::shard::{create_shard_dir, ChannelService, PeerId, Shard, ShardId};
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct State {

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
+
 use tokio::task::JoinHandle;
 
 pub struct StoppableTaskHandle<T> {
@@ -54,9 +55,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::thread;
     use std::time::Duration;
+
+    use super::*;
 
     const STEP_MILLIS: u64 = 5;
 

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -6,10 +6,9 @@ use std::path::Path;
 use atomicwrites::AtomicFile;
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
 use schemars::JsonSchema;
+use segment::types::{Distance, HnswConfig};
 use serde::{Deserialize, Serialize};
 use wal::WalOptions;
-
-use segment::types::{Distance, HnswConfig};
 
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::optimizers_builder::OptimizersConfig;

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -1,11 +1,12 @@
-use crate::config::WalConfig;
-use crate::operations::types::CollectionResult;
-use crate::optimizers_builder::OptimizersConfig;
 use merge::Merge;
 use schemars::JsonSchema;
 use segment::types::HnswConfig;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+
+use crate::config::WalConfig;
+use crate::operations::types::CollectionResult;
+use crate::optimizers_builder::OptimizersConfig;
 
 // Structures for partial update of collection params
 // ToDo: Make auto-generated somehow...
@@ -138,9 +139,10 @@ pub fn update_config<T: DeserializeOwned + Serialize, Y: DeserializeOwned + Seri
 
 #[cfg(test)]
 mod tests {
+    use segment::types::HnswConfig;
+
     use super::*;
     use crate::optimizers_builder::OptimizersConfig;
-    use segment::types::HnswConfig;
 
     #[test]
     fn test_hnsw_update() {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1,3 +1,10 @@
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+
+use api::grpc::conversions::{payload_to_proto, proto_to_payloads};
+use itertools::Itertools;
+use tonic::Status;
+
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
 use crate::operations::point_ops::PointsSelector::PointIdsSelector;
@@ -8,13 +15,7 @@ use crate::operations::types::{
     CollectionInfo, CollectionStatus, CountResult, OptimizersStatus, Record, UpdateResult,
     UpdateStatus,
 };
-
 use crate::optimizers_builder::OptimizersConfig;
-use api::grpc::conversions::{payload_to_proto, proto_to_payloads};
-use itertools::Itertools;
-use std::collections::HashMap;
-use std::num::NonZeroU32;
-use tonic::Status;
 
 impl From<api::grpc::qdrant::HnswConfigDiff> for HnswConfigDiff {
     fn from(value: api::grpc::qdrant::HnswConfigDiff) -> Self {

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -8,13 +8,13 @@ pub mod types;
 
 use std::collections::HashMap;
 
-use crate::hash_ring::HashRing;
-use crate::shard::ShardId;
 use schemars::JsonSchema;
 use segment::types::{ExtendedPointId, PayloadSchemaType};
 use serde::{Deserialize, Serialize};
 
 use self::types::CollectionResult;
+use crate::hash_ring::HashRing;
+use crate::shard::ShardId;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -138,8 +138,9 @@ impl SplitByShard for CollectionUpdateOperations {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn test_deserialize() {

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -1,6 +1,7 @@
+use segment::types::{Filter, PointIdType};
+
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::{point_ops, CollectionUpdateOperations};
-use segment::types::{Filter, PointIdType};
 
 /// Structure to define what part of the shard are affected by the operation
 pub enum OperationEffectArea {

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -3,10 +3,9 @@ use segment::types::{Filter, Payload, PayloadKeyType, PointIdType};
 use serde;
 use serde::{Deserialize, Serialize};
 
+use super::{split_iter_by_shard, OperationToShard, SplitByShard};
 use crate::hash_ring::HashRing;
 use crate::shard::ShardId;
-
-use super::{split_iter_by_shard, OperationToShard, SplitByShard};
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SetPayload {
@@ -72,9 +71,10 @@ impl SplitByShard for SetPayload {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use segment::types::Payload;
     use serde_json::Value;
+
+    use super::*;
 
     #[test]
     fn test_serialization() {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -1,18 +1,16 @@
-use crate::hash_ring::HashRing;
-use crate::operations::types::VectorType;
-use crate::shard::ShardId;
+use std::collections::HashMap;
+
 use schemars::gen::SchemaGenerator;
 use schemars::schema::{ObjectValidation, Schema, SchemaObject, SubschemaValidation};
 use schemars::JsonSchema;
 use segment::types::{Filter, Payload, PointIdType};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-use super::{
-    point_to_shard, split_iter_by_shard,
-    types::{CollectionError, CollectionResult},
-    OperationToShard, SplitByShard, Validate,
-};
+use super::types::{CollectionError, CollectionResult};
+use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard, Validate};
+use crate::hash_ring::HashRing;
+use crate::operations::types::VectorType;
+use crate::shard::ShardId;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -1,10 +1,12 @@
-use crate::operations::types::CollectionResult;
+use std::path::Path;
+use std::time::SystemTime;
+
 use api::grpc::conversions::date_time_to_proto;
 use chrono::NaiveDateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
-use std::time::SystemTime;
+
+use crate::operations::types::CollectionResult;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SnapshotDescription {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1,27 +1,26 @@
+use std::collections::HashMap;
+use std::result;
+use std::time::SystemTimeError;
+
 use futures::io;
 use schemars::JsonSchema;
-use serde;
-use serde::{Deserialize, Serialize};
-use serde_json::Error as JsonError;
-use std::result;
-use thiserror::Error;
-use tokio::{
-    sync::{mpsc::error::SendError, oneshot::error::RecvError as OneshotRecvError},
-    task::JoinError,
-};
-
+use segment::common::file_operations::FileStorageError;
 use segment::entry::entry_point::OperationError;
 use segment::types::{
     Filter, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, ScoreType, SearchParams,
     SeqNumberType, VectorElementType, WithPayloadInterface,
 };
+use serde;
+use serde::{Deserialize, Serialize};
+use serde_json::Error as JsonError;
+use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::oneshot::error::RecvError as OneshotRecvError;
+use tokio::task::JoinError;
+use tonic::codegen::http::uri::InvalidUri;
 
 use crate::config::CollectionConfig;
 use crate::wal::WalError;
-use segment::common::file_operations::FileStorageError;
-use std::collections::HashMap;
-use std::time::SystemTimeError;
-use tonic::codegen::http::uri::InvalidUri;
 
 /// Type of vector in API
 pub type VectorType = Vec<VectorElementType>;

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,15 +1,17 @@
+use std::cmp::{max, min};
+use std::path::Path;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use segment::types::HnswConfig;
+use serde::{Deserialize, Serialize};
+
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 use crate::collection_manager::optimizers::merge_optimizer::MergeOptimizer;
 use crate::collection_manager::optimizers::segment_optimizer::OptimizerThresholds;
 use crate::collection_manager::optimizers::vacuum_optimizer::VacuumOptimizer;
 use crate::config::CollectionParams;
 use crate::update_handler::Optimizer;
-use schemars::JsonSchema;
-use segment::types::HnswConfig;
-use serde::{Deserialize, Serialize};
-use std::cmp::{max, min};
-use std::path::Path;
-use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 pub struct OptimizersConfig {

--- a/lib/collection/src/shard/collection_shard_distribution.rs
+++ b/lib/collection/src/shard/collection_shard_distribution.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
+use std::path::Path;
+
 use crate::config::CollectionConfig;
 use crate::operations::types::CollectionResult;
 use crate::shard::shard_config::{ShardConfig, ShardType};
 use crate::shard::{shard_path, PeerId, ShardId};
-use std::collections::HashMap;
-use std::path::Path;
 
 #[derive(Debug)]
 pub struct CollectionShardDistribution {

--- a/lib/collection/src/shard/conversions.rs
+++ b/lib/collection/src/shard/conversions.rs
@@ -1,8 +1,3 @@
-use crate::operations::payload_ops::{DeletePayload, SetPayload};
-use crate::operations::point_ops::PointInsertOperations;
-use crate::operations::types::CollectionResult;
-use crate::operations::CreateIndex;
-use crate::shard::remote_shard::RemoteShard;
 use api::grpc::conversions::payload_to_proto;
 use api::grpc::qdrant::points_selector::PointsSelectorOneOf;
 use api::grpc::qdrant::{
@@ -14,6 +9,12 @@ use api::grpc::qdrant::{
 };
 use segment::types::{Filter, PointIdType};
 use tonic::Status;
+
+use crate::operations::payload_ops::{DeletePayload, SetPayload};
+use crate::operations::point_ops::PointInsertOperations;
+use crate::operations::types::CollectionResult;
+use crate::operations::CreateIndex;
+use crate::shard::remote_shard::RemoteShard;
 
 pub fn internal_upsert_points(
     point_insert_operations: PointInsertOperations,

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -12,13 +12,13 @@ use indicatif::ProgressBar;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::index::field_index::CardinalityEstimation;
-use tokio::fs::{copy, create_dir_all};
-use tokio::runtime::{self, Runtime};
-use tokio::sync::{mpsc, mpsc::UnboundedSender, Mutex, RwLock as TokioRwLock};
-
 use segment::segment::Segment;
 use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::{Filter, PayloadStorageType, PointIdType, SegmentConfig};
+use tokio::fs::{copy, create_dir_all};
+use tokio::runtime::{self, Runtime};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{mpsc, Mutex, RwLock as TokioRwLock};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::SegmentHolder;

--- a/lib/collection/src/shard/local_shard_operations.rs
+++ b/lib/collection/src/shard/local_shard_operations.rs
@@ -1,3 +1,15 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use itertools::Itertools;
+use segment::types::{
+    ExtendedPointId, Filter, PayloadIndexInfo, PayloadKeyType, ScoredPoint, SegmentType,
+    WithPayload, WithPayloadInterface,
+};
+use tokio::runtime::Handle;
+use tokio::sync::oneshot;
+
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CollectionStatus, CountRequest, CountResult,
@@ -7,16 +19,6 @@ use crate::operations::CollectionUpdateOperations;
 use crate::shard::local_shard::LocalShard;
 use crate::shard::ShardOperation;
 use crate::update_handler::{OperationData, UpdateSignal};
-use async_trait::async_trait;
-use itertools::Itertools;
-use segment::types::{
-    ExtendedPointId, Filter, PayloadIndexInfo, PayloadKeyType, ScoredPoint, SegmentType,
-    WithPayload, WithPayloadInterface,
-};
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tokio::sync::oneshot;
 
 #[async_trait]
 impl ShardOperation for &LocalShard {

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -6,10 +6,15 @@ pub mod proxy_shard;
 pub mod remote_shard;
 pub mod shard_config;
 
-use crate::shard::proxy_shard::ProxyShard;
-use crate::shard::remote_shard::RemoteShard;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use api::grpc::transport_channel_pool::TransportChannelPool;
+use async_trait::async_trait;
+use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
+use tokio::runtime::Handle;
+use tonic::transport::Uri;
 
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
@@ -17,12 +22,8 @@ use crate::operations::types::{
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shard::local_shard::LocalShard;
-use api::grpc::transport_channel_pool::TransportChannelPool;
-use async_trait::async_trait;
-use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tonic::transport::Uri;
+use crate::shard::proxy_shard::ProxyShard;
+use crate::shard::remote_shard::RemoteShard;
 
 pub type ShardId = u32;
 

--- a/lib/collection/src/shard/proxy_shard.rs
+++ b/lib/collection/src/shard/proxy_shard.rs
@@ -1,3 +1,17 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use segment::types::{
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
+};
+use tokio::runtime::Handle;
+use tokio::sync::{oneshot, RwLock};
+use tokio::time::timeout;
+
 use crate::operations::operation_effect::{
     EstimateOperationEffectArea, OperationEffectArea, PointsOperationEffect,
 };
@@ -9,18 +23,6 @@ use crate::operations::CollectionUpdateOperations;
 use crate::shard::local_shard::LocalShard;
 use crate::shard::ShardOperation;
 use crate::update_handler::UpdateSignal;
-use async_trait::async_trait;
-use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
-};
-use std::collections::HashSet;
-use std::path::Path;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::runtime::Handle;
-use tokio::sync::{oneshot, RwLock};
-use tokio::time::timeout;
 
 type ChangedPointsSet = Arc<RwLock<HashSet<PointIdType>>>;
 

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -1,3 +1,19 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use api::grpc::qdrant::collections_internal_client::CollectionsInternalClient;
+use api::grpc::qdrant::points_internal_client::PointsInternalClient;
+use api::grpc::qdrant::{
+    CountPoints, CountPointsInternal, GetCollectionInfoRequest, GetCollectionInfoRequestInternal,
+    GetPoints, GetPointsInternal, ScrollPoints, ScrollPointsInternal, SearchPoints,
+    SearchPointsInternal,
+};
+use async_trait::async_trait;
+use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
+use tokio::runtime::Handle;
+use tonic::transport::{Channel, Uri};
+use tonic::Status;
+
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::PointOperations;
 use crate::operations::types::{
@@ -12,20 +28,6 @@ use crate::shard::conversions::{
 };
 use crate::shard::shard_config::ShardConfig;
 use crate::shard::{ChannelService, CollectionId, PeerId, ShardId, ShardOperation};
-use api::grpc::qdrant::{
-    collections_internal_client::CollectionsInternalClient,
-    points_internal_client::PointsInternalClient, CountPoints, CountPointsInternal,
-    GetCollectionInfoRequest, GetCollectionInfoRequestInternal, GetPoints, GetPointsInternal,
-    ScrollPoints, ScrollPointsInternal, SearchPoints, SearchPointsInternal,
-};
-use async_trait::async_trait;
-use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tonic::transport::Channel;
-use tonic::transport::Uri;
-use tonic::Status;
 
 /// RemoteShard
 ///

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::operations::types::CollectionResult;
-use crate::shard::PeerId;
 use segment::common::file_operations::{atomic_save_json, read_json};
 use serde::{Deserialize, Serialize};
+
+use crate::operations::types::CollectionResult;
+use crate::shard::PeerId;
 
 pub const SHARD_CONFIG_FILE: &str = "shard_config.json";
 

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -1,6 +1,7 @@
+use serde::Serialize;
+
 use crate::config::CollectionConfig;
 use crate::operations::types::{CollectionStatus, OptimizersStatus};
-use serde::Serialize;
 
 #[derive(Serialize, Clone)]
 pub struct CollectionTelemetry {

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,16 +1,18 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::join_all;
+use itertools::Itertools;
+use parking_lot::RwLock;
+use tempdir::TempDir;
+use tokio::time::{sleep, Instant};
+
 use crate::collection::Collection;
 use crate::collection_manager::fixtures::{
     get_indexing_optimizer, get_merge_optimizer, random_segment,
 };
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder, SegmentId};
 use crate::update_handler::{Optimizer, UpdateHandler};
-use futures::future::join_all;
-use itertools::Itertools;
-use parking_lot::RwLock;
-use std::sync::Arc;
-use std::time::Duration;
-use tempdir::TempDir;
-use tokio::time::{sleep, Instant};
 
 #[tokio::test]
 async fn test_optimization_process() {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,17 @@
+use std::cmp::min;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use log::{debug, error, info, trace, warn};
+use segment::entry::entry_point::OperationResult;
+use segment::types::SeqNumberType;
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::JoinHandle;
+use tokio::time::Duration;
+
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::optimizers::segment_optimizer::SegmentOptimizer;
@@ -5,20 +19,6 @@ use crate::common::stoppable_task::{spawn_stoppable, StoppableTaskHandle};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
 use crate::wal::SerdeWal;
-use itertools::Itertools;
-use log::{debug, error, info, trace, warn};
-use segment::entry::entry_point::OperationResult;
-use segment::types::SeqNumberType;
-use std::cmp::min;
-use std::collections::HashSet;
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tokio::sync::{
-    mpsc::{self, UnboundedReceiver, UnboundedSender},
-    oneshot, Mutex,
-};
-use tokio::task::JoinHandle;
-use tokio::time::Duration;
 
 pub type Optimizer = dyn SegmentOptimizer + Sync + Send;
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -1,15 +1,14 @@
 extern crate serde_cbor;
 extern crate wal;
 
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::result;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use thiserror::Error;
-use wal::Wal;
-use wal::WalOptions;
+use wal::{Wal, WalOptions};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
@@ -122,6 +121,7 @@ mod tests {
 
     use std::fs;
     use std::os::unix::fs::MetadataExt;
+
     use tempdir::TempDir;
 
     #[test]

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -1,13 +1,10 @@
+use collection::operations::point_ops::{Batch, PointInsertOperations, PointOperations};
+use collection::operations::types::ScrollRequest;
+use collection::operations::CollectionUpdateOperations;
 use itertools::Itertools;
+use segment::types::{PayloadSelectorExclude, WithPayloadInterface};
 use serde_json::Value;
 use tempdir::TempDir;
-
-use collection::operations::{
-    point_ops::{Batch, PointInsertOperations, PointOperations},
-    types::ScrollRequest,
-    CollectionUpdateOperations,
-};
-use segment::types::{PayloadSelectorExclude, WithPayloadInterface};
 
 use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
 

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -1,22 +1,19 @@
-use itertools::Itertools;
 use std::collections::HashSet;
 
-use tempdir::TempDir;
-use tokio::runtime::Handle;
-
-use collection::operations::{
-    payload_ops::{PayloadOps, SetPayload},
-    point_ops::{PointOperations, PointStruct},
-    types::{RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus},
-    CollectionUpdateOperations,
+use collection::operations::payload_ops::{PayloadOps, SetPayload};
+use collection::operations::point_ops::{Batch, PointOperations, PointStruct};
+use collection::operations::types::{
+    CountRequest, PointRequest, RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus,
 };
+use collection::operations::CollectionUpdateOperations;
+use itertools::Itertools;
 use segment::types::{
     Condition, FieldCondition, Filter, HasIdCondition, Payload, PointIdType, WithPayloadInterface,
 };
+use tempdir::TempDir;
+use tokio::runtime::Handle;
 
 use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
-use collection::operations::point_ops::Batch;
-use collection::operations::types::{CountRequest, PointRequest};
 
 mod common;
 

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -1,3 +1,6 @@
+use std::num::NonZeroU32;
+use std::path::Path;
+
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::types::CollectionError;
@@ -5,8 +8,6 @@ use collection::optimizers_builder::OptimizersConfig;
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
 use collection::shard::{ChannelService, CollectionId};
 use segment::types::Distance;
-use std::num::NonZeroU32;
-use std::path::Path;
 
 /// Test collections for this upper bound of shards.
 /// Testing with more shards is problematic due to `number of open files problem`

--- a/lib/collection/tests/pagination_test.rs
+++ b/lib/collection/tests/pagination_test.rs
@@ -1,9 +1,10 @@
-use crate::common::{simple_collection_fixture, N_SHARDS};
 use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
 use collection::operations::types::SearchRequest;
 use collection::operations::CollectionUpdateOperations;
 use segment::types::WithPayloadInterface;
 use tokio::runtime::Handle;
+
+use crate::common::{simple_collection_fixture, N_SHARDS};
 
 mod common;
 

--- a/lib/collection/tests/snapshot_test.rs
+++ b/lib/collection/tests/snapshot_test.rs
@@ -1,10 +1,12 @@
-use crate::common::TEST_OPTIMIZERS_CONFIG;
+use std::num::NonZeroU32;
+
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
 use collection::shard::{ChannelService, Shard};
 use segment::types::Distance;
-use std::num::NonZeroU32;
+
+use crate::common::TEST_OPTIMIZERS_CONFIG;
 
 mod common;
 

--- a/lib/segment/benches/id_type_benchmark.rs
+++ b/lib/segment/benches/id_type_benchmark.rs
@@ -1,9 +1,10 @@
 mod prof;
 
+use std::collections::{BTreeMap, HashMap};
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/lib/segment/benches/prof.rs
+++ b/lib/segment/benches/prof.rs
@@ -1,5 +1,7 @@
+use std::fs::File;
 use std::io::Write;
-use std::{fs::File, os::raw::c_int, path::Path};
+use std::os::raw::c_int;
+use std::path::Path;
 
 use criterion::profiler::Profiler;
 use pprof::flamegraph::TextTruncateDirection;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -1,15 +1,15 @@
+use std::path::Path;
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Standard;
 use rand::Rng;
-use std::path::Path;
-use std::sync::Arc;
-use tempdir::TempDir;
-
 use segment::common::rocksdb_operations::open_db;
 use segment::types::{Distance, VectorElementType};
 use segment::vector_storage::simple_vector_storage::open_simple_vector_storage;
 use segment::vector_storage::VectorStorageSS;
+use tempdir::TempDir;
 
 const NUM_VECTORS: usize = 50000;
 const DIM: usize = 1000; // Larger dimensionality - greater the SIMD advantage

--- a/lib/segment/src/common/arc_atomic_ref_cell_iterator.rs
+++ b/lib/segment/src/common/arc_atomic_ref_cell_iterator.rs
@@ -1,5 +1,6 @@
-use atomic_refcell::AtomicRefCell;
 use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
 
 /// Intermediate data structure intended to help returning an iterator
 /// which depends on some guarded internal object.

--- a/lib/segment/src/common/file_operations.rs
+++ b/lib/segment/src/common/file_operations.rs
@@ -1,13 +1,12 @@
-use atomicwrites::AtomicFile;
-use atomicwrites::Error as AtomicIoError;
-use atomicwrites::OverwriteBehavior::AllowOverwrite;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::fs::File;
-use std::io::Error as IoError;
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufWriter, Error as IoError, Read, Write};
 use std::path::Path;
 use std::result;
+
+use atomicwrites::OverwriteBehavior::AllowOverwrite;
+use atomicwrites::{AtomicFile, Error as AtomicIoError};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]

--- a/lib/segment/src/common/rocksdb_operations.rs
+++ b/lib/segment/src/common/rocksdb_operations.rs
@@ -1,7 +1,8 @@
-use atomic_refcell::AtomicRefCell;
-use rocksdb::{Error, LogLevel, Options, WriteOptions, DB};
 use std::path::Path;
 use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use rocksdb::{Error, LogLevel, Options, WriteOptions, DB};
 
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 const DB_MAX_LOG_SIZE: usize = 1024 * 1024; // 1 mb

--- a/lib/segment/src/common/version.rs
+++ b/lib/segment/src/common/version.rs
@@ -1,8 +1,10 @@
-use crate::common::file_operations::{FileOperationResult, FileStorageError};
-use atomicwrites::{AllowOverwrite, AtomicFile};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+
+use atomicwrites::{AllowOverwrite, AtomicFile};
+
+use crate::common::file_operations::{FileOperationResult, FileStorageError};
 
 pub const VERSION_FILE: &str = "version.info";
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -1,3 +1,13 @@
+use std::collections::HashMap;
+use std::io::Error as IoError;
+use std::path::{Path, PathBuf};
+use std::result;
+
+use atomicwrites::Error as AtomicIoError;
+use rayon::ThreadPoolBuildError;
+use rocksdb::Error;
+use thiserror::Error;
+
 use crate::common::file_operations::FileStorageError;
 use crate::index::field_index::CardinalityEstimation;
 use crate::types::{
@@ -5,14 +15,6 @@ use crate::types::{
     ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
     VectorElementType, WithPayload,
 };
-use atomicwrites::Error as AtomicIoError;
-use rayon::ThreadPoolBuildError;
-use rocksdb::Error;
-use std::collections::HashMap;
-use std::io::Error as IoError;
-use std::path::{Path, PathBuf};
-use std::result;
-use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -1,11 +1,13 @@
+use std::marker::PhantomData;
+
+use bitvec::prelude::BitVec;
+use rand::Rng;
+
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
 use crate::types::{PointOffsetType, VectorElementType};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::simple_vector_storage::SimpleRawScorer;
-use bitvec::prelude::BitVec;
-use rand::Rng;
-use std::marker::PhantomData;
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
     (0..size).map(|_| rnd_gen.gen_range(0.0..1.0)).collect()

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -1,3 +1,10 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use rand::prelude::StdRng;
+use rand::SeedableRng;
+
 use crate::entry::entry_point::OperationResult;
 use crate::fixtures::payload_fixtures::{
     generate_diverse_payload, FLT_KEY, GEO_KEY, INT_KEY, STR_KEY,
@@ -10,11 +17,6 @@ use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::payload_storage::PayloadStorage;
 use crate::types::{PayloadSchemaType, PointIdType, PointOffsetType, SeqNumberType};
-use atomic_refcell::AtomicRefCell;
-use rand::prelude::StdRng;
-use rand::SeedableRng;
-use std::path::Path;
-use std::sync::Arc;
 
 /// Warn: Use for tests only
 ///

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,12 +1,14 @@
-use crate::types::{
-    Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, IsEmptyCondition, Payload,
-    PayloadField, Range as RangeCondition, ValuesCount, VectorElementType,
-};
+use std::ops::{Range, RangeInclusive};
+
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
-use std::ops::{Range, RangeInclusive};
+
+use crate::types::{
+    Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, IsEmptyCondition, Payload,
+    PayloadField, Range as RangeCondition, ValuesCount, VectorElementType,
+};
 
 const ADJECTIVE: &[&str] = &[
     "jobless",

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -1,14 +1,16 @@
-use crate::common::rocksdb_operations::{db_write_options, DB_MAPPING_CF, DB_VERSIONS_CF};
-use crate::entry::entry_point::OperationResult;
-use crate::id_tracker::IdTracker;
-use crate::types::{ExtendedPointId, PointIdType, PointOffsetType, SeqNumberType};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use bincode;
 use rocksdb::{IteratorMode, DB};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
 use uuid::Uuid;
+
+use crate::common::rocksdb_operations::{db_write_options, DB_MAPPING_CF, DB_VERSIONS_CF};
+use crate::entry::entry_point::OperationResult;
+use crate::id_tracker::IdTracker;
+use crate::types::{ExtendedPointId, PointIdType, PointOffsetType, SeqNumberType};
 
 /// Point Id type used for storing ids internally
 /// Should be serializable by `bincode`, therefore is not untagged.
@@ -229,11 +231,12 @@ impl IdTracker for SimpleIdTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::common::rocksdb_operations::open_db;
     use itertools::Itertools;
     use serde::de::DeserializeOwned;
     use tempdir::TempDir;
+
+    use super::*;
+    use crate::common::rocksdb_operations::open_db;
 
     fn check_bincode_serialization<
         T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug,

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 use crate::entry::entry_point::OperationResult;
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::map_index::MapIndex;
@@ -6,7 +8,6 @@ use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::types::{
     FieldCondition, FloatPayloadType, IntPayloadType, PayloadKeyType, PointOffsetType,
 };
-use serde_json::Value;
 
 pub trait PayloadFieldIndex {
     /// Return number of points with at least one value indexed in here

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -1,9 +1,11 @@
-use crate::types::{GeoBoundingBox, GeoPoint, GeoRadius};
+use std::ops::Range;
+
 use geo::algorithm::haversine_distance::HaversineDistance;
 use geo::{Coordinate, Point};
 use geohash::{decode, decode_bbox, encode, Direction, GeohashError};
 use itertools::Itertools;
-use std::ops::Range;
+
+use crate::types::{GeoBoundingBox, GeoPoint, GeoRadius};
 
 pub type GeoHash = String;
 
@@ -283,9 +285,10 @@ fn minimum_bounding_rectangle_for_circle(circle: &GeoRadius) -> GeoBoundingBox {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+
+    use super::*;
 
     const BERLIN: GeoPoint = GeoPoint {
         lat: 52.52437,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -1,3 +1,13 @@
+use std::cmp::{max, min};
+use std::collections::{BTreeMap, HashSet};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use itertools::Itertools;
+use rocksdb::{IteratorMode, DB};
+use serde_json::Value;
+
 use crate::common::rocksdb_operations::{db_write_options, recreate_cf};
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
@@ -11,14 +21,6 @@ use crate::index::field_index::{
 use crate::types::{
     FieldCondition, GeoBoundingBox, GeoPoint, GeoRadius, PayloadKeyType, PointOffsetType,
 };
-use atomic_refcell::AtomicRefCell;
-use itertools::Itertools;
-use rocksdb::{IteratorMode, DB};
-use serde_json::Value;
-use std::cmp::{max, min};
-use std::collections::{BTreeMap, HashSet};
-use std::str::FromStr;
-use std::sync::Arc;
 
 /// Max number of sub-regions computed for an input geo query
 // TODO discuss value, should it be dynamically computed?
@@ -545,15 +547,16 @@ impl PayloadFieldIndex for GeoMapIndex {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::common::rocksdb_operations::open_db_with_existing_cf;
-    use crate::fixtures::payload_fixtures::random_geo_payload;
-    use crate::types::GeoRadius;
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::SeedableRng;
     use serde_json::json;
     use tempdir::TempDir;
+
+    use super::*;
+    use crate::common::rocksdb_operations::open_db_with_existing_cf;
+    use crate::fixtures::payload_fixtures::random_geo_payload;
+    use crate::types::GeoRadius;
 
     const NYC: GeoPoint = GeoPoint {
         lat: 40.75798,

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -1,8 +1,9 @@
-use itertools::Itertools;
 use std::cmp::{max, min, Ordering};
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::ops::Bound;
+
+use itertools::Itertools;
 
 const MIN_BUCKET_SIZE: usize = 10;
 
@@ -612,15 +613,17 @@ impl Histogram {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use itertools::Itertools;
-    use rand::prelude::StdRng;
-    use rand::{Rng, SeedableRng};
-    use rand_distr::StandardNormal;
     use std::cell::Cell;
     use std::collections::BTreeSet;
     use std::io;
     use std::io::Write;
+
+    use itertools::Itertools;
+    use rand::prelude::StdRng;
+    use rand::{Rng, SeedableRng};
+    use rand_distr::StandardNormal;
+
+    use super::*;
 
     #[allow(dead_code)]
     fn print_results(points_index: &BTreeSet<Point>, histogram: &Histogram, pnt: Option<Point>) {

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use rocksdb::DB;
+
 use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::map_index::MapIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
 use crate::index::field_index::FieldIndex;
 use crate::types::{FloatPayloadType, IntPayloadType, PayloadSchemaType};
-use atomic_refcell::AtomicRefCell;
-use rocksdb::DB;
-use std::sync::Arc;
 
 /// Selects index types based on field type
 pub fn index_selector(

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -1,24 +1,23 @@
 use std::collections::{BTreeSet, HashMap};
+use std::fmt::Display;
 use std::hash::Hash;
 use std::iter;
+use std::str::FromStr;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
+use rocksdb::{IteratorMode, DB};
 use serde_json::Value;
 
 use crate::common::rocksdb_operations::{db_write_options, recreate_cf};
 use crate::entry::entry_point::{OperationError, OperationResult};
-use crate::index::field_index::PayloadFieldIndex;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
 };
 use crate::types::{
     FieldCondition, IntPayloadType, Match, MatchValue, PayloadKeyType, PointOffsetType,
     ValueVariants,
 };
-use atomic_refcell::AtomicRefCell;
-use rocksdb::{IteratorMode, DB};
-use std::fmt::Display;
-use std::str::FromStr;
-use std::sync::Arc;
 
 /// HashMap-based type of index
 pub struct MapIndex<N: Hash + Eq + Clone + Display> {
@@ -365,14 +364,15 @@ impl ValueIndexer<IntPayloadType> for MapIndex<IntPayloadType> {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::rocksdb_operations::open_db_with_existing_cf;
     use std::collections::HashSet;
     use std::fmt::Debug;
     use std::iter::FromIterator;
     use std::path::Path;
+
     use tempdir::TempDir;
 
     use super::*;
+    use crate::common::rocksdb_operations::open_db_with_existing_cf;
 
     const FIELD_NAME: &str = "test";
 

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -1,5 +1,6 @@
-use crate::types::{FieldCondition, IsEmptyCondition, PointOffsetType};
 use std::collections::HashSet;
+
+use crate::types::{FieldCondition, IsEmptyCondition, PointOffsetType};
 
 mod field_index_base;
 pub mod geo_hash;

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -552,13 +552,13 @@ impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::rocksdb_operations::open_db_with_existing_cf;
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
     use tempdir::TempDir;
 
     use super::*;
+    use crate::common::rocksdb_operations::open_db_with_existing_cf;
 
     const COLUMN_NAME: &str = "test";
 

--- a/lib/segment/src/index/field_index/stat_tools.rs
+++ b/lib/segment/src/index/field_index/stat_tools.rs
@@ -72,11 +72,13 @@ fn prob_not_select(total: usize, avg: f64, selected: usize) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashSet;
+
     use rand::prelude::StdRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
-    use std::collections::HashSet;
+
+    use super::*;
 
     fn simulate(uniq: usize, avg: usize, selected: usize) -> usize {
         let mut data: Vec<_> = vec![];

--- a/lib/segment/src/index/hnsw_index/build_cache.rs
+++ b/lib/segment/src/index/hnsw_index/build_cache.rs
@@ -1,7 +1,9 @@
-use crate::types::{PointOffsetType, ScoreType};
-use seahash::SeaHasher;
 use std::cmp::{max, min};
 use std::hash::{Hash, Hasher};
+
+use seahash::SeaHasher;
+
+use crate::types::{PointOffsetType, ScoreType};
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 struct PointPair {

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -1,7 +1,9 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
 use crate::common::file_operations::{atomic_save_json, read_json};
 use crate::entry::entry_point::OperationResult;
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 
 pub const HNSW_INDEX_CONFIG_FILE: &str = "hnsw_config.json";
 

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -1,7 +1,9 @@
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
 use crate::spaces::tools::FixedLengthPriorityQueue;
 use crate::types::PointOffsetType;
-use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct EntryPoint {
@@ -113,8 +115,9 @@ impl EntryPoints {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rand::Rng;
+
+    use super::*;
 
     #[test]
     fn test_entry_points() {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -1,3 +1,9 @@
+use std::cmp::max;
+use std::path::{Path, PathBuf};
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
 use crate::common::file_operations::{atomic_save_bin, read_bin};
 use crate::common::utils::rev_range;
 use crate::entry::entry_point::OperationResult;
@@ -8,10 +14,6 @@ use crate::index::visited_pool::{VisitedList, VisitedPool};
 use crate::spaces::tools::FixedLengthPriorityQueue;
 use crate::types::PointOffsetType;
 use crate::vector_storage::ScoredPointOffset;
-use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use std::cmp::max;
-use std::path::{Path, PathBuf};
 
 pub type LinkContainer = Vec<PointOffsetType>;
 pub type LinkContainerRef<'a> = &'a [PointOffsetType];
@@ -291,6 +293,14 @@ impl GraphLayers {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+    use std::io::Write;
+
+    use itertools::Itertools;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use tempdir::TempDir;
+
     use super::*;
     use crate::fixtures::index_fixtures::{
         random_vector, FakeFilterContext, TestRawScorerProducer,
@@ -299,12 +309,6 @@ mod tests {
     use crate::spaces::metric::Metric;
     use crate::spaces::simple::{CosineMetric, DotProductMetric};
     use crate::types::VectorElementType;
-    use itertools::Itertools;
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    use std::fs::File;
-    use std::io::Write;
-    use tempdir::TempDir;
 
     fn search_in_graph(
         query: &[VectorElementType],

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -1,3 +1,11 @@
+use std::cmp::min;
+use std::collections::BinaryHeap;
+use std::sync::atomic::AtomicUsize;
+
+use parking_lot::{Mutex, RwLock};
+use rand::distributions::Uniform;
+use rand::Rng;
+
 use crate::index::hnsw_index::entry_points::EntryPoints;
 use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LinkContainer};
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
@@ -5,12 +13,6 @@ use crate::index::visited_pool::{VisitedList, VisitedPool};
 use crate::spaces::tools::FixedLengthPriorityQueue;
 use crate::types::{PointOffsetType, ScoreType};
 use crate::vector_storage::ScoredPointOffset;
-use parking_lot::{Mutex, RwLock};
-use rand::distributions::Uniform;
-use rand::Rng;
-use std::cmp::min;
-use std::collections::BinaryHeap;
-use std::sync::atomic::AtomicUsize;
 
 pub type LockedLinkContainer = RwLock<LinkContainer>;
 pub type LockedLayersContainer = Vec<LockedLinkContainer>;
@@ -375,21 +377,21 @@ impl GraphLayersBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::index_fixtures::{
-        random_vector, FakeFilterContext, TestRawScorerProducer,
-    };
-
-    use super::*;
-    use crate::index::hnsw_index::tests::create_graph_layer_fixture;
-    use crate::spaces::metric::Metric;
-    use crate::spaces::simple::{CosineMetric, EuclidMetric};
-    use crate::types::VectorElementType;
-    use crate::vector_storage::RawScorer;
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
     use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+
+    use super::*;
+    use crate::fixtures::index_fixtures::{
+        random_vector, FakeFilterContext, TestRawScorerProducer,
+    };
+    use crate::index::hnsw_index::tests::create_graph_layer_fixture;
+    use crate::spaces::metric::Metric;
+    use crate::spaces::simple::{CosineMetric, EuclidMetric};
+    use crate::types::VectorElementType;
+    use crate::vector_storage::RawScorer;
 
     const M: usize = 8;
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1,29 +1,30 @@
+use std::cmp::max;
+use std::fs::create_dir_all;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use log::debug;
+use rand::thread_rng;
+use rayon::prelude::*;
+use rayon::ThreadPool;
+
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::sample_estimation::sample_check_cardinality;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::visited_pool::VisitedList;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::types::Condition::Field;
 use crate::types::{
     FieldCondition, Filter, HnswConfig, SearchParams, VectorElementType, VECTOR_ELEMENT_SIZE,
 };
 use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
-use atomic_refcell::AtomicRefCell;
-use log::debug;
-
-use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::visited_pool::VisitedList;
-use rand::thread_rng;
-use rayon::prelude::*;
-use rayon::ThreadPool;
-use std::cmp::max;
-use std::fs::create_dir_all;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 const HNSW_USE_HEURISTIC: bool = true;
 const BYTES_IN_KB: usize = 1024;

--- a/lib/segment/src/index/hnsw_index/search_context.rs
+++ b/lib/segment/src/index/hnsw_index/search_context.rs
@@ -1,9 +1,11 @@
+use std::collections::BinaryHeap;
+use std::iter::FromIterator;
+
+use num_traits::float::FloatCore;
+
 use crate::spaces::tools::FixedLengthPriorityQueue;
 use crate::types::ScoreType;
 use crate::vector_storage::ScoredPointOffset;
-use num_traits::float::FloatCore;
-use std::collections::BinaryHeap;
-use std::iter::FromIterator;
 
 /// Structure that holds context of the search
 pub struct SearchContext {

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -1,10 +1,11 @@
+use rand::Rng;
+
 use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::spaces::metric::Metric;
 use crate::types::PointOffsetType;
-use rand::Rng;
 
 pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
     num_vectors: usize,

--- a/lib/segment/src/index/index_base.rs
+++ b/lib/segment/src/index/index_base.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::Value;
+
 use crate::entry::entry_point::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::payload_storage::FilterContext;
@@ -6,9 +11,6 @@ use crate::types::{
     SearchParams, VectorElementType,
 };
 use crate::vector_storage::ScoredPointOffset;
-use serde_json::Value;
-use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
 
 /// Trait for vector searching
 pub trait VectorIndex {

--- a/lib/segment/src/index/key_encoding.rs
+++ b/lib/segment/src/index/key_encoding.rs
@@ -157,10 +157,11 @@ pub fn decode_i64_key_ascending(buf: &[u8]) -> (u32, i64) {
 
 #[cfg(test)]
 mod tests {
+    use std::cmp::Ordering;
+
     use crate::index::key_encoding::{
         decode_f64_ascending, decode_i64_ascending, encode_f64_ascending, encode_i64_ascending,
     };
-    use std::cmp::Ordering;
 
     #[test]
     fn test_encode_f64() {

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
 use crate::common::file_operations::{atomic_save_json, read_json};
 use crate::entry::entry_point::OperationResult;
 use crate::types::{PayloadKeyType, PayloadSchemaType};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 
 pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "config.json";
 

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,11 +1,11 @@
-use crate::index::{PayloadIndex, VectorIndex};
-use crate::payload_storage::{ConditionCheckerSS, FilterContext};
-use crate::types::{
-    Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointOffsetType,
-    SearchParams, VectorElementType,
-};
-use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 use std::collections::HashMap;
+use std::fs::create_dir_all;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use schemars::_serde_json::Value;
 
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::entry::entry_point::OperationResult;
@@ -13,12 +13,13 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use atomic_refcell::AtomicRefCell;
-use schemars::_serde_json::Value;
-use std::fs::create_dir_all;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use crate::index::{PayloadIndex, VectorIndex};
+use crate::payload_storage::{ConditionCheckerSS, FilterContext};
+use crate::types::{
+    Filter, Payload, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType, PointOffsetType,
+    SearchParams, VectorElementType,
+};
+use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -3,10 +3,12 @@
 //! Filter query is used e.g. for determining how would be faster to process the query:
 //! - use vector index or payload index first
 
+use std::cmp::{max, min};
+
+use itertools::Itertools;
+
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::types::{Condition, Filter};
-use itertools::Itertools;
-use std::cmp::{max, min};
 
 pub fn combine_should_estimations(
     estimations: &[CardinalityEstimation],
@@ -169,10 +171,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::types::{FieldCondition, HasIdCondition};
     use std::collections::HashSet;
     use std::iter::FromIterator;
+
+    use super::*;
+    use crate::types::{FieldCondition, HasIdCondition};
 
     const TOTAL: usize = 1000;
 

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
@@ -8,7 +10,6 @@ use crate::types::{
     Condition, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoRadius, Match, MatchValue,
     PointOffsetType, Range, ValueVariants,
 };
-use std::collections::HashSet;
 
 pub fn condition_converter<'a>(
     condition: &'a Condition,

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -1,3 +1,8 @@
+use std::cmp::Reverse;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
 use crate::index::query_estimator::{
@@ -7,9 +12,6 @@ use crate::index::query_optimization::condition_converter::condition_converter;
 use crate::index::query_optimization::optimized_filter::{OptimizedCondition, OptimizedFilter};
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::types::{Condition, Filter, PayloadKeyType};
-use itertools::Itertools;
-use std::cmp::Reverse;
-use std::collections::HashMap;
 
 pub type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;
 

--- a/lib/segment/src/index/query_optimization/payload_provider.rs
+++ b/lib/segment/src/index/query_optimization/payload_provider.rs
@@ -1,8 +1,10 @@
-use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::types::{OwnedPayloadRef, Payload, PointOffsetType};
-use atomic_refcell::AtomicRefCell;
 use std::ops::Deref;
 use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::types::{OwnedPayloadRef, Payload, PointOffsetType};
 
 #[derive(Clone)]
 pub struct PayloadProvider {

--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -1,5 +1,6 @@
-use crate::types::PointOffsetType;
 use std::cmp::{max, min};
+
+use crate::types::PointOffsetType;
 
 const MAX_ESTIMATED_POINTS: usize = 1000;
 
@@ -64,9 +65,10 @@ pub fn sample_check_cardinality(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+
+    use super::*;
 
     #[test]
     fn test_confidence_interval() {

--- a/lib/segment/src/index/struct_filter_context.rs
+++ b/lib/segment/src/index/struct_filter_context.rs
@@ -1,10 +1,8 @@
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
-
 use crate::index::query_optimization::optimized_filter::{check_optimized_filter, OptimizedFilter};
 use crate::index::query_optimization::optimizer::{optimize_filter, IndexesMap};
 use crate::index::query_optimization::payload_provider::PayloadProvider;
-
 use crate::payload_storage::FilterContext;
 use crate::types::{Condition, Filter, PointOffsetType};
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -2,21 +2,21 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{create_dir_all, remove_file};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-
 use std::sync::Arc;
 
-use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
-use crate::common::rocksdb_operations::open_db_with_existing_cf;
 use atomic_refcell::AtomicRefCell;
 use log::debug;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
+use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
+use crate::common::rocksdb_operations::open_db_with_existing_cf;
 use crate::entry::entry_point::OperationResult;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::index_selector::index_selector;
-use crate::index::field_index::FieldIndex;
-use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
+use crate::index::field_index::{
+    CardinalityEstimation, FieldIndex, PayloadBlockCondition, PrimaryCondition,
+};
 use crate::index::payload_config::PayloadConfig;
 use crate::index::query_estimator::estimate_filter;
 use crate::index::query_optimization::optimizer::IndexesMap;

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -1,7 +1,8 @@
 //! Structures for fast and tread-safe way to check if some points were visited or not
 
-use crate::types::PointOffsetType;
 use parking_lot::RwLock;
+
+use crate::types::PointOffsetType;
 
 /// Max number of visited lists to preserve in memory
 /// If more than this number of concurrent requests occurred - new list will be created dynamically,

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,9 +1,10 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
+use serde_json::Value;
+
 use crate::types::{
     GeoBoundingBox, GeoRadius, Match, MatchValue, Range, ValueVariants, ValuesCount,
 };
-use serde_json::Value;
 
 pub trait ValueChecker {
     fn check_match(&self, payload: &Value) -> bool;
@@ -86,9 +87,10 @@ impl ValueChecker for ValuesCount {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::types::GeoPoint;
-    use serde_json::json;
 
     #[test]
     fn test_geo_matching() {

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use crate::entry::entry_point::OperationResult;
 use crate::types::{Payload, PointOffsetType};
-use std::collections::HashMap;
 
 /// Same as `SimplePayloadStorage` but without persistence
 /// Warn: for tests only

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,4 +1,3 @@
-use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 use std::collections::HashMap;
 
 use serde_json::Value;
@@ -6,6 +5,7 @@ use serde_json::Value;
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::PayloadStorage;
+use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 
 impl PayloadStorage for InMemoryPayloadStorage {
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
@@ -56,12 +56,14 @@ impl PayloadStorage for InMemoryPayloadStorage {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
+    use serde_json::json;
+
     use super::*;
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::payload_storage::query_checker::check_payload;
     use crate::types::{Condition, FieldCondition, Filter, OwnedPayloadRef};
-    use serde_json::json;
-    use std::cell::RefCell;
 
     #[test]
     fn test_condition_checking() {

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -1,13 +1,13 @@
-use crate::common::rocksdb_operations::{db_options, db_write_options, DB_PAYLOAD_CF};
-use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
-use atomic_refcell::AtomicRefCell;
 use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use rocksdb::{IteratorMode, DB};
 use serde_json::Value;
 
+use crate::common::rocksdb_operations::{db_options, db_write_options, DB_PAYLOAD_CF};
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::payload_storage::PayloadStorage;
+use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 
 /// On-disk implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, does not keep payload in memory

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -1,6 +1,7 @@
+use serde_json::Value;
+
 use crate::entry::entry_point::OperationResult;
 use crate::types::{Filter, Payload, PayloadKeyTypeRef, PointOffsetType};
-use serde_json::Value;
 
 /// Trait for payload data storage. Should allow filter checks
 pub trait PayloadStorage {

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,10 +1,11 @@
+use serde_json::Value;
+
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::on_disk_payload_storage::OnDiskPayloadStorage;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::payload_storage::PayloadStorage;
 use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
-use serde_json::Value;
 
 pub enum PayloadStorageEnum {
     InMemoryPayloadStorage(InMemoryPayloadStorage),
@@ -99,10 +100,11 @@ impl PayloadStorage for PayloadStorageEnum {
 
 #[cfg(test)]
 mod tests {
+    use tempdir::TempDir;
+
     use super::*;
     use crate::common::rocksdb_operations::open_db;
     use crate::types::Payload;
-    use tempdir::TempDir;
 
     #[test]
     fn test_storage() {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -213,15 +213,15 @@ mod tests {
     use serde_json::json;
     use tempdir::TempDir;
 
+    use super::*;
     use crate::common::rocksdb_operations::open_db;
     use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
     use crate::id_tracker::IdTracker;
     use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
     use crate::payload_storage::PayloadStorage;
-    use crate::types::{FieldCondition, GeoBoundingBox, Range, ValuesCount};
-    use crate::types::{GeoPoint, PayloadField};
-
-    use super::*;
+    use crate::types::{
+        FieldCondition, GeoBoundingBox, GeoPoint, PayloadField, Range, ValuesCount,
+    };
 
     #[test]
     fn test_condition_checker() {

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -1,12 +1,12 @@
-use crate::common::rocksdb_operations::{db_write_options, DB_PAYLOAD_CF};
-use crate::types::{Payload, PointOffsetType};
-use atomic_refcell::AtomicRefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use rocksdb::{IteratorMode, DB};
 
+use crate::common::rocksdb_operations::{db_write_options, DB_PAYLOAD_CF};
 use crate::entry::entry_point::OperationResult;
+use crate::types::{Payload, PointOffsetType};
 
 /// In-memory implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, but only uses this storage during the initial load

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -1,4 +1,3 @@
-use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 use std::collections::HashMap;
 
 use serde_json::Value;
@@ -7,6 +6,7 @@ use crate::common::rocksdb_operations::{db_options, DB_PAYLOAD_CF};
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::payload_storage::PayloadStorage;
+use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 
 impl PayloadStorage for SimplePayloadStorage {
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
@@ -69,10 +69,10 @@ impl PayloadStorage for SimplePayloadStorage {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::common::rocksdb_operations::open_db;
     use tempdir::TempDir;
+
+    use super::*;
+    use crate::common::rocksdb_operations::open_db;
 
     #[test]
     fn test_wipe() {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,3 +1,15 @@
+use std::collections::HashMap;
+use std::fs::{remove_dir_all, rename, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use atomic_refcell::AtomicRefCell;
+use atomicwrites::{AllowOverwrite, AtomicFile};
+use fs_extra::dir::{copy_with_progress, CopyOptions, TransitProcess};
+use rocksdb::DB;
+use tar::Builder;
+
 use crate::common::version::StorageVersion;
 use crate::entry::entry_point::OperationError::ServiceError;
 use crate::entry::entry_point::{
@@ -13,16 +25,6 @@ use crate::types::{
     SegmentState, SegmentType, SeqNumberType, VectorElementType, WithPayload,
 };
 use crate::vector_storage::VectorStorageSS;
-use atomic_refcell::AtomicRefCell;
-use atomicwrites::{AllowOverwrite, AtomicFile};
-use fs_extra::dir::{copy_with_progress, CopyOptions, TransitProcess};
-use rocksdb::DB;
-use std::collections::HashMap;
-use std::fs::{remove_dir_all, rename, File};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use tar::Builder;
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 
@@ -777,14 +779,16 @@ impl SegmentEntry for Segment {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tar::Archive;
+    use tempdir::TempDir;
+    use walkdir::WalkDir;
+
     use super::*;
     use crate::entry::entry_point::SegmentEntry;
     use crate::segment_constructor::build_segment;
     use crate::types::{Distance, Indexes, SegmentConfig, StorageType};
-    use std::fs;
-    use tar::Archive;
-    use tempdir::TempDir;
-    use walkdir::WalkDir;
 
     // no longer valid since users are now allowed to store arbitrary json objects.
     // TODO(gvelo): add tests for invalid payload types on indexed fields.

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -1,14 +1,15 @@
+use core::cmp;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::common::error_logging::LogError;
 use crate::entry::entry_point::{OperationError, OperationResult, SegmentEntry};
 use crate::index::PayloadIndex;
 use crate::segment::Segment;
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{PayloadKeyType, PayloadSchemaType, SegmentConfig};
-use core::cmp;
-use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Structure for constructing segment out of several other segments
 pub struct SegmentBuilder {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1,3 +1,12 @@
+use std::fs::{create_dir_all, File};
+use std::io::Read;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use atomic_refcell::AtomicRefCell;
+use log::info;
+use uuid::Uuid;
+
 use crate::common::rocksdb_operations::open_db;
 use crate::common::version::StorageVersion;
 use crate::entry::entry_point::{OperationError, OperationResult};
@@ -16,13 +25,6 @@ use crate::types::{
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::VectorStorageSS;
-use atomic_refcell::AtomicRefCell;
-use log::info;
-use std::fs::{create_dir_all, File};
-use std::io::Read;
-use std::path::Path;
-use std::sync::{Arc, Mutex};
-use uuid::Uuid;
 
 fn sp<T>(t: T) -> Arc<AtomicRefCell<T>> {
     Arc::new(AtomicRefCell::new(t))

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -1,10 +1,9 @@
-use crate::segment::Segment;
-
-use crate::types::{Distance, Indexes, SegmentConfig};
+use std::path::Path;
 
 use crate::entry::entry_point::OperationResult;
+use crate::segment::Segment;
 use crate::segment_constructor::build_segment;
-use std::path::Path;
+use crate::types::{Distance, Indexes, SegmentConfig};
 
 /// Build new segment with plain index in given directory
 ///
@@ -31,10 +30,11 @@ pub fn build_simple_segment(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::entry::entry_point::{OperationError, SegmentEntry};
     use serde_json::json;
     use tempdir::TempDir;
+
+    use super::*;
+    use crate::entry::entry_point::{OperationError, SegmentEntry};
 
     #[test]
     fn test_create_simple_segment() {

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -1,15 +1,11 @@
-use crate::types::{Distance, ScoreType, VectorElementType};
-
 use super::metric::Metric;
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use super::simple_sse::*;
-
 #[cfg(target_arch = "x86_64")]
 use super::simple_avx::*;
-
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::simple_neon::*;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use super::simple_sse::*;
+use crate::types::{Distance, ScoreType, VectorElementType};
 
 #[cfg(target_arch = "x86_64")]
 const MIN_DIM_SIZE_AVX: usize = 32;

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -1,6 +1,6 @@
-use crate::types::{ScoreType, VectorElementType};
-
 use std::arch::x86_64::*;
+
+use crate::types::{ScoreType, VectorElementType};
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -1,8 +1,8 @@
 #[cfg(target_feature = "neon")]
-use crate::types::{ScoreType, VectorElementType};
+use std::arch::aarch64::*;
 
 #[cfg(target_feature = "neon")]
-use std::arch::aarch64::*;
+use crate::types::{ScoreType, VectorElementType};
 
 #[cfg(target_feature = "neon")]
 pub(crate) unsafe fn euclid_similarity_neon(

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -1,10 +1,9 @@
-use crate::types::{ScoreType, VectorElementType};
-
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
-
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+use crate::types::{ScoreType, VectorElementType};
 
 #[target_feature(enable = "sse")]
 unsafe fn hsum128_ps_sse(x: __m128) -> f32 {

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -1,9 +1,10 @@
-use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::collections::binary_heap::Iter as BinaryHeapIter;
 use std::collections::BinaryHeap;
 use std::iter::Rev;
 use std::vec::IntoIter as VecIntoIter;
+
+use serde::{Deserialize, Serialize};
 
 /// This is a MinHeap by default - it will keep the largest elements, pop smallest
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,13 +1,3 @@
-use crate::common::utils;
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
-use geo::prelude::HaversineDistance;
-use geo::Point;
-use itertools::Itertools;
-use ordered_float::OrderedFloat;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Formatter;
@@ -15,7 +5,19 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
+
+use geo::prelude::HaversineDistance;
+use geo::Point;
+use itertools::Itertools;
+use ordered_float::OrderedFloat;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use uuid::Uuid;
+
+use crate::common::utils;
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 
 /// Type of point index inside a segment
 pub type PointOffsetType = u32;
@@ -1095,12 +1097,12 @@ impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::common::utils::remove_value_from_json_map;
     use serde::de::DeserializeOwned;
     use serde_json;
     use serde_json::json;
+
+    use super::*;
+    use crate::common::utils::remove_value_from_json_map;
 
     #[allow(dead_code)]
     fn check_rms_serialization<T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug>(

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -1,6 +1,7 @@
-use crate::types::{PointOffsetType, VectorElementType};
 use std::cmp::max;
 use std::mem;
+
+use crate::types::{PointOffsetType, VectorElementType};
 
 type Chunk = Vec<VectorElementType>;
 

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -1,11 +1,3 @@
-use crate::entry::entry_point::OperationResult;
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
-use crate::spaces::tools::peek_top_largest_scores_iterable;
-use crate::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
-use crate::vector_storage::mmap_vectors::MmapVectors;
-use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage, VectorStorageSS};
-use atomic_refcell::AtomicRefCell;
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::Write;
 use std::marker::PhantomData;
@@ -13,6 +5,16 @@ use std::mem::size_of;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+
+use crate::entry::entry_point::OperationResult;
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
+use crate::spaces::tools::peek_top_largest_scores_iterable;
+use crate::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
+use crate::vector_storage::mmap_vectors::MmapVectors;
+use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage, VectorStorageSS};
 
 fn vf_to_u8<T>(v: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
@@ -307,11 +309,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::mem::transmute;
+
+    use tempdir::TempDir;
+
     use super::*;
     use crate::common::rocksdb_operations::open_db;
     use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
-    use std::mem::transmute;
-    use tempdir::TempDir;
 
     #[test]
     fn test_basic_persistence() {

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -1,11 +1,13 @@
-use crate::common::error_logging::LogError;
-use crate::entry::entry_point::OperationResult;
-use crate::types::{PointOffsetType, VectorElementType};
-use memmap::{Mmap, MmapMut, MmapOptions};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::mem::{size_of, transmute};
 use std::path::Path;
+
+use memmap::{Mmap, MmapMut, MmapOptions};
+
+use crate::common::error_logging::LogError;
+use crate::entry::entry_point::OperationResult;
+use crate::types::{PointOffsetType, VectorElementType};
 
 const HEADER_SIZE: usize = 4;
 const DELETED_HEADER: &[u8; 4] = b"drop";

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -1,24 +1,23 @@
 use std::marker::PhantomData;
+use std::mem::size_of;
 use std::ops::Range;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
+use bitvec::prelude::BitVec;
 use log::debug;
 use rocksdb::{IteratorMode, DB};
 use serde::{Deserialize, Serialize};
 
+use super::chunked_vectors::ChunkedVectors;
+use super::vector_storage_base::VectorStorage;
 use crate::common::rocksdb_operations::{db_write_options, DB_VECTOR_CF};
 use crate::entry::entry_point::OperationResult;
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_scores_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType, VectorElementType};
 use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorageSS};
-
-use super::chunked_vectors::ChunkedVectors;
-use super::vector_storage_base::VectorStorage;
-use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
-use atomic_refcell::AtomicRefCell;
-use bitvec::prelude::BitVec;
-use std::mem::size_of;
-use std::sync::Arc;
 
 /// In-memory vector storage with on-update persistence using `store`
 pub struct SimpleVectorStorage<TMetric: Metric> {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -1,9 +1,11 @@
-use crate::entry::entry_point::OperationResult;
-use crate::types::{PointOffsetType, ScoreType, VectorElementType};
-use ordered_float::OrderedFloat;
-use rand::Rng;
 use std::cmp::Ordering;
 use std::ops::Range;
+
+use ordered_float::OrderedFloat;
+use rand::Rng;
+
+use crate::entry::entry_point::OperationResult;
+use crate::types::{PointOffsetType, ScoreType, VectorElementType};
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct ScoredPointOffset {

--- a/lib/segment/tests/fail_recovery_test.rs
+++ b/lib/segment/tests/fail_recovery_test.rs
@@ -2,10 +2,11 @@ mod fixtures;
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::segment::empty_segment;
     use segment::entry::entry_point::{OperationError, SegmentEntry, SegmentFailedState};
     use serde_json::json;
     use tempdir::TempDir;
+
+    use crate::fixtures::segment::empty_segment;
 
     #[test]
     fn test_insert_fail_recovery() {

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicBool;
+
     use itertools::Itertools;
     use rand::{thread_rng, Rng};
     use segment::entry::entry_point::SegmentEntry;
@@ -13,8 +16,6 @@ mod tests {
         StorageType,
     };
     use serde_json::json;
-    use std::collections::HashMap;
-    use std::sync::atomic::AtomicBool;
     use tempdir::TempDir;
 
     #[test]

--- a/lib/segment/tests/fixtures/segment.rs
+++ b/lib/segment/tests/fixtures/segment.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
+
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::Distance;
 use serde_json::json;
-use std::path::Path;
 
 pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
@@ -16,7 +18,6 @@ mod tests {
         IsEmptyCondition, Payload, PayloadField, PayloadSchemaType, Range, SegmentConfig,
         StorageType, WithPayload,
     };
-    use std::path::Path;
     use tempdir::TempDir;
 
     fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segment) {

--- a/lib/segment/tests/segment_builder_test.rs
+++ b/lib/segment/tests/segment_builder_test.rs
@@ -2,16 +2,18 @@ mod fixtures;
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::segment::{build_segment_1, build_segment_2, empty_segment};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
     use itertools::Itertools;
     use segment::entry::entry_point::{OperationError, SegmentEntry};
     use segment::segment::Segment;
     use segment::segment_constructor::segment_builder::SegmentBuilder;
     use segment::types::{Indexes, SegmentConfig};
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use std::time::{Duration, Instant};
     use tempdir::TempDir;
+
+    use crate::fixtures::segment::{build_segment_1, build_segment_2, empty_segment};
 
     #[test]
     fn test_building_new_segment() {

--- a/lib/segment/tests/segment_tests.rs
+++ b/lib/segment/tests/segment_tests.rs
@@ -2,12 +2,14 @@ mod fixtures;
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::segment::build_segment_1;
-    use segment::entry::entry_point::SegmentEntry;
-    use segment::types::{Condition, Filter, WithPayload};
     use std::collections::HashSet;
     use std::iter::FromIterator;
+
+    use segment::entry::entry_point::SegmentEntry;
+    use segment::types::{Condition, Filter, WithPayload};
     use tempdir::TempDir;
+
+    use crate::fixtures::segment::build_segment_1;
 
     #[test]
     fn test_point_exclusion() {

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -1,11 +1,13 @@
-use crate::content_manager::errors::StorageError;
-use collection::shard::CollectionId;
-use segment::common::file_operations::{atomic_save_json, read_json};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+
+use collection::shard::CollectionId;
+use segment::common::file_operations::{atomic_save_json, read_json};
+use serde::{Deserialize, Serialize};
+
+use crate::content_manager::errors::StorageError;
 
 pub const ALIAS_MAPPING_CONFIG_FILE: &str = "data.json";
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,12 +1,10 @@
-use crate::content_manager::shard_distribution::ShardDistributionProposal;
-use collection::shard::{CollectionId, PeerId};
-use collection::{
-    operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff},
-    shard::ShardId,
-};
+use collection::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
+use collection::shard::{CollectionId, PeerId, ShardId};
 use schemars::JsonSchema;
 use segment::types::Distance;
 use serde::{Deserialize, Serialize};
+
+use crate::content_manager::shard_distribution::ShardDistributionProposal;
 
 // *Operation wrapper structure is only required for better OpenAPI generation
 

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -1,7 +1,9 @@
-use crate::content_manager::errors::StorageError;
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use collection::collection::Collection;
-use std::collections::HashMap;
+
+use crate::content_manager::errors::StorageError;
 
 pub type Collections = HashMap<String, Collection>;
 

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -1,3 +1,5 @@
+use tonic::Status;
+
 use crate::content_manager::collection_meta_ops::{
     AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
     CreateAliasOperation, CreateCollection, CreateCollectionOperation, DeleteAlias,
@@ -5,7 +7,6 @@ use crate::content_manager::collection_meta_ops::{
     UpdateCollection, UpdateCollectionOperation,
 };
 use crate::content_manager::errors::StorageError;
-use tonic::Status;
 
 pub fn error_to_status(error: StorageError) -> tonic::Status {
     let error_code = match &error {

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -1,6 +1,7 @@
+use std::io::Error as IoError;
+
 use collection::operations::types::CollectionError;
 use segment::common::file_operations::FileStorageError;
-use std::io::Error as IoError;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,7 +1,6 @@
-use self::{
-    collection_meta_ops::CollectionMetaOperations, consensus_state::CollectionsSnapshot,
-    errors::StorageError,
-};
+use self::collection_meta_ops::CollectionMetaOperations;
+use self::consensus_state::CollectionsSnapshot;
+use self::errors::StorageError;
 
 mod alias_mapping;
 pub mod collection_meta_ops;
@@ -13,10 +12,11 @@ pub mod shard_distribution;
 pub mod toc;
 
 pub mod consensus_ops {
-    use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
     use collection::shard::PeerId;
     use raft::eraftpb::Entry as RaftEntry;
     use serde::{Deserialize, Serialize};
+
+    use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
 
     /// Operation that should pass consensus
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -1,8 +1,9 @@
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
 use collection::shard::{PeerId, Shard, ShardId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct PeerShardCount {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -4,10 +4,8 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::runtime::Runtime;
-use tokio::sync::{RwLock, RwLockReadGuard};
-
 use collection::collection::Collection;
+use collection::collection_state;
 use collection::config::{CollectionConfig, CollectionParams};
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
@@ -16,26 +14,25 @@ use collection::operations::types::{
     SearchRequest, UpdateResult,
 };
 use collection::operations::CollectionUpdateOperations;
-use segment::types::ScoredPoint;
-
-use super::collection_meta_ops::{CreateCollectionOperation, ShardTransferOperations};
-use super::{consensus_state, CollectionContainer};
-use crate::content_manager::shard_distribution::ShardDistributionProposal;
-use crate::content_manager::{
-    alias_mapping::AliasPersistence,
-    collection_meta_ops::{
-        AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
-        CreateAliasOperation, CreateCollection, DeleteAlias, DeleteAliasOperation, RenameAlias,
-        RenameAliasOperation, UpdateCollection,
-    },
-    collections_ops::{Checker, Collections},
-    errors::StorageError,
-};
-use crate::types::{PeerAddressById, StorageConfig};
-use collection::collection_state;
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
 use collection::shard::{ChannelService, CollectionId, PeerId, ShardId};
 use collection::telemetry::CollectionTelemetry;
+use segment::types::ScoredPoint;
+use tokio::runtime::Runtime;
+use tokio::sync::{RwLock, RwLockReadGuard};
+
+use super::collection_meta_ops::{CreateCollectionOperation, ShardTransferOperations};
+use super::{consensus_state, CollectionContainer};
+use crate::content_manager::alias_mapping::AliasPersistence;
+use crate::content_manager::collection_meta_ops::{
+    AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
+    CreateAliasOperation, CreateCollection, DeleteAlias, DeleteAliasOperation, RenameAlias,
+    RenameAliasOperation, UpdateCollection,
+};
+use crate::content_manager::collections_ops::{Checker, Collections};
+use crate::content_manager::errors::StorageError;
+use crate::content_manager::shard_distribution::ShardDistributionProposal;
+use crate::types::{PeerAddressById, StorageConfig};
 
 pub const COLLECTIONS_DIR: &str = "collections";
 pub const SNAPSHOTS_TMP_DIR: &str = "snapshots_tmp";

--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -3,21 +3,25 @@
 //! It provides all functions, which could be used from REST (or any other interface), but do not
 //! implement any concrete interface.
 
-use std::{ops::Deref, sync::Arc, time::Duration};
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
 
-use content_manager::{
-    collection_meta_ops::CollectionMetaOperations, consensus_ops::ConsensusOperations,
-    consensus_state::ConsensusStateRef, errors::StorageError, toc::TableOfContent,
-};
+use content_manager::collection_meta_ops::CollectionMetaOperations;
+use content_manager::consensus_ops::ConsensusOperations;
+use content_manager::consensus_state::ConsensusStateRef;
+use content_manager::errors::StorageError;
+use content_manager::toc::TableOfContent;
 use types::ClusterStatus;
 
 pub mod content_manager;
 pub mod types;
 
 pub mod serialize_peer_addresses {
+    use std::collections::HashMap;
+
     use itertools::Itertools;
     use serde::{self, de, Deserialize, Deserializer, Serialize, Serializer};
-    use std::collections::HashMap;
 
     use crate::types::PeerAddressById;
 

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -4,17 +4,13 @@ mod tests {
 
     use collection::optimizers_builder::OptimizersConfig;
     use segment::types::Distance;
-    use storage::{
-        content_manager::{
-            collection_meta_ops::{
-                ChangeAliasesOperation, CollectionMetaOperations, CreateAlias, CreateCollection,
-                CreateCollectionOperation, DeleteAlias, RenameAlias,
-            },
-            toc::TableOfContent,
-        },
-        types::{PerformanceConfig, StorageConfig},
-        Dispatcher,
+    use storage::content_manager::collection_meta_ops::{
+        ChangeAliasesOperation, CollectionMetaOperations, CreateAlias, CreateCollection,
+        CreateCollectionOperation, DeleteAlias, RenameAlias,
     };
+    use storage::content_manager::toc::TableOfContent;
+    use storage::types::{PerformanceConfig, StorageConfig};
+    use storage::Dispatcher;
     use tempdir::TempDir;
     use tokio::runtime::Runtime;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+# Check https://rust-lang.github.io/rustfmt for more options
+
+reorder_imports = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -1,8 +1,10 @@
-use crate::actix::helpers::process_response;
+use std::sync::Arc;
+
 use actix_web::rt::time::Instant;
 use actix_web::{get, web, Responder};
-use std::sync::Arc;
 use storage::Dispatcher;
+
+use crate::actix::helpers::process_response;
 
 #[get("/cluster")]
 async fn cluster_status(dispatcher: web::Data<Arc<Dispatcher>>) -> impl Responder {

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -1,16 +1,18 @@
-use crate::actix::helpers::process_response;
-use crate::common::collections::*;
+use std::sync::Arc;
+use std::time::Duration;
+
 use actix_web::rt::time::Instant;
 use actix_web::{delete, get, patch, post, put, web, Responder};
 use serde::Deserialize;
-use std::sync::Arc;
-use std::time::Duration;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CollectionMetaOperations, CreateCollection, CreateCollectionOperation,
     DeleteCollectionOperation, UpdateCollection, UpdateCollectionOperation,
 };
 use storage::content_manager::toc::TableOfContent;
 use storage::Dispatcher;
+
+use crate::actix::helpers::process_response;
+use crate::common::collections::*;
 
 #[derive(Debug, Deserialize)]
 struct WaitTimeout {
@@ -128,8 +130,9 @@ pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
 
 #[cfg(test)]
 mod tests {
-    use super::WaitTimeout;
     use actix_web::web::Query;
+
+    use super::WaitTimeout;
 
     #[test]
     fn timeout_is_deserialized() {

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
-
 use collection::operations::types::CountRequest;
 use storage::content_manager::toc::TableOfContent;
 

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
-
 use collection::operations::types::RecommendRequest;
 use segment::types::ScoredPoint;
 use storage::content_manager::errors::StorageError;

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use actix_web::rt::time::Instant;
 use actix_web::{get, post, web, Responder};
-
 use collection::operations::types::{PointRequest, Record, ScrollRequest, ScrollResult};
 use segment::types::{PointIdType, WithPayloadInterface};
 use storage::content_manager::errors::StorageError;

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
-
 use collection::operations::types::SearchRequest;
 use storage::content_manager::toc::TableOfContent;
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,9 +1,8 @@
-use actix_files::NamedFile;
 use std::sync::Arc;
 
+use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
 use actix_web::{get, post, web, Responder, Result};
-
 use storage::content_manager::toc::TableOfContent;
 
 use crate::actix::helpers::{

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -1,8 +1,5 @@
-use crate::actix::helpers::process_response;
-use crate::common::points::{
-    do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points,
-    do_set_payload, do_upsert_points, CreateFieldIndex,
-};
+use std::sync::Arc;
+
 use actix_web::rt::time::Instant;
 use actix_web::web::Query;
 use actix_web::{delete, post, put, web, Responder};
@@ -10,8 +7,13 @@ use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
+
+use crate::actix::helpers::process_response;
+use crate::common::points::{
+    do_clear_payload, do_create_index, do_delete_index, do_delete_payload, do_delete_points,
+    do_set_payload, do_upsert_points, CreateFieldIndex,
+};
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub struct UpdateParam {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -1,9 +1,10 @@
+use std::fmt::Debug;
+
 use actix_web::rt::time::Instant;
 use actix_web::{error, Error, HttpResponse, Responder};
 use api::grpc::models::{ApiResponse, ApiStatus};
 use collection::operations::types::CollectionError;
 use serde::Serialize;
-use std::fmt::Debug;
 use storage::content_manager::errors::StorageError;
 
 pub fn collection_into_actix_error(err: CollectionError) -> Error {

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -2,16 +2,17 @@ pub mod api;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
 
-use crate::actix::api::cluster_api::config_cluster_api;
-use crate::actix::api::collections_api::config_collections_api;
+use std::sync::Arc;
+
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
 use actix_web::middleware::{Condition, Logger};
 use actix_web::web::Data;
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
-use std::sync::Arc;
 use storage::Dispatcher;
 
+use crate::actix::api::cluster_api::config_cluster_api;
+use crate::actix::api::collections_api::config_collections_api;
 use crate::actix::api::count_api::count_points;
 use crate::actix::api::recommend_api::recommend_points;
 use crate::actix::api::retrieve_api::{get_point, get_points, scroll_points};

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,5 +1,6 @@
-use parking_lot::{Condvar, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::{Condvar, Mutex};
 use tokio::runtime;
 use tokio::runtime::Runtime;
 
@@ -62,11 +63,12 @@ impl IsReady {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::Arc;
     use std::thread;
     use std::thread::sleep;
     use std::time::Duration;
+
+    use super::*;
 
     #[test]
     fn test_is_ready() {

--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -1,7 +1,8 @@
+use std::env;
+
 use api::grpc::models::VersionInfo;
 use atty::Stream;
 use colored::Colorize;
-use std::env;
 
 /// Prints welcome message
 #[rustfmt::skip]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,22 +8,22 @@ mod snapshots;
 mod tonic;
 mod user_telemetry;
 
-use consensus::Consensus;
-use log::LevelFilter;
-use slog::Drain;
 use std::io::Error;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
-use storage::content_manager::consensus_state::{ConsensusState, ConsensusStateRef, Persistent};
-use storage::Dispatcher;
 
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
 use collection::shard::ChannelService;
+use consensus::Consensus;
+use log::LevelFilter;
+use slog::Drain;
+use storage::content_manager::consensus_state::{ConsensusState, ConsensusStateRef, Persistent};
 use storage::content_manager::toc::TableOfContent;
+use storage::Dispatcher;
 
 use crate::common::helpers::create_search_runtime;
 use crate::greeting::welcome;
@@ -234,8 +234,9 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(feature = "service_debug")]
     {
-        use parking_lot::deadlock;
         use std::fmt::Write;
+
+        use parking_lot::deadlock;
 
         const DEADLOCK_CHECK_PERIOD: Duration = Duration::from_secs(10);
 

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,21 +1,20 @@
-use schemars::{schema_for, JsonSchema};
-use serde::{Deserialize, Serialize};
-
+use api::grpc::models::CollectionsResponse;
+use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
+use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
     CollectionInfo, CountRequest, CountResult, PointRequest, RecommendRequest, Record,
     ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
 };
+use schemars::{schema_for, JsonSchema};
 use segment::types::ScoredPoint;
+use serde::{Deserialize, Serialize};
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CreateCollection, UpdateCollection,
 };
+use storage::types::ClusterStatus;
 
 use crate::common::points::CreateFieldIndex;
-use api::grpc::models::CollectionsResponse;
-use collection::operations::payload_ops::{DeletePayload, SetPayload};
-use collection::operations::snapshot_ops::SnapshotDescription;
-use storage::types::ClusterStatus;
 
 mod actix;
 mod common;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
+use std::env;
+
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
-use std::env;
 use storage::types::StorageConfig;
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -1,7 +1,8 @@
-use collection::collection::Collection;
-use log::info;
 use std::fs::{remove_dir_all, rename};
 use std::path::Path;
+
+use collection::collection::Collection;
+use log::info;
 use storage::content_manager::toc::COLLECTIONS_DIR;
 
 /// Recover snapshots from the given arguments

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -1,18 +1,18 @@
-use storage::Dispatcher;
-use tonic::{Request, Response, Status};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use crate::common::collections::*;
 use api::grpc::qdrant::collections_server::Collections;
 use api::grpc::qdrant::{
     ChangeAliases, CollectionOperationResponse, CreateCollection, DeleteCollection,
     GetCollectionInfoRequest, GetCollectionInfoResponse, ListCollectionsRequest,
     ListCollectionsResponse, UpdateCollection,
 };
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
-use crate::tonic::api::collections_common::get;
 use storage::content_manager::conversions::error_to_status;
+use storage::Dispatcher;
+use tonic::{Request, Response, Status};
+
+use crate::common::collections::*;
+use crate::tonic::api::collections_common::get;
 
 pub struct CollectionsService {
     dispatcher: Arc<Dispatcher>,

--- a/src/tonic/api/collections_common.rs
+++ b/src/tonic/api/collections_common.rs
@@ -1,10 +1,12 @@
-use crate::common::collections::do_get_collection;
+use std::time::Instant;
+
 use api::grpc::qdrant::{GetCollectionInfoRequest, GetCollectionInfoResponse};
 use collection::shard::ShardId;
-use std::time::Instant;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Response, Status};
+
+use crate::common::collections::do_get_collection;
 
 pub async fn get(
     toc: &TableOfContent,

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -1,9 +1,11 @@
-use crate::tonic::api::collections_common::get;
+use std::sync::Arc;
+
 use api::grpc::qdrant::collections_internal_server::CollectionsInternal;
 use api::grpc::qdrant::{GetCollectionInfoRequestInternal, GetCollectionInfoResponse};
-use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
+
+use crate::tonic::api::collections_common::get;
 
 pub struct CollectionsInternalService {
     toc: Arc<TableOfContent>,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -1,20 +1,19 @@
-use tonic::{Request, Response, Status};
+use std::sync::Arc;
 
 use api::grpc::qdrant::points_server::Points;
-
-use crate::tonic::api::points_common::{
-    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
-    recommend, scroll, search, set_payload, upsert,
-};
 use api::grpc::qdrant::{
     ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
     DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse,
     PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse,
     SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints,
 };
-use std::sync::Arc;
-
 use storage::content_manager::toc::TableOfContent;
+use tonic::{Request, Response, Status};
+
+use crate::tonic::api::points_common::{
+    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
+    recommend, scroll, search, set_payload, upsert,
+};
 
 pub struct PointsService {
     toc: Arc<TableOfContent>,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1,8 +1,5 @@
-use crate::common::points::{
-    do_clear_payload, do_count_points, do_create_index, do_delete_index, do_delete_payload,
-    do_delete_points, do_get_points, do_scroll_points, do_search_points, do_set_payload,
-    do_upsert_points, CreateFieldIndex,
-};
+use std::time::Instant;
+
 use api::grpc::conversions::proto_to_payloads;
 use api::grpc::qdrant::{
     ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
@@ -17,10 +14,15 @@ use collection::operations::types::{
 };
 use collection::shard::ShardId;
 use segment::types::PayloadSchemaType;
-use std::time::Instant;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Response, Status};
+
+use crate::common::points::{
+    do_clear_payload, do_count_points, do_create_index, do_delete_index, do_delete_payload,
+    do_delete_points, do_get_points, do_scroll_points, do_search_points, do_set_payload,
+    do_upsert_points, CreateFieldIndex,
+};
 
 pub fn points_operation_response(
     timing: Instant,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -1,9 +1,5 @@
-use tonic::{Request, Response, Status};
+use std::sync::Arc;
 
-use crate::tonic::api::points_common::{
-    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
-    recommend, scroll, search, set_payload, upsert,
-};
 use api::grpc::qdrant::points_internal_server::PointsInternal;
 use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CountPointsInternal, CountResponse,
@@ -13,8 +9,13 @@ use api::grpc::qdrant::{
     ScrollResponse, SearchPointsInternal, SearchResponse, SetPayloadPointsInternal,
     UpsertPointsInternal,
 };
-use std::sync::Arc;
 use storage::content_manager::toc::TableOfContent;
+use tonic::{Request, Response, Status};
+
+use crate::tonic::api::points_common::{
+    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
+    recommend, scroll, search, set_payload, upsert,
+};
 
 /// This API is intended for P2P communication within a distributed deployment.
 pub struct PointsInternalService {

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -1,13 +1,18 @@
-use crate::consensus;
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+
+use api::grpc::qdrant::raft_server::Raft;
 use api::grpc::qdrant::{
-    raft_server::Raft, AddPeerToKnownMessage, AllPeers, Peer, PeerId,
-    RaftMessage as RaftMessageBytes, Uri as UriStr,
+    AddPeerToKnownMessage, AllPeers, Peer, PeerId, RaftMessage as RaftMessageBytes, Uri as UriStr,
 };
 use itertools::Itertools;
 use raft::eraftpb::{ConfChangeType, ConfChangeV2, Message as RaftMessage};
-use std::sync::{mpsc::SyncSender, Arc, Mutex};
-use storage::{content_manager::consensus_ops::ConsensusOperations, Dispatcher};
-use tonic::{async_trait, transport::Uri, Request, Response, Status};
+use storage::content_manager::consensus_ops::ConsensusOperations;
+use storage::Dispatcher;
+use tonic::transport::Uri;
+use tonic::{async_trait, Request, Response, Status};
+
+use crate::consensus;
 
 pub struct RaftService {
     message_sender: Mutex<SyncSender<consensus::Message>>,

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -1,13 +1,15 @@
-use crate::common::collections::{do_create_snapshot, do_list_snapshots};
+use std::sync::Arc;
+use std::time::Instant;
+
 use api::grpc::qdrant::snapshots_server::Snapshots;
 use api::grpc::qdrant::{
     CreateSnapshotRequest, CreateSnapshotResponse, ListSnapshotsRequest, ListSnapshotsResponse,
 };
-use std::sync::Arc;
-use std::time::Instant;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{async_trait, Request, Response, Status};
+
+use crate::common::collections::{do_create_snapshot, do_list_snapshots};
 
 pub struct SnapshotsService {
     toc: Arc<TableOfContent>,

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -1,10 +1,9 @@
 mod api;
 
-use crate::tonic::api::collections_api::CollectionsService;
-use crate::tonic::api::collections_internal_api::CollectionsInternalService;
-use crate::tonic::api::points_api::PointsService;
-use crate::tonic::api::points_internal_api::PointsInternalService;
-use crate::tonic::api::snapshots_api::SnapshotsService;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
 use ::api::grpc::models::VersionInfo;
 use ::api::grpc::qdrant::collections_internal_server::CollectionsInternalServer;
 use ::api::grpc::qdrant::collections_server::CollectionsServer;
@@ -13,12 +12,16 @@ use ::api::grpc::qdrant::points_server::PointsServer;
 use ::api::grpc::qdrant::qdrant_server::{Qdrant, QdrantServer};
 use ::api::grpc::qdrant::snapshots_server::SnapshotsServer;
 use ::api::grpc::qdrant::{HealthCheckReply, HealthCheckRequest};
-use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use storage::Dispatcher;
 use tokio::{runtime, signal};
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+use crate::tonic::api::collections_api::CollectionsService;
+use crate::tonic::api::collections_internal_api::CollectionsInternalService;
+use crate::tonic::api::points_api::PointsService;
+use crate::tonic::api::points_internal_api::PointsInternalService;
+use crate::tonic::api::snapshots_api::SnapshotsService;
 
 #[derive(Default)]
 pub struct QdrantService {}
@@ -75,8 +78,9 @@ pub fn init_internal(
     internal_grpc_port: u16,
     to_consensus: std::sync::mpsc::SyncSender<crate::consensus::Message>,
 ) -> std::io::Result<()> {
-    use crate::tonic::api::raft_api::RaftService;
     use ::api::grpc::qdrant::raft_server::RaftServer;
+
+    use crate::tonic::api::raft_api::RaftService;
 
     let toc = dispatcher.toc().clone();
     let tonic_runtime = runtime::Builder::new_multi_thread()

--- a/src/user_telemetry.rs
+++ b/src/user_telemetry.rs
@@ -1,9 +1,10 @@
-use collection::telemetry::CollectionTelemetry;
-use serde::Serialize;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::sync::Arc;
+
+use collection::telemetry::CollectionTelemetry;
+use serde::Serialize;
 use storage::Dispatcher;
 use uuid::Uuid;
 


### PR DESCRIPTION
Check https://rust-lang.github.io/rustfmt if you'd like to suggest other options for formatting
The current options are specified in `rustfmt.toml` in our source

## Handling Merge Conflicts
The best way to handle conflicts is to copy `rustfmt.toml` and run `cargo +nightly fmt --all` yourself before merging/rebasing this change
