### PR TITLE
Clippy for Rust 1.66

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -301,7 +301,7 @@ impl SegmentsSearcher {
             }
             Ok(true)
         })?;
-        Ok(point_records.into_iter().map(|(_, r)| r).collect())
+        Ok(point_records.into_values().collect())
     }
 }
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -166,7 +166,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     max_segment_size: config.optimizer_config.max_segment_size.map(|x| x as u64),
                     memmap_threshold: config.optimizer_config.memmap_threshold.map(|x| x as u64),
                     indexing_threshold: Some(config.optimizer_config.indexing_threshold as u64),
-                    flush_interval_sec: Some(config.optimizer_config.flush_interval_sec as u64),
+                    flush_interval_sec: Some(config.optimizer_config.flush_interval_sec),
                     max_optimization_threads: Some(
                         config.optimizer_config.max_optimization_threads as u64,
                     ),

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,4 +1,3 @@
-use std::cmp::{max, min};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -80,7 +79,7 @@ impl OptimizersConfig {
             let num_cpus = num_cpus::get();
             // Do not configure less than 2 and more than 8 segments
             // until it is not explicitly requested
-            min(max(2, num_cpus), 8)
+            num_cpus.clamp(2, 8)
         } else {
             self.default_segment_number
         }

--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -88,7 +88,7 @@ impl<T: Serialize + Default + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
 
     fn save_data_to(path: impl Into<PathBuf>, data: &T) -> Result<(), Error> {
         let path: PathBuf = path.into();
-        AtomicFile::new(&path, AllowOverwrite).write(|file| {
+        AtomicFile::new(path, AllowOverwrite).write(|file| {
             let writer = BufWriter::new(file);
             serde_json::to_writer(writer, data)
         })?;
@@ -164,7 +164,7 @@ mod tests {
         let dir = Builder::new().prefix("test").tempdir().unwrap();
         let counter_file = dir.path().join("counter");
         let counter: Arc<SaveOnDisk<u32>> =
-            Arc::new(SaveOnDisk::load_or_init(&counter_file).unwrap());
+            Arc::new(SaveOnDisk::load_or_init(counter_file).unwrap());
         let counter_copy = counter.clone();
         let handle = thread::spawn(move || {
             sleep(Duration::from_millis(100));
@@ -183,7 +183,7 @@ mod tests {
         let dir = Builder::new().prefix("test").tempdir().unwrap();
         let counter_file = dir.path().join("counter");
         let counter: Arc<SaveOnDisk<u32>> =
-            Arc::new(SaveOnDisk::load_or_init(&counter_file).unwrap());
+            Arc::new(SaveOnDisk::load_or_init(counter_file).unwrap());
         let counter_copy = counter.clone();
         let handle = thread::spawn(move || {
             sleep(Duration::from_millis(200));

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -508,7 +508,7 @@ impl LocalShard {
         let _wal_guard = self.wal.lock();
         let source_wal_path = self.path.join("wal");
         let options = fs_extra::dir::CopyOptions::new();
-        fs_extra::dir::copy(&source_wal_path, snapshot_shard_path, &options).map_err(|err| {
+        fs_extra::dir::copy(source_wal_path, snapshot_shard_path, &options).map_err(|err| {
             CollectionError::service_error(format!(
                 "Error while copy WAL {:?} {}",
                 snapshot_shard_path, err

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -58,7 +58,7 @@ pub fn open_db<T: AsRef<str>>(
     for vector_path in vector_pathes {
         column_families.push(vector_path.as_ref());
     }
-    let db = DB::open_cf(&db_options(), path, &column_families)?;
+    let db = DB::open_cf(&db_options(), path, column_families)?;
     Ok(Arc::new(RwLock::new(db)))
 }
 
@@ -73,7 +73,7 @@ pub fn open_db_with_existing_cf(path: &Path) -> Result<Arc<RwLock<DB>>, rocksdb:
     } else {
         vec![]
     };
-    let db = DB::open_cf(&db_options(), path, &existing_column_families)?;
+    let db = DB::open_cf(&db_options(), path, existing_column_families)?;
     Ok(Arc::new(RwLock::new(db)))
 }
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -177,8 +177,8 @@ impl IdTracker for SimpleIdTracker {
             }
             self.internal_to_version[internal_id as usize] = version;
             self.versions_db_wrapper.put(
-                &Self::store_key(&external_id),
-                &bincode::serialize(&version).unwrap(),
+                Self::store_key(&external_id),
+                bincode::serialize(&version).unwrap(),
             )?;
         }
         Ok(())
@@ -223,14 +223,14 @@ impl IdTracker for SimpleIdTracker {
             self.deleted.resize(internal_id + 1, true);
         }
         self.internal_to_external[internal_id] = external_id;
-        if self.deleted[internal_id as usize] {
+        if self.deleted[internal_id] {
             self.points_count += 1;
         }
         self.deleted.set(internal_id, false);
 
         self.mapping_db_wrapper.put(
-            &Self::store_key(&external_id),
-            &bincode::serialize(&internal_id).unwrap(),
+            Self::store_key(&external_id),
+            bincode::serialize(&internal_id).unwrap(),
         )?;
         Ok(())
     }
@@ -248,9 +248,9 @@ impl IdTracker for SimpleIdTracker {
             self.internal_to_external[internal_id as usize] = PointIdType::NumId(u64::MAX);
         }
         self.mapping_db_wrapper
-            .remove(&Self::store_key(&external_id))?;
+            .remove(Self::store_key(&external_id))?;
         self.versions_db_wrapper
-            .remove(&Self::store_key(&external_id))?;
+            .remove(Self::store_key(&external_id))?;
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -118,7 +118,7 @@ impl ValueIndexer<String> for FullTextIndex {
                 .unwrap(),
         )?;
 
-        self.db_wrapper.put(&db_idx, &db_document)?;
+        self.db_wrapper.put(db_idx, db_document)?;
 
         Ok(())
     }
@@ -138,7 +138,7 @@ impl ValueIndexer<String> for FullTextIndex {
         }
 
         let db_doc_id = Self::store_key(&id);
-        self.db_wrapper.remove(&db_doc_id)?;
+        self.db_wrapper.remove(db_doc_id)?;
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -248,7 +248,7 @@ impl GeoMapIndex {
             if let Some(ref offsets) = hash_points {
                 for point_offset in offsets.iter() {
                     let key = Self::encode_db_key(removed_geo_hash, *point_offset);
-                    self.db_wrapper.remove(&key)?;
+                    self.db_wrapper.remove(key)?;
                 }
             }
 
@@ -310,7 +310,7 @@ impl GeoMapIndex {
 
             geo_hashes.push(added_geo_hash);
 
-            self.db_wrapper.put(&key, value)?;
+            self.db_wrapper.put(key, value)?;
         }
 
         for geo_hash in &geo_hashes {

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -1,4 +1,4 @@
-use std::cmp::{max, min, Ordering};
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::ops::Bound;
@@ -61,7 +61,7 @@ impl Histogram {
 
     pub fn current_bucket_size(&self) -> usize {
         let bucket_size = (self.total_count as f64 * self.precision) as usize;
-        min(max(MIN_BUCKET_SIZE, bucket_size), self.max_bucket_size)
+        bucket_size.clamp(MIN_BUCKET_SIZE, self.max_bucket_size)
     }
 
     pub fn get_total_count(&self) -> usize {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -121,7 +121,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
             entry.insert(idx);
 
             let db_record = Self::encode_db_record(value, idx);
-            self.db_wrapper.put(&db_record, [])?;
+            self.db_wrapper.put(db_record, [])?;
         }
         self.indexed_points += 1;
         Ok(())
@@ -172,7 +172,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
                 vals.remove(&idx);
             }
             let key = MapIndex::encode_db_record(value, idx);
-            self.db_wrapper.remove(&key)?;
+            self.db_wrapper.remove(key)?;
         }
 
         Ok(())

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -207,6 +207,7 @@ impl<T: KeyEncoder + KeyDecoder + FromRangeValue + ToRangeValue + Clone> Numeric
         self.point_to_values.get(idx as usize)
     }
 
+    #[allow(clippy::manual_clamp)] // false positive
     fn range_cardinality(&self, range: &Range) -> CardinalityEstimation {
         let lbound = if let Some(lte) = range.lte {
             Included(lte)

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -540,7 +540,7 @@ impl GraphLinks for GraphLinksMmap {
 
     fn get_links_range(&self, idx: usize) -> Range<usize> {
         let offsets_slice = self.get_offsets_slice();
-        offsets_slice[idx as usize] as usize..offsets_slice[idx as usize + 1] as usize
+        offsets_slice[idx] as usize..offsets_slice[idx + 1] as usize
     }
 
     fn get_level_offset(&self, level: usize) -> usize {

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -24,7 +24,7 @@ impl OnDiskPayloadStorage {
 
     pub fn remove_from_storage(&self, point_id: PointOffsetType) -> OperationResult<()> {
         self.db_wrapper
-            .remove(&serde_cbor::to_vec(&point_id).unwrap())
+            .remove(serde_cbor::to_vec(&point_id).unwrap())
     }
 
     pub fn update_storage(
@@ -33,8 +33,8 @@ impl OnDiskPayloadStorage {
         payload: &Payload,
     ) -> OperationResult<()> {
         self.db_wrapper.put(
-            &serde_cbor::to_vec(&point_id).unwrap(),
-            &serde_cbor::to_vec(payload).unwrap(),
+            serde_cbor::to_vec(&point_id).unwrap(),
+            serde_cbor::to_vec(payload).unwrap(),
         )
     }
 

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -38,10 +38,10 @@ impl SimplePayloadStorage {
         match self.payload.get(point_id) {
             None => self
                 .db_wrapper
-                .remove(&serde_cbor::to_vec(&point_id).unwrap()),
+                .remove(serde_cbor::to_vec(&point_id).unwrap()),
             Some(payload) => self.db_wrapper.put(
-                &serde_cbor::to_vec(&point_id).unwrap(),
-                &serde_cbor::to_vec(payload).unwrap(),
+                serde_cbor::to_vec(&point_id).unwrap(),
+                serde_cbor::to_vec(payload).unwrap(),
             ),
         }
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -878,8 +878,8 @@ impl SegmentEntry for Segment {
 
         let vector_storage_flushers: Vec<_> = self
             .vector_data
-            .iter()
-            .map(|(_, v)| v.vector_storage.borrow().flusher())
+            .values()
+            .map(|v| v.vector_storage.borrow().flusher())
             .collect();
         let state = self.get_state();
         let current_path = self.current_path.clone();

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -50,8 +50,8 @@ fn create_segment(
     };
     let vector_db_names: Vec<String> = config
         .vector_data
-        .iter()
-        .map(|(vector_name, _)| get_vector_name_with_prefix(DB_VECTOR_CF, vector_name))
+        .keys()
+        .map(|vector_name| get_vector_name_with_prefix(DB_VECTOR_CF, vector_name))
         .collect();
     let database = open_db(segment_path, &vector_db_names)
         .map_err(|err| OperationError::service_error(&format!("RocksDB open error: {}", err)))?;
@@ -73,9 +73,9 @@ fn create_segment(
     let mut vector_data = HashMap::new();
     for (vector_name, vector_config) in &config.vector_data {
         let vector_storage_path =
-            segment_path.join(&get_vector_name_with_prefix("vector_storage", vector_name));
+            segment_path.join(get_vector_name_with_prefix("vector_storage", vector_name));
         let vector_index_path =
-            segment_path.join(&get_vector_name_with_prefix("vector_index", vector_name));
+            segment_path.join(get_vector_name_with_prefix("vector_index", vector_name));
 
         let vector_storage: Arc<AtomicRefCell<VectorStorageSS>> = match config.storage_type {
             StorageType::InMemory => {

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -167,8 +167,8 @@ where
         };
 
         self.db_wrapper.put(
-            &bincode::serialize(&point_id).unwrap(),
-            &bincode::serialize(&record).unwrap(),
+            bincode::serialize(&point_id).unwrap(),
+            bincode::serialize(&record).unwrap(),
         )?;
 
         Ok(())

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -266,7 +266,7 @@ mod tests {
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
-                        .vector_count() as usize,
+                        .vector_count(),
                 "{:#?}",
                 estimation
             );
@@ -341,7 +341,7 @@ mod tests {
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
-                        .vector_count() as usize,
+                        .vector_count(),
                 "{:#?}",
                 estimation
             );
@@ -370,7 +370,7 @@ mod tests {
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
-                        .vector_count() as usize,
+                        .vector_count(),
                 "{:#?}",
                 estimation
             );

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -78,7 +78,7 @@ pub fn recover_full_snapshot(snapshot_path: &str, storage_dir: &str, force: bool
 
     // Read configuration file with snapshot-to-collection mapping
     let config_path = temporary_dir.join("config.json");
-    let config_file = std::fs::File::open(&config_path).unwrap();
+    let config_file = std::fs::File::open(config_path).unwrap();
     let config_json: SnapshotConfig = serde_json::from_reader(config_file).unwrap();
 
     // Create mapping from the configuration file


### PR DESCRIPTION
As usual after a Rust release, we need to address the new Clippy lints for our CI.