### PR TITLE
allow set different M param for default HNSW and payload-related links

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -413,6 +413,7 @@
 | full_scan_threshold | [uint64](#uint64) | optional | Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold` additional indexing won&#39;t be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256 |
 | max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
 | on_disk | [bool](#bool) | optional | Store HNSW index on disk. If set to false, index will be stored in RAM. |
+| payload_m | [uint64](#uint64) | optional | Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3080,6 +3080,13 @@
             "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
             "type": "boolean",
             "nullable": true
+          },
+          "payload_m": {
+            "description": "Custom M param for hnsw graph built for payload index. If not set, default M will be used.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
@@ -4262,6 +4269,14 @@
             "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
             "default": null,
             "type": "boolean",
+            "nullable": true
+          },
+          "payload_m": {
+            "description": "Custom M param for additional payload-aware HNSW links. If not set, default M will be used.",
+            "default": null,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
             "nullable": true
           }
         }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -819,6 +819,7 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             full_scan_threshold: hnsw_config.full_scan_threshold.unwrap_or_default() as usize,
             max_indexing_threads: hnsw_config.max_indexing_threads.unwrap_or_default() as usize,
             on_disk: hnsw_config.on_disk,
+            payload_m: hnsw_config.payload_m.map(|x| x as usize),
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -90,6 +90,10 @@ message HnswConfigDiff {
   Store HNSW index on disk. If set to false, index will be stored in RAM.
    */
   optional bool on_disk = 5;
+  /*
+   Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+   */
+  optional uint64 payload_m = 6;
 }
 
 message WalConfigDiff {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -90,6 +90,10 @@ pub struct HnswConfigDiff {
     ///Store HNSW index on disk. If set to false, index will be stored in RAM.
     #[prost(bool, optional, tag="5")]
     pub on_disk: ::core::option::Option<bool>,
+    ///
+    ///Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+    #[prost(uint64, optional, tag="6")]
+    pub payload_m: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -54,6 +54,9 @@ pub struct HnswConfigDiff {
     /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false
     #[serde(default)]
     pub on_disk: Option<bool>,
+    /// Custom M param for additional payload-aware HNSW links. If not set, default M will be used.
+    #[serde(default)]
+    pub payload_m: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Merge, PartialEq, Eq, Hash)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -32,6 +32,7 @@ impl From<api::grpc::qdrant::HnswConfigDiff> for HnswConfigDiff {
             full_scan_threshold: value.full_scan_threshold.map(|v| v as usize),
             max_indexing_threads: value.max_indexing_threads.map(|v| v as usize),
             on_disk: value.on_disk,
+            payload_m: value.payload_m.map(|v| v as usize),
         }
     }
 }
@@ -152,6 +153,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     full_scan_threshold: Some(config.hnsw_config.full_scan_threshold as u64),
                     max_indexing_threads: Some(config.hnsw_config.max_indexing_threads as u64),
                     on_disk: config.hnsw_config.on_disk,
+                    payload_m: config.hnsw_config.payload_m.map(|v| v as u64),
                 }),
                 optimizer_config: Some(api::grpc::qdrant::OptimizersConfigDiff {
                     deleted_threshold: Some(config.optimizer_config.deleted_threshold),

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -20,6 +20,10 @@ pub struct HnswGraphConfig {
     pub indexing_threshold: usize,
     #[serde(default)]
     pub max_indexing_threads: usize,
+    #[serde(default)]
+    pub payload_m: Option<usize>,
+    #[serde(default)]
+    pub payload_m0: Option<usize>,
 }
 
 impl HnswGraphConfig {
@@ -28,6 +32,7 @@ impl HnswGraphConfig {
         ef_construct: usize,
         indexing_threshold: usize,
         max_indexing_threads: usize,
+        payload_m: Option<usize>,
     ) -> Self {
         HnswGraphConfig {
             m,
@@ -36,6 +41,8 @@ impl HnswGraphConfig {
             ef: ef_construct,
             indexing_threshold,
             max_indexing_threads,
+            payload_m,
+            payload_m0: payload_m.map(|v| v * 2),
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use std::cmp::{max, min};
 use std::collections::BinaryHeap;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
@@ -122,7 +122,7 @@ impl GraphLayersBuilder {
             m,
             m0,
             ef_construct,
-            level_factor: 1.0 / (m as f64).ln(),
+            level_factor: 1.0 / (max(m, 2) as f64).ln(),
             use_heuristic,
             links_layers,
             entry_points: Mutex::new(EntryPoints::new(entry_points_num)),

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -58,9 +58,13 @@ impl<'a> FilteredScorer<'a> {
                 &point_ids[0..filtered_len]
             }
         };
-
-        self.points_buffer
-            .resize(limit, ScoredPointOffset::default());
+        if limit == 0 {
+            self.points_buffer
+                .resize(filtered_point_ids.len(), ScoredPointOffset::default());
+        } else {
+            self.points_buffer
+                .resize(limit, ScoredPointOffset::default());
+        }
         let count = self
             .raw_scorer
             .score_points(filtered_point_ids, &mut self.points_buffer);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -275,6 +275,10 @@ pub struct HnswConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")] // Better backward compatibility
     pub on_disk: Option<bool>,
+    /// Custom M param for hnsw graph built for payload index. If not set, default M will be used.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    pub payload_m: Option<usize>,
 }
 
 fn default_max_indexing_threads() -> usize {
@@ -291,6 +295,7 @@ impl Default for HnswConfig {
             full_scan_threshold: DEFAULT_FULL_SCAN_THRESHOLD,
             max_indexing_threads: 0,
             on_disk: Some(false),
+            payload_m: None,
         }
     }
 }

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -79,6 +79,7 @@ mod tests {
             full_scan_threshold,
             max_indexing_threads: 2,
             on_disk: Some(false),
+            payload_m: None,
         };
 
         let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -79,6 +79,7 @@ mod tests {
             full_scan_threshold,
             max_indexing_threads: 2,
             on_disk: Some(false),
+            payload_m: None,
         };
 
         let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(


### PR DESCRIPTION
Allow to set different M parameter for payload related links in HNSW graph.
This should allow to keep independent subset of points in a single HNSW structure.

## Use-cases

Collection, that holds records from independent users.

## How to use:

Create collection with following params:

```
{
  ....,
  "hnsw_config": {
      "m": 0,
      "payload_m": 16
  }
}
```
And create payload field for some payload field.

This will create an HNSW graph which consists of non-overlapping sub-graphs. 
Sub-graphs will ensure the search performance of the requests, which have a filtering condition with the specified payload field. 
Note, that in this configuration requests over all records won't work.


