### PR TITLE
add helper functions for proper handling of paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,6 +2699,7 @@ dependencies = [
  "collection",
  "colored",
  "config",
+ "dirs",
  "env_logger",
  "futures",
  "futures-util",
@@ -2850,6 +2871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ serde_cbor = { version = "0.11.2"}
 uuid = { version = "1.2", features = ["v4", "serde"] }
 sys-info = "0.9.1"
 
+
+
 config = "~0.13.3"
 
 tokio = { version = "~1.24", features = ["full"] }
@@ -51,6 +53,9 @@ tower = "0.4.13"
 tower-layer = "0.3.2"
 num-traits = "0.2.15"
 tar = "0.4.38"
+
+# Utilities 
+dirs = "4.0.0"
 
 # Consensus related crates
 raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }


### PR DESCRIPTION
This PR add parse_path function to src/common/helper.rs file. The function will be useful for handling config, storage, and snapshots paths. It does tilde expansion and gets the absolute path for the given path.

The function will return an error if the path does not exist.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
