### PR TITLE
Prevent Vector size zero

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2437,8 +2437,8 @@
           "vector_size": {
             "description": "Size of a vectors used",
             "type": "integer",
-            "format": "uint",
-            "minimum": 0
+            "format": "uint64",
+            "minimum": 1
           },
           "distance": {
             "$ref": "#/components/schemas/Distance"

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::Path;
 
 use parking_lot::RwLock;
@@ -118,7 +118,7 @@ pub(crate) fn get_merge_optimizer(
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {
-            vector_size: dim,
+            vector_size: NonZeroU64::new(dim as u64).unwrap(),
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
             on_disk_payload: false,
@@ -141,7 +141,7 @@ pub(crate) fn get_indexing_optimizer(
         segment_path.to_owned(),
         collection_temp_dir.to_owned(),
         CollectionParams {
-            vector_size: dim,
+            vector_size: NonZeroU64::new(dim as u64).unwrap(),
             distance: Distance::Dot,
             shard_number: NonZeroU32::new(1).unwrap(),
             on_disk_payload: false,

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -206,7 +206,7 @@ impl SegmentOptimizer for IndexingOptimizer {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
+    use std::num::{NonZeroU32, NonZeroU64};
     use std::ops::Deref;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
@@ -270,7 +270,7 @@ mod tests {
             segments_dir.path().to_owned(),
             segments_temp_dir.path().to_owned(),
             CollectionParams {
-                vector_size: segment_config.vector_size,
+                vector_size: NonZeroU64::new(segment_config.vector_size as u64).unwrap(),
                 distance: segment_config.distance,
                 shard_number: NonZeroU32::new(1).unwrap(),
                 on_disk_payload: false,

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -65,7 +65,7 @@ pub trait SegmentOptimizer {
     fn temp_segment(&self) -> CollectionResult<LockedSegment> {
         let collection_params = self.collection_params();
         let config = SegmentConfig {
-            vector_size: collection_params.vector_size,
+            vector_size: collection_params.vector_size.get() as usize,
             distance: collection_params.distance,
             index: Indexes::Plain {},
             storage_type: StorageType::InMemory,
@@ -102,7 +102,7 @@ pub trait SegmentOptimizer {
         let is_on_disk = total_vectors_size >= thresholds.memmap_threshold * BYTES_IN_KB;
 
         let optimized_config = SegmentConfig {
-            vector_size: collection_params.vector_size,
+            vector_size: collection_params.vector_size.get() as usize,
             distance: collection_params.distance,
             index: if is_indexed {
                 Indexes::Hnsw(self.hnsw_config())

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -115,7 +115,7 @@ impl SegmentOptimizer for VacuumOptimizer {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
+    use std::num::{NonZeroU32, NonZeroU64};
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
@@ -200,7 +200,7 @@ mod tests {
             dir.path().to_owned(),
             temp_dir.path().to_owned(),
             CollectionParams {
-                vector_size: 4,
+                vector_size: NonZeroU64::new(4).unwrap(),
                 distance: Distance::Dot,
                 shard_number: NonZeroU32::new(1).unwrap(),
                 on_disk_payload: false,

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{Read, Write};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::Path;
 
 use atomicwrites::AtomicFile;
@@ -45,7 +45,7 @@ impl Default for WalConfig {
 #[serde(rename_all = "snake_case")]
 pub struct CollectionParams {
     /// Size of a vectors used
-    pub vector_size: usize,
+    pub vector_size: NonZeroU64,
     /// Type of distance function used for measuring distance between vectors
     pub distance: Distance,
     /// Number of shards the collection has

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use api::grpc::conversions::{payload_to_proto, proto_to_payloads};
 use itertools::Itertools;
@@ -88,7 +88,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
             ram_data_size: ram_data_size as u64,
             config: Some(api::grpc::qdrant::CollectionConfig {
                 params: Some(api::grpc::qdrant::CollectionParams {
-                    vector_size: config.params.vector_size as u64,
+                    vector_size: config.params.vector_size.get(),
                     distance: match config.params.distance {
                         segment::types::Distance::Cosine => api::grpc::qdrant::Distance::Cosine,
                         segment::types::Distance::Euclid => api::grpc::qdrant::Distance::Euclid,
@@ -205,7 +205,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
             params: match config.params {
                 None => return Err(Status::invalid_argument("Malformed CollectionParams type")),
                 Some(params) => CollectionParams {
-                    vector_size: params.vector_size as usize,
+                    vector_size: NonZeroU64::new(params.vector_size).unwrap(),
                     distance: match segment::types::Distance::from_index(params.distance) {
                         None => {
                             return Err(Status::invalid_argument(

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -270,7 +270,7 @@ impl LocalShard {
         let mut segment_holder = SegmentHolder::default();
         let mut build_handlers = vec![];
 
-        let vector_size = config.params.vector_size;
+        let vector_size = config.params.vector_size.get() as usize;
         let distance = config.params.distance;
         let segment_number = config.optimizer_config.get_number_segments();
 

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use segment::types::Distance;
 
@@ -27,7 +27,7 @@ async fn test_snapshot_collection() {
     };
 
     let collection_params = CollectionParams {
-        vector_size: 4,
+        vector_size: NonZeroU64::new(4).unwrap(),
         distance: Distance::Dot,
         shard_number: NonZeroU32::new(3).expect("Shard number can not be zero"),
         on_disk_payload: false,

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::Path;
 
 use collection::collection::Collection;
@@ -34,7 +34,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
     };
 
     let collection_params = CollectionParams {
-        vector_size: 4,
+        vector_size: NonZeroU64::new(4).unwrap(),
         distance: Distance::Dot,
         shard_number: NonZeroU32::new(shard_number).expect("Shard number can not be zero"),
         on_disk_payload: false,

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -20,6 +20,7 @@ pub struct ChunkedVectors {
 
 impl ChunkedVectors {
     pub fn new(dim: usize) -> ChunkedVectors {
+        assert_ne!(dim, 0, "The vector's dimension cannot be 0");
         let vector_size = dim * mem::size_of::<VectorElementType>();
         let chunk_capacity = max(MIN_CHUNK_CAPACITY, CHUNK_SIZE / vector_size);
         ChunkedVectors {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::{create_dir_all, read_dir, remove_dir_all};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -225,7 +225,9 @@ impl TableOfContent {
             )
         }
         let collection_params = CollectionParams {
-            vector_size,
+            vector_size: NonZeroU64::new(vector_size as u64).ok_or(StorageError::BadInput {
+                description: "`vector_size` cannot be 0".to_string(),
+            })?,
             distance,
             shard_number: NonZeroU32::new(collection_shard_distribution.shard_count() as u32)
                 .ok_or(StorageError::BadInput {


### PR DESCRIPTION
This PR prevents vector dim. of zero (https://github.com/qdrant/qdrant/issues/806).

I tried to hit a sweet spot between type safety and runtime validation.

The `CollectionParams` enforces a `NonZeroU64` for the vector size which should not be a breaking change in practice.