### PR TITLE
Record message send failures and stop consensus on service error

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4611,7 +4611,7 @@
                 "$ref": "#/components/schemas/ConsensusThreadStatus"
               },
               "message_send_failures": {
-                "description": "Failures of message send operations in consensus by peer address",
+                "description": "Consequent failures of message send operations in consensus by peer address. On the first success to send to that peer - entry is removed from this hashmap.",
                 "type": "object",
                 "additionalProperties": {
                   "$ref": "#/components/schemas/MessageSendErrors"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4578,6 +4578,7 @@
             "type": "object",
             "required": [
               "consensus_thread_status",
+              "message_send_failures",
               "peer_id",
               "peers",
               "raft_info",
@@ -4608,6 +4609,13 @@
               },
               "consensus_thread_status": {
                 "$ref": "#/components/schemas/ConsensusThreadStatus"
+              },
+              "message_send_failures": {
+                "description": "Failures of message send operations in consensus by peer address",
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/MessageSendErrors"
+                }
               }
             }
           }
@@ -4764,6 +4772,24 @@
             }
           }
         ]
+      },
+      "MessageSendErrors": {
+        "description": "Message send failures for a particular peer",
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "latest_error": {
+            "type": "string",
+            "nullable": true
+          }
+        }
       },
       "SnapshotDescription": {
         "type": "object",

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -26,7 +27,8 @@ use crate::content_manager::consensus::is_ready::IsReady;
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::consensus::persistent::Persistent;
 use crate::types::{
-    ClusterInfo, ClusterStatus, ConsensusThreadStatus, PeerAddressById, PeerInfo, RaftInfo,
+    ClusterInfo, ClusterStatus, ConsensusThreadStatus, MessageSendErrors, PeerAddressById,
+    PeerInfo, RaftInfo,
 };
 use crate::CollectionMetaOperations;
 
@@ -70,6 +72,7 @@ pub struct ConsensusState<C: CollectionContainer> {
     propose_sender: OperationSender,
     first_voter: RwLock<Option<PeerId>>,
     consensus_thread_status: RwLock<ConsensusThreadStatus>,
+    message_send_failures: RwLock<HashMap<String, MessageSendErrors>>,
 }
 
 impl<C: CollectionContainer> ConsensusState<C> {
@@ -91,7 +94,17 @@ impl<C: CollectionContainer> ConsensusState<C> {
             consensus_thread_status: RwLock::new(ConsensusThreadStatus::Working {
                 last_update: Utc::now(),
             }),
+            message_send_failures: Default::default(),
         }
+    }
+
+    pub fn record_message_send_failure<E: Error>(&self, peer_address: Uri, error: E) {
+        let mut message_send_failures = self.message_send_failures.write();
+        let mut entry = message_send_failures
+            .entry(peer_address.to_string())
+            .or_insert_with(Default::default);
+        entry.count += 1;
+        entry.latest_error = Some(error.to_string());
     }
 
     pub fn record_consensus_working(&self) {
@@ -162,6 +175,7 @@ impl<C: CollectionContainer> ConsensusState<C> {
                 is_voter,
             },
             consensus_thread_status: self.consensus_thread_status.read().clone(),
+            message_send_failures: self.message_send_failures.read().clone(),
         })
     }
 
@@ -280,7 +294,7 @@ impl<C: CollectionContainer> ConsensusState<C> {
 
         if let Err(err) = self.persistent.write().save_if_dirty() {
             log::error!("Failed to save new state of applied entries queue: {err}");
-            return false;
+            return true;
         }
 
         loop {
@@ -297,9 +311,9 @@ impl<C: CollectionContainer> ConsensusState<C> {
                     break;
                 }
             };
-            let do_increase_applied_index: bool = if entry.data.is_empty() {
+            let stop_consensus: bool = if entry.data.is_empty() {
                 // Empty entry, when the peer becomes Leader it will send an empty entry.
-                true
+                false
             } else {
                 match entry.get_entry_type() {
                     EntryType::EntryNormal => {
@@ -309,17 +323,17 @@ impl<C: CollectionContainer> ConsensusState<C> {
                                 log::debug!(
                                     "Successfully applied consensus operation entry. Index: {}. Result: {result}",
                                     entry.index);
-                                true
+                                false
                             }
                             Err(err @ StorageError::ServiceError { .. }) => {
                                 log::error!("Failed to apply collection meta operation entry with service error: {err}");
-                                // This is a service error, so we can try to reapply it later.
-                                false
+                                // This is a service error - stop consensus. Peer can be restarted when the problem is fixed.
+                                true
                             }
                             Err(err) => {
                                 log::warn!("Failed to apply collection meta operation entry with user error: {err}");
                                 // This is a user error so we can safely consider it applied but with error as it was incorrect.
-                                true
+                                false
                             }
                         }
                     }
@@ -330,33 +344,28 @@ impl<C: CollectionContainer> ConsensusState<C> {
                                     "Successfully applied configuration change entry. Index: {}.",
                                     entry.index
                                 );
-                                if stop_consensus {
-                                    return true;
-                                }
-                                true
+                                stop_consensus
                             }
                             Err(err) => {
                                 log::error!(
                                     "Failed to apply configuration change entry with error: {err}"
                                 );
-                                false
+                                true
                             }
                         }
                     }
                     ty => {
                         log::error!("Failed to apply entry: unsupported entry type {ty:?}");
-                        false
+                        true
                     }
                 }
             };
-
-            if do_increase_applied_index {
-                if let Err(err) = self.persistent.write().entry_applied() {
-                    log::error!("Failed to save new state of applied entries queue: {err}");
-                    break;
-                }
-            } else {
-                break;
+            if stop_consensus {
+                return stop_consensus;
+            }
+            if let Err(err) = self.persistent.write().entry_applied() {
+                log::error!("Failed to save new state of applied entries queue: {err}");
+                return true;
             }
         }
         false // do not stop consensus

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -108,7 +108,8 @@ pub struct ClusterInfo {
     pub raft_info: RaftInfo,
     /// Status of the thread that executes raft consensus
     pub consensus_thread_status: ConsensusThreadStatus,
-    /// Failures of message send operations in consensus by peer address
+    /// Consequent failures of message send operations in consensus by peer address.
+    /// On the first success to send to that peer - entry is removed from this hashmap.
     pub message_send_failures: HashMap<String, MessageSendErrors>,
 }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -90,6 +90,13 @@ impl From<raft::StateRole> for StateRole {
     }
 }
 
+/// Message send failures for a particular peer
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+pub struct MessageSendErrors {
+    pub count: usize,
+    pub latest_error: Option<String>,
+}
+
 /// Description of enabled cluster
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct ClusterInfo {
@@ -101,6 +108,8 @@ pub struct ClusterInfo {
     pub raft_info: RaftInfo,
     /// Status of the thread that executes raft consensus
     pub consensus_thread_status: ConsensusThreadStatus,
+    /// Failures of message send operations in consensus by peer address
+    pub message_send_failures: HashMap<String, MessageSendErrors>,
 }
 
 /// Information about current cluster status and structure
@@ -154,6 +163,7 @@ impl Anonymize for ClusterInfo {
                 .collect(),
             raft_info: self.raft_info.anonymize(),
             consensus_thread_status: self.consensus_thread_status.clone(),
+            message_send_failures: self.message_send_failures.clone(),
         }
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -577,6 +577,7 @@ impl Consensus {
         let bootstrap_uri = self.bootstrap_uri.clone();
         let consensus_config_arc = Arc::new(self.config.clone());
         let pool = self.channel_service.channel_pool.clone();
+        let store = self.store();
         let future = async move {
             let mut send_futures = Vec::new();
             for (message, address) in messages_with_address {
@@ -599,13 +600,9 @@ impl Consensus {
                         }
                     },
                 };
-                send_futures.push(send_message(address, message, pool.clone()));
+                send_futures.push(send_message(address, message, pool.clone(), store.clone()));
             }
-            for result in futures::future::join_all(send_futures).await {
-                if let Err(err) = result {
-                    log::warn!("Failed to send message: {err:#}")
-                }
-            }
+            futures::future::join_all(send_futures).await;
         };
         // Raft does not need the responses and should not wait for timeouts
         // so sending messages in parallel should be ok
@@ -657,21 +654,23 @@ async fn send_message(
     address: Uri,
     message: RaftMessage,
     transport_channel_pool: Arc<TransportChannelPool>,
-) -> anyhow::Result<()> {
+    store: ConsensusStateRef,
+) {
     let mut bytes = Vec::new();
-    <RaftMessage as prost::Message>::encode(&message, &mut bytes)
-        .context("Failed to serialize Raft message")?;
+    if let Err(err) = <RaftMessage as prost::Message>::encode(&message, &mut bytes) {
+        format!("Failed to serialize Raft message: {err}");
+    }
     let message = &GrpcRaftMessage { message: bytes };
 
-    let _response = transport_channel_pool
+    if let Err(err) = transport_channel_pool
         .with_channel(&address, |channel| async move {
             let mut client = RaftClient::new(channel);
             client.send(tonic::Request::new(message.clone())).await
         })
         .await
-        .context("Failed to send message")?;
-
-    Ok(())
+    {
+        store.record_message_send_failure(address, err);
+    }
 }
 
 #[cfg(test)]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -669,7 +669,9 @@ async fn send_message(
         })
         .await
     {
-        store.record_message_send_failure(address, err);
+        store.record_message_send_failure(&address, err);
+    } else {
+        store.record_message_send_success(&address)
     }
 }
 


### PR DESCRIPTION
1. Record message send failures instead of logging
2. Stop consensus on service error instead of trying to reapply
