### PR TITLE
enable HTTP compression middleware

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
-use actix_web::middleware::{Condition, Logger};
+use actix_web::middleware::{Compress, Condition, Logger};
 use actix_web::web::Data;
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use storage::dispatcher::Dispatcher;
@@ -71,6 +71,7 @@ pub fn init(
                 .allow_any_header();
 
             App::new()
+                .wrap(Compress::default()) // Reads the `Accept-Encoding` header to negotiate which compression codec to use.
                 .wrap(Condition::new(settings.service.enable_cors, cors))
                 .wrap(Logger::default().exclude("/")) // Avoid logging healthcheck requests
                 .wrap(actix_telemetry::ActixTelemetryTransform::new(


### PR DESCRIPTION
This PR enables the HTTP compression middleware from actix-web.

> Compress will read the Accept-Encoding header to negotiate which compression codec to use. Payloads are not compressed if the header is not sent.

By [default](https://github.com/actix/actix-web/blob/master/actix-web/Cargo.toml#L31) it supports gzip, brotli and zstd.

We can then decide if we want to request by default compressed payload in our drivers. 