### PR TITLE
Save shard transfers state on disk

### DIFF
--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -17,7 +17,7 @@ parking_lot = "0.12"
 rand = "0.8.5"
 thiserror = "1.0"
 serde = { version = "~1.0", features = ["derive"] }
-serde_json = "~1.0"
+serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git" }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -90,7 +90,7 @@ impl Collection {
         CollectionVersion::save(path)?;
         config.save(path)?;
 
-        let mut shard_holder = ShardHolder::new(path, HashRing::fair(HASH_RING_SHARD_SCALE));
+        let mut shard_holder = ShardHolder::new(path, HashRing::fair(HASH_RING_SHARD_SCALE))?;
 
         let shared_config = Arc::new(RwLock::new(config.clone()));
         for shard_id in shard_distribution.local {
@@ -204,7 +204,7 @@ impl Collection {
             log::debug!("Using raw hash ring");
             HashRing::raw()
         };
-        let mut shard_holder = ShardHolder::new(path, ring);
+        let mut shard_holder = ShardHolder::new(path, ring).expect("Can not create shard holder");
 
         let shared_config = Arc::new(RwLock::new(config.clone()));
 
@@ -277,7 +277,7 @@ impl Collection {
         let do_transfer = {
             let mut shards_holder = self.shards_holder.write().await;
             let was_not_transferred =
-                shards_holder.register_start_shard_transfer(shard_transfer.clone());
+                shards_holder.register_start_shard_transfer(shard_transfer.clone())?;
             let shard = shards_holder.get_shard(&shard_id);
 
             // Check if current node owns the shard which should be transferred
@@ -329,7 +329,7 @@ impl Collection {
             .shards_holder
             .write()
             .await
-            .register_finish_transfer(&transfer);
+            .register_finish_transfer(&transfer)?;
         let transfer_finished = self
             .transfer_tasks
             .lock()
@@ -384,7 +384,7 @@ impl Collection {
             .shards_holder
             .write()
             .await
-            .register_finish_transfer(&transfer);
+            .register_finish_transfer(&transfer)?;
         let transfer_finished = self
             .transfer_tasks
             .lock()

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -90,7 +90,7 @@ impl Collection {
         CollectionVersion::save(path)?;
         config.save(path)?;
 
-        let mut shard_holder = ShardHolder::new(HashRing::fair(HASH_RING_SHARD_SCALE));
+        let mut shard_holder = ShardHolder::new(path, HashRing::fair(HASH_RING_SHARD_SCALE));
 
         let shared_config = Arc::new(RwLock::new(config.clone()));
         for shard_id in shard_distribution.local {
@@ -204,7 +204,7 @@ impl Collection {
             log::debug!("Using raw hash ring");
             HashRing::raw()
         };
-        let mut shard_holder = ShardHolder::new(ring);
+        let mut shard_holder = ShardHolder::new(path, ring);
 
         let shared_config = Arc::new(RwLock::new(config.clone()));
 

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod hash_ring;
 pub mod operations;
 pub mod optimizers_builder;
+pub mod save_on_disk;
 pub mod shard;
 pub mod telemetry;
 mod update_handler;

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -21,6 +21,7 @@ use tokio::task::JoinError;
 use tonic::codegen::http::uri::InvalidUri;
 
 use crate::config::CollectionConfig;
+use crate::save_on_disk;
 use crate::shard::{PeerId, ShardId};
 use crate::wal::WalError;
 
@@ -468,6 +469,14 @@ impl From<RequestError<tonic::Status>> for CollectionError {
         match err {
             RequestError::FromClosure(status) => status.into(),
             RequestError::Tonic(err) => CollectionError::service_error(format!("{}", err)),
+        }
+    }
+}
+
+impl From<save_on_disk::Error> for CollectionError {
+    fn from(err: save_on_disk::Error) -> Self {
+        CollectionError::ServiceError {
+            error: err.to_string(),
         }
     }
 }

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -84,13 +84,13 @@ mod tests {
         let dir = tempdir::TempDir::new("test").unwrap();
         let counter_file = dir.path().join("counter");
         let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
-        counter.write(|counter| *counter += 1);
+        counter.write(|counter| *counter += 1).unwrap();
         assert_eq!(*counter, 1);
         assert_eq!(
             counter.to_string(),
             fs::read_to_string(&counter_file).unwrap()
         );
-        counter.write(|counter| *counter += 1);
+        counter.write(|counter| *counter += 1).unwrap();
         assert_eq!(*counter, 2);
         assert_eq!(
             counter.to_string(),
@@ -103,7 +103,7 @@ mod tests {
         let dir = tempdir::TempDir::new("test").unwrap();
         let counter_file = dir.path().join("counter");
         let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
-        counter.write(|counter| *counter += 1);
+        counter.write(|counter| *counter += 1).unwrap();
         let counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
         assert_eq!(*counter, 1)
     }

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -1,0 +1,133 @@
+use std::fs::File;
+use std::io::BufWriter;
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+
+use atomicwrites::OverwriteBehavior::AllowOverwrite;
+use atomicwrites::{AtomicFile, Error as AtomicWriteError};
+use serde::{Deserialize, Serialize};
+
+/// Functions as a smart pointer which gives a write guard and saves data on disk
+/// when write guard is dropped.
+#[derive(Clone, Debug, Default)]
+pub struct SaveOnDisk<T> {
+    data: T,
+    path: PathBuf,
+}
+
+pub struct WriteGuard<'a, T: Serialize>(&'a mut SaveOnDisk<T>);
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to save structure on disk with error: {0}")]
+    AtomicWrite(#[from] AtomicWriteError<serde_json::Error>),
+    #[error("Failed to perform io operation: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Failed to (de)serialize from/to json: {0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
+impl<T: Serialize + Default + for<'de> Deserialize<'de>> SaveOnDisk<T> {
+    pub fn load_or_init(path: impl Into<PathBuf>) -> Result<Self, Error> {
+        let path: PathBuf = path.into();
+        let data = if path.exists() {
+            let file = File::open(&path)?;
+            serde_json::from_reader(&file)?
+        } else {
+            Default::default()
+        };
+        Ok(Self { data, path })
+    }
+
+    pub fn write(&mut self) -> WriteGuard<T> {
+        WriteGuard(self)
+    }
+}
+
+impl<T> Deref for SaveOnDisk<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<'a, T: Serialize> WriteGuard<'a, T> {
+    pub fn save(&self) -> Result<(), Error> {
+        AtomicFile::new(&self.0.path, AllowOverwrite).write(|file| {
+            let writer = BufWriter::new(file);
+            serde_json::to_writer(writer, &self.0.data)
+        })?;
+        Ok(())
+    }
+}
+
+impl<'a, T: Serialize> Deref for WriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T: Serialize> DerefMut for WriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0.data
+    }
+}
+
+impl<'a, T: Serialize> Drop for WriteGuard<'a, T> {
+    fn drop(&mut self) {
+        if let Err(err) = self.save() {
+            log::error!(
+                "Failed to save structure on disk at {} with error: {err}",
+                self.0.path.display()
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::SaveOnDisk;
+
+    #[test]
+    fn saves_data() {
+        let dir = tempdir::TempDir::new("test").unwrap();
+        let counter_file = dir.path().join("counter");
+        let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
+        {
+            let mut counter_guard1 = counter.write();
+            *counter_guard1 += 1;
+        }
+        assert_eq!(*counter, 1);
+        assert_eq!(
+            counter.to_string(),
+            fs::read_to_string(&counter_file).unwrap()
+        );
+        {
+            let mut counter_guard2 = counter.write();
+            *counter_guard2 += 1;
+        }
+        assert_eq!(*counter, 2);
+        assert_eq!(
+            counter.to_string(),
+            fs::read_to_string(&counter_file).unwrap()
+        );
+    }
+
+    #[test]
+    fn loads_data() {
+        let dir = tempdir::TempDir::new("test").unwrap();
+        let counter_file = dir.path().join("counter");
+        {
+            let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
+            let mut counter_guard = counter.write();
+            *counter_guard += 1;
+        }
+        let counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
+        assert_eq!(*counter, 1)
+    }
+}

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use async_trait::async_trait;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
+use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tonic::transport::Uri;
 
@@ -155,7 +156,7 @@ impl Default for ChannelService {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardTransfer {
     pub shard_id: ShardId,
     pub to: PeerId,


### PR DESCRIPTION
Relates to #827 
Also adds a general abstraction for saving on disk.

### For later PRs
1. Add shard_transfer state to collection snapshot
2. Use `SaveOnDisk` in other places that require this functionality
