### PR TITLE
Improve load testing k6 script

### DIFF
--- a/benches/service/collection_stress.js
+++ b/benches/service/collection_stress.js
@@ -1,19 +1,65 @@
 import http from "k6/http";
-import { check } from 'k6';
+import { check, group } from 'k6';
+import { Counter } from 'k6/metrics';
 
+// test system parameters
 let host = 'http://localhost:6333'
 let collection_name = 'stress_collection';
-let upsert_url = `${host}/collections/${collection_name}/points`;
+let shard_count = 1; // increase in distributed mode
+let replica_count = 1; // increase in distributed mode
 
+// urls
+let collection_url = `${host}/collections/${collection_name}`;
+let collection_index_url = `${host}/collections/${collection_name}/index`;
+let points_url = `${host}/collections/${collection_name}/points`;
+let points_search_url = `${host}/collections/${collection_name}/points/search`;
+
+// test payload parameters
 let vector_length = 128;
 let vectors_per_batch = 32;
+
+export const options = {
+    scenarios: {
+        upsert_points: {
+            // function to execute
+            exec: "upsert_points",
+            // execution options
+            executor: "ramping-vus",
+            stages: [{
+                duration: '1m', target: 30
+            }],
+        },
+        search_points: {
+            // schedule this scenario to start after the upserts (remove for mixed workload)
+            startTime: "1m",
+            // function to execute
+            exec: "search_points",
+            // execution options
+            executor: "ramping-vus",
+            stages: [{
+                duration: "1m", target: 30
+            }],
+        },
+    },
+};
+
+const pointsCount = new Counter('points_count');
 
 var create_collection_payload = JSON.stringify(
     {
         "vectors": {
             "size": vector_length,
             "distance": "Cosine"
-        }
+        },
+        "shard_number": shard_count,
+        "replication_factor": replica_count,
+    }
+);
+
+var create_payload_index_payload = JSON.stringify(
+    {
+        "field_name": "city",
+        "field_schema": "keyword"
     }
 );
 
@@ -76,44 +122,87 @@ var cities = [
     "Hangzhou"
 ]
 
+function random_vector() {
+    return Array.from({ length: vector_length }, () => Math.random());
+}
+
+function random_city() {
+    return cities[Math.round(Math.random()*(cities.length-1))];
+}
+
 function generate_point() {
     var idx = Math.floor(Math.random() * 1000000000);
     var count = Math.floor(Math.random() * 100);
-    var vector = Array.from({ length: vector_length }, () => Math.random());
-
-    var city = cities[Math.round(Math.random()*(cities.length-1))];
+    var vector = random_vector();
+    var city = random_city();
 
     return {
         "id": idx,
         "vector": vector,
         "payload": {
-            "city": { "type": "keyword", "value": city },
-            "count": { "type": "integer", "value": count }
+            "city": city,
+            "count": count
         }
     }
 }
 
 export function setup() {
-    var url = `${host}/collections/${collection_name}`;
-
-    let res_delete = http.del(url, params);
+    // delete collection
+    let res_delete = http.del(collection_url, params);
     check(res_delete, {
         'delete_collection_payload is status 200': (r) => r.status === 200,
     });
-    let res_create = http.put(url, create_collection_payload, params);
+
+    // create a new collection
+    let res_create = http.put(collection_url, create_collection_payload, params);
     check(res_create, {
         'create_collection_payload is status 200': (r) => r.status === 200,
     });
+
+    // add payload index
+    let res_index = http.put(collection_index_url, create_payload_index_payload, params);
+    check(res_index, {
+        'create_index_payload is status 200': (r) => r.status === 200,
+    });
 }
 
-export default function () {
+export function upsert_points() {
+    pointsCount.add(vectors_per_batch);
+    // points payload
     var payload = JSON.stringify({
         "points": Array.from({ length: vectors_per_batch }, () => generate_point()),
     });
-
-    let res_upsert = http.put(upsert_url, payload, params);
+    // run upsert
+    let res_upsert = http.put(points_url, payload, params);
     check(res_upsert, {
         'upsert_points is status 200': (r) => r.status === 200,
+    });
+}
+
+export function search_points() {
+    // generate random search query
+    var filter_payload =
+        {
+            "filter": {
+                "must": [
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": random_city()
+                        }
+                    }
+                ]
+            },
+            "with_vector": true,
+            "with_payload": true,
+            "vector": random_vector(),
+            "limit": 10
+        }
+
+    let res_get = http.post(points_search_url, JSON.stringify(filter_payload), params);
+    //console.log(res_get.body);
+    check(res_get, {
+        'search_points is status 200': (r) => r.status === 200,
     });
 }
 

--- a/benches/service/run.sh
+++ b/benches/service/run.sh
@@ -4,6 +4,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 
-docker run --network=host --rm -i loadimpact/k6 run -u 10 -i 500000 --duration 30m - <"$DIR/collection_stress.js"
+docker run --network=host --rm -i loadimpact/k6 run - <"$DIR/collection_stress.js"
 
 

--- a/benches/service/stress.sh
+++ b/benches/service/stress.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-HOST="http://localhost:6333"
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-


### PR DESCRIPTION
This PR improves our basic load testing [k6](https://k6.io/docs/) script to make it more useful.

It now runs two scenarios sequentially:
- upsert random points over 1 minute while ramping up the number of virtual users to 30
- search for points using an indexed payload using the same ramping scheme

The parameters are easy to tweak for different experiments and more scenarios can be added as well.

Separating the ingestion from the search enabled me to do some manual testing on a distributed setup locally.

Hopefully more people find it useful.