### PR TITLE
Extend telemetry

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -32,7 +32,8 @@ use crate::operations::snapshot_ops::{
 use crate::operations::types::{
     CollectionClusterInfo, CollectionError, CollectionInfo, CollectionResult, CountRequest,
     CountResult, LocalShardInfo, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
-    RemoteShardInfo, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult, UsingVector,
+    RemoteShardInfo, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult,
+    UsingVector,
 };
 use crate::operations::{CollectionUpdateOperations, Validate};
 use crate::optimizers_builder::OptimizersConfig;

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -32,8 +32,7 @@ use crate::operations::snapshot_ops::{
 use crate::operations::types::{
     CollectionClusterInfo, CollectionError, CollectionInfo, CollectionResult, CountRequest,
     CountResult, LocalShardInfo, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
-    RemoteShardInfo, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch,
-    ShardTransferInfo, UpdateResult, UsingVector,
+    RemoteShardInfo, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult, UsingVector,
 };
 use crate::operations::{CollectionUpdateOperations, Validate};
 use crate::optimizers_builder::OptimizersConfig;
@@ -1275,7 +1274,6 @@ impl Collection {
         let shard_count = shards_holder.len();
         let mut local_shards = Vec::new();
         let mut remote_shards = Vec::new();
-        let mut shard_transfers = Vec::new();
         let count_request = Arc::new(CountRequest {
             filter: None,
             exact: true,
@@ -1309,24 +1307,11 @@ impl Collection {
                 });
             }
         }
-        // extract shard transfers info
-        for shard_transfer in shards_holder.shard_transfers.read().iter() {
-            let shard_id = shard_transfer.shard_id;
-            let to = shard_transfer.to;
-            let from = shard_transfer.from;
-            let sync = shard_transfer.sync;
-            shard_transfers.push(ShardTransferInfo {
-                shard_id,
-                from,
-                to,
-                sync,
-            })
-        }
+        let shard_transfers = shards_holder.get_shard_transfer_info();
 
         // sort by shard_id
         local_shards.sort_by_key(|k| k.shard_id);
         remote_shards.sort_by_key(|k| k.shard_id);
-        shard_transfers.sort_by_key(|k| k.shard_id);
 
         let info = CollectionClusterInfo {
             peer_id,
@@ -1371,13 +1356,13 @@ impl Collection {
     }
 
     pub async fn get_telemetry_data(&self) -> CollectionTelemetry {
-        let shards_telemetry = {
+        let (shards_telemetry, transfers) = {
             let mut shards_telemetry = Vec::new();
             let shards_holder = self.shards_holder.read().await;
             for shard in shards_holder.all_shards() {
                 shards_telemetry.push(shard.get_telemetry_data().await)
             }
-            shards_telemetry
+            (shards_telemetry, shards_holder.get_shard_transfer_info())
         };
 
         CollectionTelemetry {
@@ -1385,6 +1370,7 @@ impl Collection {
             init_time_ms: self.init_time.as_millis() as u64,
             config: self.config.read().await.clone(),
             shards: shards_telemetry,
+            transfers,
         }
     }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -115,7 +115,7 @@ pub struct CollectionClusterInfo {
     pub shard_transfers: Vec<ShardTransferInfo>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct ShardTransferInfo {
     pub shard_id: ShardId,
     pub from: PeerId,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -143,6 +143,7 @@ impl RemoteShard {
     pub fn get_telemetry_data(&self) -> RemoteShardTelemetry {
         RemoteShardTelemetry {
             shard_id: self.id,
+            peer_id: Some(self.peer_id),
             searches: self.telemetry_search_durations.lock().get_statistics(),
             updates: self.telemetry_update_durations.lock().get_statistics(),
         }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -645,6 +645,7 @@ impl ShardReplicaSet {
                 .iter()
                 .map(|remote| remote.get_telemetry_data())
                 .collect(),
+            replicate_states: self.replica_state.read().peers.clone(),
         }
     }
 

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -7,18 +8,21 @@ use segment::telemetry::SegmentTelemetry;
 use serde::{Deserialize, Serialize};
 
 use crate::operations::types::OptimizersStatus;
-use crate::shards::shard::ShardId;
+use crate::shards::replica_set::ReplicaState;
+use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct ReplicaSetTelemetry {
     pub id: ShardId,
     pub local: Option<LocalShardTelemetry>,
     pub remote: Vec<RemoteShardTelemetry>,
+    pub replicate_states: HashMap<PeerId, ReplicaState>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct RemoteShardTelemetry {
     pub shard_id: ShardId,
+    pub peer_id: Option<PeerId>,
     pub searches: OperationDurationStatistics,
     pub updates: OperationDurationStatistics,
 }
@@ -70,6 +74,7 @@ impl Anonymize for RemoteShardTelemetry {
     fn anonymize(&self) -> Self {
         RemoteShardTelemetry {
             shard_id: self.shard_id,
+            peer_id: None,
             searches: self.searches.anonymize(),
             updates: self.updates.anonymize(),
         }
@@ -82,6 +87,7 @@ impl Anonymize for ReplicaSetTelemetry {
             id: self.id,
             local: self.local.anonymize(),
             remote: self.remote.anonymize(),
+            replicate_states: Default::default(),
         }
     }
 }

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -22,7 +22,7 @@ impl Anonymize for CollectionTelemetry {
             config: self.config.anonymize(),
             init_time_ms: self.init_time_ms,
             shards: self.shards.anonymize(),
-            transfers: vec![]
+            transfers: vec![],
         }
     }
 }

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -3,6 +3,7 @@ use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
 
 use crate::config::CollectionConfig;
+use crate::operations::types::ShardTransferInfo;
 use crate::shards::telemetry::ReplicaSetTelemetry;
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -11,6 +12,7 @@ pub struct CollectionTelemetry {
     pub init_time_ms: u64,
     pub config: CollectionConfig,
     pub shards: Vec<ReplicaSetTelemetry>,
+    pub transfers: Vec<ShardTransferInfo>,
 }
 
 impl Anonymize for CollectionTelemetry {
@@ -20,6 +22,7 @@ impl Anonymize for CollectionTelemetry {
             config: self.config.anonymize(),
             init_time_ms: self.init_time_ms,
             shards: self.shards.anonymize(),
+            transfers: vec![]
         }
     }
 }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -76,7 +76,7 @@ impl ClusterTelemetry {
                     role: cluster_info.raft_info.role,
                     is_voter: cluster_info.raft_info.is_voter,
                     peer_id: Some(cluster_info.peer_id),
-                    consensus_thread_status: cluster_info.consensus_thread_status.clone(),
+                    consensus_thread_status: cluster_info.consensus_thread_status,
                 }),
             }
         } else {

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -1,8 +1,9 @@
+use collection::shards::shard::PeerId;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
 use storage::dispatcher::Dispatcher;
-use storage::types::{ClusterStatus, StateRole};
+use storage::types::{ClusterStatus, ConsensusThreadStatus, StateRole};
 
 use crate::settings::Settings;
 
@@ -49,6 +50,8 @@ pub struct ClusterStatusTelemetry {
     pub pending_operations: usize,
     pub role: Option<StateRole>,
     pub is_voter: bool,
+    pub peer_id: Option<PeerId>,
+    pub consensus_thread_status: ConsensusThreadStatus,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -72,6 +75,8 @@ impl ClusterTelemetry {
                     pending_operations: cluster_info.raft_info.pending_operations,
                     role: cluster_info.raft_info.role,
                     is_voter: cluster_info.raft_info.is_voter,
+                    peer_id: Some(cluster_info.peer_id),
+                    consensus_thread_status: cluster_info.consensus_thread_status.clone(),
                 }),
             }
         } else {
@@ -104,7 +109,16 @@ impl Anonymize for ClusterTelemetry {
 
 impl Anonymize for ClusterStatusTelemetry {
     fn anonymize(&self) -> Self {
-        self.clone()
+        ClusterStatusTelemetry {
+            number_of_peers: self.number_of_peers,
+            term: self.term,
+            commit: self.commit,
+            pending_operations: self.pending_operations,
+            role: self.role,
+            is_voter: self.is_voter,
+            peer_id: None,
+            consensus_thread_status: self.consensus_thread_status.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
Extend telemetry so it would be possible to build monitoring tools using only the telemetry API, avoiding extra requests to cluster and collection
