### PR TITLE
Delete snapshots API

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -130,9 +130,9 @@
     - [CreateFullSnapshotRequest](#qdrant-CreateFullSnapshotRequest)
     - [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest)
     - [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse)
-    - [DeleteFullSnapshotsRequest](#qdrant-DeleteFullSnapshotsRequest)
-    - [DeleteSnapshotsRequest](#qdrant-DeleteSnapshotsRequest)
-    - [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse)
+    - [DeleteFullSnapshotRequest](#qdrant-DeleteFullSnapshotRequest)
+    - [DeleteSnapshotRequest](#qdrant-DeleteSnapshotRequest)
+    - [DeleteSnapshotResponse](#qdrant-DeleteSnapshotResponse)
     - [ListFullSnapshotsRequest](#qdrant-ListFullSnapshotsRequest)
     - [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest)
     - [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse)
@@ -2073,9 +2073,9 @@ The JSON representation for `Value` is JSON value.
 
 
 
-<a name="qdrant-DeleteFullSnapshotsRequest"></a>
+<a name="qdrant-DeleteFullSnapshotRequest"></a>
 
-### DeleteFullSnapshotsRequest
+### DeleteFullSnapshotRequest
 
 
 
@@ -2088,9 +2088,9 @@ The JSON representation for `Value` is JSON value.
 
 
 
-<a name="qdrant-DeleteSnapshotsRequest"></a>
+<a name="qdrant-DeleteSnapshotRequest"></a>
 
-### DeleteSnapshotsRequest
+### DeleteSnapshotRequest
 
 
 
@@ -2104,9 +2104,9 @@ The JSON representation for `Value` is JSON value.
 
 
 
-<a name="qdrant-DeleteSnapshotsResponse"></a>
+<a name="qdrant-DeleteSnapshotResponse"></a>
 
-### DeleteSnapshotsResponse
+### DeleteSnapshotResponse
 
 
 
@@ -2192,10 +2192,10 @@ The JSON representation for `Value` is JSON value.
 | ----------- | ------------ | ------------- | ------------|
 | Create | [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest) | [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse) | Create collection snapshot |
 | List | [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest) | [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse) | List collection snapshots |
-| Delete | [DeleteSnapshotsRequest](#qdrant-DeleteSnapshotsRequest) | [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse) | Delete collection snapshots |
+| Delete | [DeleteSnapshotRequest](#qdrant-DeleteSnapshotRequest) | [DeleteSnapshotResponse](#qdrant-DeleteSnapshotResponse) | Delete collection snapshots |
 | CreateFull | [CreateFullSnapshotRequest](#qdrant-CreateFullSnapshotRequest) | [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse) | Create full storage snapshot |
 | ListFull | [ListFullSnapshotsRequest](#qdrant-ListFullSnapshotsRequest) | [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse) | List full storage snapshots |
-| DeleteFull | [DeleteFullSnapshotsRequest](#qdrant-DeleteFullSnapshotsRequest) | [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse) | List full storage snapshots |
+| DeleteFull | [DeleteFullSnapshotRequest](#qdrant-DeleteFullSnapshotRequest) | [DeleteSnapshotResponse](#qdrant-DeleteSnapshotResponse) | List full storage snapshots |
 
  
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -130,6 +130,9 @@
     - [CreateFullSnapshotRequest](#qdrant-CreateFullSnapshotRequest)
     - [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest)
     - [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse)
+    - [DeleteFullSnapshotsRequest](#qdrant-DeleteFullSnapshotsRequest)
+    - [DeleteSnapshotsRequest](#qdrant-DeleteSnapshotsRequest)
+    - [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse)
     - [ListFullSnapshotsRequest](#qdrant-ListFullSnapshotsRequest)
     - [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest)
     - [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse)
@@ -2070,6 +2073,52 @@ The JSON representation for `Value` is JSON value.
 
 
 
+<a name="qdrant-DeleteFullSnapshotsRequest"></a>
+
+### DeleteFullSnapshotsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| snapshot_name | [string](#string) |  | Name of the full snapshot |
+
+
+
+
+
+
+<a name="qdrant-DeleteSnapshotsRequest"></a>
+
+### DeleteSnapshotsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | Name of the collection |
+| snapshot_name | [string](#string) |  | Name of the collection snapshot |
+
+
+
+
+
+
+<a name="qdrant-DeleteSnapshotsResponse"></a>
+
+### DeleteSnapshotsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| time | [double](#double) |  | Time spent to process |
+
+
+
+
+
+
 <a name="qdrant-ListFullSnapshotsRequest"></a>
 
 ### ListFullSnapshotsRequest
@@ -2143,8 +2192,10 @@ The JSON representation for `Value` is JSON value.
 | ----------- | ------------ | ------------- | ------------|
 | Create | [CreateSnapshotRequest](#qdrant-CreateSnapshotRequest) | [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse) | Create collection snapshot |
 | List | [ListSnapshotsRequest](#qdrant-ListSnapshotsRequest) | [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse) | List collection snapshots |
+| Delete | [DeleteSnapshotsRequest](#qdrant-DeleteSnapshotsRequest) | [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse) | Delete collection snapshots |
 | CreateFull | [CreateFullSnapshotRequest](#qdrant-CreateFullSnapshotRequest) | [CreateSnapshotResponse](#qdrant-CreateSnapshotResponse) | Create full storage snapshot |
 | ListFull | [ListFullSnapshotsRequest](#qdrant-ListFullSnapshotsRequest) | [ListSnapshotsResponse](#qdrant-ListSnapshotsResponse) | List full storage snapshots |
+| DeleteFull | [DeleteFullSnapshotsRequest](#qdrant-DeleteFullSnapshotsRequest) | [DeleteSnapshotsResponse](#qdrant-DeleteSnapshotsResponse) | List full storage snapshots |
 
  
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1516,6 +1516,83 @@
       }
     },
     "/collections/{collection_name}/snapshots/{snapshot_name}": {
+      "delete": {
+        "tags": [
+          "snapshots",
+          "collections"
+        ],
+        "summary": "Delete collection snapshot",
+        "description": "Delete snapshot for a collection",
+        "operationId": "delete_snapshot",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection for which to delete a snapshot",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "snapshot_name",
+            "in": "path",
+            "description": "Name of the snapshot to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "tags": [
           "snapshots",
@@ -1697,6 +1774,73 @@
       }
     },
     "/snapshots/{snapshot_name}": {
+      "delete": {
+        "tags": [
+          "snapshots"
+        ],
+        "summary": "Delete storage snapshot",
+        "description": "Delete snapshot of the whole storage",
+        "operationId": "delete_full_snapshot",
+        "parameters": [
+          {
+            "name": "snapshot_name",
+            "in": "path",
+            "description": "Name of the full snapshot to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "tags": [
           "snapshots"

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -15,6 +15,10 @@ service Snapshots {
    */
   rpc List (ListSnapshotsRequest) returns (ListSnapshotsResponse) {}
   /*
+  Delete collection snapshots
+   */
+  rpc Delete (DeleteSnapshotsRequest) returns (DeleteSnapshotsResponse) {}
+  /*
   Create full storage snapshot
   */
   rpc CreateFull (CreateFullSnapshotRequest) returns (CreateSnapshotResponse) {}
@@ -22,12 +26,20 @@ service Snapshots {
   List full storage snapshots
    */
   rpc ListFull (ListFullSnapshotsRequest) returns (ListSnapshotsResponse) {}
+  /*
+  List full storage snapshots
+   */
+  rpc DeleteFull (DeleteFullSnapshotsRequest) returns (DeleteSnapshotsResponse) {}
 
 }
 
 message CreateFullSnapshotRequest {}
 
 message ListFullSnapshotsRequest {}
+
+message DeleteFullSnapshotsRequest {
+  string snapshot_name = 1; // Name of the full snapshot
+}
 
 message CreateSnapshotRequest {
   string collection_name = 1; // Name of the collection
@@ -37,6 +49,10 @@ message ListSnapshotsRequest {
   string collection_name = 1; // Name of the collection
 }
 
+message DeleteSnapshotsRequest {
+  string collection_name = 1; // Name of the collection
+  string snapshot_name = 2; // Name of the collection snapshot
+}
 
 message SnapshotDescription {
   string name = 1; // Name of the snapshot
@@ -52,4 +68,8 @@ message CreateSnapshotResponse {
 message ListSnapshotsResponse {
   repeated SnapshotDescription snapshot_descriptions = 1;
   double time = 2; // Time spent to process
+}
+
+message DeleteSnapshotsResponse {
+  double time = 1; // Time spent to process
 }

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -17,7 +17,7 @@ service Snapshots {
   /*
   Delete collection snapshots
    */
-  rpc Delete (DeleteSnapshotsRequest) returns (DeleteSnapshotsResponse) {}
+  rpc Delete (DeleteSnapshotRequest) returns (DeleteSnapshotResponse) {}
   /*
   Create full storage snapshot
   */
@@ -29,7 +29,7 @@ service Snapshots {
   /*
   List full storage snapshots
    */
-  rpc DeleteFull (DeleteFullSnapshotsRequest) returns (DeleteSnapshotsResponse) {}
+  rpc DeleteFull (DeleteFullSnapshotRequest) returns (DeleteSnapshotResponse) {}
 
 }
 
@@ -37,7 +37,7 @@ message CreateFullSnapshotRequest {}
 
 message ListFullSnapshotsRequest {}
 
-message DeleteFullSnapshotsRequest {
+message DeleteFullSnapshotRequest {
   string snapshot_name = 1; // Name of the full snapshot
 }
 
@@ -49,7 +49,7 @@ message ListSnapshotsRequest {
   string collection_name = 1; // Name of the collection
 }
 
-message DeleteSnapshotsRequest {
+message DeleteSnapshotRequest {
   string collection_name = 1; // Name of the collection
   string snapshot_name = 2; // Name of the collection snapshot
 }
@@ -70,6 +70,6 @@ message ListSnapshotsResponse {
   double time = 2; // Time spent to process
 }
 
-message DeleteSnapshotsResponse {
+message DeleteSnapshotResponse {
   double time = 1; // Time spent to process
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5252,7 +5252,7 @@ pub struct CreateFullSnapshotRequest {}
 pub struct ListFullSnapshotsRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteFullSnapshotsRequest {
+pub struct DeleteFullSnapshotRequest {
     /// Name of the full snapshot
     #[prost(string, tag = "1")]
     pub snapshot_name: ::prost::alloc::string::String,
@@ -5273,7 +5273,7 @@ pub struct ListSnapshotsRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteSnapshotsRequest {
+pub struct DeleteSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
@@ -5314,7 +5314,7 @@ pub struct ListSnapshotsResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteSnapshotsResponse {
+pub struct DeleteSnapshotResponse {
     /// Time spent to process
     #[prost(double, tag = "1")]
     pub time: f64,
@@ -5430,8 +5430,8 @@ pub mod snapshots_client {
         /// Delete collection snapshots
         pub async fn delete(
             &mut self,
-            request: impl tonic::IntoRequest<super::DeleteSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -5491,8 +5491,8 @@ pub mod snapshots_client {
         /// List full storage snapshots
         pub async fn delete_full(
             &mut self,
-            request: impl tonic::IntoRequest<super::DeleteFullSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::DeleteFullSnapshotRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -5533,8 +5533,8 @@ pub mod snapshots_server {
         /// Delete collection snapshots
         async fn delete(
             &self,
-            request: tonic::Request<super::DeleteSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status>;
+            request: tonic::Request<super::DeleteSnapshotRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
         ///
         /// Create full storage snapshot
         async fn create_full(
@@ -5551,8 +5551,8 @@ pub mod snapshots_server {
         /// List full storage snapshots
         async fn delete_full(
             &self,
-            request: tonic::Request<super::DeleteFullSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status>;
+            request: tonic::Request<super::DeleteFullSnapshotRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SnapshotsServer<T: Snapshots> {
@@ -5694,16 +5694,16 @@ pub mod snapshots_server {
                     struct DeleteSvc<T: Snapshots>(pub Arc<T>);
                     impl<
                         T: Snapshots,
-                    > tonic::server::UnaryService<super::DeleteSnapshotsRequest>
+                    > tonic::server::UnaryService<super::DeleteSnapshotRequest>
                     for DeleteSvc<T> {
-                        type Response = super::DeleteSnapshotsResponse;
+                        type Response = super::DeleteSnapshotResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::DeleteSnapshotsRequest>,
+                            request: tonic::Request<super::DeleteSnapshotRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).delete(request).await };
@@ -5808,16 +5808,16 @@ pub mod snapshots_server {
                     struct DeleteFullSvc<T: Snapshots>(pub Arc<T>);
                     impl<
                         T: Snapshots,
-                    > tonic::server::UnaryService<super::DeleteFullSnapshotsRequest>
+                    > tonic::server::UnaryService<super::DeleteFullSnapshotRequest>
                     for DeleteFullSvc<T> {
-                        type Response = super::DeleteSnapshotsResponse;
+                        type Response = super::DeleteSnapshotResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::DeleteFullSnapshotsRequest>,
+                            request: tonic::Request<super::DeleteFullSnapshotRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).delete_full(request).await };

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5252,6 +5252,13 @@ pub struct CreateFullSnapshotRequest {}
 pub struct ListFullSnapshotsRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteFullSnapshotsRequest {
+    /// Name of the full snapshot
+    #[prost(string, tag = "1")]
+    pub snapshot_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
@@ -5263,6 +5270,16 @@ pub struct ListSnapshotsRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteSnapshotsRequest {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Name of the collection snapshot
+    #[prost(string, tag = "2")]
+    pub snapshot_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5293,6 +5310,13 @@ pub struct ListSnapshotsResponse {
     pub snapshot_descriptions: ::prost::alloc::vec::Vec<SnapshotDescription>,
     /// Time spent to process
     #[prost(double, tag = "2")]
+    pub time: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteSnapshotsResponse {
+    /// Time spent to process
+    #[prost(double, tag = "1")]
     pub time: f64,
 }
 /// Generated client implementations.
@@ -5403,6 +5427,25 @@ pub mod snapshots_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
         ///
+        /// Delete collection snapshots
+        pub async fn delete(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Delete");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        ///
         /// Create full storage snapshot
         pub async fn create_full(
             &mut self,
@@ -5444,6 +5487,27 @@ pub mod snapshots_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        ///
+        /// List full storage snapshots
+        pub async fn delete_full(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteFullSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Snapshots/DeleteFull",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -5466,6 +5530,12 @@ pub mod snapshots_server {
             request: tonic::Request<super::ListSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
         ///
+        /// Delete collection snapshots
+        async fn delete(
+            &self,
+            request: tonic::Request<super::DeleteSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status>;
+        ///
         /// Create full storage snapshot
         async fn create_full(
             &self,
@@ -5477,6 +5547,12 @@ pub mod snapshots_server {
             &self,
             request: tonic::Request<super::ListFullSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
+        ///
+        /// List full storage snapshots
+        async fn delete_full(
+            &self,
+            request: tonic::Request<super::DeleteFullSnapshotsRequest>,
+        ) -> Result<tonic::Response<super::DeleteSnapshotsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SnapshotsServer<T: Snapshots> {
@@ -5613,6 +5689,44 @@ pub mod snapshots_server {
                     };
                     Box::pin(fut)
                 }
+                "/qdrant.Snapshots/Delete" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteSvc<T: Snapshots>(pub Arc<T>);
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::DeleteSnapshotsRequest>
+                    for DeleteSvc<T> {
+                        type Response = super::DeleteSnapshotsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteSnapshotsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/qdrant.Snapshots/CreateFull" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFullSvc<T: Snapshots>(pub Arc<T>);
@@ -5678,6 +5792,44 @@ pub mod snapshots_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = ListFullSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Snapshots/DeleteFull" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteFullSvc<T: Snapshots>(pub Arc<T>);
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::DeleteFullSnapshotsRequest>
+                    for DeleteFullSvc<T> {
+                        type Response = super::DeleteSnapshotsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteFullSnapshotsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).delete_full(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteFullSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -30,10 +30,32 @@ pub async fn get_full_snapshot_path(
     let snapshot_path = Path::new(toc.snapshots_path()).join(snapshot_name);
     if !snapshot_path.exists() {
         return Err(StorageError::NotFound {
-            description: format!("Snapshot {} not found", snapshot_name),
+            description: format!("Full storage snapshot {} not found", snapshot_name),
         });
     }
     Ok(snapshot_path)
+}
+
+pub async fn do_delete_full_snapshot(
+    toc: &TableOfContent,
+    snapshot_name: &str,
+) -> Result<bool, StorageError> {
+    let snapshot_dir = get_full_snapshot_path(toc, snapshot_name).await?;
+    log::info!("Deleting full storage snapshot {:?}", snapshot_dir);
+    tokio::fs::remove_file(snapshot_dir).await?;
+    Ok(true)
+}
+
+pub async fn do_delete_collection_snapshot(
+    toc: &TableOfContent,
+    collection_name: &str,
+    snapshot_name: &str,
+) -> Result<bool, StorageError> {
+    let collection = toc.get_collection(collection_name).await?;
+    let file_name = collection.get_snapshot_path(snapshot_name).await?;
+    log::info!("Deleting collection snapshot {:?}", file_name);
+    tokio::fs::remove_file(file_name).await?;
+    Ok(true)
 }
 
 pub async fn do_list_full_snapshots(

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -58,6 +58,27 @@ paths:
       responses: #@ response(reference("SnapshotDescription"))
 
   /collections/{collection_name}/snapshots/{snapshot_name}:
+    delete:
+      tags:
+        - snapshots
+        - collections
+      summary: Delete collection snapshot
+      description: Delete snapshot for a collection
+      operationId: delete_snapshot
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection for which to delete a snapshot
+          required: true
+          schema:
+            type: string
+        - name: snapshot_name
+          in: path
+          description: Name of the snapshot to delete
+          required: true
+          schema:
+            type: string
+      responses: #@ response(type("boolean"))
     get:
       tags:
         - snapshots
@@ -118,6 +139,20 @@ paths:
       responses: #@ response(reference("SnapshotDescription"))
 
   /snapshots/{snapshot_name}:
+    delete:
+      tags:
+        - snapshots
+      summary: Delete storage snapshot
+      description: Delete snapshot of the whole storage
+      operationId: delete_full_snapshot
+      parameters:
+        - name: snapshot_name
+          in: path
+          description: Name of the full snapshot to delete
+          required: true
+          schema:
+            type: string
+      responses: #@ response(type("boolean"))
     get:
       tags:
         - snapshots

--- a/openapi/tests/openapi_integration/test_snapshot.py
+++ b/openapi/tests/openapi_integration/test_snapshot.py
@@ -1,0 +1,102 @@
+import pytest
+
+from .helpers.helpers import request_with_validation
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+
+collection_name = 'test_collection_snapshot'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    basic_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_snapshot_operations():
+    # no snapshot on collection
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 0
+
+    # create snapshot on collection
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots',
+        method="POST",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    snapshot_name = response.json()['result']['name']
+
+    # validate it exists
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 1
+    assert response.json()['result'][0]['name'] == snapshot_name
+
+    # delete it
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/{snapshot_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name, 'snapshot_name': snapshot_name},
+    )
+    assert response.ok
+
+    # validate it is gone
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 0
+
+    # no full snapshot
+    response = request_with_validation(
+        api='/snapshots',
+        method="GET",
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 0
+
+    # create full snapshot
+    response = request_with_validation(
+        api='/snapshots',
+        method="POST",
+    )
+    assert response.ok
+    snapshot_name = response.json()['result']['name']
+
+    # validate it exists
+    response = request_with_validation(
+        api='/snapshots',
+        method="GET",
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 1
+    assert response.json()['result'][0]['name'] == snapshot_name
+
+    # delete it
+    response = request_with_validation(
+        api='/snapshots/{snapshot_name}',
+        path_params={'snapshot_name': snapshot_name},
+        method="DELETE",
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/snapshots',
+        method="GET",
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 0
+
+

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -4,10 +4,14 @@ use std::time::Instant;
 use api::grpc::qdrant::snapshots_server::Snapshots;
 use api::grpc::qdrant::{
     CreateFullSnapshotRequest, CreateSnapshotRequest, CreateSnapshotResponse,
+    DeleteFullSnapshotsRequest, DeleteSnapshotsRequest, DeleteSnapshotsResponse,
     ListFullSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse,
 };
 use storage::content_manager::conversions::error_to_status;
-use storage::content_manager::snapshots::{do_create_full_snapshot, do_list_full_snapshots};
+use storage::content_manager::snapshots::{
+    do_create_full_snapshot, do_delete_collection_snapshot, do_delete_full_snapshot,
+    do_list_full_snapshots,
+};
 use storage::content_manager::toc::TableOfContent;
 use tonic::{async_trait, Request, Response, Status};
 
@@ -56,6 +60,23 @@ impl Snapshots for SnapshotsService {
         }))
     }
 
+    async fn delete(
+        &self,
+        request: Request<DeleteSnapshotsRequest>,
+    ) -> Result<Response<DeleteSnapshotsResponse>, Status> {
+        let DeleteSnapshotsRequest {
+            collection_name,
+            snapshot_name,
+        } = request.into_inner();
+        let timing = Instant::now();
+        let _response = do_delete_collection_snapshot(&self.toc, &collection_name, &snapshot_name)
+            .await
+            .map_err(error_to_status)?;
+        Ok(Response::new(DeleteSnapshotsResponse {
+            time: timing.elapsed().as_secs_f64(),
+        }))
+    }
+
     async fn create_full(
         &self,
         _request: Request<CreateFullSnapshotRequest>,
@@ -80,6 +101,20 @@ impl Snapshots for SnapshotsService {
             .map_err(error_to_status)?;
         Ok(Response::new(ListSnapshotsResponse {
             snapshot_descriptions: snapshots.into_iter().map(|s| s.into()).collect(),
+            time: timing.elapsed().as_secs_f64(),
+        }))
+    }
+
+    async fn delete_full(
+        &self,
+        request: Request<DeleteFullSnapshotsRequest>,
+    ) -> Result<Response<DeleteSnapshotsResponse>, Status> {
+        let snapshot_name = request.into_inner().snapshot_name;
+        let timing = Instant::now();
+        let _response = do_delete_full_snapshot(&self.toc, &snapshot_name)
+            .await
+            .map_err(error_to_status)?;
+        Ok(Response::new(DeleteSnapshotsResponse {
             time: timing.elapsed().as_secs_f64(),
         }))
     }

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use api::grpc::qdrant::snapshots_server::Snapshots;
 use api::grpc::qdrant::{
     CreateFullSnapshotRequest, CreateSnapshotRequest, CreateSnapshotResponse,
-    DeleteFullSnapshotsRequest, DeleteSnapshotsRequest, DeleteSnapshotsResponse,
+    DeleteFullSnapshotRequest, DeleteSnapshotRequest, DeleteSnapshotResponse,
     ListFullSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse,
 };
 use storage::content_manager::conversions::error_to_status;
@@ -62,9 +62,9 @@ impl Snapshots for SnapshotsService {
 
     async fn delete(
         &self,
-        request: Request<DeleteSnapshotsRequest>,
-    ) -> Result<Response<DeleteSnapshotsResponse>, Status> {
-        let DeleteSnapshotsRequest {
+        request: Request<DeleteSnapshotRequest>,
+    ) -> Result<Response<DeleteSnapshotResponse>, Status> {
+        let DeleteSnapshotRequest {
             collection_name,
             snapshot_name,
         } = request.into_inner();
@@ -72,7 +72,7 @@ impl Snapshots for SnapshotsService {
         let _response = do_delete_collection_snapshot(&self.toc, &collection_name, &snapshot_name)
             .await
             .map_err(error_to_status)?;
-        Ok(Response::new(DeleteSnapshotsResponse {
+        Ok(Response::new(DeleteSnapshotResponse {
             time: timing.elapsed().as_secs_f64(),
         }))
     }
@@ -107,14 +107,14 @@ impl Snapshots for SnapshotsService {
 
     async fn delete_full(
         &self,
-        request: Request<DeleteFullSnapshotsRequest>,
-    ) -> Result<Response<DeleteSnapshotsResponse>, Status> {
+        request: Request<DeleteFullSnapshotRequest>,
+    ) -> Result<Response<DeleteSnapshotResponse>, Status> {
         let snapshot_name = request.into_inner().snapshot_name;
         let timing = Instant::now();
         let _response = do_delete_full_snapshot(&self.toc, &snapshot_name)
             .await
             .map_err(error_to_status)?;
-        Ok(Response::new(DeleteSnapshotsResponse {
+        Ok(Response::new(DeleteSnapshotResponse {
             time: timing.elapsed().as_secs_f64(),
         }))
     }


### PR DESCRIPTION
This PR adds a new API to delete snapshots tackling https://github.com/qdrant/qdrant/issues/1360

Two new REST endpoints:
- `DELETE /collections/{collection_name}/snapshots/{snapshot_name}`
- `DELETE /snapshots/{snapshot_name}`

And two new gRPC endpoints for feature parity.

A new openapi test for snapshots has been introduced to validate the behavior.

The doc and and clients integration is to be done.