### PR TITLE
Clippy next

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -244,7 +244,7 @@ mod tests {
         // Check only one new segment
         assert_eq!(after_optimization_segments.len(), 1);
 
-        let optimized_segment_id = *after_optimization_segments.get(0).unwrap();
+        let optimized_segment_id = *after_optimization_segments.first().unwrap();
 
         let holder_guard = locked_holder.read();
         let optimized_segment = holder_guard.get(optimized_segment_id).unwrap();

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -15,7 +15,7 @@ use crate::optimizers_builder::OptimizersConfig;
 
 pub const COLLECTION_CONFIG_FILE: &str = "config.json";
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct WalConfig {
     /// Size of a single WAL segment in MB
     pub wal_capacity_mb: usize,
@@ -41,7 +41,7 @@ impl Default for WalConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct CollectionParams {
     /// Size of a vectors used

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -130,7 +130,7 @@ pub struct RemoteShardInfo {
     pub peer_id: PeerId,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
     /// Request is saved to WAL and will be process in a queue

--- a/lib/collection/src/shard/shard_config.rs
+++ b/lib/collection/src/shard/shard_config.rs
@@ -8,14 +8,14 @@ use crate::shard::PeerId;
 
 pub const SHARD_CONFIG_FILE: &str = "shard_config.json";
 
-#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 pub enum ShardType {
     Local,
     Remote { peer_id: PeerId },
     Temporary, // same as local, but not ready yet
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ShardConfig {
     pub r#type: ShardType,
 }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -47,7 +47,7 @@ pub enum UpdateSignal {
 }
 
 /// Signal, used to inform Optimization process
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum OptimizerSignal {
     /// Sequential number of the operation
     Operation(SeqNumberType),

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -92,8 +92,8 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
         (start_from..(first_index + num_entries)).map(move |idx| {
             let record_bin = self.wal.entry(idx).expect("Can't read entry from WAL");
-            let record: R = serde_cbor::from_slice(&record_bin.to_vec())
-                .or_else(|_err| rmp_serde::from_slice(&record_bin.to_vec()))
+            let record: R = serde_cbor::from_slice(&record_bin)
+                .or_else(|_err| rmp_serde::from_slice(&record_bin))
                 .expect("Can't deserialize entry, probably corrupted WAL on version mismatch");
             (idx, record)
         })

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -7,7 +7,7 @@ use crate::entry::entry_point::OperationResult;
 
 pub const HNSW_INDEX_CONFIG_FILE: &str = "hnsw_config.json";
 
-#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 pub struct HnswGraphConfig {
     pub m: usize,
     /// Requested M

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -76,8 +76,7 @@ impl StructPayloadIndex {
                 indexes
                     .iter()
                     .map(|field_index| field_index.filter(field_condition))
-                    .find(|filter_iter| filter_iter.is_some())
-                    .map(|filter_iter| filter_iter.unwrap())
+                    .find_map(|filter_iter| filter_iter)
             });
         indexes
     }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -404,13 +404,10 @@ impl PayloadIndex for StructPayloadIndex {
 
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         for (field, field_index) in &mut self.field_indexes {
-            match payload.get_value(field) {
-                Some(field_value) => {
-                    for index in field_index {
-                        index.add_point(point_id, field_value)?;
-                    }
+            if let Some(field_value) = payload.get_value(field) {
+                for index in field_index {
+                    index.add_point(point_id, field_value)?;
                 }
-                None => {}
             }
         }
         self.payload.borrow_mut().assign(point_id, payload)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -172,7 +172,7 @@ impl PartialEq for ScoredPoint {
 }
 
 /// Type of segment
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SegmentType {
     /// There are no index built for the segment, all operations are available
@@ -184,14 +184,14 @@ pub enum SegmentType {
 }
 
 /// Payload field type & index information
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct PayloadIndexInfo {
     pub data_type: PayloadSchemaType,
 }
 
 /// Aggregated information about segment
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentInfo {
     pub segment_type: SegmentType,
@@ -205,7 +205,7 @@ pub struct SegmentInfo {
 }
 
 /// Additional parameters of the search
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SearchParams {
     /// Params relevant to HNSW index
@@ -393,7 +393,7 @@ impl TryFrom<GeoPointShadow> for GeoPoint {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct Payload(pub Map<String, Value>);
 
 impl Payload {
@@ -509,7 +509,7 @@ impl<'a> From<&'a Payload> for OwnedPayloadRef<'a> {
 /// {..., "payload": {"city": {"type": "keyword", "value": ["Berlin", "London"] }}},
 /// {..., "payload": {"city": {"type": "keyword", "value": "Moscow" }}},
 /// ```
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum PayloadVariant<T> {
@@ -589,7 +589,7 @@ pub fn infer_value_type(value: &Value) -> Option<PayloadSchemaType> {
 }
 
 /// Match by keyword (deprecated)
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[deprecated]
 pub struct MatchKeyword {
@@ -599,7 +599,7 @@ pub struct MatchKeyword {
 }
 
 /// Match filter request (deprecated)
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[deprecated]
 pub struct MatchInteger {
@@ -608,7 +608,7 @@ pub struct MatchInteger {
     pub integer: IntPayloadType,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ValueVariants {
     Keyword(String),
@@ -616,14 +616,14 @@ pub enum ValueVariants {
     Bool(bool),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct MatchValue {
     pub value: ValueVariants,
 }
 
 /// Match filter request
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum MatchInterface {
@@ -633,7 +633,7 @@ pub enum MatchInterface {
 }
 
 /// Match filter request
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(from = "MatchInterface")]
 #[serde(untagged)]
 pub enum Match {
@@ -704,7 +704,7 @@ impl Range {
 }
 
 /// Values count filter request
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct ValuesCount {
     /// point.key.length() < values_count.lt
@@ -848,20 +848,20 @@ impl FieldCondition {
 }
 
 /// Payload field
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct PayloadField {
     /// Payload field name
     pub key: PayloadKeyType,
 }
 
 /// Select points with empty payload for a specified field
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct IsEmptyCondition {
     pub is_empty: PayloadField,
 }
 
 /// ID-based filtering condition
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct HasIdCondition {
     pub has_id: HashSet<PointIdType>,
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -472,7 +472,7 @@ impl<'a> Deref for OwnedPayloadRef<'a> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            OwnedPayloadRef::Ref(reference) => *reference,
+            OwnedPayloadRef::Ref(reference) => reference,
             OwnedPayloadRef::Owned(owned) => owned.deref(),
         }
     }
@@ -481,7 +481,7 @@ impl<'a> Deref for OwnedPayloadRef<'a> {
 impl<'a> AsRef<Payload> for OwnedPayloadRef<'a> {
     fn as_ref(&self) -> &Payload {
         match self {
-            OwnedPayloadRef::Ref(reference) => *reference,
+            OwnedPayloadRef::Ref(reference) => reference,
             OwnedPayloadRef::Owned(owned) => owned.deref(),
         }
     }


### PR DESCRIPTION
We usually have issues in our build pipeline when new versions of Rust are released.

This is due to the pipeline always pulling the latest version which can be problematic when new Clippy lints are introduced.

In this PR, I addressed proactively a bunch of new lints about to be enabled now or in the near future.