### PR TITLE
validate geo coordinate before adding it to the payload index

### DIFF
--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -82,12 +82,12 @@ pub fn encode_max_precision(lon: f64, lat: f64) -> Result<GeoHash, GeohashError>
 pub fn geo_hash_to_box(geo_hash: &GeoHash) -> GeoBoundingBox {
     let rectangle = decode_bbox(geo_hash).unwrap();
     let top_left = GeoPoint {
-        lat: rectangle.max().y,
         lon: rectangle.min().x,
+        lat: rectangle.max().y,
     };
     let bottom_right = GeoPoint {
-        lat: rectangle.min().y,
         lon: rectangle.max().x,
+        lat: rectangle.min().y,
     };
 
     GeoBoundingBox {

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -40,6 +40,14 @@ curl -L -X PUT  "http://$QDRANT_HOST/collections/test_collection/index" \
       "field_schema": "integer"
     }' | jq
 
+curl -L -X PUT  "http://$QDRANT_HOST/collections/test_collection/index" \
+  -H 'Content-Type: application/json' \
+  --fail -s \
+  --data-raw '{
+      "field_name": "coords",
+      "field_schema": "geo"
+    }' | jq
+
 curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq
 
 # insert points
@@ -56,7 +64,7 @@ curl -L -X PUT "http://$QDRANT_HOST/collections/test_collection/points?wait=true
             "country": "Germany" ,
             "count": 1000000,
             "square": 12.5,
-            "coords": { "lat": 1.0, "lon": 2.0 }
+            "coords": { "lat": 1000.0, "lon": 2.0 }
           }
         },
         {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"]}},

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -64,7 +64,7 @@ curl -L -X PUT "http://$QDRANT_HOST/collections/test_collection/points?wait=true
             "country": "Germany" ,
             "count": 1000000,
             "square": 12.5,
-            "coords": { "lat": 1000.0, "lon": 2.0 }
+            "coords": { "lat": 1.0, "lon": 2.0 }
           }
         },
         {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"]}},


### PR DESCRIPTION
This PR brings back validation for geo coordinates before insertion into a payload index.

Malformed geo coordinates (out of the range `lat` in [-90;90] and `lon` in [-180;180]) will be ignored by index.
