### PR TITLE
Use systematically assert_http_ok for better error reporting

### DIFF
--- a/tests/consensus_tests/assertions.py
+++ b/tests/consensus_tests/assertions.py
@@ -1,0 +1,10 @@
+import requests
+
+
+def assert_http_ok(response: requests.Response):
+    if response.status_code != 200:
+        if not response.content:
+            raise Exception(f"Http request failed with status {response.status_code} and no content")
+        else:
+            raise Exception(
+                f"Http request failed with status {response.status_code} and content:\n{response.json()}")

--- a/tests/consensus_tests/check_points.py
+++ b/tests/consensus_tests/check_points.py
@@ -1,7 +1,7 @@
 import requests
 import sys
 
-from utils import assert_http_ok
+from assertions import assert_http_ok
 
 # Check that 'search' returns the same results on all peers
 for i in range(2, len(sys.argv)):

--- a/tests/consensus_tests/check_points.py
+++ b/tests/consensus_tests/check_points.py
@@ -1,6 +1,7 @@
 import requests
 import sys
 
+from utils import assert_http_ok
 
 # Check that 'search' returns the same results on all peers
 for i in range(2, len(sys.argv)):
@@ -10,7 +11,7 @@ for i in range(2, len(sys.argv)):
            "top": 3,
        }
     )
-    assert r.status_code == 200
+    assert_http_ok(r)
     assert r.json()["result"][0]["id"] == 4
     assert r.json()["result"][1]["id"] == 1
     assert r.json()["result"][2]["id"] == 3

--- a/tests/consensus_tests/create_collection_and_check.py
+++ b/tests/consensus_tests/create_collection_and_check.py
@@ -2,6 +2,7 @@ import argparse
 import requests
 import time
 
+from utils import assert_http_ok
 
 parser = argparse.ArgumentParser("Create test collection")
 parser.add_argument("collection_name")
@@ -17,7 +18,7 @@ r = requests.put(
         },
         "shard_number": 6
     })
-assert r.status_code == 200, r.text
+assert_http_ok(r)
 
 # Wait
 time.sleep(5)
@@ -28,7 +29,7 @@ while True:
     exists = True
     for port in args.ports:
         r = requests.get(f"http://127.0.0.1:{port}/collections")
-        assert r.status_code == 200
+        assert_http_ok(r)
         collections = r.json()["result"]["collections"]
         exists &= any(collection["name"] == args.collection_name for collection in collections)
     if exists:

--- a/tests/consensus_tests/create_collection_and_check.py
+++ b/tests/consensus_tests/create_collection_and_check.py
@@ -2,7 +2,7 @@ import argparse
 import requests
 import time
 
-from utils import assert_http_ok
+from assertions import assert_http_ok
 
 parser = argparse.ArgumentParser("Create test collection")
 parser.add_argument("collection_name")

--- a/tests/consensus_tests/downscale_cluster.py
+++ b/tests/consensus_tests/downscale_cluster.py
@@ -2,7 +2,7 @@ import argparse
 import requests
 import time
 
-from utils import assert_http_ok
+from assertions import assert_http_ok
 
 parser = argparse.ArgumentParser("Move all shards to first node and detach the last one")
 parser.add_argument("collection_name")

--- a/tests/consensus_tests/downscale_cluster.py
+++ b/tests/consensus_tests/downscale_cluster.py
@@ -2,6 +2,7 @@ import argparse
 import requests
 import time
 
+from utils import assert_http_ok
 
 parser = argparse.ArgumentParser("Move all shards to first node and detach the last one")
 parser.add_argument("collection_name")
@@ -11,7 +12,7 @@ args = parser.parse_args()
 
 # Check collection cluster distribution
 r = requests.get(f"http://127.0.0.1:{args.ports[0]}/collections/{args.collection_name}/cluster")
-assert r.status_code == 200, r.text
+assert_http_ok(r)
 
 """
 Example output:
@@ -62,7 +63,7 @@ max_wait = 60
 # Check that the shard is moved
 while max_wait > 0:
     r = requests.get(f"http://127.0.0.1:{args.ports[0]}/collections/{args.collection_name}/cluster")
-    assert r.status_code == 200, r.text
+    assert_http_ok(r)
     collection_cluster_status = r.json()
 
     if len(collection_cluster_status["result"]["local_shards"]) == 0:
@@ -74,5 +75,5 @@ while max_wait > 0:
 
 # Disconnect peer from the cluster
 r = requests.delete(f"http://127.0.0.1:{args.ports[0]}/cluster/peer/{from_peer}?timeout=60")
-assert r.status_code == 200, r.text
+assert_http_ok(r)
 

--- a/tests/consensus_tests/insert_points.py
+++ b/tests/consensus_tests/insert_points.py
@@ -1,31 +1,32 @@
 import requests
 import sys
 
+from utils import assert_http_ok
 
 # Create points in peer's collection
 r = requests.put(
-   f"http://127.0.0.1:{sys.argv[2]}/collections/{sys.argv[1]}/points?wait=true", json={
-       "points": [
-           {
-               "id": 1,
-               "vector": [0.05, 0.61, 0.76, 0.74],
-               "payload": {
-                   "city": "Berlin",
-                   "country": "Germany",
-                   "count": 1000000,
-                   "square": 12.5,
-                   "coords": {"lat": 1.0, "lon": 2.0}
-               }
-           },
-           {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11],
-               "payload": {"city": ["Berlin", "London"]}},
-           {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94],
-               "payload": {"city": ["Berlin", "Moscow"]}},
-           {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
-               "payload": {"city": ["London", "Moscow"]}},
-           {"id": 5, "vector": [0.24, 0.18, 0.22,
-                                0.44], "payload": {"count": [0]}},
-           {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
-       ]
-   })
-assert r.status_code == 200, r.text
+    f"http://127.0.0.1:{sys.argv[2]}/collections/{sys.argv[1]}/points?wait=true", json={
+        "points": [
+            {
+                "id": 1,
+                "vector": [0.05, 0.61, 0.76, 0.74],
+                "payload": {
+                    "city": "Berlin",
+                    "country": "Germany",
+                    "count": 1000000,
+                    "square": 12.5,
+                    "coords": {"lat": 1.0, "lon": 2.0}
+                }
+            },
+            {"id": 2, "vector": [0.19, 0.81, 0.75, 0.11],
+             "payload": {"city": ["Berlin", "London"]}},
+            {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94],
+             "payload": {"city": ["Berlin", "Moscow"]}},
+            {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80],
+             "payload": {"city": ["London", "Moscow"]}},
+            {"id": 5, "vector": [0.24, 0.18, 0.22,
+                                 0.44], "payload": {"count": [0]}},
+            {"id": 6, "vector": [0.35, 0.08, 0.11, 0.44]}
+        ]
+    })
+assert_http_ok(r)

--- a/tests/consensus_tests/insert_points.py
+++ b/tests/consensus_tests/insert_points.py
@@ -1,8 +1,7 @@
 import requests
 import sys
 
-from utils import assert_http_ok
-
+from assertions import assert_http_ok
 # Create points in peer's collection
 r = requests.put(
     f"http://127.0.0.1:{sys.argv[2]}/collections/{sys.argv[1]}/points?wait=true", json={

--- a/tests/consensus_tests/test_collection_created_after.py
+++ b/tests/consensus_tests/test_collection_created_after.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 5
 

--- a/tests/consensus_tests/test_collection_created_before.py
+++ b/tests/consensus_tests/test_collection_created_before.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 5
 N_SHARDS = 6

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -2,6 +2,7 @@ import pathlib
 import time
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 2
 N_SHARDS = 2

--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 3
 N_SHARDS = 4

--- a/tests/consensus_tests/test_collection_sharding.py
+++ b/tests/consensus_tests/test_collection_sharding.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 5
 N_SHARDS = 4

--- a/tests/consensus_tests/test_many_collections.py
+++ b/tests/consensus_tests/test_many_collections.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 5
 N_COLLECTIONS = 20

--- a/tests/consensus_tests/test_points_search.py
+++ b/tests/consensus_tests/test_points_search.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 5
 N_SHARDS = 4

--- a/tests/consensus_tests/test_recover_dead_node.py
+++ b/tests/consensus_tests/test_recover_dead_node.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 3
 N_SHARDS = 4

--- a/tests/consensus_tests/test_recover_dead_node.py
+++ b/tests/consensus_tests/test_recover_dead_node.py
@@ -56,7 +56,9 @@ def search(peer_url, city):
             ]
         }
     }
-    return requests.post(f"{peer_url}/collections/test_collection/points/search", json=q).json()["result"]
+    r_search = requests.post(f"{peer_url}/collections/test_collection/points/search", json=q)
+    assert_http_ok(r_search)
+    return r_search.json()["result"]
 
 
 def test_recover_dead_node(tmp_path: pathlib.Path):

--- a/tests/consensus_tests/test_remove_node.py
+++ b/tests/consensus_tests/test_remove_node.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from .utils import *
+from .assertions import assert_http_ok
 
 N_PEERS = 3
 N_SHARDS = 4

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -51,7 +51,7 @@ def assert_http_ok(response: requests.Response):
             raise Exception(f"Http request failed with status {response.status_code} and no content")
         else:
             raise Exception(
-                f"Http request failed with status {response.status_code} and contents:\n{response.json()}")
+                f"Http request failed with status {response.status_code} and content:\n{response.json()}")
 
 
 def assert_project_root():
@@ -333,7 +333,7 @@ def wait_collection_on_all_peers(collection_name: str, peer_api_uris: [str], max
         exists = True
         for url in peer_api_uris:
             r = requests.get(f"{url}/collections")
-            assert r.status_code == 200
+            assert_http_ok(r)
             collections = r.json()["result"]["collections"]
             exists &= any(collection["name"] == collection_name for collection in collections)
         if exists:

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -9,6 +9,7 @@ import socket
 from contextlib import closing
 from pathlib import Path
 import pytest
+from .assertions import assert_http_ok
 
 # Tracks processes that need to be killed at the end of the test
 processes = []
@@ -43,15 +44,6 @@ def get_env(p2p_port: int, grpc_port: int, http_port: int) -> dict[str, str]:
 
 def get_uri(port: int) -> str:
     return f"http://127.0.0.1:{port}"
-
-
-def assert_http_ok(response: requests.Response):
-    if response.status_code != 200:
-        if not response.content:
-            raise Exception(f"Http request failed with status {response.status_code} and no content")
-        else:
-            raise Exception(
-                f"Http request failed with status {response.status_code} and content:\n{response.json()}")
 
 
 def assert_project_root():


### PR DESCRIPTION
This PR modifies the consensus test to systematically use `assert_http_ok` for better error reporting.
