### PR TITLE
Update wal to revision 90471ad7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=94edd02ee2f7daa7054c8689b8f4fd5202690a81#94edd02ee2f7daa7054c8689b8f4fd5202690a81"
+source = "git+https://github.com/qdrant/wal.git?rev=90471ad737dbd90c49bb8944cb8aeb5ad8664d30#90471ad737dbd90c49bb8944cb8aeb5ad8664d30"
 dependencies = [
  "byteorder",
  "crc",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "94edd02ee2f7daa7054c8689b8f4fd5202690a81" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -13,7 +13,7 @@ proptest = "1.0.0"
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "94edd02ee2f7daa7054c8689b8f4fd5202690a81" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
 tokio = { version = "~1.22", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
Update to wal revision https://github.com/qdrant/wal/commit/90471ad737dbd90c49bb8944cb8aeb5ad8664d30 to get the new error logs https://github.com/qdrant/wal/pull/34.