### PR TITLE
List aliases API (rest & gRPC)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,11 +70,10 @@ Here is a quick step-by-step guide:
 2. change specs in `/openapi/*ytt.yaml`
 3. add new schema definitions to `src/schema_generator.rs`
 4. run `/tools/generate_openapi_models.sh` to generate specs
-5. move newly created openapi.json `cp docs/redoc/openapi.json docs/redoc/master/openapi.json`
-6. update integration tests `openapi/tests/openapi_integration`
-7. expose file by starting an HTTP server, for instance `python -m http.server`, in `/docs/redoc`
-8. validate specs by browsing redoc on `http://localhost:8000/?v=master`
-9. validate `openapi-merged.yaml` using [swagger editor](https://editor.swagger.io/)
+5. update integration tests `openapi/tests/openapi_integration` and run them with `./tests/openapi_integration_test.sh`
+6. expose file by starting an HTTP server, for instance `python -m http.server`, in `/docs/redoc`
+7. validate specs by browsing redoc on `http://localhost:8000/?v=master`
+8. validate `openapi-merged.yaml` using [swagger editor](https://editor.swagger.io/)
 
 ### gRPC
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -23,6 +23,7 @@
     - [HnswConfigDiff](#qdrant-HnswConfigDiff)
     - [ListAliasesRequest](#qdrant-ListAliasesRequest)
     - [ListAliasesResponse](#qdrant-ListAliasesResponse)
+    - [ListCollectionAliasesRequest](#qdrant-ListCollectionAliasesRequest)
     - [ListCollectionsRequest](#qdrant-ListCollectionsRequest)
     - [ListCollectionsResponse](#qdrant-ListCollectionsResponse)
     - [OptimizerStatus](#qdrant-OptimizerStatus)
@@ -466,6 +467,21 @@
 
 
 
+<a name="qdrant-ListCollectionAliasesRequest"></a>
+
+### ListCollectionAliasesRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+
+
+
+
+
+
 <a name="qdrant-ListCollectionsRequest"></a>
 
 ### ListCollectionsRequest
@@ -792,7 +808,8 @@ If indexation speed have more priority for your - make this parameter lower. If 
 | Update | [UpdateCollection](#qdrant-UpdateCollection) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Update parameters of the existing collection |
 | Delete | [DeleteCollection](#qdrant-DeleteCollection) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Drop collection and all associated data |
 | UpdateAliases | [ChangeAliases](#qdrant-ChangeAliases) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Update Aliases of the existing collection |
-| ListAliases | [ListAliasesRequest](#qdrant-ListAliasesRequest) | [ListAliasesResponse](#qdrant-ListAliasesResponse) | Get list name of all existing collections |
+| ListCollectionAliases | [ListCollectionAliasesRequest](#qdrant-ListCollectionAliasesRequest) | [ListAliasesResponse](#qdrant-ListAliasesResponse) | Get list of all aliases for a collection |
+| ListAliases | [ListAliasesRequest](#qdrant-ListAliasesRequest) | [ListAliasesResponse](#qdrant-ListAliasesResponse) | Get list of all aliases for all existing collections |
 
  
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4,6 +4,7 @@
 ## Table of Contents
 
 - [collections.proto](#collections-proto)
+    - [AliasDescription](#qdrant-AliasDescription)
     - [AliasOperations](#qdrant-AliasOperations)
     - [ChangeAliases](#qdrant-ChangeAliases)
     - [CollectionConfig](#qdrant-CollectionConfig)
@@ -20,6 +21,8 @@
     - [GetCollectionInfoRequest](#qdrant-GetCollectionInfoRequest)
     - [GetCollectionInfoResponse](#qdrant-GetCollectionInfoResponse)
     - [HnswConfigDiff](#qdrant-HnswConfigDiff)
+    - [ListAliasesRequest](#qdrant-ListAliasesRequest)
+    - [ListAliasesResponse](#qdrant-ListAliasesResponse)
     - [ListCollectionsRequest](#qdrant-ListCollectionsRequest)
     - [ListCollectionsResponse](#qdrant-ListCollectionsResponse)
     - [OptimizerStatus](#qdrant-OptimizerStatus)
@@ -141,6 +144,22 @@
 <p align="right"><a href="#top">Top</a></p>
 
 ## collections.proto
+
+
+
+<a name="qdrant-AliasDescription"></a>
+
+### AliasDescription
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| alias_name | [string](#string) |  | Name of the alias |
+| collection_name | [string](#string) |  | Name of the collection |
+
+
+
 
 
 
@@ -415,6 +434,32 @@
 | max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
 | on_disk | [bool](#bool) | optional | Store HNSW index on disk. If set to false, index will be stored in RAM. |
 | payload_m | [uint64](#uint64) | optional | Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used. |
+
+
+
+
+
+
+<a name="qdrant-ListAliasesRequest"></a>
+
+### ListAliasesRequest
+
+
+
+
+
+
+
+<a name="qdrant-ListAliasesResponse"></a>
+
+### ListAliasesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| aliases | [AliasDescription](#qdrant-AliasDescription) | repeated |  |
+| time | [double](#double) |  | Time spent to process |
 
 
 
@@ -747,6 +792,7 @@ If indexation speed have more priority for your - make this parameter lower. If 
 | Update | [UpdateCollection](#qdrant-UpdateCollection) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Update parameters of the existing collection |
 | Delete | [DeleteCollection](#qdrant-DeleteCollection) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Drop collection and all associated data |
 | UpdateAliases | [ChangeAliases](#qdrant-ChangeAliases) | [CollectionOperationResponse](#qdrant-CollectionOperationResponse) | Update Aliases of the existing collection |
+| ListAliases | [ListAliasesRequest](#qdrant-ListAliasesRequest) | [ListAliasesResponse](#qdrant-ListAliasesResponse) | Get list name of all existing collections |
 
  
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1167,6 +1167,133 @@
         }
       }
     },
+    "/collections/{collection_name}/aliases": {
+      "get": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "List aliases for collection",
+        "description": "Get list of all aliases for a collection",
+        "operationId": "get_collection_aliases",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CollectionsAliasesResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aliases": {
+      "get": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "List collections aliases",
+        "description": "Get list of all existing collections aliases",
+        "operationId": "get_collections_aliases",
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CollectionsAliasesResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/snapshots/recover": {
       "put": {
         "tags": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -779,6 +779,62 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "List collections aliases",
+        "description": "Get list of all existing collections aliases",
+        "operationId": "get_collections_mappings",
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CollectionsAliasesResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/collections/{collection_name}/index": {
@@ -6212,6 +6268,35 @@
           "snapshot",
           "replica"
         ]
+      },
+      "CollectionsAliasesResponse": {
+        "type": "object",
+        "required": [
+          "aliases"
+        ],
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AliasDescription"
+            }
+          }
+        }
+      },
+      "AliasDescription": {
+        "type": "object",
+        "required": [
+          "alias_name",
+          "collection_name"
+        ],
+        "properties": {
+          "alias_name": {
+            "type": "string"
+          },
+          "collection_name": {
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -277,6 +277,10 @@ message DeleteAlias {
 message ListAliasesRequest {
 }
 
+message ListCollectionAliasesRequest {
+  string collection_name = 1; // Name of the collection
+}
+
 message AliasDescription {
   string alias_name = 1; // Name of the alias
   string collection_name = 2; // Name of the collection

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -273,3 +273,16 @@ message RenameAlias {
 message DeleteAlias {
   string alias_name = 1; // Name of the alias
 }
+
+message ListAliasesRequest {
+}
+
+message AliasDescription {
+  string alias_name = 1; // Name of the alias
+  string collection_name = 2; // Name of the collection
+}
+
+message ListAliasesResponse {
+  repeated AliasDescription aliases = 1;
+  double time = 2; // Time spent to process
+}

--- a/lib/api/src/grpc/proto/collections_service.proto
+++ b/lib/api/src/grpc/proto/collections_service.proto
@@ -30,7 +30,11 @@ service Collections {
   */
   rpc UpdateAliases (ChangeAliases) returns (CollectionOperationResponse) {}
   /*
-  Get list name of all existing collections
+  Get list of all aliases for a collection
+  */
+  rpc ListCollectionAliases (ListCollectionAliasesRequest) returns (ListAliasesResponse) {}
+  /*
+  Get list of all aliases for all existing collections
   */
   rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse) {}
 }

--- a/lib/api/src/grpc/proto/collections_service.proto
+++ b/lib/api/src/grpc/proto/collections_service.proto
@@ -29,4 +29,8 @@ service Collections {
   Update Aliases of the existing collection
   */
   rpc UpdateAliases (ChangeAliases) returns (CollectionOperationResponse) {}
+  /*
+  Get list name of all existing collections
+  */
+  rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse) {}
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -416,6 +416,28 @@ pub struct DeleteAlias {
     #[prost(string, tag = "1")]
     pub alias_name: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListAliasesRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AliasDescription {
+    /// Name of the alias
+    #[prost(string, tag = "1")]
+    pub alias_name: ::prost::alloc::string::String,
+    /// Name of the collection
+    #[prost(string, tag = "2")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListAliasesResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub aliases: ::prost::alloc::vec::Vec<AliasDescription>,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Distance {
@@ -702,6 +724,27 @@ pub mod collections_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        ///
+        /// Get list name of all existing collections
+        pub async fn list_aliases(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListAliasesRequest>,
+        ) -> Result<tonic::Response<super::ListAliasesResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/ListAliases",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -747,6 +790,12 @@ pub mod collections_server {
             &self,
             request: tonic::Request<super::ChangeAliases>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ///
+        /// Get list name of all existing collections
+        async fn list_aliases(
+            &self,
+            request: tonic::Request<super::ListAliasesRequest>,
+        ) -> Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct CollectionsServer<T: Collections> {
@@ -1026,6 +1075,46 @@ pub mod collections_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UpdateAliasesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/ListAliases" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListAliasesSvc<T: Collections>(pub Arc<T>);
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ListAliasesRequest>
+                    for ListAliasesSvc<T> {
+                        type Response = super::ListAliasesResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListAliasesRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).list_aliases(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ListAliasesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -421,6 +421,13 @@ pub struct DeleteAlias {
 pub struct ListAliasesRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListCollectionAliasesRequest {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AliasDescription {
     /// Name of the alias
     #[prost(string, tag = "1")]
@@ -725,7 +732,28 @@ pub mod collections_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
-        /// Get list name of all existing collections
+        /// Get list of all aliases for a collection
+        pub async fn list_collection_aliases(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListCollectionAliasesRequest>,
+        ) -> Result<tonic::Response<super::ListAliasesResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/ListCollectionAliases",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        ///
+        /// Get list of all aliases for all existing collections
         pub async fn list_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAliasesRequest>,
@@ -791,7 +819,13 @@ pub mod collections_server {
             request: tonic::Request<super::ChangeAliases>,
         ) -> Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
-        /// Get list name of all existing collections
+        /// Get list of all aliases for a collection
+        async fn list_collection_aliases(
+            &self,
+            request: tonic::Request<super::ListCollectionAliasesRequest>,
+        ) -> Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
+        ///
+        /// Get list of all aliases for all existing collections
         async fn list_aliases(
             &self,
             request: tonic::Request<super::ListAliasesRequest>,
@@ -1075,6 +1109,46 @@ pub mod collections_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UpdateAliasesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/ListCollectionAliases" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListCollectionAliasesSvc<T: Collections>(pub Arc<T>);
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ListCollectionAliasesRequest>
+                    for ListCollectionAliasesSvc<T> {
+                        type Response = super::ListAliasesResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListCollectionAliasesRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).list_collection_aliases(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ListCollectionAliasesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -18,9 +18,9 @@ use crate::operations::point_ops::{
     Batch, FilterSelector, PointIdsList, PointStruct, PointsSelector,
 };
 use crate::operations::types::{
-    CollectionInfo, CollectionStatus, CountResult, LookupLocation, OptimizersStatus,
-    RecommendRequest, Record, SearchRequest, UpdateResult, UpdateStatus, VectorParams,
-    VectorsConfig,
+    AliasDescription, CollectionInfo, CollectionStatus, CountResult, LookupLocation,
+    OptimizersStatus, RecommendRequest, Record, SearchRequest, UpdateResult, UpdateStatus,
+    VectorParams, VectorsConfig,
 };
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::CollectionSearchRequest;
@@ -635,6 +635,15 @@ impl From<VectorParams> for api::grpc::qdrant::VectorParams {
                 Distance::Dot => api::grpc::qdrant::Distance::Dot,
             }
             .into(),
+        }
+    }
+}
+
+impl From<AliasDescription> for api::grpc::qdrant::AliasDescription {
+    fn from(value: AliasDescription) -> Self {
+        api::grpc::qdrant::AliasDescription {
+            alias_name: value.alias_name,
+            collection_name: value.collection_name,
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -699,3 +699,16 @@ impl VectorsConfig {
         }
     }
 }
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct AliasDescription {
+    pub alias_name: String,
+    pub collection_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CollectionsAliasesResponse {
+    pub aliases: Vec<AliasDescription>,
+}

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -14,7 +14,7 @@ use collection::config::{
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
-    CollectionResult, CountRequest, CountResult, PointRequest, RecommendRequest,
+    AliasDescription, CollectionResult, CountRequest, CountResult, PointRequest, RecommendRequest,
     RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch,
     UpdateResult,
 };
@@ -1018,6 +1018,22 @@ impl TableOfContent {
             .await
             .collection_aliases(collection_name);
         Ok(result)
+    }
+
+    /// List of all aliases across all collections
+    pub async fn list_aliases(&self) -> Result<Vec<AliasDescription>, StorageError> {
+        let all_collections = self.all_collections().await;
+        let mut aliases: Vec<AliasDescription> = Default::default();
+        for collection_name in &all_collections {
+            for alias in self.collection_aliases(collection_name).await? {
+                aliases.push(AliasDescription {
+                    alias_name: alias.to_string(),
+                    collection_name: collection_name.to_string(),
+                });
+            }
+        }
+
+        Ok(aliases)
     }
 
     /// Paginate over all stored points with given filtering conditions

--- a/openapi/openapi-collections.ytt.yaml
+++ b/openapi/openapi-collections.ytt.yaml
@@ -236,3 +236,28 @@ paths:
           schema:
             type: integer
       responses: #@ response(type("boolean"))
+
+  /collections/{collection_name}/aliases:
+    get:
+      tags:
+        - collections
+      summary: List aliases for collection
+      description: Get list of all aliases for a collection
+      operationId: get_collection_aliases
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection
+          required: true
+          schema:
+            type: string
+      responses: #@ response(reference("CollectionsAliasesResponse"))
+
+  /aliases:
+    get:
+      tags:
+        - collections
+      summary: List collections aliases
+      description: Get list of all existing collections aliases
+      operationId: get_collections_aliases
+      responses: #@ response(reference("CollectionsAliasesResponse"))

--- a/openapi/openapi-collections.ytt.yaml
+++ b/openapi/openapi-collections.ytt.yaml
@@ -127,6 +127,13 @@ paths:
           schema:
             type: integer
       responses: #@ response(type("boolean"))
+    get:
+      tags:
+        - collections
+      summary: List collections aliases
+      description: Get list of all existing collections aliases
+      operationId: get_collections_mappings
+      responses: #@ response(reference("CollectionsAliasesResponse"))
 
   /collections/{collection_name}/index:
     put:

--- a/openapi/tests/openapi_integration/test_alias.py
+++ b/openapi/tests/openapi_integration/test_alias.py
@@ -31,14 +31,25 @@ def test_alias_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/aliases',
+        api='/aliases',
         method="GET"
     )
     assert response.ok
     assert len(response.json()['result']['aliases']) == 1
     first_alias = response.json()['result']['aliases'][0]
     assert first_alias['alias_name'] == 'test_alias'
-    assert first_alias['collection_name'] == 'test_collection_alias'
+    assert first_alias['collection_name'] == collection_name
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/aliases',
+        path_params={'collection_name': collection_name},
+        method="GET"
+    )
+    assert response.ok
+    assert len(response.json()['result']['aliases']) == 1
+    first_alias = response.json()['result']['aliases'][0]
+    assert first_alias['alias_name'] == 'test_alias'
+    assert first_alias['collection_name'] == collection_name
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
@@ -80,7 +91,7 @@ def test_alias_operations():
     assert response.ok
 
     response = request_with_validation(
-        api='/collections/aliases',
+        api='/aliases',
         method="GET"
     )
     assert response.ok

--- a/openapi/tests/openapi_integration/test_alias.py
+++ b/openapi/tests/openapi_integration/test_alias.py
@@ -31,6 +31,16 @@ def test_alias_operations():
     assert response.ok
 
     response = request_with_validation(
+        api='/collections/aliases',
+        method="GET"
+    )
+    assert response.ok
+    assert len(response.json()['result']['aliases']) == 1
+    first_alias = response.json()['result']['aliases'][0]
+    assert first_alias['alias_name'] == 'test_alias'
+    assert first_alias['collection_name'] == 'test_collection_alias'
+
+    response = request_with_validation(
         api='/collections/{collection_name}/points/search',
         method="POST",
         path_params={'collection_name': collection_name},
@@ -68,6 +78,13 @@ def test_alias_operations():
         }
     )
     assert response.ok
+
+    response = request_with_validation(
+        api='/collections/aliases',
+        method="GET"
+    )
+    assert response.ok
+    assert len(response.json()['result']['aliases']) == 0
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',

--- a/openapi/tests/openapi_integration/test_count.py
+++ b/openapi/tests/openapi_integration/test_count.py
@@ -67,6 +67,5 @@ def test_approx_count_search():
         }
     )
     assert response.ok
-    print(response.json())
     assert response.json()['result']['count'] < 6
     assert response.json()['result']['count'] > 0

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -32,7 +32,7 @@ async fn get_collections(toc: web::Data<TableOfContent>) -> impl Responder {
     process_response(response, timing)
 }
 
-#[get("/collections/aliases")]
+#[get("/aliases")]
 async fn get_aliases(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();
     let response = do_list_aliases(toc.get_ref()).await;
@@ -44,6 +44,17 @@ async fn get_collection(toc: web::Data<TableOfContent>, path: web::Path<String>)
     let name = path.into_inner();
     let timing = Instant::now();
     let response = do_get_collection(toc.get_ref(), &name, None).await;
+    process_response(response, timing)
+}
+
+#[get("/collections/{name}/aliases")]
+async fn get_collection_aliases(
+    toc: web::Data<TableOfContent>,
+    path: web::Path<String>,
+) -> impl Responder {
+    let name = path.into_inner();
+    let timing = Instant::now();
+    let response = do_list_collection_aliases(toc.get_ref(), &name).await;
     process_response(response, timing)
 }
 
@@ -158,11 +169,12 @@ async fn update_collection_cluster(
 // Configure services
 pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
     cfg.service(get_collections)
-        .service(get_aliases) // higher priority than /collections/{name}
         .service(get_collection)
         .service(create_collection)
         .service(update_collection)
         .service(delete_collection)
+        .service(get_aliases)
+        .service(get_collection_aliases)
         .service(update_aliases)
         .service(get_cluster_info)
         .service(update_collection_cluster);

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -32,6 +32,13 @@ async fn get_collections(toc: web::Data<TableOfContent>) -> impl Responder {
     process_response(response, timing)
 }
 
+#[get("/collections/aliases")]
+async fn get_aliases(toc: web::Data<TableOfContent>) -> impl Responder {
+    let timing = Instant::now();
+    let response = do_list_aliases(toc.get_ref()).await;
+    process_response(response, timing)
+}
+
 #[get("/collections/{name}")]
 async fn get_collection(toc: web::Data<TableOfContent>, path: web::Path<String>) -> impl Responder {
     let name = path.into_inner();
@@ -151,6 +158,7 @@ async fn update_collection_cluster(
 // Configure services
 pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
     cfg.service(get_collections)
+        .service(get_aliases) // higher priority than /collections/{name}
         .service(get_collection)
         .service(create_collection)
         .service(update_collection)

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -6,7 +6,9 @@ use collection::operations::cluster_ops::{
     ReplicateShardOperation,
 };
 use collection::operations::snapshot_ops::SnapshotDescription;
-use collection::operations::types::{CollectionClusterInfo, CollectionInfo};
+use collection::operations::types::{
+    CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
+};
 use collection::shards::replica_set;
 use collection::shards::shard::ShardId;
 use collection::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
@@ -37,6 +39,13 @@ pub async fn do_list_collections(toc: &TableOfContent) -> CollectionsResponse {
         .collect_vec();
 
     CollectionsResponse { collections }
+}
+
+pub async fn do_list_aliases(
+    toc: &TableOfContent,
+) -> Result<CollectionsAliasesResponse, StorageError> {
+    let aliases = toc.list_aliases().await?;
+    Ok(CollectionsAliasesResponse { aliases })
 }
 
 pub async fn do_list_snapshots(

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -7,7 +7,7 @@ use collection::operations::cluster_ops::{
 };
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
-    CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
+    AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
 };
 use collection::shards::replica_set;
 use collection::shards::shard::ShardId;
@@ -39,6 +39,20 @@ pub async fn do_list_collections(toc: &TableOfContent) -> CollectionsResponse {
         .collect_vec();
 
     CollectionsResponse { collections }
+}
+
+pub async fn do_list_collection_aliases(
+    toc: &TableOfContent,
+    collection_name: &str,
+) -> Result<CollectionsAliasesResponse, StorageError> {
+    let mut aliases: Vec<AliasDescription> = Default::default();
+    for alias in toc.collection_aliases(collection_name).await? {
+        aliases.push(AliasDescription {
+            alias_name: alias.to_string(),
+            collection_name: collection_name.to_string(),
+        });
+    }
+    Ok(CollectionsAliasesResponse { aliases })
 }
 
 pub async fn do_list_aliases(

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -4,9 +4,9 @@ use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector};
 use collection::operations::snapshot_ops::{SnapshotDescription, SnapshotRecover};
 use collection::operations::types::{
-    CollectionClusterInfo, CollectionInfo, CountRequest, CountResult, PointRequest,
-    RecommendRequest, RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchRequest,
-    SearchRequestBatch, UpdateResult,
+    AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
+    CountRequest, CountResult, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
+    ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult,
 };
 use schemars::{schema_for, JsonSchema};
 use segment::types::ScoredPoint;
@@ -57,6 +57,8 @@ struct AllDefinitions {
     au: RecommendRequestBatch,
     av: LocksOption,
     aw: SnapshotRecover,
+    ax: CollectionsAliasesResponse,
+    ay: AliasDescription,
 }
 
 fn save_schema<T: JsonSchema>() {


### PR DESCRIPTION
This PR adds a new API for listing existing collections aliases. 

- openapi docs generated
- openapi test
- gRPC docs

This change requires to update the clients to expose the new feature.