### PR TITLE
Multiplatform build fix 2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,4 +33,4 @@ jobs:
         TAGS="-t generall/qdrant:${{ github.ref_name }}"
         TAGS="${TAGS} -t docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
         
-        docker buildx build --platform='linux/arm64' $TAGS --push .
+        docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,6 @@ on:
     # Pattern matched against refs/tags
     tags:        
       - '*'           # Push events to every tag not containing /
-    branches: [ multiplatform-build-fix-2 ]
 
 jobs:
 
@@ -32,8 +31,8 @@ jobs:
         DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
         TAGS="-t ${DOCKERHUB_TAG}"
         
-        # DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
-        # TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+        DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
+        TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
         
         GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
                 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
     # Pattern matched against refs/tags
     tags:        
       - '*'           # Push events to every tag not containing /
+    branches: [ multiplatform-build ]
 
 jobs:
 
@@ -23,11 +24,13 @@ jobs:
       env:
         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
       run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --use
+        
         docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
-        docker build . --file Dockerfile --tag "docker.pkg.github.com/qdrant/qdrant/qdrant:$RELEASE_VERSION"
-        docker push "docker.pkg.github.com/qdrant/qdrant/qdrant:$RELEASE_VERSION"
         docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
-        docker tag "docker.pkg.github.com/qdrant/qdrant/qdrant:$RELEASE_VERSION" "generall/qdrant:$RELEASE_VERSION"
-        docker push "generall/qdrant:$RELEASE_VERSION"
-        docker tag "generall/qdrant:$RELEASE_VERSION" "generall/qdrant:latest"
-        docker push "generall/qdrant:latest"
+        
+        TAGS="-t generall/qdrant:${{ github.ref_name }} -t generall/qdrant:latest"
+        TAGS="${TAGS} -t docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+        
+        docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
     # Pattern matched against refs/tags
     tags:        
       - '*'           # Push events to every tag not containing /
-    branches: [ multiplatform-build ]
+    branches: [ multiplatform-build-fix ]
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,7 +30,7 @@ jobs:
         docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
         docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
         
-        TAGS="-t generall/qdrant:${{ github.ref_name }} -t generall/qdrant:latest"
+        TAGS="-t generall/qdrant:${{ github.ref_name }}"
         TAGS="${TAGS} -t docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
         
-        docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push .
+        docker buildx build --platform='linux/arm64' $TAGS --push .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
     # Pattern matched against refs/tags
     tags:        
       - '*'           # Push events to every tag not containing /
-    branches: [ multiplatform-build-fix ]
+    branches: [ multiplatform-build-fix-2 ]
 
 jobs:
 
@@ -27,10 +27,20 @@ jobs:
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --use
         
-        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
         docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
         
-        TAGS="-t generall/qdrant:${{ github.ref_name }}"
-        TAGS="${TAGS} -t docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+        DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
+        TAGS="-t ${DOCKERHUB_TAG}"
         
+        # DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
+        # TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+        
+        GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+                
         docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push .
+        
+        docker pull $DOCKERHUB_TAG
+        
+        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
+        docker tag $DOCKERHUB_TAG $GITHUB_TAG
+        docker push $GITHUB_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,26 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 
+ARG TARGETARCH=amd64
+
 WORKDIR /qdrant
 
 COPY --from=planner /qdrant/recipe.json recipe.json
 
-RUN apt-get update ; apt-get install -y clang cmake ; rustup component add rustfmt
+RUN apt-get update ; apt-get install -y gcc-multilib ; apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu ; rustup component add rustfmt
+
+COPY ./tools/target_arch.sh ./target_arch.sh
+RUN rustup target add $(bash target_arch.sh)
 
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --target $(bash target_arch.sh) --recipe-path recipe.json
 
 COPY . .
 
 # Build actual target here
-RUN cargo build --release --bin qdrant
+RUN cargo build --release --target $(bash target_arch.sh) --bin qdrant
+
+RUN mv target/$(bash target_arch.sh)/release/qdrant /qdrant/qdrant
 
 FROM debian:11-slim
 ARG APP=/qdrant
@@ -39,7 +46,7 @@ ENV TZ=Etc/UTC \
 
 RUN mkdir -p ${APP}
 
-COPY --from=builder /qdrant/target/release/qdrant ${APP}/qdrant
+COPY --from=builder /qdrant/qdrant ${APP}/qdrant
 COPY --from=builder /qdrant/config ${APP}/config
 
 WORKDIR ${APP}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-1.63.0 AS chef
 WORKDIR /qdrant
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 
-ARG TARGETARCH=arm64
+ARG TARGETARCH=amd64
 
 WORKDIR /qdrant
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH=arm64
 
 WORKDIR /qdrant
 
 COPY --from=planner /qdrant/recipe.json recipe.json
 
-RUN apt-get update ; apt-get install -y gcc-multilib ; apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu ; rustup component add rustfmt
+RUN apt-get update && apt-get install -y gcc-multilib && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && rustup component add rustfmt
 
 COPY ./tools/target_arch.sh ./target_arch.sh
 RUN rustup target add $(bash target_arch.sh)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM lukemathwalker/cargo-chef:latest-rust-1.63.0 AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-1.63.0 AS chef
 WORKDIR /qdrant
 
 FROM chef AS planner

--- a/tools/target_arch.sh
+++ b/tools/target_arch.sh
@@ -1,0 +1,9 @@
+case $TARGETARCH in
+  "amd64")
+    echo "x86_64-unknown-linux-gnu"
+    ;;
+  "arm64")
+    echo "aarch64-unknown-linux-gnu"
+    ;;
+esac
+


### PR DESCRIPTION
### All Submissions:

- Based on https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
- If no emulator installed, it defaults to amd64 platform
- builds for `master` tag are preserved as-is on dockerhub, no multi-platform support for them for now
