### PR TITLE
handle collections transition from single-node to cluster

### DIFF
--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -330,6 +330,10 @@ impl ShardReplicaSet {
         if replica_state.read().this_peer_id != this_peer_id {
             replica_state
                 .write(|rs| {
+                    let local_state = rs.peers.remove(&rs.this_peer_id);
+                    if let Some(state) = local_state {
+                        rs.peers.insert(this_peer_id, state);
+                    }
                     rs.this_peer_id = this_peer_id;
                 })
                 .map_err(|e| {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -140,6 +140,10 @@ impl CreateCollectionOperation {
         }
     }
 
+    pub fn is_distribution_set(&self) -> bool {
+        self.distribution.is_some()
+    }
+
     pub fn take_distribution(&mut self) -> Option<ShardDistributionProposal> {
         self.distribution.take()
     }

--- a/lib/storage/src/content_manager/consensus_state.rs
+++ b/lib/storage/src/content_manager/consensus_state.rs
@@ -436,6 +436,11 @@ impl<C: CollectionContainer> ConsensusState<C> {
             .apply_state_update(move |state| state.conf_state = conf_state)
     }
 
+    /// Check if the consensus have empty operations log
+    pub fn is_new_deployment(&self) -> bool {
+        self.hard_state().term == 0
+    }
+
     pub fn hard_state(&self) -> raft::eraftpb::HardState {
         self.persistent.read().state().hard_state.clone()
     }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -51,32 +51,31 @@ impl Dispatcher {
             let op = match operation {
                 CollectionMetaOperations::CreateCollection(mut op) => {
                     self.toc.check_write_lock()?;
-                    debug_assert!(
-                        op.take_distribution().is_none(),
-                        "Distribution should be only set in this method."
-                    );
-                    let number_of_peers = state.0.peer_count();
-                    let shard_distribution = self
-                        .toc
-                        .suggest_shard_distribution(
-                            &op,
-                            NonZeroU32::new(number_of_peers as u32)
-                                .expect("Peer count should be always >= 1"),
-                        )
-                        .await;
+                    if !op.is_distribution_set() {
+                        // Suggest even distribution of shards across nodes
+                        let number_of_peers = state.0.peer_count();
+                        let shard_distribution = self
+                            .toc
+                            .suggest_shard_distribution(
+                                &op,
+                                NonZeroU32::new(number_of_peers as u32)
+                                    .expect("Peer count should be always >= 1"),
+                            )
+                            .await;
 
-                    // Expect all replicas to become active eventually
-                    for (shard_id, peer_ids) in &shard_distribution.distribution {
-                        for peer_id in peer_ids {
-                            expect_operations.push(ConsensusOperations::activate_replica(
-                                op.collection_name.clone(),
-                                *shard_id,
-                                *peer_id,
-                            ));
+                        // Expect all replicas to become active eventually
+                        for (shard_id, peer_ids) in &shard_distribution.distribution {
+                            for peer_id in peer_ids {
+                                expect_operations.push(ConsensusOperations::activate_replica(
+                                    op.collection_name.clone(),
+                                    *shard_id,
+                                    *peer_id,
+                                ));
+                            }
                         }
-                    }
 
-                    op.set_distribution(shard_distribution);
+                        op.set_distribution(shard_distribution);
+                    }
                     CollectionMetaOperations::CreateCollection(op)
                 }
                 CollectionMetaOperations::UpdateCollection(mut op) => {

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -21,6 +21,7 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
 
     runtime::Builder::new_multi_thread()
         .worker_threads(search_threads)
+        .enable_time()
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
             let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -154,8 +154,7 @@ impl Consensus {
             .build()?;
         let (sender, receiver) = mpsc::sync_channel(config.max_message_queue_size);
         // State might be initialized but the node might be shutdown without actually syncing or committing anything.
-        let is_new_deployment = state_ref.hard_state().term == 0;
-        if is_new_deployment {
+        if state_ref.is_new_deployment() {
             let leader_established_in_ms =
                 config.tick_period_ms * raft_config.max_election_tick() as u64;
             Self::init(

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod single_to_cluster;

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use collection::shards::replica_set::ReplicaState;
+use collection::shards::shard::PeerId;
+use storage::content_manager::collection_meta_ops::{
+    CollectionMetaOperations, CreateCollection, CreateCollectionOperation, SetShardReplicaState,
+};
+use storage::content_manager::consensus_state::ConsensusStateRef;
+use storage::content_manager::shard_distribution::ShardDistributionProposal;
+use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
+
+/// Processes the existing collections, which were created outside the consensus:
+/// - during the migration from single to cluster
+/// - during restoring from a backup
+pub async fn handle_existing_collections(
+    toc_arc: Arc<TableOfContent>,
+    consensus_state: ConsensusStateRef,
+    dispatcher_arc: Arc<Dispatcher>,
+    this_peer_id: PeerId,
+    collections: Vec<String>,
+) {
+    consensus_state.is_leader_established.await_ready();
+    for collection in collections {
+        let collection_obj = match toc_arc.get_collection(&collection).await {
+            Ok(collection_obj) => collection_obj,
+            Err(_) => break,
+        };
+
+        let collection_state = collection_obj.state().await;
+        let shards_number = collection_state.config.params.shard_number.get();
+
+        let mut collection_create_operation = CreateCollectionOperation::new(
+            collection.to_string(),
+            CreateCollection {
+                vectors: collection_state.config.params.vectors,
+                shard_number: Some(shards_number),
+                replication_factor: Some(collection_state.config.params.replication_factor.get()),
+                write_consistency_factor: Some(
+                    collection_state
+                        .config
+                        .params
+                        .write_consistency_factor
+                        .get(),
+                ),
+                on_disk_payload: Some(collection_state.config.params.on_disk_payload),
+                hnsw_config: Some(collection_state.config.hnsw_config.into()),
+                wal_config: Some(collection_state.config.wal_config.into()),
+                optimizers_config: Some(collection_state.config.optimizer_config.into()),
+            },
+        );
+
+        collection_create_operation.set_distribution(ShardDistributionProposal {
+            distribution: collection_state
+                .shards
+                .iter()
+                .filter_map(|(shard_id, shard_info)| {
+                    if shard_info.replicas.contains_key(&this_peer_id) {
+                        Some((*shard_id, vec![this_peer_id]))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        });
+
+        let _res = dispatcher_arc
+            .submit_collection_meta_op(
+                CollectionMetaOperations::CreateCollection(collection_create_operation),
+                None,
+            )
+            .await;
+        for (shard_id, shard_info) in collection_state.shards {
+            if shard_info.replicas.contains_key(&this_peer_id) {
+                let _res = dispatcher_arc
+                    .submit_collection_meta_op(
+                        CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
+                            collection_name: collection.to_string(),
+                            shard_id,
+                            peer_id: this_peer_id,
+                            state: ReplicaState::Active,
+                        }),
+                        None,
+                    )
+                    .await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
In cases of:

- collection is restored from snapshot
- instance with existing collections upgraded from single-node to cluster

we need to explicitly tell to the consensus, that those collections exists.
So it could replay related changes on all nodes in the cluster.

`handle_existing_collections` sends suggestions to create collection with proposed shard distribution equal to the local peer and marks newly registered shards as `Active`.

Test scenario:

- Create collection with single node deployment
- Kill and re-run qdrant in cluster deployment
- Attach another peer to cluster
- Replicate collection shard to the new node

Warn:

Log messages like:

```
[2022-11-03T22:12:09.272Z WARN  storage::content_manager::consensus_state] Failed to apply collection meta operation entry with user error: Wrong input: Collection `test_collection` already exists!
```

are expected in this scenario




