### PR TITLE
ReplicaSet ShardOperations

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1226,7 +1226,7 @@ impl Collection {
                 .map(|(shard_id, shard)| {
                     let shard_info = match shard {
                         Shard::ReplicaSet(replicas) => ShardInfo::ReplicaSet {
-                            replicas: replicas.replica_state.clone(),
+                            replicas: replicas.replica_state.read().clone(),
                         },
                         shard => ShardInfo::Single(
                             *shard

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1226,7 +1226,7 @@ impl Collection {
                 .map(|(shard_id, shard)| {
                     let shard_info = match shard {
                         Shard::ReplicaSet(replicas) => ShardInfo::ReplicaSet {
-                            replicas: replicas.replica_state.read().clone(),
+                            replicas: replicas.replica_state.clone(),
                         },
                         shard => ShardInfo::Single(
                             *shard

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -142,7 +142,15 @@ impl Collection {
         // It might be worth leaving it here for now until we have an actual impl
         // TODO: Create ReplicaSet shards
         if false {
-            let shard = ReplicaSet::new(on_replica_failure);
+            let shard = ReplicaSet::new(
+                1,
+                1,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                0.0,
+                on_replica_failure,
+            );
             shard_holder.add_shard(0, Shard::ReplicaSet(shard))
         }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -80,7 +80,7 @@ impl Collection {
         self.id.clone()
     }
 
-    pub async fn new<'a>(
+    pub async fn new(
         id: CollectionId,
         path: &Path,
         snapshots_path: &Path,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -38,6 +38,7 @@ use crate::optimizers_builder::OptimizersConfig;
 use crate::shard::collection_shard_distribution::CollectionShardDistribution;
 use crate::shard::local_shard::LocalShard;
 use crate::shard::remote_shard::RemoteShard;
+use crate::shard::replica_set::ReplicaSet;
 use crate::shard::shard_config::{ShardConfig, ShardType};
 use crate::shard::shard_holder::{LockedShardHolder, ShardHolder};
 use crate::shard::shard_versioning::versioned_shard_path;
@@ -47,8 +48,8 @@ use crate::shard::transfer::shard_transfer::{
 };
 use crate::shard::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
 use crate::shard::{
-    create_shard_dir, ChannelService, CollectionId, PeerId, Shard, ShardId, ShardOperation,
-    ShardTransfer, HASH_RING_SHARD_SCALE,
+    create_shard_dir, replica_set, ChannelService, CollectionId, PeerId, Shard, ShardId,
+    ShardOperation, ShardTransfer, HASH_RING_SHARD_SCALE,
 };
 use crate::telemetry::CollectionTelemetry;
 
@@ -79,13 +80,14 @@ impl Collection {
         self.id.clone()
     }
 
-    pub async fn new(
+    pub async fn new<'a>(
         id: CollectionId,
         path: &Path,
         snapshots_path: &Path,
         config: &CollectionConfig,
         shard_distribution: CollectionShardDistribution,
         channel_service: ChannelService,
+        on_replica_failure: replica_set::OnPeerFailure,
     ) -> Result<Self, CollectionError> {
         let start_time = std::time::Instant::now();
 
@@ -135,6 +137,13 @@ impl Collection {
                 }
             };
             shard_holder.add_shard(shard_id, Shard::Remote(shard));
+        }
+        // This is a stub to check that types and hidden lifetimes fit
+        // It might be worth leaving it here for now until we have an actual impl
+        // TODO: Create ReplicaSet shards
+        if false {
+            let shard = ReplicaSet::new(on_replica_failure);
+            shard_holder.add_shard(0, Shard::ReplicaSet(shard))
         }
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
+use futures::future::{try_join, try_join_all};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use parking_lot::RwLock;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
@@ -19,13 +24,15 @@ pub type IsActive = bool;
 
 /// A set of shard replicas.
 /// Handles operations so that the state is consistent across all the replicas of the shard.
+/// Prefers local shard for read-only operations.
+/// Perform updates on all replicas and report error if there is at least one failure.
 pub struct ReplicaSet {
     shard_id: ShardId,
     this_peer_id: PeerId,
     local: Option<LocalShard>,
-    // TODO: Remote shard should be able to query several peers
-    remote: Option<RemoteShard>,
-    pub(crate) replica_state: HashMap<PeerId, IsActive>,
+    remotes: Vec<RemoteShard>,
+    pub(crate) replica_state: RwLock<HashMap<PeerId, IsActive>>,
+    read_fan_out_ratio: f32,
 }
 
 impl ReplicaSet {
@@ -33,13 +40,12 @@ impl ReplicaSet {
         todo!()
     }
 
-    pub fn set_active(&mut self, peer_id: &PeerId, active: bool) -> CollectionResult<()> {
-        *self
-            .replica_state
-            .get_mut(peer_id)
-            .ok_or_else(|| CollectionError::NotFound {
+    pub fn set_active(&self, peer_id: &PeerId, active: bool) -> CollectionResult<()> {
+        *self.replica_state.write().get_mut(peer_id).ok_or_else(|| {
+            CollectionError::NotFound {
                 what: format!("Shard {} replica on peer {peer_id}", self.shard_id),
-            })? = active;
+            }
+        })? = active;
         Ok(())
     }
 
@@ -49,6 +55,7 @@ impl ReplicaSet {
     ) -> CollectionResult<()> {
         let removed_peers = self
             .replica_state
+            .read()
             .keys()
             .filter(|peer_id| !replicas.contains_key(peer_id))
             .copied()
@@ -61,13 +68,15 @@ impl ReplicaSet {
                 } else {
                     debug_assert!(false, "inconsistent `replica_set` map with actual shards")
                 }
-            } else if let Some(_remote_shard) = &mut self.remote {
+            } else if let Some(_remote_shard) =
+                &mut self.remotes.iter().find(|rs| rs.peer_id == peer_id)
+            {
                 todo!("remote_shard.remove_peer(peer_id)")
             }
-            self.replica_state.remove(&peer_id);
+            self.replica_state.write().remove(&peer_id);
         }
         for (peer_id, is_active) in replicas {
-            if let Some(state) = self.replica_state.get_mut(&peer_id) {
+            if let Some(state) = self.replica_state.write().get_mut(&peer_id) {
                 *state = is_active;
             } else if peer_id == self.this_peer_id {
                 todo!("clone replica from another peer or log error that it should be cloned with normal operation")
@@ -77,52 +86,200 @@ impl ReplicaSet {
         }
         Ok(())
     }
+
+    /// Check whether a peer is registered as `active`.
+    /// Unknown peers are not active.
+    pub fn peer_is_active(&self, peer_id: &PeerId) -> bool {
+        self.replica_state.read().get(peer_id) == Some(&true)
+    }
+
+    /// Execute read operation on replica set:
+    /// 1 - Prefer local replica
+    /// 2 - Otherwise uses `read_fan_out_ratio` to compute list of active remote shards.
+    /// 3 - Fallbacks to all remaining shards if the optimisations fails.
+    /// It does not report failing peer_ids to the consensus.
+    pub async fn execute_read_operation<'a, F, Fut, Res>(&'a self, read: F) -> CollectionResult<Res>
+    where
+        F: Fn(&'a (dyn ShardOperation + Send + Sync)) -> Fut,
+        Fut: Future<Output = CollectionResult<Res>> + Unpin,
+    {
+        // 1 - prefer the local shard if it is active
+        if let Some(local) = &self.local {
+            if self.peer_is_active(&self.this_peer_id) {
+                if let ok @ Ok(_) = read(local).await {
+                    return ok;
+                }
+            }
+        }
+
+        // 2 - try a subset of active remote shards in parallel for fast response
+        let active_remote_shards: Vec<_> = self
+            .remotes
+            .iter()
+            .filter(|rs| self.peer_is_active(&rs.peer_id))
+            .collect();
+
+        if active_remote_shards.is_empty() {
+            return Err(CollectionError::service_error(format!(
+                "The replica set for shard {} on peer {} has no active replica",
+                self.shard_id, self.this_peer_id
+            )));
+        }
+
+        let fan_out_selection =
+            (self.read_fan_out_ratio * active_remote_shards.len() as f32).ceil() as usize;
+
+        let mut futures = FuturesUnordered::new();
+        for remote in &active_remote_shards[0..fan_out_selection] {
+            let fut = read(*remote);
+            futures.push(fut);
+        }
+
+        // shortcut at first successful result
+        let mut captured_error = None;
+        while let Some(result) = futures.next().await {
+            match result {
+                Ok(res) => return Ok(res),
+                err @ Err(_) => captured_error = Some(err), // capture error for possible error reporting
+            }
+        }
+        debug_assert!(
+            captured_error.is_some(),
+            "there must be at least one failure"
+        );
+
+        // 3 - fallback to remaining remote shards as last chance
+        let mut futures = FuturesUnordered::new();
+        for remote in &active_remote_shards[fan_out_selection..] {
+            let fut = read(*remote);
+            futures.push(fut);
+        }
+
+        // shortcut at first successful result
+        while let Some(result) = futures.next().await {
+            if let ok @ Ok(_) = result {
+                return ok;
+            }
+        }
+        // at this point `captured_error` must be defined by construction
+        captured_error.unwrap()
+    }
 }
 
 #[async_trait::async_trait]
 impl ShardOperation for ReplicaSet {
     async fn update(
         &self,
-        _operation: CollectionUpdateOperations,
-        _wait: bool,
+        operation: CollectionUpdateOperations,
+        wait: bool,
     ) -> CollectionResult<UpdateResult> {
-        todo!()
+        // target all remote peers that are active
+        let active_remote_shards: Vec<_> = self
+            .remotes
+            .iter()
+            .filter(|rs| self.peer_is_active(&rs.peer_id))
+            .collect();
+
+        // local is defined AND the peer itself is active
+        let local_is_active = self.local.is_some() && self.peer_is_active(&self.this_peer_id);
+
+        if active_remote_shards.is_empty() && !local_is_active {
+            return Err(CollectionError::service_error(format!(
+                "The replica set for shard {} on peer {} has no active replica",
+                self.shard_id, self.this_peer_id
+            )));
+        }
+
+        let mut remote_futures = Vec::new();
+        for remote in active_remote_shards {
+            let op = operation.clone();
+            remote_futures.push(async move {
+                remote
+                    .update(op, wait)
+                    .await
+                    .map_err(|err| (remote.peer_id, err))
+            });
+        }
+
+        let all_res = match &self.local {
+            Some(local) if self.peer_is_active(&self.this_peer_id) => {
+                let local_update = async move {
+                    local
+                        .update(operation.clone(), wait)
+                        .await
+                        .map_err(|err| (self.this_peer_id, err))
+                };
+                let remote_updates = try_join_all(remote_futures);
+
+                // run local and remote shards read concurrently
+                try_join(remote_updates, local_update)
+                    .await
+                    .map(|(remote_res, _local_res)| remote_res)
+            }
+            _ => try_join_all(remote_futures).await,
+        };
+
+        match all_res {
+            Ok(results) => {
+                // return first result
+                match results.into_iter().next() {
+                    None => Err(CollectionError::service_error(format!(
+                        "None of the replicas replied for Replica set {} on peer {}",
+                        self.shard_id, self.this_peer_id
+                    ))),
+                    Some(res) => Ok(res),
+                }
+            }
+            Err((peer_id, err)) => {
+                // report failing `peer_id`
+                self.set_active(&peer_id, false)?;
+                Err(err)
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn scroll_by(
         &self,
-        _offset: Option<ExtendedPointId>,
-        _limit: usize,
-        _with_payload_interface: &WithPayloadInterface,
-        _with_vector: &WithVector,
-        _filter: Option<&Filter>,
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: &WithVector,
+        filter: Option<&Filter>,
     ) -> CollectionResult<Vec<Record>> {
-        todo!()
+        self.execute_read_operation(|shard| {
+            shard.scroll_by(offset, limit, with_payload_interface, with_vector, filter)
+        })
+        .await
     }
 
     async fn info(&self) -> CollectionResult<CollectionInfo> {
-        todo!()
+        self.execute_read_operation(|shard| shard.info()).await
     }
 
     async fn search(
         &self,
-        _request: Arc<SearchRequestBatch>,
-        _search_runtime_handle: &Handle,
+        request: Arc<SearchRequestBatch>,
+        search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        todo!()
+        self.execute_read_operation(|shard| shard.search(request.clone(), search_runtime_handle))
+            .await
     }
 
-    async fn count(&self, _request: Arc<CountRequest>) -> CollectionResult<CountResult> {
-        todo!()
+    async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
+        self.execute_read_operation(|shard| shard.count(request.clone()))
+            .await
     }
 
     async fn retrieve(
         &self,
-        _request: Arc<PointRequest>,
-        _with_payload: &WithPayload,
-        _with_vector: &WithVector,
+        request: Arc<PointRequest>,
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>> {
-        todo!()
+        self.execute_read_operation(|shard| {
+            shard.retrieve(request.clone(), with_payload, with_vector)
+        })
+        .await
     }
 }

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -21,7 +21,8 @@ use crate::operations::types::{
 use crate::operations::CollectionUpdateOperations;
 
 pub type IsActive = bool;
-pub type OnPeerFailure = Box<dyn Fn(PeerId) -> Box<dyn Future<Output = ()> + Send> + Send + Sync>;
+pub type OnPeerFailure =
+    Box<dyn Fn(PeerId, ShardId) -> Box<dyn Future<Output = ()> + Send> + Send + Sync>;
 
 /// A set of shard replicas.
 /// Handles operations so that the state is consistent across all the replicas of the shard.
@@ -58,7 +59,7 @@ impl ReplicaSet {
         }
     }
     pub async fn notify_peer_failure(&self, peer_id: PeerId) {
-        Box::into_pin(self.notify_peer_failure_cb.deref()(peer_id)).await
+        Box::into_pin(self.notify_peer_failure_cb.deref()(peer_id, self.shard_id)).await
     }
 
     pub fn peer_ids(&self) -> Vec<PeerId> {

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::ops::Deref;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::future::{try_join, try_join_all};
@@ -39,14 +38,22 @@ pub struct ReplicaSet {
 }
 
 impl ReplicaSet {
-    pub fn new(on_peer_failure: OnPeerFailure) -> Self {
+    pub fn new(
+        shard_id: ShardId,
+        this_peer_id: PeerId,
+        local: Option<LocalShard>,
+        remotes: Vec<RemoteShard>,
+        replica_state: HashMap<PeerId, IsActive>,
+        read_fan_out_ratio: f32,
+        on_peer_failure: OnPeerFailure,
+    ) -> Self {
         Self {
-            shard_id: todo!(),
-            this_peer_id: todo!(),
-            local: todo!(),
-            remotes: todo!(),
-            replica_state: todo!(),
-            read_fan_out_ratio: todo!(),
+            shard_id,
+            this_peer_id,
+            local,
+            remotes,
+            replica_state,
+            read_fan_out_ratio,
             notify_peer_failure_cb: on_peer_failure,
         }
     }

--- a/lib/collection/src/shard/replica_set.rs
+++ b/lib/collection/src/shard/replica_set.rs
@@ -161,8 +161,7 @@ impl ReplicaSet {
                 return ok;
             }
         }
-        // at this point `captured_error` must be defined by construction
-        captured_error.unwrap()
+        captured_error.expect("at this point `captured_error` must be defined by construction")
     }
 }
 

--- a/lib/collection/src/shard/shard_holder.rs
+++ b/lib/collection/src/shard/shard_holder.rs
@@ -154,7 +154,7 @@ impl ShardHolder {
         active: bool,
     ) -> CollectionResult<()> {
         if let Shard::ReplicaSet(replica_set) =
-            self.get_shard(&shard_id)
+            self.get_mut_shard(&shard_id)
                 .ok_or_else(|| CollectionError::NotFound {
                     what: format!("Shard {shard_id}"),
                 })?

--- a/lib/collection/src/shard/shard_holder.rs
+++ b/lib/collection/src/shard/shard_holder.rs
@@ -154,7 +154,7 @@ impl ShardHolder {
         active: bool,
     ) -> CollectionResult<()> {
         if let Shard::ReplicaSet(replica_set) =
-            self.get_mut_shard(&shard_id)
+            self.get_shard(&shard_id)
                 .ok_or_else(|| CollectionError::NotFound {
                     what: format!("Shard {shard_id}"),
                 })?

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -7,6 +7,7 @@ use crate::collection::Collection;
 use crate::config::{CollectionConfig, CollectionParams, WalConfig};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shard::collection_shard_distribution::CollectionShardDistribution;
+use crate::shard::replica_set::OnPeerFailure;
 use crate::shard::{ChannelService, Shard};
 
 const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
@@ -19,6 +20,10 @@ const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     flush_interval_sec: 30,
     max_optimization_threads: 2,
 };
+
+pub fn dummy_on_replica_failure() -> OnPeerFailure {
+    Box::new(move |_peer_id| Box::new(async {}))
+}
 
 #[tokio::test]
 async fn test_snapshot_collection() {
@@ -59,7 +64,7 @@ async fn test_snapshot_collection() {
         &config,
         CollectionShardDistribution::new(vec![0, 1], vec![(2, 10000)]),
         ChannelService::default(),
-        todo!(),
+        dummy_on_replica_failure(),
     )
     .await
     .unwrap();

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -59,6 +59,7 @@ async fn test_snapshot_collection() {
         &config,
         CollectionShardDistribution::new(vec![0, 1], vec![(2, 10000)]),
         ChannelService::default(),
+        todo!(),
     )
     .await
     .unwrap();

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -22,7 +22,7 @@ const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
 };
 
 pub fn dummy_on_replica_failure() -> OnPeerFailure {
-    Box::new(move |_peer_id| Box::new(async {}))
+    Box::new(move |_peer_id, _shard_id| Box::new(async {}))
 }
 
 #[tokio::test]

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -72,7 +72,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
 }
 
 pub fn dummy_on_replica_failure() -> OnPeerFailure {
-    Box::new(move |_peer_id| Box::new(async {}))
+    Box::new(move |_peer_id, _shard_id| Box::new(async {}))
 }
 
 /// Default to a collection with all the shards local

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -84,6 +84,7 @@ pub async fn new_local_collection(
         config,
         CollectionShardDistribution::all_local(Some(config.params.shard_number.into())),
         ChannelService::default(),
+        todo!(),
     )
     .await
 }

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -8,6 +8,7 @@ use collection::config::{CollectionConfig, CollectionParams, VectorParams, WalCo
 use collection::operations::types::CollectionError;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
+use collection::shard::replica_set::OnPeerFailure;
 use collection::shard::{ChannelService, CollectionId};
 use segment::types::Distance;
 
@@ -70,6 +71,10 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
     .unwrap()
 }
 
+pub fn dummy_on_replica_failure() -> OnPeerFailure {
+    Box::new(move |_peer_id| Box::new(async {}))
+}
+
 /// Default to a collection with all the shards local
 pub async fn new_local_collection(
     id: CollectionId,
@@ -84,7 +89,7 @@ pub async fn new_local_collection(
         config,
         CollectionShardDistribution::all_local(Some(config.params.shard_number.into())),
         ChannelService::default(),
-        todo!(),
+        dummy_on_replica_failure(),
     )
     .await
 }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -16,7 +16,7 @@ use collection::operations::types::{
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::shard::collection_shard_distribution::CollectionShardDistribution;
-use collection::shard::{ChannelService, CollectionId, PeerId, ShardId};
+use collection::shard::{replica_set, ChannelService, CollectionId, PeerId, ShardId};
 use collection::telemetry::CollectionTelemetry;
 use segment::types::ScoredPoint;
 use tokio::runtime::Runtime;
@@ -297,6 +297,7 @@ impl TableOfContent {
             &collection_config,
             collection_shard_distribution,
             self.channel_service.clone(),
+            self.on_peer_failure_callback(),
         )
         .await?;
 
@@ -306,6 +307,27 @@ impl TableOfContent {
             .await?;
         write_collections.insert(collection_name.to_string(), collection);
         Ok(true)
+    }
+
+    fn on_peer_failure_callback(&self) -> replica_set::OnPeerFailure {
+        let proposal_sender = self.consensus_proposal_sender.clone();
+        Box::new(move |peer_id| {
+            let proposal_sender = proposal_sender.clone();
+            Box::new(async move {
+                proposal_sender
+                    .send(ConsensusOperations::CollectionMeta(
+                        CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
+                            // TODO: fill in actual collection name and shard_id
+                            collection_name: "collection".to_string(),
+                            shard_id: 0,
+                            peer_id,
+                            active: false,
+                        })
+                        .into(),
+                    ))
+                    .unwrap();
+            })
+        })
     }
 
     async fn update_collection(
@@ -865,6 +887,7 @@ impl TableOfContent {
                             &state.config,
                             shard_distribution,
                             self.channel_service.clone(),
+                            self.on_peer_failure_callback(),
                         )
                         .await?;
                         collections.validate_collection_not_exists(id).await?;


### PR DESCRIPTION
This PR adds an implementation of `ShardOperation` for `ReplicaSet`.

## Description

Following the proposal of https://github.com/qdrant/qdrant/issues/993, the `ReplicaSet` now manages several remote shards and becomes responsible for the shard query coordination.

There is an optimization scheme for the read-only operation in order to reduce the latency:
1. prefer a local shard
2. try a subset of the remote shards concurrently (the ratio could be fully configurable)
3. try remaining remote shards 

Regarding the update operations, the processing must be acknowledged by all shards to be well formed.
Failing peers are reported as `inactive` in the `replica_state`.

## Notes for the reviewers

I was not able to have a nice `update` path because of various struggles with `async` blocks and `Iterators`.
In short I wanted to somehow iterate over trait objects from `self.remotes.iter().chain(self.local.iter())` but I was unable to align the types :man_shrugging: 

I was planning to do the usual integration testing approach at the end. 