### PR TITLE
properly format doc links for cargo doc

### DIFF
--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -77,7 +77,7 @@ pub struct OptimizersConfigDiff {
     #[serde(alias = "memmap_threshold_kb")]
     pub memmap_threshold: Option<usize>,
     /// Maximum size (in KiloBytes) of vectors allowed for plain index.
-    /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "indexing_threshold_kb")]
     pub indexing_threshold: Option<usize>,

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -50,7 +50,7 @@ pub struct OptimizersConfig {
     #[serde(default)]
     pub memmap_threshold: Option<usize>,
     /// Maximum size (in KiloBytes) of vectors allowed for plain index.
-    /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
+    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "indexing_threshold_kb")]
     pub indexing_threshold: usize,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -87,11 +87,11 @@ pub type PointIdType = ExtendedPointId;
 )]
 /// Distance function types used to compare vectors
 pub enum Distance {
-    /// https://en.wikipedia.org/wiki/Cosine_similarity
+    /// <https://en.wikipedia.org/wiki/Cosine_similarity>
     Cosine,
-    /// https://en.wikipedia.org/wiki/Euclidean_distance
+    /// <https://en.wikipedia.org/wiki/Euclidean_distance>
     Euclid,
-    /// https://en.wikipedia.org/wiki/Dot_product
+    /// <https://en.wikipedia.org/wiki/Dot_product>
     Dot,
 }
 

--- a/src/actix/actix_telemetry.rs
+++ b/src/actix/actix_telemetry.rs
@@ -20,7 +20,7 @@ pub struct ActixTelemetryTransform {
 /// Actix telemetry service. It hooks every request and looks into response status code.
 ///
 /// More about actix service with similar example
-/// https://actix.rs/docs/middleware/
+/// <https://actix.rs/docs/middleware/>
 impl<S, B> Service<ServiceRequest> for ActixTelemetryService<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
@@ -56,7 +56,7 @@ impl ActixTelemetryTransform {
 /// Actix telemetry transform. It's a builder for an actix service
 ///
 /// More about actix transform with similar example
-/// https://actix.rs/docs/middleware/
+/// <https://actix.rs/docs/middleware/>
 impl<S, B> Transform<S, ServiceRequest> for ActixTelemetryTransform
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,


### PR DESCRIPTION
Cleaning up warnings when running `cargo doc`

```
warning: this URL is not a hyperlink
  --> lib/collection/src/optimizers_builder.rs:53:32
   |
53 |     /// Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>`
   |
   = note: bare URLs are not automatically turned into clickable links

```