### PR TITLE
Scores Ordering fallbacks to ids for identical scores

### DIFF
--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -18,7 +18,13 @@ impl Eq for ScoredPointOffset {}
 
 impl Ord for ScoredPointOffset {
     fn cmp(&self, other: &Self) -> Ordering {
-        OrderedFloat(self.score).cmp(&OrderedFloat(other.score))
+        let res = OrderedFloat(self.score).cmp(&OrderedFloat(other.score));
+        // for identical scores, we fallback to sorting by ids to have a stable output
+        if res == Ordering::Equal {
+            self.idx.cmp(&other.idx)
+        } else {
+            res
+        }
     }
 }
 
@@ -107,7 +113,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ordering() {
+    fn test_ordering_score() {
         assert!(
             ScoredPointOffset {
                 idx: 10,
@@ -115,6 +121,30 @@ mod tests {
             } > ScoredPointOffset {
                 idx: 20,
                 score: 0.6
+            }
+        )
+    }
+
+    #[test]
+    fn test_ordering_fallback() {
+        assert!(
+            ScoredPointOffset {
+                idx: 10,
+                score: 0.9
+            } > ScoredPointOffset { idx: 9, score: 0.9 }
+        )
+    }
+
+    #[test]
+    fn test_ordering_equality() {
+        assert_eq!(
+            ScoredPointOffset {
+                idx: 10,
+                score: 0.9
+            },
+            ScoredPointOffset {
+                idx: 10,
+                score: 0.9
             }
         )
     }

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -254,7 +254,6 @@ mod tests {
                 estimation
             );
 
-            // warning: report flakiness at https://github.com/qdrant/qdrant/issues/534
             plain_result
                 .iter()
                 .zip(struct_result.iter())


### PR DESCRIPTION
This PR modifies the ordering of `ScoredPointOffset` to break ties using `ids` in case of identical `scores`.

This is the result of a past investigation regarding a flaky test in https://github.com/qdrant/qdrant/issues/534.
At time we were only able to add extra logging.

The flaky test appeared again in https://github.com/qdrant/qdrant/runs/8192948307?check_suite_focus=true and this time the extra logging enabled me to understand what is going on.

```
plain result [
  ScoredPoint { id: NumId(1621), version: 1622, score: 2.1598325, payload: None, vector: None },
  ScoredPoint { id: NumId(1432), version: 1433, score: 2.1338873, payload: None, vector: None },
  ScoredPoint { id: NumId(1563), version: 1564, score: 2.0912616, payload: None, vector: None },
  ScoredPoint { id: NumId(157), version: 158, score: 2.0738618, payload: None, vector: None },
  ScoredPoint { id: NumId(1507), version: 1508, score: 2.0738618, payload: None, vector: None }]

struct result[
  ScoredPoint { id: NumId(1621), version: 1622, score: 2.1598325, payload: None, vector: None },
  ScoredPoint { id: NumId(1432), version: 1433, score: 2.1338873, payload: None, vector: None },
  ScoredPoint { id: NumId(1563), version: 1564, score: 2.0912616, payload: None, vector: None },
  ScoredPoint { id: NumId(1507), version: 1508, score: 2.0738618, payload: None, vector: None },
  ScoredPoint { id: NumId(157), version: 158, score: 2.0738618, payload: None, vector: None }]',
```

The two last points have a score of `2.0738618` so we need the same deterministic way to order ties in both index types.

I have added extra unit tests.