### PR TITLE
Fixes replica set todos for collection state

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -71,7 +71,7 @@ pub struct Collection {
     path: PathBuf,
     snapshots_path: PathBuf,
     telemetry: CollectionTelemetry,
-    channel_service: ChannelService,
+    pub(crate) channel_service: ChannelService,
     transfer_tasks: Mutex<TransferTasksPool>,
 }
 


### PR DESCRIPTION
### Changes
1. Fixes https://github.com/qdrant/qdrant/issues/1094
3. Fixes https://github.com/qdrant/qdrant/issues/1093

Due to our current design, there is no need to generate replica_changes for `todo!("supply replica changes");`, as `handle_replica_changes` function assumes that it is the start of the operation. Instead everything is already handled based on supplied state.
