### PR TITLE
Dependatbot targets dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: cargo
+    target-branch: "dev"
     directory: /
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels: [dependencies]
   - package-ecosystem: "github-actions"
+    target-branch: "dev"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
   - package-ecosystem: docker
+    target-branch: "dev"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot should target our newly created `dev` branch to not introduce unnecessary into `master`

It currently still target master for instance https://github.com/qdrant/qdrant/pull/1063

![dependabot](https://user-images.githubusercontent.com/606963/192726501-ac48d43f-9f8d-4e87-9cb8-f0ca7fb13ea6.png)

This PR changes the configuration in the `master` branch as well to make it effective.