### PR TITLE
Use tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "smallvec",
  "tracing",
@@ -282,7 +282,7 @@ dependencies = [
  "chrono",
  "prost 0.10.4",
  "prost-types 0.10.1",
- "rand 0.8.5",
+ "rand",
  "schemars",
  "segment",
  "serde",
@@ -818,7 +818,7 @@ dependencies = [
  "num_cpus",
  "ordered-float",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "rmp-serde",
  "schemars",
  "segment",
@@ -827,7 +827,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",
@@ -1314,12 +1314,6 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -2514,7 +2508,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2686,7 +2680,7 @@ dependencies = [
  "storage",
  "sys-info",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",
@@ -2740,7 +2734,7 @@ dependencies = [
  "getset",
  "protobuf",
  "raft-proto",
- "rand 0.8.5",
+ "rand",
  "slog",
  "thiserror",
 ]
@@ -2758,26 +2752,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2787,23 +2768,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2821,7 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2830,7 +2796,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2855,15 +2821,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3137,7 +3094,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "pprof",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "rayon",
  "rmp-serde",
@@ -3148,7 +3105,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror",
  "uuid",
  "walkdir",
@@ -3365,14 +3322,14 @@ dependencies = [
  "proptest",
  "prost 0.9.0",
  "raft",
- "rand 0.8.5",
+ "rand",
  "schemars",
  "segment",
  "serde",
  "serde_cbor",
  "serde_json",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",
@@ -3466,16 +3423,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -3743,7 +3690,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -3972,7 +3919,7 @@ dependencies = [
  "fs2",
  "log 0.4.17",
  "memmap 0.5.2",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 rusty-hook = "^0.11.2"
 
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 criterion = "0.3"
 
 [dependencies]

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -71,7 +71,7 @@ impl CollectionUpdater {
 #[cfg(test)]
 mod tests {
     use segment::types::{Payload, WithPayload};
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::build_test_holder;
@@ -82,7 +82,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_point_ops() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segments = build_test_holder(dir.path());
         let points = vec![1.into(), 500.into()];
@@ -140,7 +140,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_payload_ops() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segments = build_test_holder(dir.path());
 
         let payload: Payload = serde_json::from_str(r#"{"color":"red"}"#).unwrap();

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -601,14 +601,14 @@ mod tests {
     use std::fs::read_dir;
 
     use segment::types::FieldCondition;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 
     #[test]
     fn test_writing() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
         let deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_read_filter() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
 
         let filter = Filter::new_must_not(Condition::Field(FieldCondition::new_match(
@@ -713,7 +713,7 @@ mod tests {
 
     #[test]
     fn test_take_snapshot() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let original_segment = LockedSegment::new(build_segment_1(dir.path()));
         let original_segment_2 = LockedSegment::new(build_segment_2(dir.path()));
         let write_segment = LockedSegment::new(empty_segment(dir.path()));
@@ -748,7 +748,7 @@ mod tests {
 
         proxy_segment2.upsert_point(201, 11.into(), &vec6).unwrap();
 
-        let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
+        let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         eprintln!("Snapshot into {:?}", snapshot_dir.path());
 
         proxy_segment.take_snapshot(snapshot_dir.path()).unwrap();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -435,14 +435,14 @@ mod tests {
 
     use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
     use segment::types::Distance;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::{build_segment_1, build_segment_2};
 
     #[test]
     fn test_add_and_swap() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segment1 = build_segment_1(dir.path());
         let segment2 = build_segment_2(dir.path());
 
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_aloha_locking() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segment1 = build_segment_1(dir.path());
         let segment2 = build_segment_2(dir.path());
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_apply_to_appendable() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segment1 = build_segment_1(dir.path());
         let mut segment2 = build_segment_2(dir.path());
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_all() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segment1 = build_segment_1(dir.path());
         let segment2 = build_segment_2(dir.path());
 
@@ -548,7 +548,7 @@ mod tests {
         let sid2 = holder.add(segment2);
         assert_ne!(sid1, sid2);
 
-        let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
+        let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         holder.snapshot_all_segments(snapshot_dir.path()).unwrap();
 
         let archive_count = read_dir(&snapshot_dir).unwrap().into_iter().count();

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -245,7 +245,7 @@ mod tests {
     use segment::fixtures::index_fixtures::random_vector;
     use segment::types::{Payload, PayloadSchemaType, StorageType};
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::random_segment;
@@ -272,8 +272,11 @@ mod tests {
         let stopped = AtomicBool::new(false);
         let dim = 256;
 
-        let segments_dir = TempDir::new("segments_dir").unwrap();
-        let segments_temp_dir = TempDir::new("segments_temp_dir").unwrap();
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let segments_temp_dir = Builder::new()
+            .prefix("segments_temp_dir")
+            .tempdir()
+            .unwrap();
         let mut opnum = 101..1000000;
 
         let small_segment = random_segment(segments_dir.path(), opnum.next().unwrap(), 25, dim);

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -153,7 +153,7 @@ mod tests {
     use std::sync::Arc;
 
     use parking_lot::RwLock;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::{get_merge_optimizer, random_segment};
@@ -161,8 +161,8 @@ mod tests {
 
     #[test]
     fn test_max_merge_size() {
-        let dir = TempDir::new("segment_dir").unwrap();
-        let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
         let mut holder = SegmentHolder::default();
         let dim = 256;
@@ -195,8 +195,8 @@ mod tests {
 
     #[test]
     fn test_merge_optimizer() {
-        let dir = TempDir::new("segment_dir").unwrap();
-        let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
         let mut holder = SegmentHolder::default();
         let dim = 256;

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -140,7 +140,7 @@ mod tests {
     use rand::Rng;
     use segment::types::Distance;
     use serde_json::{json, Value};
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::random_segment;
@@ -148,8 +148,8 @@ mod tests {
 
     #[test]
     fn test_vacuum_conditions() {
-        let temp_dir = TempDir::new("segment_temp_dir").unwrap();
-        let dir = TempDir::new("segment_dir").unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let mut holder = SegmentHolder::default();
         let segment_id = holder.add(random_segment(dir.path(), 100, 200, 4));
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -141,14 +141,14 @@ async fn search_in_segment(
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::collection_manager::fixtures::build_test_holder;
 
     #[tokio::test]
     async fn test_segments_search() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segment_holder = build_test_holder(dir.path());
 
@@ -179,7 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retrieve() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segment_holder = build_test_holder(dir.path());
 
         let records = SegmentsSearcher::retrieve(

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::entry::entry_point::SegmentEntry;
 use segment::types::{PayloadKeyType, PayloadSchemaType, PointIdType};
-use tempdir::TempDir;
+use tempfile::Builder;
 
 use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
@@ -42,7 +42,7 @@ fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> Seg
 
 #[test]
 fn test_update_proxy_segments() {
-    let dir = TempDir::new("segment_dir").unwrap();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
     let segment1 = build_segment_1(dir.path());
     let segment2 = build_segment_2(dir.path());
@@ -78,7 +78,7 @@ fn test_update_proxy_segments() {
 
 #[test]
 fn test_move_points_to_copy_on_write() {
-    let dir = TempDir::new("segment_dir").unwrap();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
     let segment1 = build_segment_1(dir.path());
     let segment2 = build_segment_2(dir.path());

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -77,11 +77,13 @@ impl<T> Deref for SaveOnDisk<T> {
 mod tests {
     use std::fs;
 
+    use tempfile::Builder;
+
     use super::SaveOnDisk;
 
     #[test]
     fn saves_data() {
-        let dir = tempdir::TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let counter_file = dir.path().join("counter");
         let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
         counter.write(|counter| *counter += 1).unwrap();
@@ -100,7 +102,7 @@ mod tests {
 
     #[test]
     fn loads_data() {
-        let dir = tempdir::TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let counter_file = dir.path().join("counter");
         let mut counter: SaveOnDisk<u32> = SaveOnDisk::load_or_init(&counter_file).unwrap();
         counter.write(|counter| *counter += 1).unwrap();

--- a/lib/collection/src/shard/shard_holder.rs
+++ b/lib/collection/src/shard/shard_holder.rs
@@ -307,7 +307,7 @@ impl LockedShardHolder {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::shard::remote_shard::RemoteShard;
@@ -315,8 +315,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_shard_holder() {
-        let shard_dir = TempDir::new("shard").unwrap();
-        let collection_dir = TempDir::new("collection").unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+        let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
         let shard = RemoteShard::init(
             2,

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use futures::future::join_all;
 use itertools::Itertools;
 use parking_lot::RwLock;
-use tempdir::TempDir;
+use tempfile::Builder;
 use tokio::time::{sleep, Instant};
 
 use crate::collection::Collection;
@@ -18,8 +18,8 @@ use crate::update_handler::{Optimizer, UpdateHandler};
 
 #[tokio::test]
 async fn test_optimization_process() {
-    let dir = TempDir::new("segment_dir").unwrap();
-    let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
     let dim = 256;
     let mut holder = SegmentHolder::default();
@@ -72,8 +72,8 @@ async fn test_optimization_process() {
 
 #[tokio::test]
 async fn test_cancel_optimization() {
-    let dir = TempDir::new("segment_dir").unwrap();
-    let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
     let mut holder = SegmentHolder::default();
     let dim = 256;

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -1,6 +1,7 @@
 use std::num::{NonZeroU32, NonZeroU64};
 
 use segment::types::Distance;
+use tempfile::Builder;
 
 use crate::collection::Collection;
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
@@ -40,9 +41,12 @@ async fn test_snapshot_collection() {
         hnsw_config: Default::default(),
     };
 
-    let snapshots_path = tempdir::TempDir::new("test_snapshots").unwrap();
-    let collection_dir = tempdir::TempDir::new("test_collection").unwrap();
-    let recover_dir = tempdir::TempDir::new("test_collection_rec").unwrap();
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let recover_dir = Builder::new()
+        .prefix("test_collection_rec")
+        .tempdir()
+        .unwrap();
     let collection_name = "test".to_string();
     let collection_name_rec = "test_rec".to_string();
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -117,16 +117,16 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 mod tests {
     use super::*;
 
-    extern crate tempdir;
+    extern crate tempfile;
 
     use std::fs;
     use std::os::unix::fs::MetadataExt;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     #[test]
     fn test_wal() {
-        let dir = TempDir::new("wal_test").unwrap();
+        let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
         let wal_options = WalOptions {
             segment_capacity: 32 * 1024 * 1024,
             segment_queue_len: 0,

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -4,7 +4,7 @@ use collection::operations::CollectionUpdateOperations;
 use itertools::Itertools;
 use segment::types::{PayloadSelectorExclude, WithPayloadInterface};
 use serde_json::Value;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
 
@@ -17,7 +17,7 @@ async fn test_collection_reloading() {
 }
 
 async fn test_collection_reloading_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
     {
         let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
@@ -63,7 +63,7 @@ async fn test_collection_payload_reloading() {
 }
 
 async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
     {
         let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
@@ -128,7 +128,7 @@ async fn test_collection_payload_custom_payload() {
 }
 
 async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
     {
         let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use segment::types::{
     Condition, FieldCondition, Filter, HasIdCondition, Payload, PointIdType, WithPayloadInterface,
 };
-use tempdir::TempDir;
+use tempfile::Builder;
 use tokio::runtime::Handle;
 
 use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
@@ -25,7 +25,7 @@ async fn test_collection_updater() {
 }
 
 async fn test_collection_updater_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
@@ -89,7 +89,7 @@ async fn test_collection_search_with_payload_and_vector() {
 }
 
 async fn test_collection_search_with_payload_and_vector_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
@@ -165,7 +165,7 @@ async fn test_collection_loading() {
 }
 
 async fn test_collection_loading_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
     {
         let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
@@ -288,7 +288,7 @@ async fn test_recommendation_api() {
 }
 
 async fn test_recommendation_api_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(
@@ -349,7 +349,7 @@ async fn test_read_api() {
 }
 
 async fn test_read_api_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
@@ -405,7 +405,7 @@ async fn test_collection_delete_points_by_filter() {
 }
 
 async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
 
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
@@ -481,7 +481,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
 
 #[tokio::test]
 async fn test_promote_temporary_shards() {
-    let collection_dir = TempDir::new("collection").unwrap();
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
     let mut collection = simple_collection_fixture(collection_dir.path(), 1).await;
 
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(

--- a/lib/collection/tests/pagination_test.rs
+++ b/lib/collection/tests/pagination_test.rs
@@ -2,6 +2,7 @@ use collection::operations::point_ops::{PointInsertOperations, PointOperations, 
 use collection::operations::types::SearchRequest;
 use collection::operations::CollectionUpdateOperations;
 use segment::types::WithPayloadInterface;
+use tempfile::Builder;
 use tokio::runtime::Handle;
 
 use crate::common::{simple_collection_fixture, N_SHARDS};
@@ -15,7 +16,10 @@ async fn test_collection_paginated_search() {
 }
 
 async fn test_collection_paginated_search_with_shards(shard_number: u32) {
-    let collection_dir = tempdir::TempDir::new("test_collection_paginated_search").unwrap();
+    let collection_dir = Builder::new()
+        .prefix("test_collection_paginated_search")
+        .tempdir()
+        .unwrap();
 
     let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dev-dependencies]
 pprof = { version = "0.10", features = ["flamegraph", "prost-codec"] }
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 criterion = "0.3"
 rmp-serde = "~1.1"
 rand_distr = "0.4.3"

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -10,7 +10,7 @@ use segment::fixtures::payload_context_fixture::{
 use segment::fixtures::payload_fixtures::random_must_filter;
 use segment::index::PayloadIndex;
 use segment::types::PointOffsetType;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 const NUM_POINTS: usize = 100000;
 const CHECK_SAMPLE_SIZE: usize = 1000;
@@ -21,7 +21,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(seed);
     let mut group = c.benchmark_group("conditional-search-group");
 
-    let dir = TempDir::new("storage_dir").unwrap();
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let plain_index = create_plain_payload_index(dir.path(), NUM_POINTS, seed);
 
     let mut result_size = 0;
@@ -89,7 +89,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
 
     let seed = 42;
 
-    let dir = TempDir::new("storage_dir").unwrap();
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let struct_index = create_struct_payload_index(dir.path(), NUM_POINTS, seed);
 
     let mut result_size = 0;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -9,7 +9,7 @@ use segment::common::rocksdb_operations::open_db;
 use segment::types::{Distance, VectorElementType};
 use segment::vector_storage::simple_vector_storage::open_simple_vector_storage;
 use segment::vector_storage::VectorStorageSS;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 const NUM_VECTORS: usize = 50000;
 const DIM: usize = 1000; // Larger dimensionality - greater the SIMD advantage
@@ -40,7 +40,7 @@ fn init_vector_storage(
 }
 
 fn benchmark_naive(c: &mut Criterion) {
-    let dir = TempDir::new("storage_dir").unwrap();
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
     let dist = Distance::Dot;
     let storage = init_vector_storage(dir.path(), DIM, NUM_VECTORS, dist);

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -233,7 +233,7 @@ impl IdTracker for SimpleIdTracker {
 mod tests {
     use itertools::Itertools;
     use serde::de::DeserializeOwned;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_iterator() {
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
 
         let mut id_tracker = SimpleIdTracker::open(db).unwrap();

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -566,7 +566,7 @@ mod tests {
     use rand::prelude::StdRng;
     use rand::SeedableRng;
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db_with_existing_cf;
@@ -600,7 +600,7 @@ mod tests {
     }
 
     fn build_random_index(num_points: usize, num_geo_values: usize) -> GeoMapIndex {
-        let tmp_dir = TempDir::new("test_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
 
         let mut rnd = StdRng::seed_from_u64(42);
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     fn match_cardinality_point_with_multi_far_geo_payload() {
-        let tmp_dir = TempDir::new("test_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
 
         let mut index = GeoMapIndex::new(db, FIELD_NAME);
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn match_cardinality_point_with_multi_close_geo_payload() {
-        let tmp_dir = TempDir::new("test_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
 
         let mut index = GeoMapIndex::new(db, FIELD_NAME);
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     fn load_from_disk() {
-        let tmp_dir = TempDir::new("test_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         {
             let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
 

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -389,7 +389,7 @@ mod tests {
     use std::iter::FromIterator;
     use std::path::Path;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db_with_existing_cf;
@@ -439,7 +439,7 @@ mod tests {
             vec![25],
         ];
 
-        let tmp_dir = TempDir::new("store_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
         save_map_index(&data, tmp_dir.path());
         load_map_index(&data, tmp_dir.path());
     }
@@ -470,7 +470,7 @@ mod tests {
             vec![String::from("PPGG")],
         ];
 
-        let tmp_dir = TempDir::new("store_dir").unwrap();
+        let tmp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
         save_map_index(&data, tmp_dir.path());
         load_map_index(&data, tmp_dir.path());
     }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -571,7 +571,7 @@ mod tests {
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
-    use tempdir::TempDir;
+    use tempfile::{Builder, TempDir};
 
     use super::*;
     use crate::common::rocksdb_operations::open_db_with_existing_cf;
@@ -579,7 +579,10 @@ mod tests {
     const COLUMN_NAME: &str = "test";
 
     fn get_index() -> (TempDir, NumericIndex<f64>) {
-        let tmp_dir = TempDir::new("test_numeric_index").unwrap();
+        let tmp_dir = Builder::new()
+            .prefix("test_numeric_index")
+            .tempdir()
+            .unwrap();
         let db = open_db_with_existing_cf(tmp_dir.path()).unwrap();
         let index: NumericIndex<_> = NumericIndex::new(db, COLUMN_NAME);
         index.recreate().unwrap();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -340,7 +340,7 @@ mod tests {
     use itertools::Itertools;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::fixtures::index_fixtures::{
@@ -431,7 +431,7 @@ mod tests {
 
         let res1 = search_in_graph(&query, top, &vector_holder, &graph_layers);
 
-        let dir = TempDir::new("graph_dir").unwrap();
+        let dir = Builder::new().prefix("graph_dir").tempdir().unwrap();
 
         let path = GraphLayers::get_path(dir.path());
         graph_layers.save(&path).unwrap();

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -100,7 +100,7 @@ impl PayloadStorage for PayloadStorageEnum {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_storage() {
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
 
         let mut storage: PayloadStorageEnum = SimplePayloadStorage::open(db).unwrap().into();
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_on_disk_storage() {
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
 
         {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -211,7 +211,7 @@ mod tests {
     use std::collections::HashSet;
 
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_condition_checker() {
-        let dir = TempDir::new("db_dir").unwrap();
+        let dir = Builder::new().prefix("db_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
 
         let payload: Payload = json!(

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -69,14 +69,14 @@ impl PayloadStorage for SimplePayloadStorage {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
 
     #[test]
     fn test_wipe() {
-        let dir = TempDir::new("db_dir").unwrap();
+        let dir = Builder::new().prefix("db_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
 
         let mut storage = SimplePayloadStorage::open(db).unwrap();
@@ -116,7 +116,7 @@ mod tests {
         }"#;
 
         let payload: Payload = serde_json::from_str(data).unwrap();
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
         let mut storage = SimplePayloadStorage::open(db).unwrap();
         storage.assign(100, &payload).unwrap();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -792,7 +792,7 @@ mod tests {
     use std::fs;
 
     use tar::Archive;
-    use tempdir::TempDir;
+    use tempfile::Builder;
     use walkdir::WalkDir;
 
     use super::*;
@@ -813,7 +813,7 @@ mod tests {
     //         "array": [1, "hello"],
     //     }"#;
     //
-    //     let dir = TempDir::new("payload_dir").unwrap();
+    //     let dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
     //     let dim = 2;
     //     let config = SegmentConfig {
     //         vector_size: dim,
@@ -846,7 +846,7 @@ mod tests {
             }
         }"#;
 
-        let dir = TempDir::new("payload_dir").unwrap();
+        let dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
         let dim = 2;
         let config = SegmentConfig {
             vector_size: dim,
@@ -926,7 +926,7 @@ mod tests {
             }
         }"#;
 
-        let segment_base_dir = TempDir::new("segment_dir").unwrap();
+        let segment_base_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let config = SegmentConfig {
             vector_size: 2,
             index: Indexes::Plain {},
@@ -948,7 +948,7 @@ mod tests {
             .count();
         assert_eq!(segment_file_count, 20);
 
-        let snapshot_dir = TempDir::new("snapshot_dir").unwrap();
+        let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
 
         // snapshotting!
         segment.take_snapshot(snapshot_dir.path()).unwrap();
@@ -975,7 +975,10 @@ mod tests {
         assert!(archive_name.starts_with(segment_id));
 
         // decompress archive
-        let snapshot_decompress_dir = TempDir::new("snapshot_decompress_dir").unwrap();
+        let snapshot_decompress_dir = Builder::new()
+            .prefix("snapshot_decompress_dir")
+            .tempdir()
+            .unwrap();
         let archive_file = File::open(archive).unwrap();
         let mut ar = Archive::new(archive_file);
         ar.unpack(snapshot_decompress_dir.path()).unwrap();
@@ -999,7 +1002,7 @@ mod tests {
             }
         }"#;
 
-        let segment_base_dir = TempDir::new("segment_dir").unwrap();
+        let segment_base_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let config = SegmentConfig {
             vector_size: 2,
             index: Indexes::Plain {},
@@ -1021,7 +1024,7 @@ mod tests {
             .count();
         assert_eq!(segment_file_count, 20);
 
-        let segment_copy_dir = TempDir::new("segment_copy_dir").unwrap();
+        let segment_copy_dir = Builder::new().prefix("segment_copy_dir").tempdir().unwrap();
         let full_copy_path = segment
             .copy_segment_directory(segment_copy_dir.path())
             .unwrap();

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -31,21 +31,21 @@ pub fn build_simple_segment(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::entry::entry_point::{OperationError, SegmentEntry};
 
     #[test]
     fn test_create_simple_segment() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segment = build_simple_segment(dir.path(), 100, Distance::Dot).unwrap();
         eprintln!(" = {:?}", segment.version());
     }
 
     #[test]
     fn test_add_and_search() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
 
         let wrong_vec = vec![1.0, 1.0, 1.0];

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -311,7 +311,7 @@ where
 mod tests {
     use std::mem::transmute;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn test_basic_persistence() {
         let dist = Distance::Dot;
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let storage = open_memmap_vector_storage(dir.path(), 4, dist).unwrap();
         let mut borrowed_storage = storage.borrow_mut();
@@ -332,7 +332,7 @@ mod tests {
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
         {
-            let dir2 = TempDir::new("db_dir").unwrap();
+            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path()).unwrap();
             let storage2 = open_simple_vector_storage(db, 4, dist).unwrap();
             {
@@ -355,7 +355,7 @@ mod tests {
         borrowed_storage.delete(2).unwrap();
 
         {
-            let dir2 = TempDir::new("db_dir").unwrap();
+            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path()).unwrap();
             let storage2 = open_simple_vector_storage(db, 4, dist).unwrap();
             {
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn test_mmap_raw_scorer() {
         let dist = Distance::Dot;
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let storage = open_memmap_vector_storage(dir.path(), 4, dist).unwrap();
         let mut borrowed_storage = storage.borrow_mut();
 
@@ -398,7 +398,7 @@ mod tests {
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
         {
-            let dir2 = TempDir::new("db_dir").unwrap();
+            let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path()).unwrap();
             let storage2 = open_simple_vector_storage(db, 4, dist).unwrap();
             {

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -331,14 +331,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use crate::common::rocksdb_operations::open_db;
 
     #[test]
     fn test_score_points() {
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path()).unwrap();
         let distance = Distance::Dot;
         let dim = 4;

--- a/lib/segment/tests/fail_recovery_test.rs
+++ b/lib/segment/tests/fail_recovery_test.rs
@@ -4,13 +4,13 @@ mod fixtures;
 mod tests {
     use segment::entry::entry_point::{OperationError, SegmentEntry, SegmentFailedState};
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use crate::fixtures::segment::empty_segment;
 
     #[test]
     fn test_insert_fail_recovery() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let vec1 = vec![1.0, 0.0, 1.0, 1.0];
 

--- a/lib/segment/tests/filtering_context_check.rs
+++ b/lib/segment/tests/filtering_context_check.rs
@@ -9,7 +9,7 @@ mod tests {
     use segment::fixtures::payload_fixtures::random_filter;
     use segment::index::PayloadIndex;
     use segment::types::PointOffsetType;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     const NUM_POINTS: usize = 2000;
     const ATTEMPTS: usize = 100;
@@ -19,7 +19,7 @@ mod tests {
         let seed = 42;
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let dir = TempDir::new("storage_dir").unwrap();
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let plain_index = create_plain_payload_index(dir.path(), NUM_POINTS, seed);
         let struct_index = create_struct_payload_index(dir.path(), NUM_POINTS, seed);
 

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -16,7 +16,7 @@ mod tests {
         StorageType,
     };
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     #[test]
     fn test_filterable_hnsw() {
@@ -34,8 +34,8 @@ mod tests {
 
         let mut rnd = thread_rng();
 
-        let dir = TempDir::new("segment_dir").unwrap();
-        let hnsw_dir = TempDir::new("hnsw_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
 
         let config = SegmentConfig {
             vector_size: dim,

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -18,7 +18,7 @@ mod tests {
         IsEmptyCondition, Payload, PayloadField, PayloadSchemaType, Range, SegmentConfig,
         StorageType, WithPayload,
     };
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segment) {
         let mut rnd = StdRng::seed_from_u64(42);
@@ -114,8 +114,8 @@ mod tests {
 
     #[test]
     fn test_is_empty_conditions() {
-        let dir1 = TempDir::new("segment1_dir").unwrap();
-        let dir2 = TempDir::new("segment2_dir").unwrap();
+        let dir1 = Builder::new().prefix("segment1_dir").tempdir().unwrap();
+        let dir2 = Builder::new().prefix("segment2_dir").tempdir().unwrap();
 
         let (struct_segment, plain_segment) = build_test_segments(dir1.path(), dir2.path());
 
@@ -159,8 +159,8 @@ mod tests {
 
     #[test]
     fn test_cardinality_estimation() {
-        let dir1 = TempDir::new("segment1_dir").unwrap();
-        let dir2 = TempDir::new("segment2_dir").unwrap();
+        let dir1 = Builder::new().prefix("segment1_dir").tempdir().unwrap();
+        let dir2 = Builder::new().prefix("segment2_dir").tempdir().unwrap();
 
         let (struct_segment, _) = build_test_segments(dir1.path(), dir2.path());
 
@@ -199,8 +199,8 @@ mod tests {
     #[test]
     fn test_struct_payload_index() {
         // Compare search with plain and struct indexes
-        let dir1 = TempDir::new("segment1_dir").unwrap();
-        let dir2 = TempDir::new("segment2_dir").unwrap();
+        let dir1 = Builder::new().prefix("segment1_dir").tempdir().unwrap();
+        let dir2 = Builder::new().prefix("segment2_dir").tempdir().unwrap();
 
         let dim = 5;
 
@@ -263,8 +263,8 @@ mod tests {
         // Compare search with plain and struct indexes
         let mut rnd = rand::thread_rng();
 
-        let dir1 = TempDir::new("segment1_dir").unwrap();
-        let dir2 = TempDir::new("segment2_dir").unwrap();
+        let dir1 = Builder::new().prefix("segment1_dir").tempdir().unwrap();
+        let dir2 = Builder::new().prefix("segment2_dir").tempdir().unwrap();
 
         let dim = 5;
 

--- a/lib/segment/tests/segment_builder_test.rs
+++ b/lib/segment/tests/segment_builder_test.rs
@@ -11,14 +11,14 @@ mod tests {
     use segment::segment::Segment;
     use segment::segment_constructor::segment_builder::SegmentBuilder;
     use segment::types::{Indexes, SegmentConfig};
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use crate::fixtures::segment::{build_segment_1, build_segment_2, empty_segment};
 
     #[test]
     fn test_building_new_segment() {
-        let dir = TempDir::new("segment_dir").unwrap();
-        let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
         let stopped = AtomicBool::new(false);
 
@@ -73,8 +73,8 @@ mod tests {
     fn estimate_build_time(segment: &Segment, stop_timeout_millis: u64) -> (u64, bool) {
         let stopped = Arc::new(AtomicBool::new(false));
 
-        let dir = TempDir::new("segment_dir1").unwrap();
-        let temp_dir = TempDir::new("segment_temp_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir1").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
         let segment_config = SegmentConfig {
             vector_size: segment.segment_config.vector_size,
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_building_cancellation() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let mut segment = empty_segment(dir.path());
 

--- a/lib/segment/tests/segment_tests.rs
+++ b/lib/segment/tests/segment_tests.rs
@@ -7,13 +7,13 @@ mod tests {
 
     use segment::entry::entry_point::SegmentEntry;
     use segment::types::{Condition, Filter, WithPayload};
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use crate::fixtures::segment::build_segment_1;
 
     #[test]
     fn test_point_exclusion() {
-        let dir = TempDir::new("segment_dir").unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segment = build_segment_1(dir.path());
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 proptest = "1.0.0"
 
 [dependencies]

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -574,6 +574,7 @@ mod tests {
     use proptest::prelude::*;
     use raft::eraftpb::Entry;
     use raft::storage::{MemStorage, Storage};
+    use tempfile::Builder;
 
     use super::ConsensusState;
     use crate::content_manager::consensus::consensus_wal::ConsensusOpWal;
@@ -584,7 +585,7 @@ mod tests {
 
     #[test]
     fn update_is_applied() {
-        let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
         let mut state = Persistent::load_or_init(dir.path(), false).unwrap();
         assert_eq!(state.state().hard_state.commit, 0);
         state
@@ -606,7 +607,7 @@ mod tests {
 
     #[test]
     fn state_is_loaded() {
-        let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
         let mut state = Persistent::load_or_init(dir.path(), false).unwrap();
         state
             .apply_state_update(|state| state.hard_state.commit = 1)
@@ -635,7 +636,7 @@ mod tests {
 
     #[test]
     fn correct_entry_with_offset() {
-        let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
         let mut wal = ConsensusOpWal::new(dir.path().to_str().unwrap());
         wal.append_entries(vec![Entry {
             index: 4,
@@ -657,7 +658,7 @@ mod tests {
 
     #[test]
     fn at_least_1_entry() {
-        let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
         let mut wal = ConsensusOpWal::new(dir.path().to_str().unwrap());
         wal.append_entries(vec![
             Entry {
@@ -729,7 +730,7 @@ mod tests {
     proptest! {
         #[test]
         fn check_first_and_last_indexes(entries in gen_entries(0, 100)) {
-            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
             let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
             prop_assert_eq!(mem_storage.last_index(), consensus_state.last_index());
             prop_assert_eq!(mem_storage.first_index(), consensus_state.first_index());
@@ -737,7 +738,7 @@ mod tests {
 
         #[test]
         fn check_term(entries in gen_entries(0, 100), id in 0u64..100) {
-            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
             let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
             prop_assert_eq!(mem_storage.term(id), consensus_state.term(id))
         }
@@ -748,7 +749,7 @@ mod tests {
                 len in 1u64..100,
                 max_size in proptest::option::of(proptest::num::u64::ANY)
             ) {
-            let dir = tempdir::TempDir::new("raft_state_test").unwrap();
+            let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
             let (consensus_state, mem_storage) = setup_storages(entries, dir.path());
             let mut high = low + len;
             let last_index = mem_storage.last_index().unwrap();

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -12,12 +12,12 @@ mod tests {
     use storage::content_manager::toc::TableOfContent;
     use storage::dispatcher::Dispatcher;
     use storage::types::{PerformanceConfig, StorageConfig};
-    use tempdir::TempDir;
+    use tempfile::Builder;
     use tokio::runtime::Runtime;
 
     #[test]
     fn test_alias_operation() {
-        let storage_dir = TempDir::new("storage").unwrap();
+        let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
 
         let config = StorageConfig {
             storage_path: storage_dir.path().to_str().unwrap().to_string(),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -683,7 +683,7 @@ mod tests {
     use storage::content_manager::consensus_state::{ConsensusState, ConsensusStateRef};
     use storage::content_manager::toc::TableOfContent;
     use storage::dispatcher::Dispatcher;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::Consensus;
     use crate::settings::ConsensusConfig;
@@ -691,7 +691,7 @@ mod tests {
     #[test]
     fn collection_creation_passes_consensus() {
         // Given
-        let storage_dir = TempDir::new("storage").unwrap();
+        let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
         let mut settings = crate::Settings::new().expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());


### PR DESCRIPTION
This commit replaces tempdir with tempfile.
tempdir is archived.

Closes #544

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [X] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [X] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

The test `consensus::tests::collection_creation_passes_consensus` fails locally on Windows 11.

```
test consensus::tests::collection_creation_passes_consensus ... FAILED

failures:

---- consensus::tests::collection_creation_passes_consensus stdout ----
thread 'consensus::tests::collection_creation_passes_consensus' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }', lib\storage\src\content_manager\consensus\consensus_wal.rs:22:61
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

it doesn't look related to this change, and originates from https://github.com/qdrant/wal/blob/0dd3943113ff7ec2fbc5428bb77ba206c8492fa9/src/lib.rs#L118. I'll open an issue for that now

