### PR TITLE
Peer id in snapshot name

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1389,10 +1389,11 @@ impl Collection {
         Ok(snapshot_path)
     }
 
-    pub async fn create_snapshot(&self, temp_dir: &Path) -> CollectionResult<SnapshotDescription> {
+    pub async fn create_snapshot(&self, temp_dir: &Path, this_peer_id: PeerId) -> CollectionResult<SnapshotDescription> {
         let snapshot_name = format!(
-            "{}-{}.snapshot",
+            "{}-{}-{}.snapshot",
             self.name(),
+            this_peer_id,
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S")
         );
         let snapshot_path = self.snapshots_path.join(&snapshot_name);

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1389,7 +1389,11 @@ impl Collection {
         Ok(snapshot_path)
     }
 
-    pub async fn create_snapshot(&self, temp_dir: &Path, this_peer_id: PeerId) -> CollectionResult<SnapshotDescription> {
+    pub async fn create_snapshot(
+        &self,
+        temp_dir: &Path,
+        this_peer_id: PeerId,
+    ) -> CollectionResult<SnapshotDescription> {
         let snapshot_name = format!(
             "{}-{}-{}.snapshot",
             self.name(),

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -88,7 +88,7 @@ async fn test_snapshot_collection() {
     let snapshots_tmp_dir = collection_dir.path().join("snapshots_tmp");
     std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
     let snapshot_description = collection
-        .create_snapshot(&snapshots_tmp_dir)
+        .create_snapshot(&snapshots_tmp_dir, 0)
         .await
         .unwrap();
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1109,7 +1109,9 @@ impl TableOfContent {
         // snapshot directory is mounted as network share and multiple writes to it could be slow
         let tmp_dir = Path::new(&self.storage_config.storage_path).join(SNAPSHOTS_TMP_DIR);
         tokio::fs::create_dir_all(&tmp_dir).await?;
-        Ok(collection.create_snapshot(&tmp_dir, self.this_peer_id).await?)
+        Ok(collection
+            .create_snapshot(&tmp_dir, self.this_peer_id)
+            .await?)
     }
 
     pub async fn suggest_shard_distribution(

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1109,7 +1109,7 @@ impl TableOfContent {
         // snapshot directory is mounted as network share and multiple writes to it could be slow
         let tmp_dir = Path::new(&self.storage_config.storage_path).join(SNAPSHOTS_TMP_DIR);
         tokio::fs::create_dir_all(&tmp_dir).await?;
-        Ok(collection.create_snapshot(&tmp_dir).await?)
+        Ok(collection.create_snapshot(&tmp_dir, self.this_peer_id).await?)
     }
 
     pub async fn suggest_shard_distribution(


### PR DESCRIPTION
Add peer id into the snapshot name to distinguish snapshots from different nodes