### PR TITLE
Save consensus logs in case of CI failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,6 +56,14 @@ jobs:
         shell: bash
       - name: Run integration tests - multiple peers - pytest
         run: pytest ./tests/consensus_tests
+      - name: upload logs in case of failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: consensus-test-logs
+          retention-days: 90 # default max value
+          path: |
+            *.log
       
   test-consensus-compose:
     

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,8 +62,7 @@ jobs:
         with:
           name: consensus-test-logs
           retention-days: 90 # default max value
-          path: |
-            *.log
+          path: consensus_test_logs
       
   test-consensus-compose:
     

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.idea
 /storage
 /snapshots
+/consensus_test_logs
 *.log

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -77,8 +77,8 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None) -> 
     grpc_port = get_port() if port is None else port + 1
     http_port = get_port() if port is None else port + 2
     env = get_env(p2p_port, grpc_port, http_port)
-    test_name = init_pytest_log_folder()
-    log_file = open(f"{test_name}/{log_file}", "w")
+    test_log_folder = init_pytest_log_folder()
+    log_file = open(f"{test_log_folder}/{log_file}", "w")
     print(f"Starting follower peer with bootstrap uri {bootstrap_uri},"
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")
 
@@ -95,8 +95,8 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None) -> Tuple[str, str
     grpc_port = get_port() if port is None else port + 1
     http_port = get_port() if port is None else port + 2
     env = get_env(p2p_port, grpc_port, http_port)
-    test_name = init_pytest_log_folder()
-    log_file = open(f"{test_name}/{log_file}", "w")
+    test_log_folder = init_pytest_log_folder()
+    log_file = open(f"{test_log_folder}/{log_file}", "w")
     bootstrap_uri = get_uri(p2p_port)
     print(f"\nStarting first peer with uri {bootstrap_uri},"
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -58,13 +58,27 @@ def get_qdrant_exec() -> str:
     return qdrant_exec
 
 
+def get_pytest_current_test_name() -> str:
+    # https://docs.pytest.org/en/latest/example/simple.html#pytest-current-test-environment-variable
+    return os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]
+
+
+def init_pytest_log_folder() -> str:
+    test_name = get_pytest_current_test_name()
+    log_folder = f"consensus_test_logs/{test_name}"
+    if not os.path.exists(log_folder):
+        os.makedirs(log_folder)
+    return log_folder
+
+
 # Starts a peer and returns its api_uri
 def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None) -> str:
     p2p_port = get_port() if port is None else port + 0
     grpc_port = get_port() if port is None else port + 1
     http_port = get_port() if port is None else port + 2
     env = get_env(p2p_port, grpc_port, http_port)
-    log_file = open(log_file, "w")
+    test_name = init_pytest_log_folder()
+    log_file = open(f"{test_name}/{log_file}", "w")
     print(f"Starting follower peer with bootstrap uri {bootstrap_uri},"
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")
 
@@ -81,7 +95,8 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None) -> Tuple[str, str
     grpc_port = get_port() if port is None else port + 1
     http_port = get_port() if port is None else port + 2
     env = get_env(p2p_port, grpc_port, http_port)
-    log_file = open(log_file, "w")
+    test_name = init_pytest_log_folder()
+    log_file = open(f"{test_name}/{log_file}", "w")
     bootstrap_uri = get_uri(p2p_port)
     print(f"\nStarting first peer with uri {bootstrap_uri},"
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")


### PR DESCRIPTION
This PR enables to capture the logs of the peers used for consensus test in case of failure (https://github.com/qdrant/qdrant/issues/1318)

This is done using the [upload-artifact](https://github.com/actions/upload-artifact) Github action.

The logs files will be kept for 90 days as part of our free plan usage.

The links to the artifact can be found by clicking on the "Summary" button and scrolling all the way down.
![logs-action](https://user-images.githubusercontent.com/606963/211895459-f0c870f6-aabf-4c04-802f-dde11ff57c7a.png)

For example https://github.com/qdrant/qdrant/suites/10313659846/artifacts/507345404