### PR TITLE
Fix: Do not rely on empty message for `is_leader_established` flag

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -742,6 +742,8 @@ mod tests {
         });
         // Wait for Raft to establish the leader
         is_leader_established.await_ready();
+        // Peer needs some time to commit empty entry
+        thread::sleep_ms(2000);
         // Leader election produces a raft log entry
         assert_eq!(consensus_state.hard_state().commit, 1);
         // Initially there are 0 collections


### PR DESCRIPTION
Explicitly set `is_leader_established` only on soft state change, when corresponding role is set.

Do not rely on `empty entry` being transmitted because it makes tests easier. It is difficult to tell if the precondition of it being always empty when a leader is elected holds true.
