### PR TITLE
Use less ram for id tracker

### DIFF
--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -35,13 +35,13 @@ impl FixtureIdTracker {
 }
 
 impl IdTracker for FixtureIdTracker {
-    fn version(&self, _external_id: PointIdType) -> Option<SeqNumberType> {
+    fn internal_version(&self, _internal_id: PointOffsetType) -> Option<SeqNumberType> {
         Some(0)
     }
 
-    fn set_version(
+    fn set_internal_version(
         &mut self,
-        _external_id: PointIdType,
+        _internal_id: PointOffsetType,
         _version: SeqNumberType,
     ) -> OperationResult<()> {
         Ok(())

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -8,13 +8,11 @@ use crate::types::{PointIdType, PointOffsetType, SeqNumberType};
 /// as well as for keeping track on point version
 /// Internal ids are useful for contiguous-ness
 pub trait IdTracker {
-    /// Returns version of the stored point
-    fn version(&self, external_id: PointIdType) -> Option<SeqNumberType>;
+    fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType>;
 
-    /// Update version of the point
-    fn set_version(
+    fn set_internal_version(
         &mut self,
-        external_id: PointIdType,
+        internal_id: PointOffsetType,
         version: SeqNumberType,
     ) -> OperationResult<()>;
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use bincode;
+use bitvec::vec::BitVec;
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};
@@ -52,31 +53,42 @@ fn external_to_stored_id(point_id: &PointIdType) -> StoredPointId {
 }
 
 pub struct SimpleIdTracker {
-    internal_to_external: HashMap<PointOffsetType, PointIdType>,
+    deleted: BitVec,
+    internal_to_external: Vec<PointIdType>,
     external_to_internal_num: BTreeMap<u64, PointOffsetType>,
     external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType>,
     external_to_version_num: HashMap<u64, SeqNumberType>,
     external_to_version_uuid: HashMap<Uuid, SeqNumberType>,
-    max_internal_id: PointOffsetType,
+    points_count: usize,
     mapping_db_wrapper: DatabaseColumnWrapper,
     versions_db_wrapper: DatabaseColumnWrapper,
 }
 
 impl SimpleIdTracker {
     pub fn open(store: Arc<RwLock<DB>>) -> OperationResult<Self> {
-        let mut internal_to_external: HashMap<PointOffsetType, PointIdType> = Default::default();
+        let mut deleted = BitVec::new();
+        let mut internal_to_external: Vec<PointIdType> = Default::default();
         let mut external_to_internal_num: BTreeMap<u64, PointOffsetType> = Default::default();
         let mut external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType> = Default::default();
         let mut external_to_version_num: HashMap<u64, SeqNumberType> = Default::default();
         let mut external_to_version_uuid: HashMap<Uuid, SeqNumberType> = Default::default();
-        let mut max_internal_id = 0;
+        let mut points_count = 0;
 
         let mapping_db_wrapper = DatabaseColumnWrapper::new(store.clone(), DB_MAPPING_CF);
         for (key, val) in mapping_db_wrapper.lock_db().iter()? {
             let external_id = Self::restore_key(&key);
-            let internal_id: PointOffsetType = bincode::deserialize(&val).unwrap();
-            let replaced = internal_to_external.insert(internal_id, external_id);
-            if let Some(replaced_id) = replaced {
+            let internal_id: PointOffsetType =
+                bincode::deserialize::<PointOffsetType>(&val).unwrap();
+            if internal_id as usize >= internal_to_external.len() {
+                internal_to_external.resize(internal_id as usize + 1, PointIdType::NumId(u64::MAX));
+            }
+            if internal_id as usize >= deleted.len() {
+                deleted.resize(internal_id as usize + 1, true);
+            }
+
+            let replaced_id = internal_to_external[internal_id as usize];
+            internal_to_external[internal_id as usize] = external_id;
+            if !deleted[internal_id as usize] {
                 // Fixing corrupted mapping - this id should be recovered from WAL
                 // This should not happen in normal operation, but it can happen if
                 // the database is corrupted.
@@ -93,7 +105,11 @@ impl SimpleIdTracker {
                         external_to_internal_uuid.remove(&uuid);
                     }
                 }
+            } else {
+                points_count += 1;
             }
+            deleted.set(internal_id as usize, false);
+
             match external_id {
                 PointIdType::NumId(idx) => {
                     external_to_internal_num.insert(idx, internal_id);
@@ -102,7 +118,6 @@ impl SimpleIdTracker {
                     external_to_internal_uuid.insert(uuid, internal_id);
                 }
             }
-            max_internal_id = max_internal_id.max(internal_id);
         }
 
         let versions_db_wrapper = DatabaseColumnWrapper::new(store, DB_VERSIONS_CF);
@@ -120,12 +135,13 @@ impl SimpleIdTracker {
         }
 
         Ok(SimpleIdTracker {
+            deleted,
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
             external_to_version_num,
             external_to_version_uuid,
-            max_internal_id,
+            points_count,
             mapping_db_wrapper,
             versions_db_wrapper,
         })
@@ -177,7 +193,12 @@ impl IdTracker for SimpleIdTracker {
     }
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
-        self.internal_to_external.get(&internal_id).copied()
+        if let Some(deleted) = self.deleted.get(internal_id as usize) {
+            if !deleted {
+                return self.internal_to_external.get(internal_id as usize).copied();
+            }
+        }
+        None
     }
 
     fn set_link(
@@ -193,8 +214,20 @@ impl IdTracker for SimpleIdTracker {
                 self.external_to_internal_uuid.insert(uuid, internal_id);
             }
         }
-        self.internal_to_external.insert(internal_id, external_id);
-        self.max_internal_id = self.max_internal_id.max(internal_id);
+
+        let internal_id = internal_id as usize;
+        if internal_id >= self.internal_to_external.len() {
+            self.internal_to_external
+                .resize(internal_id + 1, PointIdType::NumId(u64::MAX));
+        }
+        if internal_id >= self.deleted.len() {
+            self.deleted.resize(internal_id + 1, true);
+        }
+        self.internal_to_external[internal_id] = external_id;
+        if self.deleted[internal_id as usize] {
+            self.points_count += 1;
+        }
+        self.deleted.set(internal_id, false);
 
         self.mapping_db_wrapper.put(
             &Self::store_key(&external_id),
@@ -216,10 +249,13 @@ impl IdTracker for SimpleIdTracker {
             PointIdType::NumId(idx) => self.external_to_internal_num.remove(idx),
             PointIdType::Uuid(uuid) => self.external_to_internal_uuid.remove(uuid),
         };
-        match internal_id {
-            Some(x) => self.internal_to_external.remove(&x),
-            None => None,
-        };
+        if let Some(internal_id) = internal_id {
+            if !self.deleted[internal_id as usize] {
+                self.points_count -= 1;
+            }
+            self.deleted.set(internal_id as usize, true);
+            self.internal_to_external[internal_id as usize] = PointIdType::NumId(u64::MAX);
+        }
         self.mapping_db_wrapper
             .remove(&Self::store_key(&external_id))?;
         self.versions_db_wrapper
@@ -243,7 +279,10 @@ impl IdTracker for SimpleIdTracker {
     }
 
     fn iter_internal(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
-        Box::new(self.internal_to_external.keys().copied())
+        Box::new(
+            (0..self.internal_to_external.len() as PointOffsetType)
+                .filter(move |i| !self.deleted[*i as usize]),
+        )
     }
 
     fn iter_from(
@@ -295,7 +334,7 @@ impl IdTracker for SimpleIdTracker {
     }
 
     fn points_count(&self) -> usize {
-        self.internal_to_external.len()
+        self.points_count
     }
 
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
@@ -303,7 +342,7 @@ impl IdTracker for SimpleIdTracker {
     }
 
     fn max_id(&self) -> PointOffsetType {
-        self.max_internal_id
+        std::cmp::max(1, self.internal_to_external.len() as PointOffsetType) - 1
     }
 
     fn mapping_flusher(&self) -> Flusher {

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -433,4 +433,37 @@ mod tests {
         let last = id_tracker.iter_from(Some(first_four[3].0)).collect_vec();
         assert_eq!(last.len(), 7);
     }
+
+    #[test]
+    fn test_mixed_types_iterator() {
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+
+        let mut id_tracker = SimpleIdTracker::open(db).unwrap();
+
+        let mut values: Vec<PointIdType> = vec![
+            100.into(),
+            PointIdType::Uuid(Uuid::from_u128(123_u128)),
+            PointIdType::Uuid(Uuid::from_u128(156_u128)),
+            150.into(),
+            120.into(),
+            PointIdType::Uuid(Uuid::from_u128(12_u128)),
+            180.into(),
+            110.into(),
+            115.into(),
+            PointIdType::Uuid(Uuid::from_u128(673_u128)),
+            190.into(),
+            177.into(),
+            PointIdType::Uuid(Uuid::from_u128(971_u128)),
+        ];
+
+        for (id, value) in values.iter().enumerate() {
+            id_tracker.set_link(*value, id as PointOffsetType).unwrap();
+        }
+
+        let sorted_from_tracker = id_tracker.iter_from(None).map(|(k, _)| k).collect_vec();
+        values.sort();
+
+        assert_eq!(sorted_from_tracker, values);
+    }
 }

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -232,12 +232,12 @@ impl IdTracker for SimpleIdTracker {
             .external_to_internal_num
             .keys()
             .copied()
-            .map(|k| PointIdType::NumId(k));
+            .map(PointIdType::NumId);
         let iter_uuid = self
             .external_to_internal_uuid
             .keys()
             .copied()
-            .map(|k| PointIdType::Uuid(k));
+            .map(PointIdType::Uuid);
         // order is important here, we want to iterate over the u64 ids first
         Box::new(iter_num.chain(iter_uuid))
     }


### PR DESCRIPTION
After RAM usage investigation we got that simple id tracker requires a lot of RAM. For test storage with 3M points tracker uses `473MB`. This PR implements ram usage optimization for the id tracker. On test storage id tracker uses only `208MB`.

The method of measurement is simple. I used a separate binary that only loads the id tracker and does nothing. Ram is measured by `top`.

The main idea of reducing is avoiding complicated key for `BTreeMap` and reducing the lenght of `HashMap` using `Vec` instead.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
