### PR TITLE
Fix Clippy following Rust update

### DIFF
--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -97,7 +97,7 @@ fn batch_search_bench(c: &mut Criterion) {
 
     let rnd_batch = create_rnd_batch();
 
-    handle.block_on((&shard).update(rnd_batch, true)).unwrap();
+    handle.block_on(shard.update(rnd_batch, true)).unwrap();
 
     let mut group = c.benchmark_group("batch-search-bench");
 
@@ -138,7 +138,7 @@ fn batch_search_bench(c: &mut Criterion) {
                             with_vector: None,
                             score_threshold: None,
                         };
-                        let result = (&shard)
+                        let result = shard
                             .search(
                                 Arc::new(SearchRequestBatch {
                                     searches: vec![search_query],
@@ -174,7 +174,7 @@ fn batch_search_bench(c: &mut Criterion) {
                     }
 
                     let search_query = SearchRequestBatch { searches };
-                    let result = (&shard)
+                    let result = shard
                         .search(Arc::new(search_query), search_runtime_handle)
                         .await
                         .unwrap();

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -441,10 +441,7 @@ impl SegmentEntry for ProxySegment {
         let deleted_points = self.deleted_points.read();
         let mut read_points = self.wrapped_segment.get().read().read_range(from, to);
         if !deleted_points.is_empty() {
-            read_points = read_points
-                .into_iter()
-                .filter(|idx| !deleted_points.contains(idx))
-                .collect();
+            read_points.retain(|idx| !deleted_points.contains(idx))
         }
         let mut write_segment_points = self.write_segment.get().read().read_range(from, to);
         read_points.append(&mut write_segment_points);


### PR DESCRIPTION
A new Rust version was released today, as usual small fixes are required for our CI using `latest`.

This time no formatting, just a single Clippy entry.

```bash
error: this expression can be written more simply using `.retain()`
   --> lib/collection/src/collection_manager/holders/proxy_segment.rs:444:13
    |
444 | /             read_points = read_points
445 | |                 .into_iter()
446 | |                 .filter(|idx| !deleted_points.contains(idx))
447 | |                 .collect();
    | |__________________________^ help: consider calling `.retain()` instead: `read_points.retain(|idx| !deleted_points.contains(idx))`
    |
    = note: `-D clippy::manual-retain` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_retain
```