### PR TITLE
Raft snapshot logic for handling transfers

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1061,9 +1061,16 @@ impl Collection {
         this_peer_id: PeerId,
         collection_path: &Path,
         channel_service: ChannelService,
+        abort_transfer: impl FnMut(ShardTransfer),
     ) -> CollectionResult<()> {
         state
-            .apply(this_peer_id, self, collection_path, channel_service)
+            .apply(
+                this_peer_id,
+                self,
+                collection_path,
+                channel_service,
+                abort_transfer,
+            )
             .await
     }
 


### PR DESCRIPTION
Some of the logic related to transfers was triggered only on entry application and did not account for the cases where entries were compacted into a snapshot. This PR addresses this issue.