### PR TITLE
Force sync vector storage offset

### DIFF
--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -3,6 +3,7 @@ use std::fs::{create_dir_all, File};
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use log::info;
 use parking_lot::Mutex;

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -3,7 +3,6 @@ use std::fs::{create_dir_all, File};
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
-
 use atomic_refcell::AtomicRefCell;
 use log::info;
 use parking_lot::Mutex;

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -157,12 +157,16 @@ where
         panic!("Can't put vector in mmap storage")
     }
 
-    fn update_vector(
+    fn insert_vector(
         &mut self,
         _key: PointOffsetType,
         _vector: Vec<VectorElementType>,
-    ) -> OperationResult<PointOffsetType> {
+    ) -> OperationResult<()> {
         panic!("Can't directly update vector in mmap storage")
+    }
+
+    fn next_id(&self) -> PointOffsetType {
+        panic!("There are no available for insertion ids in mmap storage")
     }
 
     fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -209,18 +209,22 @@ where
         Ok(new_id)
     }
 
-    fn update_vector(
+    fn insert_vector(
         &mut self,
         key: PointOffsetType,
         vector: Vec<VectorElementType>,
-    ) -> OperationResult<PointOffsetType> {
+    ) -> OperationResult<()> {
         self.vectors.insert(key, &vector);
         if self.deleted.len() <= (key as usize) {
-            self.deleted.resize(key as usize + 1, false);
+            self.deleted.resize(key as usize + 1, true);
         }
         self.deleted.set(key as usize, false);
         self.update_stored(key)?;
-        Ok(key)
+        Ok(())
+    }
+
+    fn next_id(&self) -> PointOffsetType {
+        self.vectors.len() as PointOffsetType
     }
 
     fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -57,11 +57,13 @@ pub trait VectorStorage {
     /// Number of all stored vectors including deleted
     fn get_vector(&self, key: PointOffsetType) -> Option<Vec<VectorElementType>>;
     fn put_vector(&mut self, vector: Vec<VectorElementType>) -> OperationResult<PointOffsetType>;
-    fn update_vector(
+    fn insert_vector(
         &mut self,
         key: PointOffsetType,
         vector: Vec<VectorElementType>,
-    ) -> OperationResult<PointOffsetType>;
+    ) -> OperationResult<()>;
+    /// Returns next available id
+    fn next_id(&self) -> PointOffsetType;
     fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>>;
     fn delete(&mut self, key: PointOffsetType) -> OperationResult<()>;
     fn is_deleted(&self, key: PointOffsetType) -> bool;


### PR DESCRIPTION
### All Submissions:

- replace `update_vector` with `insert_vector` which assumes in-place change semantics
- Use `insert_vector` with max id to ensure synced named vector storage offsets 