### PR TITLE
Do not panic if config.optimizer_config.max_optimization_threads is 0

### DIFF
--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -62,17 +62,24 @@ impl LocalShard {
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = shared_config.read().await;
-        let optimize_runtime = runtime::Builder::new_multi_thread()
+        let mut optimize_runtime_builder = runtime::Builder::new_multi_thread();
+
+        optimize_runtime_builder
             .worker_threads(3)
             .enable_time()
             .thread_name_fn(move || {
                 static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
                 let optimizer_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("collection-{collection_id}-shard-{id}-optimizer-{optimizer_id}")
-            })
-            .max_blocking_threads(config.optimizer_config.max_optimization_threads)
-            .build()
-            .unwrap();
+            });
+
+        if config.optimizer_config.max_optimization_threads > 0 {
+            // panics if val is not larger than 0.
+            optimize_runtime_builder
+                .max_blocking_threads(config.optimizer_config.max_optimization_threads);
+        }
+
+        let optimize_runtime = optimize_runtime_builder.build().unwrap();
 
         let locked_wal = Arc::new(Mutex::new(wal));
 


### PR DESCRIPTION
This PR prevents the panic when `config.optimizer_config.max_optimization_threads` is 0

```
thread 'main' panicked at 'Max blocking threads cannot be set to 0', /qdrant/lib/collection/src/shard/local_shard.rs:73:14
```

Tested manually.