### PR TITLE
remove suggesting changes in replications on replication factor change

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -2,7 +2,6 @@ use std::cmp::max;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -1482,45 +1481,6 @@ impl Collection {
         }
 
         Ok(())
-    }
-
-    pub async fn suggest_shard_replica_changes(
-        &self,
-        new_repl_factor: NonZeroU32,
-        _all_peers: HashSet<PeerId>,
-    ) -> CollectionResult<HashSet<replica_set::Change>> {
-        let changes: HashSet<Change> = HashSet::new();
-
-        let shard_holder = self.shards_holder.read().await;
-        let mut shard_to_peers: HashMap<ShardId, HashSet<PeerId>> = HashMap::new();
-
-        for (shard_id, replica_set) in shard_holder.get_shards() {
-            let peers = replica_set.peers();
-            shard_to_peers.insert(*shard_id, peers.keys().copied().collect());
-        }
-
-        // ToDo: functions to use:
-        // * suggest_transfer_source
-        // * suggest_peer_to_add_replica
-        // * suggest_peer_to_remove_replica
-
-        for (_shard_id, replica_set) in shard_holder.get_shards() {
-            let peers = replica_set.peers();
-            let current_number_of_replicas = peers.len();
-            let required_number_of_replicas = new_repl_factor.get() as usize;
-            if current_number_of_replicas < required_number_of_replicas {
-                // We need to add replicas
-                // ToDo add replicas
-                log::warn!("Automatic replica addition is not implemented yet");
-            }
-            if current_number_of_replicas > required_number_of_replicas {
-                // We need to remove replicas
-                // ToDo remove replicas
-                log::warn!("Automatic replica removal is not implemented yet");
-            }
-        }
-
-        Ok(changes)
     }
 
     pub async fn remove_shards_at_peer(&self, peer_id: PeerId) -> CollectionResult<()> {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -189,6 +189,14 @@ impl UpdateCollectionOperation {
         }
     }
 
+    // Returns `true` if there are replica changes associated with this operation
+    pub fn have_replica_changes(&self) -> bool {
+        self.shard_replica_changes
+            .as_ref()
+            .map(|changes| !changes.is_empty())
+            .unwrap_or(false)
+    }
+
     pub fn take_shard_replica_changes(&mut self) -> Option<Vec<replica_set::Change>> {
         self.shard_replica_changes.take()
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1083,26 +1083,6 @@ impl TableOfContent {
         shard_distribution
     }
 
-    pub async fn suggest_shard_replica_changes(
-        &self,
-        collection: &CollectionId,
-        new_repl_factor: NonZeroU32,
-    ) -> Result<HashSet<replica_set::Change>, StorageError> {
-        let n_peers = self.peer_address_by_id().len();
-        if new_repl_factor.get() as usize > n_peers {
-            log::warn!("Replication factor ({new_repl_factor}) is set higher than the number of peers ({n_peers}). Until more peers are added the collection will be underreplicated.")
-        }
-        let changes = self
-            .get_collection(collection)
-            .await?
-            .suggest_shard_replica_changes(
-                new_repl_factor,
-                self.peer_address_by_id().into_keys().collect(),
-            )
-            .await?;
-        Ok(changes)
-    }
-
     pub async fn get_telemetry_data(&self) -> Vec<CollectionTelemetry> {
         let mut result = Vec::new();
         let all_collections = self.all_collections().await;

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -79,21 +79,6 @@ impl Dispatcher {
                     op.set_distribution(shard_distribution);
                     CollectionMetaOperations::CreateCollection(op)
                 }
-                CollectionMetaOperations::UpdateCollection(mut op) => {
-                    if let Some(repl_factor) = op
-                        .update_collection
-                        .params
-                        .as_ref()
-                        .and_then(|params| params.replication_factor)
-                    {
-                        let changes = self
-                            .toc
-                            .suggest_shard_replica_changes(&op.collection_name, repl_factor)
-                            .await?;
-                        op.set_shard_replica_changes(changes.into_iter().collect());
-                    }
-                    CollectionMetaOperations::UpdateCollection(op)
-                }
                 op => op,
             };
 


### PR DESCRIPTION
Since we do not automatically re-balance the collection across peers on other events, it might make sense to do same in case of replication factor change. For sake of consistency