### PR TITLE
Full reassign payload on upsert

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -543,6 +543,12 @@ impl Collection {
             let shards_holder = self.shards_holder.read().await;
             let shard_to_op = shards_holder.split_by_shard(operation);
 
+            if shard_to_op.is_empty() {
+                return Err(CollectionError::bad_request(format!(
+                    "Empty update request"
+                )));
+            }
+
             let shard_requests = shard_to_op
                 .into_iter()
                 .map(move |(shard, operation)| shard.update(operation, wait));

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -544,9 +544,9 @@ impl Collection {
             let shard_to_op = shards_holder.split_by_shard(operation);
 
             if shard_to_op.is_empty() {
-                return Err(CollectionError::bad_request(format!(
-                    "Empty update request"
-                )));
+                return Err(CollectionError::bad_request(
+                    "Empty update request".to_string(),
+                ));
             }
 
             let shard_requests = shard_to_op

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -158,7 +158,7 @@ fn upsert_with_payload(
 ) -> OperationResult<bool> {
     let mut res = segment.upsert_vector(op_num, point_id, vectors)?;
     if let Some(full_payload) = payload {
-        res &= segment.set_payload(op_num, point_id, full_payload)?;
+        res &= segment.set_full_payload(op_num, point_id, full_payload)?;
     }
     Ok(res)
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -58,10 +58,12 @@ pub trait ValueIndexer<T> {
     fn add_point(&mut self, id: PointOffsetType, payload: &Value) -> OperationResult<()> {
         match payload {
             Value::Array(values) => {
+                self.remove_point(id)?;
                 self.add_many(id, values.iter().flat_map(|x| self.get_value(x)).collect())
             }
             _ => {
                 if let Some(x) = self.get_value(payload) {
+                    self.remove_point(id)?;
                     self.add_many(id, vec![x])
                 } else {
                     Ok(())

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -92,7 +92,6 @@ impl FullTextIndex {
 
 impl ValueIndexer<String> for FullTextIndex {
     fn add_many(&mut self, idx: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
-
         if values.is_empty() {
             return Ok(());
         }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -92,9 +92,6 @@ impl FullTextIndex {
 
 impl ValueIndexer<String> for FullTextIndex {
     fn add_many(&mut self, idx: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
-        if self.get_doc(idx).is_some() {
-            self.remove_point(idx)?;
-        }
 
         if values.is_empty() {
             return Ok(());

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -284,7 +284,6 @@ impl GeoMapIndex {
         idx: PointOffsetType,
         values: &[GeoPoint],
     ) -> OperationResult<()> {
-
         if values.is_empty() {
             return Ok(());
         }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -284,11 +284,6 @@ impl GeoMapIndex {
         idx: PointOffsetType,
         values: &[GeoPoint],
     ) -> OperationResult<()> {
-        if let Some(existing_vals) = self.get_values(idx) {
-            if !existing_vals.is_empty() {
-                self.remove_point(idx)?;
-            }
-        }
 
         if values.is_empty() {
             return Ok(());

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -106,12 +106,6 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 
     fn add_many_to_map(&mut self, idx: PointOffsetType, values: Vec<N>) -> OperationResult<()> {
-        if let Some(existing_vals) = self.get_values(idx) {
-            if !existing_vals.is_empty() {
-                self.remove_point(idx)?;
-            }
-        }
-
         if values.is_empty() {
             return Ok(());
         }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -134,11 +134,6 @@ impl<T: KeyEncoder + KeyDecoder + FromRangeValue + ToRangeValue + Clone> Numeric
         idx: PointOffsetType,
         values: impl IntoIterator<Item = T>,
     ) -> OperationResult<()> {
-        if let Some(existing_vals) = self.get_values(idx) {
-            if !existing_vals.is_empty() {
-                self.remove_point(idx)?;
-            }
-        }
 
         if self.point_to_values.len() <= idx as usize {
             self.point_to_values.resize(idx as usize + 1, Vec::new())

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -134,7 +134,6 @@ impl<T: KeyEncoder + KeyDecoder + FromRangeValue + ToRangeValue + Clone> Numeric
         idx: PointOffsetType,
         values: impl IntoIterator<Item = T>,
     ) -> OperationResult<()> {
-
         if self.point_to_values.len() <= idx as usize {
             self.point_to_values.resize(idx as usize + 1, Vec::new())
         }


### PR DESCRIPTION
Now upsert will set exact payload as provided in the query and as it was intended.
(before fix it would override only specified fields)

Fixes replica sync transfer