### PR TITLE
Add the option to load alternative configuration file

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -840,8 +840,7 @@ mod tests {
     fn collection_creation_passes_consensus() {
         // Given
         let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
-        let mut settings =
-            crate::Settings::new(Some("config/config".into())).expect("Can't read config.");
+        let mut settings = crate::Settings::new(None).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
         env_logger::init();

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -840,7 +840,8 @@ mod tests {
     fn collection_creation_passes_consensus() {
         // Given
         let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
-        let mut settings = crate::Settings::new().expect("Can't read config.");
+        let mut settings =
+            crate::Settings::new(Some("config/config".into())).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
         env_logger::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,14 +86,21 @@ struct Args {
     /// Use `/collections/<collection-name>/snapshots/recover` API instead.
     #[arg(long, value_name = "PATH")]
     storage_snapshot: Option<String>,
+
+    /// Path to an alternative configuration file.
+    /// Format: <config_file_path>
+    ///
+    /// Default path : config/config.yaml
+    #[arg(long, value_name = "PATH")]
+    config_path: Option<String>,
 }
 
 fn main() -> anyhow::Result<()> {
-    let settings = Settings::new().expect("Can't read config.");
+    let args = Args::parse();
+    let settings = Settings::new(args.config_path).expect("Can't read config.");
 
     setup_logger(&settings.log_level);
     setup_panic_hook();
-    let args = Args::parse();
 
     segment::madvise::set_global(settings.storage.mmap_advice);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -117,7 +117,7 @@ fn default_connection_pool_size() -> usize {
 impl Settings {
     #[allow(dead_code)]
     pub fn new(config_path: Option<String>) -> Result<Self, ConfigError> {
-        let config_path = config_path.unwrap_or("config/config".into());
+        let config_path = config_path.unwrap_or_else(|| "config/config".into());
         let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
 
         let s = Config::builder()
@@ -163,6 +163,6 @@ mod tests {
     fn test_read_default_config() {
         let key = "RUN_MODE";
         env::set_var(key, "TEST");
-        Settings::new(Some("config/config".into())).unwrap();
+        Settings::new(None).unwrap();
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -116,12 +116,13 @@ fn default_connection_pool_size() -> usize {
 
 impl Settings {
     #[allow(dead_code)]
-    pub fn new() -> Result<Self, ConfigError> {
+    pub fn new(config_path: Option<String>) -> Result<Self, ConfigError> {
+        let config_path = config_path.unwrap_or("config/config".into());
         let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
 
         let s = Config::builder()
             // Start off by merging in the "default" configuration file
-            .add_source(File::with_name("config/config"))
+            .add_source(File::with_name(&config_path))
             // Add in the current environment file
             // Default to 'development' env
             // Note that this file is _optional_
@@ -162,6 +163,6 @@ mod tests {
     fn test_read_default_config() {
         let key = "RUN_MODE";
         env::set_var(key, "TEST");
-        Settings::new().unwrap();
+        Settings::new(Some("config/config".into())).unwrap();
     }
 }


### PR DESCRIPTION
Add an optional CLI arg for `qdrant` bin for selecting an alternative config file. 

This will help running two peers locally.

Example:
```sh
$ ./target/release/qdrant --config-path /path/to/config/file
```
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
