### PR TITLE
Shard build refactoring

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -546,8 +546,6 @@ impl Collection {
     }
 
     /// Initiate local partial shard
-    ///
-    /// Drops existing temporary shards for `shard_id`.
     pub async fn initiate_local_partial_shard(&self, shard_id: ShardId) -> CollectionResult<()> {
         let shards_holder = self.shards_holder.read().await;
         let replica_set = match shards_holder.get_shard(&shard_id) {

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -8,7 +8,7 @@ use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
 };
-use segment::entry::entry_point::{check_optimization_stopped, SegmentEntry};
+use segment::entry::entry_point::{check_process_stopped, SegmentEntry};
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
@@ -321,7 +321,7 @@ pub trait SegmentOptimizer {
         ids: Vec<SegmentId>,
         stopped: &AtomicBool,
     ) -> CollectionResult<bool> {
-        check_optimization_stopped(stopped)?;
+        check_process_stopped(stopped)?;
 
         let mut timer = ScopeDurationMeasurer::new(&self.get_telemetry_counter());
         timer.set_success(false);
@@ -352,7 +352,7 @@ pub trait SegmentOptimizer {
             return Ok(false);
         }
 
-        check_optimization_stopped(stopped)?;
+        check_process_stopped(stopped)?;
 
         let tmp_segment = self.temp_segment()?;
 
@@ -395,7 +395,7 @@ pub trait SegmentOptimizer {
             proxy_ids
         };
 
-        check_optimization_stopped(stopped).map_err(|error| {
+        check_process_stopped(stopped).map_err(|error| {
             self.handle_cancellation(&segments, &proxy_ids, &tmp_segment);
             error
         })?;
@@ -432,7 +432,7 @@ pub trait SegmentOptimizer {
 
         // ---- SLOW PART ENDS HERE -----
 
-        check_optimization_stopped(stopped).map_err(|error| {
+        check_process_stopped(stopped).map_err(|error| {
             self.handle_cancellation(&segments, &proxy_ids, &tmp_segment);
             error
         })?;

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -101,7 +101,7 @@ impl LocalShard {
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
         wal: SerdeWal<CollectionUpdateOperations>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
-        collection_path: &Path,
+        shard_path: &Path,
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = shared_config.read().await;
@@ -147,7 +147,7 @@ impl LocalShard {
             update_handler: Arc::new(Mutex::new(update_handler)),
             runtime_handle: Some(optimize_runtime),
             update_sender: ArcSwap::from_pointee(update_sender),
-            path: collection_path.to_owned(),
+            path: shard_path.to_owned(),
             before_drop_called: false,
             optimizers,
         }
@@ -251,19 +251,6 @@ impl LocalShard {
 
     pub fn segments_path(shard_path: &Path) -> PathBuf {
         shard_path.join("segments")
-    }
-
-    pub async fn build_temp(
-        id: ShardId,
-        collection_id: CollectionId,
-        shard_path: &Path,
-        shared_config: Arc<TokioRwLock<CollectionConfig>>,
-    ) -> CollectionResult<LocalShard> {
-        // initialize temporary shard config file
-        let temp_shard_config = ShardConfig::new_temp();
-        let shard = Self::build(id, collection_id, shard_path, shared_config).await?;
-        temp_shard_config.save(shard_path)?;
-        Ok(shard)
     }
 
     pub async fn build_local(

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::result;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomicwrites::Error as AtomicIoError;
 use rayon::ThreadPoolBuildError;
@@ -58,6 +59,15 @@ impl OperationError {
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
+}
+
+pub fn check_optimization_stopped(stopped: &AtomicBool) -> OperationResult<()> {
+    if stopped.load(Ordering::Relaxed) {
+        return Err(OperationError::Cancelled {
+            description: "optimization cancelled by service".to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -61,10 +61,10 @@ impl OperationError {
     }
 }
 
-pub fn check_optimization_stopped(stopped: &AtomicBool) -> OperationResult<()> {
+pub fn check_process_stopped(stopped: &AtomicBool) -> OperationResult<()> {
     if stopped.load(Ordering::Relaxed) {
         return Err(OperationError::Cancelled {
-            description: "optimization cancelled by service".to_string(),
+            description: "process cancelled by service".to_string(),
         });
     }
     Ok(())

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -16,7 +16,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::{check_optimization_stopped, OperationError, OperationResult};
+use crate::entry::entry_point::{check_process_stopped, OperationError, OperationResult};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -153,7 +153,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             points_to_index
                 .into_par_iter()
                 .try_for_each(|block_point_id| {
-                    check_optimization_stopped(stopped)?;
+                    check_process_stopped(stopped)?;
 
                     let vector = vector_storage.get_vector(block_point_id).unwrap();
                     let raw_scorer = vector_storage.raw_scorer(vector);
@@ -324,7 +324,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .build()?;
 
         for vector_id in vector_storage.iter_ids() {
-            check_optimization_stopped(stopped)?;
+            check_process_stopped(stopped)?;
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(vector_id, level);
         }
@@ -334,7 +334,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
 
             pool.install(|| {
                 ids.into_par_iter().try_for_each(|vector_id| {
-                    check_optimization_stopped(stopped)?;
+                    check_process_stopped(stopped)?;
                     let vector = vector_storage.get_vector(vector_id).unwrap();
                     let raw_scorer = vector_storage.raw_scorer(vector);
                     let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
@@ -373,7 +373,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 let min_block_size = self.config.indexing_threshold;
 
                 for payload_block in payload_index.payload_blocks(&field, min_block_size) {
-                    check_optimization_stopped(stopped)?;
+                    check_process_stopped(stopped)?;
                     if payload_block.cardinality > max_block_size {
                         continue;
                     }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -16,7 +16,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::entry::entry_point::{check_optimization_stopped, OperationError, OperationResult};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -153,11 +153,8 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             points_to_index
                 .into_par_iter()
                 .try_for_each(|block_point_id| {
-                    if stopped.load(Ordering::Relaxed) {
-                        return Err(OperationError::Cancelled {
-                            description: "Cancelled by external thread".to_string(),
-                        });
-                    }
+                    check_optimization_stopped(stopped)?;
+
                     let vector = vector_storage.get_vector(block_point_id).unwrap();
                     let raw_scorer = vector_storage.raw_scorer(vector);
                     let block_condition_checker = BuildConditionChecker {
@@ -327,6 +324,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .build()?;
 
         for vector_id in vector_storage.iter_ids() {
+            check_optimization_stopped(stopped)?;
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(vector_id, level);
         }
@@ -336,17 +334,13 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
 
             pool.install(|| {
                 ids.into_par_iter().try_for_each(|vector_id| {
-                    if stopped.load(Ordering::Relaxed) {
-                        return Err(OperationError::Cancelled {
-                            description: "Cancelled by external thread".to_string(),
-                        });
-                    }
+                    check_optimization_stopped(stopped)?;
                     let vector = vector_storage.get_vector(vector_id).unwrap();
                     let raw_scorer = vector_storage.raw_scorer(vector);
                     let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
 
                     graph_layers_builder.link_new_point(vector_id, points_scorer);
-                    Ok(())
+                    Ok::<_, OperationError>(())
                 })
             })?;
 
@@ -379,11 +373,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 let min_block_size = self.config.indexing_threshold;
 
                 for payload_block in payload_index.payload_blocks(&field, min_block_size) {
-                    if stopped.load(Ordering::Relaxed) {
-                        return Err(OperationError::Cancelled {
-                            description: "Cancelled by external thread".to_string(),
-                        });
-                    }
+                    check_optimization_stopped(stopped)?;
                     if payload_block.cardinality > max_block_size {
                         continue;
                     }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -2,10 +2,12 @@ use core::cmp;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use crate::common::error_logging::LogError;
-use crate::entry::entry_point::{OperationError, OperationResult, SegmentEntry};
+use crate::entry::entry_point::{
+    check_optimization_stopped, OperationError, OperationResult, SegmentEntry,
+};
 use crate::index::PayloadIndex;
 use crate::segment::Segment;
 use crate::segment_constructor::{build_segment, load_segment};
@@ -88,6 +90,7 @@ impl SegmentBuilder {
 
                 let mut internal_id_iter = None;
                 for (vector_name, vector_storage) in &mut vector_storages {
+                    check_optimization_stopped(stopped)?;
                     let other_vector_storage = other_vector_storages.get(vector_name);
                     if other_vector_storage.is_none() {
                         return Err(OperationError::service_error(&format!(
@@ -96,7 +99,8 @@ impl SegmentBuilder {
                         )));
                     }
                     let other_vector_storage = other_vector_storage.unwrap();
-                    let new_internal_range = vector_storage.update_from(&**other_vector_storage)?;
+                    let new_internal_range =
+                        vector_storage.update_from(&**other_vector_storage, stopped)?;
                     internal_id_iter =
                         Some(new_internal_range.zip(other_vector_storage.iter_ids()));
                 }
@@ -107,11 +111,8 @@ impl SegmentBuilder {
                 }
 
                 for (new_internal_id, old_internal_id) in internal_id_iter.unwrap() {
-                    if stopped.load(Ordering::Relaxed) {
-                        return Err(OperationError::Cancelled {
-                            description: "Cancelled by external thread".to_string(),
-                        });
-                    }
+                    check_optimization_stopped(stopped)?;
+
                     let external_id =
                         if let Some(external_id) = other_id_tracker.external_id(old_internal_id) {
                             external_id
@@ -183,11 +184,7 @@ impl SegmentBuilder {
 
             for (field, payload_schema) in &self.indexed_fields {
                 segment.create_field_index(segment.version(), field, Some(payload_schema))?;
-                if stopped.load(Ordering::Relaxed) {
-                    return Err(OperationError::Cancelled {
-                        description: "Cancelled by external thread".to_string(),
-                    });
-                }
+                check_optimization_stopped(stopped)?;
             }
 
             for vector_data in segment.vector_data.values_mut() {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 use crate::common::error_logging::LogError;
 use crate::entry::entry_point::{
-    check_optimization_stopped, OperationError, OperationResult, SegmentEntry,
+    check_process_stopped, OperationError, OperationResult, SegmentEntry,
 };
 use crate::index::PayloadIndex;
 use crate::segment::Segment;
@@ -90,7 +90,7 @@ impl SegmentBuilder {
 
                 let mut internal_id_iter = None;
                 for (vector_name, vector_storage) in &mut vector_storages {
-                    check_optimization_stopped(stopped)?;
+                    check_process_stopped(stopped)?;
                     let other_vector_storage = other_vector_storages.get(vector_name);
                     if other_vector_storage.is_none() {
                         return Err(OperationError::service_error(&format!(
@@ -111,7 +111,7 @@ impl SegmentBuilder {
                 }
 
                 for (new_internal_id, old_internal_id) in internal_id_iter.unwrap() {
-                    check_optimization_stopped(stopped)?;
+                    check_process_stopped(stopped)?;
 
                     let external_id =
                         if let Some(external_id) = other_id_tracker.external_id(old_internal_id) {
@@ -184,7 +184,7 @@ impl SegmentBuilder {
 
             for (field, payload_schema) in &self.indexed_fields {
                 segment.create_field_index(segment.version(), field, Some(payload_schema))?;
-                check_optimization_stopped(stopped)?;
+                check_process_stopped(stopped)?;
             }
 
             for vector_data in segment.vector_data.values_mut() {

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -11,7 +11,7 @@ use atomic_refcell::AtomicRefCell;
 
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::{check_optimization_stopped, OperationResult};
+use crate::entry::entry_point::{check_process_stopped, OperationResult};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -191,7 +191,7 @@ where
                 .open(&self.vectors_path)?;
 
             for id in other.iter_ids() {
-                check_optimization_stopped(stopped)?;
+                check_process_stopped(stopped)?;
                 let vector = &other.get_vector(id).unwrap();
                 let raw_bites = vf_to_u8(vector);
                 file.write_all(raw_bites)?;

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -4,13 +4,14 @@ use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::OperationResult;
+use crate::entry::entry_point::{check_optimization_stopped, OperationResult};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -169,7 +170,11 @@ where
         panic!("There are no available for insertion ids in mmap storage")
     }
 
-    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {
+    fn update_from(
+        &mut self,
+        other: &VectorStorageSS,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
 
         let start_index = self.mmap_store.as_ref().unwrap().num_vectors as PointOffsetType;
@@ -186,6 +191,7 @@ where
                 .open(&self.vectors_path)?;
 
             for id in other.iter_ids() {
+                check_optimization_stopped(stopped)?;
                 let vector = &other.get_vector(id).unwrap();
                 let raw_bites = vf_to_u8(vector);
                 file.write_all(raw_bites)?;
@@ -349,7 +355,9 @@ mod tests {
                 borrowed_storage2.put_vector(vec2.clone()).unwrap();
                 borrowed_storage2.put_vector(vec3.clone()).unwrap();
             }
-            borrowed_storage.update_from(&*storage2.borrow()).unwrap();
+            borrowed_storage
+                .update_from(&*storage2.borrow(), &Default::default())
+                .unwrap();
         }
 
         assert_eq!(borrowed_storage.vector_count(), 3);
@@ -371,7 +379,9 @@ mod tests {
                 borrowed_storage2.put_vector(vec4).unwrap();
                 borrowed_storage2.put_vector(vec5).unwrap();
             }
-            borrowed_storage.update_from(&*storage2.borrow()).unwrap();
+            borrowed_storage
+                .update_from(&*storage2.borrow(), &Default::default())
+                .unwrap();
         }
 
         assert_eq!(borrowed_storage.vector_count(), 4);
@@ -417,7 +427,9 @@ mod tests {
                 borrowed_storage2.put_vector(vec4).unwrap();
                 borrowed_storage2.put_vector(vec5).unwrap();
             }
-            borrowed_storage.update_from(&*storage2.borrow()).unwrap();
+            borrowed_storage
+                .update_from(&*storage2.borrow(), &Default::default())
+                .unwrap();
         }
 
         let query = vec![-1.0, -1.0, -1.0, -1.0];

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -16,7 +16,7 @@ use super::vector_storage_base::VectorStorage;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::{check_optimization_stopped, OperationError, OperationResult};
+use crate::entry::entry_point::{check_process_stopped, OperationError, OperationResult};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -235,7 +235,7 @@ where
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
         for point_id in other.iter_ids() {
-            check_optimization_stopped(stopped)?;
+            check_process_stopped(stopped)?;
             let other_vector = other.get_vector(point_id).unwrap();
             // Do not perform preprocessing - vectors should be already processed
             self.deleted.push(false);

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -15,7 +16,7 @@ use super::vector_storage_base::VectorStorage;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
-use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::entry::entry_point::{check_optimization_stopped, OperationError, OperationResult};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -227,9 +228,14 @@ where
         self.vectors.len() as PointOffsetType
     }
 
-    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>> {
+    fn update_from(
+        &mut self,
+        other: &VectorStorageSS,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
         for point_id in other.iter_ids() {
+            check_optimization_stopped(stopped)?;
             let other_vector = other.get_vector(point_id).unwrap();
             // Do not perform preprocessing - vectors should be already processed
             self.deleted.push(false);

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::ops::Range;
+use std::sync::atomic::AtomicBool;
 
 use ordered_float::OrderedFloat;
 use rand::Rng;
@@ -64,7 +65,11 @@ pub trait VectorStorage {
     ) -> OperationResult<()>;
     /// Returns next available id
     fn next_id(&self) -> PointOffsetType;
-    fn update_from(&mut self, other: &VectorStorageSS) -> OperationResult<Range<PointOffsetType>>;
+    fn update_from(
+        &mut self,
+        other: &VectorStorageSS,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
     fn delete(&mut self, key: PointOffsetType) -> OperationResult<()>;
     fn is_deleted(&self, key: PointOffsetType) -> bool;
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -541,7 +541,11 @@ impl TableOfContent {
             removed.before_drop().await;
             let path = self.get_collection_path(collection_name);
             drop(removed);
-            remove_dir_all(path).map_err(|err| {
+
+            // Move collection to ".deleted" folder to prevent accidental reuse
+            let deleted_path = path.with_extension("deleted");
+            tokio::fs::rename(path, &deleted_path).await?;
+            remove_dir_all(deleted_path).map_err(|err| {
                 StorageError::service_error(&format!(
                     "Can't delete collection {}, error: {}",
                     collection_name, err

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -545,8 +545,8 @@ impl TableOfContent {
 
             // Move collection to ".deleted" folder to prevent accidental reuse
             let uuid = Uuid::new_v4().to_string();
-            let removed_collections_path = Path::new(&self.storage_config.storage_path)
-                .join(".deleted");
+            let removed_collections_path =
+                Path::new(&self.storage_config.storage_path).join(".deleted");
             tokio::fs::create_dir_all(&removed_collections_path).await?;
             let deleted_path = removed_collections_path
                 .join(collection_name)


### PR DESCRIPTION
- Add more checks for `stop-optimization` to speed up collection destruction while optimizer is still working
- move collection to temp shard before removing, so that if delete is not finished, it won't be reused
- minor renaming