### PR TITLE
keep search runtime handle inside the collection

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -90,6 +90,8 @@ pub struct Collection {
     // Lock is acquired for read on update operation and can be acquired for write externally,
     // which will block all update operations until the lock is released.
     updates_lock: RwLock<()>,
+    // Search runtime handle.
+    search_runtime: Handle,
 }
 
 impl Collection {
@@ -108,6 +110,7 @@ impl Collection {
         channel_service: ChannelService,
         on_replica_failure: replica_set::OnPeerFailure,
         request_shard_transfer: RequestShardTransfer,
+        search_runtime: Option<Handle>,
     ) -> Result<Self, CollectionError> {
         let start_time = std::time::Instant::now();
 
@@ -162,6 +165,7 @@ impl Collection {
             init_time: start_time.elapsed(),
             is_initialized: Arc::new(Default::default()),
             updates_lock: RwLock::new(()),
+            search_runtime: search_runtime.unwrap_or_else(Handle::current),
         })
     }
 
@@ -188,6 +192,7 @@ impl Collection {
         true
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn load(
         collection_id: CollectionId,
         this_peer_id: PeerId,
@@ -196,6 +201,7 @@ impl Collection {
         channel_service: ChannelService,
         on_replica_failure: replica_set::OnPeerFailure,
         request_shard_transfer: RequestShardTransfer,
+        search_runtime: Option<Handle>,
     ) -> Self {
         let start_time = std::time::Instant::now();
         let stored_version = CollectionVersion::load(path)
@@ -263,6 +269,7 @@ impl Collection {
             init_time: start_time.elapsed(),
             is_initialized: Arc::new(Default::default()),
             updates_lock: RwLock::new(()),
+            search_runtime: search_runtime.unwrap_or_else(Handle::current),
         }
     }
 
@@ -735,7 +742,6 @@ impl Collection {
     pub async fn search_batch(
         &self,
         request: SearchRequestBatch,
-        search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         // shortcuts batch if all requests with limit=0
@@ -788,11 +794,7 @@ impl Collection {
                 searches: without_payload_requests,
             };
             let without_payload_results = self
-                ._search_batch(
-                    without_payload_batch,
-                    search_runtime_handle,
-                    shard_selection,
-                )
+                ._search_batch(without_payload_batch, shard_selection)
                 .await?;
             let filled_results = without_payload_results
                 .into_iter()
@@ -807,9 +809,7 @@ impl Collection {
                 });
             try_join_all(filled_results).await
         } else {
-            let result = self
-                ._search_batch(request, search_runtime_handle, shard_selection)
-                .await?;
+            let result = self._search_batch(request, shard_selection).await?;
             Ok(result)
         }
     }
@@ -817,7 +817,6 @@ impl Collection {
     pub async fn _search_batch(
         &self,
         request: SearchRequestBatch,
-        search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let batch_size = request.searches.len();
@@ -829,7 +828,7 @@ impl Collection {
             let target_shards = shard_holder.target_shard(shard_selection)?;
             let all_searches = target_shards
                 .iter()
-                .map(|shard| shard.search(request.clone(), search_runtime_handle));
+                .map(|shard| shard.search(request.clone(), &self.search_runtime));
             try_join_all(all_searches).await?
         };
 
@@ -909,7 +908,6 @@ impl Collection {
     pub async fn search(
         &self,
         request: SearchRequest,
-        search_runtime_handle: &Handle,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         if request.limit == 0 {
@@ -919,9 +917,7 @@ impl Collection {
         let request_batch = SearchRequestBatch {
             searches: vec![request],
         };
-        let results = self
-            ._search_batch(request_batch, search_runtime_handle, shard_selection)
-            .await?;
+        let results = self._search_batch(request_batch, shard_selection).await?;
         Ok(results.into_iter().next().unwrap())
     }
 

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -7,7 +7,6 @@ use segment::data_types::vectors::{NamedVector, VectorElementType, DEFAULT_VECTO
 use segment::types::{
     Condition, Filter, HasIdCondition, PointIdType, ScoredPoint, WithPayloadInterface, WithVector,
 };
-use tokio::runtime::Handle;
 use tokio::sync::RwLockReadGuard;
 
 use crate::collection::Collection;
@@ -41,7 +40,6 @@ fn avg_vectors<'a>(
 
 pub async fn recommend_by<'a, F, Fut>(
     request: RecommendRequest,
-    search_runtime_handle: &Handle,
     collection: &Collection,
     collection_by_name: F,
 ) -> CollectionResult<Vec<ScoredPoint>>
@@ -56,13 +54,7 @@ where
     let request_batch = RecommendRequestBatch {
         searches: vec![request],
     };
-    let results = recommend_batch_by(
-        request_batch,
-        search_runtime_handle,
-        collection,
-        collection_by_name,
-    )
-    .await?;
+    let results = recommend_batch_by(request_batch, collection, collection_by_name).await?;
     Ok(results.into_iter().next().unwrap())
 }
 
@@ -132,7 +124,6 @@ fn get_search_vector_name(request: &RecommendRequest) -> String {
 ///
 pub async fn recommend_batch_by<'a, F, Fut>(
     request_batch: RecommendRequestBatch,
-    search_runtime_handle: &Handle,
     collection: &Collection,
     collection_by_name: F,
 ) -> CollectionResult<Vec<Vec<ScoredPoint>>>
@@ -301,7 +292,5 @@ where
 
     let search_batch_request = SearchRequestBatch { searches };
 
-    collection
-        .search_batch(search_batch_request, search_runtime_handle, None)
-        .await
+    collection.search_batch(search_batch_request, None).await
 }

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -81,6 +81,7 @@ async fn test_snapshot_collection() {
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
     )
     .await
     .unwrap();
@@ -106,6 +107,7 @@ async fn test_snapshot_collection() {
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
     )
     .await;
 

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -13,7 +13,6 @@ use segment::types::{
     Condition, FieldCondition, Filter, HasIdCondition, Payload, PointIdType, WithPayloadInterface,
 };
 use tempfile::Builder;
-use tokio::runtime::Handle;
 
 use crate::common::{load_local_collection, simple_collection_fixture, N_SHARDS};
 
@@ -69,9 +68,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let search_res = collection
-        .search(search_request, &Handle::current(), None)
-        .await;
+    let search_res = collection.search(search_request, None).await;
 
     match search_res {
         Ok(res) => {
@@ -127,9 +124,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
         score_threshold: None,
     };
 
-    let search_res = collection
-        .search(search_request, &Handle::current(), None)
-        .await;
+    let search_res = collection.search(search_request, None).await;
 
     match search_res {
         Ok(res) => {
@@ -332,7 +327,6 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
             limit: 5,
             ..Default::default()
         },
-        &Handle::current(),
         &collection,
         |_name| async { unreachable!("Should not be called in this test") },
     )

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -97,6 +97,7 @@ pub async fn new_local_collection(
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
     )
     .await;
 
@@ -126,6 +127,7 @@ pub async fn load_local_collection(
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
     )
     .await
 }

--- a/lib/collection/tests/multi_vec_test.rs
+++ b/lib/collection/tests/multi_vec_test.rs
@@ -16,7 +16,6 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{NamedVector, VectorStruct};
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
-use tokio::runtime::Handle;
 
 use crate::common::{new_local_collection, N_SHARDS, TEST_OPTIMIZERS_CONFIG};
 
@@ -126,10 +125,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let result = collection
-        .search(full_search_request, &Handle::current(), None)
-        .await
-        .unwrap();
+    let result = collection.search(full_search_request, None).await.unwrap();
 
     for hit in result {
         match hit.vector.unwrap() {
@@ -154,9 +150,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let result = collection
-        .search(failed_search_request, &Handle::current(), None)
-        .await;
+    let result = collection.search(failed_search_request, None).await;
 
     assert!(
         matches!(result, Err(CollectionError::BadInput { .. })),
@@ -179,10 +173,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let result = collection
-        .search(full_search_request, &Handle::current(), None)
-        .await
-        .unwrap();
+    let result = collection.search(full_search_request, None).await.unwrap();
 
     for hit in result {
         match hit.vector.unwrap() {
@@ -223,7 +214,6 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             limit: 10,
             ..Default::default()
         },
-        &Handle::current(),
         &collection,
         |_name| async { unreachable!("should not be called in this test") },
     )
@@ -247,7 +237,6 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             using: Some(VEC_NAME1.to_string().into()),
             ..Default::default()
         },
-        &Handle::current(),
         &collection,
         |_name| async { unreachable!("should not be called in this test") },
     )

--- a/lib/collection/tests/pagination_test.rs
+++ b/lib/collection/tests/pagination_test.rs
@@ -3,7 +3,6 @@ use collection::operations::types::SearchRequest;
 use collection::operations::CollectionUpdateOperations;
 use segment::types::WithPayloadInterface;
 use tempfile::Builder;
-use tokio::runtime::Handle;
 
 use crate::common::{simple_collection_fixture, N_SHARDS};
 
@@ -53,10 +52,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let reference_result = collection
-        .search(full_search_request, &Handle::current(), None)
-        .await
-        .unwrap();
+    let reference_result = collection.search(full_search_request, None).await.unwrap();
 
     assert_eq!(reference_result.len(), 100);
     assert_eq!(reference_result[0].id, 999.into());
@@ -76,10 +72,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let page_1_result = collection
-        .search(page_1_request, &Handle::current(), None)
-        .await
-        .unwrap();
+    let page_1_result = collection.search(page_1_request, None).await.unwrap();
 
     // Check that the first page is the same as the reference result
     assert_eq!(page_1_result.len(), 10);
@@ -98,10 +91,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let page_9_result = collection
-        .search(page_9_request, &Handle::current(), None)
-        .await
-        .unwrap();
+    let page_9_result = collection.search(page_9_request, None).await.unwrap();
 
     // Check that the 9th page is the same as the reference result
     assert_eq!(page_9_result.len(), 10);


### PR DESCRIPTION
- Keep search runtime handle inside the collection, so `search` and `recommend` methods won't require explicit argument
