### PR TITLE
ensure consequent entries in consensus wal

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -148,7 +148,13 @@ impl ConsensusOpWal {
 
             let mut buf = vec![];
             entry.encode(&mut buf)?;
-            let _wal_index = self.0.append(&buf)?;
+            let wal_index = self.0.append(&buf)?;
+            #[cfg(debug_assertions)]
+            if let Some(offset) = index_offset {
+                debug_assert!(wal_index == index - offset);
+            } else {
+                debug_assert!(wal_index == 0)
+            }
         }
         Ok(())
     }

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -8,11 +8,11 @@ use raft::util::limit_size;
 use wal::Wal;
 
 use crate::content_manager::consensus_state;
-use crate::StorageError;
+use crate::{ConsensusOperations, StorageError};
 
 const COLLECTIONS_META_WAL_DIR: &str = "collections_meta_wal";
 
-pub struct ConsensusOpWal(pub Wal);
+pub struct ConsensusOpWal(Wal);
 
 impl ConsensusOpWal {
     pub fn new(storage_path: &str) -> Self {
@@ -20,6 +20,10 @@ impl ConsensusOpWal {
         create_dir_all(&collections_meta_wal_path)
             .expect("Can't create Collections meta Wal directory");
         ConsensusOpWal(Wal::open(collections_meta_wal_path).unwrap())
+    }
+
+    pub fn clear(&mut self) -> Result<(), StorageError> {
+        Ok(self.0.clear()?)
     }
 
     pub fn entry(&self, id: u64) -> raft::Result<RaftEntry> {
@@ -74,13 +78,171 @@ impl ConsensusOpWal {
         Ok(entry.transpose()?)
     }
 
+    /// Difference between raft index and WAL record number.
+    /// Difference might be different because of consensus snapshot.
+    fn index_offset(&self) -> Result<Option<u64>, StorageError> {
+        let last_known_index = self.0.first_index();
+        let first_entry = self.first_entry()?;
+        let offset = first_entry.map(|entry| entry.index - last_known_index);
+        Ok(offset)
+    }
+
     pub fn append_entries(&mut self, entries: Vec<RaftEntry>) -> Result<(), StorageError> {
         for entry in entries {
-            log::debug!("Appending entry: {entry:?}");
+            let operation_opt = ConsensusOperations::try_from(&entry).ok();
+
+            let index = entry.index;
+            let current_index = self.0.last_index();
+            let index_offset = self.index_offset()?;
+
+            match index_offset {
+                Some(offset) => {
+                    // Assume we can't skip index numbers in WAL except for snapshot
+                    // Example: 2 <= 0 + 1 + 1
+                    debug_assert!(
+                        index <= current_index + offset + 1,
+                        "Expected no index skip: {} <= {} + {}",
+                        index,
+                        current_index,
+                        offset
+                    );
+
+                    if index < current_index + offset {
+                        // If there is a conflict, example:
+                        // Offset = 1
+                        // raft index = 10
+                        // wal index = 11
+                        // expected_wal_index = 10 - 1 = 9
+                        // 10 < 11 + 1
+                        if index < offset {
+                            return Err(StorageError::service_error(&format!(
+                                "Wal index conflict, raft index: {}, wal index: {}, offset: {}",
+                                index, current_index, offset
+                            )));
+                        }
+                        log::debug!(
+                            "Truncate conflicting WAL entries from index {}, raft: {}",
+                            index - offset,
+                            index
+                        );
+                        self.0.truncate(index - offset)?;
+                    } // else:
+                      // Offset = 1
+                      // raft index = 11
+                      // wal index = 10
+                      // expected_wal_index = 11 - 1 = 10
+                      // 11 < 10 + 1
+                }
+                None => {
+                    // There is no offset => there are no records in WAL
+                    // If there are no records, conflict is impossible
+                    // So we do nothing
+                }
+            }
+
+            if let Some(operation) = operation_opt {
+                let term = entry.term;
+                log::debug!(
+                    "Appending operation: term: {term}, index: {index} {operation:?}, entry: "
+                );
+            } else {
+                log::debug!("Appending entry: {entry:?}");
+            }
+
             let mut buf = vec![];
             entry.encode(&mut buf)?;
-            self.0.append(&buf)?;
+            let _wal_index = self.0.append(&buf)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use raft::eraftpb::Entry;
+
+    use super::*;
+
+    #[test]
+    fn test_log_rewrite() {
+        let entries_orig = vec![
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 1,
+                data: vec![1, 2, 3],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 2,
+                data: vec![1, 2, 3],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 3,
+                data: vec![1, 2, 3],
+                context: vec![],
+                sync_log: false,
+            },
+        ];
+
+        let entries_new = vec![
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 2,
+                data: vec![2, 2, 2],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 3,
+                data: vec![3, 3, 3],
+                context: vec![],
+                sync_log: false,
+            },
+        ];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        wal.append_entries(entries_orig).unwrap();
+        wal.append_entries(entries_new.clone()).unwrap();
+
+        let result_entries = wal.entries(1, 4, None).unwrap();
+        assert_eq!(result_entries.len(), 3);
+
+        assert_eq!(result_entries[0].data, vec![1, 2, 3]);
+        assert_eq!(result_entries[1].data, vec![2, 2, 2]);
+        assert_eq!(result_entries[2].data, vec![3, 3, 3]);
+
+        wal.clear().unwrap();
+
+        wal.append_entries(entries_new).unwrap();
+
+        assert_eq!(wal.index_offset().unwrap(), Some(2));
+
+        let broken_entry = vec![Entry {
+            entry_type: 0,
+            term: 1,
+            index: 1, // Index 1 can't be overwritten, because it is already compacted
+            data: vec![5, 5, 5],
+            context: vec![],
+            sync_log: false,
+        }];
+
+        // Some errors can't be corrected
+        assert!(matches!(
+            wal.append_entries(broken_entry),
+            Err(StorageError::ServiceError { .. })
+        ));
     }
 }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -188,6 +188,7 @@ impl Persistent {
             let writer = BufWriter::new(file);
             serde_cbor::to_writer(writer, self)
         });
+        log::debug!("Saved state: {:?}", self);
         self.dirty.store(result.is_err(), Ordering::Relaxed);
         Ok(result?)
     }

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -368,7 +368,7 @@ impl<C: CollectionContainer> ConsensusState<C> {
         }
         let data: SnapshotData = snapshot.get_data().try_into()?;
         self.toc.apply_collections_snapshot(data.collections_data)?;
-        self.wal.lock().0.clear()?;
+        self.wal.lock().clear()?;
         self.persistent
             .write()
             .update_from_snapshot(meta, data.address_by_id)?;

--- a/tests/consensus_tests/docker-compose.yaml
+++ b/tests/consensus_tests/docker-compose.yaml
@@ -7,10 +7,15 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
+      - QDRANT__LOG_LEVEL=DEBUG
     ports:
       - "6333:6333"
       - "6334:6334"
     command: ./qdrant --uri 'http://qdrant_node_1:6335'
+    deploy:
+      resources:
+        limits:
+          cpus: '0.05'
 
   qdrant_node_follower:
     image: qdrant_consensus:latest
@@ -18,12 +23,17 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
+      - QDRANT__LOG_LEVEL=DEBUG
     depends_on:
       - qdrant_node_1
     ports:
       - "6433:6333"
       - "6434:6334"
-    command: bash -c "sleep 5 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower:6335'"
+    command: bash -c "sleep 2 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower:6335'"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.05'
 
   qdrant_node_follower_2:
     image: qdrant_consensus:latest
@@ -31,9 +41,14 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
+      - QDRANT__LOG_LEVEL=DEBUG
     depends_on:
       - qdrant_node_1
     ports:
       - "6533:6333"
       - "6534:6334"
-    command: bash -c "sleep 6 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower_2:6335'"
+    command: bash -c "sleep 3 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower_2:6335'"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.05'

--- a/tests/consensus_tests/docker-compose.yaml
+++ b/tests/consensus_tests/docker-compose.yaml
@@ -11,10 +11,7 @@ services:
       - "6333:6333"
       - "6334:6334"
     command: ./qdrant --uri 'http://qdrant_node_1:6335'
-    deploy:
-      resources:
-        limits:
-          cpus: '0.05'
+
 
   qdrant_node_follower:
     image: qdrant_consensus:latest

--- a/tests/consensus_tests/docker-compose.yaml
+++ b/tests/consensus_tests/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
-      - QDRANT__LOG_LEVEL=DEBUG
     ports:
       - "6333:6333"
       - "6334:6334"
@@ -23,17 +22,13 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
-      - QDRANT__LOG_LEVEL=DEBUG
     depends_on:
       - qdrant_node_1
     ports:
       - "6433:6333"
       - "6434:6334"
-    command: bash -c "sleep 2 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower:6335'"
-    deploy:
-      resources:
-        limits:
-          cpus: '0.05'
+    command: bash -c "sleep 5 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower:6335'"
+
 
   qdrant_node_follower_2:
     image: qdrant_consensus:latest
@@ -41,14 +36,9 @@ services:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
-      - QDRANT__LOG_LEVEL=DEBUG
     depends_on:
       - qdrant_node_1
     ports:
       - "6533:6333"
       - "6534:6334"
-    command: bash -c "sleep 3 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower_2:6335'"
-    deploy:
-      resources:
-        limits:
-          cpus: '0.05'
+    command: bash -c "sleep 6 && ./qdrant --bootstrap 'http://qdrant_node_1:6335' --uri 'http://qdrant_node_follower_2:6335'"


### PR DESCRIPTION
### All Submissions:

- Raft paper proposes, that in case of leader conflict, entries with higher term should override submitted, but not yet committed entries in the consensus WAL.
- Previous implementation of consensus WAL didn't consider this case and only performed append to WAL, which caused inconsistency and undefined behavior of the raft-rs.
- This PR introduces index checks in the consensus WAL, allowing it to override existing entries based on raft index of the newly received entries.
- New code also assumes, the WAL index is not identical, but monotonous and does not contain any skips comparing to Raft index. In other words, WAL Index have a constant offset comparing to Raft index

Additional context:

reproduction of original bug involves multiple parallel consensus-related requests in combination with either high load, low memory, or very strict limitation of system resources (in our experiments, limiting to 5% of a single CPU). In this case the instances was slow enough to timeout on consensus heartbeat.  

