### PR TITLE
limit set to zero returns an empty result

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -607,6 +607,9 @@ impl Collection {
         search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
+        if request.limit == 0 {
+            return Ok(vec![]);
+        }
         // `recommend_by` is a special case of recommend_by_batch with a single batch
         let request_batch = RecommendRequestBatch {
             searches: vec![request],
@@ -623,6 +626,10 @@ impl Collection {
         search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        // shortcuts batch if all requests with limit=0
+        if request_batch.searches.iter().all(|s| s.limit == 0) {
+            return Ok(vec![]);
+        }
         // pack all reference vector ids
         let mut all_reference_vectors_ids = HashSet::new();
         for request in &request_batch.searches {
@@ -752,6 +759,10 @@ impl Collection {
         search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        // shortcuts batch if all requests with limit=0
+        if request.searches.iter().all(|s| s.limit == 0) {
+            return Ok(vec![]);
+        }
         // A factor which determines if we need to use the 2-step search or not
         // Should be adjusted based on usage statistics.
         const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
@@ -922,6 +933,9 @@ impl Collection {
         search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
+        if request.limit == 0 {
+            return Ok(vec![]);
+        }
         // search is a special case of search_batch with a single batch
         let request_batch = SearchRequestBatch {
             searches: vec![request],

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -116,7 +116,7 @@ where
     I: IntoIterator<Item = E>,
 {
     if top == 0 {
-        return elements.into_iter().collect();
+        return vec![];
     }
 
     // If small values is better - PQ should pop-out big values first.
@@ -133,7 +133,7 @@ where
     I: IntoIterator<Item = E>,
 {
     if top == 0 {
-        return elements.into_iter().collect();
+        return vec![];
     }
 
     // If big values is better - PQ should pop-out small values first.


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/1082

Enabling users to fetch the entire data set by using `limit:0` is dangerous.

The current behavior is not documented and looks like a bug.

This PR proposes to return an empty result instead which makes the semantic clearer.

The check is done first at a high level with `collection.rs` and then the sorting helpers have been updated to reflect this new behavior.

Applies to:
- search
- search_batch
- recommend
- recommend_batch

A follow up work would be to cap the maximum `limit` to protect the system. 


