### PR TITLE
update tonic 0.8 & prost 0.11

### DIFF
--- a/.github/scripts/protoc.sh
+++ b/.github/scripts/protoc.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v3.12.4/protoc-3.12.4-linux-x86_64.zip
-unzip protoc-3.12.4-linux-x86_64.zip -d /tmp/protoc
-sudo mv /tmp/protoc/bin/protoc /usr/bin/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,10 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
-        run: sudo apt-get install clang
-      - name: Install protoc
-        run: .github/scripts/protoc.sh
-        shell: bash
+        run: sudo apt-get install clang protobuf-compiler
       - name: Build
         run: cargo build --features service_debug
       - name: Run integration tests
@@ -46,15 +43,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
-        run: sudo apt-get install clang
+        run: sudo apt-get install clang protobuf-compiler
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install pytest
         run: pip install pytest requests
-      - name: Install protoc
-        run: .github/scripts/protoc.sh
-        shell: bash
       - name: Build
         run: cargo build --features service_debug
       - name: Run integration tests - 1 peer

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -33,10 +33,7 @@ jobs:
       with:
         key: clippy
     - name: Install dependencies
-      run: sudo apt-get install clang
-    - name: Install protoc
-      run: .github/scripts/protoc.sh
-      shell: bash
+      run: sudo apt-get install clang protobuf-compiler
     - name: Check code formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
     - name: Install dependencies
-      run: sudo apt-get install clang
-    - name: Install protoc
-      run: .github/scripts/protoc.sh
-      shell: bash
+      run: sudo apt-get install clang protobuf-compiler
     - name: Run tests
       run: cargo test --all
 

--- a/.github/workflows/storage-compat.yml
+++ b/.github/workflows/storage-compat.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get install clang git-lfs
+        run: sudo apt-get install clang git-lfs protobuf-compiler
       - name: Setup git-lfs
         run: git lfs install
       - name: Install minimal stable
@@ -25,9 +25,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: actions/checkout@v3
-      - name: Install protoc
-        run: .github/scripts/protoc.sh
-        shell: bash
       - uses: Swatinem/rust-cache@v2
       - name: Run storage compatibility test
         run: ./tests/storage-compat/storage-compatibility.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,8 +296,8 @@ name = "api"
 version = "0.11.1"
 dependencies = [
  "chrono",
- "prost 0.10.4",
- "prost-types 0.10.1",
+ "prost",
+ "prost-types",
  "rand",
  "schemars",
  "segment",
@@ -417,9 +417,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.16"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -435,9 +435,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -456,6 +456,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -769,7 +770,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -792,15 +793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1606,15 +1598,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -2051,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -2576,9 +2559,9 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot",
- "prost 0.11.2",
- "prost-build 0.11.2",
- "prost-derive 0.11.2",
+ "prost",
+ "prost-build",
+ "prost-derive",
  "sha2",
  "smallvec",
  "symbolic-demangle",
@@ -2657,74 +2640,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive 0.10.1",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
-dependencies = [
- "bytes",
- "prost-derive 0.11.2",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log 0.4.17",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck 0.4.0",
- "itertools",
- "lazy_static",
- "log 0.4.17",
- "multimap",
- "petgraph",
- "prost 0.10.4",
- "prost-types 0.10.1",
- "regex",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2734,45 +2655,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck",
  "itertools",
  "lazy_static",
  "log 0.4.17",
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.11.2",
- "prost-types 0.11.2",
+ "prost",
+ "prost-types",
  "regex",
  "syn",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2790,32 +2685,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost 0.10.4",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes",
- "prost 0.11.2",
+ "prost",
 ]
 
 [[package]]
@@ -2826,13 +2701,13 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "protobuf-build"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2be70fa994657539e3c872cc54363c9bf28b0d7a7f774df70e9fd760df3bc4"
+checksum = "6fb3c02f54ecaf12572c1a60dbdb36b1f8f713a16105881143f2be84cca5bbe3"
 dependencies = [
  "bitflags",
  "proc-macro2",
- "prost-build 0.9.0",
+ "prost-build",
  "quote",
  "syn",
 ]
@@ -2860,7 +2735,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "parking_lot",
- "prost 0.9.0",
+ "prost",
  "raft",
  "raft-proto",
  "rusty-hook",
@@ -2923,7 +2798,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 [[package]]
 name = "raft"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?rev=52d84aac8734369d81c2d77413ea3ab8e58e0af9#52d84aac8734369d81c2d77413ea3ab8e58e0af9"
+source = "git+https://github.com/tikv/raft-rs?rev=5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7#5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7"
 dependencies = [
  "fxhash",
  "getset",
@@ -2937,10 +2812,10 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?rev=52d84aac8734369d81c2d77413ea3ab8e58e0af9#52d84aac8734369d81c2d77413ea3ab8e58e0af9"
+source = "git+https://github.com/tikv/raft-rs?rev=5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7#5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7"
 dependencies = [
  "lazy_static",
- "prost 0.9.0",
+ "prost",
  "protobuf",
  "protobuf-build",
 ]
@@ -3273,6 +3148,12 @@ checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "rusty-fork"
@@ -3667,7 +3548,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "proptest",
- "prost 0.9.0",
+ "prost",
  "raft",
  "rand",
  "reqwest",
@@ -4018,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4037,8 +3918,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.10.4",
- "prost-derive 0.10.1",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4051,13 +3932,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.10.4",
+ "prost-build",
  "quote",
  "syn",
 ]
@@ -4212,12 +4093,6 @@ checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,18 @@ tokio = { version = "~1.23", features = ["full"] }
 actix-web = { version = "4.2.1", optional = true }
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
-tonic = { version = "0.7.2", features = ["compression"] }
+tonic = { version = "0.8.3", features = ["gzip"] }
 tower = "0.4.13"
 tower-layer = "0.3.2"
 num-traits = "0.2.15"
 tar = "0.4.38"
 
 # Consensus related crates
-raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
+raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
-prost = "=0.9.0"
-raft-proto = {  git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false}
+prost = "0.11.3"
+raft-proto = {  git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false}
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Building for $TARGETARCH, arch: $(bash target_arch.sh)"
 
 COPY --from=planner /qdrant/recipe.json recipe.json
 
-RUN apt-get update && apt-get install -y gcc-multilib && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && rustup component add rustfmt
+RUN apt-get update && apt-get install -y gcc-multilib && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler && rustup component add rustfmt
 
 
 RUN rustup target add $(bash target_arch.sh)

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = { version = "0.7.2", features = ["compression"] }
-prost = "0.10.1"
-prost-types = "0.10.1"
+tonic = { version = "0.8.3", features = ["gzip"] }
+prost = "0.11.3"
+prost-types = "0.11.2"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
@@ -22,4 +22,4 @@ thiserror = "1.0"
 segment = {path = "../segment"}
 
 [build-dependencies]
-tonic-build = { version = "0.7.2", features = ["prost", "compression"] }
+tonic-build = { version = "0.8.4", features = ["prost"] }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1,288 +1,287 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorParams {
     /// Size of the vectors
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub size: u64,
     /// Distance function used for comparing vectors
-    #[prost(enumeration="Distance", tag="2")]
+    #[prost(enumeration = "Distance", tag = "2")]
     pub distance: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorParamsMap {
-    #[prost(map="string, message", tag="1")]
+    #[prost(map = "string, message", tag = "1")]
     pub map: ::std::collections::HashMap<::prost::alloc::string::String, VectorParams>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorsConfig {
-    #[prost(oneof="vectors_config::Config", tags="1, 2")]
+    #[prost(oneof = "vectors_config::Config", tags = "1, 2")]
     pub config: ::core::option::Option<vectors_config::Config>,
 }
 /// Nested message and enum types in `VectorsConfig`.
 pub mod vectors_config {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Config {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Params(super::VectorParams),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         ParamsMap(super::VectorParamsMap),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoRequest {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListCollectionsRequest {
-}
+pub struct ListCollectionsRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionDescription {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub result: ::core::option::Option<CollectionInfo>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListCollectionsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub collections: ::prost::alloc::vec::Vec<CollectionDescription>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizerStatus {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub ok: bool,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub error: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HnswConfigDiff {
     ///
-    ///Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
-    #[prost(uint64, optional, tag="1")]
+    /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
+    #[prost(uint64, optional, tag = "1")]
     pub m: ::core::option::Option<u64>,
     ///
-    ///Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.
-    #[prost(uint64, optional, tag="2")]
+    /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.
+    #[prost(uint64, optional, tag = "2")]
     pub ef_construct: ::core::option::Option<u64>,
     ///
-    ///Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
-    ///If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
-    ///in this case full-scan search should be preferred by query planner and additional indexing is not required.
-    ///Note: 1Kb = 1 vector of size 256
-    #[prost(uint64, optional, tag="3")]
+    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// If payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
+    /// Note: 1Kb = 1 vector of size 256
+    #[prost(uint64, optional, tag = "3")]
     pub full_scan_threshold: ::core::option::Option<u64>,
     ///
-    ///Number of parallel threads used for background index building. If 0 - auto selection.
-    #[prost(uint64, optional, tag="4")]
+    /// Number of parallel threads used for background index building. If 0 - auto selection.
+    #[prost(uint64, optional, tag = "4")]
     pub max_indexing_threads: ::core::option::Option<u64>,
     ///
-    ///Store HNSW index on disk. If set to false, index will be stored in RAM.
-    #[prost(bool, optional, tag="5")]
+    /// Store HNSW index on disk. If set to false, index will be stored in RAM.
+    #[prost(bool, optional, tag = "5")]
     pub on_disk: ::core::option::Option<bool>,
     ///
-    ///Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
-    #[prost(uint64, optional, tag="6")]
+    /// Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+    #[prost(uint64, optional, tag = "6")]
     pub payload_m: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {
     /// Size of a single WAL block file
-    #[prost(uint64, optional, tag="1")]
+    #[prost(uint64, optional, tag = "1")]
     pub wal_capacity_mb: ::core::option::Option<u64>,
     /// Number of segments to create in advance
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub wal_segments_ahead: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizersConfigDiff {
     ///
-    ///The minimal fraction of deleted vectors in a segment, required to perform segment optimization
-    #[prost(double, optional, tag="1")]
+    /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
+    #[prost(double, optional, tag = "1")]
     pub deleted_threshold: ::core::option::Option<f64>,
     ///
-    ///The minimal number of vectors in a segment, required to perform segment optimization
-    #[prost(uint64, optional, tag="2")]
+    /// The minimal number of vectors in a segment, required to perform segment optimization
+    #[prost(uint64, optional, tag = "2")]
     pub vacuum_min_vector_number: ::core::option::Option<u64>,
     ///
-    ///Target amount of segments optimizer will try to keep.
-    ///Real amount of segments may vary depending on multiple parameters:
+    /// Target amount of segments optimizer will try to keep.
+    /// Real amount of segments may vary depending on multiple parameters:
     ///
-    ///- Amount of stored points.
-    ///- Current write RPS.
+    /// - Amount of stored points.
+    /// - Current write RPS.
     ///
-    ///It is recommended to select default number of segments as a factor of the number of search threads,
-    ///so that each segment would be handled evenly by one of the threads.
-    #[prost(uint64, optional, tag="3")]
+    /// It is recommended to select default number of segments as a factor of the number of search threads,
+    /// so that each segment would be handled evenly by one of the threads.
+    #[prost(uint64, optional, tag = "3")]
     pub default_segment_number: ::core::option::Option<u64>,
     ///
-    ///Do not create segments larger this size (in KiloBytes).
-    ///Large segments might require disproportionately long indexation times,
-    ///therefore it makes sense to limit the size of segments.
+    /// Do not create segments larger this size (in KiloBytes).
+    /// Large segments might require disproportionately long indexation times,
+    /// therefore it makes sense to limit the size of segments.
     ///
-    ///If indexation speed have more priority for your - make this parameter lower.
-    ///If search speed is more important - make this parameter higher.
-    ///Note: 1Kb = 1 vector of size 256
-    #[prost(uint64, optional, tag="4")]
+    /// If indexation speed have more priority for your - make this parameter lower.
+    /// If search speed is more important - make this parameter higher.
+    /// Note: 1Kb = 1 vector of size 256
+    #[prost(uint64, optional, tag = "4")]
     pub max_segment_size: ::core::option::Option<u64>,
     ///
-    ///Maximum size (in KiloBytes) of vectors to store in-memory per segment.
-    ///Segments larger than this threshold will be stored as read-only memmaped file.
-    ///To enable memmap storage, lower the threshold
-    ///Note: 1Kb = 1 vector of size 256
-    #[prost(uint64, optional, tag="5")]
+    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+    /// Segments larger than this threshold will be stored as read-only memmaped file.
+    /// To enable memmap storage, lower the threshold
+    /// Note: 1Kb = 1 vector of size 256
+    #[prost(uint64, optional, tag = "5")]
     pub memmap_threshold: ::core::option::Option<u64>,
     ///
-    ///Maximum size (in KiloBytes) of vectors allowed for plain index.
-    ///Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
-    ///Note: 1Kb = 1 vector of size 256
-    #[prost(uint64, optional, tag="6")]
+    /// Maximum size (in KiloBytes) of vectors allowed for plain index.
+    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
+    /// Note: 1Kb = 1 vector of size 256
+    #[prost(uint64, optional, tag = "6")]
     pub indexing_threshold: ::core::option::Option<u64>,
     ///
-    ///Interval between forced flushes.
-    #[prost(uint64, optional, tag="7")]
+    /// Interval between forced flushes.
+    #[prost(uint64, optional, tag = "7")]
     pub flush_interval_sec: ::core::option::Option<u64>,
     ///
-    ///Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
-    #[prost(uint64, optional, tag="8")]
+    /// Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
+    #[prost(uint64, optional, tag = "8")]
     pub max_optimization_threads: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollection {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Configuration of vector index
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
     /// Configuration of the Write-Ahead-Log
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub wal_config: ::core::option::Option<WalConfigDiff>,
     /// Configuration of the optimizers
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Number of shards in the collection, default = 1
-    #[prost(uint32, optional, tag="7")]
+    #[prost(uint32, optional, tag = "7")]
     pub shard_number: ::core::option::Option<u32>,
     /// If true - point's payload will not be stored in memory
-    #[prost(bool, optional, tag="8")]
+    #[prost(bool, optional, tag = "8")]
     pub on_disk_payload: ::core::option::Option<bool>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-    #[prost(uint64, optional, tag="9")]
+    #[prost(uint64, optional, tag = "9")]
     pub timeout: ::core::option::Option<u64>,
     /// Configuration for vectors
-    #[prost(message, optional, tag="10")]
+    #[prost(message, optional, tag = "10")]
     pub vectors_config: ::core::option::Option<VectorsConfig>,
     /// Number of replicas of each shard that network tries to maintain, default = 1
-    #[prost(uint32, optional, tag="11")]
+    #[prost(uint32, optional, tag = "11")]
     pub replication_factor: ::core::option::Option<u32>,
     /// How many replicas should apply the operation for us to consider it successful, default = 1
-    #[prost(uint32, optional, tag="12")]
+    #[prost(uint32, optional, tag = "12")]
     pub write_consistency_factor: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollection {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// New configuration parameters for the collection
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub timeout: ::core::option::Option<u64>,
     /// New configuration parameters for the collection
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<CollectionParamsDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCollection {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub timeout: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionOperationResponse {
     /// if operation made changes
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub result: bool,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionParams {
     /// Number of shards in collection
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub shard_number: u32,
     /// If true - point's payload will not be stored in memory
-    #[prost(bool, tag="4")]
+    #[prost(bool, tag = "4")]
     pub on_disk_payload: bool,
     /// Configuration for vectors
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub vectors_config: ::core::option::Option<VectorsConfig>,
     /// Number of replicas of each shard that network tries to maintain
-    #[prost(uint32, optional, tag="6")]
+    #[prost(uint32, optional, tag = "6")]
     pub replication_factor: ::core::option::Option<u32>,
     /// How many replicas should apply the operation for us to consider it successful
-    #[prost(uint32, optional, tag="7")]
+    #[prost(uint32, optional, tag = "7")]
     pub write_consistency_factor: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionParamsDiff {
     /// Number of replicas of each shard that network tries to maintain
-    #[prost(uint32, optional, tag="1")]
+    #[prost(uint32, optional, tag = "1")]
     pub replication_factor: ::core::option::Option<u32>,
     /// How many replicas should apply the operation for us to consider it successful
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub write_consistency_factor: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionConfig {
     /// Collection parameters
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<CollectionParams>,
     /// Configuration of vector index
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
     /// Configuration of the optimizers
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub optimizer_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Configuration of the Write-Ahead-Log
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub wal_config: ::core::option::Option<WalConfigDiff>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TextIndexParams {
     /// Tokenizer type
-    #[prost(enumeration="TokenizerType", tag="1")]
+    #[prost(enumeration = "TokenizerType", tag = "1")]
     pub tokenizer: i32,
     /// If true - all tokens will be lowercased
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub lowercase: ::core::option::Option<bool>,
     /// Minimal token length
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub min_token_len: ::core::option::Option<u64>,
     /// Maximal token length
-    #[prost(uint64, optional, tag="4")]
+    #[prost(uint64, optional, tag = "4")]
     pub max_token_len: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PayloadIndexParams {
-    #[prost(oneof="payload_index_params::IndexParams", tags="1")]
+    #[prost(oneof = "payload_index_params::IndexParams", tags = "1")]
     pub index_params: ::core::option::Option<payload_index_params::IndexParams>,
 }
 /// Nested message and enum types in `PayloadIndexParams`.
@@ -290,97 +289,100 @@ pub mod payload_index_params {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum IndexParams {
         /// Parameters for text index
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         TextIndexParams(super::TextIndexParams),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PayloadSchemaInfo {
     /// Field data type
-    #[prost(enumeration="PayloadSchemaType", tag="1")]
+    #[prost(enumeration = "PayloadSchemaType", tag = "1")]
     pub data_type: i32,
     /// Field index parameters
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub params: ::core::option::Option<PayloadIndexParams>,
     /// Number of points indexed within this field indexed
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub points: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionInfo {
     /// operating condition of the collection
-    #[prost(enumeration="CollectionStatus", tag="1")]
+    #[prost(enumeration = "CollectionStatus", tag = "1")]
     pub status: i32,
     /// status of collection optimizers
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub optimizer_status: ::core::option::Option<OptimizerStatus>,
     /// number of vectors in the collection
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub vectors_count: u64,
     /// Number of independent segments
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub segments_count: u64,
     /// Configuration
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub config: ::core::option::Option<CollectionConfig>,
     /// Collection data types
-    #[prost(map="string, message", tag="8")]
-    pub payload_schema: ::std::collections::HashMap<::prost::alloc::string::String, PayloadSchemaInfo>,
+    #[prost(map = "string, message", tag = "8")]
+    pub payload_schema: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        PayloadSchemaInfo,
+    >,
     /// number of points in the collection
-    #[prost(uint64, tag="9")]
+    #[prost(uint64, tag = "9")]
     pub points_count: u64,
     /// number of indexed vectors in the collection.
-    #[prost(uint64, optional, tag="10")]
+    #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChangeAliases {
     /// List of actions
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub actions: ::prost::alloc::vec::Vec<AliasOperations>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub timeout: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AliasOperations {
-    #[prost(oneof="alias_operations::Action", tags="1, 2, 3")]
+    #[prost(oneof = "alias_operations::Action", tags = "1, 2, 3")]
     pub action: ::core::option::Option<alias_operations::Action>,
 }
 /// Nested message and enum types in `AliasOperations`.
 pub mod alias_operations {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Action {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         CreateAlias(super::CreateAlias),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         RenameAlias(super::RenameAlias),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         DeleteAlias(super::DeleteAlias),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateAlias {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// New name of the alias
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub alias_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RenameAlias {
     /// Name of the alias to rename
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub old_alias_name: ::prost::alloc::string::String,
     /// Name of the alias
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub new_alias_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteAlias {
     /// Name of the alias
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub alias_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -390,6 +392,20 @@ pub enum Distance {
     Cosine = 1,
     Euclid = 2,
     Dot = 3,
+}
+impl Distance {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Distance::UnknownDistance => "UnknownDistance",
+            Distance::Cosine => "Cosine",
+            Distance::Euclid => "Euclid",
+            Distance::Dot => "Dot",
+        }
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -402,6 +418,20 @@ pub enum CollectionStatus {
     /// Something went wrong
     Red = 3,
 }
+impl CollectionStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            CollectionStatus::UnknownCollectionStatus => "UnknownCollectionStatus",
+            CollectionStatus::Green => "Green",
+            CollectionStatus::Yellow => "Yellow",
+            CollectionStatus::Red => "Red",
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PayloadSchemaType {
@@ -412,6 +442,22 @@ pub enum PayloadSchemaType {
     Geo = 4,
     Text = 5,
 }
+impl PayloadSchemaType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            PayloadSchemaType::UnknownType => "UnknownType",
+            PayloadSchemaType::Keyword => "Keyword",
+            PayloadSchemaType::Integer => "Integer",
+            PayloadSchemaType::Float => "Float",
+            PayloadSchemaType::Geo => "Geo",
+            PayloadSchemaType::Text => "Text",
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TokenizerType {
@@ -420,10 +466,25 @@ pub enum TokenizerType {
     Whitespace = 2,
     Word = 3,
 }
+impl TokenizerType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TokenizerType::Unknown => "Unknown",
+            TokenizerType::Prefix => "Prefix",
+            TokenizerType::Whitespace => "Whitespace",
+            TokenizerType::Word => "Word",
+        }
+    }
+}
 /// Generated client implementations.
 pub mod collections_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct CollectionsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -450,6 +511,10 @@ pub mod collections_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -469,23 +534,23 @@ pub mod collections_client {
         {
             CollectionsClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         ///
-        ///Get detailed information about specified existing collection
+        /// Get detailed information about specified existing collection
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequest>,
@@ -504,7 +569,7 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Get list name of all existing collections
+        /// Get list name of all existing collections
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListCollectionsRequest>,
@@ -523,7 +588,7 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Create new collection with given parameters
+        /// Create new collection with given parameters
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateCollection>,
@@ -544,7 +609,7 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Update parameters of the existing collection
+        /// Update parameters of the existing collection
         pub async fn update(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateCollection>,
@@ -565,7 +630,7 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Drop collection and all associated data
+        /// Drop collection and all associated data
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteCollection>,
@@ -586,7 +651,7 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Update Aliases of the existing collection
+        /// Update Aliases of the existing collection
         pub async fn update_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ChangeAliases>,
@@ -612,41 +677,41 @@ pub mod collections_client {
 pub mod collections_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with CollectionsServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with CollectionsServer.
     #[async_trait]
     pub trait Collections: Send + Sync + 'static {
         ///
-        ///Get detailed information about specified existing collection
+        /// Get detailed information about specified existing collection
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequest>,
         ) -> Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
         ///
-        ///Get list name of all existing collections
+        /// Get list name of all existing collections
         async fn list(
             &self,
             request: tonic::Request<super::ListCollectionsRequest>,
         ) -> Result<tonic::Response<super::ListCollectionsResponse>, tonic::Status>;
         ///
-        ///Create new collection with given parameters
+        /// Create new collection with given parameters
         async fn create(
             &self,
             request: tonic::Request<super::CreateCollection>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
-        ///Update parameters of the existing collection
+        /// Update parameters of the existing collection
         async fn update(
             &self,
             request: tonic::Request<super::UpdateCollection>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
-        ///Drop collection and all associated data
+        /// Drop collection and all associated data
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteCollection>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
-        ///Update Aliases of the existing collection
+        /// Update Aliases of the existing collection
         async fn update_aliases(
             &self,
             request: tonic::Request<super::ChangeAliases>,
@@ -680,16 +745,16 @@ pub mod collections_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -976,30 +1041,31 @@ pub mod collections_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Collections> tonic::transport::NamedService for CollectionsServer<T> {
+    impl<T: Collections> tonic::server::NamedService for CollectionsServer<T> {
         const NAME: &'static str = "qdrant.Collections";
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoRequestInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub get_collection_info_request: ::core::option::Option<GetCollectionInfoRequest>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitiateShardTransferRequest {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Id of the temporary shard
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 /// Generated client implementations.
 pub mod collections_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct CollectionsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1026,6 +1092,10 @@ pub mod collections_internal_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -1045,23 +1115,23 @@ pub mod collections_internal_client {
         {
             CollectionsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         ///
-        ///Get collection info
+        /// Get collection info
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequestInternal>,
@@ -1082,7 +1152,7 @@ pub mod collections_internal_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Initiate shard transfer
+        /// Initiate shard transfer
         pub async fn initiate(
             &mut self,
             request: impl tonic::IntoRequest<super::InitiateShardTransferRequest>,
@@ -1108,17 +1178,17 @@ pub mod collections_internal_client {
 pub mod collections_internal_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with CollectionsInternalServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with CollectionsInternalServer.
     #[async_trait]
     pub trait CollectionsInternal: Send + Sync + 'static {
         ///
-        ///Get collection info
+        /// Get collection info
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequestInternal>,
         ) -> Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
         ///
-        ///Initiate shard transfer
+        /// Initiate shard transfer
         async fn initiate(
             &self,
             request: tonic::Request<super::InitiateShardTransferRequest>,
@@ -1152,16 +1222,16 @@ pub mod collections_internal_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -1297,7 +1367,7 @@ pub mod collections_internal_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: CollectionsInternal> tonic::transport::NamedService
+    impl<T: CollectionsInternal> tonic::server::NamedService
     for CollectionsInternalServer<T> {
         const NAME: &'static str = "qdrant.CollectionsInternal";
     }
@@ -1313,7 +1383,7 @@ pub mod collections_internal_server {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
-    #[prost(map="string, message", tag="1")]
+    #[prost(map = "string, message", tag = "1")]
     pub fields: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
 }
 /// `Value` represents a dynamically typed value which can be either
@@ -1325,7 +1395,7 @@ pub struct Struct {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Value {
     /// The kind of value.
-    #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "value::Kind", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub kind: ::core::option::Option<value::Kind>,
 }
 /// Nested message and enum types in `Value`.
@@ -1334,25 +1404,25 @@ pub mod value {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         /// Represents a null value.
-        #[prost(enumeration="super::NullValue", tag="1")]
+        #[prost(enumeration = "super::NullValue", tag = "1")]
         NullValue(i32),
         /// Represents a double value.
-        #[prost(double, tag="2")]
+        #[prost(double, tag = "2")]
         DoubleValue(f64),
         /// Represents an integer value
-        #[prost(int64, tag="3")]
+        #[prost(int64, tag = "3")]
         IntegerValue(i64),
         /// Represents a string value.
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         StringValue(::prost::alloc::string::String),
         /// Represents a boolean value.
-        #[prost(bool, tag="5")]
+        #[prost(bool, tag = "5")]
         BoolValue(bool),
         /// Represents a structured value.
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         StructValue(super::Struct),
         /// Represents a repeated `Value`.
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         ListValue(super::ListValue),
     }
 }
@@ -1362,26 +1432,33 @@ pub mod value {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub values: ::prost::alloc::vec::Vec<Value>,
 }
 /// `NullValue` is a singleton enumeration to represent the null value for the
 /// `Value` type union.
 ///
-///  The JSON representation for `NullValue` is JSON `null`.
+///   The JSON representation for `NullValue` is JSON `null`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum NullValue {
     /// Null value.
     NullValue = 0,
 }
-// ---------------------------------------------
-// ------------- Point Id Requests -------------
-// ---------------------------------------------
-
+impl NullValue {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            NullValue::NullValue => "NULL_VALUE",
+        }
+    }
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointId {
-    #[prost(oneof="point_id::PointIdOptions", tags="1, 2")]
+    #[prost(oneof = "point_id::PointIdOptions", tags = "1, 2")]
     pub point_id_options: ::core::option::Option<point_id::PointIdOptions>,
 }
 /// Nested message and enum types in `PointId`.
@@ -1389,153 +1466,149 @@ pub mod point_id {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PointIdOptions {
         /// Numerical ID of the point
-        #[prost(uint64, tag="1")]
+        #[prost(uint64, tag = "1")]
         Num(u64),
         /// UUID
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         Uuid(::prost::alloc::string::String),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
-    #[prost(float, repeated, tag="1")]
+    #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
 }
-// ---------------------------------------------
-// ---------------- RPC Requests ---------------
-// ---------------------------------------------
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub points: ::prost::alloc::vec::Vec<PointStruct>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Affected points
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub points: ::core::option::Option<PointsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// List of points to retrieve
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub ids: ::prost::alloc::vec::Vec<PointId>,
     /// Options for specifying which payload to include or not
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub with_payload: ::core::option::Option<WithPayloadSelector>,
     /// Options for specifying which vectors to include into response
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// New payload values
-    #[prost(map="string, message", tag="3")]
+    #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     /// List of point to modify, deprecated
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub points: ::prost::alloc::vec::Vec<PointId>,
     /// Affected points
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub points_selector: ::core::option::Option<PointsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePayloadPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// List of keys to delete
-    #[prost(string, repeated, tag="3")]
+    #[prost(string, repeated, tag = "3")]
     pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Affected points, deprecated
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub points: ::prost::alloc::vec::Vec<PointId>,
     /// Affected points
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub points_selector: ::core::option::Option<PointsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearPayloadPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Affected points
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub points: ::core::option::Option<PointsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateFieldIndexCollection {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Field name to index
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub field_name: ::prost::alloc::string::String,
     /// Field type.
-    #[prost(enumeration="FieldType", optional, tag="4")]
+    #[prost(enumeration = "FieldType", optional, tag = "4")]
     pub field_type: ::core::option::Option<i32>,
     /// Payload index params.
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub field_index_params: ::core::option::Option<PayloadIndexParams>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteFieldIndexCollection {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Field name to delete
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub field_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PayloadIncludeSelector {
     /// List of payload keys to include into result
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PayloadExcludeSelector {
     /// List of payload keys to exclude from the result
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WithPayloadSelector {
-    #[prost(oneof="with_payload_selector::SelectorOptions", tags="1, 2, 3")]
+    #[prost(oneof = "with_payload_selector::SelectorOptions", tags = "1, 2, 3")]
     pub selector_options: ::core::option::Option<with_payload_selector::SelectorOptions>,
 }
 /// Nested message and enum types in `WithPayloadSelector`.
@@ -1543,43 +1616,43 @@ pub mod with_payload_selector {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SelectorOptions {
         /// If `true` - return all payload, if `false` - none
-        #[prost(bool, tag="1")]
+        #[prost(bool, tag = "1")]
         Enable(bool),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Include(super::PayloadIncludeSelector),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Exclude(super::PayloadExcludeSelector),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedVectors {
-    #[prost(map="string, message", tag="1")]
+    #[prost(map = "string, message", tag = "1")]
     pub vectors: ::std::collections::HashMap<::prost::alloc::string::String, Vector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vectors {
-    #[prost(oneof="vectors::VectorsOptions", tags="1, 2")]
+    #[prost(oneof = "vectors::VectorsOptions", tags = "1, 2")]
     pub vectors_options: ::core::option::Option<vectors::VectorsOptions>,
 }
 /// Nested message and enum types in `Vectors`.
 pub mod vectors {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum VectorsOptions {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Vector(super::Vector),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Vectors(super::NamedVectors),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorsSelector {
     /// List of vectors to include into result
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WithVectorsSelector {
-    #[prost(oneof="with_vectors_selector::SelectorOptions", tags="1, 2")]
+    #[prost(oneof = "with_vectors_selector::SelectorOptions", tags = "1, 2")]
     pub selector_options: ::core::option::Option<with_vectors_selector::SelectorOptions>,
 }
 /// Nested message and enum types in `WithVectorsSelector`.
@@ -1587,327 +1660,319 @@ pub mod with_vectors_selector {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SelectorOptions {
         /// If `true` - return all vectors, if `false` - none
-        #[prost(bool, tag="1")]
+        #[prost(bool, tag = "1")]
         Enable(bool),
         /// List of payload keys to include into result
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Include(super::VectorsSelector),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchParams {
     ///
-    ///Params relevant to HNSW index. Size of the beam in a beam-search.
-    ///Larger the value - more accurate the result, more time required for search.
-    #[prost(uint64, optional, tag="1")]
+    /// Params relevant to HNSW index. Size of the beam in a beam-search.
+    /// Larger the value - more accurate the result, more time required for search.
+    #[prost(uint64, optional, tag = "1")]
     pub hnsw_ef: ::core::option::Option<u64>,
     ///
-    ///Search without approximation. If set to true, search may run long but with exact results.
-    #[prost(bool, optional, tag="2")]
+    /// Search without approximation. If set to true, search may run long but with exact results.
+    #[prost(bool, optional, tag = "2")]
     pub exact: ::core::option::Option<bool>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// vector
-    #[prost(float, repeated, tag="2")]
+    #[prost(float, repeated, tag = "2")]
     pub vector: ::prost::alloc::vec::Vec<f32>,
     /// Filter conditions - return only those points that satisfy the specified conditions
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub filter: ::core::option::Option<Filter>,
     /// Max number of result
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub limit: u64,
     /// Options for specifying which payload to include or not
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub with_payload: ::core::option::Option<WithPayloadSelector>,
     /// Search config
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub params: ::core::option::Option<SearchParams>,
     /// If provided - cut off results with worse scores
-    #[prost(float, optional, tag="8")]
+    #[prost(float, optional, tag = "8")]
     pub score_threshold: ::core::option::Option<f32>,
     /// Offset of the result
-    #[prost(uint64, optional, tag="9")]
+    #[prost(uint64, optional, tag = "9")]
     pub offset: ::core::option::Option<u64>,
     /// Which vector to use for search, if not specified - use default vector
-    #[prost(string, optional, tag="10")]
+    #[prost(string, optional, tag = "10")]
     pub vector_name: ::core::option::Option<::prost::alloc::string::String>,
     /// Options for specifying which vectors to include into response
-    #[prost(message, optional, tag="11")]
+    #[prost(message, optional, tag = "11")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchPoints {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPoints {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub filter: ::core::option::Option<Filter>,
     /// Start with this ID
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub offset: ::core::option::Option<PointId>,
     /// Max number of result
-    #[prost(uint32, optional, tag="4")]
+    #[prost(uint32, optional, tag = "4")]
     pub limit: ::core::option::Option<u32>,
     /// Options for specifying which payload to include or not
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub with_payload: ::core::option::Option<WithPayloadSelector>,
     /// Options for specifying which vectors to include into response
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Look for vectors closest to those
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub positive: ::prost::alloc::vec::Vec<PointId>,
     /// Try to avoid vectors like this
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub negative: ::prost::alloc::vec::Vec<PointId>,
     /// Filter conditions - return only those points that satisfy the specified conditions
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub filter: ::core::option::Option<Filter>,
     /// Max number of result
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub limit: u64,
     /// Options for specifying which payload to include or not
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub with_payload: ::core::option::Option<WithPayloadSelector>,
     /// Search config
-    #[prost(message, optional, tag="8")]
+    #[prost(message, optional, tag = "8")]
     pub params: ::core::option::Option<SearchParams>,
     /// If provided - cut off results with worse scores
-    #[prost(float, optional, tag="9")]
+    #[prost(float, optional, tag = "9")]
     pub score_threshold: ::core::option::Option<f32>,
     /// Offset of the result
-    #[prost(uint64, optional, tag="10")]
+    #[prost(uint64, optional, tag = "10")]
     pub offset: ::core::option::Option<u64>,
     /// Define which vector to use for recommendation, if not specified - default vector
-    #[prost(string, optional, tag="11")]
+    #[prost(string, optional, tag = "11")]
     pub using: ::core::option::Option<::prost::alloc::string::String>,
     /// Options for specifying which vectors to include into response
-    #[prost(message, optional, tag="12")]
+    #[prost(message, optional, tag = "12")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendBatchPoints {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub recommend_points: ::prost::alloc::vec::Vec<RecommendPoints>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub filter: ::core::option::Option<Filter>,
     /// If `true` - return exact count, if `false` - return approximate count
-    #[prost(bool, optional, tag="3")]
+    #[prost(bool, optional, tag = "3")]
     pub exact: ::core::option::Option<bool>,
 }
-// ---------------------------------------------
-// ---------------- RPC Response ---------------
-// ---------------------------------------------
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsOperationResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub result: ::core::option::Option<UpdateResult>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateResult {
     /// Number of operation
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub operation_id: u64,
     /// Operation status
-    #[prost(enumeration="UpdateStatus", tag="2")]
+    #[prost(enumeration = "UpdateStatus", tag = "2")]
     pub status: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScoredPoint {
     /// Point id
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<PointId>,
     /// Payload
-    #[prost(map="string, message", tag="2")]
+    #[prost(map = "string, message", tag = "2")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     /// Similarity score
-    #[prost(float, tag="3")]
+    #[prost(float, tag = "3")]
     pub score: f32,
     /// Last update operation applied to this point
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub version: u64,
     /// Vectors to search
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub vectors: ::core::option::Option<Vectors>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchResult {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<BatchResult>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub result: ::core::option::Option<CountResult>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollResponse {
     /// Use this offset for the next query
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub next_page_offset: ::core::option::Option<PointId>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub result: ::prost::alloc::vec::Vec<RetrievedPoint>,
     /// Time spent to process
-    #[prost(double, tag="3")]
+    #[prost(double, tag = "3")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountResult {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub count: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetrievedPoint {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<PointId>,
-    #[prost(map="string, message", tag="2")]
+    #[prost(map = "string, message", tag = "2")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub vectors: ::core::option::Option<Vectors>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<RetrievedPoint>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendBatchResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<BatchResult>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
-// ---------------------------------------------
-// ------------- Filter Conditions -------------
-// ---------------------------------------------
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Filter {
     /// At least one of those conditions should match
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub should: ::prost::alloc::vec::Vec<Condition>,
     /// All conditions must match
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub must: ::prost::alloc::vec::Vec<Condition>,
     /// All conditions must NOT match
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub must_not: ::prost::alloc::vec::Vec<Condition>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Condition {
-    #[prost(oneof="condition::ConditionOneOf", tags="1, 2, 3, 4")]
+    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3, 4")]
     pub condition_one_of: ::core::option::Option<condition::ConditionOneOf>,
 }
 /// Nested message and enum types in `Condition`.
 pub mod condition {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum ConditionOneOf {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Field(super::FieldCondition),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         IsEmpty(super::IsEmptyCondition),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         HasId(super::HasIdCondition),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         Filter(super::Filter),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IsEmptyCondition {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HasIdCondition {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub has_id: ::prost::alloc::vec::Vec<PointId>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldCondition {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
     /// Check if point has field with a given value
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub r#match: ::core::option::Option<Match>,
     /// Check if points value lies in a given range
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub range: ::core::option::Option<Range>,
     /// Check if points geo location lies in a given area
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub geo_bounding_box: ::core::option::Option<GeoBoundingBox>,
     /// Check if geo point is within a given radius
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub geo_radius: ::core::option::Option<GeoRadius>,
     /// Check number of values for a specific field
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub values_count: ::core::option::Option<ValuesCount>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Match {
-    #[prost(oneof="r#match::MatchValue", tags="1, 2, 3, 4")]
+    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4")]
     pub match_value: ::core::option::Option<r#match::MatchValue>,
 }
 /// Nested message and enum types in `Match`.
@@ -1915,101 +1980,95 @@ pub mod r#match {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum MatchValue {
         /// Match string keyword
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Keyword(::prost::alloc::string::String),
         /// Match integer
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         Integer(i64),
         /// Match boolean
-        #[prost(bool, tag="3")]
+        #[prost(bool, tag = "3")]
         Boolean(bool),
         /// Match text
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         Text(::prost::alloc::string::String),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Range {
-    #[prost(double, optional, tag="1")]
+    #[prost(double, optional, tag = "1")]
     pub lt: ::core::option::Option<f64>,
-    #[prost(double, optional, tag="2")]
+    #[prost(double, optional, tag = "2")]
     pub gt: ::core::option::Option<f64>,
-    #[prost(double, optional, tag="3")]
+    #[prost(double, optional, tag = "3")]
     pub gte: ::core::option::Option<f64>,
-    #[prost(double, optional, tag="4")]
+    #[prost(double, optional, tag = "4")]
     pub lte: ::core::option::Option<f64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoBoundingBox {
     /// north-west corner
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub top_left: ::core::option::Option<GeoPoint>,
     /// south-east corner
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub bottom_right: ::core::option::Option<GeoPoint>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoRadius {
     /// Center of the circle
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub center: ::core::option::Option<GeoPoint>,
     /// In meters
-    #[prost(float, tag="2")]
+    #[prost(float, tag = "2")]
     pub radius: f32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValuesCount {
-    #[prost(uint64, optional, tag="1")]
+    #[prost(uint64, optional, tag = "1")]
     pub lt: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub gt: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="3")]
+    #[prost(uint64, optional, tag = "3")]
     pub gte: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag="4")]
+    #[prost(uint64, optional, tag = "4")]
     pub lte: ::core::option::Option<u64>,
 }
-// ---------------------------------------------
-// -------------- Points Selector --------------
-// ---------------------------------------------
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsSelector {
-    #[prost(oneof="points_selector::PointsSelectorOneOf", tags="1, 2")]
-    pub points_selector_one_of: ::core::option::Option<points_selector::PointsSelectorOneOf>,
+    #[prost(oneof = "points_selector::PointsSelectorOneOf", tags = "1, 2")]
+    pub points_selector_one_of: ::core::option::Option<
+        points_selector::PointsSelectorOneOf,
+    >,
 }
 /// Nested message and enum types in `PointsSelector`.
 pub mod points_selector {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PointsSelectorOneOf {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Points(super::PointsIdsList),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Filter(super::Filter),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsIdsList {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub ids: ::prost::alloc::vec::Vec<PointId>,
 }
-// ---------------------------------------------
-// ------------------- Point -------------------
-// ---------------------------------------------
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointStruct {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<PointId>,
-    #[prost(map="string, message", tag="3")]
+    #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub vectors: ::core::option::Option<Vectors>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPoint {
-    #[prost(double, tag="1")]
+    #[prost(double, tag = "1")]
     pub lon: f64,
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub lat: f64,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -2021,6 +2080,21 @@ pub enum FieldType {
     Geo = 3,
     Text = 4,
 }
+impl FieldType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FieldType::Keyword => "FieldTypeKeyword",
+            FieldType::Integer => "FieldTypeInteger",
+            FieldType::Float => "FieldTypeFloat",
+            FieldType::Geo => "FieldTypeGeo",
+            FieldType::Text => "FieldTypeText",
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum UpdateStatus {
@@ -2030,10 +2104,24 @@ pub enum UpdateStatus {
     /// Update is applied and ready for search
     Completed = 2,
 }
+impl UpdateStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            UpdateStatus::UnknownUpdateStatus => "UnknownUpdateStatus",
+            UpdateStatus::Acknowledged => "Acknowledged",
+            UpdateStatus::Completed => "Completed",
+        }
+    }
+}
 /// Generated client implementations.
 pub mod points_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PointsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2060,6 +2148,10 @@ pub mod points_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -2079,23 +2171,23 @@ pub mod points_client {
         {
             PointsClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         ///
-        ///Perform insert + updates on points. If point with given ID already exists - it will be overwritten.
+        /// Perform insert + updates on points. If point with given ID already exists - it will be overwritten.
         pub async fn upsert(
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPoints>,
@@ -2114,7 +2206,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Delete points
+        /// Delete points
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePoints>,
@@ -2133,7 +2225,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Retrieve points
+        /// Retrieve points
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoints>,
@@ -2152,7 +2244,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Set payload for points
+        /// Set payload for points
         pub async fn set_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
@@ -2171,7 +2263,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Overwrite payload for points
+        /// Overwrite payload for points
         pub async fn overwrite_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
@@ -2192,7 +2284,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Delete specified key payload for points
+        /// Delete specified key payload for points
         pub async fn delete_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPoints>,
@@ -2213,7 +2305,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Remove all payload for specified points
+        /// Remove all payload for specified points
         pub async fn clear_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPoints>,
@@ -2234,7 +2326,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Create index for field in collection
+        /// Create index for field in collection
         pub async fn create_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollection>,
@@ -2255,7 +2347,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Delete field index for collection
+        /// Delete field index for collection
         pub async fn delete_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollection>,
@@ -2276,7 +2368,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Retrieve closest points based on vector similarity and given filtering conditions
+        /// Retrieve closest points based on vector similarity and given filtering conditions
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPoints>,
@@ -2295,7 +2387,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Retrieve closest points based on vector similarity and given filtering conditions
+        /// Retrieve closest points based on vector similarity and given filtering conditions
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPoints>,
@@ -2316,7 +2408,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Iterate over all or filtered points points
+        /// Iterate over all or filtered points points
         pub async fn scroll(
             &mut self,
             request: impl tonic::IntoRequest<super::ScrollPoints>,
@@ -2335,7 +2427,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+        /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPoints>,
@@ -2354,7 +2446,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+        /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         pub async fn recommend_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendBatchPoints>,
@@ -2375,7 +2467,7 @@ pub mod points_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Count points in collection with given filtering conditions
+        /// Count points in collection with given filtering conditions
         pub async fn count(
             &mut self,
             request: impl tonic::IntoRequest<super::CountPoints>,
@@ -2399,95 +2491,95 @@ pub mod points_client {
 pub mod points_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with PointsServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with PointsServer.
     #[async_trait]
     pub trait Points: Send + Sync + 'static {
         ///
-        ///Perform insert + updates on points. If point with given ID already exists - it will be overwritten.
+        /// Perform insert + updates on points. If point with given ID already exists - it will be overwritten.
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Delete points
+        /// Delete points
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Retrieve points
+        /// Retrieve points
         async fn get(
             &self,
             request: tonic::Request<super::GetPoints>,
         ) -> Result<tonic::Response<super::GetResponse>, tonic::Status>;
         ///
-        ///Set payload for points
+        /// Set payload for points
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Overwrite payload for points
+        /// Overwrite payload for points
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Delete specified key payload for points
+        /// Delete specified key payload for points
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Remove all payload for specified points
+        /// Remove all payload for specified points
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPoints>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Create index for field in collection
+        /// Create index for field in collection
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollection>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Delete field index for collection
+        /// Delete field index for collection
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollection>,
         ) -> Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
-        ///Retrieve closest points based on vector similarity and given filtering conditions
+        /// Retrieve closest points based on vector similarity and given filtering conditions
         async fn search(
             &self,
             request: tonic::Request<super::SearchPoints>,
         ) -> Result<tonic::Response<super::SearchResponse>, tonic::Status>;
         ///
-        ///Retrieve closest points based on vector similarity and given filtering conditions
+        /// Retrieve closest points based on vector similarity and given filtering conditions
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPoints>,
         ) -> Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>;
         ///
-        ///Iterate over all or filtered points points
+        /// Iterate over all or filtered points points
         async fn scroll(
             &self,
             request: tonic::Request<super::ScrollPoints>,
         ) -> Result<tonic::Response<super::ScrollResponse>, tonic::Status>;
         ///
-        ///Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+        /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPoints>,
         ) -> Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
         ///
-        ///Look for the points which are closer to stored positive examples and at the same time further to negative examples.
+        /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         async fn recommend_batch(
             &self,
             request: tonic::Request<super::RecommendBatchPoints>,
         ) -> Result<tonic::Response<super::RecommendBatchResponse>, tonic::Status>;
         ///
-        ///Count points in collection with given filtering conditions
+        /// Count points in collection with given filtering conditions
         async fn count(
             &self,
             request: tonic::Request<super::CountPoints>,
@@ -2521,16 +2613,16 @@ pub mod points_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -3151,131 +3243,136 @@ pub mod points_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Points> tonic::transport::NamedService for PointsServer<T> {
+    impl<T: Points> tonic::server::NamedService for PointsServer<T> {
         const NAME: &'static str = "qdrant.Points";
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPoints {
     /// name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
-    #[prost(bool, optional, tag="2")]
+    #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub points: ::prost::alloc::vec::Vec<PointStruct>,
     /// Start of the sync range
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub from_id: ::core::option::Option<PointId>,
     /// End of the sync range
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub to_id: ::core::option::Option<PointId>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub sync_points: ::core::option::Option<SyncPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub upsert_points: ::core::option::Option<UpsertPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub delete_points: ::core::option::Option<DeletePoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePayloadPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub delete_payload_points: ::core::option::Option<DeletePayloadPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearPayloadPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub clear_payload_points: ::core::option::Option<ClearPayloadPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateFieldIndexCollectionInternal {
-    #[prost(message, optional, tag="1")]
-    pub create_field_index_collection: ::core::option::Option<CreateFieldIndexCollection>,
-    #[prost(uint32, tag="2")]
+    #[prost(message, optional, tag = "1")]
+    pub create_field_index_collection: ::core::option::Option<
+        CreateFieldIndexCollection,
+    >,
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteFieldIndexCollectionInternal {
-    #[prost(message, optional, tag="1")]
-    pub delete_field_index_collection: ::core::option::Option<DeleteFieldIndexCollection>,
-    #[prost(uint32, tag="2")]
+    #[prost(message, optional, tag = "1")]
+    pub delete_field_index_collection: ::core::option::Option<
+        DeleteFieldIndexCollection,
+    >,
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub search_points: ::core::option::Option<SearchPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchPointsInternal {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub scroll_points: ::core::option::Option<ScrollPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub recommend_points: ::core::option::Option<RecommendPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub get_points: ::core::option::Option<GetPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountPointsInternal {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub count_points: ::core::option::Option<CountPoints>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PointsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -3302,6 +3399,10 @@ pub mod points_internal_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -3321,19 +3422,19 @@ pub mod points_internal_client {
         {
             PointsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         pub async fn upsert(
@@ -3627,7 +3728,7 @@ pub mod points_internal_client {
 pub mod points_internal_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer.
     #[async_trait]
     pub trait PointsInternal: Send + Sync + 'static {
         async fn upsert(
@@ -3719,16 +3820,16 @@ pub mod points_internal_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -4373,52 +4474,53 @@ pub mod points_internal_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: PointsInternal> tonic::transport::NamedService for PointsInternalServer<T> {
+    impl<T: PointsInternal> tonic::server::NamedService for PointsInternalServer<T> {
         const NAME: &'static str = "qdrant.PointsInternal";
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RaftMessage {
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub message: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllPeers {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub all_peers: ::prost::alloc::vec::Vec<Peer>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub first_peer_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Peer {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub uri: ::prost::alloc::string::String,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddPeerToKnownMessage {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub uri: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub port: ::core::option::Option<u32>,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerId {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Uri {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub uri: ::prost::alloc::string::String,
 }
 /// Generated client implementations.
 pub mod raft_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct RaftClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4445,6 +4547,10 @@ pub mod raft_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -4464,19 +4570,19 @@ pub mod raft_client {
         {
             RaftClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Send Raft message to another peer
@@ -4568,7 +4674,7 @@ pub mod raft_client {
 pub mod raft_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with RaftServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with RaftServer.
     #[async_trait]
     pub trait Raft: Send + Sync + 'static {
         /// Send Raft message to another peer
@@ -4627,16 +4733,16 @@ pub mod raft_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -4843,60 +4949,59 @@ pub mod raft_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Raft> tonic::transport::NamedService for RaftServer<T> {
+    impl<T: Raft> tonic::server::NamedService for RaftServer<T> {
         const NAME: &'static str = "qdrant.Raft";
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateFullSnapshotRequest {
-}
+pub struct CreateFullSnapshotRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListFullSnapshotsRequest {
-}
+pub struct ListFullSnapshotsRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSnapshotRequest {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSnapshotsRequest {
     /// Name of the collection
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotDescription {
     /// Name of the snapshot
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Creation time of the snapshot
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub creation_time: ::core::option::Option<::prost_types::Timestamp>,
     /// Size of the snapshot in bytes
-    #[prost(int64, tag="3")]
+    #[prost(int64, tag = "3")]
     pub size: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSnapshotResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub snapshot_description: ::core::option::Option<SnapshotDescription>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSnapshotsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub snapshot_descriptions: ::prost::alloc::vec::Vec<SnapshotDescription>,
     /// Time spent to process
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub time: f64,
 }
 /// Generated client implementations.
 pub mod snapshots_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SnapshotsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4923,6 +5028,10 @@ pub mod snapshots_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -4942,23 +5051,23 @@ pub mod snapshots_client {
         {
             SnapshotsClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         ///
-        ///Create collection snapshot
+        /// Create collection snapshot
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
@@ -4977,7 +5086,7 @@ pub mod snapshots_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///List collection snapshots
+        /// List collection snapshots
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
@@ -4996,7 +5105,7 @@ pub mod snapshots_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///Create full storage snapshot
+        /// Create full storage snapshot
         pub async fn create_full(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFullSnapshotRequest>,
@@ -5017,7 +5126,7 @@ pub mod snapshots_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        ///List full storage snapshots
+        /// List full storage snapshots
         pub async fn list_full(
             &mut self,
             request: impl tonic::IntoRequest<super::ListFullSnapshotsRequest>,
@@ -5043,29 +5152,29 @@ pub mod snapshots_client {
 pub mod snapshots_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with SnapshotsServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with SnapshotsServer.
     #[async_trait]
     pub trait Snapshots: Send + Sync + 'static {
         ///
-        ///Create collection snapshot
+        /// Create collection snapshot
         async fn create(
             &self,
             request: tonic::Request<super::CreateSnapshotRequest>,
         ) -> Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
         ///
-        ///List collection snapshots
+        /// List collection snapshots
         async fn list(
             &self,
             request: tonic::Request<super::ListSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
         ///
-        ///Create full storage snapshot
+        /// Create full storage snapshot
         async fn create_full(
             &self,
             request: tonic::Request<super::CreateFullSnapshotRequest>,
         ) -> Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
         ///
-        ///List full storage snapshots
+        /// List full storage snapshots
         async fn list_full(
             &self,
             request: tonic::Request<super::ListFullSnapshotsRequest>,
@@ -5099,16 +5208,16 @@ pub mod snapshots_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -5317,24 +5426,24 @@ pub mod snapshots_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Snapshots> tonic::transport::NamedService for SnapshotsServer<T> {
+    impl<T: Snapshots> tonic::server::NamedService for SnapshotsServer<T> {
         const NAME: &'static str = "qdrant.Snapshots";
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HealthCheckRequest {
-}
+pub struct HealthCheckRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckReply {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
 }
 /// Generated client implementations.
 pub mod qdrant_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct QdrantClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -5361,6 +5470,10 @@ pub mod qdrant_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -5380,19 +5493,19 @@ pub mod qdrant_client {
         {
             QdrantClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         pub async fn health_check(
@@ -5420,7 +5533,7 @@ pub mod qdrant_client {
 pub mod qdrant_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QdrantServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QdrantServer.
     #[async_trait]
     pub trait Qdrant: Send + Sync + 'static {
         async fn health_check(
@@ -5456,16 +5569,16 @@ pub mod qdrant_server {
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
-        /// Enable decompressing requests with `gzip`.
+        /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.accept_compression_encodings.enable_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with `gzip`, if the client supports it.
+        /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.send_compression_encodings.enable_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
             self
         }
     }
@@ -5562,7 +5675,7 @@ pub mod qdrant_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Qdrant> tonic::transport::NamedService for QdrantServer<T> {
+    impl<T: Qdrant> tonic::server::NamedService for QdrantServer<T> {
         const NAME: &'static str = "qdrant.Qdrant";
     }
 }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -33,7 +33,7 @@ env_logger = "0.10.0"
 merge = "0.1.0"
 async-trait = "0.1.59"
 arc-swap = "1.5.1"
-tonic = "0.7.2"
+tonic = { version = "0.8.3", features = ["gzip"] }
 tower = "0.4.13"
 uuid = { version = "1.2", features = ["v4", "serde"] }
 url = { version = "2", features = ["serde"] }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -21,7 +21,7 @@ schemars = { version = "0.8.11", features = ["uuid1", "preserve_order"] }
 itertools = "0.10"
 async-trait = "0.1.59"
 log = "0.4"
-tonic = { version = "0.7.2", features = ["compression"] }
+tonic = { version = "0.8.3", features = ["gzip"] }
 http = "0.2"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 tar = "0.4.38"
@@ -29,8 +29,8 @@ chrono = { version = "~0.4", features = ["serde"] }
 
 # Consensus related
 atomicwrites = { version = "0.3.1" }
-raft = { git = "https://github.com/tikv/raft-rs", rev = "52d84aac8734369d81c2d77413ea3ab8e58e0af9", features = ["prost-codec"], default-features = false }
-prost = { version = "=0.9.0" } # version of prost used by raft
+raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }
+prost = { version = "0.11.3" } # version of prost used by raft
 serde_cbor = { version = "0.11.2" }
 
 segment = { path = "../segment" }

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -17,6 +17,7 @@ use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use tokio::{runtime, signal};
+use tonic::codec::CompressionEncoding;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
@@ -70,17 +71,25 @@ pub fn init(
                 .layer(tonic_telemetry::TonicTelemetryLayer::new(
                     telemetry_collector,
                 ))
-                .add_service(QdrantServer::new(qdrant_service).send_gzip().accept_gzip())
+                .add_service(
+                    QdrantServer::new(qdrant_service)
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
+                )
                 .add_service(
                     CollectionsServer::new(collections_service)
-                        .send_gzip()
-                        .accept_gzip(),
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
                 )
-                .add_service(PointsServer::new(points_service).send_gzip().accept_gzip())
+                .add_service(
+                    PointsServer::new(points_service)
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
+                )
                 .add_service(
                     SnapshotsServer::new(snapshot_service)
-                        .send_gzip()
-                        .accept_gzip(),
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
                 )
                 .serve_with_shutdown(socket, async {
                     signal::ctrl_c().await.unwrap();
@@ -128,18 +137,26 @@ pub fn init_internal(
                 .layer(tonic_telemetry::TonicTelemetryLayer::new(
                     telemetry_collector,
                 ))
-                .add_service(QdrantServer::new(qdrant_service).send_gzip().accept_gzip())
+                .add_service(
+                    QdrantServer::new(qdrant_service)
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
+                )
                 .add_service(
                     CollectionsInternalServer::new(collections_internal_service)
-                        .send_gzip()
-                        .accept_gzip(),
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
                 )
                 .add_service(
                     PointsInternalServer::new(points_internal_service)
-                        .send_gzip()
-                        .accept_gzip(),
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
                 )
-                .add_service(RaftServer::new(raft_service).send_gzip().accept_gzip())
+                .add_service(
+                    RaftServer::new(raft_service)
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip),
+                )
                 .serve_with_shutdown(socket, async {
                     signal::ctrl_c().await.unwrap();
                     log::debug!("Stopping internal gRPC");


### PR DESCRIPTION
We have been stuck on old versions of `tonic` and `prost` due to incompatibilities with the `raft-rs` project.

I have updated the upstream dependencies in order to unblock us:
- https://github.com/tikv/protobuf-build/pull/63
- https://github.com/tikv/raft-rs/pull/496

As a result, pulling the latest version of `raft-rs` enables us to upgrade both `tonic` and `prost` to the latest version.
- https://github.com/tokio-rs/prost/releases/tag/v0.11.0
- https://github.com/hyperium/tonic/blob/master/CHANGELOG.md#080-2022-07-29

I took this opportunity to cleanup the way we install `protoc` on our CI since we can now use a package manager https://github.com/qdrant/qdrant/pull/452#issuecomment-1092999981

I have tested that the current rust grpc client still works with those changes.
