### PR TITLE
Explicitly flush consensus WAL after

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?branch=flushing-investigation#46d825dbb213e16dc7cbfe4ff12550f1077ac6d1"
+source = "git+https://github.com/qdrant/wal.git?rev=0e652e4180be376081fb6a3f2c04fa770d4868a8#0e652e4180be376081fb6a3f2c04fa770d4868a8"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=90471ad737dbd90c49bb8944cb8aeb5ad8664d30#90471ad737dbd90c49bb8944cb8aeb5ad8664d30"
+source = "git+https://github.com/qdrant/wal.git?branch=flushing-investigation#46d825dbb213e16dc7cbfe4ff12550f1077ac6d1"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?branch=flush-after-truncation#209dbc425f98570c3ff047e31a70549991a1c5f2"
+source = "git+https://github.com/qdrant/wal.git?rev=3bfa813f494638c0f5afbca744b45e1c380827bf#3bfa813f494638c0f5afbca744b45e1c380827bf"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3660,6 +3660,7 @@ dependencies = [
  "atomicwrites",
  "chrono",
  "collection",
+ "env_logger",
  "futures",
  "http",
  "itertools",
@@ -4298,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=0e652e4180be376081fb6a3f2c04fa770d4868a8#0e652e4180be376081fb6a3f2c04fa770d4868a8"
+source = "git+https://github.com/qdrant/wal.git?branch=flush-after-truncation#ae8d75276d6fe801e61b365b7e3f116f5fe92a63"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?branch=flush-after-truncation#ae8d75276d6fe801e61b365b7e3f116f5fe92a63"
+source = "git+https://github.com/qdrant/wal.git?branch=flush-after-truncation#209dbc425f98570c3ff047e31a70549991a1c5f2"
 dependencies = [
  "byteorder",
  "crc",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "0e652e4180be376081fb6a3f2c04fa770d4868a8" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "flush-after-truncation" }
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "flushing-investigation" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "0e652e4180be376081fb6a3f2c04fa770d4868a8" }
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "flush-after-truncation" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "3bfa813f494638c0f5afbca744b45e1c380827bf"}
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "flushing-investigation" }
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -403,7 +403,7 @@ impl UpdateHandler {
         }
     }
 
-    /// Returns confirmed version after flush of all segements
+    /// Returns confirmed version after flush of all segments
     ///
     /// # Errors
     /// Returns an error on flush failure

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -63,6 +63,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         })
     }
 
+    /// Write a record to the WAL but does guarantee durability.
     pub fn write(&mut self, entity: &R) -> Result<u64> {
         // ToDo: Replace back to faster rmp, once this https://github.com/serde-rs/serde/issues/2055 solved
         let binary_entity = serde_cbor::to_vec(&entity).unwrap();

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "flush-after-truncation" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "3bfa813f494638c0f5afbca744b45e1c380827bf" }
 tokio = { version = "~1.23", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -8,12 +8,13 @@ edition = "2021"
 [dev-dependencies]
 tempfile = "3.3.0"
 proptest = "1.0.0"
+env_logger = "0.10.0"
 
 [dependencies]
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "0e652e4180be376081fb6a3f2c04fa770d4868a8" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "flush-after-truncation" }
 tokio = { version = "~1.23", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -13,7 +13,7 @@ proptest = "1.0.0"
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "90471ad737dbd90c49bb8944cb8aeb5ad8664d30" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "flushing-investigation" }
 tokio = { version = "~1.23", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -13,7 +13,7 @@ proptest = "1.0.0"
 num_cpus = "1.14"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "flushing-investigation" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "0e652e4180be376081fb6a3f2c04fa770d4868a8" }
 tokio = { version = "~1.23", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -148,8 +148,10 @@ impl ConsensusOpWal {
 
             let mut buf = vec![];
             entry.encode(&mut buf)?;
+            eprintln!("append entry: {:?}", entry);
             #[allow(unused_variables)]
             let wal_index = self.0.append(&buf)?;
+            eprintln!("wal index: {} {:?}", wal_index, self.0);
             #[cfg(debug_assertions)]
             if let Some(offset) = index_offset {
                 debug_assert!(wal_index == index - offset);
@@ -157,6 +159,9 @@ impl ConsensusOpWal {
                 debug_assert!(wal_index == 0)
             }
         }
+        // flush consensus WAL to disk
+        eprintln!("flush");
+        self.0.flush_open_segments()?;
         Ok(())
     }
 }
@@ -229,9 +234,9 @@ mod tests {
         assert_eq!(result_entries[2].data, vec![3, 3, 3]);
 
         wal.clear().unwrap();
-
+        eprintln!("before");
         wal.append_entries(entries_new).unwrap();
-
+        eprintln!("after");
         assert_eq!(wal.index_offset().unwrap(), Some(2));
 
         let broken_entry = vec![Entry {

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -160,8 +160,7 @@ impl ConsensusOpWal {
             }
         }
         // flush consensus WAL to disk
-        eprintln!("flush");
-        self.0.flush_open_segments()?;
+        self.0.flush_open_segment()?;
         Ok(())
     }
 }

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -148,10 +148,8 @@ impl ConsensusOpWal {
 
             let mut buf = vec![];
             entry.encode(&mut buf)?;
-            eprintln!("append entry: {:?}", entry);
             #[allow(unused_variables)]
             let wal_index = self.0.append(&buf)?;
-            eprintln!("wal index: {} {:?}", wal_index, self.0);
             #[cfg(debug_assertions)]
             if let Some(offset) = index_offset {
                 debug_assert!(wal_index == index - offset);
@@ -173,6 +171,7 @@ mod tests {
 
     #[test]
     fn test_log_rewrite() {
+        env_logger::init();
         let entries_orig = vec![
             Entry {
                 entry_type: 0,
@@ -233,9 +232,7 @@ mod tests {
         assert_eq!(result_entries[2].data, vec![3, 3, 3]);
 
         wal.clear().unwrap();
-        eprintln!("before");
         wal.append_entries(entries_new).unwrap();
-        eprintln!("after");
         assert_eq!(wal.index_offset().unwrap(), Some(2));
 
         let broken_entry = vec![Entry {


### PR DESCRIPTION
This PR improves the reliability of the consensus WAL by explicitly flushing it after appending entries.

Otherwise, it is possible to lose data in case of crash.

To get there, the wal dependency had to be updated to:
- expose a flushing method for open segment
- support flushing truncated segment without crashing

See https://github.com/qdrant/wal/pull/36 for more details.


-- previous WIP description --

Trying to flush explicitly consensus wal breaks a unit test with a panic.

```
thread 'content_manager::consensus::consensus_wal::tests::test_log_rewrite' panicked at 'start = 80, end = 56', /home/agourlay/.cargo/git/checkouts/wal-b8dc0c9a3902e8fe/0e652e4/src/segment.rs:377:9
stack backtrace:
   0:     0x563aac06f980 - std::backtrace_rs::backtrace::libunwind::trace::h32eb3e08e874dd27
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x563aac06f980 - std::backtrace_rs::backtrace::trace_unsynchronized::haa3f451d27bc11a5
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x563aac06f980 - std::sys_common::backtrace::_print_fmt::h5b94a01bb4289bb5
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/sys_common/backtrace.rs:66:5
   3:     0x563aac06f980 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hb070b7fa7e3175df
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/sys_common/backtrace.rs:45:22
   4:     0x563aac09569e - core::fmt::write::hd5207aebbb9a86e9
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/fmt/mod.rs:1202:17
   5:     0x563aac06b715 - std::io::Write::write_fmt::h3bd699bbd129ab8a
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/io/mod.rs:1679:15
   6:     0x563aac071443 - std::sys_common::backtrace::_print::h7a21be552fdf58da
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/sys_common/backtrace.rs:48:5
   7:     0x563aac071443 - std::sys_common::backtrace::print::ha85c41fe4dd80b13
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/sys_common/backtrace.rs:35:9
   8:     0x563aac071443 - std::panicking::default_hook::{{closure}}::h04cca40023d0eeca
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:295:22
   9:     0x563aac07112f - std::panicking::default_hook::haa3ca8c310ed5402
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:314:9
  10:     0x563aac071aea - std::panicking::rust_panic_with_hook::h7b190ce1a948faac
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:698:17
  11:     0x563aac0719a1 - std::panicking::begin_panic_handler::{{closure}}::hbafbfdc3e1b97f68
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:586:13
  12:     0x563aac06fe2c - std::sys_common::backtrace::__rust_end_short_backtrace::hda93e5fef243b4c0
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/sys_common/backtrace.rs:138:18
  13:     0x563aac071702 - rust_begin_unwind
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
  14:     0x563aab804693 - core::panicking::panic_fmt::h8d17ca1073d9a733
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
  15:     0x563aab80455d - core::panicking::panic::hf0565452d0d0936c
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:48:5
  16:     0x563aabbe72c8 - wal::segment::Segment::flush::h3fb2475f0f946ee4
                               at /home/agourlay/.cargo/git/checkouts/wal-b8dc0c9a3902e8fe/46d825d/src/segment.rs:377:9
  17:     0x563aabbcd23f - wal::Wal::flush_open_segments::h41a4b0efb41155da
                               at /home/agourlay/.cargo/git/checkouts/wal-b8dc0c9a3902e8fe/46d825d/src/lib.rs:241:9
  18:     0x563aabab23fb - storage::content_manager::consensus::consensus_wal::ConsensusOpWal::append_entries::hd435b16ab130000c
                               at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus/consensus_wal.rs:164:9
  19:     0x563aabad4d59 - storage::content_manager::consensus::consensus_wal::tests::test_log_rewrite::h75b08ae154286562
                               at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus/consensus_wal.rs:238:9
  20:     0x563aab85eeba - storage::content_manager::consensus::consensus_wal::tests::test_log_rewrite::{{closure}}::h240938748cd10723
                               at /home/agourlay/Workspace/qdrant/lib/storage/src/content_manager/consensus/consensus_wal.rs:176:5
  21:     0x563aaba703fe - core::ops::function::FnOnce::call_once::hbe7a0b8a4bb77111
                               at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/fu
```

To reproduce run ` cargo test -p storage test_log_rewrite -- --nocapture`