### PR TITLE
Id mapper inconsistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.17",
+ "log",
  "memchr",
  "pin-project-lite",
  "tokio",
@@ -29,7 +29,7 @@ dependencies = [
  "actix-web",
  "derive_more",
  "futures-util",
- "log 0.4.17",
+ "log",
  "once_cell",
  "smallvec",
 ]
@@ -50,7 +50,7 @@ dependencies = [
  "derive_more",
  "futures-core",
  "http-range",
- "log 0.4.17",
+ "log",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -193,7 +193,7 @@ dependencies = [
  "http",
  "itoa",
  "language-tags",
- "log 0.4.17",
+ "log",
  "mime",
  "once_cell",
  "pin-project-lite",
@@ -308,7 +308,7 @@ version = "0.11.1"
 dependencies = [
  "chrono",
  "env_logger",
- "log 0.4.17",
+ "log",
  "prost",
  "prost-types",
  "rand",
@@ -804,7 +804,7 @@ dependencies = [
  "hashring",
  "indicatif",
  "itertools",
- "log 0.4.17",
+ "log",
  "merge",
  "num_cpus",
  "ordered-float",
@@ -1172,7 +1172,7 @@ checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "humantime",
  "is-terminal",
- "log 0.4.17",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -1206,17 +1206,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "eventual"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bda6d089b434ca50f3d6feb5fca421309b8bac97b8be9af51cff879fa3f54b"
-dependencies = [
- "log 0.3.9",
- "syncbox",
- "time 0.1.45",
 ]
 
 [[package]]
@@ -1452,7 +1441,7 @@ dependencies = [
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
- "log 0.4.17",
+ "log",
  "num-traits",
  "robust",
  "rstar",
@@ -1802,7 +1791,7 @@ dependencies = [
  "atty",
  "indexmap",
  "itoa",
- "log 0.4.17",
+ "log",
  "num-format",
  "once_cell",
  "quick-xml",
@@ -2030,15 +2019,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
-]
-
-[[package]]
-name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
@@ -2148,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
- "log 0.4.17",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
@@ -2167,7 +2147,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2539,7 +2519,7 @@ dependencies = [
  "findshlibs",
  "inferno",
  "libc",
- "log 0.4.17",
+ "log",
  "nix",
  "once_cell",
  "parking_lot",
@@ -2642,7 +2622,7 @@ dependencies = [
  "heck",
  "itertools",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multimap",
  "petgraph",
  "prettyplease",
@@ -2715,7 +2695,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools",
- "log 0.4.17",
+ "log",
  "num-traits",
  "num_cpus",
  "parking_lot",
@@ -2929,7 +2909,7 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "log 0.4.17",
+ "log",
  "mime",
  "native-tls",
  "once_cell",
@@ -3088,7 +3068,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
- "log 0.4.17",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -3251,7 +3231,7 @@ dependencies = [
  "geohash",
  "itertools",
  "json-patch",
- "log 0.4.17",
+ "log",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -3423,7 +3403,7 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
 dependencies = [
- "log 0.4.17",
+ "log",
  "slog",
  "slog-scope",
 ]
@@ -3479,7 +3459,7 @@ dependencies = [
  "futures",
  "http",
  "itertools",
- "log 0.4.17",
+ "log",
  "num_cpus",
  "parking_lot",
  "proptest",
@@ -3553,16 +3533,6 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
-name = "syncbox"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bc2b72659ac27a2d0e7c4166c8596578197c4c41f767deab12c81f523b85c7"
-dependencies = [
- "log 0.3.9",
- "time 0.1.45",
-]
 
 [[package]]
 name = "sys-info"
@@ -3945,7 +3915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log 0.4.17",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4096,16 +4066,15 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=3bfa813f494638c0f5afbca744b45e1c380827bf#3bfa813f494638c0f5afbca744b45e1c380827bf"
+source = "git+https://github.com/qdrant/wal.git?rev=492d83258fb81abcab6d5173345be09abb2e16eb#492d83258fb81abcab6d5173345be09abb2e16eb"
 dependencies = [
  "byteorder",
  "crc",
  "crossbeam-channel",
  "docopt",
  "env_logger",
- "eventual",
  "fs2",
- "log 0.4.17",
+ "log",
  "memmap",
  "rand",
  "rand_distr",
@@ -4129,7 +4098,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.17",
+ "log",
  "try-lock",
 ]
 
@@ -4162,7 +4131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
+ "log",
  "once_cell",
  "proc-macro2",
  "quote",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "3bfa813f494638c0f5afbca744b45e1c380827bf"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "492d83258fb81abcab6d5173345be09abb2e16eb"}
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -388,6 +388,12 @@ impl UpdateHandler {
             };
 
             trace!("Attempting flushing");
+            if let Err(err) = wal.lock().flush() {
+                error!("Failed to flush wal: {}", err);
+                segments.write().report_optimizer_error(err);
+                continue;
+            }
+
             let confirmed_version = Self::flush_segments(segments.clone());
             let confirmed_version = match confirmed_version {
                 Ok(version) => version,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -19,7 +19,7 @@ use crate::collection_manager::optimizers::segment_optimizer::SegmentOptimizer;
 use crate::common::stoppable_task::{spawn_stoppable, StoppableTaskHandle};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
-use crate::wal::SerdeWal;
+use crate::wal::{SerdeWal, WalError};
 
 pub const UPDATE_QUEUE_SIZE: usize = 100;
 
@@ -388,9 +388,16 @@ impl UpdateHandler {
             };
 
             trace!("Attempting flushing");
-            if let Err(err) = wal.lock().flush() {
-                error!("Failed to flush wal: {}", err);
-                segments.write().report_optimizer_error(err);
+            let wal_flash_job = wal.lock().flush_async();
+
+            if let Err(err) = wal_flash_job.join() {
+                error!("Failed to flush wal: {:?}", err);
+                segments
+                    .write()
+                    .report_optimizer_error(WalError::WriteWalError(format!(
+                        "WAL flush error: {:?}",
+                        err
+                    )));
                 continue;
             }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -67,9 +67,12 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn write(&mut self, entity: &R) -> Result<u64> {
         // ToDo: Replace back to faster rmp, once this https://github.com/serde-rs/serde/issues/2055 solved
         let binary_entity = serde_cbor::to_vec(&entity).unwrap();
-        self.wal
+        let res = self
+            .wal
             .append(&binary_entity)
-            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
+            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
+        self.wal.flush_open_segment()?;
+        Ok(res)
     }
 
     pub fn read_all(&'s self) -> impl Iterator<Item = (u64, R)> + 's {

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -71,7 +71,8 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
             .wal
             .append(&binary_entity)
             .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
-        self.wal.flush_open_segment()?;
+        self.wal.flush_open_segment()
+            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
         Ok(res)
     }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::result;
+use std::thread::JoinHandle;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -114,6 +115,10 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         self.wal
             .flush_open_segment()
             .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
+    }
+
+    pub fn flush_async(&mut self) -> JoinHandle<std::io::Result<()>> {
+        self.wal.flush_open_segment_async()
     }
 }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -67,14 +67,9 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn write(&mut self, entity: &R) -> Result<u64> {
         // ToDo: Replace back to faster rmp, once this https://github.com/serde-rs/serde/issues/2055 solved
         let binary_entity = serde_cbor::to_vec(&entity).unwrap();
-        let res = self
-            .wal
-            .append(&binary_entity)
-            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
         self.wal
-            .flush_open_segment()
-            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
-        Ok(res)
+            .append(&binary_entity)
+            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
     }
 
     pub fn read_all(&'s self) -> impl Iterator<Item = (u64, R)> + 's {
@@ -113,6 +108,12 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         self.wal
             .prefix_truncate(until_index)
             .map_err(|err| WalError::TruncateWalError(format!("{:?}", err)))
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.wal
+            .flush_open_segment()
+            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
     }
 }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -71,7 +71,8 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
             .wal
             .append(&binary_entity)
             .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
-        self.wal.flush_open_segment()
+        self.wal
+            .flush_open_segment()
             .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))?;
         Ok(res)
     }

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -112,8 +112,8 @@ impl IdTracker for FixtureIdTracker {
         Box::new(self.ids.iter().copied())
     }
 
-    fn max_id(&self) -> PointOffsetType {
-        self.ids.last().copied().unwrap()
+    fn internal_size(&self) -> usize {
+        self.ids.len()
     }
 
     fn mapping_flusher(&self) -> Flusher {

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -50,8 +50,8 @@ pub trait IdTracker {
     /// Iterate over all non-removed internal ids (offsets)
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 
-    /// Max stored ID
-    fn max_id(&self) -> PointOffsetType;
+    /// Total number of internal ids (offsets), including removed ones
+    fn internal_size(&self) -> usize;
 
     /// Flush id mapping to disk
     fn mapping_flusher(&self) -> Flusher;

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -334,8 +334,8 @@ impl IdTracker for SimpleIdTracker {
         self.iter_internal()
     }
 
-    fn max_id(&self) -> PointOffsetType {
-        std::cmp::max(1, self.internal_to_external.len() as PointOffsetType) - 1
+    fn internal_size(&self) -> usize {
+        self.internal_to_external.len()
     }
 
     fn mapping_flusher(&self) -> Flusher {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -355,9 +355,7 @@ impl PayloadIndex for StructPayloadIndex {
 
             // CPU-optimized strategy here: points are made unique before applying other filters.
             // ToDo: Implement iterator which holds the `visited_pool` and borrowed `vector_storage_ref` to prevent `preselected` array creation
-            let mut visited_list = self
-                .visited_pool
-                .get(points_iterator_ref.max_id() as usize + 1);
+            let mut visited_list = self.visited_pool.get(points_iterator_ref.internal_size());
 
             #[allow(clippy::needless_collect)]
                 let preselected: Vec<PointOffsetType> = query_cardinality

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::collections::HashMap;
 use std::fs::{remove_dir_all, rename, File};
 use std::path::{Path, PathBuf};
@@ -591,11 +590,7 @@ impl SegmentEntry for Segment {
                 segment.update_vector(existing_internal_id, processed_vectors)?;
                 Ok((true, Some(existing_internal_id)))
             } else {
-                let mut new_index = 0;
-                for vector_data in segment.vector_data.values() {
-                    let vector_storage = vector_data.vector_storage.borrow();
-                    new_index = max(new_index, vector_storage.next_id());
-                }
+                let new_index = segment.id_tracker.borrow().internal_size() as PointOffsetType;
 
                 for (vector_name, processed_vector) in processed_vectors {
                     let vector_name: &str = &vector_name;

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -166,10 +166,6 @@ where
         panic!("Can't directly update vector in mmap storage")
     }
 
-    fn next_id(&self) -> PointOffsetType {
-        panic!("There are no available for insertion ids in mmap storage")
-    }
-
     fn update_from(
         &mut self,
         other: &VectorStorageSS,

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -224,10 +224,6 @@ where
         Ok(())
     }
 
-    fn next_id(&self) -> PointOffsetType {
-        self.vectors.len() as PointOffsetType
-    }
-
     fn update_from(
         &mut self,
         other: &VectorStorageSS,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -63,8 +63,6 @@ pub trait VectorStorage {
         key: PointOffsetType,
         vector: Vec<VectorElementType>,
     ) -> OperationResult<()>;
-    /// Returns next available id
-    fn next_id(&self) -> PointOffsetType;
     fn update_from(
         &mut self,
         other: &VectorStorageSS,

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "3bfa813f494638c0f5afbca744b45e1c380827bf" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "492d83258fb81abcab6d5173345be09abb2e16eb" }
 tokio = { version = "~1.23", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/tests/consensus_tests/test_cluster_rejoin.py
+++ b/tests/consensus_tests/test_cluster_rejoin.py
@@ -29,8 +29,8 @@ def test_rejoin_cluster(tmp_path: pathlib.Path):
 
     for i in range(0, 2):
         print(f"creating collection {i}")
-        drop_collection(peer_api_uris[0], timeout=1)
-        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=1)
+        drop_collection(peer_api_uris[0], timeout=3)
+        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
         # Collection might not be ready yet, we don't care
         upsert_random_points(peer_api_uris[0], 100)
         print(f"after recovery end {i}")
@@ -42,15 +42,15 @@ def test_rejoin_cluster(tmp_path: pathlib.Path):
         "test_collection2",
         shard_number=N_SHARDS,
         replication_factor=N_REPLICA,
-        timeout=1
+        timeout=3
     )
 
     new_url = start_peer(peer_dirs[-1], f"peer_0_restarted.log", bootstrap_uri, port=20000)
 
     for i in range(0, 5):
         print(f"after recovery start {i}")
-        drop_collection(peer_api_uris[0], timeout=1)
-        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=1)
+        drop_collection(peer_api_uris[0], timeout=3)
+        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
         upsert_random_points(peer_api_uris[0], 500, fail_on_error=False)
         print(f"after recovery end {i}")
         res = requests.get(f"{new_url}/collections")


### PR DESCRIPTION
 - enable async wal flush in the flush worker
 - use index form id-mapper instead of vector storage id to prevent orphan id links in case of unfinished flush