### PR TITLE
Indexed vectors in collection info

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -206,7 +206,8 @@
 | ram_data_size | [uint64](#uint64) |  | Used RAM (not implemented) |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
-| points_count | [uint64](#uint64) |  | number of vectors in the collection |
+| points_count | [uint64](#uint64) |  | number of points in the collection |
+| indexed_vectors_count | [uint64](#uint64) | optional | number of indexed vectors in the collection. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2383,6 +2383,7 @@
         "required": [
           "config",
           "disk_data_size",
+          "indexed_vectors_count",
           "optimizer_status",
           "payload_schema",
           "points_count",
@@ -2400,6 +2401,12 @@
           },
           "vectors_count": {
             "description": "Number of vectors in collection",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "indexed_vectors_count": {
+            "description": "Number of indexed vectors in the collection",
             "type": "integer",
             "format": "uint",
             "minimum": 0

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -180,11 +180,12 @@ message CollectionInfo {
   OptimizerStatus optimizer_status = 2; // status of collection optimizers
   uint64 vectors_count = 3; // number of vectors in the collection
   uint64 segments_count = 4; // Number of independent segments
-  uint64 disk_data_size = 5; // Used disk space
-  uint64 ram_data_size = 6; // Used RAM (not implemented)
+  uint64 disk_data_size = 5 [deprecated = true]; // Used disk space
+  uint64 ram_data_size = 6 [deprecated = true]; // Used RAM (not implemented)
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
-  uint64 points_count = 9; // number of vectors in the collection
+  uint64 points_count = 9; // number of points in the collection
+  optional uint64 indexed_vectors_count = 10; // number of indexed vectors in the collection.
 }
 
 message ChangeAliases {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -231,9 +231,11 @@ pub struct CollectionInfo {
     #[prost(uint64, tag="4")]
     pub segments_count: u64,
     /// Used disk space
+    #[deprecated]
     #[prost(uint64, tag="5")]
     pub disk_data_size: u64,
     /// Used RAM (not implemented)
+    #[deprecated]
     #[prost(uint64, tag="6")]
     pub ram_data_size: u64,
     /// Configuration
@@ -242,9 +244,12 @@ pub struct CollectionInfo {
     /// Collection data types
     #[prost(map="string, message", tag="8")]
     pub payload_schema: ::std::collections::HashMap<::prost::alloc::string::String, PayloadSchemaInfo>,
-    /// number of vectors in the collection
+    /// number of points in the collection
     #[prost(uint64, tag="9")]
     pub points_count: u64,
+    /// number of indexed vectors in the collection.
+    #[prost(uint64, optional, tag="10")]
+    pub indexed_vectors_count: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChangeAliases {

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -950,6 +950,7 @@ impl Collection {
                 info.optimizer_status =
                     max(info.optimizer_status.clone(), shard_info.optimizer_status);
                 info.vectors_count += shard_info.vectors_count;
+                info.indexed_vectors_count += shard_info.indexed_vectors_count;
                 info.points_count += shard_info.points_count;
                 info.segments_count += shard_info.segments_count;
                 info.disk_data_size += shard_info.disk_data_size;

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -269,7 +269,9 @@ impl TryFrom<api::grpc::qdrant::GetCollectionInfoResponse> for CollectionInfo {
                     }
                 },
                 vectors_count: collection_info_response.vectors_count as usize,
-                indexed_vectors_count: collection_info_response.indexed_vectors_count.unwrap_or_default() as usize,
+                indexed_vectors_count: collection_info_response
+                    .indexed_vectors_count
+                    .unwrap_or_default() as usize,
                 points_count: collection_info_response.points_count as usize,
                 segments_count: collection_info_response.segments_count as usize,
                 disk_data_size: collection_info_response.disk_data_size as usize,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -53,11 +53,13 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfigDiff {
 }
 
 impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
+    #[allow(deprecated)]
     fn from(value: CollectionInfo) -> Self {
         let CollectionInfo {
             status,
             optimizer_status,
             vectors_count,
+            indexed_vectors_count,
             points_count,
             segments_count,
             disk_data_size,
@@ -83,6 +85,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                 }
             }),
             vectors_count: vectors_count as u64,
+            indexed_vectors_count: Some(indexed_vectors_count as u64),
             points_count: points_count as u64,
             segments_count: segments_count as u64,
             disk_data_size: disk_data_size as u64,
@@ -247,6 +250,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
 impl TryFrom<api::grpc::qdrant::GetCollectionInfoResponse> for CollectionInfo {
     type Error = Status;
 
+    #[allow(deprecated)]
     fn try_from(
         collection_info_response: api::grpc::qdrant::GetCollectionInfoResponse,
     ) -> Result<Self, Self::Error> {
@@ -265,6 +269,7 @@ impl TryFrom<api::grpc::qdrant::GetCollectionInfoResponse> for CollectionInfo {
                     }
                 },
                 vectors_count: collection_info_response.vectors_count as usize,
+                indexed_vectors_count: collection_info_response.indexed_vectors_count.unwrap_or_default() as usize,
                 points_count: collection_info_response.points_count as usize,
                 segments_count: collection_info_response.segments_count as usize,
                 disk_data_size: collection_info_response.disk_data_size as usize,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -74,6 +74,8 @@ pub struct CollectionInfo {
     pub optimizer_status: OptimizersStatus,
     /// Number of vectors in collection
     pub vectors_count: usize,
+    /// Number of indexed vectors in the collection
+    pub indexed_vectors_count: usize,
     /// Number of points in collection
     pub points_count: usize,
     /// Number of segments in collection

--- a/lib/collection/src/shard/forward_proxy_shard.rs
+++ b/lib/collection/src/shard/forward_proxy_shard.rs
@@ -26,8 +26,8 @@ use crate::telemetry::ShardTelemetry;
 /// It can be used to provide all read and write operations while the wrapped shard is being transferred to another node.
 /// Proxy forwards all operations to remote shards.
 pub struct ForwardProxyShard {
-    wrapped_shard: LocalShard,
-    remote_shard: RemoteShard,
+    pub(crate) wrapped_shard: LocalShard,
+    pub(crate) remote_shard: RemoteShard,
     /// Lock required to protect transfer-in-progress updates.
     /// It should block data updating operations while the batch it being transferred.
     update_lock: Mutex<()>,

--- a/lib/collection/src/shard/local_shard_operations.rs
+++ b/lib/collection/src/shard/local_shard_operations.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use itertools::Itertools;
+use segment::entry::entry_point::SegmentEntry;
 use segment::types::{
     ExtendedPointId, Filter, PayloadIndexInfo, PayloadKeyType, ScoredPoint, SegmentType,
     WithPayload, WithPayloadInterface,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
-use segment::entry::entry_point::SegmentEntry;
-use crate::collection_manager::holders::segment_holder::LockedSegment;
 
+use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CollectionStatus, CountRequest, CountResult,

--- a/lib/collection/src/shard/local_shard_operations.rs
+++ b/lib/collection/src/shard/local_shard_operations.rs
@@ -9,6 +9,8 @@ use segment::types::{
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
+use segment::entry::entry_point::SegmentEntry;
+use crate::collection_manager::holders::segment_holder::LockedSegment;
 
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::operations::types::{
@@ -96,6 +98,7 @@ impl ShardOperation for LocalShard {
         let collection_config = self.config.read().await.clone();
         let segments = self.segments().read();
         let mut vectors_count = 0;
+        let mut indexed_vectors_count = 0;
         let mut points_count = 0;
         let mut segments_count = 0;
         let mut ram_size = 0;
@@ -104,7 +107,27 @@ impl ShardOperation for LocalShard {
         let mut schema: HashMap<PayloadKeyType, PayloadIndexInfo> = Default::default();
         for (_idx, segment) in segments.iter() {
             segments_count += 1;
-            let segment_info = segment.get().read().info();
+
+            let segment_info = match segment {
+                LockedSegment::Original(original_segment) => {
+                    let info = original_segment.read().info();
+                    if info.segment_type == SegmentType::Indexed {
+                        indexed_vectors_count += info.num_vectors;
+                    }
+                    info
+                }
+                LockedSegment::Proxy(proxy_segment) => {
+                    let proxy_segment_lock = proxy_segment.read();
+                    let proxy_segment_info = proxy_segment_lock.info();
+
+                    let wrapped_info = proxy_segment_lock.wrapped_segment.get().read().info();
+                    if wrapped_info.segment_type == SegmentType::Indexed {
+                        indexed_vectors_count += wrapped_info.num_vectors;
+                    }
+                    proxy_segment_info
+                }
+            };
+
             if segment_info.segment_type == SegmentType::Special {
                 status = CollectionStatus::Yellow;
             }
@@ -129,6 +152,7 @@ impl ShardOperation for LocalShard {
             status,
             optimizer_status,
             vectors_count,
+            indexed_vectors_count,
             points_count,
             segments_count,
             disk_data_size: disk_size,

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -36,6 +36,7 @@ use crate::telemetry::ShardTelemetry;
 /// RemoteShard
 ///
 /// Remote Shard is a representation of a shard that is located on a remote peer.
+#[derive(Clone)]
 pub struct RemoteShard {
     pub(crate) id: ShardId,
     pub(crate) collection_id: CollectionId,

--- a/lib/collection/src/shard/remote_shard.rs
+++ b/lib/collection/src/shard/remote_shard.rs
@@ -36,7 +36,6 @@ use crate::telemetry::ShardTelemetry;
 /// RemoteShard
 ///
 /// Remote Shard is a representation of a shard that is located on a remote peer.
-#[derive(Clone)]
 pub struct RemoteShard {
     pub(crate) id: ShardId,
     pub(crate) collection_id: CollectionId,

--- a/lib/collection/src/shard/transfer/shard_transfer.rs
+++ b/lib/collection/src/shard/transfer/shard_transfer.rs
@@ -342,12 +342,12 @@ pub async fn validate_indexing_progress(
         {
             break;
         }
-        sleep(Duration::from_secs(30)).await;
-        attempt += 1;
         // Report progress every 20 attempts (around 10 minutes)
         if attempt.rem_euclid(20) == 0 {
             log::info!("Waiting for optimizer on {}:{} on peer {} to finish transfer. (indexing progress {}/{})", collection_id, shard_id, peer_id, indexed_vector_count, vector_count);
         }
+        attempt += 1;
+        sleep(Duration::from_secs(30)).await;
     }
     Ok(())
 }

--- a/lib/collection/src/shard/transfer/shard_transfer.rs
+++ b/lib/collection/src/shard/transfer/shard_transfer.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::common::stoppable_task_async::{spawn_async_stoppable, StoppableAsyncTaskHandle};
-use crate::operations::types::{CollectionError, CollectionResult, OptimizersStatus};
+use crate::operations::types::{
+    CollectionError, CollectionResult, CollectionStatus, OptimizersStatus,
+};
 use crate::shard::forward_proxy_shard::ForwardProxyShard;
 use crate::shard::remote_shard::RemoteShard;
 use crate::shard::shard_config::ShardConfig;
@@ -21,6 +23,9 @@ use crate::shard::{
 const TRANSFER_BATCH_SIZE: usize = 100;
 const RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_RETRY_COUNT: usize = 3;
+const INDEXED_THRESHOLD: f64 = 0.85;
+const OPTIMIZATION_CHECK_INTERVALS: Duration = Duration::from_secs(10);
+const MAX_OPTIMIZATION_TIME: Duration = Duration::from_secs(60 * 30); // 30 minutes
 
 async fn transfer_batches(
     shard_holder: Arc<LockedShardHolder>,
@@ -275,15 +280,13 @@ pub async fn transfer_shard(
     // * Transfer difference between snapshot and current shard state
 
     remote_shard.initiate_transfer().await?;
-    let vector_count_at_transfer_start = {
+    {
         let mut shard_holder_guard = shard_holder.write().await;
         let transferring_shard = shard_holder_guard.remove_shard(shard_id);
         match transferring_shard {
             Some(Shard::Local(local_shard)) => {
-                let vector_count = local_shard.info().await?.vectors_count;
-                let proxy_shard = ForwardProxyShard::new(local_shard, remote_shard.clone());
+                let proxy_shard = ForwardProxyShard::new(local_shard, remote_shard);
                 shard_holder_guard.add_shard(shard_id, Shard::ForwardProxy(proxy_shard));
-                vector_count
             }
             Some(shard) => {
                 // return shard back
@@ -302,31 +305,22 @@ pub async fn transfer_shard(
         }
     };
     // Transfer contents batch by batch
-    transfer_batches(shard_holder, shard_id, stopped.clone()).await?;
+    transfer_batches(shard_holder.clone(), shard_id, stopped.clone()).await?;
 
     // Validate that the new shard reached a certain level of indexing before promoting it to not slowdown the search requests
-    validate_indexing_progress(
-        shard_id,
-        collection_id,
-        peer_id,
-        vector_count_at_transfer_start,
-        &remote_shard,
-        stopped,
-    )
-    .await
+    validate_indexing_progress(shard_holder, shard_id, collection_id, peer_id, stopped).await
 }
 
 pub async fn validate_indexing_progress(
+    shard_holder: Arc<LockedShardHolder>,
     shard_id: ShardId,
     collection_id: CollectionId,
     peer_id: PeerId,
-    vector_count_at_transfer_start: usize,
-    remote_shard: &RemoteShard,
     stopped: Arc<AtomicBool>,
 ) -> CollectionResult<()> {
-    // threshold currently at 90% of the initial vector count
-    let indexing_threshold = (vector_count_at_transfer_start as f64 * 0.9) as usize;
-    let mut attempt: i64 = 0;
+    let mut attempt: u64 = 0;
+    let max_attempts = MAX_OPTIMIZATION_TIME.as_secs() / OPTIMIZATION_CHECK_INTERVALS.as_secs();
+
     loop {
         if stopped.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(CollectionError::Cancelled {
@@ -334,20 +328,68 @@ pub async fn validate_indexing_progress(
             });
         }
 
-        let shard_info = remote_shard.info().await?;
-        let vector_count = shard_info.vectors_count;
-        let indexed_vector_count = shard_info.indexed_vectors_count;
-        if shard_info.optimizer_status == OptimizersStatus::Ok
-            || indexed_vector_count >= indexing_threshold
-        {
+        let (local_info, remote_info) = {
+            let shard_holder_guard = shard_holder.read().await;
+
+            let proxy_shard = match shard_holder_guard.get_shard(&shard_id) {
+                Some(Shard::ForwardProxy(forward_proxy)) => forward_proxy,
+                _ => {
+                    return Err(CollectionError::service_error(format!(
+                        "Proxy shard is gone: {}, {}",
+                        shard_id, collection_id
+                    )))
+                }
+            };
+
+            let local_info = proxy_shard.wrapped_shard.info().await?;
+            let remote_info = proxy_shard.remote_shard.info().await?;
+            (local_info, remote_info)
+        };
+
+        match remote_info.status {
+            CollectionStatus::Green => break, // all good
+            CollectionStatus::Yellow => {}    // ???, need to dig deeper
+            CollectionStatus::Red => {
+                // that's a trap!
+                return Err(CollectionError::service_error(format!(
+                    "Remote shard is red: {}, {}",
+                    shard_id, collection_id
+                )));
+            }
+        }
+
+        match remote_info.optimizer_status {
+            OptimizersStatus::Ok => {}
+            OptimizersStatus::Error(optimizer_error) => {
+                return Err(CollectionError::service_error(format!(
+                    "Remote shard optimizer error: {} shard_id: {}, collection: {}",
+                    optimizer_error, shard_id, collection_id
+                )))
+            }
+        }
+
+        // Now we try heuristics to prevent infinite awaiting of the remote shard to be green
+
+        let expected_indexing_progress =
+            (local_info.indexed_vectors_count as f64 * INDEXED_THRESHOLD) as usize;
+        if remote_info.indexed_vectors_count >= expected_indexing_progress {
             break;
         }
+
+        let indexed_vector_count = remote_info.indexed_vectors_count;
+
         // Report progress every 20 attempts (around 10 minutes)
         if attempt.rem_euclid(20) == 0 {
-            log::info!("Waiting for optimizer on {}:{} on peer {} to finish transfer. (indexing progress {}/{})", collection_id, shard_id, peer_id, indexed_vector_count, vector_count);
+            log::info!("Waiting for optimizer on {}:{} on peer {} to finish transfer. (indexing progress {}/{})", collection_id, shard_id, peer_id, indexed_vector_count, expected_indexing_progress);
         }
         attempt += 1;
-        sleep(Duration::from_secs(30)).await;
+
+        if attempt > max_attempts {
+            log::info!("Max waiting for indexing reached on {}:{} on peer {}. (indexing progress {}/{}). Finalizing transfer anyway", collection_id, shard_id, peer_id, indexed_vector_count, expected_indexing_progress);
+            break;
+        }
+
+        sleep(OPTIMIZATION_CHECK_INTERVALS).await;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR enables a smooth shard promotion at the end of the shard transfer.

Currently the shard is promoted right after the last points are sent over.
This cause a significant slowdown of the search requests because the indexes are not yet ready.

In this PR, we make sure the new shard reached a certain level in terms of indexing before triggering the promotion.
To do so we had to expose the number of indexed vector in the collection info.