### PR TITLE
Hnsw links memmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "segment"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atomic_refcell",
  "atomicwrites",

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -412,6 +412,7 @@
 | ef_construct | [uint64](#uint64) | optional | Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index. |
 | full_scan_threshold | [uint64](#uint64) | optional | Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won&#39;t be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256 |
 | max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
+| on_disk | [bool](#bool) | optional | Store HNSW index on disk. If set to false, index will be stored in RAM. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2909,6 +2909,11 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          },
+          "on_disk": {
+            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2911,9 +2911,10 @@
             "minimum": 0
           },
           "on_disk": {
-            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM.",
-            "default": false,
-            "type": "boolean"
+            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
+            "default": null,
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -4082,6 +4083,12 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0,
+            "nullable": true
+          },
+          "on_disk": {
+            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
+            "default": null,
+            "type": "boolean",
             "nullable": true
           }
         }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -818,6 +818,7 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             ef_construct: hnsw_config.ef_construct.unwrap_or_default() as usize,
             full_scan_threshold: hnsw_config.full_scan_threshold.unwrap_or_default() as usize,
             max_indexing_threads: hnsw_config.max_indexing_threads.unwrap_or_default() as usize,
+            on_disk: hnsw_config.on_disk.unwrap_or_default(),
         }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -818,7 +818,7 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             ef_construct: hnsw_config.ef_construct.unwrap_or_default() as usize,
             full_scan_threshold: hnsw_config.full_scan_threshold.unwrap_or_default() as usize,
             max_indexing_threads: hnsw_config.max_indexing_threads.unwrap_or_default() as usize,
-            on_disk: hnsw_config.on_disk.unwrap_or_default(),
+            on_disk: hnsw_config.on_disk,
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -86,6 +86,10 @@ message HnswConfigDiff {
   Number of parallel threads used for background index building. If 0 - auto selection.
    */
   optional uint64 max_indexing_threads = 4;
+  /*
+  Store HNSW index on disk. If set to false, index will be stored in RAM.
+   */
+  optional bool on_disk = 5;
 }
 
 message WalConfigDiff {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -86,6 +86,10 @@ pub struct HnswConfigDiff {
     ///Number of parallel threads used for background index building. If 0 - auto selection.
     #[prost(uint64, optional, tag="4")]
     pub max_indexing_threads: ::core::option::Option<u64>,
+    ///
+    ///Store HNSW index on disk. If set to false, index will be stored in RAM.
+    #[prost(bool, optional, tag="5")]
+    pub on_disk: ::core::option::Option<bool>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -48,6 +48,9 @@ pub struct HnswConfigDiff {
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "full_scan_threshold_kb")]
     pub full_scan_threshold: Option<usize>,
+    /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false
+    #[serde(default)]
+    pub on_disk: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Merge, PartialEq, Eq, Hash)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -30,6 +30,7 @@ impl From<api::grpc::qdrant::HnswConfigDiff> for HnswConfigDiff {
             m: value.m.map(|v| v as usize),
             ef_construct: value.ef_construct.map(|v| v as usize),
             full_scan_threshold: value.full_scan_threshold.map(|v| v as usize),
+            on_disk: value.on_disk,
         }
     }
 }
@@ -149,7 +150,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     ef_construct: Some(config.hnsw_config.ef_construct as u64),
                     full_scan_threshold: Some(config.hnsw_config.full_scan_threshold as u64),
                     max_indexing_threads: Some(config.hnsw_config.max_indexing_threads as u64),
-                    on_disk: Some(config.hnsw_config.on_disk),
+                    on_disk: config.hnsw_config.on_disk,
                 }),
                 optimizer_config: Some(api::grpc::qdrant::OptimizersConfigDiff {
                     deleted_threshold: Some(config.optimizer_config.deleted_threshold),

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -149,6 +149,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     ef_construct: Some(config.hnsw_config.ef_construct as u64),
                     full_scan_threshold: Some(config.hnsw_config.full_scan_threshold as u64),
                     max_indexing_threads: Some(config.hnsw_config.max_indexing_threads as u64),
+                    on_disk: Some(config.hnsw_config.on_disk),
                 }),
                 optimizer_config: Some(api::grpc::qdrant::OptimizersConfigDiff {
                     deleted_threshold: Some(config.optimizer_config.deleted_threshold),

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segment"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
 edition = "2021"
 

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -7,6 +7,7 @@ use segment::data_types::vectors::VectorElementType;
 use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+use segment::index::hnsw_index::graph_links::GraphLinksRam;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::metric::Metric;
 use segment::spaces::simple::CosineMetric;
@@ -22,7 +23,7 @@ const USE_HEURISTIC: bool = true;
 
 fn build_index<TMetric: Metric>(
     num_vectors: usize,
-) -> (TestRawScorerProducer<TMetric>, GraphLayers) {
+) -> (TestRawScorerProducer<TMetric>, GraphLayers<GraphLinksRam>) {
     let mut rng = thread_rng();
 
     let vector_holder = TestRawScorerProducer::<TMetric>::new(DIM, num_vectors, &mut rng);

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -38,7 +38,10 @@ fn build_index<TMetric: Metric>(
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
-    (vector_holder, graph_layers_builder.into_graph_layers(None).unwrap())
+    (
+        vector_holder,
+        graph_layers_builder.into_graph_layers(None).unwrap(),
+    )
 }
 
 fn hnsw_build_asymptotic(c: &mut Criterion) {

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -38,7 +38,7 @@ fn build_index<TMetric: Metric>(
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
-    (vector_holder, graph_layers_builder.into_graph_layers())
+    (vector_holder, graph_layers_builder.into_graph_layers(None).unwrap())
 }
 
 fn hnsw_build_asymptotic(c: &mut Criterion) {

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -35,7 +35,9 @@ fn hnsw_benchmark(c: &mut Criterion) {
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
-    let graph_layers = graph_layers_builder.into_graph_layers::<GraphLinksRam>(None).unwrap();
+    let graph_layers = graph_layers_builder
+        .into_graph_layers::<GraphLinksRam>(None)
+        .unwrap();
 
     group.bench_function("hnsw_search", |b| {
         b.iter(|| {

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -5,6 +5,7 @@ use rand::rngs::StdRng;
 use rand::{thread_rng, SeedableRng};
 use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+use segment::index::hnsw_index::graph_links::GraphLinksRam;
 use segment::index::hnsw_index::point_scorer::FilteredScorer;
 use segment::spaces::simple::CosineMetric;
 use segment::types::PointOffsetType;
@@ -34,7 +35,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
-    let graph_layers = graph_layers_builder.into_graph_layers();
+    let graph_layers = graph_layers_builder.into_graph_layers::<GraphLinksRam>();
 
     group.bench_function("hnsw_search", |b| {
         b.iter(|| {

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -35,7 +35,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
-    let graph_layers = graph_layers_builder.into_graph_layers::<GraphLinksRam>();
+    let graph_layers = graph_layers_builder.into_graph_layers::<GraphLinksRam>(None).unwrap();
 
     group.bench_function("hnsw_search", |b| {
         b.iter(|| {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -200,45 +200,6 @@ impl GraphLayersBase for GraphLayers {
 ///
 /// Assume all scores are similarities. Larger score = closer points
 impl GraphLayers {
-    fn new_with_params(
-        num_vectors: usize, // Initial number of points in index
-        m: usize,           // Expected M for non-first layer
-        m0: usize,          // Expected M for first layer
-        ef_construct: usize,
-        entry_points_num: usize, // Depends on number of points
-        reserve: bool,
-    ) -> Self {
-        let mut links_layers: Vec<LayersContainer> = vec![];
-
-        for _i in 0..num_vectors {
-            let mut links: LinkContainer = Vec::new();
-            if reserve {
-                links.reserve(m0);
-            }
-            links_layers.push(vec![links]);
-        }
-
-        GraphLayers {
-            max_level: 0,
-            m,
-            m0,
-            ef_construct,
-            links: Default::default(),
-            entry_points: EntryPoints::new(entry_points_num),
-            visited_pool: VisitedPool::new(),
-        }
-    }
-
-    pub fn new(
-        num_vectors: usize, // Initial number of points in index
-        m: usize,           // Expected M for non-first layer
-        m0: usize,          // Expected M for first layer
-        ef_construct: usize,
-        entry_points_num: usize, // Depends on number of points
-    ) -> Self {
-        Self::new_with_params(num_vectors, m, m0, ef_construct, entry_points_num, true)
-    }
-
     fn num_points(&self) -> usize {
         self.links.num_points()
     }
@@ -348,8 +309,15 @@ mod tests {
         let vector_holder =
             TestRawScorerProducer::<DotProductMetric>::new(dim, num_vectors, &mut rng);
 
-        let mut graph_layers =
-            GraphLayers::new(num_vectors, m, m * 2, ef_construct, entry_points_num);
+        let mut graph_layers = GraphLayers {
+            max_level: 0,
+            m,
+            m0: 2 * m,
+            ef_construct,
+            links: Default::default(),
+            entry_points: EntryPoints::new(entry_points_num),
+            visited_pool: VisitedPool::new(),
+        };
 
         let mut graph_links = vec![vec![Vec::new()]; num_vectors];
         graph_links[0][0] = vec![1, 2, 3, 4, 5, 6];

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -187,8 +187,7 @@ impl<TGraphLinks: GraphLinks> GraphLayersBase for GraphLayers<TGraphLinks> {
 /// Object contains links between nodes for HNSW search
 ///
 /// Assume all scores are similarities. Larger score = closer points
-impl<TGraphLinks: GraphLinks> GraphLayers<TGraphLinks>
-{
+impl<TGraphLinks: GraphLinks> GraphLayers<TGraphLinks> {
     pub fn point_level(&self, point_id: PointOffsetType) -> usize {
         self.links.point_level(point_id)
     }
@@ -229,7 +228,8 @@ impl<TGraphLinks: GraphLinks> GraphLayers<TGraphLinks>
 }
 
 impl<TGraphLinks> GraphLayers<TGraphLinks>
-where TGraphLinks: GraphLinks
+where
+    TGraphLinks: GraphLinks,
 {
     pub fn load(graph_path: &Path, links_path: &Path) -> OperationResult<Self> {
         let try_self: Result<Self, _> = read_bin(graph_path);
@@ -239,7 +239,7 @@ where TGraphLinks: GraphLinks
                 let links = TGraphLinks::load_from_file(links_path)?;
                 slf.links = links;
                 Ok(slf)
-            },
+            }
             Err(err) => {
                 let try_legacy: Result<GraphLayersBackwardCompatibility, _> = read_bin(graph_path);
                 if let Ok(legacy) = try_legacy {
@@ -367,8 +367,14 @@ mod tests {
 
         let dir = Builder::new().prefix("graph_dir").tempdir().unwrap();
         let links_path = GraphLayers::<GraphLinksRam>::get_links_path(dir.path());
-        let (vector_holder, graph_layers) =
-            create_graph_layer_fixture::<CosineMetric, _>(num_vectors, M, dim, false, &mut rng, Some(&links_path));
+        let (vector_holder, graph_layers) = create_graph_layer_fixture::<CosineMetric, _>(
+            num_vectors,
+            M,
+            dim,
+            false,
+            &mut rng,
+            Some(&links_path),
+        );
 
         let query = random_vector(&mut rng, dim);
 
@@ -443,8 +449,14 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(42);
 
-        let (vector_holder, graph_layers) =
-            create_graph_layer_fixture::<CosineMetric, _>(num_vectors, M, dim, true, &mut rng, None);
+        let (vector_holder, graph_layers) = create_graph_layer_fixture::<CosineMetric, _>(
+            num_vectors,
+            M,
+            dim,
+            true,
+            &mut rng,
+            None,
+        );
 
         let graph_json = serde_json::to_string_pretty(&graph_layers).unwrap();
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::graph_links::GraphLinks;
-use crate::common::file_operations::{atomic_save_bin, read_bin};
+use crate::common::file_operations::{atomic_save_bin, read_bin, FileStorageError};
 use crate::common::utils::rev_range;
 use crate::entry::entry_point::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
@@ -232,7 +232,14 @@ where
     TGraphLinks: GraphLinks,
 {
     pub fn load(graph_path: &Path, links_path: &Path) -> OperationResult<Self> {
-        let try_self: Result<Self, _> = read_bin(graph_path);
+        let try_self: Result<Self, FileStorageError> = if links_path.exists() {
+            read_bin(graph_path)
+        } else {
+            Err(FileStorageError::generic_error(&format!(
+                "Links file does not exists: {:?}",
+                links_path
+            )))
+        };
 
         match try_self {
             Ok(mut slf) => {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -35,7 +35,6 @@ pub struct GraphLayersBackwardCompatibility {
 impl From<GraphLayersBackwardCompatibility> for GraphLayers {
     fn from(gl: GraphLayersBackwardCompatibility) -> Self {
         GraphLayers {
-            max_level: gl.max_level,
             m: gl.m,
             m0: gl.m0,
             ef_construct: gl.ef_construct,
@@ -48,7 +47,6 @@ impl From<GraphLayersBackwardCompatibility> for GraphLayers {
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct GraphLayers {
-    pub(super) max_level: usize,
     pub(super) m: usize,
     pub(super) m0: usize,
     pub(super) ef_construct: usize,
@@ -310,7 +308,6 @@ mod tests {
             TestRawScorerProducer::<DotProductMetric>::new(dim, num_vectors, &mut rng);
 
         let mut graph_layers = GraphLayers {
-            max_level: 0,
             m,
             m0: 2 * m,
             ef_construct,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -73,7 +73,6 @@ impl GraphLayersBuilder {
             .collect();
 
         GraphLayers {
-            max_level: self.max_level.load(std::sync::atomic::Ordering::Relaxed),
             m: self.m,
             m0: self.m0,
             ef_construct: self.ef_construct,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -67,7 +67,10 @@ impl GraphLayersBase for GraphLayersBuilder {
 }
 
 impl GraphLayersBuilder {
-    pub fn into_graph_layers<TGraphLinks: GraphLinks>(self, path: Option<&Path>) -> OperationResult<GraphLayers<TGraphLinks>> {
+    pub fn into_graph_layers<TGraphLinks: GraphLinks>(
+        self,
+        path: Option<&Path>,
+    ) -> OperationResult<GraphLayers<TGraphLinks>> {
         let unlocker_links_layers = self
             .links_layers
             .into_iter()
@@ -579,7 +582,9 @@ mod tests {
             });
         }
 
-        let graph = graph_layers_builder.into_graph_layers::<GraphLinksRam>(None).unwrap();
+        let graph = graph_layers_builder
+            .into_graph_layers::<GraphLinksRam>(None)
+            .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query);
@@ -660,7 +665,9 @@ mod tests {
             });
         }
 
-        let graph = graph_layers_builder.into_graph_layers::<GraphLinksRam>(None).unwrap();
+        let graph = graph_layers_builder
+            .into_graph_layers::<GraphLinksRam>(None)
+            .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
         let raw_scorer = vector_holder.get_raw_scorer(query);
@@ -694,7 +701,9 @@ mod tests {
             graph_layers_builder.set_levels(idx, level);
             graph_layers_builder.link_new_point(idx, scorer);
         }
-        let graph_layers = graph_layers_builder.into_graph_layers::<GraphLinksRam>(None).unwrap();
+        let graph_layers = graph_layers_builder
+            .into_graph_layers::<GraphLinksRam>(None)
+            .unwrap();
 
         let num_points = graph_layers.links.num_points();
         eprintln!("number_points = {:#?}", num_points);

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -319,20 +319,6 @@ impl GraphLinksConverter {
     }
 }
 
-impl TryFrom<GraphLinksConverter> for GraphLinksMmap {
-    type Error = OperationError;
-
-    fn try_from(converter: GraphLinksConverter) -> Result<Self, Self::Error> {
-        if let Some(path) = converter.path {
-            GraphLinksMmap::load_from_file(&path)
-        } else {
-            Err(OperationError::service_error(
-                "Can`t create GraphLinksMmap from GraphLinksConverter without path",
-            ))
-        }
-    }
-}
-
 pub trait GraphLinks: Default {
     fn load_from_file(path: &Path) -> OperationResult<Self>;
 

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -168,7 +168,7 @@ impl GraphLinksConverter {
             .read(true)
             .write(true)
             .create(true)
-            .open(&path)?;
+            .open(path)?;
 
         let header = GraphLinksFileHeader {
             point_count: self.reindex.len() as u64,
@@ -206,7 +206,7 @@ impl GraphLinksConverter {
             for level in 0..header.levels_count as usize {
                 level_offsets.push(offsets_pos as u64 - 1);
                 self.iterate_level_points(level, |_, links| {
-                    links_mmap[links_pos..links_pos + links.len()].copy_from_slice(&links);
+                    links_mmap[links_pos..links_pos + links.len()].copy_from_slice(links);
                     links_pos += links.len();
 
                     offsets_mmap[offsets_pos] = links_pos as u64;
@@ -278,12 +278,12 @@ pub trait GraphLinks: Default {
     fn links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
         if level == 0 {
             let links_range = self.get_links_range(point_id as usize);
-            &self.get_links(links_range)
+            self.get_links(links_range)
         } else {
             let reindexed_point_id = self.reindex(point_id) as usize;
             let layer_offsets_start = self.get_level_offset(level);
             let links_range = self.get_links_range(layer_offsets_start + reindexed_point_id);
-            &self.get_links(links_range)
+            self.get_links(links_range)
         }
     }
 
@@ -455,7 +455,7 @@ impl GraphLinks for GraphLinksMmap {
             .read(true)
             .write(false)
             .create(false)
-            .open(&path)?;
+            .open(path)?;
 
         let mmap = unsafe { Mmap::map(&file)? };
         let header = GraphLinksFileHeader::load(&mmap);

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -2,7 +2,180 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::PointOffsetType;
+use crate::{types::PointOffsetType, entry::entry_point::OperationResult};
+
+pub trait GraphLinks: Default {
+    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()>;
+
+    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()>;
+
+    fn offsets_len(&self) -> usize;
+
+    fn total_links_len(&self) -> usize;
+
+    fn levels_count(&self) -> usize;
+
+    fn get_links(&self, range: Range<usize>) -> &[PointOffsetType];
+
+    fn get_links_range(&self, idx: usize) -> Range<usize>;
+
+    fn get_level_offset(&self, level: usize) -> usize;
+
+    fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType;
+
+    fn push_offset(&mut self, offset: usize) -> OperationResult<()>;
+
+    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()>;
+
+    fn push_level_offset(&mut self, level_offset: usize);
+
+    fn num_points(&self) -> usize;
+
+    // Convert from graph layers builder links
+    // `Vec<Vec<Vec<_>>>` means:
+    // vector of points -> vector of layers for specific point -> vector of links for specific point and layer
+    fn from_vec(&mut self, edges: &Vec<Vec<Vec<PointOffsetType>>>) -> OperationResult<()> {
+        if edges.is_empty() {
+            return Ok(());
+        }
+
+        // create map from index in `offsets` to point_id
+        let mut back_index: Vec<usize> = (0..edges.len()).collect();
+        // sort by max layer and use this map to build `Self.reindex`
+        back_index.sort_unstable_by_key(|&i| edges[i].len());
+        back_index.reverse();
+
+        // `reindex` is map from point id to index in `Self.offsets`
+        let mut reindex = vec![0; back_index.len()];
+        for i in 0..back_index.len() {
+            reindex[back_index[i]] = i as PointOffsetType;
+        }
+
+        // estimate size of `links` and `offsets`
+        let mut links_len = 0;
+        let mut offsets_len = 1;
+        for point in edges.iter() {
+            for layer in point.iter() {
+                links_len += layer.len();
+                offsets_len += 1;
+            }
+        }
+
+        // because back_index is sorted by point`s max layer, we can retrieve max level from `point_id = back_index[0]`
+        let levels_count = edges[back_index[0]].len();
+
+        self.allocate(reindex.len(), levels_count, offsets_len as usize, links_len as usize)?;
+        self.set_reindex(&reindex)?;
+        self.push_offset(0)?;
+
+        // fill level 0 links. level 0 is required
+        debug_assert!(levels_count > 0);
+        self.fill_level_links(0, 0..edges.len(), edges)?;
+
+        // fill other levels links
+        for level in 1..levels_count {
+            let point_id_iter = back_index
+                .iter()
+                .cloned()
+                .take_while(|&point_id| level < edges[point_id].len());
+            self.fill_level_links(level, point_id_iter, edges)?;
+        }
+
+        Ok(())
+    }
+
+    // Convert into graph builder format
+    fn to_vec(&self) -> Vec<Vec<Vec<PointOffsetType>>> {
+        let mut result = Vec::new();
+        let num_points = self.num_points();
+        for i in 0..num_points {
+            let mut layers = Vec::new();
+            let num_levels = self.point_level(i as PointOffsetType) + 1;
+            for level in 0..num_levels {
+                let links = self.links(i as PointOffsetType, level).to_vec();
+                layers.push(links);
+            }
+            result.push(layers);
+        }
+        result
+    }
+
+    fn links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
+        if level == 0 {
+            self.get_links_at_zero_level(point_id)
+        } else {
+            self.get_links_at_nonzero_level(point_id, level)
+        }
+    }
+
+    fn point_level(&self, point_id: PointOffsetType) -> usize {
+        let reindexed_point_id = self.reindex(point_id) as usize;
+        // level 0 is always present, start checking from level 1. Stop checking when level is incorrect
+        for level in 1.. {
+            if let Some(offsets_range) = self.get_level_offsets_range(level) {
+                if offsets_range.start + reindexed_point_id >= offsets_range.end {
+                    // incorrect level because point_id is out of range
+                    return level - 1;
+                }
+            } else {
+                // incorrect level because this level is larger that avaliable levels
+                return level - 1;
+            }
+        }
+        unreachable!()
+    }
+
+    fn get_links_at_zero_level(&self, point_id: PointOffsetType) -> &[PointOffsetType] {
+        let links_range = self.get_links_range(point_id as usize);
+        &self.get_links(links_range)
+    }
+
+    fn get_links_at_nonzero_level(
+        &self,
+        point_id: PointOffsetType,
+        level: usize,
+    ) -> &[PointOffsetType] {
+        debug_assert!(level > 0);
+        let reindexed_point_id = self.reindex(point_id) as usize;
+        let layer_offsets_start = self.get_level_offset(level);
+        let links_range = self.get_links_range(layer_offsets_start + reindexed_point_id);
+        &self.get_links(links_range)
+    }
+
+    fn get_level_offsets_range(&self, level: usize) -> Option<Range<usize>> {
+        if level < self.levels_count() {
+            let layer_offsets_start = self.get_level_offset(level);
+            let layer_offsets_end = if level + 1 < self.levels_count() {
+                // `level` is not last, next level_offsets is end of range
+                self.get_level_offset(level + 1)
+            } else {
+                // `level` is last, next `offsets.len()` is end of range
+                self.offsets_len() - 1
+            };
+            Some(layer_offsets_start..layer_offsets_end)
+        } else {
+            None
+        }
+    }
+
+    fn fill_level_links<I>(
+        &mut self,
+        level: usize,
+        level_points_iter: I,
+        edges: &[Vec<Vec<PointOffsetType>>],
+    ) -> OperationResult<()> where
+        I: Iterator<Item = usize>,
+    {
+        self.push_level_offset(self.offsets_len() - 1);
+
+        for point_id in level_points_iter {
+            let links = &edges[point_id][level];
+            self.push_links(links)?;
+            self.push_offset(self.total_links_len())?;
+        }
+        Ok(())
+    }
+}
 
 /*
 Links data for whole graph layers.
@@ -36,7 +209,7 @@ for lvl > 0:
 links offset = level_offsets[level] + offsets[reindex[point_id]]
 */
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
-pub struct GraphLinks {
+pub struct GraphLinksRam {
     // all flattened links of all levels
     links: Vec<PointOffsetType>,
     // all ranges in `links`. each range is `links[offsets[i]..offsets[i+1]]`
@@ -48,222 +221,126 @@ pub struct GraphLinks {
     reindex: Vec<PointOffsetType>,
 }
 
-impl GraphLinks {
-    // Convert from graph layers builder links
-    // `Vec<Vec<Vec<_>>>` means:
-    // vector of points -> vector of layers for specific point -> vector of links for specific point and layer
-    pub fn from_vec(edges: &Vec<Vec<Vec<PointOffsetType>>>) -> Self {
-        if edges.is_empty() {
-            return Self::default();
-        }
-
-        // create map from index in `offsets` to point_id
-        let mut back_index: Vec<usize> = (0..edges.len()).collect();
-        // sort by max layer and use this map to build `Self.reindex`
-        back_index.sort_unstable_by_key(|&i| edges[i].len());
-        back_index.reverse();
-
-        // `reindex` is map from point id to index in `Self.offsets`
-        let mut reindex = vec![0; back_index.len()];
-        for i in 0..back_index.len() {
-            reindex[back_index[i]] = i as PointOffsetType;
-        }
-
-        let mut graph_links = GraphLinks {
-            links: Vec::new(),
-            offsets: vec![0],
-            level_offsets: Vec::new(),
-            reindex,
-        };
-
-        // because back_index is sorted by point`s max layer, we can retrieve max level from `point_id = back_index[0]`
-        let levels_count = edges[back_index[0]].len();
-
-        // fill level 0 links. level 0 is required
-        debug_assert!(levels_count > 0);
-        graph_links.fill_level_links(0, 0..edges.len(), edges);
-
-        // fill other levels links
-        for level in 1..levels_count {
-            let point_id_iter = back_index
-                .iter()
-                .cloned()
-                .take_while(|&point_id| level < edges[point_id].len());
-            graph_links.fill_level_links(level, point_id_iter, edges);
-        }
-
-        graph_links
+impl GraphLinks for GraphLinksRam {
+    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()> {
+        self.links.reserve(links_len);
+        self.offsets.reserve(offsets_len);
+        self.level_offsets.reserve(levels_count);
+        self.reindex.reserve(points_count);
+        Ok(())
     }
 
-    // Convert into graph builder format
-    pub fn to_vec(&self) -> Vec<Vec<Vec<PointOffsetType>>> {
-        let mut result = Vec::new();
-        let num_points = self.num_points();
-        for i in 0..num_points {
-            let mut layers = Vec::new();
-            let num_levels = self.point_level(i as PointOffsetType) + 1;
-            for level in 0..num_levels {
-                let links = self.links(i as PointOffsetType, level).to_vec();
-                layers.push(links);
-            }
-            result.push(layers);
-        }
-        result
+    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()> {
+        self.reindex = rendex.to_vec();
+        Ok(())
     }
 
-    pub fn links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
-        if level == 0 {
-            self.get_links_at_zero_level(point_id)
-        } else {
-            self.get_links_at_nonzero_level(point_id, level)
-        }
+    fn offsets_len(&self) -> usize {
+        self.offsets.len()
     }
 
-    pub fn num_points(&self) -> usize {
+    fn total_links_len(&self) -> usize {
+        self.links.len()
+    }
+
+    fn levels_count(&self) -> usize {
+        self.level_offsets.len()
+    }
+
+    fn get_links(&self, range: Range<usize>) -> &[PointOffsetType] {
+        &self.links[range]
+    }
+
+    fn get_links_range(&self, idx: usize) -> Range<usize> {
+        let start = self.offsets[idx];
+        let end = self.offsets[idx + 1];
+        start..end
+    }
+
+    fn get_level_offset(&self, level: usize) -> usize {
+        self.level_offsets[level]
+    }
+
+    fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType {
+        self.reindex[point_id as usize]
+    }
+
+    fn push_offset(&mut self, offset: usize) -> OperationResult<()> {
+        self.offsets.push(offset);
+        Ok(())
+    }
+
+    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()> {
+        self.links.extend_from_slice(links);
+        Ok(())
+    }
+
+    fn push_level_offset(&mut self, level_offset: usize) {
+        self.level_offsets.push(level_offset);
+    }
+
+    fn num_points(&self) -> usize {
         self.reindex.len()
-    }
-
-    pub fn point_level(&self, point_id: PointOffsetType) -> usize {
-        let reindexed_point_id = self.reindex[point_id as usize] as usize;
-        // level 0 is always present, start checking from level 1. Stop checking when level is incorrect
-        for level in 1.. {
-            if let Some(offsets_range) = self.get_level_offsets_range(level) {
-                if offsets_range.start + reindexed_point_id >= offsets_range.end {
-                    // incorrect level because point_id is out of range
-                    return level - 1;
-                }
-            } else {
-                // incorrect level because this level is larger that avaliable levels
-                return level - 1;
-            }
-        }
-        unreachable!()
-    }
-
-    fn get_links_at_zero_level(&self, point_id: PointOffsetType) -> &[PointOffsetType] {
-        let start = self.offsets[point_id as usize];
-        let end = self.offsets[point_id as usize + 1];
-        &self.links[start..end]
-    }
-
-    fn get_links_at_nonzero_level(
-        &self,
-        point_id: PointOffsetType,
-        level: usize,
-    ) -> &[PointOffsetType] {
-        debug_assert!(level > 0);
-        let reindexed_point_id = self.reindex[point_id as usize] as usize;
-        let layer_offsets_start = self.level_offsets[level];
-        let start = self.offsets[layer_offsets_start + reindexed_point_id];
-        let end = self.offsets[layer_offsets_start + reindexed_point_id + 1];
-        &self.links[start..end]
-    }
-
-    fn get_level_offsets_range(&self, level: usize) -> Option<Range<usize>> {
-        if level < self.level_offsets.len() {
-            let layer_offsets_start = self.level_offsets[level];
-            let layer_offsets_end = if level + 1 < self.level_offsets.len() {
-                // `level` is not last, next level_offsets is end of range
-                self.level_offsets[level + 1]
-            } else {
-                // `level` is last, next `offsets.len()` is end of range
-                self.offsets.len() - 1
-            };
-            Some(layer_offsets_start..layer_offsets_end)
-        } else {
-            None
-        }
-    }
-
-    fn fill_level_links<I>(
-        &mut self,
-        level: usize,
-        level_points_iter: I,
-        edges: &[Vec<Vec<PointOffsetType>>],
-    ) where
-        I: Iterator<Item = usize>,
-    {
-        self.level_offsets.push(self.offsets.len() - 1);
-
-        for point_id in level_points_iter {
-            let links = &edges[point_id][level];
-            self.links.extend_from_slice(links);
-            self.offsets.push(self.links.len());
-        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use rand::Rng;
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct GraphLinksMmap {
+    
+    // start offet of each level in `offsets`
+    level_offsets: Vec<usize>,
+}
 
-    use super::*;
-    use crate::types::PointOffsetType;
+impl GraphLinks for GraphLinksMmap {
+    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()> {
+        todo!()
+    }
 
-    #[test]
-    fn test_graph_links_construction() {
-        // no points
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()> {
+        todo!()
+    }
 
-        // 2 points without any links
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![]], vec![vec![]]];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn offsets_len(&self) -> usize {
+        todo!()
+    }
 
-        // one link at level 0
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![1]], vec![vec![0]]];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn total_links_len(&self) -> usize {
+        todo!()
+    }
 
-        // 3 levels with no links at second level
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
-            vec![vec![1, 2]],
-            vec![vec![0, 2], vec![], vec![2]],
-            vec![vec![0, 1], vec![], vec![1]],
-        ];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn levels_count(&self) -> usize {
+        todo!()
+    }
 
-        // 3 levels with no links at last level
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
-            vec![vec![1, 2], vec![2], vec![]],
-            vec![vec![0, 2], vec![1], vec![]],
-            vec![vec![0, 1]],
-        ];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn get_links(&self, range: Range<usize>) -> &[PointOffsetType] {
+        todo!()
+    }
 
-        // 4 levels with random unexists links
-        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
-            vec![vec![1, 2, 5, 6]],
-            vec![vec![0, 2, 7, 8], vec![], vec![34, 45, 10]],
-            vec![vec![0, 1, 1, 2], vec![3, 5, 9], vec![9, 8], vec![9], vec![]],
-            vec![vec![0, 1, 5, 6], vec![1, 5, 0]],
-            vec![vec![0, 1, 9, 18], vec![1, 5, 6], vec![5], vec![9]],
-        ];
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn get_links_range(&self, idx: usize) -> Range<usize> {
+        todo!()
+    }
 
-        // fully random links
-        let mut rng = rand::thread_rng();
-        let points_count = 100;
-        let max_levels_count = 10;
-        let links: Vec<Vec<Vec<PointOffsetType>>> = (0..points_count)
-            .map(|_| {
-                let levels_count = rng.gen_range(1..max_levels_count);
-                (0..levels_count)
-                    .map(|_| {
-                        let links_count = rng.gen_range(0..max_levels_count);
-                        (0..links_count)
-                            .map(|_| rng.gen_range(0..points_count) as PointOffsetType)
-                            .collect()
-                    })
-                    .collect()
-            })
-            .collect();
-        let cmp_links = GraphLinks::from_vec(&links).to_vec();
-        assert_eq!(links, cmp_links);
+    fn get_level_offset(&self, level: usize) -> usize {
+        todo!()
+    }
+
+    fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType {
+        todo!()
+    }
+
+    fn push_offset(&mut self, offset: usize) -> OperationResult<()> {
+        todo!()
+    }
+
+    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()> {
+        todo!()
+    }
+
+    fn push_level_offset(&mut self, level_offset: usize) {
+        todo!()
+    }
+
+    fn num_points(&self) -> usize {
+        todo!()
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -427,13 +427,10 @@ impl GraphLinks for GraphLinksRam {
     }
 
     fn from_converter(converter: GraphLinksConverter) -> OperationResult<Self> {
-        if let Some(path) = converter.path {
-            GraphLinksRam::load_from_file(&path)
-        } else {
-            let mut data = vec![0; converter.data_size() as usize];
-            converter.serialize_to(&mut data);
-            Ok(GraphLinksRam::load_from_memory(&data))
-        }
+        let mut data = vec![0; converter.data_size() as usize];
+        converter.serialize_to(&mut data);
+        drop(converter);
+        Ok(GraphLinksRam::load_from_memory(&data))
     }
 
     fn offsets_len(&self) -> usize {

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -1,181 +1,10 @@
-use std::ops::Range;
+use std::{ops::Range, path::Path, fs::OpenOptions, mem::{size_of, transmute}};
 
-use serde::{Deserialize, Serialize};
+use memmap2::{MmapMut, Mmap};
 
-use crate::{types::PointOffsetType, entry::entry_point::OperationResult};
+use crate::{types::PointOffsetType, entry::entry_point::{OperationResult, OperationError}};
 
-pub trait GraphLinks: Default {
-    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()>;
-
-    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()>;
-
-    fn offsets_len(&self) -> usize;
-
-    fn total_links_len(&self) -> usize;
-
-    fn levels_count(&self) -> usize;
-
-    fn get_links(&self, range: Range<usize>) -> &[PointOffsetType];
-
-    fn get_links_range(&self, idx: usize) -> Range<usize>;
-
-    fn get_level_offset(&self, level: usize) -> usize;
-
-    fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType;
-
-    fn push_offset(&mut self, offset: usize) -> OperationResult<()>;
-
-    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()>;
-
-    fn push_level_offset(&mut self, level_offset: usize);
-
-    fn num_points(&self) -> usize;
-
-    // Convert from graph layers builder links
-    // `Vec<Vec<Vec<_>>>` means:
-    // vector of points -> vector of layers for specific point -> vector of links for specific point and layer
-    fn from_vec(&mut self, edges: &Vec<Vec<Vec<PointOffsetType>>>) -> OperationResult<()> {
-        if edges.is_empty() {
-            return Ok(());
-        }
-
-        // create map from index in `offsets` to point_id
-        let mut back_index: Vec<usize> = (0..edges.len()).collect();
-        // sort by max layer and use this map to build `Self.reindex`
-        back_index.sort_unstable_by_key(|&i| edges[i].len());
-        back_index.reverse();
-
-        // `reindex` is map from point id to index in `Self.offsets`
-        let mut reindex = vec![0; back_index.len()];
-        for i in 0..back_index.len() {
-            reindex[back_index[i]] = i as PointOffsetType;
-        }
-
-        // estimate size of `links` and `offsets`
-        let mut links_len = 0;
-        let mut offsets_len = 1;
-        for point in edges.iter() {
-            for layer in point.iter() {
-                links_len += layer.len();
-                offsets_len += 1;
-            }
-        }
-
-        // because back_index is sorted by point`s max layer, we can retrieve max level from `point_id = back_index[0]`
-        let levels_count = edges[back_index[0]].len();
-
-        self.allocate(reindex.len(), levels_count, offsets_len as usize, links_len as usize)?;
-        self.set_reindex(&reindex)?;
-        self.push_offset(0)?;
-
-        // fill level 0 links. level 0 is required
-        debug_assert!(levels_count > 0);
-        self.fill_level_links(0, 0..edges.len(), edges)?;
-
-        // fill other levels links
-        for level in 1..levels_count {
-            let point_id_iter = back_index
-                .iter()
-                .cloned()
-                .take_while(|&point_id| level < edges[point_id].len());
-            self.fill_level_links(level, point_id_iter, edges)?;
-        }
-
-        Ok(())
-    }
-
-    // Convert into graph builder format
-    fn to_vec(&self) -> Vec<Vec<Vec<PointOffsetType>>> {
-        let mut result = Vec::new();
-        let num_points = self.num_points();
-        for i in 0..num_points {
-            let mut layers = Vec::new();
-            let num_levels = self.point_level(i as PointOffsetType) + 1;
-            for level in 0..num_levels {
-                let links = self.links(i as PointOffsetType, level).to_vec();
-                layers.push(links);
-            }
-            result.push(layers);
-        }
-        result
-    }
-
-    fn links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
-        if level == 0 {
-            self.get_links_at_zero_level(point_id)
-        } else {
-            self.get_links_at_nonzero_level(point_id, level)
-        }
-    }
-
-    fn point_level(&self, point_id: PointOffsetType) -> usize {
-        let reindexed_point_id = self.reindex(point_id) as usize;
-        // level 0 is always present, start checking from level 1. Stop checking when level is incorrect
-        for level in 1.. {
-            if let Some(offsets_range) = self.get_level_offsets_range(level) {
-                if offsets_range.start + reindexed_point_id >= offsets_range.end {
-                    // incorrect level because point_id is out of range
-                    return level - 1;
-                }
-            } else {
-                // incorrect level because this level is larger that avaliable levels
-                return level - 1;
-            }
-        }
-        unreachable!()
-    }
-
-    fn get_links_at_zero_level(&self, point_id: PointOffsetType) -> &[PointOffsetType] {
-        let links_range = self.get_links_range(point_id as usize);
-        &self.get_links(links_range)
-    }
-
-    fn get_links_at_nonzero_level(
-        &self,
-        point_id: PointOffsetType,
-        level: usize,
-    ) -> &[PointOffsetType] {
-        debug_assert!(level > 0);
-        let reindexed_point_id = self.reindex(point_id) as usize;
-        let layer_offsets_start = self.get_level_offset(level);
-        let links_range = self.get_links_range(layer_offsets_start + reindexed_point_id);
-        &self.get_links(links_range)
-    }
-
-    fn get_level_offsets_range(&self, level: usize) -> Option<Range<usize>> {
-        if level < self.levels_count() {
-            let layer_offsets_start = self.get_level_offset(level);
-            let layer_offsets_end = if level + 1 < self.levels_count() {
-                // `level` is not last, next level_offsets is end of range
-                self.get_level_offset(level + 1)
-            } else {
-                // `level` is last, next `offsets.len()` is end of range
-                self.offsets_len() - 1
-            };
-            Some(layer_offsets_start..layer_offsets_end)
-        } else {
-            None
-        }
-    }
-
-    fn fill_level_links<I>(
-        &mut self,
-        level: usize,
-        level_points_iter: I,
-        edges: &[Vec<Vec<PointOffsetType>>],
-    ) -> OperationResult<()> where
-        I: Iterator<Item = usize>,
-    {
-        self.push_level_offset(self.offsets_len() - 1);
-
-        for point_id in level_points_iter {
-            let links = &edges[point_id][level];
-            self.push_links(links)?;
-            self.push_offset(self.total_links_len())?;
-        }
-        Ok(())
-    }
-}
+pub const MMAP_PANIC_MESSAGE: &str = "Mmap links are not loaded";
 
 /*
 Links data for whole graph layers.
@@ -208,39 +37,325 @@ reindex:           142350  142350 142350 142350  (same for each level)
 for lvl > 0:
 links offset = level_offsets[level] + offsets[reindex[point_id]]
 */
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+
+#[derive(Default)]
+struct GraphLinksFileHeader {
+    pub point_count: u64,
+    pub levels_count: u64,
+    pub total_links_len: u64,
+    pub total_offsets_len: u64,
+}
+
+impl GraphLinksFileHeader {
+    pub fn raw_size() -> usize {
+        size_of::<u64>() * 4
+    }
+
+    pub fn save(&self, mmap: &mut MmapMut) {
+        let byte_slice = &mut mmap[0..Self::raw_size()];
+        let arr: &mut [u64] = unsafe { transmute(byte_slice) };
+        arr[0] = self.point_count;
+        arr[1] = self.levels_count;
+        arr[2] = self.total_links_len;
+        arr[3] = self.total_offsets_len;
+    }
+
+    pub fn load(mmap: &Mmap) -> GraphLinksFileHeader {
+        let byte_slice = &mmap[0..Self::raw_size()];
+        let arr: &[u64] = unsafe { transmute(byte_slice) };
+        GraphLinksFileHeader {
+            point_count: arr[0],
+            levels_count: arr[1],
+            total_links_len: arr[2],
+            total_offsets_len: arr[3],
+        }
+    }
+
+    pub fn get_file_size(&self) -> u64 {
+        self.get_offsets_range().end as u64
+    }
+
+    pub fn get_level_offsets_range(&self) -> Range<usize> {
+        let start = 64;
+        start..start + self.levels_count as usize * size_of::<u64>()
+    }
+
+    pub fn get_reindex_range(&self) -> Range<usize> {
+        let start = self.get_level_offsets_range().end;
+        start..start + self.point_count as usize * size_of::<PointOffsetType>()
+    }
+
+    pub fn get_links_range(&self) -> Range<usize> {
+        let start = self.get_reindex_range().end;
+        start..start + self.total_links_len as usize * size_of::<PointOffsetType>()
+    }
+
+    pub fn get_offsets_range(&self) -> Range<usize> {
+        let start = self.get_links_range().end;
+        start..start + self.total_offsets_len as usize * size_of::<u64>()
+    }
+}
+
+struct GraphLinksConverter {
+    pub edges: Vec<Vec<Vec<PointOffsetType>>>,
+    pub reindex: Vec<PointOffsetType>,
+    pub back_index: Vec<usize>,
+    pub total_links_len: usize,
+    pub total_offsets_len: usize,
+}
+
+impl GraphLinksConverter {
+    pub fn new(edges: Vec<Vec<Vec<PointOffsetType>>>) -> Self {
+        if edges.is_empty() {
+            return Self {
+                edges,
+                reindex: Vec::new(),
+                back_index: Vec::new(),
+                total_links_len: 0,
+                total_offsets_len: 1,
+            };
+        }
+
+        // create map from index in `offsets` to point_id
+        let mut back_index: Vec<usize> = (0..edges.len()).collect();
+        // sort by max layer and use this map to build `Self.reindex`
+        back_index.sort_unstable_by_key(|&i| edges[i].len());
+        back_index.reverse();
+
+        // `reindex` is map from point id to index in `Self.offsets`
+        let mut reindex = vec![0; back_index.len()];
+        for i in 0..back_index.len() {
+            reindex[back_index[i]] = i as PointOffsetType;
+        }
+
+        // estimate size of `links` and `offsets`
+        let mut total_links_len = 0;
+        let mut total_offsets_len = 1;
+        for point in edges.iter() {
+            for layer in point.iter() {
+                total_links_len += layer.len();
+                total_offsets_len += 1;
+            }
+        }
+
+        Self {
+            edges,
+            reindex,
+            back_index,
+            total_links_len,
+            total_offsets_len,
+        }
+    }
+
+    pub fn save_to_file(&mut self, path: &Path) -> OperationResult<()> {
+        let file = OpenOptions::new()
+            .read(false)
+            .write(true)
+            .create(true)
+            .open(&path)?;
+
+        let header = GraphLinksFileHeader {
+            point_count: self.reindex.len() as u64,
+            levels_count: self.get_levels_count() as u64,
+            total_links_len: self.total_links_len as u64,
+            total_offsets_len: self.total_offsets_len as u64,
+        };
+
+        file.set_len(header.get_file_size())?;
+
+        let mut mmap = unsafe { MmapMut::map_mut(&file)? };
+        header.save(&mut mmap);
+
+        {
+            let reindex_range = header.get_reindex_range();
+            let reindex_byte_slice = &mut mmap[reindex_range];
+            let reindex_slice: &mut [PointOffsetType] = unsafe { transmute(reindex_byte_slice) };
+            reindex_slice.copy_from_slice(&self.reindex);
+        }
+
+        let mut level_offsets = Vec::new();
+        {
+            let links_range = header.get_links_range();
+            let offsets_range = header.get_offsets_range();
+            let union_range = links_range.start..offsets_range.end;
+            let (links_mmap, offsets_mmap) = mmap[union_range].as_mut().split_at_mut(links_range.len());
+            let links_mmap: &mut[PointOffsetType] = unsafe { transmute(links_mmap) };
+            let offsets_mmap: &mut[u64] = unsafe { transmute(offsets_mmap) };
+            offsets_mmap[0] = 0;
+
+            let mut links_pos = 0;
+            let mut offsets_pos = 1;
+            for level in 0..header.levels_count as usize {
+                level_offsets.push(offsets_pos as u64);
+                self.iterate_level_points(level, |_, links| {
+                    links_mmap[links_pos..links_pos + links.len()].copy_from_slice(&links);
+                    links_pos += links.len();
+
+                    offsets_mmap[offsets_pos] = links_pos as u64;
+                    offsets_pos += 1;
+                });
+            }
+        }
+
+        {
+            let level_offsets_range = header.get_reindex_range();
+            let level_offsets_byte_slice = &mut mmap[level_offsets_range];
+            let level_offsets_slice: &mut [u64] = unsafe { transmute(level_offsets_byte_slice) };
+            level_offsets_slice.copy_from_slice(&level_offsets);
+        }
+
+        mmap.flush()?;
+        Ok(())
+    }
+
+    pub fn get_levels_count(&self) -> usize {
+        // because back_index is sorted by point`s max layer, we can retrieve max level from `point_id = back_index[0]`
+        self.edges[self.back_index[0]].len()
+    }
+
+    pub fn iterate_level_points<F>(&mut self, level: usize, mut f: F)
+    where F: FnMut(usize, &mut Vec<PointOffsetType>)
+    {
+        let edges_len = self.edges.len();
+        if level == 0 {
+            (0..edges_len).for_each(|point_id| 
+                f(point_id, &mut self.edges[point_id][0])
+            );
+        } else {
+            for i in 0..edges_len {
+                let point_id = self.back_index[i];
+                if level >= self.edges[point_id].len() {
+                    break;
+                }
+                f(point_id, &mut self.edges[point_id][level]);
+            }
+        }
+    }
+}
+
+pub trait GraphLinks: Default {
+    fn load_from_file(path: &Path) -> OperationResult<Self>;
+
+    fn offsets_len(&self) -> usize;
+
+    fn levels_count(&self) -> usize;
+
+    fn get_links(&self, range: Range<usize>) -> &[PointOffsetType];
+
+    fn get_links_range(&self, idx: usize) -> Range<usize>;
+
+    fn get_level_offset(&self, level: usize) -> usize;
+
+    fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType;
+
+    fn num_points(&self) -> usize;
+
+    // Convert from graph layers builder links
+    // `Vec<Vec<Vec<_>>>` means:
+    // vector of points -> vector of layers for specific point -> vector of links for specific point and layer
+    fn from_vec(edges: Vec<Vec<Vec<PointOffsetType>>>, path: Option<&Path>) -> OperationResult<Self>;
+
+    fn links(&self, point_id: PointOffsetType, level: usize) -> &[PointOffsetType] {
+        if level == 0 {
+            let links_range = self.get_links_range(point_id as usize);
+            &self.get_links(links_range)
+        } else {
+            let reindexed_point_id = self.reindex(point_id) as usize;
+            let layer_offsets_start = self.get_level_offset(level);
+            let links_range = self.get_links_range(layer_offsets_start + reindexed_point_id);
+            &self.get_links(links_range)
+        }
+    }
+
+    fn point_level(&self, point_id: PointOffsetType) -> usize {
+        let reindexed_point_id = self.reindex(point_id) as usize;
+        // level 0 is always present, start checking from level 1. Stop checking when level is incorrect
+        for level in 1.. {
+            if let Some(offsets_range) = self.get_level_offsets_range(level) {
+                if offsets_range.start + reindexed_point_id >= offsets_range.end {
+                    // incorrect level because point_id is out of range
+                    return level - 1;
+                }
+            } else {
+                // incorrect level because this level is larger that avaliable levels
+                return level - 1;
+            }
+        }
+        unreachable!()
+    }
+
+    fn get_level_offsets_range(&self, level: usize) -> Option<Range<usize>> {
+        if level < self.levels_count() {
+            let layer_offsets_start = self.get_level_offset(level);
+            let layer_offsets_end = if level + 1 < self.levels_count() {
+                // `level` is not last, next level_offsets is end of range
+                self.get_level_offset(level + 1)
+            } else {
+                // `level` is last, next `offsets.len()` is end of range
+                self.offsets_len() - 1
+            };
+            Some(layer_offsets_start..layer_offsets_end)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Default)]
 pub struct GraphLinksRam {
     // all flattened links of all levels
     links: Vec<PointOffsetType>,
     // all ranges in `links`. each range is `links[offsets[i]..offsets[i+1]]`
     // ranges are sorted by level
-    offsets: Vec<usize>,
+    offsets: Vec<u64>,
     // start offet of each level in `offsets`
-    level_offsets: Vec<usize>,
+    level_offsets: Vec<u64>,
     // for level 1 and above: reindex[point_id] = index of point_id in offsets
     reindex: Vec<PointOffsetType>,
 }
 
 impl GraphLinks for GraphLinksRam {
-    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()> {
-        self.links.reserve(links_len);
-        self.offsets.reserve(offsets_len);
-        self.level_offsets.reserve(levels_count);
-        self.reindex.reserve(points_count);
-        Ok(())
+    fn load_from_file(path: &Path) -> OperationResult<Self> {
+        let mmap = GraphLinksMmap::load_from_file(path)?;
+
+        Ok(Self {
+            links: mmap.get_links_slice().to_vec(),
+            offsets: mmap.get_offsets_slice().to_vec(),
+            level_offsets: mmap.level_offsets.clone(),
+            reindex: mmap.get_reindex_slice().to_vec(),
+        })
     }
 
-    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()> {
-        self.reindex = rendex.to_vec();
-        Ok(())
+    fn from_vec(edges: Vec<Vec<Vec<PointOffsetType>>>, path: Option<&Path>) -> OperationResult<Self> {
+        let mut graph_links = GraphLinksRam {
+            links: Vec::new(),
+            offsets: vec![0],
+            level_offsets: Vec::new(),
+            reindex: Vec::new(),
+        };
+
+        let mut converter = GraphLinksConverter::new(edges);
+        if let Some(path) = path {
+            converter.save_to_file(path)?;
+        }
+
+        if !converter.edges.is_empty() {
+            let levels_count = converter.get_levels_count();
+            for level in 0..levels_count {
+                graph_links.level_offsets.push(graph_links.offsets.len() as u64 - 1);
+                converter.iterate_level_points(level, |_, links| {
+                    graph_links.links.extend_from_slice(links);
+                    graph_links.offsets.push(graph_links.links.len() as u64);
+                    links.clear();
+                });
+            }
+            graph_links.reindex = converter.reindex;
+        }
+        Ok(graph_links)
     }
 
     fn offsets_len(&self) -> usize {
         self.offsets.len()
-    }
-
-    fn total_links_len(&self) -> usize {
-        self.links.len()
     }
 
     fn levels_count(&self) -> usize {
@@ -254,29 +369,15 @@ impl GraphLinks for GraphLinksRam {
     fn get_links_range(&self, idx: usize) -> Range<usize> {
         let start = self.offsets[idx];
         let end = self.offsets[idx + 1];
-        start..end
+        start as usize..end as usize
     }
 
     fn get_level_offset(&self, level: usize) -> usize {
-        self.level_offsets[level]
+        self.level_offsets[level] as usize
     }
 
     fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType {
         self.reindex[point_id as usize]
-    }
-
-    fn push_offset(&mut self, offset: usize) -> OperationResult<()> {
-        self.offsets.push(offset);
-        Ok(())
-    }
-
-    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()> {
-        self.links.extend_from_slice(links);
-        Ok(())
-    }
-
-    fn push_level_offset(&mut self, level_offset: usize) {
-        self.level_offsets.push(level_offset);
     }
 
     fn num_points(&self) -> usize {
@@ -284,63 +385,193 @@ impl GraphLinks for GraphLinksRam {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[derive(Default)]
 pub struct GraphLinksMmap {
-    
-    // start offet of each level in `offsets`
-    level_offsets: Vec<usize>,
+    mmap: Option<Mmap>,
+    header: GraphLinksFileHeader,
+    level_offsets: Vec<u64>,
+}
+
+impl GraphLinksMmap {
+    fn get_reindex_slice(&self) -> &[PointOffsetType] {
+        if let Some(mmap) = &self.mmap {
+            let reindex_range = self.header.get_reindex_range();
+            let reindex_byte_slice = &mmap[reindex_range];
+            unsafe { transmute(reindex_byte_slice) }
+        } else {
+            panic!("{}", MMAP_PANIC_MESSAGE);
+        }
+    }
+
+    fn get_links_slice(&self) -> &[PointOffsetType] {
+        if let Some(mmap) = &self.mmap {
+            let links_range = self.header.get_links_range();
+            let links_byte_slice = &mmap[links_range];
+            unsafe { transmute(links_byte_slice) }
+        } else {
+            panic!("{}", "Mmap links are not loaded");
+        }
+    }
+
+    fn get_offsets_slice(&self) -> &[u64] {
+        if let Some(mmap) = &self.mmap {
+            let offsets_range = self.header.get_offsets_range();
+            let offsets_byte_slice = &mmap[offsets_range];
+            unsafe { transmute(offsets_byte_slice) }
+        } else {
+            panic!("{}", MMAP_PANIC_MESSAGE);
+        }
+    }
 }
 
 impl GraphLinks for GraphLinksMmap {
-    fn allocate(&mut self, points_count: usize, levels_count: usize, offsets_len: usize, links_len: usize) -> OperationResult<()> {
-        todo!()
+    fn load_from_file(path: &Path) -> OperationResult<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(false)
+            .create(false)
+            .open(&path)?;
+        
+        let mmap = unsafe { Mmap::map(&file)? };
+        let header = GraphLinksFileHeader::load(&mmap);
+        let level_offsets_range = header.get_level_offsets_range();
+        let level_offsets_byte_slice = &mmap[level_offsets_range];
+        let level_offsets: &[u64] = unsafe { transmute(level_offsets_byte_slice) };
+        let level_offsets = level_offsets.to_vec();
+
+        Ok(Self {
+            mmap: Some(mmap),
+            header,
+            level_offsets,
+        })
     }
 
-    fn set_reindex(&mut self, rendex: &[PointOffsetType]) -> OperationResult<()> {
-        todo!()
+    fn from_vec(edges: Vec<Vec<Vec<PointOffsetType>>>, path: Option<&Path>) -> OperationResult<Self> {
+        let mut converter = GraphLinksConverter::new(edges);
+        if let Some(path) = path {
+            converter.save_to_file(path)?;
+            Self::load_from_file(path)
+        } else {
+            Err(OperationError::service_error("path is required for GraphLinksMmap"))
+        }
     }
 
     fn offsets_len(&self) -> usize {
-        todo!()
-    }
-
-    fn total_links_len(&self) -> usize {
-        todo!()
+        self.header.get_offsets_range().len() / size_of::<u64>()
     }
 
     fn levels_count(&self) -> usize {
-        todo!()
+        self.level_offsets.len()
     }
 
     fn get_links(&self, range: Range<usize>) -> &[PointOffsetType] {
-        todo!()
+        &self.get_links_slice()[range]
     }
 
     fn get_links_range(&self, idx: usize) -> Range<usize> {
-        todo!()
+        let offsets_slice = self.get_offsets_slice();
+        offsets_slice[idx as usize] as usize..offsets_slice[idx as usize + 1] as usize
     }
 
     fn get_level_offset(&self, level: usize) -> usize {
-        todo!()
+        self.level_offsets[level] as usize
     }
 
     fn reindex(&self, point_id: PointOffsetType) -> PointOffsetType {
-        todo!()
-    }
-
-    fn push_offset(&mut self, offset: usize) -> OperationResult<()> {
-        todo!()
-    }
-
-    fn push_links(&mut self, links: &[PointOffsetType]) -> OperationResult<()> {
-        todo!()
-    }
-
-    fn push_level_offset(&mut self, level_offset: usize) {
-        todo!()
+        self.get_reindex_slice()[point_id as usize]
     }
 
     fn num_points(&self) -> usize {
-        todo!()
+        self.header.point_count as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+    use crate::types::PointOffsetType;
+
+    fn to_vec(links: &GraphLinksRam) -> Vec<Vec<Vec<PointOffsetType>>> {
+        let mut result = Vec::new();
+        let num_points = links.num_points();
+        for i in 0..num_points {
+            let mut layers = Vec::new();
+            let num_levels = links.point_level(i as PointOffsetType) + 1;
+            for level in 0..num_levels {
+                let links = links.links(i as PointOffsetType, level).to_vec();
+                layers.push(links);
+            }
+            result.push(layers);
+        }
+        result
+    }
+
+    #[test]
+    fn test_graph_links_construction() {
+        // no points
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // 2 points without any links
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![]], vec![vec![]]];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // one link at level 0
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![vec![vec![1]], vec![vec![0]]];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // 3 levels with no links at second level
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
+            vec![vec![1, 2]],
+            vec![vec![0, 2], vec![], vec![2]],
+            vec![vec![0, 1], vec![], vec![1]],
+        ];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // 3 levels with no links at last level
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
+            vec![vec![1, 2], vec![2], vec![]],
+            vec![vec![0, 2], vec![1], vec![]],
+            vec![vec![0, 1]],
+        ];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // 4 levels with random unexists links
+        let links: Vec<Vec<Vec<PointOffsetType>>> = vec![
+            vec![vec![1, 2, 5, 6]],
+            vec![vec![0, 2, 7, 8], vec![], vec![34, 45, 10]],
+            vec![vec![0, 1, 1, 2], vec![3, 5, 9], vec![9, 8], vec![9], vec![]],
+            vec![vec![0, 1, 5, 6], vec![1, 5, 0]],
+            vec![vec![0, 1, 9, 18], vec![1, 5, 6], vec![5], vec![9]],
+        ];
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
+
+        // fully random links
+        let mut rng = rand::thread_rng();
+        let points_count = 100;
+        let max_levels_count = 10;
+        let links: Vec<Vec<Vec<PointOffsetType>>> = (0..points_count)
+            .map(|_| {
+                let levels_count = rng.gen_range(1..max_levels_count);
+                (0..levels_count)
+                    .map(|_| {
+                        let links_count = rng.gen_range(0..max_levels_count);
+                        (0..links_count)
+                            .map(|_| rng.gen_range(0..points_count) as PointOffsetType)
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
+        let cmp_links = to_vec(&GraphLinksRam::from_vec(links.clone(), None).unwrap());
+        assert_eq!(links, cmp_links);
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -11,6 +11,7 @@ use rand::thread_rng;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 
+use super::graph_links::GraphLinks;
 use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
@@ -29,8 +30,6 @@ use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
 use crate::types::{FieldCondition, Filter, HnswConfig, SearchParams, VECTOR_ELEMENT_SIZE};
 use crate::vector_storage::{ScoredPointOffset, VectorStorageSS};
-
-use super::graph_links::GraphLinks;
 
 const HNSW_USE_HEURISTIC: bool = true;
 const BYTES_IN_KB: usize = 1024;
@@ -52,8 +51,7 @@ struct SearchesTelemetry {
     exact_unfiltered: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
-impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks>
-{
+impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
     pub fn open(
         path: &Path,
         vector_storage: Arc<AtomicRefCell<VectorStorageSS>>,
@@ -217,8 +215,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks>
     }
 }
 
-impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks>
-{
+impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
     fn search(
         &self,
         vectors: &[&[VectorElementType]],

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -1,3 +1,5 @@
+mod test_compact_graph_layer;
+
 use std::path::Path;
 
 use rand::Rng;
@@ -10,14 +12,13 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::spaces::metric::Metric;
 use crate::types::PointOffsetType;
 
-pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
+pub(crate) fn create_graph_layer_builder_fixture<TMetric: Metric, R>(
     num_vectors: usize,
     m: usize,
     dim: usize,
     use_heuristic: bool,
     rng: &mut R,
-    links_path: Option<&Path>,
-) -> (TestRawScorerProducer<TMetric>, GraphLayers<GraphLinksRam>)
+) -> (TestRawScorerProducer<TMetric>, GraphLayersBuilder)
 where
     R: Rng + ?Sized,
 {
@@ -44,6 +45,22 @@ where
         graph_layers_builder.set_levels(idx, level);
         graph_layers_builder.link_new_point(idx, scorer);
     }
+    (vector_holder, graph_layers_builder)
+}
+
+pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
+    num_vectors: usize,
+    m: usize,
+    dim: usize,
+    use_heuristic: bool,
+    rng: &mut R,
+    links_path: Option<&Path>,
+) -> (TestRawScorerProducer<TMetric>, GraphLayers<GraphLinksRam>)
+where
+    R: Rng + ?Sized,
+{
+    let (vector_holder, graph_layers_builder) =
+        create_graph_layer_builder_fixture(num_vectors, m, dim, use_heuristic, rng);
 
     (
         vector_holder,

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use rand::Rng;
 
 use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
@@ -15,6 +17,7 @@ pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
     dim: usize,
     use_heuristic: bool,
     rng: &mut R,
+    links_path: Option<&Path>,
 ) -> (TestRawScorerProducer<TMetric>, GraphLayers<GraphLinksRam>)
 where
     R: Rng + ?Sized,
@@ -43,5 +46,5 @@ where
         graph_layers_builder.link_new_point(idx, scorer);
     }
 
-    (vector_holder, graph_layers_builder.into_graph_layers())
+    (vector_holder, graph_layers_builder.into_graph_layers(links_path).unwrap())
 }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -2,14 +2,13 @@ use std::path::Path;
 
 use rand::Rng;
 
+use super::graph_links::GraphLinksRam;
 use crate::fixtures::index_fixtures::{FakeFilterContext, TestRawScorerProducer};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::spaces::metric::Metric;
 use crate::types::PointOffsetType;
-
-use super::graph_links::GraphLinksRam;
 
 pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
     num_vectors: usize,
@@ -46,5 +45,8 @@ where
         graph_layers_builder.link_new_point(idx, scorer);
     }
 
-    (vector_holder, graph_layers_builder.into_graph_layers(links_path).unwrap())
+    (
+        vector_holder,
+        graph_layers_builder.into_graph_layers(links_path).unwrap(),
+    )
 }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -7,13 +7,15 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::spaces::metric::Metric;
 use crate::types::PointOffsetType;
 
+use super::graph_links::GraphLinksRam;
+
 pub(crate) fn create_graph_layer_fixture<TMetric: Metric, R>(
     num_vectors: usize,
     m: usize,
     dim: usize,
     use_heuristic: bool,
     rng: &mut R,
-) -> (TestRawScorerProducer<TMetric>, GraphLayers)
+) -> (TestRawScorerProducer<TMetric>, GraphLayers<GraphLinksRam>)
 where
     R: Rng + ?Sized,
 {

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -1,0 +1,84 @@
+use std::cmp::max;
+
+use itertools::Itertools;
+use rand::prelude::StdRng;
+use rand::SeedableRng;
+
+use crate::fixtures::index_fixtures::random_vector;
+use crate::index::hnsw_index::graph_layers::GraphLayersBase;
+use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
+use crate::index::hnsw_index::graph_links::GraphLinksRam;
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::index::hnsw_index::tests::create_graph_layer_builder_fixture;
+use crate::spaces::simple::CosineMetric;
+use crate::vector_storage::ScoredPointOffset;
+
+fn search_in_builder(
+    builder: &GraphLayersBuilder,
+    top: usize,
+    ef: usize,
+    mut points_scorer: FilteredScorer,
+) -> Vec<ScoredPointOffset> {
+    let entry_point = match builder
+        .get_entry_points()
+        .get_entry_point(|point_id| points_scorer.check_point(point_id))
+    {
+        None => return vec![],
+        Some(ep) => ep,
+    };
+
+    let zero_level_entry = builder.search_entry(
+        entry_point.point_id,
+        entry_point.level,
+        0,
+        &mut points_scorer,
+    );
+
+    let nearest =
+        builder.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer, &[]);
+    nearest.into_iter().take(top).collect_vec()
+}
+
+#[test]
+/// Check that HNSW index with raw and compacted links gives the same results
+fn test_compact_graph_layers() {
+    let num_vectors = 1000;
+    let num_queries = 100;
+    let m = 16;
+    let dim = 8;
+    let top = 5;
+    let ef = 100;
+
+    let mut rng = StdRng::seed_from_u64(42);
+
+    let (vector_holder, graph_layers_builder) =
+        create_graph_layer_builder_fixture::<CosineMetric, _>(num_vectors, m, dim, false, &mut rng);
+
+    let queries = (0..num_queries)
+        .map(|_| random_vector(&mut rng, dim))
+        .collect_vec();
+
+    let reference_results = queries
+        .iter()
+        .map(|query| {
+            let raw_scorer = vector_holder.get_raw_scorer(query.clone());
+            let scorer = FilteredScorer::new(&raw_scorer, None);
+            search_in_builder(&graph_layers_builder, top, ef, scorer)
+        })
+        .collect_vec();
+
+    let graph_layers = graph_layers_builder
+        .into_graph_layers::<GraphLinksRam>(None)
+        .unwrap();
+
+    let results = queries
+        .iter()
+        .map(|query| {
+            let raw_scorer = vector_holder.get_raw_scorer(query.clone());
+            let scorer = FilteredScorer::new(&raw_scorer, None);
+            graph_layers.search(top, ef, scorer)
+        })
+        .collect_vec();
+
+    assert_eq!(reference_results, results);
+}

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -169,22 +169,21 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
         info!("Migrating segment {} -> {}", stored_version, app_version,);
 
         if stored_version > app_version {
-            log::warn!(
+            return Err(OperationError::service_error(&format!(
                 "Data version {} is newer than application version {}. \
                 Please upgrade the application. Compatibility is not guaranteed.",
-                stored_version,
-                app_version
-            );
+                stored_version, app_version
+            )));
         }
 
-        if stored_version.major < 3 {
+        if stored_version.major == 0 && stored_version.minor < 3 {
             return Err(OperationError::service_error(&format!(
                 "Segment version({}) is not compatible with current version({})",
                 stored_version, app_version
             )));
         }
 
-        if stored_version.minor == 3 {
+        if stored_version.major == 0 && stored_version.minor == 3 {
             let segment_state = load_segment_state_v3(path)?;
             Segment::save_state(&segment_state, path)?;
         }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -16,6 +16,7 @@ use crate::common::version::StorageVersion;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
+use crate::index::hnsw_index::graph_links::{GraphLinksRam, GraphLinksMmap};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::PlainIndex;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -99,14 +100,14 @@ fn create_segment(
                 payload_index.clone(),
             )),
             Indexes::Hnsw(hnsw_config) => if hnsw_config.on_disk {
-                sp(HNSWIndex::open(
+                sp(HNSWIndex::<GraphLinksRam>::open(
                     &vector_index_path,
                     vector_storage.clone(),
                     payload_index.clone(),
                     hnsw_config,
                 )?)
             } else {
-                sp(HNSWIndex::open(
+                sp(HNSWIndex::<GraphLinksMmap>::open(
                     &vector_index_path,
                     vector_storage.clone(),
                     payload_index.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -16,7 +16,7 @@ use crate::common::version::StorageVersion;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
-use crate::index::hnsw_index::graph_links::{GraphLinksRam, GraphLinksMmap};
+use crate::index::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::PlainIndex;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -99,20 +99,22 @@ fn create_segment(
                 vector_storage.clone(),
                 payload_index.clone(),
             )),
-            Indexes::Hnsw(hnsw_config) => if hnsw_config.on_disk {
-                sp(HNSWIndex::<GraphLinksMmap>::open(
-                    &vector_index_path,
-                    vector_storage.clone(),
-                    payload_index.clone(),
-                    hnsw_config,
-                )?)
-            } else {
-                sp(HNSWIndex::<GraphLinksRam>::open(
-                    &vector_index_path,
-                    vector_storage.clone(),
-                    payload_index.clone(),
-                    hnsw_config,
-                )?)
+            Indexes::Hnsw(hnsw_config) => {
+                if hnsw_config.on_disk {
+                    sp(HNSWIndex::<GraphLinksMmap>::open(
+                        &vector_index_path,
+                        vector_storage.clone(),
+                        payload_index.clone(),
+                        hnsw_config,
+                    )?)
+                } else {
+                    sp(HNSWIndex::<GraphLinksRam>::open(
+                        &vector_index_path,
+                        vector_storage.clone(),
+                        payload_index.clone(),
+                        hnsw_config,
+                    )?)
+                }
             }
         };
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -98,12 +98,21 @@ fn create_segment(
                 vector_storage.clone(),
                 payload_index.clone(),
             )),
-            Indexes::Hnsw(hnsw_config) => sp(HNSWIndex::open(
-                &vector_index_path,
-                vector_storage.clone(),
-                payload_index.clone(),
-                hnsw_config,
-            )?),
+            Indexes::Hnsw(hnsw_config) => if hnsw_config.on_disk {
+                sp(HNSWIndex::open(
+                    &vector_index_path,
+                    vector_storage.clone(),
+                    payload_index.clone(),
+                    hnsw_config,
+                )?)
+            } else {
+                sp(HNSWIndex::open(
+                    &vector_index_path,
+                    vector_storage.clone(),
+                    payload_index.clone(),
+                    hnsw_config,
+                )?)
+            }
         };
 
         vector_data.insert(

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -100,14 +100,14 @@ fn create_segment(
                 payload_index.clone(),
             )),
             Indexes::Hnsw(hnsw_config) => if hnsw_config.on_disk {
-                sp(HNSWIndex::<GraphLinksRam>::open(
+                sp(HNSWIndex::<GraphLinksMmap>::open(
                     &vector_index_path,
                     vector_storage.clone(),
                     payload_index.clone(),
                     hnsw_config,
                 )?)
             } else {
-                sp(HNSWIndex::<GraphLinksMmap>::open(
+                sp(HNSWIndex::<GraphLinksRam>::open(
                     &vector_index_path,
                     vector_storage.clone(),
                     payload_index.clone(),

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -271,7 +271,7 @@ pub struct HnswConfig {
     /// Number of parallel threads used for background index building. If 0 - auto selection.
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
-    // Store HNSW index on disk. If set to false, index will be stored in RAM.
+    /// Store HNSW index on disk. If set to false, index will be stored in RAM.
     #[serde(default)]
     pub on_disk: bool,
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -271,9 +271,10 @@ pub struct HnswConfig {
     /// Number of parallel threads used for background index building. If 0 - auto selection.
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
-    /// Store HNSW index on disk. If set to false, index will be stored in RAM.
+    /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false
     #[serde(default)]
-    pub on_disk: bool,
+    #[serde(skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    pub on_disk: Option<bool>,
 }
 
 fn default_max_indexing_threads() -> usize {
@@ -287,7 +288,7 @@ impl Default for HnswConfig {
             ef_construct: 100,
             full_scan_threshold: DEFAULT_FULL_SCAN_THRESHOLD,
             max_indexing_threads: 0,
-            on_disk: false,
+            on_disk: Some(false),
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -271,6 +271,9 @@ pub struct HnswConfig {
     /// Number of parallel threads used for background index building. If 0 - auto selection.
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
+    // Store HNSW index on disk. If set to false, index will be stored in RAM.
+    #[serde(default)]
+    pub on_disk: bool,
 }
 
 fn default_max_indexing_threads() -> usize {
@@ -284,6 +287,7 @@ impl Default for HnswConfig {
             ef_construct: 100,
             full_scan_threshold: DEFAULT_FULL_SCAN_THRESHOLD,
             max_indexing_threads: 0,
+            on_disk: false,
         }
     }
 }

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -8,6 +8,7 @@ mod tests {
     use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
     use segment::entry::entry_point::SegmentEntry;
     use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
+    use segment::index::hnsw_index::graph_links::GraphLinksRam;
     use segment::index::hnsw_index::hnsw::HNSWIndex;
     use segment::index::{PayloadIndex, VectorIndex};
     use segment::segment_constructor::build_segment;
@@ -80,7 +81,7 @@ mod tests {
             on_disk: false,
         };
 
-        let mut hnsw_index = HNSWIndex::open(
+        let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
             hnsw_dir.path(),
             segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_storage

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -78,7 +78,7 @@ mod tests {
             ef_construct,
             full_scan_threshold,
             max_indexing_threads: 2,
-            on_disk: false,
+            on_disk: Some(false),
         };
 
         let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -77,6 +77,7 @@ mod tests {
             ef_construct,
             full_scan_threshold,
             max_indexing_threads: 2,
+            on_disk: false,
         };
 
         let mut hnsw_index = HNSWIndex::open(

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -8,6 +8,7 @@ mod tests {
     use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
     use segment::entry::entry_point::SegmentEntry;
     use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
+    use segment::index::hnsw_index::graph_links::GraphLinksRam;
     use segment::index::hnsw_index::hnsw::HNSWIndex;
     use segment::index::{PayloadIndex, VectorIndex};
     use segment::segment_constructor::build_segment;
@@ -80,7 +81,7 @@ mod tests {
             on_disk: false,
         };
 
-        let mut hnsw_index = HNSWIndex::open(
+        let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
             hnsw_dir.path(),
             segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_storage

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -78,7 +78,7 @@ mod tests {
             ef_construct,
             full_scan_threshold,
             max_indexing_threads: 2,
-            on_disk: false,
+            on_disk: Some(false),
         };
 
         let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -77,6 +77,7 @@ mod tests {
             ef_construct,
             full_scan_threshold,
             max_indexing_threads: 2,
+            on_disk: false,
         };
 
         let mut hnsw_index = HNSWIndex::open(


### PR DESCRIPTION
Performance difference between RAM and MMAP modes.

Test data: 40M points, dim 128, mmap vector storage and on disk payload.
Running in docker with different RAM limits. each row in table describes ram limit and searces count.

| Searches        | Links in RAM           | Links in MMAP  |
| ------------- |:-------------:| -----:|
| 3GB <br> 2K searches  | Out of memory | Avg: 1.3601s <br> p95: 1.6185s |
| 5GB <br> 2K searches | Avg: 1.1130s <br> p95: 1.3149s <br><br>  Avg: 1.1011s <br> p95: 1.2989s   |   Avg: 1.1233s <br> p95: 1.3426s <br><br> Avg: 1.1266s <br> p95: 1.3498s |
| 10GB <br> 2K searches | Avg: 0.7178s <br> p95: 0.9333s <br><br>  Avg: 0.7145s <br> p95: 0.9063s   |   Avg: 0.7334s <br> p95: 0.8898s <br><br> Avg: 0.7280s <br> p95: 0.8906s |
| 20GB  <br>  15K searches | Avg: 0.0682s <br> p95: 0.0899s <br><br>  Avg: 0.0676s <br> p95: 0.0903s   |   Avg: 0.1590s <br> p95: 0.1961s <br><br> Avg: 0.1577s <br> p95: 0.1933s |
| 50GB  <br> 30K searches | Avg: 0.0021s <br> p95: 0.0019s <br><br>  Avg: 0.0021s <br> p95: 0.0019s   |   Avg: 0.0023s <br> p95: 0.0022s <br><br> Avg: 0.0023s <br> p95: 0.0022s |

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
