### PR TITLE
Faster snapshot creation

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -509,12 +509,12 @@ mod tests {
     use std::{thread, time};
 
     use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
-    use segment::types::{Distance, PayloadFieldSchema, PayloadKeyType};
+    use segment::types::Distance;
     use serde_json::json;
     use tempfile::Builder;
 
     use super::*;
-    use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
+    use crate::collection_manager::fixtures::{build_segment_1, build_segment_2};
 
     #[test]
     fn test_add_and_swap() {

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::path::Path;
 use std::result;
 use std::thread::JoinHandle;
 
@@ -119,6 +120,10 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
     pub fn flush_async(&mut self) -> JoinHandle<std::io::Result<()>> {
         self.wal.flush_open_segment_async()
+    }
+
+    pub fn path(&self) -> &Path {
+        self.wal.path()
     }
 }
 


### PR DESCRIPTION
The current process of snapshot creation might be slow, if shard is currently under optimization.
But instead of trying to save proper state of the segments, why don't we just fix all problems on the load?

This PR significantly simplifies process of snapshot creation, while also introducing additional checks for recovery and points updates:

- Deduplication process will remove outdated and redundant copies of points from the shard's segments

There is also an async removal of tmp files, I don't expect a significant speedup there, just nice-to-have optimization
