### PR TITLE
remove deprecate point ids param in gprc

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1015,7 +1015,6 @@ The JSON representation for `Value` is JSON value.
 | collection_name | [string](#string) |  | name of the collection |
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | keys | [string](#string) | repeated | List of keys to delete |
-| points | [PointId](#qdrant-PointId) | repeated | Affected points, deprecated |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
 
 
@@ -1676,7 +1675,6 @@ The JSON representation for `Value` is JSON value.
 | collection_name | [string](#string) |  | name of the collection |
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | payload | [SetPayloadPoints.PayloadEntry](#qdrant-SetPayloadPoints-PayloadEntry) | repeated | New payload values |
-| points | [PointId](#qdrant-PointId) | repeated | List of point to modify, deprecated |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -48,7 +48,7 @@ message SetPayloadPoints {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
   map<string, Value> payload = 3; // New payload values
-  repeated PointId points = 4; // List of point to modify, deprecated
+  reserved 4; // List of point to modify, deprecated
   optional PointsSelector points_selector = 5; // Affected points
 }
 
@@ -56,7 +56,7 @@ message DeletePayloadPoints {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
   repeated string keys = 3; // List of keys to delete
-  repeated PointId points = 4; // Affected points, deprecated
+  reserved 4; // Affected points, deprecated
   optional PointsSelector points_selector = 5; // Affected points
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1571,9 +1571,6 @@ pub struct SetPayloadPoints {
     /// New payload values
     #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
-    /// List of point to modify, deprecated
-    #[prost(message, repeated, tag = "4")]
-    pub points: ::prost::alloc::vec::Vec<PointId>,
     /// Affected points
     #[prost(message, optional, tag = "5")]
     pub points_selector: ::core::option::Option<PointsSelector>,
@@ -1590,9 +1587,6 @@ pub struct DeletePayloadPoints {
     /// List of keys to delete
     #[prost(string, repeated, tag = "3")]
     pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Affected points, deprecated
-    #[prost(message, repeated, tag = "4")]
-    pub points: ::prost::alloc::vec::Vec<PointId>,
     /// Affected points
     #[prost(message, optional, tag = "5")]
     pub points_selector: ::core::option::Option<PointsSelector>,
@@ -1805,12 +1799,13 @@ pub struct ScrollPoints {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LookupLocation {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
     /// Which vector to use for search, if not specified - use default vector
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub vector_name: ::core::option::Option<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPoints {
     /// name of the collection
@@ -1847,7 +1842,7 @@ pub struct RecommendPoints {
     #[prost(message, optional, tag = "12")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
     /// Name of the collection to use for points lookup, if not specified - use current collection
-    #[prost(message, optional, tag="13")]
+    #[prost(message, optional, tag = "13")]
     pub lookup_from: ::core::option::Option<LookupLocation>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -99,13 +99,10 @@ pub fn internal_set_payload(
     shard: &RemoteShard,
     wait: bool,
 ) -> SetPayloadPointsInternal {
-    let mut selected_points = vec![];
-
     let points_selector = if let Some(points) = set_payload.points {
-        selected_points = points.into_iter().map(|id| id.into()).collect();
         Some(PointsSelector {
             points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: selected_points.clone(),
+                ids: points.into_iter().map(|id| id.into()).collect(),
             })),
         })
     } else {
@@ -120,7 +117,6 @@ pub fn internal_set_payload(
             collection_name: shard.collection_id.clone(),
             wait: Some(wait),
             payload: payload_to_proto(set_payload.payload),
-            points: selected_points, // ToDo: Deprecated
             points_selector,
         }),
     }
@@ -131,12 +127,10 @@ pub fn internal_delete_payload(
     shard: &RemoteShard,
     wait: bool,
 ) -> DeletePayloadPointsInternal {
-    let mut selected_points = vec![];
     let points_selector = if let Some(points) = delete_payload.points {
-        selected_points = points.into_iter().map(|id| id.into()).collect();
         Some(PointsSelector {
             points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: selected_points.clone(),
+                ids: points.into_iter().map(|id| id.into()).collect(),
             })),
         })
     } else {
@@ -151,7 +145,6 @@ pub fn internal_delete_payload(
             collection_name: shard.collection_id.clone(),
             wait: Some(wait),
             keys: delete_payload.keys,
-            points: selected_points, // ToDo: Deprecated
             points_selector,
         }),
     }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -152,7 +152,6 @@ pub async fn set_payload(
         collection_name,
         wait,
         payload,
-        points,
         points_selector,
     } = set_payload_points;
 
@@ -163,11 +162,7 @@ pub async fn set_payload(
             PointsSelector::FilterSelector(filter) => (None, Some(filter.filter)),
         }
     } else {
-        let points = points
-            .into_iter()
-            .map(|point| point.try_into())
-            .collect::<Result<_, _>>()?;
-        (Some(points), None)
+        return Err(Status::invalid_argument("points_selector is expected"));
     };
 
     let operation = collection::operations::payload_ops::SetPayload {
@@ -200,7 +195,6 @@ pub async fn overwrite_payload(
         collection_name,
         wait,
         payload,
-        points,
         points_selector,
     } = set_payload_points;
 
@@ -211,11 +205,7 @@ pub async fn overwrite_payload(
             PointsSelector::FilterSelector(filter) => (None, Some(filter.filter)),
         }
     } else {
-        let points = points
-            .into_iter()
-            .map(|point| point.try_into())
-            .collect::<Result<_, _>>()?;
-        (Some(points), None)
+        return Err(Status::invalid_argument("points_selector is expected"));
     };
 
     let operation = collection::operations::payload_ops::SetPayload {
@@ -248,7 +238,6 @@ pub async fn delete_payload(
         collection_name,
         wait,
         keys,
-        points,
         points_selector,
     } = delete_payload_points;
 
@@ -259,11 +248,7 @@ pub async fn delete_payload(
             PointsSelector::FilterSelector(filter) => (None, Some(filter.filter)),
         }
     } else {
-        let points = points
-            .into_iter()
-            .map(|point| point.try_into())
-            .collect::<Result<_, _>>()?;
-        (Some(points), None)
+        return Err(Status::invalid_argument("points_selector is expected"));
     };
 
     let operation = DeletePayload {


### PR DESCRIPTION
Removes version compatibility code, used for https://github.com/qdrant/qdrant/pull/1249

Issue: https://github.com/qdrant/qdrant/issues/1248

NOTE: merge on major release
