### PR TITLE
ignore points with missing expernal ids instead of panic

### DIFF
--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -113,7 +113,19 @@ impl SegmentBuilder {
                             description: "Cancelled by external thread".to_string(),
                         });
                     }
-                    let external_id = other_id_tracker.external_id(old_internal_id).unwrap();
+                    let external_id =
+                        if let Some(external_id) = other_id_tracker.external_id(old_internal_id) {
+                            external_id
+                        } else {
+                            log::warn!(
+                                "Cannot find external id for internal id {}, skipping",
+                                old_internal_id
+                            );
+                            for vector_storage in vector_storages.values_mut() {
+                                vector_storage.delete(new_internal_id)?;
+                            }
+                            continue;
+                        };
                     let other_version = other_id_tracker.version(external_id).unwrap();
 
                     match id_tracker.version(external_id) {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -171,11 +171,15 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
 
     let segment_state = Segment::load_state(path)?;
 
-    Ok(Some(create_segment(
-        segment_state.version,
-        path,
-        &segment_state.config,
-    )?))
+    let segment = create_segment(segment_state.version, path, &segment_state.config)?;
+
+    #[cfg(debug_assertions)]
+    {
+        log::debug!("Checking segment consistency: {}", path.display());
+        segment.check_consistency()?;
+    }
+
+    Ok(Some(segment))
 }
 
 /// Build segment instance using given configuration.


### PR DESCRIPTION
There is a possible scenario, where the `id_tracker` operation fails - the vectors storage stays updated. Even after proper recovery, the inserted vectors are no longer associated with external IDs. 

This PR allows to ignore abandoned ids instead of panicking.

Additional changes:

- Adds logging for the errored state of the segment
- Enables consistency checking in debug build
- Improves payload moving in multiple vector case