### PR TITLE
remove malformed doctest configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "qdrant"
 version = "0.10.4"
 authors = ["Andrey Vasnetsov <andrey@vasnetsov.com>"]
 edition = "2021"
-doctest = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Currently the build contains the following warning

```
warning: /home/agourlay/Workspace/qdrant/Cargo.toml: unused manifest key: package.doctest
```

Looking at the documentation, it seems that the key `doctest` is only valid within a `[lib]` section.

https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-doctest-field

Also we have no doc tests to run.

```
agourlay@agourlay-thinkpad:~/Workspace/qdrant$ cargo test --all --doc
    Finished test [unoptimized + debuginfo] target(s) in 0.19s
   Doc-tests api

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests collection

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests segment

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests storage

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

I propose to simply remove the key to have a warning free build.