### PR TITLE
Fix transfer abort on restart

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4133,6 +4133,20 @@
           {
             "type": "object",
             "required": [
+              "consensus_thread_status"
+            ],
+            "properties": {
+              "consensus_thread_status": {
+                "type": "string",
+                "enum": [
+                  "stopped"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
               "consensus_thread_status",
               "err"
             ],
@@ -5047,21 +5061,25 @@
         }
       },
       "ClusterOperations": {
-        "oneOf": [
+        "anyOf": [
           {
-            "description": "Move shard to a different peer",
-            "type": "object",
-            "required": [
-              "move_shard"
-            ],
-            "properties": {
-              "move_shard": {
-                "$ref": "#/components/schemas/MoveShard"
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/components/schemas/MoveShardOperation"
+          },
+          {
+            "$ref": "#/components/schemas/AbortTransferOperation"
           }
         ]
+      },
+      "MoveShardOperation": {
+        "type": "object",
+        "required": [
+          "move_shard"
+        ],
+        "properties": {
+          "move_shard": {
+            "$ref": "#/components/schemas/MoveShard"
+          }
+        }
       },
       "MoveShard": {
         "type": "object",
@@ -5085,6 +5103,17 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
+          }
+        }
+      },
+      "AbortTransferOperation": {
+        "type": "object",
+        "required": [
+          "abort_transfer"
+        ],
+        "properties": {
+          "abort_transfer": {
+            "$ref": "#/components/schemas/MoveShard"
           }
         }
       }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -244,6 +244,11 @@ impl Collection {
             .map(|shard| matches!(shard, Shard::Local(_)))
     }
 
+    pub async fn check_transfer_exists(&self, transfer: &ShardTransfer) -> bool {
+        let shard_holder_read = self.shards_holder.read().await;
+        shard_holder_read.shard_transfers.contains(transfer)
+    }
+
     pub async fn get_outgoing_transfers(&self, current_peer_id: &PeerId) -> Vec<ShardTransfer> {
         let shard_holder = self.shards_holder.read().await;
         shard_holder

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -5,10 +5,24 @@ use crate::shard::{PeerId, ShardId};
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum ClusterOperations {
     /// Move shard to a different peer
-    #[serde(rename = "move_shard")]
-    MoveShard(MoveShard),
+    MoveShard(MoveShardOperation),
+    /// Abort currently running shard moving operation
+    AbortTransfer(AbortTransferOperation),
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct MoveShardOperation {
+    pub move_shard: MoveShard,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AbortTransferOperation {
+    pub abort_transfer: MoveShard,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -371,7 +371,12 @@ impl<C: CollectionContainer> ConsensusState<C> {
         self.persistent.read().save()
     }
 
-    pub async fn propose_consensus_op(
+    pub async fn propose_consensus_op(&self, operation: ConsensusOperations) -> Result<(), StorageError> {
+        self.is_leader_established.await_ready();
+        self.propose_sender.send(operation)
+    }
+
+    pub async fn propose_consensus_op_with_await(
         &self,
         operation: ConsensusOperations,
         wait_timeout: Option<Duration>,

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -371,7 +371,10 @@ impl<C: CollectionContainer> ConsensusState<C> {
         self.persistent.read().save()
     }
 
-    pub async fn propose_consensus_op(&self, operation: ConsensusOperations) -> Result<(), StorageError> {
+    pub async fn propose_consensus_op(
+        &self,
+        operation: ConsensusOperations,
+    ) -> Result<(), StorageError> {
         self.is_leader_established.await_ready();
         self.propose_sender.send(operation)
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -412,7 +412,9 @@ impl TableOfContent {
         let proposal_sender = self.consensus_proposal_sender.clone();
         for collection in collections.values() {
             for transfer in collection.get_outgoing_transfers(&self.this_peer_id).await {
-                proposal_sender.cancel_transfer(collection.name(), transfer, reason)?;
+                let cancel_transfer =
+                    ConsensusOperations::abort_transfer(collection.name(), transfer, reason);
+                proposal_sender.send(cancel_transfer)?;
             }
         }
         Ok(())
@@ -444,10 +446,12 @@ impl TableOfContent {
                             transfer.shard_id, self.this_peer_id
                         ),
                     });
-                    self.consensus_proposal_sender.cancel_transfer(
-                        collection_id,
-                        transfer,
-                        "Bad source peer",
+                    self.consensus_proposal_sender.send(
+                        ConsensusOperations::abort_transfer(
+                            collection_id,
+                            transfer,
+                            "Bad source peer",
+                        ),
                     )?;
                     return err;
                 }
@@ -457,12 +461,11 @@ impl TableOfContent {
                 let transfer_clone = transfer.clone();
 
                 let on_finish = async move {
-                    let operation = ConsensusOperations::CollectionMeta(Box::new(
-                        CollectionMetaOperations::TransferShard(
-                            collection_id_clone,
-                            ShardTransferOperations::Finish(transfer_clone),
-                        ),
-                    ));
+                    let operation = ConsensusOperations::finish_transfer(
+                        collection_id_clone,
+                        transfer_clone,
+                    );
+
                     if let Err(error) = proposal_sender.send(operation) {
                         log::error!("Can't report transfer progress to consensus: {}", error)
                     };
@@ -473,11 +476,13 @@ impl TableOfContent {
                 let transfer_clone = transfer.clone();
 
                 let on_failure = async move {
-                    if let Err(error) = proposal_sender.cancel_transfer(
-                        collection_id_clone,
-                        transfer_clone,
-                        "transmission failed",
-                    ) {
+                    if let Err(error) =
+                        proposal_sender.send(ConsensusOperations::abort_transfer(
+                            collection_id_clone,
+                            transfer_clone,
+                            "transmission failed",
+                        ))
+                    {
                         log::error!("Can't report transfer progress to consensus: {}", error)
                     };
                 };
@@ -736,11 +741,13 @@ impl TableOfContent {
                             let proposal_sender = self.consensus_proposal_sender.clone();
                             // In some cases on state application it might be needed to abort the transfer
                             let abort_transfer = |transfer| {
-                                if let Err(error) = proposal_sender.cancel_transfer(
-                                    id.clone(),
-                                    transfer,
-                                    "sender was not up to date",
-                                ) {
+                                if let Err(error) =
+                                    proposal_sender.send(ConsensusOperations::abort_transfer(
+                                        id.clone(),
+                                        transfer,
+                                        "sender was not up to date",
+                                    ))
+                                {
                                     log::error!(
                                         "Can't report transfer progress to consensus: {}",
                                         error

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -446,13 +446,12 @@ impl TableOfContent {
                             transfer.shard_id, self.this_peer_id
                         ),
                     });
-                    self.consensus_proposal_sender.send(
-                        ConsensusOperations::abort_transfer(
+                    self.consensus_proposal_sender
+                        .send(ConsensusOperations::abort_transfer(
                             collection_id,
                             transfer,
                             "Bad source peer",
-                        ),
-                    )?;
+                        ))?;
                     return err;
                 }
 
@@ -461,10 +460,8 @@ impl TableOfContent {
                 let transfer_clone = transfer.clone();
 
                 let on_finish = async move {
-                    let operation = ConsensusOperations::finish_transfer(
-                        collection_id_clone,
-                        transfer_clone,
-                    );
+                    let operation =
+                        ConsensusOperations::finish_transfer(collection_id_clone, transfer_clone);
 
                     if let Err(error) = proposal_sender.send(operation) {
                         log::error!("Can't report transfer progress to consensus: {}", error)
@@ -476,13 +473,11 @@ impl TableOfContent {
                 let transfer_clone = transfer.clone();
 
                 let on_failure = async move {
-                    if let Err(error) =
-                        proposal_sender.send(ConsensusOperations::abort_transfer(
-                            collection_id_clone,
-                            transfer_clone,
-                            "transmission failed",
-                        ))
-                    {
+                    if let Err(error) = proposal_sender.send(ConsensusOperations::abort_transfer(
+                        collection_id_clone,
+                        transfer_clone,
+                        "transmission failed",
+                    )) {
                         log::error!("Can't report transfer progress to consensus: {}", error)
                     };
                 };

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -56,7 +56,7 @@ impl Dispatcher {
                 op => op,
             };
             state
-                .propose_consensus_op(
+                .propose_consensus_op_with_await(
                     ConsensusOperations::CollectionMeta(Box::new(op)),
                     wait_timeout,
                 )

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -31,7 +31,7 @@ async fn remove_peer(dispatcher: web::Data<Dispatcher>, peer_id: web::Path<u64>)
     let response = match dispatcher.consensus_state() {
         Some(consensus_state) => {
             consensus_state
-                .propose_consensus_op(ConsensusOperations::RemovePeer(peer_id), None)
+                .propose_consensus_op_with_await(ConsensusOperations::RemovePeer(peer_id), None)
                 .await
         }
         None => Err(StorageError::BadRequest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn main() -> anyhow::Result<()> {
 
         let handle = Consensus::run(
             &slog_logger,
-            consensus_state,
+            consensus_state.clone(),
             args.bootstrap,
             args.uri.map(|uri| uri.to_string()),
             settings.service.host.clone(),
@@ -198,6 +198,7 @@ fn main() -> anyhow::Result<()> {
 
         runtime_handle
             .block_on(async {
+                consensus_state.is_leader_established.await_ready();
                 toc_arc
                     .cancel_outgoing_all_transfers("Source peer restarted")
                     .await

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -82,7 +82,7 @@ impl Raft for RaftService {
 
         // the consensus operation can take up to DEFAULT_META_OP_WAIT
         self.consensus_state
-            .propose_consensus_op(ConsensusOperations::AddPeer(peer.id, uri.to_string()), None)
+            .propose_consensus_op_with_await(ConsensusOperations::AddPeer(peer.id, uri.to_string()), None)
             .await
             .map_err(|err| Status::internal(format!("Failed to add peer: {err}")))?;
         let addresses = self.consensus_state.peer_address_by_id();

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -82,7 +82,10 @@ impl Raft for RaftService {
 
         // the consensus operation can take up to DEFAULT_META_OP_WAIT
         self.consensus_state
-            .propose_consensus_op_with_await(ConsensusOperations::AddPeer(peer.id, uri.to_string()), None)
+            .propose_consensus_op_with_await(
+                ConsensusOperations::AddPeer(peer.id, uri.to_string()),
+                None,
+            )
             .await
             .map_err(|err| Status::internal(format!("Failed to add peer: {err}")))?;
         let addresses = self.consensus_state.peer_address_by_id();


### PR DESCRIPTION
- Wait for consensus leader to be elected before sending transfer cancellations
- Expose API for manual aborting transfers