### PR TITLE
do not abort transfer task if it was finished with success

### DIFF
--- a/lib/collection/src/common/stoppable_task_async.rs
+++ b/lib/collection/src/common/stoppable_task_async.rs
@@ -2,15 +2,17 @@ use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
+use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
-pub struct StoppableAsyncTaskHandle<T> {
+pub struct StoppableAsyncTaskHandle<T: Clone> {
     pub join_handle: JoinHandle<T>,
+    result_holder: Arc<Mutex<Option<T>>>,
     finished: Arc<AtomicBool>,
     stopped: Weak<AtomicBool>,
 }
 
-impl<T> StoppableAsyncTaskHandle<T> {
+impl<T: Clone> StoppableAsyncTaskHandle<T> {
     pub fn is_finished(&self) -> bool {
         self.finished.load(Ordering::Relaxed)
     }
@@ -25,6 +27,10 @@ impl<T> StoppableAsyncTaskHandle<T> {
         self.ask_to_stop();
         self.join_handle
     }
+
+    pub fn get_result(&self) -> Option<T> {
+        self.result_holder.lock().clone()
+    }
 }
 
 pub fn spawn_async_stoppable<F, T>(f: F) -> StoppableAsyncTaskHandle<T::Output>
@@ -32,7 +38,7 @@ where
     F: FnOnce(Arc<AtomicBool>) -> T,
     F: Send + 'static,
     T: Future + Send + 'static,
-    T::Output: Send + 'static,
+    T::Output: Clone + Send + 'static,
 {
     let finished = Arc::new(AtomicBool::new(false));
     let finished_c = finished.clone();
@@ -42,14 +48,21 @@ where
     // Weak reference is sufficient
     let stopped_w = Arc::downgrade(&stopped);
 
+    let result_holder = Arc::new(Mutex::new(None));
+    let result_holder_c = result_holder.clone();
+
     StoppableAsyncTaskHandle {
         join_handle: tokio::task::spawn(async move {
             let res = f(stopped).await;
+            let mut result_holder_w = result_holder_c.lock();
+            result_holder_w.replace(res.clone());
+
             // We use `Release` ordering to ensure that `f` won't be moved after the `store`
             // by the compiler
             finished.store(true, Ordering::Release);
             res
         }),
+        result_holder,
         stopped: stopped_w,
         finished: finished_c,
     }

--- a/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
+++ b/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
@@ -40,6 +40,17 @@ impl TransferTasksPool {
         }
     }
 
+    /// Return true if task finished
+    /// Return false if task failed or stopped
+    /// Return None if task not found or not finished
+    pub fn get_task_result(&self, transfer_key: &ShardTransferKey) -> Option<bool> {
+        if let Some(task) = self.tasks.get(transfer_key) {
+            task.get_result()
+        } else {
+            None
+        }
+    }
+
     /// Returns true if the task was actually stopped
     /// Returns false if the task was not found
     pub async fn stop_if_exists(&mut self, transfer_key: &ShardTransferKey) -> TaskResult {


### PR DESCRIPTION
Before we were trying to abort transfer regardless of it's actual result in case if transfer task was cancelled, assuming that the consensus channel ordered proposals properly. But apparently this assumption does not hold.

So now, we explicitly check the result of transfer task in order to report proper result of transfer to the consensus.