### PR TITLE
[sharding] Collection cluster info API

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -682,6 +682,75 @@
         }
       }
     },
+    "/collections/{collection_name}/cluster": {
+      "get": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "Collection cluster info",
+        "description": "Get cluster information for a collection",
+        "operationId": "get_cluster_info",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to retrieve the cluster info for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CollectionClusterInfo"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/snapshots": {
       "get": {
         "tags": [
@@ -3667,7 +3736,7 @@
             ]
           },
           "exact": {
-            "description": "If true, count exact number of points. If false, count approximate number of points faster.",
+            "description": "If true, count exact number of points. If false, count approximate number of points faster. Approximate count might be unreliable during the indexing process. Default: true",
             "default": true,
             "type": "boolean"
           }
@@ -3686,6 +3755,77 @@
             "minimum": 0
           }
         }
+      },
+      "CollectionClusterInfo": {
+        "description": "Current clustering distribution for the collection",
+        "type": "object",
+        "required": [
+          "shards"
+        ],
+        "properties": {
+          "shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardInfo"
+            }
+          }
+        }
+      },
+      "ShardInfo": {
+        "oneOf": [
+          {
+            "description": "Local shard with `shard_id` id",
+            "type": "object",
+            "required": [
+              "local"
+            ],
+            "properties": {
+              "local": {
+                "type": "object",
+                "required": [
+                  "shard_id"
+                ],
+                "properties": {
+                  "shard_id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Remote shard with `shard_id` id on `peer_id` peer",
+            "type": "object",
+            "required": [
+              "remote"
+            ],
+            "properties": {
+              "remote": {
+                "type": "object",
+                "required": [
+                  "peer_id",
+                  "shard_id"
+                ],
+                "properties": {
+                  "shard_id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0
+                  },
+                  "peer_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3760,72 +3760,61 @@
         "description": "Current clustering distribution for the collection",
         "type": "object",
         "required": [
-          "shards"
+          "local_shards",
+          "remote_shards",
+          "shard_count"
         ],
         "properties": {
-          "shards": {
+          "shard_count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "local_shards": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ShardInfo"
+              "$ref": "#/components/schemas/LocalShardInfo"
+            }
+          },
+          "remote_shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RemoteShardInfo"
             }
           }
         }
       },
-      "ShardInfo": {
-        "oneOf": [
-          {
-            "description": "Local shard with `shard_id` id",
-            "type": "object",
-            "required": [
-              "local"
-            ],
-            "properties": {
-              "local": {
-                "type": "object",
-                "required": [
-                  "shard_id"
-                ],
-                "properties": {
-                  "shard_id": {
-                    "type": "integer",
-                    "format": "uint32",
-                    "minimum": 0
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Remote shard with `shard_id` id on `peer_id` peer",
-            "type": "object",
-            "required": [
-              "remote"
-            ],
-            "properties": {
-              "remote": {
-                "type": "object",
-                "required": [
-                  "peer_id",
-                  "shard_id"
-                ],
-                "properties": {
-                  "shard_id": {
-                    "type": "integer",
-                    "format": "uint32",
-                    "minimum": 0
-                  },
-                  "peer_id": {
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
+      "LocalShardInfo": {
+        "type": "object",
+        "required": [
+          "shard_id"
+        ],
+        "properties": {
+          "shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           }
-        ]
+        }
+      },
+      "RemoteShardInfo": {
+        "type": "object",
+        "required": [
+          "peer_id",
+          "shard_id"
+        ],
+        "properties": {
+          "shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "peer_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        }
       }
     }
   }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3761,22 +3761,32 @@
         "type": "object",
         "required": [
           "local_shards",
+          "peer_id",
           "remote_shards",
           "shard_count"
         ],
         "properties": {
+          "peer_id": {
+            "description": "ID of this peer",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
           "shard_count": {
+            "description": "Total number of shards",
             "type": "integer",
             "format": "uint",
             "minimum": 0
           },
           "local_shards": {
+            "description": "Local shards",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/LocalShardInfo"
             }
           },
           "remote_shards": {
+            "description": "Remote shards",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RemoteShardInfo"
@@ -3787,12 +3797,20 @@
       "LocalShardInfo": {
         "type": "object",
         "required": [
+          "points_count",
           "shard_id"
         ],
         "properties": {
           "shard_id": {
+            "description": "Local shard id",
             "type": "integer",
             "format": "uint32",
+            "minimum": 0
+          },
+          "points_count": {
+            "description": "Number of points in the shard",
+            "type": "integer",
+            "format": "uint",
             "minimum": 0
           }
         }
@@ -3805,11 +3823,13 @@
         ],
         "properties": {
           "shard_id": {
+            "description": "Remote shard id",
             "type": "integer",
             "format": "uint32",
             "minimum": 0
           },
           "peer_id": {
+            "description": "Remote peer id",
             "type": "integer",
             "format": "uint64",
             "minimum": 0

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -38,7 +38,7 @@ use crate::shard::shard_config::{ShardConfig, ShardType};
 use crate::shard::shard_holder::{LockedShardHolder, ShardHolder};
 use crate::shard::{
     create_shard_dir, shard_path, ChannelService, CollectionId, PeerId, Shard, ShardId,
-    HASH_RING_SHARD_SCALE,
+    ShardOperation, HASH_RING_SHARD_SCALE,
 };
 use crate::telemetry::CollectionTelemetry;
 
@@ -731,14 +731,15 @@ impl Collection {
     }
 
     pub async fn cluster_info(&self, peer_id: PeerId) -> CollectionResult<CollectionClusterInfo> {
-        let shard_count = self.shards.len();
+        let shards = self.shards_holder.read().await;
+        let shard_count = shards.len();
         let mut local_shards = Vec::new();
         let mut remote_shards = Vec::new();
         let count_request = Arc::new(CountRequest {
             filter: None,
             exact: true,
         });
-        for (shard_id, shard) in &self.shards {
+        for (shard_id, shard) in shards.get_shards() {
             let shard_id = *shard_id;
             match shard {
                 Shard::Local(ls) => {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -20,6 +20,7 @@ use tokio::task::JoinError;
 use tonic::codegen::http::uri::InvalidUri;
 
 use crate::config::CollectionConfig;
+use crate::shard::{PeerId, ShardId};
 use crate::wal::WalError;
 
 /// Type of vector in API
@@ -83,6 +84,21 @@ pub struct CollectionInfo {
     pub config: CollectionConfig,
     /// Types of stored payload
     pub payload_schema: HashMap<PayloadKeyType, PayloadIndexInfo>,
+}
+
+/// Current clustering distribution for the collection
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct CollectionClusterInfo {
+    pub shards: Vec<ShardInfo>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ShardInfo {
+    /// Local shard with `shard_id` id
+    Local { shard_id: ShardId },
+    /// Remote shard with `shard_id` id on `peer_id` peer
+    Remote { shard_id: ShardId, peer_id: PeerId },
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -89,16 +89,22 @@ pub struct CollectionInfo {
 /// Current clustering distribution for the collection
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CollectionClusterInfo {
-    pub shards: Vec<ShardInfo>,
+    pub shard_count: usize,
+    pub local_shards: Vec<LocalShardInfo>,
+    pub remote_shards: Vec<RemoteShardInfo>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ShardInfo {
-    /// Local shard with `shard_id` id
-    Local { shard_id: ShardId },
-    /// Remote shard with `shard_id` id on `peer_id` peer
-    Remote { shard_id: ShardId, peer_id: PeerId },
+pub struct LocalShardInfo {
+    pub shard_id: ShardId,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct RemoteShardInfo {
+    pub shard_id: ShardId,
+    pub peer_id: PeerId,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -89,21 +89,31 @@ pub struct CollectionInfo {
 /// Current clustering distribution for the collection
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CollectionClusterInfo {
+    /// ID of this peer
+    pub peer_id: PeerId,
+    /// Total number of shards
     pub shard_count: usize,
+    /// Local shards
     pub local_shards: Vec<LocalShardInfo>,
+    /// Remote shards
     pub remote_shards: Vec<RemoteShardInfo>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct LocalShardInfo {
+    /// Local shard id
     pub shard_id: ShardId,
+    /// Number of points in the shard
+    pub points_count: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct RemoteShardInfo {
+    /// Remote shard id
     pub shard_id: ShardId,
+    /// Remote peer id
     pub peer_id: PeerId,
 }
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -46,7 +46,7 @@ pub struct TableOfContent {
     search_runtime: Runtime,
     collection_management_runtime: Runtime,
     alias_persistence: RwLock<AliasPersistence>,
-    this_peer_id: PeerId,
+    pub this_peer_id: PeerId,
     channel_service: ChannelService,
 }
 

--- a/openapi/openapi-collections.ytt.yaml
+++ b/openapi/openapi-collections.ytt.yaml
@@ -184,3 +184,19 @@ paths:
           schema:
             type: boolean
       responses: #@ response(reference("UpdateResult"))
+
+  /collections/{collection_name}/cluster:
+    get:
+      tags:
+        - collections
+      summary: Collection cluster info
+      description: Get cluster information for a collection
+      operationId: get_cluster_info
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to retrieve the cluster info for
+          required: true
+          schema:
+            type: string
+      responses: #@ response(reference("CollectionClusterInfo"))

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -118,6 +118,17 @@ async fn update_aliases(
     process_response(response, timing)
 }
 
+#[get("/collections/{name}/cluster")]
+async fn get_cluster_info(
+    toc: web::Data<Arc<TableOfContent>>,
+    path: web::Path<String>,
+) -> impl Responder {
+    let name = path.into_inner();
+    let timing = Instant::now();
+    let response = do_get_collection_cluster(&toc.into_inner(), &name).await;
+    process_response(response, timing)
+}
+
 // Configure services
 pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
     cfg.service(get_collections)
@@ -125,7 +136,8 @@ pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
         .service(create_collection)
         .service(update_collection)
         .service(delete_collection)
-        .service(update_aliases);
+        .service(update_aliases)
+        .service(get_cluster_info);
 }
 
 #[cfg(test)]

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -1,6 +1,6 @@
 use api::grpc::models::{CollectionDescription, CollectionsResponse};
 use collection::operations::snapshot_ops::SnapshotDescription;
-use collection::operations::types::CollectionInfo;
+use collection::operations::types::{CollectionClusterInfo, CollectionInfo};
 use collection::shard::ShardId;
 use itertools::Itertools;
 use storage::content_manager::errors::StorageError;
@@ -42,4 +42,12 @@ pub async fn do_create_snapshot(
     collection_name: &str,
 ) -> Result<SnapshotDescription, StorageError> {
     toc.create_snapshot(collection_name).await
+}
+
+pub async fn do_get_collection_cluster(
+    toc: &TableOfContent,
+    name: &str,
+) -> Result<CollectionClusterInfo, StorageError> {
+    let collection = toc.get_collection(name).await?;
+    Ok(collection.cluster_info().await?)
 }

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -49,5 +49,5 @@ pub async fn do_get_collection_cluster(
     name: &str,
 ) -> Result<CollectionClusterInfo, StorageError> {
     let collection = toc.get_collection(name).await?;
-    Ok(collection.cluster_info().await?)
+    Ok(collection.cluster_info(toc.this_peer_id).await?)
 }

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -3,8 +3,8 @@ use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
-    CollectionInfo, CountRequest, CountResult, PointRequest, RecommendRequest, Record,
-    ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
+    CollectionClusterInfo, CollectionInfo, CountRequest, CountResult, PointRequest,
+    RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, UpdateResult,
 };
 use schemars::{schema_for, JsonSchema};
 use segment::types::ScoredPoint;
@@ -46,6 +46,7 @@ struct AllDefinitions {
     am: SnapshotDescription,
     an: CountRequest,
     ao: CountResult,
+    ap: CollectionClusterInfo,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -47,6 +47,10 @@ def test_collection_sharding(tmp_path: pathlib.Path):
     # Check that it exists on all peers
     wait_for_uniform_collection_existence("test_collection", peer_api_uris)
 
+    # Check collection's cluster info
+    collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], "test_collection")
+    assert len(collection_cluster_info["shards"]) == N_SHARDS
+
     # Create points in first peer's collection
     r = requests.put(
         f"{peer_api_uris[0]}/collections/test_collection/points?wait=true", json={

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -49,7 +49,7 @@ def test_collection_sharding(tmp_path: pathlib.Path):
 
     # Check collection's cluster info
     collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], "test_collection")
-    assert len(collection_cluster_info["shards"]) == N_SHARDS
+    assert collection_cluster_info["shard_count"] == N_SHARDS
 
     # Create points in first peer's collection
     r = requests.put(

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -110,6 +110,17 @@ def print_clusters_info(peer_api_uris: [str]):
         print(json.dumps(get_cluster_info(uri), indent=4))
 
 
+def get_collection_cluster_info(peer_api_uri: str, collection_name: str) -> dict:
+    r = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster")
+    assert_http_ok(r)
+    res = r.json()["result"]
+    return res
+
+
+def print_collection_cluster_info(peer_api_uri: str, collection_name: str):
+    print(json.dumps(get_collection_cluster_info(peer_api_uri, collection_name), indent=4))
+
+
 def get_leader(peer_api_uri: str) -> str:
     r = requests.get(f"{peer_api_uri}/cluster")
     assert_http_ok(r)


### PR DESCRIPTION
This PR adds a new REST API to get the collection cluster info. (#624)

With this API an operator can get extra information about the shard topology of a given collection.

It is tested via the sharding consensus test, here is an example of output.

edit: new format

```json
{
    "shard_count": 6,
    "local_shards": [
        {
            "shard_id": 2
        }
    ],
    "remote_shards": [
        {
            "shard_id": 0,
            "peer_id": 5206661873001331473
        },
        {
            "shard_id": 1,
            "peer_id": 9153846410978676289
        },
        {
            "shard_id": 3,
            "peer_id": 11473594217186723880
        },
        {
            "shard_id": 4,
            "peer_id": 17502153356522390965
        },
        {
            "shard_id": 5,
            "peer_id": 5206661873001331473
        }
    ]
}
```