### PR TITLE
Add taplo to check Cargo.toml

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -28,6 +28,11 @@ jobs:
         toolchain: stable
         override: true
         components: rustfmt, clippy
+    - name: Install taplo
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: taplo-cli
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
       with:
@@ -41,3 +46,6 @@ jobs:
       run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+    - name: Check toml format
+      shell: bash
+      run: taplo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,62 +7,65 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = [ "web", "parking_lot" ]
+default = ["web", "parking_lot"]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
 [dev-dependencies]
-tempfile = "3.3.0"
 rusty-hook = "^0.11.2"
-
+tempfile = "3.3.0"
 
 [dependencies]
 
-parking_lot = { version = "0.12.1", features=["deadlock_detection"], optional = true }
+parking_lot = { version = "0.12.1", features = ["deadlock_detection"], optional = true }
 
-num_cpus = "1.14"
-thiserror = "1.0"
-log = "0.4"
-env_logger = "0.10.0"
-atty = "0.2"
-colored = "2"
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = "~1.0"
-chrono = { version = "~0.4", features = ["serde"] }
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono"] }
-itertools = "0.10"
 anyhow = "1.0.66"
+atty = "0.2"
+chrono = { version = "~0.4", features = ["serde"] }
+clap = { version = "4.0.27", features = ["derive"] }
+colored = "2"
+env_logger = "0.10.0"
 futures = "0.3.25"
 futures-util = "0.3.24"
-clap = { version = "4.0.27", features = ["derive"] }
-serde_cbor = { version = "0.11.2"}
-uuid = { version = "1.2", features = ["v4", "serde"] }
+itertools = "0.10"
+log = "0.4"
+num_cpus = "1.14"
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono"] }
+serde = { version = "~1.0", features = ["derive"] }
+serde_cbor = { version = "0.11.2" }
+serde_json = "~1.0"
 sys-info = "0.9.1"
+thiserror = "1.0"
+uuid = { version = "1.2", features = ["v4", "serde"] }
 
 config = "~0.13.3"
 
 tokio = { version = "~1.23", features = ["full"] }
 
-actix-web = { version = "4.2.1", optional = true }
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
+actix-web = { version = "4.2.1", optional = true }
+num-traits = "0.2.15"
+tar = "0.4.38"
 tonic = { version = "0.7.2", features = ["compression"] }
 tower = "0.4.13"
 tower-layer = "0.3.2"
-num-traits = "0.2.15"
-tar = "0.4.38"
 
 # Consensus related crates
-raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
+prost = "=0.9.0"
+raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = [
+    "prost-codec",
+], default-features = false }
+raft-proto = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = [
+    "prost-codec",
+], default-features = false }
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
-prost = "=0.9.0"
-raft-proto = {  git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false}
 
-segment = { path = "lib/segment" }
-collection = { path = "lib/collection" }
-storage = { path = "lib/storage" }
 api = { path = "lib/api" }
+collection = { path = "lib/collection" }
+segment = { path = "lib/segment" }
+storage = { path = "lib/storage" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = { version = "0.7.2", features = ["compression"] }
+chrono = { version = "~0.4", features = ["serde"] }
 prost = "0.10.1"
 prost-types = "0.10.1"
+rand = "0.8.5"
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
-uuid = { version = "1.2", features = ["v4", "serde"] }
-tower = "0.4.13"
-tokio = "1.23.0"
-rand = "0.8.5"
-chrono = { version = "~0.4", features = ["serde"] }
 thiserror = "1.0"
+tokio = "1.23.0"
+tonic = { version = "0.7.2", features = ["compression"] }
+tower = "0.4.13"
+uuid = { version = "1.2", features = ["v4", "serde"] }
 
-segment = {path = "../segment"}
+segment = { path = "../segment" }
 
 [build-dependencies]
 tonic-build = { version = "0.7.2", features = ["prost", "compression"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -7,48 +7,48 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-tempfile = "3.3.0"
 criterion = "0.4"
 pprof = { version = "0.11", features = ["flamegraph", "prost-codec"] }
+tempfile = "3.3.0"
 
 [dependencies]
 
 parking_lot = "0.12"
 
-rand = "0.8.5"
-thiserror = "1.0"
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = { version = "~1.0", features = ["std"] }
-serde_cbor = "0.11.2"
-rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
-ordered-float = "3.4"
 hashring = "0.3.0"
+ordered-float = "3.4"
+rand = "0.8.5"
+rmp-serde = "~1.1"
+serde = { version = "~1.0", features = ["derive"] }
+serde_cbor = "0.11.2"
+serde_json = { version = "~1.0", features = ["std"] }
+thiserror = "1.0"
+wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
 
-tokio = {version = "~1.23", features = ["full"]}
-futures = "0.3.25"
-atomicwrites = "0.3.1"
-log = "0.4"
-env_logger = "0.10.0"
-merge = "0.1.0"
-async-trait = "0.1.59"
 arc-swap = "1.5.1"
+async-trait = "0.1.59"
+atomicwrites = "0.3.1"
+env_logger = "0.10.0"
+futures = "0.3.25"
+log = "0.4"
+merge = "0.1.0"
+tokio = { version = "~1.23", features = ["full"] }
 tonic = "0.7.2"
 tower = "0.4.13"
-uuid = { version = "1.2", features = ["v4", "serde"] }
 url = { version = "2", features = ["serde"] }
+uuid = { version = "1.2", features = ["v4", "serde"] }
 
-segment = {path = "../segment"}
-api = {path = "../api"}
+api = { path = "../api" }
+segment = { path = "../segment" }
 
-itertools = "0.10"
-indicatif = "0.17.2"
 chrono = { version = "~0.4", features = ["serde"] }
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono", "url"] }
-num_cpus = "1.14.0"
-tar = "0.4.38"
 fs_extra = "1.2.0"
+indicatif = "0.17.2"
+itertools = "0.10"
+num_cpus = "1.14.0"
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order", "chrono", "url"] }
 semver = "1.0.14"
+tar = "0.4.38"
 
 [[bench]]
 name = "hash_ring_bench"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -7,45 +7,44 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-pprof = { version = "0.11", features = ["flamegraph", "prost-codec"] }
-tempfile = "3.3.0"
 criterion = "0.4"
-rmp-serde = "~1.1"
+pprof = { version = "0.11", features = ["flamegraph", "prost-codec"] }
 rand_distr = "0.4.3"
+rmp-serde = "~1.1"
+tempfile = "3.3.0"
 walkdir = "2.3.2"
 
 [dependencies]
 
-parking_lot = "0.12"
-rayon = "1.6.0"
-num_cpus = "1.14"
-itertools = "0.10"
-rocksdb = { version = "0.19.0", default-features = false, features = [ "snappy" ] }
-uuid = { version = "1.2", features = ["v4", "serde"] }
-bincode = "1.3"
-serde = { version = "~1.0", features = ["derive", "rc"] }
-serde_json = "~1.0"
-serde_cbor = "0.11.2"
-ordered-float = "3.4"
-thiserror = "1.0"
 atomic_refcell = "0.1.8"
 atomicwrites = "0.3.1"
-memmap2 = "0.5.8"
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
-log = "0.4"
+bincode = "1.3"
+bitvec = "1.0.1"
+fs_extra = "1.2.0"
 geo = "0.23.0"
 geohash = "0.12.0"
-num-traits = "0.2.15"
-num-derive = "0.3.3"
-rand = "0.8"
-bitvec = "1.0.1"
-seahash = "4.1.0"
+itertools = "0.10"
 json-patch = "0.2.7"
-tar = "0.4.38"
-fs_extra = "1.2.0"
+log = "0.4"
+memmap2 = "0.5.8"
+num-derive = "0.3.3"
+num-traits = "0.2.15"
+num_cpus = "1.14"
+ordered-float = "3.4"
+parking_lot = "0.12"
+rand = "0.8"
+rayon = "1.6.0"
+rocksdb = { version = "0.19.0", default-features = false, features = ["snappy"] }
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
+seahash = "4.1.0"
 semver = "1.0.14"
+serde = { version = "~1.0", features = ["derive", "rc"] }
+serde_cbor = "0.11.2"
+serde_json = "~1.0"
+tar = "0.4.38"
+thiserror = "1.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
-
+uuid = { version = "1.2", features = ["v4", "serde"] }
 
 [[bench]]
 name = "vector_search"
@@ -78,4 +77,3 @@ harness = false
 [[bench]]
 name = "map_benchmark"
 harness = false
-

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -6,39 +6,41 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
-tempfile = "3.3.0"
 proptest = "1.0.0"
+tempfile = "3.3.0"
 
 [dependencies]
+async-trait = "0.1.59"
+chrono = { version = "~0.4", features = ["serde"] }
+http = "0.2"
+itertools = "0.10"
+log = "0.4"
 num_cpus = "1.14"
-thiserror = "1.0"
+parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
-tokio = { version = "~1.23", features = ["rt-multi-thread"] }
+schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
-schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
-itertools = "0.10"
-async-trait = "0.1.59"
-log = "0.4"
-tonic = { version = "0.7.2", features = ["compression"] }
-http = "0.2"
-parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 tar = "0.4.38"
-chrono = { version = "~0.4", features = ["serde"] }
+thiserror = "1.0"
+tokio = { version = "~1.23", features = ["rt-multi-thread"] }
+tonic = { version = "0.7.2", features = ["compression"] }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }
-raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
 prost = { version = "=0.9.0" } # version of prost used by raft
+raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = [
+    "prost-codec",
+], default-features = false }
 serde_cbor = { version = "0.11.2" }
 
-segment = { path = "../segment" }
-collection = { path = "../collection" }
-api = { path = "../api" }
-futures = "0.3.25"
 anyhow = "1.0.66"
-uuid = "1.2.1"
-url = "2.3.1"
-reqwest = { version = "0.11", features = ["stream", "rustls-tls"] }
+api = { path = "../api" }
+collection = { path = "../collection" }
+futures = "0.3.25"
 openssl = { version = "0.10", features = ["vendored"] }
+reqwest = { version = "0.11", features = ["stream", "rustls-tls"] }
+segment = { path = "../segment" }
+url = "2.3.1"
+uuid = "1.2.1"

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,36 @@
+## https://taplo.tamasfe.dev/configuration/file.html
+
+include = ["**/Cargo.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 120
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '    '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = ["dependencies", "dev-dependencies", "build-dependencies"]
+formatting = { reorder_keys = true }


### PR DESCRIPTION
Add [taplo](https://taplo.tamasfe.dev/configuration/file.html#rules) to check `Cargo.toml` files.

If you make changes for `Cargo.toml`, please run `taplo fmt` before pushing.
