### PR TITLE
AddPeer in one consensus operation

### DIFF
--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -11,9 +11,12 @@ service Raft {
   // Returns uri by id if bootstrap knows this peer
   rpc WhoIs (PeerId) returns (Uri);
   // Send to bootstrap peer
-  // Proposes to add this peer Uri and ID to a map of all peers
+  // Adds peer to the network
   // Returns all peers
   rpc AddPeerToKnown (AddPeerToKnownMessage) returns (AllPeers);
+  // DEPRECATED
+  // Its functionality is now included in `AddPeerToKnown`
+  //
   // Send to bootstrap peer
   // Proposes to add this peer as participant of consensus
   rpc AddPeerAsParticipant (PeerId) returns (google.protobuf.Empty);

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3853,7 +3853,7 @@ pub mod raft_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Send to bootstrap peer
-        /// Proposes to add this peer Uri and ID to a map of all peers
+        /// Adds peer to the network
         /// Returns all peers
         pub async fn add_peer_to_known(
             &mut self,
@@ -3874,6 +3874,9 @@ pub mod raft_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        /// DEPRECATED
+        /// Its functionality is now included in `AddPeerToKnown`
+        ///
         /// Send to bootstrap peer
         /// Proposes to add this peer as participant of consensus
         pub async fn add_peer_as_participant(
@@ -3916,12 +3919,15 @@ pub mod raft_server {
             request: tonic::Request<super::PeerId>,
         ) -> Result<tonic::Response<super::Uri>, tonic::Status>;
         /// Send to bootstrap peer
-        /// Proposes to add this peer Uri and ID to a map of all peers
+        /// Adds peer to the network
         /// Returns all peers
         async fn add_peer_to_known(
             &self,
             request: tonic::Request<super::AddPeerToKnownMessage>,
         ) -> Result<tonic::Response<super::AllPeers>, tonic::Status>;
+        /// DEPRECATED
+        /// Its functionality is now included in `AddPeerToKnown`
+        ///
         /// Send to bootstrap peer
         /// Proposes to add this peer as participant of consensus
         async fn add_peer_as_participant(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -665,7 +665,6 @@ async fn send_message(
 mod tests {
     use std::sync::Arc;
     use std::thread;
-    
 
     use collection::shard::ChannelService;
     use segment::types::Distance;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -15,7 +15,6 @@ use raft::eraftpb::Message as RaftMessage;
 use raft::prelude::*;
 use raft::{SoftState, StateRole};
 use storage::content_manager::consensus_ops::ConsensusOperations;
-use storage::content_manager::consensus_ops::ConsensusOperations::RemovePeer;
 use storage::content_manager::consensus_state::ConsensusStateRef;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
@@ -32,7 +31,6 @@ type Node = RawNode<ConsensusStateRef>;
 pub enum Message {
     FromClient(ConsensusOperations),
     FromPeer(Box<RaftMessage>),
-    ConfChange(ConfChangeV2),
 }
 
 pub struct Consensus {
@@ -165,7 +163,6 @@ impl Consensus {
                 p2p_port,
                 &config,
                 &runtime,
-                sender.clone(),
                 leader_established_in_ms,
             )
             .context("Failed to initialize Consensus for new Raft state")?;
@@ -200,7 +197,6 @@ impl Consensus {
         p2p_port: u16,
         config: &ConsensusConfig,
         runtime: &Runtime,
-        sender: SyncSender<Message>,
         leader_established_in_ms: u64,
     ) -> anyhow::Result<()> {
         if let Some(bootstrap_peer) = bootstrap_peer {
@@ -220,18 +216,11 @@ impl Consensus {
             let tick_period = config.tick_period_ms;
             log::info!("With current tick period of {tick_period}ms, leader will be established in approximately {leader_established_in_ms}ms. To avoid rejected operations - add peers and submit operations only after this period.");
             // First peer needs to add its own address
-            let message = Message::FromClient(ConsensusOperations::AddPeer(
+            state_ref.add_peer(
                 state_ref.this_peer_id(),
-                uri.ok_or_else(|| anyhow::anyhow!("First peer should specify its uri."))?,
-            ));
-            let is_leader_established = state_ref.is_leader_established.clone();
-            thread::spawn(move || {
-                // Wait for the leader to be established
-                is_leader_established.await_ready();
-                if let Err(err) = sender.send(message) {
-                    log::error!("Failed to send message to add this peer to known peers: {err}")
-                }
-            });
+                uri.ok_or_else(|| anyhow::anyhow!("First peer should specify its uri."))?
+                    .parse()?,
+            )?;
             Ok(())
         }
     }
@@ -280,6 +269,7 @@ impl Consensus {
         // This needs to be propagated manually to other peers as it is not contained in any log entry.
         state_ref.set_first_voter(all_peers.first_peer_id);
         state_ref.set_conf_state(ConfState::from((vec![all_peers.first_peer_id], vec![])))?;
+        // TODO: Remove in the next version after 0.10 as it does nothing and is left for compatability
         client
             .add_peer_as_participant(tonic::Request::new(api::grpc::qdrant::PeerId { id }))
             .await
@@ -345,7 +335,7 @@ impl Consensus {
             }
             Ok(Message::FromClient(operation)) => {
                 let result = match operation {
-                    RemovePeer(peer_id) => {
+                    ConsensusOperations::RemovePeer(peer_id) => {
                         let mut change = ConfChangeV2::default();
                         change.set_changes(vec![raft_proto::new_conf_change_single(
                             peer_id,
@@ -353,6 +343,15 @@ impl Consensus {
                         )]);
                         log::debug!("Proposing network configuration change: {:?}", change);
                         self.node.propose_conf_change(vec![], change)
+                    }
+                    ConsensusOperations::AddPeer(peer_id, uri) => {
+                        let mut change = ConfChangeV2::default();
+                        change.set_changes(vec![raft_proto::new_conf_change_single(
+                            peer_id,
+                            ConfChangeType::AddLearnerNode,
+                        )]);
+                        log::debug!("Proposing network configuration change: {:?}", change);
+                        self.node.propose_conf_change(uri.into_bytes(), change)
                     }
                     _ => {
                         let message = match serde_cbor::to_vec(&operation) {
@@ -375,10 +374,6 @@ impl Consensus {
                         return Ok(());
                     }
                 }
-            }
-            Ok(Message::ConfChange(change)) => {
-                log::debug!("Proposing network configuration change: {:?}", change);
-                self.node.propose_conf_change(vec![], change)?
             }
             Err(RecvTimeoutError::Timeout) => (),
             Err(RecvTimeoutError::Disconnected) => {
@@ -670,7 +665,7 @@ async fn send_message(
 mod tests {
     use std::sync::Arc;
     use std::thread;
-    use std::time::Duration;
+    
 
     use collection::shard::ChannelService;
     use segment::types::Distance;
@@ -746,11 +741,8 @@ mod tests {
         });
         // Wait for Raft to establish the leader
         is_leader_established.await_ready();
-        // And also wait for it to commit its own address
-        thread::sleep(Duration::from_secs(10));
         // Leader election produces a raft log entry
-        // Address commit also produces a raft log entry
-        assert_eq!(consensus_state.hard_state().commit, 2);
+        assert_eq!(consensus_state.hard_state().commit, 1);
         // Initially there are 0 collections
         assert_eq!(toc_arc.all_collections_sync().len(), 0);
 
@@ -777,7 +769,7 @@ mod tests {
             .unwrap();
 
         // Then
-        assert_eq!(consensus_state.hard_state().commit, 3);
+        assert_eq!(consensus_state.hard_state().commit, 2);
         assert_eq!(toc_arc.all_collections_sync(), vec!["test"]);
     }
 }


### PR DESCRIPTION
Adds a peer similar to the removal for consistency. PR tries to stay compatible with the previous version so that migration can happen without downtime.

Closes https://github.com/qdrant/qdrant/issues/915