### PR TITLE
Write lock for user requests

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -228,7 +228,6 @@ impl TableOfContent {
         operation: CreateCollection,
         collection_shard_distribution: CollectionShardDistribution,
     ) -> Result<bool, StorageError> {
-
         let CreateCollection {
             vectors,
             shard_number,
@@ -823,7 +822,6 @@ impl TableOfContent {
         shard_selection: Option<ShardId>,
         wait: bool,
     ) -> Result<UpdateResult, StorageError> {
-
         let collection = self.get_collection(collection_name).await?;
         let result = match shard_selection {
             Some(shard_selection) => {
@@ -834,7 +832,7 @@ impl TableOfContent {
             None => {
                 self.check_write_lock()?;
                 collection.update_from_client(operation, wait).await
-            },
+            }
         };
         result.map_err(|err| err.into())
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -830,7 +830,9 @@ impl TableOfContent {
                     .await
             }
             None => {
-                self.check_write_lock()?;
+                if operation.is_write_operation() {
+                    self.check_write_lock()?;
+                }
                 collection.update_from_client(operation, wait).await
             }
         };
@@ -1058,7 +1060,7 @@ impl TableOfContent {
 
     /// Returns an error if the write lock is set
     pub fn check_write_lock(&self) -> Result<(), StorageError> {
-        if operation.is_write_operation() && self.is_write_locked.load(Ordering::Relaxed) {
+        if self.is_write_locked.load(Ordering::Relaxed) {
             return Err(StorageError::Locked {
                 description: self
                     .lock_error_message

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -228,15 +228,6 @@ impl TableOfContent {
         operation: CreateCollection,
         collection_shard_distribution: CollectionShardDistribution,
     ) -> Result<bool, StorageError> {
-        if self.is_write_locked.load(Ordering::Relaxed) {
-            return Err(StorageError::Locked {
-                description: self
-                    .lock_error_message
-                    .lock()
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_WRITE_LOCK_ERROR_MESSAGE.to_string()),
-            });
-        }
 
         let CreateCollection {
             vectors,
@@ -832,15 +823,6 @@ impl TableOfContent {
         shard_selection: Option<ShardId>,
         wait: bool,
     ) -> Result<UpdateResult, StorageError> {
-        if operation.is_write_operation() && self.is_write_locked.load(Ordering::Relaxed) {
-            return Err(StorageError::Locked {
-                description: self
-                    .lock_error_message
-                    .lock()
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_WRITE_LOCK_ERROR_MESSAGE.to_string()),
-            });
-        }
 
         let collection = self.get_collection(collection_name).await?;
         let result = match shard_selection {
@@ -849,7 +831,10 @@ impl TableOfContent {
                     .update_from_peer(operation, shard_selection, wait)
                     .await
             }
-            None => collection.update_from_client(operation, wait).await,
+            None => {
+                self.check_write_lock()?;
+                collection.update_from_client(operation, wait).await
+            },
         };
         result.map_err(|err| err.into())
     }
@@ -1071,6 +1056,20 @@ impl TableOfContent {
 
     pub fn get_lock_error_message(&self) -> Option<String> {
         self.lock_error_message.lock().clone()
+    }
+
+    /// Returns an error if the write lock is set
+    pub fn check_write_lock(&self) -> Result<(), StorageError> {
+        if operation.is_write_operation() && self.is_write_locked.load(Ordering::Relaxed) {
+            return Err(StorageError::Locked {
+                description: self
+                    .lock_error_message
+                    .lock()
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_WRITE_LOCK_ERROR_MESSAGE.to_string()),
+            });
+        }
+        Ok(())
     }
 
     fn peer_has_shards_sync(&self, peer_id: PeerId) -> bool {

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -88,11 +88,8 @@ impl Dispatcher {
                 )
                 .await
         } else {
-            match &operation {
-                CollectionMetaOperations::CreateCollection(_) => {
-                    self.toc.check_write_lock()?;
-                }
-                _ => {}
+            if let CollectionMetaOperations::CreateCollection(_) = &operation {
+                self.toc.check_write_lock()?;
             }
             self.toc.perform_collection_meta_op(operation).await
         }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -47,6 +47,7 @@ impl Dispatcher {
         if let Some(state) = self.consensus_state.as_ref() {
             let op = match operation {
                 CollectionMetaOperations::CreateCollection(mut op) => {
+                    self.toc.check_write_lock()?;
                     debug_assert!(
                         op.take_distribution().is_none(),
                         "Distribution should be only set in this method."
@@ -87,6 +88,12 @@ impl Dispatcher {
                 )
                 .await
         } else {
+            match &operation {
+                CollectionMetaOperations::CreateCollection(_) => {
+                    self.toc.check_write_lock()?;
+                }
+                _ => {}
+            }
             self.toc.perform_collection_meta_op(operation).await
         }
     }

--- a/openapi/tests/openapi_integration/test_db_lock.py
+++ b/openapi/tests/openapi_integration/test_db_lock.py
@@ -1,0 +1,78 @@
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_collection'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    basic_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_lock_db_for_writes():
+    response = request_with_validation(
+        api='/locks',
+        method="POST",
+        path_params={},
+        body={
+            "write": True,
+            "error_message": "integration test"
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/locks',
+        method="GET",
+    )
+
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 10,
+                    "vector": [0.05, -0.61, -0.76, 0.74],
+                    "payload": {"city": "Gdansk"}
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert "integration test" in response.text
+
+    response = request_with_validation(
+        api='/locks',
+        method="POST",
+        path_params={},
+        body={
+            "write": False,
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 10,
+                    "vector": [0.05, -0.61, -0.76, 0.74],
+                    "payload": {"city": "Gdansk"}
+                }
+            ]
+        }
+    )
+    assert response.ok


### PR DESCRIPTION
Move write operation lock on the request level. Allow to apply write operations submitted by consensus or other peers even if lock exists - it should ensure cluster integrity and prevent chain reaction in case of lover resources.
Write operation lock should be applied on all nodes of the cluster and only in case if it is not possible to move shards for more even load distribution