### PR TITLE
Bump wal to latest revision 94edd02

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
  "atomicwrites",
  "chrono",
  "criterion",
- "env_logger 0.10.0",
+ "env_logger",
  "fs_extra",
  "futures",
  "hashring",
@@ -1163,19 +1163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.17",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2864,7 +2851,7 @@ dependencies = [
  "collection",
  "colored",
  "config",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "futures-util",
  "itertools",
@@ -4311,12 +4298,13 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=0dd3943113ff7ec2fbc5428bb77ba206c8492fa9#0dd3943113ff7ec2fbc5428bb77ba206c8492fa9"
+source = "git+https://github.com/qdrant/wal.git?rev=94edd02ee2f7daa7054c8689b8f4fd5202690a81#94edd02ee2f7daa7054c8689b8f4fd5202690a81"
 dependencies = [
  "byteorder",
  "crc",
+ "crossbeam-channel",
  "docopt",
- "env_logger 0.9.3",
+ "env_logger",
  "eventual",
  "fs2",
  "log 0.4.17",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "0dd3943113ff7ec2fbc5428bb77ba206c8492fa9" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "94edd02ee2f7daa7054c8689b8f4fd5202690a81" }
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -1,6 +1,3 @@
-extern crate serde_cbor;
-extern crate wal;
-
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::result;
@@ -115,14 +112,12 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    extern crate tempfile;
-
     use std::fs;
     use std::os::unix::fs::MetadataExt;
 
     use tempfile::Builder;
+
+    use super::*;
 
     #[test]
     fn test_wal() {

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -13,7 +13,7 @@ proptest = "1.0.0"
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "0dd3943113ff7ec2fbc5428bb77ba206c8492fa9" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "94edd02ee2f7daa7054c8689b8f4fd5202690a81" }
 tokio = { version = "~1.22", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
This PR gets us to the latest revision of the [wal](https://github.com/qdrant/wal) project.

It contains mostly internal cleanups and dependencies updates.

The goal is to diminish the diff shipped when merging later https://github.com/qdrant/wal/pull/32