### PR TITLE
add parameter that defines a source of truth for snapshot recovery

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6153,8 +6153,19 @@
             "description": "Examples: - URL `http://localhost:8080/collections/my_collection/snapshots/my_snapshot` - Local path `file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot`",
             "type": "string",
             "format": "uri"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/SnapshotPriority"
           }
         }
+      },
+      "SnapshotPriority": {
+        "description": "Defines source of truth for snapshot recovery `Snapshot` means - prefer snapshot data over the current state `Replica` means - prefer existing data over the snapshot",
+        "type": "string",
+        "enum": [
+          "snapshot",
+          "replica"
+        ]
       }
     }
   }

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -9,12 +9,29 @@ use url::Url;
 
 use crate::operations::types::CollectionResult;
 
+/// Defines source of truth for snapshot recovery
+/// `Snapshot` means - prefer snapshot data over the current state
+/// `Replica` means - prefer existing data over the snapshot
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotPriority {
+    Snapshot,
+    #[default]
+    Replica,
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SnapshotRecover {
     /// Examples:
     /// - URL `http://localhost:8080/collections/my_collection/snapshots/my_snapshot`
     /// - Local path `file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot`
     pub location: Url,
+
+    /// Defines which data should be used as a source of truth if there are other replicas in the cluster.
+    /// If set to `Snapshot`, the snapshot will be used as a source of truth, and the current state will be overwritten.
+    /// If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.
+    #[serde(default)]
+    pub priority: SnapshotPriority,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -19,12 +19,13 @@ pub mod consensus_ops {
     use collection::shards::replica_set::ReplicaState;
     use collection::shards::shard::PeerId;
     use collection::shards::transfer::shard_transfer::ShardTransfer;
-    use collection::shards::CollectionId;
+    use collection::shards::{replica_set, CollectionId};
     use raft::eraftpb::Entry as RaftEntry;
     use serde::{Deserialize, Serialize};
 
     use crate::content_manager::collection_meta_ops::{
-        CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations,
+        CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations, UpdateCollection,
+        UpdateCollectionOperation,
     };
 
     /// Operation that should pass consensus
@@ -79,6 +80,26 @@ pub mod consensus_ops {
                     state,
                 })
                 .into(),
+            )
+        }
+
+        pub fn remove_replica(
+            collection_name: CollectionId,
+            shard_id: u32,
+            peer_id: PeerId,
+        ) -> Self {
+            let mut operation = UpdateCollectionOperation::new(
+                collection_name,
+                UpdateCollection {
+                    optimizers_config: None,
+                    params: None,
+                },
+            );
+            operation
+                .set_shard_replica_changes(vec![replica_set::Change::Remove(shard_id, peer_id)]);
+
+            ConsensusOperations::CollectionMeta(
+                CollectionMetaOperations::UpdateCollection(operation).into(),
             )
         }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -2,20 +2,54 @@ use std::path::Path;
 
 use collection::collection::Collection;
 use collection::config::CollectionConfig;
-use collection::operations::snapshot_ops::SnapshotRecover;
+use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};
 use collection::shards::replica_set::ReplicaState;
+use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::shard_config::ShardType;
 use collection::shards::shard_versioning::latest_shard_paths;
 
 use crate::content_manager::snapshots::download::{download_snapshot, downloaded_snapshots_dir};
 use crate::{StorageError, TableOfContent};
 
+async fn activate_shard(
+    toc: &TableOfContent,
+    collection: &Collection,
+    peer_id: PeerId,
+    shard_id: &ShardId,
+) -> Result<(), StorageError> {
+    // No other active replicas, we can activate this shard
+    // as there is no de-sync possible
+    if toc.is_distributed() {
+        log::debug!(
+            "Activating shard {} of collection {} with consensus",
+            shard_id,
+            &collection.name()
+        );
+        toc.send_set_replica_state_proposal(
+            collection.name(),
+            peer_id,
+            *shard_id,
+            ReplicaState::Active,
+        )?;
+    } else {
+        log::debug!(
+            "Activating shard {} of collection {} locally",
+            shard_id,
+            &collection.name()
+        );
+        collection
+            .set_shard_replica_state(*shard_id, peer_id, ReplicaState::Active)
+            .await?;
+    }
+    Ok(())
+}
+
 pub async fn do_recover_from_snapshot(
     toc: &TableOfContent,
     collection_name: &str,
     source: SnapshotRecover,
 ) -> Result<bool, StorageError> {
-    let SnapshotRecover { location } = source;
+    let SnapshotRecover { location, priority } = source;
 
     let collection = toc.get_collection(collection_name).await?;
 
@@ -135,47 +169,57 @@ pub async fn do_recover_from_snapshot(
                 .collect();
 
             if other_active_replicas.is_empty() {
-                // No other active replicas, we can activate this shard
-                // as there is no de-sync possible
-                if toc.is_distributed() {
-                    log::debug!(
-                        "Activating shard {} of collection {} with consensus",
-                        shard_id,
-                        collection_name
-                    );
-                    toc.send_set_replica_state_proposal(
-                        collection_name.to_string(),
-                        this_peer_id,
-                        *shard_id,
-                        ReplicaState::Active,
-                    )?;
-                } else {
-                    log::debug!(
-                        "Activating shard {} of collection {} locally",
-                        shard_id,
-                        collection_name
-                    );
-                    collection
-                        .set_shard_replica_state(*shard_id, this_peer_id, ReplicaState::Active)
-                        .await?;
-                }
+                activate_shard(toc, &collection, this_peer_id, shard_id).await?;
             } else {
-                let (replica_peer_id, _state) = other_active_replicas.into_iter().next().unwrap();
-                log::debug!(
-                    "Running synchronization for shard {} of collection {} from {}",
-                    shard_id,
-                    collection_name,
-                    replica_peer_id
-                );
+                match priority {
+                    SnapshotPriority::Snapshot => {
+                        // Snapshot is the source of truth, we need to remove all other replicas
+                        activate_shard(toc, &collection, this_peer_id, shard_id).await?;
 
-                // assume that if there is another peers, the server is distributed
-                toc.request_shard_transfer(
-                    collection_name.to_string(),
-                    *shard_id,
-                    *replica_peer_id,
-                    this_peer_id,
-                    true,
-                )?;
+                        let mut replicas_to_keep = state.config.params.replication_factor.get() - 1;
+
+                        for (peer_id, _) in other_active_replicas {
+                            if replicas_to_keep > 0 {
+                                // Keep this replica
+                                replicas_to_keep -= 1;
+
+                                toc.send_set_replica_state_proposal(
+                                    collection_name.to_string(),
+                                    *peer_id,
+                                    *shard_id,
+                                    ReplicaState::Dead,
+                                )?;
+                            } else {
+                                // Don't need more replicas, remove this one
+                                toc.request_remove_replica(
+                                    collection_name.to_string(),
+                                    *shard_id,
+                                    *peer_id,
+                                )?;
+                            }
+                        }
+                    }
+                    SnapshotPriority::Replica => {
+                        // Replica is the source of truth, we need to sync recovered data with this replica
+                        let (replica_peer_id, _state) =
+                            other_active_replicas.into_iter().next().unwrap();
+                        log::debug!(
+                            "Running synchronization for shard {} of collection {} from {}",
+                            shard_id,
+                            collection_name,
+                            replica_peer_id
+                        );
+
+                        // assume that if there is another peers, the server is distributed
+                        toc.request_shard_transfer(
+                            collection_name.to_string(),
+                            *shard_id,
+                            *replica_peer_id,
+                            this_peer_id,
+                            true,
+                        )?;
+                    }
+                }
             }
         }
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -398,6 +398,16 @@ impl TableOfContent {
         proposal_sender.send(operation)
     }
 
+    fn send_remove_replica_proposal_op(
+        proposal_sender: &OperationSender,
+        collection_name: String,
+        peer_id: PeerId,
+        shard_id: ShardId,
+    ) -> Result<(), StorageError> {
+        let operation = ConsensusOperations::remove_replica(collection_name, shard_id, peer_id);
+        proposal_sender.send(operation)
+    }
+
     fn on_peer_failure_callback(
         proposal_sender: Option<OperationSender>,
         collection_name: String,
@@ -485,6 +495,23 @@ impl TableOfContent {
             };
             let operation = ConsensusOperations::start_transfer(collection_name, transfer_request);
             proposal_sender.send(operation)?;
+        }
+        Ok(())
+    }
+
+    pub fn request_remove_replica(
+        &self,
+        collection_name: String,
+        shard_id: ShardId,
+        peer_id: PeerId,
+    ) -> Result<(), StorageError> {
+        if let Some(proposal_sender) = &self.consensus_proposal_sender {
+            Self::send_remove_replica_proposal_op(
+                proposal_sender,
+                collection_name,
+                peer_id,
+                shard_id,
+            )?;
         }
         Ok(())
     }


### PR DESCRIPTION
In distributed deployment it might be ambiguous how to properly synchronize recovered data if there are more than one replica of it in the cluster.

The default implementation assumed, that the existing replicas always have priority over the data saved in snapshot.
It made sense if you use snapshots for faster replications or there are no other replicas in the collection.

This, however, is not always a desirable behavior. For example, if the whole collection needs to be recovered, the existing empty replicas may counter the recovery. 

This PR allows to select what data should be considered the source of truth during recovery - other existing replicas or the snapshot.