### PR TITLE
Improve WAL recovery progress bar

### DIFF
--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::thread;
 
 use arc_swap::ArcSwap;
-use indicatif::ProgressBar;
+use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use segment::index::field_index::CardinalityEstimation;
@@ -175,7 +175,7 @@ impl LocalShard {
 
         let collection = LocalShard::new(
             id,
-            collection_id,
+            collection_id.clone(),
             segment_holder,
             shared_config,
             wal,
@@ -184,7 +184,7 @@ impl LocalShard {
         )
         .await;
 
-        collection.load_from_wal().await;
+        collection.load_from_wal(collection_id).await;
 
         collection
     }
@@ -344,10 +344,16 @@ impl LocalShard {
     }
 
     /// Loads latest collection operations from WAL
-    pub async fn load_from_wal(&self) {
+    pub async fn load_from_wal(&self, collection_id: CollectionId) {
         let wal = self.wal.lock().await;
         let bar = ProgressBar::new(wal.len());
-        bar.set_message("Recovering collection");
+
+        let progress_style = ProgressStyle::default_bar()
+            .template("{msg} [{elapsed_precise}] {wide_bar} {pos}/{len} (eta:{eta})")
+            .expect("Failed to create progress style");
+        bar.set_style(progress_style);
+
+        bar.set_message(format!("Recovering collection {}", collection_id));
         let segments = self.segments();
         // ToDo: Start from minimal applied version
         for (op_num, update) in wal.read_all() {


### PR DESCRIPTION
This PR improves the styling of the progress bar displayed while recovering the content of the WAL.

I looked into this topic because I found it weird that the progress bar did not have a message although we are using:

```rust
bar.set_message("Recovering collection");
```

The doc. says

> For the message to be visible, the {msg} placeholder must be present in the template

So I ended up:
- fixing the message display
- adding the collection name to the message
- adding the elapsed time and ETA

The new look in action

![progress](https://user-images.githubusercontent.com/606963/183602092-96910f03-7943-4901-9681-76b1ae408595.png)
