### PR TITLE
Fix segment snapshotting (#1321)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/storage-compat/storage.tar.bz2 filter=lfs diff=lfs merge=lfs -text
+tests/storage-compat/collection.snapshot.gz filter=lfs diff=lfs merge=lfs -text

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -11,6 +11,7 @@ use segment::entry::entry_point::{
     OperationError, OperationResult, SegmentEntry, SegmentFailedState,
 };
 use segment::index::field_index::CardinalityEstimation;
+use segment::segment::Segment;
 use segment::segment_constructor::load_segment;
 use segment::telemetry::SegmentTelemetry;
 use segment::types::{
@@ -700,7 +701,7 @@ impl SegmentEntry for ProxySegment {
         self.write_segment.get().read().vector_dims()
     }
 
-    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()> {
+    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<PathBuf> {
         log::info!(
             "Taking a snapshot of a proxy segment into {:?}",
             snapshot_dir_path
@@ -713,12 +714,28 @@ impl SegmentEntry for ProxySegment {
         // stable copy of the deleted points at the time of the snapshot
         let deleted_points_copy = deleted_points_guard.clone();
 
-        // create unique dir. to hold data copy of wrapped segment
-        let copy_target_dir = snapshot_dir_path.join(format!("segment_copy_{}", Uuid::new_v4()));
-        create_dir_all(&copy_target_dir)?;
+        // parse wrapped segment id from it's data path
+        let wrapped_segment_id = wrapped_segment_guard
+            .data_path()
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
-        // copy proxy segment current wrapped data
-        let full_copy_path: PathBuf = todo!();
+        // create temporary dir for operations on wrapped segment data
+        let tmp_dir_path = snapshot_dir_path.join(format!("segment_copy_{}", Uuid::new_v4()));
+        create_dir_all(&tmp_dir_path)?;
+
+        // snapshot wrapped segment data into the temporary dir
+        let archive_path = wrapped_segment_guard.take_snapshot(&tmp_dir_path)?;
+
+        // restore a copy of the wrapped segment data into the temporary dir
+        Segment::restore_snapshot(&archive_path, &wrapped_segment_id)?;
+
+        // build a path to a copy of the wrapped segment data
+        let full_copy_path = tmp_dir_path.join(&wrapped_segment_id);
+
         // snapshot write_segment
         let write_segment_rw = self.write_segment.get();
         let write_segment_guard = write_segment_rw.read();
@@ -744,12 +761,16 @@ impl SegmentEntry for ProxySegment {
         for deleted_point in deleted_points_copy {
             in_memory_wrapped_segment.delete_point(write_segment_version, deleted_point)?;
         }
-        in_memory_wrapped_segment.take_snapshot(snapshot_dir_path)?;
+
+        let archive_path = in_memory_wrapped_segment.take_snapshot(snapshot_dir_path)?;
+
         // release segment resources
         drop(in_memory_wrapped_segment);
+
         // delete temporary copy
-        remove_dir_all(copy_target_dir)?;
-        Ok(())
+        remove_dir_all(tmp_dir_path)?;
+
+        Ok(archive_path)
     }
 
     fn get_telemetry_data(&self) -> SegmentTelemetry {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -751,7 +751,7 @@ impl SegmentEntry for ProxySegment {
 
         // load copy of wrapped segment in memory
         let mut in_memory_wrapped_segment = load_segment(&full_copy_path)?.ok_or_else(|| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "Failed to load segment from {:?}",
                 full_copy_path
             ))

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -718,7 +718,7 @@ impl SegmentEntry for ProxySegment {
         create_dir_all(&copy_target_dir)?;
 
         // copy proxy segment current wrapped data
-        let full_copy_path = wrapped_segment_guard.copy_segment_directory(&copy_target_dir)?;
+        let full_copy_path: PathBuf = todo!();
         // snapshot write_segment
         let write_segment_rw = self.write_segment.get();
         let write_segment_guard = write_segment_rw.read();
@@ -750,15 +750,6 @@ impl SegmentEntry for ProxySegment {
         // delete temporary copy
         remove_dir_all(copy_target_dir)?;
         Ok(())
-    }
-
-    /// This implementation delegates to the `wrapped_segment` copy directory
-    /// Other members from the proxy segment won't be copied!
-    fn copy_segment_directory(&self, target_dir_path: &Path) -> OperationResult<PathBuf> {
-        self.wrapped_segment
-            .get()
-            .read()
-            .copy_segment_directory(target_dir_path)
     }
 
     fn get_telemetry_data(&self) -> SegmentTelemetry {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -427,7 +427,7 @@ impl<'s> SegmentHolder {
         for segment in self.segments.values() {
             let segment_lock = segment.get();
             let read_segment = segment_lock.read();
-            read_segment.take_snapshot(snapshot_dir_path)?
+            read_segment.take_snapshot(snapshot_dir_path)?;
         }
         Ok(())
     }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -63,7 +63,7 @@ impl LockedSegment {
             LockedSegment::Original(segment) => {
                 match try_unwrap_with_timeout(segment, DROP_SPIN_TIMEOUT, DROP_DATA_TIMEOUT) {
                     Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                    Err(locked_segment) => Err(OperationError::service_error(&format!(
+                    Err(locked_segment) => Err(OperationError::service_error(format!(
                         "Removing segment which is still in use: {:?}",
                         locked_segment.read().data_path()
                     ))),
@@ -72,7 +72,7 @@ impl LockedSegment {
             LockedSegment::Proxy(proxy) => {
                 match try_unwrap_with_timeout(proxy, DROP_SPIN_TIMEOUT, DROP_DATA_TIMEOUT) {
                     Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                    Err(locked_segment) => Err(OperationError::service_error(&format!(
+                    Err(locked_segment) => Err(OperationError::service_error(format!(
                         "Removing segment which is still in use: {:?}",
                         locked_segment.read().data_path()
                     ))),

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -264,7 +264,7 @@ impl SegmentsSearcher {
 
         segments.read().read_points(points, |id, segment| {
             let version = segment.point_version(id).ok_or_else(|| {
-                OperationError::service_error(&format!("No version for point {}", id))
+                OperationError::service_error(format!("No version for point {}", id))
             })?;
             // If this point was not found yet or this segment have later version
             if !point_version.contains_key(&id) || point_version[&id] < version {

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -123,7 +123,7 @@ impl DatabaseColumnWrapper {
         let cf_handle = self.get_column_family(&db)?;
         db.put_cf_opt(cf_handle, key, value, &Self::get_write_options())
             .map_err(|err| {
-                OperationError::service_error(&format!("RocksDB put_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB put_cf error: {}", err))
             })?;
         Ok(())
     }
@@ -137,7 +137,7 @@ impl DatabaseColumnWrapper {
         let result = db
             .get_pinned_cf(cf_handle, key)
             .map_err(|err| {
-                OperationError::service_error(&format!("RocksDB get_pinned_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB get_pinned_cf error: {}", err))
             })?
             .map(|value| f(&value));
         Ok(result)
@@ -150,7 +150,7 @@ impl DatabaseColumnWrapper {
         let db = self.database.read();
         let cf_handle = self.get_column_family(&db)?;
         db.delete_cf(cf_handle, key).map_err(|err| {
-            OperationError::service_error(&format!("RocksDB delete_cf error: {}", err))
+            OperationError::service_error(format!("RocksDB delete_cf error: {}", err))
         })?;
         Ok(())
     }
@@ -168,14 +168,14 @@ impl DatabaseColumnWrapper {
         Box::new(move || {
             let db = database.read();
             let column_family = db.cf_handle(&column_name).ok_or_else(|| {
-                OperationError::service_error(&format!(
+                OperationError::service_error(format!(
                     "RocksDB cf_handle error: Cannot find column family {}",
                     &column_name
                 ))
             })?;
 
             db.flush_cf(column_family).map_err(|err| {
-                OperationError::service_error(&format!("RocksDB flush_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB flush_cf error: {}", err))
             })?;
             Ok(())
         })
@@ -186,7 +186,7 @@ impl DatabaseColumnWrapper {
         if db.cf_handle(&self.column_name).is_none() {
             db.create_cf(&self.column_name, &db_options())
                 .map_err(|err| {
-                    OperationError::service_error(&format!("RocksDB create_cf error: {}", err))
+                    OperationError::service_error(format!("RocksDB create_cf error: {}", err))
                 })?;
         }
         Ok(())
@@ -201,7 +201,7 @@ impl DatabaseColumnWrapper {
         let mut db = self.database.write();
         if db.cf_handle(&self.column_name).is_some() {
             db.drop_cf(&self.column_name).map_err(|err| {
-                OperationError::service_error(&format!("RocksDB drop_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB drop_cf error: {}", err))
             })?;
         }
         Ok(())
@@ -224,7 +224,7 @@ impl DatabaseColumnWrapper {
         db: &'a parking_lot::RwLockReadGuard<'b, DB>,
     ) -> OperationResult<&'a ColumnFamily> {
         db.cf_handle(&self.column_name).ok_or_else(|| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "RocksDB cf_handle error: Cannot find column family {}",
                 &self.column_name
             ))
@@ -241,7 +241,7 @@ impl<'a> LockedDatabaseColumnWrapper<'a> {
 impl<'a> DatabaseColumnIterator<'a> {
     pub fn new(db: &'a DB, column_name: &str) -> OperationResult<DatabaseColumnIterator<'a>> {
         let handle = db.cf_handle(column_name).ok_or_else(|| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "RocksDB cf_handle error: Cannot find column family {}",
                 column_name
             ))

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -8,7 +8,7 @@ type CowKey<'a> = Cow<'a, str>;
 type CowValue<'a> = Cow<'a, [VectorElementType]>;
 type TinyMap<'a> = tiny_map::TinyMap<CowKey<'a>, CowValue<'a>>;
 
-#[derive(Clone, PartialEq, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct NamedVectors<'a> {
     map: TinyMap<'a>,
 }

--- a/lib/segment/src/data_types/tiny_map.rs
+++ b/lib/segment/src/data_types/tiny_map.rs
@@ -1,20 +1,22 @@
+use std::{borrow, iter, mem, slice};
+
 use tinyvec::TinyVec;
 
 pub const CAPACITY: usize = 3;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct TinyMap<K, V>
 where
-    K: Clone + Default,
-    V: Clone + Default,
+    K: Default,
+    V: Default,
 {
     list: TinyVec<[(K, V); CAPACITY]>,
 }
 
 impl<K, V> TinyMap<K, V>
 where
-    K: Clone + PartialEq + Default,
-    V: Clone + PartialEq + Default,
+    K: Default,
+    V: Default,
 {
     pub fn new() -> Self {
         Self {
@@ -26,11 +28,49 @@ where
         self.list.push((key, value));
     }
 
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    pub fn iter(&self) -> slice::Iter<'_, (K, V)> {
+        self.list.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, (K, V)> {
+        self.list.iter_mut()
+    }
+
+    pub fn clear(&mut self) {
+        self.list.clear();
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.list.iter().map(|(k, _)| k)
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.list.iter().map(|(_, v)| v)
+    }
+
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.list.iter_mut().map(|(_, v)| v)
+    }
+}
+
+impl<K, V> TinyMap<K, V>
+where
+    K: Default + Eq,
+    V: Default,
+{
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let found = self.list.iter_mut().find(|(k, _)| k == &key);
         match found {
             Some((_, v)) => {
-                let old = std::mem::replace(v, value);
+                let old = mem::replace(v, value);
                 Some(old)
             }
             None => {
@@ -42,7 +82,7 @@ where
 
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: borrow::Borrow<Q>,
         Q: Eq,
     {
         self.list
@@ -53,7 +93,7 @@ where
 
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: borrow::Borrow<Q>,
         Q: Eq,
     {
         self.list
@@ -73,61 +113,19 @@ where
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.list.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.list.is_empty()
-    }
-
-    pub fn iter(&self) -> std::slice::Iter<'_, (K, V)> {
-        self.list.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, (K, V)> {
-        self.list.iter_mut()
-    }
-
-    pub fn clear(&mut self) {
-        self.list.clear();
-    }
-
-    pub fn keys(&self) -> impl Iterator<Item = &K> {
-        self.list.iter().map(|(k, _)| k)
-    }
-
-    pub fn values(&self) -> impl Iterator<Item = &V> {
-        self.list.iter().map(|(_, v)| v)
-    }
-
-    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
-        self.list.iter_mut().map(|(_, v)| v)
-    }
-
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
     where
-        K: std::borrow::Borrow<Q>,
+        K: borrow::Borrow<Q>,
         Q: Eq,
     {
         self.list.iter().any(|(k, _)| k.borrow() == key)
     }
 }
 
-impl<K, V> Default for TinyMap<K, V>
-where
-    K: Clone + PartialEq + Default,
-    V: Clone + PartialEq + Default,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<K, V> PartialEq for TinyMap<K, V>
 where
-    K: Clone + PartialEq + Eq + Default,
-    V: Clone + PartialEq + Default,
+    K: Default + Eq,
+    V: Default + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -146,8 +144,8 @@ where
 
 impl<K, V> IntoIterator for TinyMap<K, V>
 where
-    K: Clone + Default,
-    V: Clone + Default,
+    K: Default,
+    V: Default,
 {
     type Item = (K, V);
 
@@ -158,14 +156,14 @@ where
     }
 }
 
-impl<K, V> std::iter::FromIterator<(K, V)> for TinyMap<K, V>
+impl<K, V> iter::FromIterator<(K, V)> for TinyMap<K, V>
 where
-    K: Clone + Default,
-    V: Clone + Default,
+    K: Default,
+    V: Default,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         Self {
-            list: std::iter::FromIterator::from_iter(iter),
+            list: iter::FromIterator::from_iter(iter),
         }
     }
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -329,11 +329,6 @@ pub trait SegmentEntry {
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
     fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()>;
 
-    /// Copy the segment directory structure into `target_dir_path`
-    ///
-    /// Return the `Path` of the copy
-    fn copy_segment_directory(&self, target_dir_path: &Path) -> OperationResult<PathBuf>;
-
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self) -> SegmentTelemetry;
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -100,13 +100,13 @@ impl From<FileStorageError> for OperationError {
     fn from(err: FileStorageError) -> Self {
         match err {
             FileStorageError::IoError { description } => {
-                OperationError::service_error(&format!("IO Error: {}", description))
+                OperationError::service_error(format!("IO Error: {}", description))
             }
             FileStorageError::UserAtomicIoError => {
                 OperationError::service_error("Unknown atomic write error")
             }
             FileStorageError::GenericError { description } => {
-                OperationError::service_error(&description)
+                OperationError::service_error(description)
             }
         }
     }
@@ -114,7 +114,7 @@ impl From<FileStorageError> for OperationError {
 
 impl From<serde_cbor::Error> for OperationError {
     fn from(err: serde_cbor::Error) -> Self {
-        OperationError::service_error(&format!("Failed to parse data: {}", err))
+        OperationError::service_error(format!("Failed to parse data: {}", err))
     }
 }
 
@@ -131,19 +131,19 @@ impl<E> From<AtomicIoError<E>> for OperationError {
 
 impl From<IoError> for OperationError {
     fn from(err: IoError) -> Self {
-        OperationError::service_error(&format!("IO Error: {}", err))
+        OperationError::service_error(format!("IO Error: {}", err))
     }
 }
 
 impl From<serde_json::Error> for OperationError {
     fn from(err: serde_json::Error) -> Self {
-        OperationError::service_error(&format!("Json error: {}", err))
+        OperationError::service_error(format!("Json error: {}", err))
     }
 }
 
 impl From<fs_extra::error::Error> for OperationError {
     fn from(err: fs_extra::error::Error) -> Self {
-        OperationError::service_error(&format!("File system error: {}", err))
+        OperationError::service_error(format!("File system error: {}", err))
     }
 }
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -53,9 +53,9 @@ pub enum OperationError {
 }
 
 impl OperationError {
-    pub fn service_error(description: &str) -> OperationError {
+    pub fn service_error(description: impl Into<String>) -> OperationError {
         OperationError::ServiceError {
-            description: description.to_string(),
+            description: description.into(),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -327,7 +327,7 @@ pub trait SegmentEntry {
     /// Take a snapshot of the segment.
     ///
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
-    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<()>;
+    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<PathBuf>;
 
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self) -> SegmentTelemetry;

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -36,13 +36,13 @@ impl FullTextIndex {
 
     fn serialize_document(document: &Document) -> OperationResult<Vec<u8>> {
         serde_cbor::to_vec(document).map_err(|e| {
-            OperationError::service_error(&format!("Failed to serialize document: {}", e))
+            OperationError::service_error(format!("Failed to serialize document: {}", e))
         })
     }
 
     fn deserialize_document(data: &[u8]) -> OperationResult<Document> {
         serde_cbor::from_slice(data).map_err(|e| {
-            OperationError::service_error(&format!("Failed to deserialize document: {}", e))
+            OperationError::service_error(format!("Failed to deserialize document: {}", e))
         })
     }
 

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -302,7 +302,7 @@ impl GeoMapIndex {
         for added_point in values {
             let added_geo_hash: GeoHash = encode_max_precision(added_point.lon, added_point.lat)
                 .map_err(|e| {
-                    OperationError::service_error(&format!("Malformed geo points: {}", e))
+                    OperationError::service_error(format!("Malformed geo points: {}", e))
                 })?;
 
             let key = Self::encode_db_key(&added_geo_hash, idx);

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -422,4 +422,15 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             unfiltered_exact: tm.exact_unfiltered.lock().get_statistics(),
         }
     }
+
+    fn files(&self) -> Vec<PathBuf> {
+        if self.graph.is_some() {
+            vec![
+                GraphLayers::<TGraphLinks>::get_path(&self.path),
+                GraphLayers::<TGraphLinks>::get_links_path(&self.path),
+            ]
+        } else {
+            vec![]
+        }
+    }
 }

--- a/lib/segment/src/index/index_base.rs
+++ b/lib/segment/src/index/index_base.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
@@ -30,6 +31,8 @@ pub trait VectorIndex {
     fn build_index(&mut self, stopped: &AtomicBool) -> OperationResult<()>;
 
     fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry;
+
+    fn files(&self) -> Vec<PathBuf>;
 }
 
 pub trait PayloadIndex {
@@ -102,6 +105,10 @@ pub trait PayloadIndex {
         &self,
         key: PayloadKeyTypeRef,
     ) -> OperationResult<Option<PayloadSchemaType>>;
+
+    fn take_database_snapshot(&self, path: &Path) -> OperationResult<()>;
+
+    fn files(&self) -> Vec<PathBuf>;
 }
 
 pub type VectorIndexSS = dyn VectorIndex + Sync + Send;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -183,6 +183,14 @@ impl PayloadIndex for PlainPayloadIndex {
     ) -> OperationResult<Option<PayloadSchemaType>> {
         unreachable!()
     }
+
+    fn take_database_snapshot(&self, _: &Path) -> OperationResult<()> {
+        unreachable!()
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![self.config_path()]
+    }
 }
 
 pub struct PlainIndex {
@@ -256,6 +264,10 @@ impl VectorIndex for PlainIndex {
             filtered_exact: OperationDurationStatistics::default(),
             unfiltered_exact: OperationDurationStatistics::default(),
         }
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -146,9 +146,8 @@ impl StructPayloadIndex {
             PayloadConfig::default()
         };
 
-        let db = open_db_with_existing_cf(path).map_err(|err| {
-            OperationError::service_error(&format!("RocksDB open error: {}", err))
-        })?;
+        let db = open_db_with_existing_cf(path)
+            .map_err(|err| OperationError::service_error(format!("RocksDB open error: {}", err)))?;
 
         let mut index = StructPayloadIndex {
             payload,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -283,6 +283,13 @@ impl StructPayloadIndex {
             })
             .collect()
     }
+
+    pub fn restore_database_snapshot(
+        snapshot_path: &Path,
+        segment_path: &Path,
+    ) -> OperationResult<()> {
+        crate::rocksdb_backup::restore(snapshot_path, &segment_path.join("payload_index"))
+    }
 }
 
 impl PayloadIndex for StructPayloadIndex {
@@ -490,5 +497,13 @@ impl PayloadIndex for StructPayloadIndex {
             Ok(false)
         })?;
         Ok(schema)
+    }
+
+    fn take_database_snapshot(&self, path: &Path) -> OperationResult<()> {
+        crate::rocksdb_backup::create(&self.db.read(), path)
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![self.config_path()]
     }
 }

--- a/lib/segment/src/lib.rs
+++ b/lib/segment/src/lib.rs
@@ -16,6 +16,7 @@ pub mod telemetry;
 pub mod data_types;
 #[allow(deprecated)]
 pub mod types;
+pub mod utils;
 pub mod vector_storage;
 
 #[macro_use]

--- a/lib/segment/src/lib.rs
+++ b/lib/segment/src/lib.rs
@@ -7,6 +7,7 @@ mod id_tracker;
 pub mod index;
 pub mod madvise;
 pub mod payload_storage;
+pub mod rocksdb_backup;
 pub mod segment;
 pub mod segment_constructor;
 pub mod spaces;

--- a/lib/segment/src/rocksdb_backup.rs
+++ b/lib/segment/src/rocksdb_backup.rs
@@ -1,0 +1,57 @@
+use std::fs;
+use std::path::Path;
+
+use crate::entry::entry_point::{OperationError, OperationResult};
+
+pub fn create(db: &rocksdb::DB, backup_path: &Path) -> OperationResult<()> {
+    if !backup_path.exists() {
+        create_dir_all(backup_path)?;
+    } else if !backup_path.is_dir() {
+        return Err(not_a_directory_error(backup_path));
+    } else if backup_path.read_dir().unwrap().next().is_some() {
+        return Err(directory_not_empty_error(backup_path));
+    }
+
+    backup_engine(backup_path)?
+        .create_new_backup(&db)
+        .map_err(|err| service_error(format!("failed to create RocksDB backup: {err}")))
+}
+
+pub fn restore(backup_path: &Path, restore_path: &Path) -> OperationResult<()> {
+    backup_engine(backup_path)?
+        .restore_from_latest_backup(restore_path, restore_path, &Default::default())
+        .map_err(|err| service_error(format!("failed to restore RocksDB backup: {err}")))
+}
+
+fn backup_engine(path: &Path) -> OperationResult<rocksdb::backup::BackupEngine> {
+    rocksdb::backup::BackupEngine::open(&Default::default(), &path).map_err(|err| {
+        service_error(format!(
+            "failed to open RocksDB backup engine {path:?}: {err}"
+        ))
+    })
+}
+
+fn create_dir_all(path: &Path) -> OperationResult<()> {
+    fs::create_dir_all(&path).map_err(|err| {
+        service_error(format!(
+            "failed to create RocksDB backup directory {path:?}: {err}"
+        ))
+    })
+}
+
+fn not_a_directory_error(path: &Path) -> OperationError {
+    service_error(format!("RocksDB backup path {path:?} is not a directory"))
+}
+
+fn directory_not_empty_error(path: &Path) -> OperationError {
+    service_error(format!(
+        "RockDB backup directory {path:?} already exists and is not empty"
+    ))
+}
+
+fn service_error(description: impl Into<String>) -> OperationError {
+    OperationError::ServiceError {
+        description: description.into(),
+        backtrace: None,
+    }
+}

--- a/lib/segment/src/rocksdb_backup.rs
+++ b/lib/segment/src/rocksdb_backup.rs
@@ -13,7 +13,7 @@ pub fn create(db: &rocksdb::DB, backup_path: &Path) -> OperationResult<()> {
     }
 
     backup_engine(backup_path)?
-        .create_new_backup(&db)
+        .create_new_backup(db)
         .map_err(|err| service_error(format!("failed to create RocksDB backup: {err}")))
 }
 
@@ -24,7 +24,7 @@ pub fn restore(backup_path: &Path, restore_path: &Path) -> OperationResult<()> {
 }
 
 fn backup_engine(path: &Path) -> OperationResult<rocksdb::backup::BackupEngine> {
-    rocksdb::backup::BackupEngine::open(&Default::default(), &path).map_err(|err| {
+    rocksdb::backup::BackupEngine::open(&Default::default(), path).map_err(|err| {
         service_error(format!(
             "failed to open RocksDB backup engine {path:?}: {err}"
         ))
@@ -32,7 +32,7 @@ fn backup_engine(path: &Path) -> OperationResult<rocksdb::backup::BackupEngine> 
 }
 
 fn create_dir_all(path: &Path) -> OperationResult<()> {
-    fs::create_dir_all(&path).map_err(|err| {
+    fs::create_dir_all(path).map_err(|err| {
         service_error(format!(
             "failed to create RocksDB backup directory {path:?}: {err}"
         ))

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1626,58 +1626,6 @@ mod tests {
     }
 
     #[test]
-    fn test_copy_segment_directory() {
-        let data = r#"
-        {
-            "name": "John Doe",
-            "age": 43,
-            "metadata": {
-                "height": 50,
-                "width": 60
-            }
-        }"#;
-
-        let segment_base_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let config = SegmentConfig {
-            vector_data: HashMap::from([(
-                DEFAULT_VECTOR_NAME.to_owned(),
-                VectorDataConfig {
-                    size: 2,
-                    distance: Distance::Dot,
-                },
-            )]),
-            index: Indexes::Plain {},
-            storage_type: StorageType::InMemory,
-            payload_storage_type: Default::default(),
-        };
-
-        let mut segment = build_segment(segment_base_dir.path(), &config).unwrap();
-        segment
-            .upsert_vector(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
-            .unwrap();
-
-        let payload: Payload = serde_json::from_str(data).unwrap();
-        segment.set_full_payload(0, 0.into(), &payload).unwrap();
-        segment.flush(true).unwrap();
-
-        // Recursively count all files and folders in directory and subdirectories.
-        let segment_file_count = WalkDir::new(segment.current_path.clone())
-            .into_iter()
-            .count();
-        assert_eq!(segment_file_count, 20);
-
-        let segment_copy_dir = Builder::new().prefix("segment_copy_dir").tempdir().unwrap();
-        let full_copy_path = segment
-            .copy_segment_directory(segment_copy_dir.path())
-            .unwrap();
-
-        // Recursively count all files and folders in directory and subdirectories.
-        let copy_segment_file_count = WalkDir::new(full_copy_path).into_iter().count();
-
-        assert_eq!(copy_segment_file_count, segment_file_count);
-    }
-
-    #[test]
     fn test_background_flush() {
         let data = r#"
         {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -327,7 +327,10 @@ impl Segment {
             crate::rocksdb_backup::restore(&db_backup_path, &segment_path)?;
 
             if payload_index_db_backup.is_dir() {
-                StructPayloadIndex::restore_database_snapshot(&payload_index_db_backup, &segment_path)?;
+                StructPayloadIndex::restore_database_snapshot(
+                    &payload_index_db_backup,
+                    &segment_path,
+                )?;
             }
 
             let files_path = snapshot_path.join(SNAPSHOT_FILES_PATH);

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -130,7 +130,7 @@ impl Segment {
             // Failed operations should not be skipped,
             // fail if newer operation is attempted before proper recovery
             if *failed_version < op_num {
-                return Err(OperationError::service_error(&format!(
+                return Err(OperationError::service_error(format!(
                     "Not recovered from previous error: {}",
                     error
                 )));
@@ -391,7 +391,7 @@ impl Segment {
             .map(|(point_id, scored_point_offset)| {
                 let point_offset = scored_point_offset.idx;
                 let point_version = id_tracker.internal_version(point_offset).ok_or_else(|| {
-                    OperationError::service_error(&format!(
+                    OperationError::service_error(format!(
                         "Corrupter id_tracker, no version for point {}",
                         point_id
                     ))
@@ -768,7 +768,7 @@ impl SegmentEntry for Segment {
         if let Some(vector) = vector_opt {
             Ok(vector)
         } else {
-            Err(OperationError::service_error(&format!(
+            Err(OperationError::service_error(format!(
                 "Vector {vector_name} not found at offset {internal_id}"
             )))
         }
@@ -1005,21 +1005,21 @@ impl SegmentEntry for Segment {
         let flush_op = move || {
             // Flush mapping first to prevent having orphan internal ids.
             id_tracker_mapping_flusher().map_err(|err| {
-                OperationError::service_error(&format!(
+                OperationError::service_error(format!(
                     "Failed to flush id_tracker mapping: {}",
                     err
                 ))
             })?;
             for vector_storage_flusher in vector_storage_flushers {
                 vector_storage_flusher().map_err(|err| {
-                    OperationError::service_error(&format!(
+                    OperationError::service_error(format!(
                         "Failed to flush vector_storage: {}",
                         err
                     ))
                 })?;
             }
             payload_index_flusher().map_err(|err| {
-                OperationError::service_error(&format!("Failed to flush payload_index: {}", err))
+                OperationError::service_error(format!("Failed to flush payload_index: {}", err))
             })?;
             // Id Tracker contains versions of points. We need to flush it after vector_storage and payload_index flush.
             // This is because vector_storage and payload_index flush are not atomic.
@@ -1028,13 +1028,13 @@ impl SegmentEntry for Segment {
             //  by simply overriding data in vector and payload storages.
             // Once versions are saved - points are considered persisted.
             id_tracker_versions_flusher().map_err(|err| {
-                OperationError::service_error(&format!(
+                OperationError::service_error(format!(
                     "Failed to flush id_tracker versions: {}",
                     err
                 ))
             })?;
             Self::save_state(&state, &current_path).map_err(|err| {
-                OperationError::service_error(&format!("Failed to flush segment state: {}", err))
+                OperationError::service_error(format!("Failed to flush segment state: {}", err))
             })?;
             *persisted_version.lock() = state.version;
 
@@ -1061,7 +1061,7 @@ impl SegmentEntry for Segment {
         deleted_path.set_extension("deleted");
         rename(&current_path, &deleted_path)?;
         remove_dir_all(&deleted_path).map_err(|err| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "Can't remove segment data at {}, error: {}",
                 deleted_path.to_str().unwrap_or_default(),
                 err

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -84,7 +84,7 @@ impl SegmentBuilder {
 
                 if vector_storages.len() != other_vector_storages.len() {
                     return Err(OperationError::service_error(
-                        &format!("Self and other segments have different vector names count. Self count: {}, other count: {}", vector_storages.len(), other_vector_storages.len()),
+                        format!("Self and other segments have different vector names count. Self count: {}, other count: {}", vector_storages.len(), other_vector_storages.len()),
                     ));
                 }
 
@@ -93,7 +93,7 @@ impl SegmentBuilder {
                     check_process_stopped(stopped)?;
                     let other_vector_storage = other_vector_storages.get(vector_name);
                     if other_vector_storage.is_none() {
-                        return Err(OperationError::service_error(&format!(
+                        return Err(OperationError::service_error(format!(
                             "Cannot update from other segment because if missing vector name {}",
                             vector_name
                         )));
@@ -200,7 +200,7 @@ impl SegmentBuilder {
             .describe("Moving segment data after optimization")?;
 
         load_segment(&self.destination_path)?.ok_or_else(|| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "Segment loading error: {}",
                 self.destination_path.display()
             ))

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -54,7 +54,7 @@ fn create_segment(
         .map(|vector_name| get_vector_name_with_prefix(DB_VECTOR_CF, vector_name))
         .collect();
     let database = open_db(segment_path, &vector_db_names)
-        .map_err(|err| OperationError::service_error(&format!("RocksDB open error: {}", err)))?;
+        .map_err(|err| OperationError::service_error(format!("RocksDB open error: {}", err)))?;
 
     let payload_storage = match config.payload_storage_type {
         PayloadStorageType::InMemory => sp(SimplePayloadStorage::open(database.clone())?.into()),
@@ -169,7 +169,7 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
         info!("Migrating segment {} -> {}", stored_version, app_version,);
 
         if stored_version > app_version {
-            return Err(OperationError::service_error(&format!(
+            return Err(OperationError::service_error(format!(
                 "Data version {} is newer than application version {}. \
                 Please upgrade the application. Compatibility is not guaranteed.",
                 stored_version, app_version
@@ -177,7 +177,7 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
         }
 
         if stored_version.major == 0 && stored_version.minor < 3 {
-            return Err(OperationError::service_error(&format!(
+            return Err(OperationError::service_error(format!(
                 "Segment version({}) is not compatible with current version({})",
                 stored_version, app_version
             )));
@@ -273,7 +273,7 @@ fn load_segment_state_v3(segment_path: &Path) -> OperationResult<SegmentState> {
             }
         })
         .map_err(|err| {
-            OperationError::service_error(&format!(
+            OperationError::service_error(format!(
                 "Failed to read segment {}. Error: {}",
                 path.to_str().unwrap(),
                 err

--- a/lib/segment/src/utils/fs.rs
+++ b/lib/segment/src/utils/fs.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+use std::{fmt, fs};
+
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::utils;
+
+/// Move all files and directories from the `dir` directory to the `dest_dir` directory.
+///
+/// - `<dir>/child/directory` will be merged with `<dest-dir>/child/directory` if one alredy exists
+/// - `<dir>/some/file` will overwrite `<dest-dir>/some/file` if one already exists
+pub fn move_all(dir: &Path, dest_dir: &Path) -> OperationResult<()> {
+    assert_is_dir(dir)?;
+    assert_is_dir(dest_dir)?;
+
+    move_all_impl(dir, dir, dest_dir)
+}
+
+fn move_all_impl(base: &Path, dir: &Path, dest_dir: &Path) -> OperationResult<()> {
+    let entries = dir
+        .read_dir()
+        .map_err(|err| failed_to_read_dir_error(dir, err))?;
+
+    for entry in entries {
+        let path = entry
+            .map_err(|err| failed_to_read_dir_error(dir, err))?
+            .path();
+
+        let name = utils::path::strip_prefix(&path, base)
+            .map_err(|err| failed_to_move_error(&path, dest_dir, err))?;
+
+        let dest = dest_dir.join(name);
+
+        if path.is_dir() && dest.exists() {
+            move_all_impl(base, &path, &dest)?;
+        } else {
+            if let Some(dir) = dest.parent() {
+                if !dir.exists() {
+                    fs::create_dir_all(dir).map_err(|err| {
+                        OperationError::service_error(format!(
+                            "failed to create {dir:?} directory: {err}"
+                        ))
+                    })?;
+                }
+            }
+
+            fs::rename(&path, &dest).map_err(|err| failed_to_move_error(name, &dest, err))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_is_dir(dir: &Path) -> OperationResult<()> {
+    if dir.is_dir() {
+        Ok(())
+    } else {
+        Err(not_a_dir_error(dir))
+    }
+}
+
+fn not_a_dir_error(dir: &Path) -> OperationError {
+    OperationError::service_error(format!(
+        "path {dir:?} is not a directory (or does not exist)"
+    ))
+}
+
+fn failed_to_read_dir_error(dir: &Path, err: impl fmt::Display) -> OperationError {
+    OperationError::service_error(format!("failed to read {dir:?} directory: {err}"))
+}
+
+fn failed_to_move_error(path: &Path, dest: &Path, err: impl fmt::Display) -> OperationError {
+    OperationError::service_error(format!("failed to move {path:?} to {dest:?}: {err}"))
+}

--- a/lib/segment/src/utils/fs.rs
+++ b/lib/segment/src/utils/fs.rs
@@ -6,7 +6,7 @@ use crate::utils;
 
 /// Move all files and directories from the `dir` directory to the `dest_dir` directory.
 ///
-/// - `<dir>/child/directory` will be merged with `<dest-dir>/child/directory` if one alredy exists
+/// - `<dir>/child/directory` will be merged with `<dest-dir>/child/directory` if one already exists
 /// - `<dir>/some/file` will overwrite `<dest-dir>/some/file` if one already exists
 pub fn move_all(dir: &Path, dest_dir: &Path) -> OperationResult<()> {
     assert_is_dir(dir)?;

--- a/lib/segment/src/utils/mod.rs
+++ b/lib/segment/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod fs;
+pub mod path;
+pub mod tar;

--- a/lib/segment/src/utils/path.rs
+++ b/lib/segment/src/utils/path.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+use crate::entry::entry_point::{OperationError, OperationResult};
+
+pub fn strip_prefix<'a>(path: &'a Path, prefix: &Path) -> OperationResult<&'a Path> {
+    path.strip_prefix(prefix).map_err(|err| {
+        OperationError::service_error(format!(
+            "failed to strip {prefix:?} prefix from {path:?}: {err}"
+        ))
+    })
+}

--- a/lib/segment/src/utils/tar.rs
+++ b/lib/segment/src/utils/tar.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+use std::{fmt, io};
+
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::utils;
+
+/// Append `file` to the archive under `dest_dir` directory at `file`'s path relative to `base`.
+///
+/// E.g.:
+/// - if `base` is `/some/directory/`
+/// - `file` is `/some/directory/file/path`
+/// - and `dest_dir` is `/inside/the/archive/`
+/// - then the `file` will be added to the archive at path `/inside/the/archive/file/path`
+pub fn append_file_relative_to_base(
+    builder: &mut tar::Builder<impl io::Write>,
+    base: &Path,
+    file: &Path,
+    dest_dir: &Path,
+) -> OperationResult<()> {
+    let name =
+        utils::path::strip_prefix(file, base).map_err(|err| failed_to_append_error(file, err))?;
+
+    append_file(builder, file, &dest_dir.join(name))
+}
+
+pub fn append_file(
+    builder: &mut tar::Builder<impl io::Write>,
+    file: &Path,
+    dest: &Path,
+) -> OperationResult<()> {
+    builder
+        .append_path_with_name(file, dest)
+        .map_err(|err| failed_to_append_error(file, err))
+}
+
+/// Create "failed to append <path> to the archive" error.
+pub fn failed_to_append_error(path: &Path, err: impl fmt::Display) -> OperationError {
+    OperationError::service_error(format!(
+        "failed to append {path:?} path to the archive: {err}"
+    ))
+}

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -307,6 +307,10 @@ where
         let vector = self.get_vector(point).unwrap();
         self.score_points(&vector, points, top)
     }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![self.vectors_path.clone(), self.deleted_path.clone()]
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -321,6 +321,10 @@ where
         let vector = self.get_vector(point).unwrap();
         self.score_points(&vector, points, top)
     }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        vec![]
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::ops::Range;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 use ordered_float::OrderedFloat;
@@ -89,6 +90,8 @@ pub trait VectorStorage {
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset>;
+
+    fn files(&self) -> Vec<PathBuf>;
 
     /// Iterator over `n` random ids which are not deleted
     fn sample_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {

--- a/tests/storage-compat/collection.snapshot.gz
+++ b/tests/storage-compat/collection.snapshot.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bab0608c7646b3b0f967a6a5e02fd2d7ba045d4707a870cf8ed0a20581359c9
+size 529795


### PR DESCRIPTION
So, the error in #1321 happens this way:

- as it turned out, RocksDB runs background jobs (i.e., threads) that may do database optimization
  - in particular, reorganize `.sst` files on disk
- so, `Segment::take_snapshot` calls `tar::Builder::append_dir_all`
- `tar::Builder::append_dir_all` gets a list of files in segment's directory and starts reading and adding them to the archive one by one
- and while `tar::Builder::append_dir_all` is iterating through this list of files, RocksDB's background job deletes/renames one of the `.sst` files in the segment's directory and `tar::Builder::append_dir_all` fails with "file does not exist" error

This PR fix `Segment::take_snapshot` to use `rocksd::backup::BackupEngine` to "snapshot" RocksDB databases.

__TODO:__
- [x] Fix snapshotting of segments with _memmapped vector storage_
  - I've changed the way snapshot archive is created, but didn't account for vector storage memmaps
- [x] Fix `ProxySegment::take_snapshot`, as it relies on `Segment::copy_segment_directory`, which likely subject to the same bug regarding RocksDB `.sst` files
  - Seems like the fix should be rather trivial, if we simply replace `Segment::copy_segment_directory` with `Segment::take_snapshot` and `Segment::restore_snapshot`