### PR TITLE
Remove some blocking IO calls on Tokio threads

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1350,6 +1350,9 @@ impl Collection {
             .await
     }
 
+    /// Restore collection from snapshot
+    ///
+    /// This method performs blocking IO.
     pub fn restore_snapshot(snapshot_path: &Path, target_dir: &Path) -> CollectionResult<()> {
         // decompress archive
         let archive_file = std::fs::File::open(snapshot_path)?;

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -1,6 +1,5 @@
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
-use std::fs::remove_file;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -189,7 +188,7 @@ impl LocalShard {
         for entry in segment_dirs {
             let segments_path = entry.unwrap().path();
             if segments_path.ends_with("deleted") {
-                std::fs::remove_dir_all(&segments_path).map_err(|_| {
+                remove_dir_all(&segments_path).await.map_err(|_| {
                     CollectionError::service_error(format!(
                         "Can't remove marked-for-remove segment {}",
                         segments_path.to_str().unwrap()
@@ -479,7 +478,7 @@ impl LocalShard {
                 }
                 let segment_id = segment_id_opt.unwrap();
                 Segment::restore_snapshot(&entry_path, &segment_id)?;
-                remove_file(&entry_path)?;
+                std::fs::remove_file(&entry_path)?;
             }
         }
         Ok(())

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -1,6 +1,5 @@
 use core::cmp;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
@@ -196,7 +195,7 @@ impl SegmentBuilder {
         }
 
         // Move fully constructed segment into collection directory and load back to RAM
-        fs::rename(&self.temp_path, &self.destination_path)
+        std::fs::rename(&self.temp_path, &self.destination_path)
             .describe("Moving segment data after optimization")?;
 
         load_segment(&self.destination_path)?.ok_or_else(|| {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fs::{create_dir_all, File};
+use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
@@ -210,7 +210,7 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
 pub fn build_segment(path: &Path, config: &SegmentConfig) -> OperationResult<Segment> {
     let segment_path = path.join(Uuid::new_v4().to_string());
 
-    create_dir_all(&segment_path)?;
+    std::fs::create_dir_all(&segment_path)?;
 
     let segment = create_segment(0, &segment_path, config)?;
     segment.save_current_state()?;

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -81,8 +81,12 @@ pub async fn do_recover_from_snapshot(
 
     log::debug!("Unpacking snapshot to {}", tmp_collection_dir.display());
 
-    // Unpack snapshot collection to the target folder
-    Collection::restore_snapshot(&snapshot_path, &tmp_collection_dir)?;
+    let tmp_collection_dir_clone = tmp_collection_dir.clone();
+    let restoring = tokio::task::spawn_blocking(move || {
+        // Unpack snapshot collection to the target folder
+        Collection::restore_snapshot(&snapshot_path, &tmp_collection_dir_clone)
+    });
+    restoring.await??;
 
     let snapshot_config = CollectionConfig::load(&tmp_collection_dir)?;
 


### PR DESCRIPTION
This PR removes a few blocking IO calls made on the Tokio runtime and makes blocking calls clearer where possible.
