### PR TITLE
exclude / from actix logger middleware

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -72,7 +72,7 @@ pub fn init(
 
             App::new()
                 .wrap(Condition::new(settings.service.enable_cors, cors))
-                .wrap(Logger::default())
+                .wrap(Logger::default().exclude("/")) // Avoid logging healthcheck requests
                 .wrap(actix_telemetry::ActixTelemetryTransform::new(
                     actix_telemetry_collector.clone(),
                 ))


### PR DESCRIPTION
Avoid this:

![image](https://user-images.githubusercontent.com/1935623/197060823-214e740d-7381-451c-af92-5c5daf8bcbff.png)
