### PR TITLE
Disable mmap threshold

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,7 +54,8 @@ storage:
     # Segments larger than this threshold will be stored as read-only memmaped file.
     # To enable memmap storage, lower the threshold
     # Note: 1Kb = 1 vector of size 256
-    memmap_threshold_kb: 200000
+    # If not set, mmap will not be used.
+    memmap_threshold_kb: null
 
     # Maximum size (in KiloBytes) of vectors allowed for plain index.
     # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2511,7 +2511,6 @@
           "indexing_threshold",
           "max_optimization_threads",
           "max_segment_size",
-          "memmap_threshold",
           "vacuum_min_vector_number"
         ],
         "properties": {
@@ -2540,9 +2539,11 @@
           },
           "memmap_threshold": {
             "description": "Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256",
+            "default": null,
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "indexing_threshold": {
             "description": "Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md Note: 1Kb = 1 vector of size 256",

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -123,9 +123,9 @@ impl IndexingOptimizer {
                 };
 
                 let big_for_mmap =
-                    vector_size >= self.thresholds_config.memmap_threshold * BYTES_IN_KB;
+                    vector_size >= self.thresholds_config.memmap_threshold.saturating_mul(BYTES_IN_KB);
                 let big_for_index =
-                    vector_size >= self.thresholds_config.indexing_threshold * BYTES_IN_KB;
+                    vector_size >= self.thresholds_config.indexing_threshold.saturating_mul( BYTES_IN_KB);
 
                 let require_indexing =
                     (big_for_mmap && !is_memmaped) || (big_for_index && !is_vector_indexed);
@@ -153,7 +153,7 @@ impl IndexingOptimizer {
         if let Some((idx, size)) = smallest_unindexed {
             if *idx != selected_segment_id
                 && selected_segment_size + size
-                    < self.thresholds_config.max_segment_size * BYTES_IN_KB
+                    < self.thresholds_config.max_segment_size.saturating_mul(BYTES_IN_KB)
             {
                 return vec![selected_segment_id, *idx];
             }
@@ -164,7 +164,7 @@ impl IndexingOptimizer {
         if let Some((idx, size)) = smallest_indexed {
             if idx != selected_segment_id
                 && selected_segment_size + size
-                    < self.thresholds_config.max_segment_size * BYTES_IN_KB
+                    < self.thresholds_config.max_segment_size.saturating_mul( BYTES_IN_KB)
             {
                 return vec![selected_segment_id, idx];
             }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -122,10 +122,16 @@ impl IndexingOptimizer {
                     StorageType::Mmap => true,
                 };
 
-                let big_for_mmap =
-                    vector_size >= self.thresholds_config.memmap_threshold.saturating_mul(BYTES_IN_KB);
-                let big_for_index =
-                    vector_size >= self.thresholds_config.indexing_threshold.saturating_mul( BYTES_IN_KB);
+                let big_for_mmap = vector_size
+                    >= self
+                        .thresholds_config
+                        .memmap_threshold
+                        .saturating_mul(BYTES_IN_KB);
+                let big_for_index = vector_size
+                    >= self
+                        .thresholds_config
+                        .indexing_threshold
+                        .saturating_mul(BYTES_IN_KB);
 
                 let require_indexing =
                     (big_for_mmap && !is_memmaped) || (big_for_index && !is_vector_indexed);
@@ -153,7 +159,10 @@ impl IndexingOptimizer {
         if let Some((idx, size)) = smallest_unindexed {
             if *idx != selected_segment_id
                 && selected_segment_size + size
-                    < self.thresholds_config.max_segment_size.saturating_mul(BYTES_IN_KB)
+                    < self
+                        .thresholds_config
+                        .max_segment_size
+                        .saturating_mul(BYTES_IN_KB)
             {
                 return vec![selected_segment_id, *idx];
             }
@@ -164,7 +173,10 @@ impl IndexingOptimizer {
         if let Some((idx, size)) = smallest_indexed {
             if idx != selected_segment_id
                 && selected_segment_size + size
-                    < self.thresholds_config.max_segment_size.saturating_mul( BYTES_IN_KB)
+                    < self
+                        .thresholds_config
+                        .max_segment_size
+                        .saturating_mul(BYTES_IN_KB)
             {
                 return vec![selected_segment_id, idx];
             }

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -159,7 +159,7 @@ mod tests {
             vacuum_min_vector_number: 1000,
             default_segment_number: 10,
             max_segment_size: 100_000,
-            memmap_threshold: 100_000,
+            memmap_threshold: None,
             indexing_threshold: 50_000,
             flush_interval_sec: 30,
             max_optimization_threads: 1,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -113,7 +113,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                         config.optimizer_config.default_segment_number as u64,
                     ),
                     max_segment_size: Some(config.optimizer_config.max_segment_size as u64),
-                    memmap_threshold: Some(config.optimizer_config.memmap_threshold as u64),
+                    memmap_threshold: config.optimizer_config.memmap_threshold.map(|x| x as u64),
                     indexing_threshold: Some(config.optimizer_config.indexing_threshold as u64),
                     flush_interval_sec: Some(config.optimizer_config.flush_interval_sec as u64),
                     max_optimization_threads: Some(
@@ -178,7 +178,7 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfig {
             default_segment_number: optimizer_config.default_segment_number.unwrap_or_default()
                 as usize,
             max_segment_size: optimizer_config.max_segment_size.unwrap_or_default() as usize,
-            memmap_threshold: optimizer_config.memmap_threshold.unwrap_or_default() as usize,
+            memmap_threshold: optimizer_config.memmap_threshold.map(|x| x as usize),
             indexing_threshold: optimizer_config.indexing_threshold.unwrap_or_default() as usize,
             flush_interval_sec: optimizer_config.flush_interval_sec.unwrap_or_default(),
             max_optimization_threads: optimizer_config

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -42,7 +42,8 @@ pub struct OptimizersConfig {
     /// To enable memmap storage, lower the threshold
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
-    pub memmap_threshold: usize,
+    #[serde(default)]
+    pub memmap_threshold: Option<usize>,
     /// Maximum size (in KiloBytes) of vectors allowed for plain index.
     /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
     /// Note: 1Kb = 1 vector of size 256
@@ -77,7 +78,7 @@ pub fn build_optimizers(
     let temp_segments_path = shard_path.join("temp_segments");
 
     let threshold_config = OptimizerThresholds {
-        memmap_threshold: optimizers_config.memmap_threshold,
+        memmap_threshold: optimizers_config.memmap_threshold.unwrap_or(usize::MAX),
         indexing_threshold: optimizers_config.indexing_threshold,
         max_segment_size: optimizers_config.max_segment_size,
     };

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -13,7 +13,7 @@ const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     vacuum_min_vector_number: 1000,
     default_segment_number: 2,
     max_segment_size: 100_000,
-    memmap_threshold: 100_000,
+    memmap_threshold: None,
     indexing_threshold: 50_000,
     flush_interval_sec: 30,
     max_optimization_threads: 2,

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -20,7 +20,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     vacuum_min_vector_number: 1000,
     default_segment_number: 2,
     max_segment_size: 100_000,
-    memmap_threshold: 100_000,
+    memmap_threshold: None,
     indexing_threshold: 50_000,
     flush_interval_sec: 30,
     max_optimization_threads: 2,

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -33,7 +33,7 @@ mod tests {
                 vacuum_min_vector_number: 100,
                 default_segment_number: 2,
                 max_segment_size: 100_000,
-                memmap_threshold: 100,
+                memmap_threshold: Some(100),
                 indexing_threshold: 100,
                 flush_interval_sec: 2,
                 max_optimization_threads: 2,


### PR DESCRIPTION
### All Submissions:
It might become confusing and inconvenient if we need to extend the max segment size and we forget to also extend the mmap.
So this PR allows to disable (and disables by default) the mmap feature without specifying the concrete threshold