### PR TITLE
a third attempt to implement peer removal + integration test

### DIFF
--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -306,6 +306,8 @@ impl<C: CollectionContainer> ConsensusState<C> {
                 )
                 .map(|()| true),
             ConsensusOperations::RemovePeer(_peer_id) => {
+                // RemovePeer should be converted into native ConfChangeV2 message before sending to the Raft.
+                // So we do not expect to receive RemovePeer operation as a normal entry.
                 debug_assert!(false, "Do not expect RemovePeer to be directly proposed");
                 Ok(false)
             }

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use collection::collection_state;
 use collection::shard::{CollectionId, PeerId};
 use parking_lot::{Mutex, RwLock};
-use raft::eraftpb::{ConfChangeV2, Entry as RaftEntry};
+use raft::eraftpb::{ConfChangeType, ConfChangeV2, Entry as RaftEntry};
 use raft::{GetEntriesContext, RaftState, RawNode, SoftState, StateRole, Storage};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
@@ -88,6 +88,10 @@ impl<C: CollectionContainer> ConsensusState<C> {
         }
     }
 
+    pub fn on_consensus_stopped(&self) {
+        *self.consensus_thread_status.write() = ConsensusThreadStatus::Stopped
+    }
+
     pub fn on_consensus_thread_err<E: Display>(&self, err: E) {
         *self.consensus_thread_status.write() = ConsensusThreadStatus::StoppedWithErr {
             err: err.to_string(),
@@ -158,13 +162,33 @@ impl<C: CollectionContainer> ConsensusState<C> {
         &self,
         entry: &RaftEntry,
         raw_node: &mut RawNode<T>,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         let change: ConfChangeV2 = prost::Message::decode(entry.get_data())?;
+
         let conf_state = raw_node.apply_conf_change(&change)?;
+        log::debug!("Applied conf state {:?}", conf_state);
         self.persistent
             .write()
             .apply_state_update(|state| state.conf_state = conf_state)?;
-        Ok(())
+
+        let mut stop_consensus: bool = false;
+        for single_change in &change.changes {
+            if single_change.change_type == ConfChangeType::RemoveNode as i32 {
+                log::debug!("Remove node {}", single_change.node_id);
+                if self.this_peer_id() == single_change.node_id {
+                    stop_consensus = true;
+                }
+                self.remove_peer(single_change.node_id)?;
+                let operation = ConsensusOperations::RemovePeer(single_change.node_id);
+                let on_apply = self.on_consensus_op_apply.lock().remove(&operation);
+                if let Some(on_apply) = on_apply {
+                    if on_apply.send(Ok(true)).is_err() {
+                        log::warn!("Failed to notify on consensus operation completion: channel receiver is dropped")
+                    }
+                }
+            }
+        }
+        Ok(stop_consensus)
     }
 
     pub fn set_unapplied_entries(
@@ -178,12 +202,13 @@ impl<C: CollectionContainer> ConsensusState<C> {
             .map_err(raft_error_other)
     }
 
-    pub fn apply_entries<T: Storage>(&self, raw_node: &mut RawNode<T>) {
+    /// Return `true` if consensus should be stopped.
+    pub fn apply_entries<T: Storage>(&self, raw_node: &mut RawNode<T>) -> bool {
         use raft::eraftpb::EntryType;
 
         if let Err(err) = self.persistent.write().save_if_dirty() {
             log::error!("Failed to save new state of applied entries queue: {err}");
-            return;
+            return false;
         }
 
         loop {
@@ -197,7 +222,7 @@ impl<C: CollectionContainer> ConsensusState<C> {
                 Ok(entry) => entry,
                 Err(err) => {
                     log::error!("Failed to get entry at index {entry_index}: {err}");
-                    return;
+                    break;
                 }
             };
             let do_increase_applied_index: bool = if entry.data.is_empty() {
@@ -228,11 +253,14 @@ impl<C: CollectionContainer> ConsensusState<C> {
                     }
                     EntryType::EntryConfChangeV2 => {
                         match self.apply_conf_change_entry(&entry, raw_node) {
-                            Ok(()) => {
+                            Ok(stop_consensus) => {
                                 log::debug!(
                                     "Successfully applied configuration change entry. Index: {}.",
                                     entry.index
                                 );
+                                if stop_consensus {
+                                    return true;
+                                }
                                 true
                             }
                             Err(err) => {
@@ -253,12 +281,13 @@ impl<C: CollectionContainer> ConsensusState<C> {
             if do_increase_applied_index {
                 if let Err(err) = self.persistent.write().entry_applied() {
                     log::error!("Failed to save new state of applied entries queue: {err}");
-                    return;
+                    break;
                 }
             } else {
-                return;
+                break;
             }
         }
+        false // do not stop consensus
     }
 
     pub fn apply_normal_entry(&self, entry: &RaftEntry) -> Result<bool, StorageError> {
@@ -276,7 +305,10 @@ impl<C: CollectionContainer> ConsensusState<C> {
                     })?,
                 )
                 .map(|()| true),
-            ConsensusOperations::RemovePeer(peer_id) => self.remove_peer(peer_id).map(|()| true),
+            ConsensusOperations::RemovePeer(_peer_id) => {
+                debug_assert!(false, "Do not expect RemovePeer to be directly proposed");
+                Ok(false)
+            }
         };
         if let Some(on_apply) = on_apply {
             if on_apply.send(result.clone()).is_err() {
@@ -333,11 +365,6 @@ impl<C: CollectionContainer> ConsensusState<C> {
     }
 
     pub fn remove_peer(&self, peer_id: PeerId) -> Result<(), StorageError> {
-        if self.toc.peer_has_shards(peer_id) {
-            return Err(StorageError::BadRequest {
-                description: format!("Cannot remove peer {peer_id} as there are shards on it"),
-            });
-        }
         self.toc.remove_peer(peer_id);
         self.persistent.read().save()
     }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -117,6 +117,7 @@ pub enum ClusterStatus {
 #[serde(rename_all = "snake_case")]
 pub enum ConsensusThreadStatus {
     Working,
+    Stopped,
     StoppedWithErr { err: String },
 }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -559,7 +559,6 @@ impl Consensus {
         messages: Vec<RaftMessage>,
         peer_address_by_id: PeerAddressById,
     ) -> Result<(), StorageError> {
-        // let peer_address_by_id = state.peer_address_by_id();
         let messages_with_address: Vec<_> = messages
             .into_iter()
             .map(|message| {

--- a/tests/consensus_tests/downscale_cluster.py
+++ b/tests/consensus_tests/downscale_cluster.py
@@ -1,0 +1,78 @@
+import argparse
+import requests
+import time
+
+
+parser = argparse.ArgumentParser("Move all shards to first node and detach the last one")
+parser.add_argument("collection_name")
+parser.add_argument("ports", type=int, nargs="+")
+args = parser.parse_args()
+
+
+# Check collection cluster distribution
+r = requests.get(f"http://127.0.0.1:{args.ports[0]}/collections/{args.collection_name}/cluster")
+assert r.status_code == 200, r.text
+
+"""
+Example output:
+{
+    "result": {
+        "peer_id": 1995564390118081002,
+        "shard_count": 3,
+        "local_shards": [
+            {
+                "shard_id": 0,
+                "points_count": 1
+            }
+        ],
+        "remote_shards": [
+            {
+                "shard_id": 1,
+                "peer_id": 3084118168649519856
+            },
+            {
+                "shard_id": 2,
+                "peer_id": 10993045052641065997
+            }
+        ],
+        "shard_transfers": []
+    },
+    "status": "ok",
+    "time": 0.000013974
+}
+"""
+
+collection_cluster_status = r.json()
+from_peer = collection_cluster_status["result"]['peer_id']
+to_peer = collection_cluster_status["result"]["remote_shards"][0]["peer_id"]
+
+
+for local_shards in collection_cluster_status["result"]["local_shards"]:
+    shard_id = local_shards["shard_id"]
+    r = requests.post(f"http://127.0.0.1:{args.ports[0]}/collections/{args.collection_name}/cluster", json={
+        "move_shard": {
+            "from_peer_id": from_peer,
+            "shard_id": shard_id,
+            "to_peer_id": to_peer
+        }
+    })
+
+max_wait = 60
+
+# Check that the shard is moved
+while max_wait > 0:
+    r = requests.get(f"http://127.0.0.1:{args.ports[0]}/collections/{args.collection_name}/cluster")
+    assert r.status_code == 200, r.text
+    collection_cluster_status = r.json()
+
+    if len(collection_cluster_status["result"]["local_shards"]) == 0:
+        break
+
+    max_wait -= 1
+    time.sleep(1)
+
+
+# Disconnect peer from the cluster
+r = requests.delete(f"http://127.0.0.1:{args.ports[0]}/cluster/peer/{from_peer}")
+assert r.status_code == 200, r.text
+

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -38,3 +38,13 @@ done
 python3 create_collection_and_check.py test_collection_1 6433 6333
 # Points from the 1st collection can be retrieved
 python3 check_points.py test_collection 6433 6333
+
+curl -X DELETE "http://127.0.0.1/collections/test_collection_1" \
+  -H 'Content-Type: application/json' \
+  --fail -s
+
+# Transfer shards away from 6433 and disconnect in from cluster
+python3 downscale_cluster.py test_collection 6433 6333
+
+# Check points after downscale
+python3 check_points.py test_collection 6333

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -39,7 +39,7 @@ python3 create_collection_and_check.py test_collection_1 6433 6333
 # Points from the 1st collection can be retrieved
 python3 check_points.py test_collection 6433 6333
 
-curl -X DELETE "http://127.0.0.1/collections/test_collection_1" \
+curl -X DELETE "http://127.0.0.1:6333/collections/test_collection_1" \
   -H 'Content-Type: application/json' \
   --fail -s
 


### PR DESCRIPTION
Changes from the last attempt:

- Create a copy of id_to_address on the start of tick loop, so it should preserve addresses for at least tick duration
- on removed peer:
  - Remove all other peer
  - Stop consensus

With this changes removed leader stops sending pings and re-election happens properly