### PR TITLE
Remove unecessary Arc for web::Data

### DIFF
--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::{get, web, Responder};
 use storage::dispatcher::Dispatcher;
@@ -7,7 +5,7 @@ use storage::dispatcher::Dispatcher;
 use crate::actix::helpers::process_response;
 
 #[get("/cluster")]
-async fn cluster_status(dispatcher: web::Data<Arc<Dispatcher>>) -> impl Responder {
+async fn cluster_status(dispatcher: web::Data<Dispatcher>) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher.cluster_status();
     process_response(Ok(response), timing)

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use actix_web::rt::time::Instant;
@@ -26,26 +25,23 @@ impl WaitTimeout {
 }
 
 #[get("/collections")]
-async fn get_collections(toc: web::Data<Arc<TableOfContent>>) -> impl Responder {
+async fn get_collections(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();
-    let response = Ok(do_list_collections(&toc.into_inner()).await);
+    let response = Ok(do_list_collections(toc.get_ref()).await);
     process_response(response, timing)
 }
 
 #[get("/collections/{name}")]
-async fn get_collection(
-    toc: web::Data<Arc<TableOfContent>>,
-    path: web::Path<String>,
-) -> impl Responder {
+async fn get_collection(toc: web::Data<TableOfContent>, path: web::Path<String>) -> impl Responder {
     let name = path.into_inner();
     let timing = Instant::now();
-    let response = do_get_collection(&toc.into_inner(), &name, None).await;
+    let response = do_get_collection(toc.get_ref(), &name, None).await;
     process_response(response, timing)
 }
 
 #[put("/collections/{name}")]
 async fn create_collection(
-    dispatcher: web::Data<Arc<Dispatcher>>,
+    dispatcher: web::Data<Dispatcher>,
     path: web::Path<String>,
     operation: web::Json<CreateCollection>,
     web::Query(query): web::Query<WaitTimeout>,
@@ -66,7 +62,7 @@ async fn create_collection(
 
 #[patch("/collections/{name}")]
 async fn update_collection(
-    dispatcher: web::Data<Arc<Dispatcher>>,
+    dispatcher: web::Data<Dispatcher>,
     path: web::Path<String>,
     operation: web::Json<UpdateCollection>,
     web::Query(query): web::Query<WaitTimeout>,
@@ -87,7 +83,7 @@ async fn update_collection(
 
 #[delete("/collections/{name}")]
 async fn delete_collection(
-    dispatcher: web::Data<Arc<Dispatcher>>,
+    dispatcher: web::Data<Dispatcher>,
     path: web::Path<String>,
     web::Query(query): web::Query<WaitTimeout>,
 ) -> impl Responder {
@@ -104,7 +100,7 @@ async fn delete_collection(
 
 #[post("/collections/aliases")]
 async fn update_aliases(
-    dispatcher: web::Data<Arc<Dispatcher>>,
+    dispatcher: web::Data<Dispatcher>,
     operation: web::Json<ChangeAliasesOperation>,
     web::Query(query): web::Query<WaitTimeout>,
 ) -> impl Responder {
@@ -120,12 +116,12 @@ async fn update_aliases(
 
 #[get("/collections/{name}/cluster")]
 async fn get_cluster_info(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
 ) -> impl Responder {
     let name = path.into_inner();
     let timing = Instant::now();
-    let response = do_get_collection_cluster(&toc.into_inner(), &name).await;
+    let response = do_get_collection_cluster(toc.get_ref(), &name).await;
     process_response(response, timing)
 }
 

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use collection::operations::types::CountRequest;
@@ -10,20 +8,15 @@ use crate::common::points::do_count_points;
 
 #[post("/collections/{name}/points/count")]
 pub async fn count_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     request: web::Json<CountRequest>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response = do_count_points(
-        &toc.into_inner(),
-        &collection_name,
-        request.into_inner(),
-        None,
-    )
-    .await;
+    let response =
+        do_count_points(toc.get_ref(), &collection_name, request.into_inner(), None).await;
 
     process_response(response, timing)
 }

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use collection::operations::types::RecommendRequest;
@@ -19,14 +17,14 @@ async fn do_recommend_points(
 
 #[post("/collections/{name}/points/recommend")]
 pub async fn recommend_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     request: web::Json<RecommendRequest>,
 ) -> impl Responder {
     let name = path.into_inner();
     let timing = Instant::now();
 
-    let response = do_recommend_points(&toc.into_inner(), &name, request.into_inner()).await;
+    let response = do_recommend_points(toc.get_ref(), &name, request.into_inner()).await;
 
     process_response(response, timing)
 }

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::{get, post, web, Responder};
 use collection::operations::types::{PointRequest, Record, ScrollRequest, ScrollResult};
@@ -35,7 +33,7 @@ async fn scroll_get_points(
 
 #[get("/collections/{name}/points/{id}")]
 pub async fn get_point(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<(String, String)>,
 ) -> impl Responder {
     let timing = Instant::now();
@@ -54,7 +52,7 @@ pub async fn get_point(
         }
     };
 
-    let response = do_get_point(&toc.into_inner(), &collection_name, point_id).await;
+    let response = do_get_point(toc.get_ref(), &collection_name, point_id).await;
 
     let response = match response {
         Ok(record) => match record {
@@ -70,33 +68,26 @@ pub async fn get_point(
 
 #[post("/collections/{name}/points")]
 pub async fn get_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     request: web::Json<PointRequest>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response = do_get_points(
-        &toc.into_inner(),
-        &collection_name,
-        request.into_inner(),
-        None,
-    )
-    .await;
+    let response = do_get_points(toc.get_ref(), &collection_name, request.into_inner(), None).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/points/scroll")]
 pub async fn scroll_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     request: web::Json<ScrollRequest>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response =
-        scroll_get_points(&toc.into_inner(), &collection_name, request.into_inner()).await;
+    let response = scroll_get_points(toc.get_ref(), &collection_name, request.into_inner()).await;
     process_response(response, timing)
 }

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use collection::operations::types::SearchRequest;
@@ -10,20 +8,15 @@ use crate::common::points::do_search_points;
 
 #[post("/collections/{name}/points/search")]
 pub async fn search_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     request: web::Json<SearchRequest>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
     let timing = Instant::now();
 
-    let response = do_search_points(
-        &toc.into_inner(),
-        &collection_name,
-        request.into_inner(),
-        None,
-    )
-    .await;
+    let response =
+        do_search_points(toc.get_ref(), &collection_name, request.into_inner(), None).await;
 
     process_response(response, timing)
 }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
 use actix_web::{get, post, web, Responder, Result};
@@ -40,59 +38,56 @@ pub async fn do_get_snapshot(
 }
 
 #[get("/collections/{name}/snapshots")]
-async fn list_snapshots(
-    toc: web::Data<Arc<TableOfContent>>,
-    path: web::Path<String>,
-) -> impl Responder {
+async fn list_snapshots(toc: web::Data<TableOfContent>, path: web::Path<String>) -> impl Responder {
     let collection_name = path.into_inner();
 
     let timing = Instant::now();
-    let response = do_list_snapshots(&toc.into_inner(), &collection_name).await;
+    let response = do_list_snapshots(toc.get_ref(), &collection_name).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/snapshots")]
 async fn create_snapshot(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
 
     let timing = Instant::now();
-    let response = do_create_snapshot(&toc.into_inner(), &collection_name).await;
+    let response = do_create_snapshot(toc.get_ref(), &collection_name).await;
     process_response(response, timing)
 }
 
 #[get("/collections/{name}/snapshots/{snapshot_name}")]
 async fn get_snapshot(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<(String, String)>,
 ) -> impl Responder {
     let (collection_name, snapshot_name) = path.into_inner();
-    do_get_snapshot(&toc.into_inner(), &collection_name, &snapshot_name).await
+    do_get_snapshot(toc.get_ref(), &collection_name, &snapshot_name).await
 }
 
 #[get("/snapshots")]
-async fn list_full_snapshots(toc: web::Data<Arc<TableOfContent>>) -> impl Responder {
+async fn list_full_snapshots(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();
-    let response = do_list_full_snapshots(&toc.into_inner()).await;
+    let response = do_list_full_snapshots(toc.get_ref()).await;
     process_response(response, timing)
 }
 
 #[post("/snapshots")]
-async fn create_full_snapshot(toc: web::Data<Arc<TableOfContent>>) -> impl Responder {
+async fn create_full_snapshot(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();
-    let response = do_create_full_snapshot(&toc.into_inner()).await;
+    let response = do_create_full_snapshot(toc.get_ref()).await;
     process_response(response, timing)
 }
 
 #[get("/snapshots/{snapshot_name}")]
 async fn get_full_snapshot(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
 ) -> impl Responder {
     let snapshot_name = path.into_inner();
-    do_get_full_snapshot(&toc.into_inner(), &snapshot_name).await
+    do_get_full_snapshot(toc.get_ref(), &snapshot_name).await
 }
 
 // Configure services

--- a/src/actix/api/telemetry_api.rs
+++ b/src/actix/api/telemetry_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::web::Query;
 use actix_web::{get, web, Responder};
@@ -18,7 +16,7 @@ pub struct TelemetryParam {
 
 #[get("/telemetry")]
 async fn telemetry(
-    telemetry_collector: web::Data<Arc<Mutex<TelemetryCollector>>>,
+    telemetry_collector: web::Data<Mutex<TelemetryCollector>>,
     params: Query<TelemetryParam>,
 ) -> impl Responder {
     let timing = Instant::now();

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::rt::time::Instant;
 use actix_web::web::Query;
 use actix_web::{delete, post, put, web, Responder};
@@ -22,7 +20,7 @@ pub struct UpdateParam {
 
 #[put("/collections/{name}/points")]
 pub async fn upsert_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<PointInsertOperations>,
     params: Query<UpdateParam>,
@@ -32,14 +30,13 @@ pub async fn upsert_points(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_upsert_points(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_upsert_points(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/points/delete")]
 pub async fn delete_points(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<PointsSelector>,
     params: Query<UpdateParam>,
@@ -49,14 +46,13 @@ pub async fn delete_points(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_delete_points(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_delete_points(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/points/payload")]
 pub async fn set_payload(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<SetPayload>,
     params: Query<UpdateParam>,
@@ -66,13 +62,13 @@ pub async fn set_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response = do_set_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_set_payload(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/points/payload/delete")]
 pub async fn delete_payload(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<DeletePayload>,
     params: Query<UpdateParam>,
@@ -82,14 +78,13 @@ pub async fn delete_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_delete_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_delete_payload(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[post("/collections/{name}/points/payload/clear")]
 pub async fn clear_payload(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<PointsSelector>,
     params: Query<UpdateParam>,
@@ -99,14 +94,13 @@ pub async fn clear_payload(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_clear_payload(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_clear_payload(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[put("/collections/{name}/index")]
 pub async fn create_field_index(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<String>,
     operation: web::Json<CreateFieldIndex>,
     params: Query<UpdateParam>,
@@ -116,14 +110,13 @@ pub async fn create_field_index(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_create_index(&toc.into_inner(), &collection_name, operation, None, wait).await;
+    let response = do_create_index(toc.get_ref(), &collection_name, operation, None, wait).await;
     process_response(response, timing)
 }
 
 #[delete("/collections/{name}/index/{field_name}")]
 pub async fn delete_field_index(
-    toc: web::Data<Arc<TableOfContent>>,
+    toc: web::Data<TableOfContent>,
     path: web::Path<(String, String)>,
     params: Query<UpdateParam>,
 ) -> impl Responder {
@@ -131,8 +124,7 @@ pub async fn delete_field_index(
     let wait = params.wait.unwrap_or(false);
     let timing = Instant::now();
 
-    let response =
-        do_delete_index(&toc.into_inner(), &collection_name, field_name, None, wait).await;
+    let response = do_delete_index(toc.get_ref(), &collection_name, field_name, None, wait).await;
     process_response(response, timing)
 }
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -57,9 +57,9 @@ pub fn init(
     settings: Settings,
 ) -> std::io::Result<()> {
     actix_web::rt::System::new().block_on(async {
-        let toc_data = web::Data::new(dispatcher.toc().clone());
-        let dispatcher_data = web::Data::new(dispatcher);
-        let telemetry_data = web::Data::new(telemetry_collector.clone());
+        let toc_data = web::Data::from(dispatcher.toc().clone());
+        let dispatcher_data = web::Data::from(dispatcher);
+        let telemetry_data = web::Data::from(telemetry_collector.clone());
         HttpServer::new(move || {
             let cors = Cors::default()
                 .allow_any_origin()


### PR DESCRIPTION
This PR removes an unnecessary layer of indirection in our usage of Actix's `web::Data`.

The `web::Data` is a wrapper for an `Arc<T>`

```rust
pub struct Data<T: ?Sized>(Arc<T>);
```

This is what `web::Data::new` does under the hood

```rust
    pub fn new(state: T) -> Data<T> {
        Data(Arc::new(state))
    }
```

This is why we get the following definitions in our services

```rust
    toc: web::Data<Arc<TableOfContent>>,
```

This means we have two layers of stacked `Arc`.

This PR simplify this by using a single layer of `Arc` via the `web::Data::from` method which accepts an existing `Arc`.

I do not expect a visible performance improvement but that is definitely cleaner IMHO.
