### PR TITLE
Recover distributed collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tower",
+ "url",
  "uuid",
  "wal",
 ]
@@ -902,6 +903,16 @@ dependencies = [
  "percent-encoding",
  "time 0.3.14",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1259,6 +1270,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,7 +1579,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
- "spin",
+ "spin 0.9.4",
  "stable_deref_trait",
 ]
 
@@ -1658,6 +1684,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1706,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1742,6 +1794,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -2046,6 +2104,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log 0.4.17",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2255,51 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "openssl"
+version = "0.10.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2874,12 +2995,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log 0.4.17",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b221de559e4a29df3b957eec92bc0de6bc8eaf6ca9cfed43e5e1d67ff65a34"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3004,6 +3183,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log 0.4.17",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3264,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "url",
  "uuid",
 ]
 
@@ -3076,10 +3287,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "segment"
@@ -3316,6 +3560,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
@@ -3349,6 +3599,7 @@ dependencies = [
  "prost 0.9.0",
  "raft",
  "rand",
+ "reqwest",
  "schemars",
  "segment",
  "serde",
@@ -3359,6 +3610,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "url",
+ "uuid",
  "wal",
 ]
 
@@ -3638,6 +3891,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +4168,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4019,6 +4300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4348,25 @@ checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -4153,6 +4465,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "wyz"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1111,6 +1111,86 @@
         }
       }
     },
+    "/collections/{collection_name}/snapshots/recover": {
+      "put": {
+        "tags": [
+          "snapshots",
+          "collections"
+        ],
+        "summary": "Recover from a snapshot",
+        "description": "Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection.",
+        "operationId": "recover_from_snapshot",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Snapshot to recover from",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotRecover"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/snapshots": {
       "get": {
         "tags": [
@@ -5902,6 +5982,19 @@
           },
           "write": {
             "type": "boolean"
+          }
+        }
+      },
+      "SnapshotRecover": {
+        "type": "object",
+        "required": [
+          "location"
+        ],
+        "properties": {
+          "location": {
+            "description": "Examples: - URL `http://localhost:8080/collections/my_collection/snapshots/my_snapshot` - Local path `file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot`",
+            "type": "string",
+            "format": "uri"
           }
         }
       }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -36,6 +36,7 @@ arc-swap = "1.5.1"
 tonic = "0.7.2"
 tower = "0.4.13"
 uuid = { version = "1.2", features = ["v4", "serde"] }
+url = { version = "2", features = ["serde"] }
 
 segment = {path = "../segment"}
 api = {path = "../api"}
@@ -43,7 +44,7 @@ api = {path = "../api"}
 itertools = "0.10"
 indicatif = "0.17.2"
 chrono = { version = "~0.4", features = ["serde"] }
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono"] }
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono", "url"] }
 num_cpus = "1.14.0"
 tar = "0.4.38"
 fs_extra = "1.2.0"

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1455,7 +1455,7 @@ impl Collection {
         &self,
         snapshot_shard_path: &Path,
         shard_id: ShardId,
-    ) -> CollectionResult<()> {
+    ) -> CollectionResult<bool> {
         let shard_holder = self.shards_holder.read().await;
         let replica_set =
             shard_holder

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1451,7 +1451,7 @@ impl Collection {
 
     pub fn restore_snapshot(snapshot_path: &Path, target_dir: &Path) -> CollectionResult<()> {
         // decompress archive
-        let archive_file = std::fs::File::open(snapshot_path).unwrap();
+        let archive_file = std::fs::File::open(snapshot_path)?;
         let mut ar = tar::Archive::new(archive_file);
         ar.unpack(target_dir)?;
 

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -5,8 +5,14 @@ use api::grpc::conversions::date_time_to_proto;
 use chrono::NaiveDateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::operations::types::CollectionResult;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct SnapshotRecover {
+    pub location: Url,
+}
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SnapshotDescription {

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -11,6 +11,9 @@ use crate::operations::types::CollectionResult;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SnapshotRecover {
+    /// Examples:
+    /// - URL `http://localhost:8080/collections/my_collection/snapshots/my_snapshot`
+    /// - Local path `file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot`
     pub location: Url,
 }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -58,6 +58,23 @@ pub struct LocalShard {
 
 /// Shard holds information about segments and WAL.
 impl LocalShard {
+    pub async fn move_data(from: &Path, to: &Path) -> CollectionResult<()> {
+        let wal_from = Self::wal_path(from);
+        let wal_to = Self::wal_path(to);
+        let segments_from = Self::segments_path(from);
+        let segments_to = Self::segments_path(to);
+        tokio::fs::rename(wal_from, wal_to).await?;
+        tokio::fs::rename(segments_from, segments_to).await?;
+        Ok(())
+    }
+
+    /// Checks if path have local shard data present
+    pub async fn check_data(shard_path: &Path) -> bool {
+        let wal_path = Self::wal_path(shard_path);
+        let segments_path = Self::segments_path(shard_path);
+        wal_path.exists() && segments_path.exists()
+    }
+
     /// Clear local shard related data.
     ///
     /// Do NOT remove config file.
@@ -149,7 +166,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
-    ) -> LocalShard {
+    ) -> CollectionResult<LocalShard> {
         let collection_config = shared_config.read().await;
 
         let wal_path = Self::wal_path(shard_path);
@@ -160,47 +177,43 @@ impl LocalShard {
             wal_path.to_str().unwrap(),
             &(&collection_config.wal_config).into(),
         )
-        .expect("Can't read WAL");
+        .map_err(|e| CollectionError::service_error(format!("Wal error: {}", e)))?;
 
-        let segment_dirs = std::fs::read_dir(&segments_path).unwrap_or_else(|err| {
-            panic!(
+        let segment_dirs = std::fs::read_dir(&segments_path).map_err(|err| {
+            CollectionError::service_error(format!(
                 "Can't read segments directory due to {}\nat {}",
                 err,
                 segments_path.to_str().unwrap()
-            )
-        });
+            ))
+        })?;
 
         let mut load_handlers = vec![];
 
         for entry in segment_dirs {
             let segments_path = entry.unwrap().path();
             if segments_path.ends_with("deleted") {
-                std::fs::remove_dir_all(&segments_path).unwrap_or_else(|_| {
-                    panic!(
+                std::fs::remove_dir_all(&segments_path).map_err(|_| {
+                    CollectionError::service_error(format!(
                         "Can't remove marked-for-remove segment {}",
                         segments_path.to_str().unwrap()
-                    )
-                });
+                    ))
+                })?;
                 continue;
             }
             load_handlers.push(
                 thread::Builder::new()
                     .name("shard-load".to_string())
-                    .spawn(move || load_segment(&segments_path))
-                    .unwrap(),
+                    .spawn(move || load_segment(&segments_path))?,
             );
         }
 
         for handler in load_handlers {
-            let res = handler.join();
-            if let Err(err) = res {
-                panic!("Can't load segment {:?}", err);
-            }
-            let res = res.unwrap();
-            if let Err(res) = res {
-                panic!("Can't load segment {:?}", res);
-            }
-            let segment_opt = res.unwrap();
+            let segment_opt = handler.join().map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Can't join segment load thread: {:?}",
+                    err.type_id()
+                ))
+            })??;
             if let Some(segment) = segment_opt {
                 segment_holder.add(segment);
             }
@@ -228,7 +241,7 @@ impl LocalShard {
 
         collection.load_from_wal(collection_id).await;
 
-        collection
+        Ok(collection)
     }
 
     pub fn shard_path(&self) -> PathBuf {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -158,9 +158,6 @@ impl LocalShard {
     }
 
     /// Recovers shard from disk.
-    ///
-    /// WARN: This method intended to be used only on the initial start of the node.
-    /// It does not implement any logic to recover from a failure. Will panic if there is a failure.
     pub async fn load(
         id: ShardId,
         collection_id: CollectionId,

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -652,9 +652,9 @@ impl ShardReplicaSet {
     pub async fn restore_local_replica_from(&self, replica_path: &Path) -> CollectionResult<bool> {
         if LocalShard::check_data(replica_path).await {
             let mut local = self.local.write().await;
-            let removing_local = local.take();
+            let removed_local = local.take();
 
-            if let Some(mut removing_local) = removing_local {
+            if let Some(mut removing_local) = removed_local {
                 removing_local.before_drop().await;
                 LocalShard::clear(&self.shard_path).await?;
             }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -209,7 +209,8 @@ impl ShardHolder {
                             &path,
                             shared_collection_config.clone(),
                         )
-                        .await;
+                        .await
+                        .unwrap();
                         replica_set
                             .set_local(local_shard, Some(ReplicaState::Active))
                             .await
@@ -228,7 +229,8 @@ impl ShardHolder {
                             &path,
                             shared_collection_config.clone(),
                         )
-                        .await;
+                        .await
+                        .unwrap();
 
                         replica_set
                             .set_local(temp_shard, Some(ReplicaState::Partial))

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "0dd3943113ff7ec2fbc5428bb77ba206c8492fa9" }
-tokio = {version = "~1.21", features = ["rt-multi-thread"]}
+tokio = { version = "~1.21", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
@@ -23,7 +23,7 @@ async-trait = "0.1.58"
 log = "0.4"
 tonic = "0.7.2"
 http = "0.2"
-parking_lot = { version = "0.12.1", features=["deadlock_detection", "serde"]}
+parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 tar = "0.4.38"
 chrono = { version = "~0.4", features = ["serde"] }
 
@@ -33,8 +33,11 @@ raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77
 prost = { version = "=0.9.0" } # version of prost used by raft
 serde_cbor = { version = "0.11.2" }
 
-segment = {path = "../segment"}
-collection = {path = "../collection"}
-api = {path = "../api"}
+segment = { path = "../segment" }
+collection = { path = "../collection" }
+api = { path = "../api" }
 futures = "0.3.25"
 anyhow = "1.0.66"
+uuid = "1.2.1"
+url = "2.3.1"
+reqwest = { version = "0.11", features = ["stream", "rustls-tls"] }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -32,6 +32,12 @@ impl StorageError {
         }
     }
 
+    pub fn bad_input(description: &str) -> StorageError {
+        StorageError::BadInput {
+            description: description.to_string(),
+        }
+    }
+
     /// Used to override the `description` field of the resulting `StorageError`
     pub fn from_inconsistent_shard_failure(
         err: CollectionError,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -188,3 +188,11 @@ impl From<tonic::transport::Error> for StorageError {
         }
     }
 }
+
+impl From<reqwest::Error> for StorageError {
+    fn from(err: reqwest::Error) -> Self {
+        StorageError::ServiceError {
+            description: format!("Http request error: {}", err),
+        }
+    }
+}

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -69,7 +69,7 @@ pub mod consensus_ops {
             collection_name: CollectionId,
             shard_id: u32,
             peer_id: PeerId,
-            state: ReplicaState
+            state: ReplicaState,
         ) -> Self {
             ConsensusOperations::CollectionMeta(
                 CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
@@ -78,7 +78,7 @@ pub mod consensus_ops {
                     peer_id,
                     state,
                 })
-                    .into(),
+                .into(),
             )
         }
 

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -65,20 +65,29 @@ pub mod consensus_ops {
             )))
         }
 
-        pub fn activate_replica(
+        pub fn set_replica_state(
             collection_name: CollectionId,
             shard_id: u32,
             peer_id: PeerId,
+            state: ReplicaState
         ) -> Self {
             ConsensusOperations::CollectionMeta(
                 CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
                     collection_name,
                     shard_id,
                     peer_id,
-                    state: ReplicaState::Active,
+                    state,
                 })
-                .into(),
+                    .into(),
             )
+        }
+
+        pub fn activate_replica(
+            collection_name: CollectionId,
+            shard_id: u32,
+            peer_id: PeerId,
+        ) -> Self {
+            Self::set_replica_state(collection_name, shard_id, peer_id, ReplicaState::Active)
         }
 
         pub fn deactivate_replica(
@@ -86,15 +95,7 @@ pub mod consensus_ops {
             shard_id: u32,
             peer_id: PeerId,
         ) -> Self {
-            ConsensusOperations::CollectionMeta(
-                CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
-                    collection_name,
-                    shard_id,
-                    peer_id,
-                    state: ReplicaState::Dead,
-                })
-                .into(),
-            )
+            Self::set_replica_state(collection_name, shard_id, peer_id, ReplicaState::Dead)
         }
 
         pub fn start_transfer(collection_id: CollectionId, transfer: ShardTransfer) -> Self {

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -60,12 +60,10 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
             download_file(&url, &download_to).await?;
             Ok(download_to)
         }
-        _ => {
-            Err(StorageError::bad_request(&format!(
-                "URL {} with schema {} is not supported",
-                url,
-                url.scheme()
-            )))
-        }
+        _ => Err(StorageError::bad_request(&format!(
+            "URL {} with schema {} is not supported",
+            url,
+            url.scheme()
+        ))),
     }
 }

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -30,6 +30,15 @@ async fn download_file(url: &Url, path: &Path) -> Result<(), StorageError> {
     let mut file = File::create(path).await?;
 
     let response = reqwest::get(url.clone()).await?;
+
+    if !response.status().is_success() {
+        return Err(StorageError::bad_input(&format!(
+            "Failed to download snapshot from {}: status - {}",
+            url,
+            response.status()
+        )));
+    }
+
     let mut stream = response.bytes_stream();
 
     while let Some(chunk_result) = stream.next().await {

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+
+use futures::StreamExt;
+use reqwest;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use url::Url;
+use uuid::Uuid;
+
+use crate::StorageError;
+
+fn downloaded_snapshots_dir(snapshots_dir: &str) -> PathBuf {
+    Path::new(snapshots_dir).join("downloaded-snapshots")
+}
+
+fn random_name() -> String {
+    format!("{}.snapshot", Uuid::new_v4().to_string())
+}
+
+fn snapshot_name(url: &Url) -> String {
+    let path = Path::new(url.path());
+
+    path.file_name()
+        .and_then(|x| x.to_str())
+        .map(|x| x.to_string())
+        .unwrap_or_else(random_name)
+}
+
+async fn download_files(url: &Url, path: &Path) -> Result<(), StorageError> {
+    let mut file = File::create(path).await?;
+
+    let response = reqwest::get(url.clone()).await?;
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result?;
+        file.write_all(&chunk).await?;
+    }
+
+    file.flush().await?;
+
+    Ok(())
+}
+
+pub async fn download_snapshot(url: Url, snapshots_dir: &str) -> Result<PathBuf, StorageError> {
+    match url.scheme() {
+        "file" => {
+            let local_file_path = Path::new(url.path());
+            if !local_file_path.exists() {
+                return Err(StorageError::bad_request(&format!(
+                    "Snapshot file {:?} does not exist",
+                    local_file_path
+                )));
+            }
+            Ok(local_file_path.to_path_buf())
+        }
+        "http" | "https" => {
+            let download_to = Path::new(snapshots_dir).join(snapshot_name(&url));
+
+            download_files(&url, &download_to).await?;
+            Ok(download_to)
+        }
+        _ => {
+            return Err(StorageError::bad_request(&format!(
+                "URL {} with schema {} is not supported",
+                url,
+                url.scheme()
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_parsing() {
+        let remote_url = Url::parse("http://localhost:6333/collections/test_collection/snapshots/test_collection-2022-08-04-10-49-10.snapshot").unwrap();
+        let local_url =
+            Url::parse("file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot")
+                .unwrap();
+
+        eprintln!("local_url_abs.path() = {:#?}", remote_url.path());
+    }
+}

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -1,9 +1,9 @@
+mod download;
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use collection::operations::snapshot_ops::{
-    get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
-};
+use collection::operations::snapshot_ops::{get_snapshot_description, list_snapshots_in_directory, SnapshotDescription, SnapshotRecover};
 use serde::{Deserialize, Serialize};
 use tar::Builder as TarBuilder;
 use tokio::io::AsyncWriteExt;
@@ -31,6 +31,15 @@ pub async fn get_full_snapshot_path(
         });
     }
     Ok(snapshot_path)
+}
+
+pub async fn do_recover_from_snapshot(
+    toc: &TableOfContent,
+    snapshot_name: &str,
+    source: SnapshotRecover
+) -> Result<bool, StorageError> {
+    // toc.snapshots_path();
+    todo!()
 }
 
 pub async fn do_list_full_snapshots(

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -3,7 +3,9 @@ mod download;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use collection::operations::snapshot_ops::{get_snapshot_description, list_snapshots_in_directory, SnapshotDescription, SnapshotRecover};
+use collection::operations::snapshot_ops::{
+    get_snapshot_description, list_snapshots_in_directory, SnapshotDescription, SnapshotRecover,
+};
 use serde::{Deserialize, Serialize};
 use tar::Builder as TarBuilder;
 use tokio::io::AsyncWriteExt;
@@ -36,7 +38,7 @@ pub async fn get_full_snapshot_path(
 pub async fn do_recover_from_snapshot(
     toc: &TableOfContent,
     snapshot_name: &str,
-    source: SnapshotRecover
+    source: SnapshotRecover,
 ) -> Result<bool, StorageError> {
     // toc.snapshots_path();
     todo!()

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -1,10 +1,11 @@
-mod download;
+pub mod download;
+pub mod recover;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use collection::operations::snapshot_ops::{
-    get_snapshot_description, list_snapshots_in_directory, SnapshotDescription, SnapshotRecover,
+    get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
 };
 use serde::{Deserialize, Serialize};
 use tar::Builder as TarBuilder;
@@ -33,15 +34,6 @@ pub async fn get_full_snapshot_path(
         });
     }
     Ok(snapshot_path)
-}
-
-pub async fn do_recover_from_snapshot(
-    toc: &TableOfContent,
-    snapshot_name: &str,
-    source: SnapshotRecover,
-) -> Result<bool, StorageError> {
-    // toc.snapshots_path();
-    todo!()
 }
 
 pub async fn do_list_full_snapshots(

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -61,14 +61,14 @@ pub async fn do_recover_from_snapshot(
     if snapshot_config.params.vectors != state.config.params.vectors {
         return Err(StorageError::bad_input(&format!(
             "Snapshot is not compatible with existing collection: Collection vectors: {:?} Snapshot Vectors: {:?}",
-            state.config.params.vectors, state.config.params.vectors
+            state.config.params.vectors, snapshot_config.params.vectors
         )));
     }
     // Check shard number
     if snapshot_config.params.shard_number != state.config.params.shard_number {
         return Err(StorageError::bad_input(&format!(
             "Snapshot is not compatible with existing collection: Collection shard number: {:?} Snapshot shard number: {:?}",
-            state.config.params.shard_number, state.config.params.shard_number
+            state.config.params.shard_number, snapshot_config.params.shard_number
         )));
     }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -118,7 +118,7 @@ pub async fn do_recover_from_snapshot(
                 continue;
             }
 
-            // If this is te only replica, we can activate it
+            // If this is the only replica, we can activate it
             // If not - de-sync is possible, so we need to run synchronization
             let other_active_replicas: Vec<_> = shard_info
                 .replicas

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -17,6 +17,8 @@ pub async fn do_recover_from_snapshot(
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location } = source;
 
+    let collection = toc.get_collection(collection_name).await?;
+
     let snapshot_download_path = downloaded_snapshots_dir(toc.snapshots_path());
     tokio::fs::create_dir_all(&snapshot_download_path).await?;
 
@@ -51,8 +53,6 @@ pub async fn do_recover_from_snapshot(
     Collection::restore_snapshot(&snapshot_path, &tmp_collection_dir)?;
 
     let snapshot_config = CollectionConfig::load(&tmp_collection_dir)?;
-
-    let collection = toc.get_collection(collection_name).await?;
 
     let state = collection.state().await;
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1231,22 +1231,7 @@ impl CollectionContainer for TableOfContent {
     fn remove_peer(&self, peer_id: PeerId) -> Result<(), StorageError> {
         self.collection_management_runtime.block_on(async {
             // Validation:
-            // 1. Check that we are not removing some unique shards
-
-            for collection_name in self.all_collections().await {
-                let collection = self.get_collection(&collection_name).await?;
-                let collection_state = collection.state().await;
-                for (shard_id, shard) in collection_state.shards.iter() {
-                    if shard.replicas.len() == 1 && shard.replicas.contains_key(&peer_id) {
-                        return Err(StorageError::bad_request(&format!(
-                            "Cannot remove peer {} because it is the only replica of shard {} of collection {}",
-                            peer_id,
-                            shard_id,
-                            collection_name
-                        )));
-                    }
-                }
-            }
+            // 1. Check that we are not removing some unique shards (removed)
 
             // Validation passed
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -23,7 +23,7 @@ use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
-use collection::shards::transfer::shard_transfer::validate_transfer;
+use collection::shards::transfer::shard_transfer::{validate_transfer, ShardTransfer};
 use collection::shards::{replica_set, CollectionId};
 use collection::telemetry::CollectionTelemetry;
 use segment::types::ScoredPoint;
@@ -149,6 +149,11 @@ impl TableOfContent {
             is_write_locked: AtomicBool::new(false),
             lock_error_message: parking_lot::Mutex::new(None),
         }
+    }
+
+    /// Return `true` if service is working in distributed mode.
+    pub fn is_distributed(&self) -> bool {
+        self.consensus_proposal_sender.is_some()
     }
 
     fn get_collection_path(&self, collection_name: &str) -> PathBuf {
@@ -372,18 +377,31 @@ impl TableOfContent {
         Ok(())
     }
 
+    fn send_set_replica_state_proposal_op(
+        proposal_sender: &OperationSender,
+        collection_name: String,
+        peer_id: PeerId,
+        shard_id: ShardId,
+        state: ReplicaState,
+    ) -> Result<(), StorageError> {
+        let operation =
+            ConsensusOperations::set_replica_state(collection_name, shard_id, peer_id, state);
+        proposal_sender.send(operation)
+    }
+
     fn on_peer_failure_callback(
         proposal_sender: Option<OperationSender>,
         collection_name: String,
     ) -> replica_set::OnPeerFailure {
         Arc::new(move |peer_id, shard_id| {
             if let Some(proposal_sender) = &proposal_sender {
-                let operation = ConsensusOperations::deactivate_replica(
+                if let Err(send_error) = Self::send_set_replica_state_proposal_op(
+                    proposal_sender,
                     collection_name.clone(),
-                    shard_id,
                     peer_id,
-                );
-                if let Err(send_error) = proposal_sender.send(operation) {
+                    shard_id,
+                    ReplicaState::Dead,
+                ) {
                     log::error!(
                         "Can't send proposal to deactivate replica on peer {} of shard {} of collection {}. Error: {}",
                         peer_id,
@@ -396,6 +414,25 @@ impl TableOfContent {
                 log::error!("Can't send proposal to deactivate replica. Error: this is a single node deployment");
             }
         })
+    }
+
+    pub fn send_set_replica_state_proposal(
+        &self,
+        collection_name: String,
+        peer_id: PeerId,
+        shard_id: ShardId,
+        state: ReplicaState,
+    ) -> Result<(), StorageError> {
+        if let Some(operation_sender) = &self.consensus_proposal_sender {
+            Self::send_set_replica_state_proposal_op(
+                operation_sender,
+                collection_name,
+                peer_id,
+                shard_id,
+                state,
+            )?;
+        }
+        Ok(())
     }
 
     fn request_shard_transfer_callback(
@@ -420,6 +457,27 @@ impl TableOfContent {
                 log::error!("Can't send proposal to request shard transfer. Error: this is a single node deployment");
             }
         })
+    }
+
+    pub fn request_shard_transfer(
+        &self,
+        collection_name: String,
+        shard_id: ShardId,
+        from_peer: PeerId,
+        to_peer: PeerId,
+        sync: bool,
+    ) -> Result<(), StorageError> {
+        if let Some(proposal_sender) = &self.consensus_proposal_sender {
+            let transfer_request = ShardTransfer {
+                shard_id,
+                from: from_peer,
+                to: to_peer,
+                sync,
+            };
+            let operation = ConsensusOperations::start_transfer(collection_name, transfer_request);
+            proposal_sender.send(operation)?;
+        }
+        Ok(())
     }
 
     async fn update_collection(

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -1,6 +1,28 @@
 #@ load("openapi.lib.yml", "response", "reference", "type", "array")
 
 paths:
+  /collections/{collection_name}/snapshots/recover:
+    put:
+      tags:
+        - snapshots
+        - collections
+      summary: Recover from a snapshot
+      description: Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection.
+      operationId: recover_from_snapshot
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Snapshot to recover from
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SnapshotRecover"
+      responses: #@ response(type("boolean"))
 
   /collections/{collection_name}/snapshots:
     get:

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,8 +1,10 @@
 use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
-use actix_web::{get, post, web, Responder, Result};
+use actix_web::{get, post, put, web, Responder, Result};
+use collection::operations::snapshot_ops::SnapshotRecover;
 use storage::content_manager::snapshots::{
-    do_create_full_snapshot, do_list_full_snapshots, get_full_snapshot_path,
+    do_create_full_snapshot, do_list_full_snapshots, do_recover_from_snapshot,
+    get_full_snapshot_path,
 };
 use storage::content_manager::toc::TableOfContent;
 
@@ -58,6 +60,21 @@ async fn create_snapshot(
     process_response(response, timing)
 }
 
+#[put("/collections/{name}/snapshots/recover")]
+async fn recover_from_snapshot(
+    toc: web::Data<TableOfContent>,
+    path: web::Path<String>,
+    request: web::Json<SnapshotRecover>,
+) -> impl Responder {
+    let collection_name = path.into_inner();
+    let snapshot_recover = request.into_inner();
+
+    let timing = Instant::now();
+    let response =
+        do_recover_from_snapshot(toc.get_ref(), &collection_name, snapshot_recover).await;
+    process_response(response, timing)
+}
+
 #[get("/collections/{name}/snapshots/{snapshot_name}")]
 async fn get_snapshot(
     toc: web::Data<TableOfContent>,
@@ -94,6 +111,7 @@ async fn get_full_snapshot(
 pub fn config_snapshots_api(cfg: &mut web::ServiceConfig) {
     cfg.service(list_snapshots)
         .service(create_snapshot)
+        .service(recover_from_snapshot)
         .service(get_snapshot)
         .service(list_full_snapshots)
         .service(create_full_snapshot)

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,12 +1,11 @@
 use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
-use actix_web::{get, post, put, Responder, Result, web};
+use actix_web::{get, post, put, web, Responder, Result};
 use collection::operations::snapshot_ops::SnapshotRecover;
-use storage::content_manager::snapshots::{
-    do_create_full_snapshot, do_list_full_snapshots,
-    get_full_snapshot_path,
-};
 use storage::content_manager::snapshots::recover::do_recover_from_snapshot;
+use storage::content_manager::snapshots::{
+    do_create_full_snapshot, do_list_full_snapshots, get_full_snapshot_path,
+};
 use storage::content_manager::toc::TableOfContent;
 
 use crate::actix::helpers::{

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,11 +1,12 @@
 use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
-use actix_web::{get, post, put, web, Responder, Result};
+use actix_web::{get, post, put, Responder, Result, web};
 use collection::operations::snapshot_ops::SnapshotRecover;
 use storage::content_manager::snapshots::{
-    do_create_full_snapshot, do_list_full_snapshots, do_recover_from_snapshot,
+    do_create_full_snapshot, do_list_full_snapshots,
     get_full_snapshot_path,
 };
+use storage::content_manager::snapshots::recover::do_recover_from_snapshot;
 use storage::content_manager::toc::TableOfContent;
 
 use crate::actix::helpers::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,17 @@ struct Args {
 
     /// List of paths to snapshot files.
     /// Format: <snapshot_file_path>:<target_collection_name>
+    ///
+    /// WARN: Do not use this option if you are recovering collection in existing distributed cluster.
+    /// Use `/collections/<collection-name>/snapshots/recover` API instead.
     #[arg(long, value_name = "PATH:NAME", alias = "collection-snapshot")]
     snapshot: Option<Vec<String>>,
 
     /// Path to snapshot of multiple collections.
     /// Format: <snapshot_file_path>
+    ///
+    /// WARN: Do not use this option if you are recovering collection in existing distributed cluster.
+    /// Use `/collections/<collection-name>/snapshots/recover` API instead.
     #[arg(long, value_name = "PATH")]
     storage_snapshot: Option<String>,
 }

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -2,7 +2,7 @@ use api::grpc::models::CollectionsResponse;
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
-use collection::operations::snapshot_ops::SnapshotDescription;
+use collection::operations::snapshot_ops::{SnapshotDescription, SnapshotRecover};
 use collection::operations::types::{
     CollectionClusterInfo, CollectionInfo, CountRequest, CountResult, PointRequest,
     RecommendRequest, RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchRequest,
@@ -56,6 +56,7 @@ struct AllDefinitions {
     at: SearchRequestBatch,
     au: RecommendRequestBatch,
     av: LocksOption,
+    aw: SnapshotRecover,
 }
 
 fn save_schema<T: JsonSchema>() {

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -1,0 +1,60 @@
+import random
+
+import requests
+
+from consensus_tests.assertions import assert_http_ok
+
+CITIES = ["London", "New York", "Paris", "Tokyo", "Berlin", "Rome", "Madrid", "Moscow"]
+
+
+def random_vector():
+    return [random.random() for _ in range(4)]
+
+
+def upsert_random_points(peer_url, num):
+    # Create points in first peer's collection
+    r_batch = requests.put(
+        f"{peer_url}/collections/test_collection/points?wait=true", json={
+            "points": [
+                {
+                    "id": i,
+                    "vector": random_vector(),
+                    "payload": {"city": random.choice(CITIES)}
+                } for i in range(num)
+            ]
+        })
+    assert_http_ok(r_batch)
+
+
+def create_collection(peer_url, collection="test_collection", shard_number=1, replication_factor=1, timeout=10):
+    # Create collection in first peer
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}?timeout={timeout}", json={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot"
+            },
+            "shard_number": shard_number,
+            "replication_factor": replication_factor,
+        })
+    assert_http_ok(r_batch)
+
+
+def search(peer_url, vector, city):
+    q = {
+        "vector": vector,
+        "top": 10,
+        "with_vector": False,
+        "with_payload": True,
+        "filter": {
+            "must": [
+                {
+                    "key": "city",
+                    "match": {"value": city}
+                }
+            ]
+        }
+    }
+    r_search = requests.post(f"{peer_url}/collections/test_collection/points/search", json=q)
+    assert_http_ok(r_search)
+    return r_search.json()["result"]

--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -1,0 +1,122 @@
+import pathlib
+
+import requests
+from .fixtures import create_collection, upsert_random_points, random_vector, search
+from .utils import *
+from .assertions import assert_http_ok
+
+N_PEERS = 3
+N_SHARDS = 3
+COLLECTION_NAME = "test_collection"
+
+
+def create_snapshot(peer_api_uri):
+    r = requests.post(f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots")
+    assert_http_ok(r)
+    return r.json()["result"]["name"]
+
+
+def get_peer_id(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["peer_id"]
+
+
+def get_local_shards(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]['local_shards']
+
+
+def recover_snapshot(peer_api_uri, snapshot_url):
+    r = requests.put(f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/recover",
+                     json={"location": snapshot_url})
+    assert_http_ok(r)
+    return r.json()["result"]
+
+
+def test_recover_from_snapshot_1(tmp_path: pathlib.Path):
+    recover_from_snapshot(tmp_path, 1)
+
+
+def test_recover_from_snapshot_2(tmp_path: pathlib.Path):
+    recover_from_snapshot(tmp_path, 2)
+
+
+def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=n_replicas)
+    wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)
+    upsert_random_points(peer_api_uris[0], 100)
+
+    query_city = "London"
+    query_vector = random_vector()
+
+    search_result = search(peer_api_uris[0], query_vector, query_city)
+    assert len(search_result) > 0
+
+    snapshot_name = create_snapshot(peer_api_uris[-1])
+    assert snapshot_name is not None
+
+    # move file
+    snapshot_path = Path(peer_dirs[-1]) / "snapshots" / COLLECTION_NAME / snapshot_name
+    assert snapshot_path.exists()
+    snapshot_path.rename(Path(peer_dirs[0]) / "snapshots" / COLLECTION_NAME / snapshot_name)
+
+    process_peer_id = get_peer_id(peer_api_uris[-1])
+    local_shards = get_local_shards(peer_api_uris[-1])
+
+    # Kill last peer
+    p = processes.pop()
+    p.kill()
+
+    # Remove last peer from cluster
+    res = requests.delete(f"{peer_api_uris[0]}/cluster/peer/{process_peer_id}?force=true")
+    assert_http_ok(res)
+
+    new_peer_dir = make_peer_folder(tmp_path, N_PEERS + 1)
+    new_url = start_peer(new_peer_dir, f"peer_snapshot_{N_PEERS + 1}.log", bootstrap_uri)
+
+    # Wait node is up and synced
+    while True:
+        try:
+            res = requests.get(f"{new_url}/collections")
+        except requests.exceptions.ConnectionError:
+            time.sleep(1)
+            continue
+        if not res.ok:
+            time.sleep(1)  # Wait to node is up
+            continue
+        collections = set(collection['name'] for collection in res.json()["result"]['collections'])
+        if COLLECTION_NAME not in collections:
+            time.sleep(1)  # Wait to sync with consensus
+            continue
+        break
+
+    # Recover snapshot
+    # All nodes share the same snapshot directory, so it is fine to use any
+    snapshot_url = f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/snapshots/{snapshot_name}"
+
+    print(f"Recovering snapshot {snapshot_url} on {new_url}")
+
+    recover_snapshot(new_url, snapshot_url)
+
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=[new_url])
+
+    new_local_shards = get_local_shards(new_url)
+
+    new_local_shards = sorted(new_local_shards, key=lambda x: x['shard_id'])
+    local_shards = sorted(local_shards, key=lambda x: x['shard_id'])
+
+    assert len(new_local_shards) == len(local_shards)
+    for i in range(len(new_local_shards)):
+        assert new_local_shards[i] == local_shards[i]
+
+    new_search_result = search(new_url, query_vector, query_city)
+
+    assert len(new_search_result) == len(search_result)
+    for i in range(len(new_search_result)):
+        assert new_search_result[i] == search_result[i]

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -114,13 +114,18 @@ def start_cluster(tmp_path, num_peers):
     return peer_api_uris, peer_dirs, bootstrap_uri
 
 
+def make_peer_folder(base_path: Path, peer_number: int) -> Path:
+    peer_dir = base_path / f"peer{peer_number}"
+    peer_dir.mkdir()
+    shutil.copytree("config", peer_dir / "config")
+    return peer_dir
+
+
 def make_peer_folders(base_path: Path, n_peers: int) -> list[Path]:
     peer_dirs = []
     for i in range(n_peers):
-        peer_dir = base_path / f"peer{i}"
-        peer_dir.mkdir()
+        peer_dir = make_peer_folder(base_path, i)
         peer_dirs.append(peer_dir)
-        shutil.copytree("config", peer_dir / "config")
     return peer_dirs
 
 


### PR DESCRIPTION
Related to https://github.com/qdrant/qdrant/issues/1213

Introduces a new API for recovering existing collection (can't recover non-exiting collection from snapshot in distributed more, as collections are managed by consensus).
API can be used for recovery un-replicated shards and for speeding up replications of existing collections by avoiding indexing re-building with snapshots.