### PR TITLE
[sharding] Promote temporary shard at the end of transfer

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -248,7 +248,7 @@ impl Collection {
     pub async fn finish_shard_transfer(&self, shard_id: ShardId) -> CollectionResult<()> {
         let mut shards_holder = self.shards_holder.write().await;
         shards_holder
-            .finish_transfer(&self.path, self.id.clone(), shard_id)
+            .finish_transfer(&self.path, self.id.clone(), shard_id, self.config.clone())
             .await
     }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -265,9 +265,9 @@ impl Collection {
             let shard_holder = self.shards_holder.read().await;
             let temp_shard_opt = shard_holder.get_temporary_shard(&shard_id);
             let temp_shard = match temp_shard_opt {
-                 Some(shard) => shard,
-                 None => return Ok(()),
-            }
+                Some(shard) => shard,
+                None => return Ok(()),
+            };
             match temp_shard {
                 Local(local_temp_shard) => {
                     let shard_path = local_temp_shard.shard_path();

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -264,10 +264,10 @@ impl Collection {
         {
             let shard_holder = self.shards_holder.read().await;
             let temp_shard_opt = shard_holder.get_temporary_shard(&shard_id);
-            if temp_shard_opt.is_none() {
-                return Ok(());
+            let temp_shard = match temp_shard_opt {
+                 Some(shard) => shard,
+                 None => return Ok(()),
             }
-            let temp_shard = temp_shard_opt.unwrap();
             match temp_shard {
                 Local(local_temp_shard) => {
                     let shard_path = local_temp_shard.shard_path();

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -75,9 +75,7 @@ impl State {
                             shard_path,
                             channel_service.clone(),
                         )?;
-                        shards_holder
-                            .add_shard(shard_id, Shard::Remote(shard))
-                            .await;
+                        shards_holder.add_shard(shard_id, Shard::Remote(shard));
                     }
                 }
             }

--- a/lib/collection/src/shard/collection_shard_distribution.rs
+++ b/lib/collection/src/shard/collection_shard_distribution.rs
@@ -1,10 +1,6 @@
 use std::collections::HashMap;
-use std::path::Path;
 
-use crate::config::CollectionConfig;
-use crate::operations::types::CollectionResult;
-use crate::shard::shard_config::{ShardConfig, ShardType};
-use crate::shard::{shard_path, PeerId, ShardId};
+use crate::shard::{PeerId, ShardId};
 
 #[derive(Debug)]
 pub struct CollectionShardDistribution {
@@ -51,31 +47,6 @@ impl CollectionShardDistribution {
             .collect();
 
         Self { local, remote }
-    }
-
-    /// Read remote & local shard info from file system
-    pub fn from_local_state(collection_path: &Path) -> CollectionResult<Self> {
-        let config = CollectionConfig::load(collection_path).unwrap_or_else(|err| {
-            panic!(
-                "Can't read collection config due to {}\nat {}",
-                err,
-                collection_path.to_str().unwrap()
-            )
-        });
-        let shard_number = config.params.shard_number.get();
-        let mut local_shards = Vec::new();
-        let mut remote_shards = Vec::new();
-
-        for shard_id in 0..shard_number {
-            let shard_path = shard_path(collection_path, shard_id);
-            let shard_config = ShardConfig::load(&shard_path)?;
-            match shard_config.r#type {
-                ShardType::Local => local_shards.push(shard_id),
-                ShardType::Remote { peer_id } => remote_shards.push((shard_id, peer_id)),
-            }
-        }
-
-        Ok(Self::new(local_shards, remote_shards))
     }
 
     pub fn shard_count(&self) -> usize {

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -191,6 +191,10 @@ impl LocalShard {
         collection
     }
 
+    pub fn shard_path(&self) -> PathBuf {
+        self.path.clone()
+    }
+
     pub fn wal_path(shard_path: &Path) -> PathBuf {
         shard_path.join("wal")
     }
@@ -199,7 +203,17 @@ impl LocalShard {
         shard_path.join("segments")
     }
 
-    /// Creates new empty shard with given configuration, initializing all storages, optimizers and directories.
+    pub async fn build_temp(
+        id: ShardId,
+        collection_id: CollectionId,
+        shard_path: &Path,
+        shared_config: Arc<TokioRwLock<CollectionConfig>>,
+    ) -> CollectionResult<LocalShard> {
+        // initialize temporary shard config file
+        let temp_shard_config = ShardConfig::new_temp();
+        Self::_build(id, collection_id, shard_path, shared_config, temp_shard_config).await
+    }
+
     pub async fn build(
         id: ShardId,
         collection_id: CollectionId,
@@ -208,7 +222,18 @@ impl LocalShard {
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file
         let local_shard_config = ShardConfig::new_local();
-        local_shard_config.save(shard_path)?;
+        Self::_build(id, collection_id, shard_path, shared_config, local_shard_config).await
+    }
+
+    /// Creates new empty shard with given configuration, initializing all storages, optimizers and directories.
+    async fn _build(
+        id: ShardId,
+        collection_id: CollectionId,
+        shard_path: &Path,
+        shared_config: Arc<TokioRwLock<CollectionConfig>>,
+        config: ShardConfig,
+    ) -> CollectionResult<LocalShard> {
+        config.save(shard_path)?;
 
         let config = shared_config.read().await;
 

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -211,7 +211,14 @@ impl LocalShard {
     ) -> CollectionResult<LocalShard> {
         // initialize temporary shard config file
         let temp_shard_config = ShardConfig::new_temp();
-        Self::_build(id, collection_id, shard_path, shared_config, temp_shard_config).await
+        Self::_build(
+            id,
+            collection_id,
+            shard_path,
+            shared_config,
+            temp_shard_config,
+        )
+        .await
     }
 
     pub async fn build(
@@ -222,7 +229,14 @@ impl LocalShard {
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file
         let local_shard_config = ShardConfig::new_local();
-        Self::_build(id, collection_id, shard_path, shared_config, local_shard_config).await
+        Self::_build(
+            id,
+            collection_id,
+            shard_path,
+            shared_config,
+            local_shard_config,
+        )
+        .await
     }
 
     /// Creates new empty shard with given configuration, initializing all storages, optimizers and directories.

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -26,8 +26,8 @@ use crate::operations::CollectionUpdateOperations;
 use crate::shard::local_shard::LocalShard;
 use crate::shard::proxy_shard::ProxyShard;
 use crate::shard::remote_shard::RemoteShard;
-use crate::telemetry::ShardTelemetry;
 use crate::shard::shard_versioning::suggest_next_version_path;
+use crate::telemetry::ShardTelemetry;
 
 pub type ShardId = u32;
 

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -6,6 +6,7 @@ pub mod proxy_shard;
 pub mod remote_shard;
 pub mod shard_config;
 pub mod shard_holder;
+pub mod shard_versioning;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -26,6 +27,7 @@ use crate::shard::local_shard::LocalShard;
 use crate::shard::proxy_shard::ProxyShard;
 use crate::shard::remote_shard::RemoteShard;
 use crate::telemetry::ShardTelemetry;
+use crate::shard::shard_versioning::suggest_next_version_path;
 
 pub type ShardId = u32;
 
@@ -114,6 +116,8 @@ pub const HASH_RING_SHARD_SCALE: u32 = 100;
 
 pub type CollectionId = String;
 
+pub type ShardVersion = usize;
+
 pub type PeerId = u64;
 
 #[derive(Clone)]
@@ -149,19 +153,22 @@ pub struct ShardTransfer {
     pub to: PeerId,
 }
 
-pub fn shard_path(collection_path: &Path, shard_id: ShardId) -> PathBuf {
-    collection_path.join(format!("{shard_id}"))
-}
-
 pub async fn create_shard_dir(
     collection_path: &Path,
     shard_id: ShardId,
 ) -> CollectionResult<PathBuf> {
-    let shard_path = shard_path(collection_path, shard_id);
-    tokio::fs::create_dir_all(&shard_path)
-        .await
-        .map_err(|err| CollectionError::ServiceError {
-            error: format!("Can't create shard {shard_id} directory. Error: {}", err),
-        })?;
-    Ok(shard_path)
+    loop {
+        let shard_path = suggest_next_version_path(collection_path, shard_id).await?;
+
+        match tokio::fs::create_dir(&shard_path).await {
+            Ok(_) => return Ok(shard_path),
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    continue;
+                } else {
+                    return Err(CollectionError::from(e));
+                }
+            }
+        }
+    }
 }

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -35,6 +35,11 @@ impl ShardConfig {
         Self { r#type }
     }
 
+    pub fn new_temp() -> Self {
+        let r#type = ShardType::Temporary;
+        Self { r#type }
+    }
+
     pub fn load(shard_path: &Path) -> CollectionResult<Self> {
         let config_path = Self::get_config_path(shard_path);
         // shard config was introduced in 0.8.0

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -8,10 +8,11 @@ use crate::shard::PeerId;
 
 pub const SHARD_CONFIG_FILE: &str = "shard_config.json";
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq)]
 pub enum ShardType {
     Local,
     Remote { peer_id: PeerId },
+    Temporary, // same as local, but not ready yet
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]

--- a/lib/collection/src/shard/shard_versioning.rs
+++ b/lib/collection/src/shard/shard_versioning.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+
+use crate::operations::types::{CollectionError, CollectionResult};
+use crate::shard::shard_config::{ShardConfig, ShardType};
+use crate::shard::{ShardId, ShardVersion};
+
+pub async fn shards_versions(
+    collection_path: &Path,
+    shard_id: ShardId,
+) -> CollectionResult<Vec<(ShardVersion, PathBuf)>> {
+    let mut entries = tokio::fs::read_dir(collection_path).await?;
+    let mut all_versions: Vec<(ShardVersion, PathBuf)> = vec![];
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.is_dir() {
+            let file_name_opt = path.file_name().and_then(|file_name| file_name.to_str());
+
+            if file_name_opt.is_none() {
+                continue;
+            }
+
+            let file_name = file_name_opt.unwrap();
+
+            if file_name.starts_with(&format!("{shard_id}-", shard_id = shard_id)) {
+                let version_opt = file_name
+                    .split('-')
+                    .nth(1)
+                    .and_then(|version_str| version_str.parse::<ShardVersion>().ok());
+
+                if version_opt.is_none() {
+                    continue;
+                }
+                let version = version_opt.unwrap();
+                all_versions.push((version, path.clone()));
+            } else if file_name == format!("{shard_id}", shard_id = shard_id) {
+                let version = 0;
+                all_versions.push((version, path.clone()));
+            }
+        }
+    }
+    all_versions.sort_by_key(|(version, _)| *version);
+    all_versions = all_versions.into_iter().rev().collect();
+    Ok(all_versions)
+}
+
+pub fn versioned_shard_path(
+    collection_path: &Path,
+    shard_id: ShardId,
+    version: ShardVersion,
+) -> PathBuf {
+    if version == 0 {
+        collection_path.join(format!("{shard_id}"))
+    } else {
+        collection_path.join(format!("{shard_id}-{version}"))
+    }
+}
+
+pub async fn suggest_next_version_path(
+    collection_path: &Path,
+    shard_id: ShardId,
+) -> CollectionResult<PathBuf> {
+    // Assume `all_versions` is sorted by version in descending order.
+    let all_versions = shards_versions(collection_path, shard_id).await?;
+    if all_versions.is_empty() {
+        return Ok(versioned_shard_path(collection_path, shard_id, 0));
+    }
+    let (last_version, _) = all_versions.first().unwrap();
+    Ok(versioned_shard_path(
+        collection_path,
+        shard_id,
+        last_version + 1,
+    ))
+}
+
+pub async fn latest_shard_paths(
+    collection_path: &Path,
+    shard_id: ShardId,
+) -> CollectionResult<Vec<(PathBuf, ShardVersion, ShardType)>> {
+    // Assume `all_versions` is sorted by version in descending order.
+    let mut res = vec![];
+    let mut seen_temp_shard = false;
+    let all_versions = shards_versions(collection_path, shard_id).await?;
+    for (version, path) in all_versions {
+        let shard_config = ShardConfig::load(&path)?;
+
+        match shard_config.r#type {
+            ShardType::Local => {
+                res.push((path, version, shard_config.r#type));
+                break; // We don't need older local shards.
+            }
+            ShardType::Remote { .. } => {
+                res.push((path, version, shard_config.r#type));
+                break; // We don't need older remote shards.
+            }
+            ShardType::Temporary => {
+                if !seen_temp_shard {
+                    res.push((path, version, shard_config.r#type));
+                    seen_temp_shard = true;
+                }
+            }
+        };
+    }
+    if (seen_temp_shard && res.len() < 2) || res.is_empty() {
+        return Err(CollectionError::service_error(format!(
+            "No shard found: {shard_id} at {collection_path}",
+            shard_id = shard_id,
+            collection_path = collection_path.display()
+        )));
+    }
+    Ok(res)
+}

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -477,3 +477,63 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
     assert_eq!(result.points.get(2).unwrap().id, 4.into());
     collection.before_drop().await;
 }
+
+#[tokio::test]
+async fn test_promote_temporary_shards() {
+    let collection_dir = TempDir::new("collection").unwrap();
+    let mut collection = simple_collection_fixture(collection_dir.path(), 2).await;
+
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        Batch {
+            ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8]
+                .into_iter()
+                .map(|x| x.into())
+                .collect_vec(),
+            vectors: vec![
+                vec![0.0, 0.0, 1.0, 1.0],
+                vec![1.0, 0.0, 0.0, 0.0],
+                vec![1.0, 0.0, 0.0, 0.0],
+                vec![0.0, 1.0, 0.0, 0.0],
+                vec![0.0, 1.0, 0.0, 0.0],
+                vec![0.0, 0.0, 1.0, 0.0],
+                vec![0.0, 0.0, 1.0, 0.0],
+                vec![0.0, 0.0, 0.0, 1.0],
+                vec![0.0, 0.0, 0.0, 1.0],
+            ],
+            payloads: None,
+        }
+        .into(),
+    ));
+
+    collection
+        .update_from_client(insert_points, true)
+        .await
+        .unwrap();
+
+    let scroll_request = ScrollRequest {
+        offset: None,
+        limit: Some(2),
+        filter: None,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: false,
+    };
+
+    // validate collection non empty
+    let result = collection
+        .scroll_by(scroll_request.clone(), None)
+        .await
+        .unwrap();
+    assert_eq!(result.points.len(), 2);
+
+    // initiate temporary shard for shard_id 1
+    collection.initiate_temporary_shard(1).await.unwrap();
+
+    // promote temporary shard for shard_id 1
+    collection.promote_temporary_shard(1).await.unwrap();
+
+    // validate collection still non empty
+    let result = collection.scroll_by(scroll_request, None).await.unwrap();
+    assert_eq!(result.points.len(), 2);
+
+    collection.before_drop().await;
+}

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -481,7 +481,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
 #[tokio::test]
 async fn test_promote_temporary_shards() {
     let collection_dir = TempDir::new("collection").unwrap();
-    let mut collection = simple_collection_fixture(collection_dir.path(), 2).await;
+    let mut collection = simple_collection_fixture(collection_dir.path(), 1).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
         Batch {
@@ -526,14 +526,14 @@ async fn test_promote_temporary_shards() {
     assert_eq!(result.points.len(), 2);
 
     // initiate temporary shard for shard_id 1
-    collection.initiate_temporary_shard(1).await.unwrap();
+    collection.initiate_temporary_shard(0).await.unwrap();
 
     // promote temporary shard for shard_id 1
-    collection.promote_temporary_shard(1).await.unwrap();
+    collection.promote_temporary_shard(0).await.unwrap();
 
-    // validate collection still non empty
+    // validate collection is empty now
     let result = collection.scroll_by(scroll_request, None).await.unwrap();
-    assert_eq!(result.points.len(), 2);
+    assert_eq!(result.points.len(), 0);
 
     collection.before_drop().await;
 }


### PR DESCRIPTION
This PR is part a follow up to https://github.com/qdrant/qdrant/pull/829 (https://github.com/qdrant/qdrant/issues/789)

It adds a mechanism to promote a temporary shard as a local shard at the end of the shard transfer which is triggered through consensus via `finish_transfer`.

I tried my best to make the span of the write locks as short as possible to not block the reads but it is still significant.

There is a unit test for creating and promoting a temporary shard.