### PR TITLE
Fixing missed leader inconsistency - transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,8 @@ name = "api"
 version = "0.11.1"
 dependencies = [
  "chrono",
+ "env_logger",
+ "log 0.4.17",
  "prost",
  "prost-types",
  "rand",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4"
+env_logger = "0.10.0"
 tonic = { version = "0.8.3", features = ["gzip"] }
 prost = "0.11.3"
 prost-types = "0.11.2"

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -202,7 +202,7 @@ impl TransportChannelPool {
             res = self.check_connectability(uri) => {
                Err(res)
             }
-            res = tokio::time::sleep(max_timeout) => {
+            _res = tokio::time::sleep(max_timeout) => {
                 Err(Status::deadline_exceeded("Timeout exceeded"))
             }
         };

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -203,6 +203,7 @@ impl TransportChannelPool {
                Err(res)
             }
             _res = tokio::time::sleep(max_timeout) => {
+                log::debug!("Timeout reached for uri: {}", uri);
                 Err(Status::deadline_exceeded("Timeout exceeded"))
             }
         };
@@ -216,6 +217,7 @@ impl TransportChannelPool {
                         self.get_created_at(uri).await.unwrap_or_else(Instant::now),
                     );
                     if channel_uptime > CHANNEL_TTL {
+                        log::debug!("dropping channel pool for uri: {}", uri);
                         self.drop_pool(uri).await;
                         let channel = self.get_or_create_pooled_channel(uri).await?;
                         f(channel).await.map_err(RequestError::FromClosure)

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -193,9 +193,7 @@ impl TransportChannelPool {
         timeout: Option<Duration>,
     ) -> Result<T, RequestError<Status>> {
         let channel = self.get_or_create_pooled_channel(uri).await?;
-        let max_timeout = timeout.unwrap_or_else(|| {
-            self.grpc_timeout + self.connection_timeout
-        });
+        let max_timeout = timeout.unwrap_or_else(|| self.grpc_timeout + self.connection_timeout);
 
         let result: Result<T, Status> = select! {
             res = f(channel) => {

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -139,6 +139,16 @@ impl ShardHolder {
         shard_transfers
     }
 
+    pub fn get_related_transfers(&self, shard_id: &ShardId, peer_id: &PeerId) -> Vec<ShardTransfer> {
+        self.shard_transfers
+            .read()
+            .iter()
+            .filter(|transfer| transfer.shard_id == *shard_id)
+            .filter(|transfer| transfer.from == *peer_id || transfer.to == *peer_id)
+            .cloned()
+            .collect()
+    }
+
     pub fn set_shard_replica_state(
         &self,
         shard_id: ShardId,

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -139,7 +139,11 @@ impl ShardHolder {
         shard_transfers
     }
 
-    pub fn get_related_transfers(&self, shard_id: &ShardId, peer_id: &PeerId) -> Vec<ShardTransfer> {
+    pub fn get_related_transfers(
+        &self,
+        shard_id: &ShardId,
+        peer_id: &PeerId,
+    ) -> Vec<ShardTransfer> {
         self.shard_transfers
             .read()
             .iter()

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -227,6 +227,20 @@ pub async fn transfer_shard(
     transfer_batches(shard_holder.clone(), shard_id, stopped.clone()).await
 }
 
+pub fn validate_transfer_exists(
+    transfer_key: &ShardTransferKey,
+    current_transfers: &HashSet<ShardTransfer>,
+) -> CollectionResult<()> {
+    if !current_transfers.iter().any(|t| &t.key() == transfer_key) {
+        return Err(CollectionError::bad_request(format!(
+            "There is no transfer for shard {} from {} to {}",
+            transfer_key.shard_id, transfer_key.from, transfer_key.to
+        )));
+    }
+
+    Ok(())
+}
+
 /// Confirms that the transfer makes sense with the current state cluster
 ///
 /// Checks:

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -84,10 +84,12 @@ def test_triple_replication(tmp_path: pathlib.Path):
                     for peer_api_uri in peer_api_uris:
                         res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
-                        
+
                 for peer_api_uri in peer_api_uris:
                     res = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": True})
                     print(res.json())
+
+                processes.clear()
 
                 assert False, f"Points count is not equal on all peers: {points_counts}"
             break

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -59,7 +59,7 @@ def test_triple_replication(tmp_path: pathlib.Path):
 
     time.sleep(0.3)
 
-    upload_process.terminate()
+    upload_process.kill()
 
     timeout = 10
     while True:

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -89,8 +89,6 @@ def test_triple_replication(tmp_path: pathlib.Path):
                     res = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": True})
                     print(res.json())
 
-                processes.clear()
-
                 assert False, f"Points count is not equal on all peers: {points_counts}"
             break
 

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -84,8 +84,9 @@ def test_triple_replication(tmp_path: pathlib.Path):
                     for peer_api_uri in peer_api_uris:
                         res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
-
-                    res = requests.post(f"{peer_api_uris}/collections/test_collection/points/count", json={"exact": True})
+                        
+                for peer_api_uri in peer_api_uris:
+                    res = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": True})
                     print(res.json())
 
                 assert False, f"Points count is not equal on all peers: {points_counts}"

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -75,7 +75,17 @@ def test_triple_replication(tmp_path: pathlib.Path):
                 all_active = False
 
         if all_active:
-            assert len(points_counts) == 1
+            if len(points_counts) != 1:
+                with open("test_triple_replication.log", "w") as f:
+                    for peer_api_uri in peer_api_uris:
+                        collection_name = "test_collection"
+                        res = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster", timeout=10)
+                        f.write(f"{peer_api_uri} {res.json()['result']}\n")
+                    for peer_api_uri in peer_api_uris:
+                        res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
+                        f.write(f"{peer_api_uri} {res.json()['result']}\n")
+
+                assert False, f"Points count is not equal on all peers: {points_counts}"
             break
 
         time.sleep(1)

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -85,6 +85,9 @@ def test_triple_replication(tmp_path: pathlib.Path):
                         res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
                         f.write(f"{peer_api_uri} {res.json()['result']}\n")
 
+                    res = requests.post(f"{peer_api_uris}/collections/test_collection/points/count", json={"exact": True})
+                    print(res.json())
+
                 assert False, f"Points count is not equal on all peers: {points_counts}"
             break
 


### PR DESCRIPTION
- add explicit timeout into connection pool, decrease timeout for consensus related messages to about 2xtick time
- Add auto-abort for transfers in case if source or target replica fails
- implement double-write strategy for maintaining consistency during the transfer finishing: now partial remote shards also forward the updates