### PR TITLE
Remove dir all Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "rand",
+ "remove_dir_all 0.7.0",
  "rmp-serde",
  "schemars",
  "segment",
@@ -2630,6 +2631,7 @@ dependencies = [
  "prost 0.9.0",
  "raft",
  "raft-proto",
+ "remove_dir_all 0.7.0",
  "rusty-hook",
  "schemars",
  "segment",
@@ -2817,6 +2819,19 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+dependencies = [
+ "libc",
+ "log 0.4.17",
+ "num_cpus",
+ "rayon",
  "winapi 0.3.9",
 ]
 
@@ -3053,6 +3068,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
+ "remove_dir_all 0.7.0",
  "rmp-serde",
  "rocksdb",
  "schemars",
@@ -3283,6 +3299,7 @@ dependencies = [
  "prost 0.9.0",
  "raft",
  "rand",
+ "remove_dir_all 0.7.0",
  "schemars",
  "segment",
  "serde",
@@ -3395,7 +3412,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all",
+ "remove_dir_all 0.5.3",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tower = "0.4.13"
 tower-layer = "0.3.1"
 num-traits = "0.2.15"
 tar = "0.4.38"
+remove_dir_all = "0.7.0"
 
 # Consensus related crates
 raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -24,6 +24,7 @@ rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "0dd3943113ff7ec2fbc5428bb77ba206c8492fa9" }
 ordered-float = "3.2"
 hashring = "0.3.0"
+remove_dir_all = "0.7.0"
 
 tokio = {version = "~1.21", features = ["full"]}
 futures = "0.3.24"

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
-use std::fs::{create_dir_all, remove_dir_all};
+use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -713,7 +713,7 @@ impl SegmentEntry for ProxySegment {
         // release segment resources
         drop(in_memory_wrapped_segment);
         // delete temporary copy
-        remove_dir_all(copy_target_dir)?;
+        remove_dir_all::remove_dir_all(copy_target_dir)?;
         Ok(())
     }
 

--- a/lib/collection/src/shard/local_shard.rs
+++ b/lib/collection/src/shard/local_shard.rs
@@ -145,7 +145,7 @@ impl LocalShard {
         for entry in segment_dirs {
             let segments_path = entry.unwrap().path();
             if segments_path.ends_with("deleted") {
-                std::fs::remove_dir_all(&segments_path).unwrap_or_else(|_| {
+                remove_dir_all::remove_dir_all(&segments_path).unwrap_or_else(|_| {
                     panic!(
                         "Can't remove marked-for-remove segment {}",
                         segments_path.to_str().unwrap()

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -45,7 +45,7 @@ tar = "0.4.38"
 fs_extra = "1.2.0"
 semver = "1.0.14"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
-
+remove_dir_all = "0.7.0"
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fs::{remove_dir_all, rename, File};
+use std::fs::{rename, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -896,7 +896,7 @@ impl SegmentEntry for Segment {
         let mut deleted_path = current_path.clone();
         deleted_path.set_extension("deleted");
         rename(&current_path, &deleted_path)?;
-        remove_dir_all(&deleted_path).map_err(|err| {
+        remove_dir_all::remove_dir_all(&deleted_path).map_err(|err| {
             OperationError::service_error(&format!(
                 "Can't remove segment data at {}, error: {}",
                 deleted_path.to_str().unwrap_or_default(),

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -26,6 +26,7 @@ http = "0.2"
 parking_lot = { version = "0.12.1", features=["deadlock_detection", "serde"]}
 tar = "0.4.38"
 chrono = { version = "~0.4", features = ["serde"] }
+remove_dir_all = "0.7.0"
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::fs::{create_dir_all, read_dir, remove_dir_all};
+use std::fs::{create_dir_all, read_dir};
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -341,7 +341,7 @@ impl TableOfContent {
             removed.before_drop().await;
             let path = self.get_collection_path(collection_name);
             drop(removed);
-            remove_dir_all(path).map_err(|err| StorageError::ServiceError {
+            remove_dir_all::remove_dir_all(path).map_err(|err| StorageError::ServiceError {
                 description: format!(
                     "Can't delete collection {}, error: {}",
                     collection_name, err

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -1,4 +1,4 @@
-use std::fs::{remove_dir_all, rename};
+use std::fs::rename;
 use std::path::Path;
 
 use collection::collection::Collection;
@@ -52,7 +52,7 @@ pub fn recover_snapshots(mapping: &[String], force: bool, storage_dir: &str) {
         }
         // Remove collection_path directory if exists
         if collection_path.exists() {
-            if let Err(err) = remove_dir_all(&collection_path) {
+            if let Err(err) = remove_dir_all::remove_dir_all(&collection_path) {
                 panic!("Failed to remove collection {}: {}", collection_name, err);
             }
         }
@@ -104,5 +104,5 @@ pub fn recover_full_snapshot(snapshot_path: &str, storage_dir: &str, force: bool
     }
 
     // Remove temporary directory
-    remove_dir_all(&temporary_dir).unwrap();
+    remove_dir_all::remove_dir_all(&temporary_dir).unwrap();
 }


### PR DESCRIPTION
https://lib.rs/crates/remove_dir_all

```
remove_dir_all - on non-Windows this is a re-export of std::fs::remove_dir_all. 
For Windows an implementation that handles the locking of directories that occurs when deleting directory trees rapidly.
```