### PR TITLE
Fix panic on substraction overflow

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -492,7 +492,7 @@ impl SegmentEntry for ProxySegment {
         let write_segment_count = self.write_segment.get().read().points_count();
         count += wrapped_segment_count;
         count += write_segment_count;
-        count -= count.saturating_sub(deleted_points_count);
+        count = count.saturating_sub(deleted_points_count);
         count
     }
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -491,8 +491,8 @@ impl SegmentEntry for ProxySegment {
         let wrapped_segment_count = self.wrapped_segment.get().read().points_count();
         let write_segment_count = self.write_segment.get().read().points_count();
         count += wrapped_segment_count;
-        count -= deleted_points_count;
         count += write_segment_count;
+        count -= count.saturating_sub(deleted_points_count);
         count
     }
 


### PR DESCRIPTION
Fix the following panic observed during testing.

```
qdrant::startup] Panic occurred in file lib/collection/src/collection_manager/holders/proxy_segment.rs at line 494: attempt to subtract with overflow
```

I also reordered the instruction to first perform all the additions.