### PR TITLE
propagate payload index to temporary segment during optimization

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -17,3 +17,6 @@ storage:
   optimizers:
     # Minimum interval between forced flushes.
     flush_interval_sec: 5
+
+    # Do not create too much segments in dev
+    default_segment_number: 2

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -581,7 +581,7 @@ pub enum PayloadSchemaParams {
     Text(TextIndexParams),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum PayloadFieldSchema {

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -148,6 +148,7 @@ impl ConsensusOpWal {
 
             let mut buf = vec![];
             entry.encode(&mut buf)?;
+            #[allow(unused_variables)]
             let wal_index = self.0.append(&buf)?;
             #[cfg(debug_assertions)]
             if let Some(offset) = index_offset {


### PR DESCRIPTION
Temporary segments, created during the optimization, now should have same payload indexes as the optimized segments.
Temporary segments are then promoted to regular ones, should have same indexing pattern
