### PR TITLE
Fix sharding distribution by using current distribution

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -222,6 +222,11 @@ impl Collection {
         }
     }
 
+    pub async fn shard_distribution(&self, this_peer_id: PeerId) -> Vec<(ShardId, PeerId)> {
+        let shard_holder_read = self.shards_holder.read().await;
+        shard_holder_read.shard_distribution(this_peer_id)
+    }
+
     fn send_shard(&self, _shard_id: ShardId) {
         todo!()
     }

--- a/lib/collection/src/shard/shard_holder.rs
+++ b/lib/collection/src/shard/shard_holder.rs
@@ -75,6 +75,17 @@ impl ShardHolder {
         self.shards.values()
     }
 
+    pub fn shard_distribution(&self, this_peer_id: PeerId) -> Vec<(ShardId, PeerId)> {
+        self.shards
+            .iter()
+            .map(|(shard_id, shard)| match shard {
+                Shard::Local(_) => (*shard_id, this_peer_id),
+                Shard::Proxy(_) => (*shard_id, this_peer_id),
+                Shard::Remote(r) => (*shard_id, r.peer_id),
+            })
+            .collect()
+    }
+
     pub fn get_temporary_shard(&self, shard_id: &ShardId) -> Option<&Shard> {
         self.temporary_shards.get(shard_id)
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -745,7 +745,15 @@ impl TableOfContent {
         known_peers_set.insert(self.this_peer_id());
         let known_peers: Vec<_> = known_peers_set.into_iter().collect();
 
-        let shard_distribution = ShardDistributionProposal::new(shard_number, &known_peers, vec![]);
+        let mut current_distribution = Vec::new();
+        let known_collections = self.collections.read().await;
+        for (_, col) in known_collections.iter() {
+            let collection_distribution = col.shard_distribution(self.this_peer_id).await;
+            current_distribution.extend(collection_distribution);
+        }
+
+        let shard_distribution =
+            ShardDistributionProposal::new(shard_number, &known_peers, current_distribution);
 
         log::debug!(
             "Suggesting distribution for {} shards for collection '{}' among {} peers {:?}",


### PR DESCRIPTION
This PR fixes the shard distribution proposal to account with the current distribution.

Discovered via `/tests/consensus_tests/test_many_collections.py` which is broken on my system locally with

```bash
[2022-07-25T09:21:20.181Z ERROR storage::content_manager::consensus_state] Failed to apply collection meta operation entry with error: Service internal error: persistence error: IO error: While opendir: ./storage/collections/test_collection_10/0/segments/48319110-3321-497f-834e-94e11586f1c8: Too many open files
```

Manually bisecting shows that it is happening since this [PR](https://github.com/qdrant/qdrant/pull/825).

The distribution of shards is not even anymore, a single peer gets up top 12 shards on my machine before reaching the limit of open files per process.

The issue is that the current distribution is not fed anymore into the `ShardDistributionProposal` which is behaving properly by assuming there are no existing shards. This creates overtime an unbalanced cluster.

The fix is to compute and inject the current shard distribution.

I am now able to run `/tests/consensus_tests/test_many_collections.py` locally again!