### PR TITLE
Replication related API changes

### DIFF
--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -164,7 +164,7 @@ message UpdateCollection {
   string collection_name = 1; // Name of the collection
   optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection
   optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-  optional CollectionParamsDiff params = 4; // New configuration parameters for the collection}
+  optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
 }
 
 message DeleteCollection {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -157,12 +157,14 @@ message CreateCollection {
   optional bool on_disk_payload = 8; // If true - point's payload will not be stored in memory
   optional uint64 timeout = 9; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
   optional VectorsConfig vectors_config = 10; // Configuration for vectors
+  optional uint32 replication_factor = 11; // Number of replicas of each shard that network tries to maintain, default = 1
 }
 
 message UpdateCollection {
   string collection_name = 1; // Name of the collection
   optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection
   optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+  optional CollectionParamsDiff params = 4; // New configuration parameters for the collection}
 }
 
 message DeleteCollection {
@@ -181,6 +183,11 @@ message CollectionParams {
   uint32 shard_number = 3; // Number of shards in collection
   bool on_disk_payload = 4; // If true - point's payload will not be stored in memory
   optional VectorsConfig vectors_config = 5; // Configuration for vectors
+  uint32 replication_factor = 6; // Number of replicas of each shard that network tries to maintain
+}
+
+message CollectionParamsDiff {
+  optional uint32 replication_factor = 1; // Number of replicas of each shard that network tries to maintain
 }
 
 message CollectionConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -175,6 +175,9 @@ pub struct CreateCollection {
     /// Configuration for vectors
     #[prost(message, optional, tag="10")]
     pub vectors_config: ::core::option::Option<VectorsConfig>,
+    /// Number of replicas of each shard that network tries to maintain, default = 1
+    #[prost(uint32, optional, tag="11")]
+    pub replication_factor: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollection {
@@ -187,6 +190,9 @@ pub struct UpdateCollection {
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag="3")]
     pub timeout: ::core::option::Option<u64>,
+    /// New configuration parameters for the collection}
+    #[prost(message, optional, tag="4")]
+    pub params: ::core::option::Option<CollectionParamsDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCollection {
@@ -217,6 +223,15 @@ pub struct CollectionParams {
     /// Configuration for vectors
     #[prost(message, optional, tag="5")]
     pub vectors_config: ::core::option::Option<VectorsConfig>,
+    /// Number of replicas of each shard that network tries to maintain
+    #[prost(uint32, tag="6")]
+    pub replication_factor: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionParamsDiff {
+    /// Number of replicas of each shard that network tries to maintain
+    #[prost(uint32, optional, tag="1")]
+    pub replication_factor: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionConfig {

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -53,8 +53,6 @@ pub struct CollectionParams {
     #[serde(default = "default_shard_number")]
     pub shard_number: NonZeroU32,
     /// Number of replicas for each shard
-    // TODO: do not skip in v1.0 (when replication ships)
-    #[serde(skip)]
     #[serde(default = "default_replication_factor")]
     pub replication_factor: NonZeroU32,
     /// If true - point's payload will not be stored in memory.

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -7,10 +7,8 @@ use segment::data_types::vectors::{NamedVector, VectorStruct, DEFAULT_VECTOR_NAM
 use segment::types::Distance;
 use tonic::Status;
 
-use crate::config::{
-    default_replication_factor, CollectionConfig, CollectionParams, VectorParams, VectorsConfig,
-    WalConfig,
-};
+use super::config_diff::CollectionParamsDiff;
+use crate::config::{CollectionConfig, CollectionParams, VectorParams, VectorsConfig, WalConfig};
 use crate::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
 use crate::operations::point_ops::PointsSelector::PointIdsSelector;
 use crate::operations::point_ops::{
@@ -39,6 +37,22 @@ impl From<api::grpc::qdrant::WalConfigDiff> for WalConfigDiff {
             wal_capacity_mb: value.wal_capacity_mb.map(|v| v as usize),
             wal_segments_ahead: value.wal_segments_ahead.map(|v| v as usize),
         }
+    }
+}
+
+impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
+    type Error = Status;
+
+    fn try_from(value: api::grpc::qdrant::CollectionParamsDiff) -> Result<Self, Self::Error> {
+        Ok(Self {
+            replication_factor: value
+                .replication_factor
+                .map(|factor| {
+                    NonZeroU32::new(factor)
+                        .ok_or_else(|| Status::invalid_argument("`replication_factor` cannot be 0"))
+                })
+                .transpose()?,
+        })
     }
 }
 
@@ -115,6 +129,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                         Some(api::grpc::qdrant::VectorsConfig { config })
                     },
                     shard_number: config.params.shard_number.get(),
+                    replication_factor: config.params.replication_factor.get(),
                     on_disk_payload: config.params.on_disk_payload,
                 }),
                 hnsw_config: Some(api::grpc::qdrant::HnswConfigDiff {
@@ -243,43 +258,40 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
         Ok(Self {
             params: match config.params {
                 None => return Err(Status::invalid_argument("Malformed CollectionParams type")),
-                Some(params) => {
-                    CollectionParams {
-                        vectors: match params.vectors_config {
+                Some(params) => CollectionParams {
+                    vectors: match params.vectors_config {
+                        None => {
+                            return Err(Status::invalid_argument(
+                                "Expected `vectors` - configuration for vector storage",
+                            ))
+                        }
+                        Some(vector_config) => match vector_config.config {
                             None => {
                                 return Err(Status::invalid_argument(
                                     "Expected `vectors` - configuration for vector storage",
                                 ))
                             }
-                            Some(vector_config) => match vector_config.config {
-                                None => {
-                                    return Err(Status::invalid_argument(
-                                        "Expected `vectors` - configuration for vector storage",
-                                    ))
-                                }
-                                Some(api::grpc::qdrant::vectors_config::Config::Params(params)) => {
-                                    VectorsConfig::Single(params.try_into()?)
-                                }
-                                Some(api::grpc::qdrant::vectors_config::Config::ParamsMap(
-                                    params_map,
-                                )) => VectorsConfig::Multi(
-                                    params_map
-                                        .map
-                                        .into_iter()
-                                        .map(|(k, v)| Ok((k, v.try_into()?)))
-                                        .collect::<Result<BTreeMap<String, VectorParams>, Status>>(
-                                        )?,
-                                ),
-                            },
+                            Some(api::grpc::qdrant::vectors_config::Config::Params(params)) => {
+                                VectorsConfig::Single(params.try_into()?)
+                            }
+                            Some(api::grpc::qdrant::vectors_config::Config::ParamsMap(
+                                params_map,
+                            )) => VectorsConfig::Multi(
+                                params_map
+                                    .map
+                                    .into_iter()
+                                    .map(|(k, v)| Ok((k, v.try_into()?)))
+                                    .collect::<Result<BTreeMap<String, VectorParams>, Status>>()?,
+                            ),
                         },
-                        shard_number: NonZeroU32::new(params.shard_number).ok_or_else(|| {
-                            Status::invalid_argument("`shard_number` cannot be zero")
-                        })?,
-                        on_disk_payload: params.on_disk_payload,
-                        // TODO: use `repliction_factor` from `config`
-                        replication_factor: default_replication_factor(),
-                    }
-                }
+                    },
+                    shard_number: NonZeroU32::new(params.shard_number)
+                        .ok_or_else(|| Status::invalid_argument("`shard_number` cannot be zero"))?,
+                    on_disk_payload: params.on_disk_payload,
+                    replication_factor: NonZeroU32::new(params.replication_factor).ok_or_else(
+                        || Status::invalid_argument("`replication_factor` cannot be zero"),
+                    )?,
+                },
             },
             hnsw_config: match config.hnsw_config {
                 None => return Err(Status::invalid_argument("Malformed HnswConfig type")),

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,5 +1,7 @@
 use collection::config::VectorsConfig;
-use collection::operations::config_diff::{HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff};
+use collection::operations::config_diff::{
+    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff,
+};
 use collection::shard::{CollectionId, PeerId, ShardId, ShardTransfer};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -92,6 +94,11 @@ pub struct CreateCollection {
     /// Minimum is 1
     #[serde(default)]
     pub shard_number: Option<u32>,
+    /// Number of shards replicas.
+    /// Default is 1
+    /// Minimum is 1
+    #[serde(default)]
+    pub replication_factor: Option<u32>,
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
@@ -122,6 +129,8 @@ pub struct UpdateCollection {
     /// Custom params for Optimizers.  If none - values from service configuration file are used.
     /// This operation is blocking, it will only proceed ones all current optimizations are complete
     pub optimizers_config: Option<OptimizersConfigDiff>, // ToDo: Allow updates for other configuration params as well
+    /// Collection base params.  If none - values from service configuration file are used.
+    pub params: Option<CollectionParamsDiff>,
 }
 
 /// Operation for updating parameters of the existing collection

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -214,7 +214,10 @@ impl<C: CollectionContainer> ConsensusState<C> {
                         }
                     } else if entry.get_context().is_empty() {
                         // Allow empty context for compatibility
-                        // TODO: remove in the next version after 0.10
+                        log::warn!(
+                            "Outdated peer addition entry found with index: {}",
+                            entry.get_index()
+                        )
                     } else {
                         // Should not be reachable as it is checked in API
                         return Err(StorageError::ServiceError {

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -53,6 +53,7 @@ impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {
                 optimizers_config: value.optimizers_config.map(|v| v.into()),
                 shard_number: value.shard_number,
                 on_disk_payload: value.on_disk_payload,
+                replication_factor: value.replication_factor,
             },
         }))
     }
@@ -65,7 +66,8 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
         Ok(Self::UpdateCollection(UpdateCollectionOperation {
             collection_name: value.collection_name,
             update_collection: UpdateCollection {
-                optimizers_config: value.optimizers_config.map(|v| v.into()),
+                optimizers_config: value.optimizers_config.map(Into::into),
+                params: value.params.map(TryInto::try_into).transpose()?,
             },
         }))
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use collection::collection::Collection;
 use collection::collection_state;
 use collection::collection_state::ShardInfo;
-use collection::config::{CollectionConfig, CollectionParams};
-use collection::operations::config_diff::{CollectionParamsDiff, DiffConfig};
+use collection::config::{default_replication_factor, CollectionConfig, CollectionParams};
+use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
     CountRequest, CountResult, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
@@ -208,6 +208,7 @@ impl TableOfContent {
             hnsw_config: hnsw_config_diff,
             wal_config: wal_config_diff,
             optimizers_config: optimizers_config_diff,
+            replication_factor,
         } = operation;
 
         self.collections
@@ -226,6 +227,8 @@ impl TableOfContent {
                 "If shard number was supplied then this exact number should be used in a distribution"
             )
         }
+        let replication_factor =
+            replication_factor.unwrap_or_else(|| default_replication_factor().get());
 
         let collection_params = CollectionParams {
             vectors,
@@ -234,8 +237,11 @@ impl TableOfContent {
                     description: "`shard_number` cannot be 0".to_string(),
                 })?,
             on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
-            // TODO: use `replication_factor` supplied in `CreateCollection`
-            replication_factor: collection::config::default_replication_factor(),
+            replication_factor: NonZeroU32::new(replication_factor).ok_or(
+                StorageError::BadInput {
+                    description: "`replication_factor` cannot be 0".to_string(),
+                },
+            )?,
         };
         let wal_config = match wal_config_diff {
             None => self.storage_config.wal.clone(),
@@ -304,9 +310,10 @@ impl TableOfContent {
         collection_name: &str,
         operation: UpdateCollection,
     ) -> Result<bool, StorageError> {
-        let UpdateCollection { optimizers_config } = operation;
-        // TODO: get `params` from `UpdateCollection`
-        let params: Option<CollectionParamsDiff> = None;
+        let UpdateCollection {
+            optimizers_config,
+            params,
+        } = operation;
         let collection = self.get_collection(collection_name).await?;
         if let Some(diff) = optimizers_config {
             collection.update_optimizer_params_from_diff(diff).await?
@@ -908,8 +915,11 @@ impl TableOfContent {
             .collect();
         known_peers_set.insert(self.this_peer_id());
         let known_peers: Vec<_> = known_peers_set.into_iter().collect();
-        // TODO: Get from `op` after version 0.10
-        let replication_factor = NonZeroU32::new(1).unwrap();
+        let replication_factor = op
+            .create_collection
+            .replication_factor
+            .and_then(NonZeroU32::new)
+            .unwrap_or_else(default_replication_factor);
 
         let shard_distribution =
             ShardDistributionProposal::new(shard_number, replication_factor, &known_peers);

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -80,6 +80,7 @@ mod tests {
                             optimizers_config: None,
                             shard_number: Some(1),
                             on_disk_payload: None,
+                            replication_factor: None,
                         },
                     }),
                     None,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -269,11 +269,6 @@ impl Consensus {
         // This needs to be propagated manually to other peers as it is not contained in any log entry.
         state_ref.set_first_voter(all_peers.first_peer_id);
         state_ref.set_conf_state(ConfState::from((vec![all_peers.first_peer_id], vec![])))?;
-        // TODO: Remove in the next version after 0.10 as it does nothing and is left for compatability
-        client
-            .add_peer_as_participant(tonic::Request::new(api::grpc::qdrant::PeerId { id }))
-            .await
-            .context("Failed to add peer as participant")?;
         Ok(())
     }
 
@@ -767,6 +762,7 @@ mod tests {
                             optimizers_config: None,
                             shard_number: Some(2),
                             on_disk_payload: None,
+                            replication_factor: None,
                         },
                     }),
                     None,


### PR DESCRIPTION
Several `todo` fixes that propagate API for replication from internal to external. As replication is planned to be enabled for the next release.
