### PR TITLE
fix collection loading

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -94,9 +94,6 @@ impl Collection {
     ) -> Result<Self, CollectionError> {
         let start_time = std::time::Instant::now();
 
-        CollectionVersion::save(path)?;
-        config.save(path)?;
-
         let mut shard_holder = ShardHolder::new(path, HashRing::fair(HASH_RING_SHARD_SCALE))?;
 
         let shared_config = Arc::new(RwLock::new(config.clone()));
@@ -158,6 +155,10 @@ impl Collection {
         }
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));
+
+        // Once the config is persisted - the collection is considered to be successfully created.
+        CollectionVersion::save(path)?;
+        config.save(path)?;
 
         Ok(Self {
             id: id.clone(),

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -154,6 +154,12 @@ impl CollectionConfig {
         file.read_to_string(&mut contents)?;
         Ok(serde_json::from_str(&contents)?)
     }
+
+    /// Check if collection config exists
+    pub fn check(path: &Path) -> bool {
+        let config_path = path.join(COLLECTION_CONFIG_FILE);
+        config_path.exists()
+    }
 }
 
 impl CollectionParams {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -80,6 +80,15 @@ impl TableOfContent {
             let collection_path = entry
                 .expect("Can't access of one of the collection files")
                 .path();
+
+            if !CollectionConfig::check(&collection_path) {
+                log::warn!(
+                    "Collection config is not found in the collection directory: {:?}, skipping",
+                    collection_path
+                );
+                continue;
+            }
+
             let collection_name = collection_path
                 .file_name()
                 .expect("Can't resolve a filename of one of the collection files")


### PR DESCRIPTION
### All Submissions:

Fixes issue, where collection become inconsistent if some of the shards creation failed.

New logic:

- create collection shards first - save collection config as the last step
- If collection does not have config - it is considered malformed and skipped with warning
 
