### PR TITLE
Faster filtered scroll

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -9,7 +9,7 @@ use futures::future::{join_all, try_join_all};
 use itertools::Itertools;
 use segment::common::version::StorageVersion;
 use segment::data_types::vectors::{NamedVector, VectorElementType, DEFAULT_VECTOR_NAME};
-use segment::spaces::tools::{peek_top_largest_scores_iterable, peek_top_smallest_scores_iterable};
+use segment::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterable};
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, Order, ScoredPoint, WithPayload,
     WithPayloadInterface, WithVector,
@@ -843,10 +843,10 @@ impl Collection {
                     .distance;
                 let mut top_res = match distance.distance_order() {
                     Order::LargeBetter => {
-                        peek_top_largest_scores_iterable(res, request.limit + request.offset)
+                        peek_top_largest_iterable(res, request.limit + request.offset)
                     }
                     Order::SmallBetter => {
-                        peek_top_smallest_scores_iterable(res, request.limit + request.offset)
+                        peek_top_smallest_iterable(res, request.limit + request.offset)
                     }
                 };
                 // Remove `offset` from top result only for client requests

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -410,7 +410,7 @@ impl SegmentEntry for ProxySegment {
     fn read_filtered<'a>(
         &'a self,
         offset: Option<PointIdType>,
-        limit: usize,
+        limit: Option<usize>,
         filter: Option<&'a Filter>,
     ) -> Vec<PointIdType> {
         let deleted_points = self.deleted_points.read();
@@ -993,20 +993,23 @@ mod tests {
             "blue".to_string().into(),
         )));
 
-        let original_points = original_segment.get().read().read_filtered(None, 100, None);
+        let original_points = original_segment
+            .get()
+            .read()
+            .read_filtered(None, Some(100), None);
 
         let original_points_filtered =
             original_segment
                 .get()
                 .read()
-                .read_filtered(None, 100, Some(&filter));
+                .read_filtered(None, Some(100), Some(&filter));
 
         let mut proxy_segment = wrap_proxy(&dir, original_segment);
 
         proxy_segment.delete_point(100, 2.into()).unwrap();
 
-        let proxy_res = proxy_segment.read_filtered(None, 100, None);
-        let proxy_res_filtered = proxy_segment.read_filtered(None, 100, Some(&filter));
+        let proxy_res = proxy_segment.read_filtered(None, Some(100), None);
+        let proxy_res_filtered = proxy_segment.read_filtered(None, Some(100), Some(&filter));
 
         assert_eq!(original_points_filtered.len() - 1, proxy_res_filtered.len());
         assert_eq!(original_points.len() - 1, proxy_res.len());

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::VectorElementType;
 use segment::entry::entry_point::OperationError;
-use segment::spaces::tools::peek_top_largest_scores_iterable;
+use segment::spaces::tools::peek_top_largest_iterable;
 use segment::types::{
     Filter, PointIdType, ScoredPoint, SearchParams, SeqNumberType, WithPayload,
     WithPayloadInterface, WithVector,
@@ -73,7 +73,7 @@ impl SegmentsSearcher {
             .zip(request.searches.iter())
             .map(|(all_search_results_per_vector, req)| {
                 let mut seen_idx: HashSet<PointIdType> = HashSet::new();
-                peek_top_largest_scores_iterable(
+                peek_top_largest_iterable(
                     all_search_results_per_vector
                         .into_iter()
                         .sorted_by_key(|a| (a.id, 1 - a.version as i64)) // Prefer higher version first

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -108,7 +108,7 @@ pub(crate) fn clear_payload_by_filter(
     let mut points_to_clear: Vec<PointIdType> = Vec::new();
 
     segments.apply_segments(|s| {
-        let points = s.read_filtered(None, usize::MAX, Some(filter));
+        let points = s.read_filtered(None, None, Some(filter));
         points_to_clear.extend_from_slice(points.as_slice());
         Ok(true)
     })?;

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -82,7 +82,7 @@ fn test_update_proxy_segments() {
     let all_ids = segments
         .read()
         .iter()
-        .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, 100, None))
+        .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, Some(100), None))
         .sorted()
         .collect_vec();
 

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -525,7 +525,7 @@ impl LocalShard {
         }
         let all_points: BTreeSet<_> = segments
             .iter()
-            .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, usize::MAX, filter))
+            .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, None, filter))
             .collect();
         Ok(all_points)
     }

--- a/lib/collection/src/shard/local_shard_operations.rs
+++ b/lib/collection/src/shard/local_shard_operations.rs
@@ -79,7 +79,12 @@ impl ShardOperation for LocalShard {
         let point_ids = segments
             .read()
             .iter()
-            .flat_map(|(_, segment)| segment.get().read().read_filtered(offset, limit, filter))
+            .flat_map(|(_, segment)| {
+                segment
+                    .get()
+                    .read()
+                    .read_filtered(offset, Some(limit), filter)
+            })
             .sorted()
             .dedup()
             .take(limit)

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -232,7 +232,7 @@ pub trait SegmentEntry {
     fn read_filtered<'a>(
         &'a self,
         offset: Option<PointIdType>,
-        limit: usize,
+        limit: Option<usize>,
         filter: Option<&'a Filter>,
     ) -> Vec<PointIdType>;
 

--- a/lib/segment/src/fixtures/mod.rs
+++ b/lib/segment/src/fixtures/mod.rs
@@ -1,3 +1,4 @@
 pub mod index_fixtures;
 pub mod payload_context_fixture;
 pub mod payload_fixtures;
+pub mod segment_fixtures;

--- a/lib/segment/src/fixtures/segment_fixtures.rs
+++ b/lib/segment/src/fixtures/segment_fixtures.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use crate::data_types::named_vectors::NamedVectors;
+use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
+use crate::entry::entry_point::SegmentEntry;
+use crate::fixtures::index_fixtures::random_vector;
+use crate::fixtures::payload_fixtures::generate_diverse_payload;
+use crate::segment::Segment;
+use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
+use crate::types::Distance;
+
+pub fn random_segment(path: &Path, num_points: usize) -> Segment {
+    let dim = 4;
+    let distance = Distance::Dot;
+
+    let mut rnd_gen = rand::thread_rng();
+
+    let mut segment = build_simple_segment(path, dim, distance).unwrap();
+
+    for point_id in 0..num_points {
+        let vector = random_vector(&mut rnd_gen, dim);
+        let payload = generate_diverse_payload(&mut rnd_gen);
+
+        segment
+            .upsert_vector(
+                100,
+                (point_id as u64).into(),
+                &NamedVectors::from_ref(DEFAULT_VECTOR_NAME, &vector),
+            )
+            .unwrap();
+        segment
+            .set_payload(100, (point_id as u64).into(), &payload)
+            .unwrap();
+    }
+
+    segment
+}

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -23,11 +23,13 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndexSS};
+use crate::spaces::tools::peek_top_smallest_iterable;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
     PointIdType, PointOffsetType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
     SegmentState, SegmentType, SeqNumberType, WithPayload, WithVector,
+    DEFAULT_SCROLL_SCAN_THRESHOLD,
 };
 use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
 
@@ -636,7 +638,7 @@ impl SegmentEntry for Segment {
     fn read_filtered<'a>(
         &'a self,
         offset: Option<PointIdType>,
-        limit: usize,
+        limit: Option<usize>,
         filter: Option<&'a Filter>,
     ) -> Vec<PointIdType> {
         match filter {
@@ -645,18 +647,48 @@ impl SegmentEntry for Segment {
                 .borrow()
                 .iter_from(offset)
                 .map(|x| x.0)
-                .take(limit)
+                .take(limit.unwrap_or(usize::MAX))
                 .collect(),
             Some(condition) => {
                 let payload_index = self.payload_index.borrow();
-                let filter_context = payload_index.filter_context(condition);
-                self.id_tracker
-                    .borrow()
-                    .iter_from(offset)
-                    .filter(move |(_, internal_id)| filter_context.check(*internal_id))
-                    .map(|x| x.0)
-                    .take(limit)
-                    .collect()
+                let query_cardinality = payload_index.estimate_cardinality(condition);
+
+                // ToDo: update this threshold based on telemetry
+                let full_scan_threshold = DEFAULT_SCROLL_SCAN_THRESHOLD;
+
+                if query_cardinality.max < full_scan_threshold {
+                    let id_tracker = self.id_tracker.borrow();
+
+                    let ids_iterator =
+                        payload_index
+                            .query_points(condition)
+                            .filter_map(|internal_id| {
+                                let external_id = id_tracker.external_id(internal_id);
+                                match external_id {
+                                    Some(external_id) => match offset {
+                                        Some(offset) if external_id < offset => None,
+                                        _ => Some(external_id),
+                                    },
+                                    None => None,
+                                }
+                            });
+
+                    let mut page = match limit {
+                        Some(limit) => peek_top_smallest_iterable(ids_iterator, limit),
+                        None => ids_iterator.collect(),
+                    };
+                    page.sort_unstable();
+                    page
+                } else {
+                    let filter_context = payload_index.filter_context(condition);
+                    self.id_tracker
+                        .borrow()
+                        .iter_from(offset)
+                        .filter(move |(_, internal_id)| filter_context.check(*internal_id))
+                        .map(|x| x.0)
+                        .take(limit.unwrap_or(usize::MAX))
+                        .collect()
+                }
             }
         }
     }
@@ -881,7 +913,7 @@ impl SegmentEntry for Segment {
         filter: &'a Filter,
     ) -> OperationResult<usize> {
         let mut deleted_points = 0;
-        for point_id in self.read_filtered(None, usize::MAX, Some(filter)) {
+        for point_id in self.read_filtered(None, None, Some(filter)) {
             deleted_points += self.delete_point(op_num, point_id)? as usize;
         }
 

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -111,42 +111,42 @@ impl<T: Ord> IntoIterator for FixedLengthPriorityQueue<T> {
     }
 }
 
-pub fn peek_top_smallest_scores_iterable<I, E: Ord>(scores: I, top: usize) -> Vec<E>
+pub fn peek_top_smallest_iterable<I, E: Ord>(elements: I, top: usize) -> Vec<E>
 where
     I: IntoIterator<Item = E>,
 {
     if top == 0 {
-        return scores.into_iter().collect();
+        return elements.into_iter().collect();
     }
 
     // If small values is better - PQ should pop-out big values first.
     // Hence is should be min-heap
     let mut pq = FixedLengthPriorityQueue::new(top);
-    for score_point in scores {
-        pq.push(Reverse(score_point));
+    for element in elements {
+        pq.push(Reverse(element));
     }
     pq.into_vec().into_iter().map(|Reverse(x)| x).collect()
 }
 
-pub fn peek_top_largest_scores_iterable<I, E: Ord>(scores: I, top: usize) -> Vec<E>
+pub fn peek_top_largest_iterable<I, E: Ord>(elements: I, top: usize) -> Vec<E>
 where
     I: IntoIterator<Item = E>,
 {
     if top == 0 {
-        return scores.into_iter().collect();
+        return elements.into_iter().collect();
     }
 
     // If big values is better - PQ should pop-out small values first.
     // Hence is should be min-heap
     let mut pq = FixedLengthPriorityQueue::new(top);
-    for score_point in scores {
-        pq.push(score_point);
+    for element in elements {
+        pq.push(element);
     }
     pq.into_vec()
 }
 
 pub fn peek_top_scores<E: Ord + Clone>(scores: &[E], top: usize) -> Vec<E> {
-    peek_top_largest_scores_iterable(scores.iter().cloned(), top)
+    peek_top_largest_iterable(scores.iter().cloned(), top)
 }
 
 #[cfg(test)]
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_peek_top_rev() {
         let data = vec![10, 20, 40, 5, 100, 33, 84, 65, 20, 43, 44, 42];
-        let res = peek_top_smallest_scores_iterable(data.into_iter(), 3);
+        let res = peek_top_smallest_iterable(data.into_iter(), 3);
         assert_eq!(res, vec![5, 10, 20]);
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -351,8 +351,6 @@ pub struct VectorDataConfig {
 /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
 pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 20_000;
 
-pub const DEFAULT_SCROLL_SCAN_THRESHOLD: usize = 10_000;
-
 /// Persistable state of segment configuration
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -351,6 +351,8 @@ pub struct VectorDataConfig {
 /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
 pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 20_000;
 
+pub const DEFAULT_SCROLL_SCAN_THRESHOLD: usize = 10_000;
+
 /// Persistable state of segment configuration
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -13,7 +13,7 @@ use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
-use crate::spaces::tools::peek_top_largest_scores_iterable;
+use crate::spaces::tools::peek_top_largest_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType};
 use crate::vector_storage::mmap_vectors::MmapVectors;
 use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage, VectorStorageSS};
@@ -281,7 +281,7 @@ where
                     score: TMetric::similarity(preprocessed_vector, other_vector),
                 }
             });
-        peek_top_largest_scores_iterable(scores, top)
+        peek_top_largest_iterable(scores, top)
     }
 
     fn score_all(&self, vector: &[VectorElementType], top: usize) -> Vec<ScoredPointOffset> {
@@ -297,7 +297,7 @@ where
             }
         });
 
-        peek_top_largest_scores_iterable(scores, top)
+        peek_top_largest_iterable(scores, top)
     }
 
     fn score_internal(

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -18,7 +18,7 @@ use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
-use crate::spaces::tools::peek_top_largest_scores_iterable;
+use crate::spaces::tools::peek_top_largest_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType};
 use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorageSS};
 
@@ -296,7 +296,7 @@ where
                     score: TMetric::similarity(&preprocessed_vector, other_vector),
                 }
             });
-        peek_top_largest_scores_iterable(scores, top)
+        peek_top_largest_iterable(scores, top)
     }
 
     fn score_all(&self, vector: &[VectorElementType], top: usize) -> Vec<ScoredPointOffset> {
@@ -312,7 +312,7 @@ where
                     score: TMetric::similarity(&preprocessed_vector, other_vector),
                 }
             });
-        peek_top_largest_scores_iterable(scores, top)
+        peek_top_largest_iterable(scores, top)
     }
 
     fn score_internal(

--- a/lib/segment/tests/scroll_filtering_test.rs
+++ b/lib/segment/tests/scroll_filtering_test.rs
@@ -1,0 +1,38 @@
+#[cfg(test)]
+mod tests {
+    use rand::prelude::StdRng;
+    use rand::{Rng, SeedableRng};
+    use segment::fixtures::payload_fixtures::random_filter;
+    use segment::fixtures::segment_fixtures::random_segment;
+    use tempfile::Builder;
+
+    const NUM_POINTS: usize = 2000;
+    const ATTEMPTS: usize = 100;
+
+    #[test]
+    fn test_filtering_context_consistency() {
+        let seed = 42;
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+
+        let segment = random_segment(dir.path(), NUM_POINTS);
+
+        for _ in 0..ATTEMPTS {
+            let filter = random_filter(&mut rng, 3);
+
+            let random_offset = rng.gen_range(0..10);
+
+            let read_by_index_res =
+                segment.filtered_read_by_index(Some(random_offset.into()), Some(10), &filter);
+            let read_by_stream_res =
+                segment.filtered_read_by_id_stream(Some(random_offset.into()), Some(10), &filter);
+
+            assert_eq!(
+                read_by_index_res, read_by_stream_res,
+                "filter: {:#?}",
+                filter
+            );
+        }
+    }
+}


### PR DESCRIPTION
### All Submissions:

- old scroll implementation did a full scan, if the filter had low cardinality, which resulted in very high latency of the scroll query
- proposed implementation works similar to query planner, it estimates the cardinality of the filter first and then decides if it makes sense to use index first or filter the ids.
- This implementation resolves the case, where user wants to select some records from DB using the secondary index.

Our of scope:

current boundary threshold is hard-coded and naive. It would require additional telemetry data to decide how to adjust it.

Issue detected in demo by @joein 
