### PR TITLE
Batch recommendation API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -73,6 +73,8 @@
     - [PointsOperationResponse](#qdrant-PointsOperationResponse)
     - [PointsSelector](#qdrant-PointsSelector)
     - [Range](#qdrant-Range)
+    - [RecommendBatchPoints](#qdrant-RecommendBatchPoints)
+    - [RecommendBatchResponse](#qdrant-RecommendBatchResponse)
     - [RecommendPoints](#qdrant-RecommendPoints)
     - [RecommendResponse](#qdrant-RecommendResponse)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
@@ -1199,6 +1201,38 @@ The JSON representation for `Value` is JSON value.
 
 
 
+<a name="qdrant-RecommendBatchPoints"></a>
+
+### RecommendBatchPoints
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+| recommend_points | [RecommendPoints](#qdrant-RecommendPoints) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-RecommendBatchResponse"></a>
+
+### RecommendBatchResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| result | [BatchResult](#qdrant-BatchResult) | repeated |  |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
 <a name="qdrant-RecommendPoints"></a>
 
 ### RecommendPoints
@@ -1600,6 +1634,7 @@ The JSON representation for `Value` is JSON value.
 | SearchBatch | [SearchBatchPoints](#qdrant-SearchBatchPoints) | [SearchBatchResponse](#qdrant-SearchBatchResponse) | Retrieve closest points based on vector similarity and given filtering conditions |
 | Scroll | [ScrollPoints](#qdrant-ScrollPoints) | [ScrollResponse](#qdrant-ScrollResponse) | Iterate over all or filtered points points |
 | Recommend | [RecommendPoints](#qdrant-RecommendPoints) | [RecommendResponse](#qdrant-RecommendResponse) | Look for the points which are closer to stored positive examples and at the same time further to negative examples. |
+| RecommendBatch | [RecommendBatchPoints](#qdrant-RecommendBatchPoints) | [RecommendBatchResponse](#qdrant-RecommendBatchResponse) | Look for the points which are closer to stored positive examples and at the same time further to negative examples. |
 | Count | [CountPoints](#qdrant-CountPoints) | [CountResponse](#qdrant-CountResponse) | Count points in collection with given filtering conditions |
 
  

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2277,6 +2277,91 @@
         }
       }
     },
+    "/collections/{collection_name}/points/recommend/batch": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Recommend batch points",
+        "description": "Look for the points which are closer to stored positive examples and at the same time further to negative examples.",
+        "operationId": "recommend_batch_points",
+        "requestBody": {
+          "description": "Request points based on positive and negative examples.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecommendRequestBatch"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to search in",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ScoredPoint"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/points/count": {
       "post": {
         "tags": [
@@ -5212,6 +5297,20 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SearchRequest"
+            }
+          }
+        }
+      },
+      "RecommendRequestBatch": {
+        "type": "object",
+        "required": [
+          "searches"
+        ],
+        "properties": {
+          "searches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RecommendRequest"
             }
           }
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -144,6 +144,11 @@ message RecommendPoints {
   optional uint64 offset = 10; // Offset of the result
 }
 
+message RecommendBatchPoints {
+  string collection_name = 1; // Name of the collection
+  repeated RecommendPoints recommend_points = 2;
+}
+
 message CountPoints {
   string collection_name = 1; // name of the collection
   Filter filter = 2; // Filter conditions - return only those points that satisfy the specified conditions
@@ -220,6 +225,11 @@ message GetResponse {
 
 message RecommendResponse {
   repeated ScoredPoint result = 1;
+  double time = 2; // Time spent to process
+}
+
+message RecommendBatchResponse {
+  repeated BatchResult result = 1;
   double time = 2; // Time spent to process
 }
 

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -56,6 +56,10 @@ service Points {
    */
   rpc Recommend (RecommendPoints) returns (RecommendResponse) {}
   /*
+  Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+   */
+  rpc RecommendBatch (RecommendBatchPoints) returns (RecommendBatchResponse) {}
+  /*
    Count points in collection with given filtering conditions
    */
   rpc Count (CountPoints) returns (CountResponse) {}

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -275,6 +275,12 @@ pub struct RecommendRequest {
     pub score_threshold: Option<ScoreType>,
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct RecommendRequestBatch {
+    pub searches: Vec<RecommendRequest>,
+}
+
 /// Count Request
 /// Counts the number of points which satisfy the given filter.
 /// If filter is not provided, the count of all points in the collection will be returned.

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -10,8 +10,8 @@ use collection::config::{CollectionConfig, CollectionParams};
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
-    CountRequest, CountResult, PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult,
-    SearchRequest, SearchRequestBatch, UpdateResult,
+    CountRequest, CountResult, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
+    ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult,
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
@@ -550,6 +550,29 @@ impl TableOfContent {
         let collection = self.get_collection(collection_name).await?;
         collection
             .recommend_by(request, self.search_runtime.handle(), shard_selection)
+            .await
+            .map_err(|err| err.into())
+    }
+
+    /// Recommend points in a batchi fashion using positive and negative example from the request
+    ///
+    /// # Arguments
+    ///
+    /// * `collection_name` - for what collection do we recommend
+    /// * `request` - [`RecommendRequestBatch`]
+    ///
+    /// # Result
+    ///
+    /// Points with recommendation score
+    pub async fn recommend_batch(
+        &self,
+        collection_name: &str,
+        request: RecommendRequestBatch,
+        shard_selection: Option<ShardId>,
+    ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+        let collection = self.get_collection(collection_name).await?;
+        collection
+            .recommend_batch_by(request, self.search_runtime.handle(), shard_selection)
             .await
             .map_err(|err| err.into())
     }

--- a/openapi/openapi-main.ytt.yaml
+++ b/openapi/openapi-main.ytt.yaml
@@ -326,6 +326,29 @@ paths:
             type: string
       responses: #@ response(array(reference("ScoredPoint")))
 
+  /collections/{collection_name}/points/recommend/batch:
+    post:
+      tags:
+        - points
+      summary: Recommend batch points
+      description: Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+      operationId: recommend_batch_points
+      requestBody:
+        description: Request points based on positive and negative examples.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecommendRequestBatch"
+
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to search in
+          required: true
+          schema:
+            type: string
+      responses: #@ response(array(array(reference("ScoredPoint"))))
+
   /collections/{collection_name}/points/count:
     post:
       tags:

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -1,6 +1,6 @@
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
-use collection::operations::types::RecommendRequest;
+use collection::operations::types::{RecommendRequest, RecommendRequestBatch};
 use segment::types::ScoredPoint;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
@@ -27,4 +27,32 @@ pub async fn recommend_points(
     let response = do_recommend_points(toc.get_ref(), &name, request.into_inner()).await;
 
     process_response(response, timing)
+}
+
+async fn do_recommend_batch_points(
+    toc: &TableOfContent,
+    collection_name: &str,
+    request: RecommendRequestBatch,
+) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+    toc.recommend_batch(collection_name, request, None).await
+}
+
+#[post("/collections/{name}/points/recommend/batch")]
+pub async fn recommend_batch_points(
+    toc: web::Data<TableOfContent>,
+    path: web::Path<String>,
+    request: web::Json<RecommendRequestBatch>,
+) -> impl Responder {
+    let name = path.into_inner();
+    let timing = Instant::now();
+
+    let response = do_recommend_batch_points(toc.get_ref(), &name, request.into_inner()).await;
+
+    process_response(response, timing)
+}
+
+// Configure services
+pub fn config_recommend_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(recommend_points)
+        .service(recommend_batch_points);
 }

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -16,7 +16,7 @@ use storage::dispatcher::Dispatcher;
 use crate::actix::api::cluster_api::config_cluster_api;
 use crate::actix::api::collections_api::config_collections_api;
 use crate::actix::api::count_api::count_points;
-use crate::actix::api::recommend_api::recommend_points;
+use crate::actix::api::recommend_api::config_recommend_api;
 use crate::actix::api::retrieve_api::{get_point, get_points, scroll_points};
 use crate::actix::api::search_api::config_search_api;
 use crate::actix::api::snapshot_api::config_snapshots_api;
@@ -91,10 +91,10 @@ pub fn init(
                 .configure(config_cluster_api)
                 .configure(config_telemetry_api)
                 .configure(config_search_api)
+                .configure(config_recommend_api)
                 .service(get_point)
                 .service(get_points)
                 .service(scroll_points)
-                .service(recommend_points)
                 .service(count_points)
         })
         .workers(max_web_workers(&settings))

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -5,8 +5,8 @@ use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
     CollectionClusterInfo, CollectionInfo, CountRequest, CountResult, PointRequest,
-    RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch,
-    UpdateResult,
+    RecommendRequest, RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchRequest,
+    SearchRequestBatch, UpdateResult,
 };
 use schemars::{schema_for, JsonSchema};
 use segment::types::ScoredPoint;
@@ -53,6 +53,7 @@ struct AllDefinitions {
     aq: TelemetryData,
     ar: ClusterOperations,
     at: SearchRequestBatch,
+    au: RecommendRequestBatch,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -4,16 +4,16 @@ use api::grpc::qdrant::points_server::Points;
 use api::grpc::qdrant::{
     ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
     DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse,
-    PointsOperationResponse, RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse,
-    SearchBatchPoints, SearchBatchResponse, SearchPoints, SearchResponse, SetPayloadPoints,
-    UpsertPoints,
+    PointsOperationResponse, RecommendBatchPoints, RecommendBatchResponse, RecommendPoints,
+    RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse,
+    SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints,
 };
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
-    recommend, scroll, search, search_batch, set_payload, upsert,
+    recommend, recommend_batch, scroll, search, search_batch, set_payload, upsert,
 };
 
 pub struct PointsService {
@@ -111,6 +111,17 @@ impl Points for PointsService {
         request: Request<RecommendPoints>,
     ) -> Result<Response<RecommendResponse>, Status> {
         recommend(self.toc.as_ref(), request.into_inner(), None).await
+    }
+
+    async fn recommend_batch(
+        &self,
+        request: Request<RecommendBatchPoints>,
+    ) -> Result<Response<RecommendBatchResponse>, Status> {
+        let RecommendBatchPoints {
+            collection_name,
+            recommend_points,
+        } = request.into_inner();
+        recommend_batch(self.toc.as_ref(), collection_name, recommend_points, None).await
     }
 
     async fn count(

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -73,8 +73,8 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
                  "payload": {"city": ["Berlin", "Moscow"]}},
                 {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
                  "payload": {"city": ["London", "Moscow"]}},
-                {"id": 5, "vector": [0.24, 0.18, 0.22,
-                                     0.44], "payload": {"count": [0]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44],
+                 "payload": {"count": [0]}},
                 {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
             ]
         })

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -72,8 +72,8 @@ def test_collection_sharding(tmp_path: pathlib.Path):
                     "payload": {"city": ["Berlin", "Moscow"]}},
                 {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
                     "payload": {"city": ["London", "Moscow"]}},
-                {"id": 5, "vector": [0.24, 0.18, 0.22,
-                                     0.44], "payload": {"count": [0]}},
+                {"id": 5, "vector": [0.24, 0.18, 0.22, 0.44],
+                    "payload": {"count": [0]}},
                 {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
             ]
         })

--- a/tests/consensus_tests/test_many_collections.py
+++ b/tests/consensus_tests/test_many_collections.py
@@ -50,4 +50,3 @@ def test_many_collections(tmp_path: pathlib.Path):
     # Check that all collections exist on all peers
     for i in range(1, N_COLLECTIONS + 1):
         wait_for_uniform_collection_existence(f"test_collection_{i}", peer_api_uris)
-


### PR DESCRIPTION
This PR adds a batch recommendation API #952 

- built on top of the new batched search API
- perform points retrieval in a batched fashion as well
- REST API tested by comparing the result of the batched version with the regular version
- hardened some tests to actually compare the expected payload across peers in distributed mode
- fixed a sneaky issue regarding double application of the `offset`

Once there is a consensus on the implementation, I will refactor the non-batched version so that it uses the batch version with a single request to avoid code duplication.