### PR TITLE
Peer removal API

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -69,7 +69,7 @@
         }
       }
     },
-    "/cluster/status": {
+    "/cluster": {
       "get": {
         "tags": [
           "cluster"
@@ -4611,6 +4611,7 @@
               "Local": {
                 "type": "object",
                 "required": [
+                  "optimizers",
                   "segments"
                 ],
                 "properties": {
@@ -4618,6 +4619,12 @@
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/SegmentTelemetry"
+                    }
+                  },
+                  "optimizers": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/OptimizerTelemetry"
                     }
                   }
                 }
@@ -4928,7 +4935,93 @@
         }
       },
       "PayloadIndexTelemetry": {
-        "type": "object"
+        "type": "object",
+        "required": [
+          "points_count",
+          "points_values_count"
+        ],
+        "properties": {
+          "points_values_count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "points_count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "histogram_bucket_size": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
+      },
+      "OptimizerTelemetry": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Indexing"
+            ],
+            "properties": {
+              "Indexing": {
+                "type": "object",
+                "required": [
+                  "optimizations"
+                ],
+                "properties": {
+                  "optimizations": {
+                    "$ref": "#/components/schemas/TelemetryOperationStatistics"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Merge"
+            ],
+            "properties": {
+              "Merge": {
+                "type": "object",
+                "required": [
+                  "optimizations"
+                ],
+                "properties": {
+                  "optimizations": {
+                    "$ref": "#/components/schemas/TelemetryOperationStatistics"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Vacuum"
+            ],
+            "properties": {
+              "Vacuum": {
+                "type": "object",
+                "required": [
+                  "optimizations"
+                ],
+                "properties": {
+                  "optimizations": {
+                    "$ref": "#/components/schemas/TelemetryOperationStatistics"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "WebApiTelemetry": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -69,7 +69,7 @@
         }
       }
     },
-    "/cluster": {
+    "/cluster/status": {
       "get": {
         "tags": [
           "cluster"
@@ -118,6 +118,75 @@
                     },
                     "result": {
                       "$ref": "#/components/schemas/ClusterStatus"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cluster/peer/{peer_id}": {
+      "delete": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "Remove peer from the cluster",
+        "description": "Tries to remove peer from the cluster. Will return an error if peer has shards on it.",
+        "operationId": "remove_peer",
+        "parameters": [
+          {
+            "name": "peer_id",
+            "in": "path",
+            "description": "Id of the peer",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
                     }
                   }
                 }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -133,6 +133,16 @@ impl Persistent {
         self.save()
     }
 
+    pub fn remove_peer(&mut self, peer_id: PeerId) -> Result<(), StorageError> {
+        self.peer_address_by_id
+            .write()
+            .remove(&peer_id)
+            .ok_or_else(|| StorageError::NotFound {
+                description: format!("Peer with id {peer_id} not found"),
+            })?;
+        self.save()
+    }
+
     pub fn last_applied_entry(&self) -> Option<u64> {
         self.apply_progress_queue.get_last_applied()
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,3 +1,5 @@
+use collection::shard::PeerId;
+
 use self::collection_meta_ops::CollectionMetaOperations;
 use self::consensus_state::CollectionsSnapshot;
 use self::errors::StorageError;
@@ -25,6 +27,7 @@ pub mod consensus_ops {
     pub enum ConsensusOperations {
         CollectionMeta(Box<CollectionMetaOperations>),
         AddPeer(PeerId, String),
+        RemovePeer(PeerId),
     }
 
     impl TryFrom<&RaftEntry> for ConsensusOperations {
@@ -47,4 +50,6 @@ pub trait CollectionContainer {
     fn collections_snapshot(&self) -> CollectionsSnapshot;
 
     fn apply_collections_snapshot(&self, data: CollectionsSnapshot) -> Result<(), StorageError>;
+
+    fn peer_has_shards(&self, peer_id: PeerId) -> bool;
 }

--- a/openapi/openapi-cluster.ytt.yaml
+++ b/openapi/openapi-cluster.ytt.yaml
@@ -1,7 +1,7 @@
 #@ load("openapi.lib.yml", "response", "reference", "type", "array")
 
 paths:
-  /cluster:
+  /cluster/status:
     get:
       tags:
         - cluster
@@ -9,3 +9,19 @@ paths:
       description: Get information about the current state and composition of the cluster
       operationId: cluster_status
       responses: #@ response(reference("ClusterStatus"))
+
+  /cluster/peer/{peer_id}:
+    delete:
+      tags:
+        - cluster
+      summary: Remove peer from the cluster
+      description: Tries to remove peer from the cluster. Will return an error if peer has shards on it.
+      operationId: remove_peer
+      parameters:
+        - name: peer_id
+          in: path
+          description: Id of the peer
+          required: true
+          schema:
+            type: integer
+      responses: #@ response(type("boolean"))

--- a/openapi/openapi-cluster.ytt.yaml
+++ b/openapi/openapi-cluster.ytt.yaml
@@ -1,7 +1,7 @@
 #@ load("openapi.lib.yml", "response", "reference", "type", "array")
 
 paths:
-  /cluster/status:
+  /cluster:
     get:
       tags:
         - cluster

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -1,14 +1,32 @@
 use actix_web::rt::time::Instant;
-use actix_web::{get, web, Responder};
+use actix_web::{delete, get, web, Responder};
+use storage::content_manager::consensus_ops::ConsensusOperations;
+use storage::content_manager::errors::StorageError;
 use storage::dispatcher::Dispatcher;
 
 use crate::actix::helpers::process_response;
 
-#[get("/cluster")]
+#[get("/cluster/status")]
 async fn cluster_status(dispatcher: web::Data<Dispatcher>) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher.cluster_status();
     process_response(Ok(response), timing)
+}
+
+#[delete("/cluster/peer/{peer_id}")]
+async fn remove_peer(dispatcher: web::Data<Dispatcher>, peer_id: web::Path<u64>) -> impl Responder {
+    let timing = Instant::now();
+    let response = match dispatcher.consensus_state() {
+        Some(consensus_state) => {
+            consensus_state
+                .propose_consensus_op(ConsensusOperations::RemovePeer(*peer_id), None)
+                .await
+        }
+        None => Err(StorageError::BadRequest {
+            description: "Distributed deployment is disabled.".to_string(),
+        }),
+    };
+    process_response(response, timing)
 }
 
 // Configure services

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -6,7 +6,7 @@ use storage::dispatcher::Dispatcher;
 
 use crate::actix::helpers::process_response;
 
-#[get("/cluster/status")]
+#[get("/cluster")]
 async fn cluster_status(dispatcher: web::Data<Dispatcher>) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher.cluster_status();


### PR DESCRIPTION
Relates to #874 

## Design Decisions
Do not shutdown peer if it receives its own removal from consensus. Peer should be later shutdown by script/admin. Otherwise it could interfere with Kubernetes cluster management (it can try to restart the peer). 
