### PR TITLE
Add extra logging to node consensus recovery process

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -313,9 +313,15 @@ impl Consensus {
                         res
                     );
                 } else {
+                    log::debug!(
+                        "Successfully recovered from peer with id {} at {}",
+                        peer_id,
+                        peer_uri
+                    );
                     return Ok(());
                 }
             }
+            log::error!("Failed to recover from any peer");
         }
 
         Ok(())

--- a/tests/consensus_tests/assertions.py
+++ b/tests/consensus_tests/assertions.py
@@ -3,8 +3,9 @@ import requests
 
 def assert_http_ok(response: requests.Response):
     if response.status_code != 200:
+        base_msg = f"HTTP request to {response.url} failed with status code {response.status_code} after {response.elapsed.total_seconds()}s"
         if not response.content:
-            raise Exception(f"Http request failed with status {response.status_code} and no content")
+            raise Exception(f"{base_msg} and without response body")
         else:
             raise Exception(
-                f"Http request failed with status {response.status_code} and content:\n{response.json()}")
+                f"{base_msg} with response body:\n{response.json()}")


### PR DESCRIPTION
The change is originally motivated by https://github.com/qdrant/qdrant/issues/1315

This small PR adds extra logging to the node recovery process and improves the HTTP assertion to display more info.
