### PR TITLE
Fix telemetry web init

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -58,12 +58,12 @@ pub fn init(
     actix_web::rt::System::new().block_on(async {
         let toc_data = web::Data::from(dispatcher.toc().clone());
         let dispatcher_data = web::Data::from(dispatcher);
-        let telemetry_collector_data = web::Data::new(telemetry_collector.clone());
         let actix_telemetry_collector = telemetry_collector
             .lock()
             .await
             .actix_telemetry_collector
             .clone();
+        let telemetry_collector_data = web::Data::from(telemetry_collector);
         HttpServer::new(move || {
             let cors = Cors::default()
                 .allow_any_origin()


### PR DESCRIPTION
Init telemetry thought `web::Data::from` instead of `web::Data::new`. Maybe telemetry branch was merged a bit of time after the migration to `web::Data::from` (this migration happened at the same time when telemetry was in develop)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
