### PR TITLE
Replica set

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -325,6 +325,7 @@ impl Collection {
                         debug_assert!(!was_not_transferred);
                         false // Shard if already in transferring state
                     }
+                    Shard::ReplicaSet(_) => todo!(),
                 },
             }
         };
@@ -463,6 +464,7 @@ impl Collection {
                 Shard::ForwardProxy(_) => {
                     debug_assert!(false, "Proxy shard should not be temporary");
                 }
+                Shard::ReplicaSet(_) => todo!(),
             }
         }
 
@@ -1004,6 +1006,7 @@ impl Collection {
                     Shard::Proxy(shard) => shard.on_optimizer_config_update().await?,
                     Shard::ForwardProxy(shard) => shard.on_optimizer_config_update().await?,
                     Shard::Remote(_) => {} // Do nothing for remote shards
+                    Shard::ReplicaSet(_) => todo!(),
                 }
             }
         }
@@ -1034,6 +1037,7 @@ impl Collection {
                     Shard::Remote(_) => {} // Do nothing for remote shards
                     Shard::Proxy(proxy) => proxy.on_optimizer_config_update().await?,
                     Shard::ForwardProxy(proxy) => proxy.on_optimizer_config_update().await?,
+                    Shard::ReplicaSet(_) => todo!(),
                 }
             }
         }
@@ -1123,6 +1127,7 @@ impl Collection {
                         points_count,
                     })
                 }
+                Shard::ReplicaSet(_) => todo!(),
             }
         }
         // extract shard transfers info
@@ -1244,6 +1249,7 @@ impl Collection {
                         // copy shard directory to snapshot directory
                         remote_shard.create_snapshot(&shard_snapshot_path).await?;
                     }
+                    Shard::ReplicaSet(_) => todo!(),
                 }
             }
         }
@@ -1312,6 +1318,7 @@ impl Collection {
                 Shard::Proxy(_proxy_shard) => (*shard_id, local_peer_id),
                 Shard::ForwardProxy(_proxy_shard) => (*shard_id, local_peer_id),
                 Shard::Remote(remote_shard) => (*shard_id, remote_shard.peer_id),
+                Shard::ReplicaSet(_) => todo!(),
             })
             .collect()
     }

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tonic::transport::Uri;
 
+use self::replica_set::ReplicaSet;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
     Record, SearchRequestBatch, UpdateResult,
@@ -35,8 +36,6 @@ use crate::shard::proxy_shard::ProxyShard;
 use crate::shard::remote_shard::RemoteShard;
 use crate::shard::shard_versioning::suggest_next_version_path;
 use crate::telemetry::ShardTelemetry;
-
-use self::replica_set::ReplicaSet;
 
 pub type ShardId = u32;
 

--- a/lib/collection/src/shard/mod.rs
+++ b/lib/collection/src/shard/mod.rs
@@ -5,6 +5,8 @@ pub mod local_shard;
 pub mod local_shard_operations;
 pub mod proxy_shard;
 pub mod remote_shard;
+#[allow(dead_code)]
+pub mod replica_set;
 pub mod shard_config;
 pub mod shard_holder;
 pub mod shard_versioning;
@@ -34,11 +36,13 @@ use crate::shard::remote_shard::RemoteShard;
 use crate::shard::shard_versioning::suggest_next_version_path;
 use crate::telemetry::ShardTelemetry;
 
+use self::replica_set::ReplicaSet;
+
 pub type ShardId = u32;
 
 /// Shard
 ///
-/// A shard can either be local or remote
+/// Contains a part of the collection's points
 ///
 #[allow(clippy::large_enum_variant)]
 pub enum Shard {
@@ -46,6 +50,7 @@ pub enum Shard {
     Remote(RemoteShard),
     Proxy(ProxyShard),
     ForwardProxy(ForwardProxyShard),
+    ReplicaSet(ReplicaSet),
 }
 
 impl Shard {
@@ -55,6 +60,7 @@ impl Shard {
             Shard::Remote(remote_shard) => remote_shard,
             Shard::Proxy(proxy_shard) => proxy_shard,
             Shard::ForwardProxy(proxy_shard) => proxy_shard,
+            Shard::ReplicaSet(replica_set) => replica_set,
         }
     }
 
@@ -64,6 +70,7 @@ impl Shard {
             Shard::Remote(_) => (),
             Shard::Proxy(proxy_shard) => proxy_shard.before_drop().await,
             Shard::ForwardProxy(proxy_shard) => proxy_shard.before_drop().await,
+            Shard::ReplicaSet(_) => todo!(),
         }
     }
 
@@ -73,6 +80,7 @@ impl Shard {
             Shard::Remote(remote) => remote.peer_id,
             Shard::Proxy(_) => this_peer_id,
             Shard::ForwardProxy(_) => this_peer_id,
+            Shard::ReplicaSet(_) => todo!(),
         }
     }
 
@@ -82,6 +90,7 @@ impl Shard {
             Shard::Remote(remote_shard) => remote_shard.get_telemetry_data(),
             Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data(),
             Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
+            Shard::ReplicaSet(_) => todo!(),
         }
     }
 }

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -3,15 +3,14 @@ use std::sync::Arc;
 use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
 use tokio::runtime::Handle;
 
-use crate::operations::{
-    types::{
-        CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
-        SearchRequestBatch, UpdateResult,
-    },
-    CollectionUpdateOperations,
+use super::local_shard::LocalShard;
+use super::remote_shard::RemoteShard;
+use super::ShardOperation;
+use crate::operations::types::{
+    CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
+    SearchRequestBatch, UpdateResult,
 };
-
-use super::{local_shard::LocalShard, remote_shard::RemoteShard, ShardOperation};
+use crate::operations::CollectionUpdateOperations;
 
 pub struct Replica<T: ShardOperation> {
     shard: T,

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use segment::types::{ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface};
+use tokio::runtime::Handle;
+
+use crate::operations::{
+    types::{
+        CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
+        SearchRequestBatch, UpdateResult,
+    },
+    CollectionUpdateOperations,
+};
+
+use super::{local_shard::LocalShard, remote_shard::RemoteShard, ShardOperation};
+
+pub struct Replica<T: ShardOperation> {
+    shard: T,
+    pub is_active: bool,
+}
+
+/// A set of shard replicas.
+/// Handles operations so that the state is consistent across all the replicas of the shard.
+pub struct ReplicaSet {
+    local: Option<Replica<LocalShard>>,
+    remote: Vec<Replica<RemoteShard>>,
+}
+
+#[async_trait::async_trait]
+impl ShardOperation for ReplicaSet {
+    async fn update(
+        &self,
+        _operation: CollectionUpdateOperations,
+        _wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        todo!()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn scroll_by(
+        &self,
+        _offset: Option<ExtendedPointId>,
+        _limit: usize,
+        _with_payload_interface: &WithPayloadInterface,
+        _with_vector: bool,
+        _filter: Option<&Filter>,
+    ) -> CollectionResult<Vec<Record>> {
+        todo!()
+    }
+
+    async fn info(&self) -> CollectionResult<CollectionInfo> {
+        todo!()
+    }
+
+    async fn search(
+        &self,
+        _request: Arc<SearchRequestBatch>,
+        _search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        todo!()
+    }
+
+    async fn count(&self, _request: Arc<CountRequest>) -> CollectionResult<CountResult> {
+        todo!()
+    }
+
+    async fn retrieve(
+        &self,
+        _request: Arc<PointRequest>,
+        _with_payload: &WithPayload,
+        _with_vector: bool,
+    ) -> CollectionResult<Vec<Record>> {
+        todo!()
+    }
+}

--- a/lib/collection/src/shard/shard_holder.rs
+++ b/lib/collection/src/shard/shard_holder.rs
@@ -177,6 +177,7 @@ impl ShardHolder {
                                 Some(temp) => temp,
                             }
                         }
+                        Shard::ReplicaSet(_) => todo!(),
                     },
                 };
                 Ok(vec![target_shard])
@@ -292,6 +293,7 @@ impl LockedShardHolder {
                     "Shard {} is not local on peer",
                     id
                 ))),
+                Shard::ReplicaSet(_) => todo!(),
             },
         }
     }


### PR DESCRIPTION
Introduces a general structure that handles synchronizing operations across shard replicas. Assuming that one peer cannot contain more than one replica of the same shard.

`todo()` are safe as the ReplicaSet type of shard is never created