### PR TITLE
Remove unecessary async declaration

### DIFF
--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -128,8 +128,8 @@ impl ForwardProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
-    pub async fn get_telemetry_data(&self) -> LocalShardTelemetry {
-        self.wrapped_shard.get_telemetry_data().await
+    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+        self.wrapped_shard.get_telemetry_data()
     }
 
     /// Forward `before_drop` to `wrapped_shard`

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -69,7 +69,7 @@ impl LocalShard {
     }
 
     /// Checks if path have local shard data present
-    pub async fn check_data(shard_path: &Path) -> bool {
+    pub fn check_data(shard_path: &Path) -> bool {
         let wal_path = Self::wal_path(shard_path);
         let segments_path = Self::segments_path(shard_path);
         wal_path.exists() && segments_path.exists()
@@ -236,7 +236,7 @@ impl LocalShard {
         )
         .await;
 
-        collection.load_from_wal(collection_id).await;
+        collection.load_from_wal(collection_id);
 
         Ok(collection)
     }
@@ -373,7 +373,7 @@ impl LocalShard {
     }
 
     /// Loads latest collection operations from WAL
-    pub async fn load_from_wal(&self, collection_id: CollectionId) {
+    pub fn load_from_wal(&self, collection_id: CollectionId) {
         let wal = self.wal.lock();
         let bar = ProgressBar::new(wal.len());
 
@@ -491,7 +491,7 @@ impl LocalShard {
             .snapshot_all_segments(&snapshot_segments_shard_path)?;
 
         // snapshot all shard's WAL
-        self.snapshot_wal(snapshot_shard_path).await?;
+        self.snapshot_wal(snapshot_shard_path)?;
 
         // copy shard's config
         let shard_config_path = ShardConfig::get_config_path(&self.path);
@@ -503,7 +503,7 @@ impl LocalShard {
     /// snapshot WAL
     ///
     /// copies all WAL files into `snapshot_shard_path/wal`
-    pub async fn snapshot_wal(&self, snapshot_shard_path: &Path) -> CollectionResult<()> {
+    pub fn snapshot_wal(&self, snapshot_shard_path: &Path) -> CollectionResult<()> {
         // lock wal during snapshot
         let _wal_guard = self.wal.lock();
         let source_wal_path = self.path.join("wal");
@@ -517,7 +517,7 @@ impl LocalShard {
         Ok(())
     }
 
-    pub async fn estimate_cardinality<'a>(
+    pub fn estimate_cardinality<'a>(
         &'a self,
         filter: Option<&'a Filter>,
     ) -> CollectionResult<CardinalityEstimation> {
@@ -541,7 +541,7 @@ impl LocalShard {
         Ok(cardinality)
     }
 
-    pub async fn read_filtered<'a>(
+    pub fn read_filtered<'a>(
         &'a self,
         filter: Option<&'a Filter>,
     ) -> CollectionResult<BTreeSet<PointIdType>> {
@@ -558,7 +558,7 @@ impl LocalShard {
         Ok(all_points)
     }
 
-    pub async fn get_telemetry_data(&self) -> LocalShardTelemetry {
+    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         let segments: Vec<_> = self
             .segments()
             .read()

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -146,12 +146,10 @@ impl ShardOperation for LocalShard {
 
     async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
         let total_count = if request.exact {
-            let all_points = self.read_filtered(request.filter.as_ref()).await?;
+            let all_points = self.read_filtered(request.filter.as_ref())?;
             all_points.len()
         } else {
-            self.estimate_cardinality(request.filter.as_ref())
-                .await?
-                .exp
+            self.estimate_cardinality(request.filter.as_ref())?.exp
         };
         Ok(CountResult { count: total_count })
     }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -114,8 +114,8 @@ impl ProxyShard {
         self.wrapped_shard.before_drop().await
     }
 
-    pub async fn get_telemetry_data(&self) -> LocalShardTelemetry {
-        self.wrapped_shard.get_telemetry_data().await
+    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+        self.wrapped_shard.get_telemetry_data()
     }
 }
 
@@ -133,12 +133,12 @@ impl ShardOperation for ProxyShard {
             OperationEffectArea::Empty => PointsOperationEffect::Empty,
             OperationEffectArea::Points(points) => PointsOperationEffect::Some(points),
             OperationEffectArea::Filter(filter) => {
-                let cardinality = local_shard.estimate_cardinality(Some(&filter)).await?;
+                let cardinality = local_shard.estimate_cardinality(Some(&filter))?;
                 // validate the size of the change set before retrieving it
                 if cardinality.max > MAX_CHANGES_TRACKED_COUNT {
                     PointsOperationEffect::Many
                 } else {
-                    let points = local_shard.read_filtered(Some(&filter)).await?;
+                    let points = local_shard.read_filtered(Some(&filter))?;
                     PointsOperationEffect::Some(points.into_iter().collect())
                 }
             }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -678,11 +678,9 @@ impl ShardReplicaSet {
 
     pub(crate) async fn get_telemetry_data(&self) -> ReplicaSetTelemetry {
         let local_shard = self.local.read().await;
-        let local = if let Some(local_shard) = &*local_shard {
-            Some(local_shard.get_telemetry_data().await)
-        } else {
-            None
-        };
+        let local = local_shard
+            .as_ref()
+            .map(|local_shard| local_shard.get_telemetry_data());
         ReplicaSetTelemetry {
             id: self.shard_id,
             local,
@@ -699,7 +697,7 @@ impl ShardReplicaSet {
 
     /// Returns if local shard was recovered from path
     pub async fn restore_local_replica_from(&self, replica_path: &Path) -> CollectionResult<bool> {
-        if LocalShard::check_data(replica_path).await {
+        if LocalShard::check_data(replica_path) {
             let mut local = self.local.write().await;
             let removed_local = local.take();
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -48,11 +48,11 @@ impl Shard {
         }
     }
 
-    pub async fn get_telemetry_data(&self) -> LocalShardTelemetry {
+    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         let mut telemetry = match self {
-            Shard::Local(local_shard) => local_shard.get_telemetry_data().await,
-            Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data().await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data().await,
+            Shard::Local(local_shard) => local_shard.get_telemetry_data(),
+            Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data(),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
         };
         telemetry.variant_name = Some(self.variant_name().to_string());
         telemetry


### PR DESCRIPTION
I have spotted a few places which do not require `async fn` and followed the call sites for cleanup.