### PR TITLE
Fix consensus wal data loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=492d83258fb81abcab6d5173345be09abb2e16eb#492d83258fb81abcab6d5173345be09abb2e16eb"
+source = "git+https://github.com/qdrant/wal.git?rev=0519d97c1f806e2787abcfecf96d13d87556e8c0#0519d97c1f806e2787abcfecf96d13d87556e8c0"
 dependencies = [
  "byteorder",
  "crc",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "492d83258fb81abcab6d5173345be09abb2e16eb"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "0519d97c1f806e2787abcfecf96d13d87556e8c0"}
 ordered-float = "3.4"
 hashring = "0.3.0"
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "492d83258fb81abcab6d5173345be09abb2e16eb" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "0519d97c1f806e2787abcfecf96d13d87556e8c0" }
 tokio = { version = "~1.24", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -334,7 +334,7 @@ mod tests {
         let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
 
         // append overlapping entries
-        wal.append_entries(entries_new.clone()).unwrap();
+        wal.append_entries(entries_new).unwrap();
         assert_eq!(wal.0.num_segments(), 1);
         assert_eq!(wal.0.num_entries(), 4);
         assert_eq!(wal.index_offset().unwrap(), Some(1));

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -169,9 +169,13 @@ mod tests {
 
     use super::*;
 
+    fn init_logger() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
     #[test]
-    fn test_log_rewrite() {
-        env_logger::init();
+    fn test_log_compaction_rewrite() {
+        init_logger();
         let entries_orig = vec![
             Entry {
                 entry_type: 0,
@@ -249,5 +253,108 @@ mod tests {
             wal.append_entries(broken_entry),
             Err(StorageError::ServiceError { .. })
         ));
+    }
+
+    #[test]
+    fn test_log_rewrite() {
+        init_logger();
+        let entries_orig = vec![
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 1,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 2,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 3,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+        ];
+
+        let entries_new = vec![
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 2,
+                data: vec![2, 2, 2],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 3,
+                data: vec![2, 2, 2],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 4,
+                data: vec![2, 2, 2],
+                context: vec![],
+                sync_log: false,
+            },
+        ];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+
+        // append original entries
+        wal.append_entries(entries_orig).unwrap();
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 3);
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 3);
+
+        let result_entries = wal.entries(1, 4, None).unwrap();
+        assert_eq!(result_entries.len(), 3);
+        assert_eq!(result_entries[0].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[1].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[2].data, vec![1, 1, 1]);
+
+        // drop wal to check persistence
+        drop(wal);
+        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+
+        // append overlapping entries
+        wal.append_entries(entries_new.clone()).unwrap();
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 4);
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 4);
+
+        let result_entries = wal.entries(1, 5, None).unwrap();
+        assert_eq!(result_entries.len(), 4);
+        assert_eq!(result_entries[0].data, vec![1, 1, 1]); // survived the truncation
+        assert_eq!(result_entries[1].data, vec![2, 2, 2]);
+        assert_eq!(result_entries[2].data, vec![2, 2, 2]);
+        assert_eq!(result_entries[3].data, vec![2, 2, 2]);
+
+        // drop wal to check persistence
+        drop(wal);
+        let wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 4); // fails here because we lost data!
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 4);
     }
 }


### PR DESCRIPTION
This PR fixes the inconsistent state in a distributed setup causing panics at startup (https://github.com/qdrant/qdrant/issues/1235) 

This can be observed when recovering from a split brain when the raft log needs to be reconciled.

In that case the leader will override the conflicting entries in the raft logs of the followers to remove diverging histories.

To do so we truncate our consensus wal at the first conflicting index when appending entries.

The source of the issue is a bug in the truncation logic which has been very difficult to spot https://github.com/qdrant/wal/pull/38

This PR updates the version of the wal crate and ships a unit test proving that the log is now persisted properly.