### PR TITLE
Persist replica state for ReplicaSet

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -2,6 +2,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::num::NonZeroU32;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -1234,7 +1235,7 @@ impl Collection {
                 .map(|(shard_id, shard)| {
                     let shard_info = match shard {
                         Shard::ReplicaSet(replicas) => ShardInfo::ReplicaSet {
-                            replicas: replicas.replica_state.clone(),
+                            replicas: replicas.replica_state.deref().clone(),
                         },
                         shard => ShardInfo::Single(
                             *shard

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::BufWriter;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
@@ -56,7 +56,7 @@ impl<T: Serialize + Default + for<'de> Deserialize<'de>> SaveOnDisk<T> {
         Ok(output)
     }
 
-    fn save(&self) -> Result<(), Error> {
+    pub fn save(&self) -> Result<(), Error> {
         AtomicFile::new(&self.path, AllowOverwrite).write(|file| {
             let writer = BufWriter::new(file);
             serde_json::to_writer(writer, &self.data)
@@ -70,6 +70,12 @@ impl<T> Deref for SaveOnDisk<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.data
+    }
+}
+
+impl<T> DerefMut for SaveOnDisk<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }
 


### PR DESCRIPTION
This PR adds persistence for the `replica_state` from `ReplicaSet`.

It uses the existing `SaveOnDisk` infrastructure.