### PR TITLE
Collections share a single optimizer runtime

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,6 +23,10 @@ storage:
   performance:
     # Number of parallel threads used for search operations. If 0 - auto selection.
     max_search_threads: 0
+    # Max total number of threads, which can be used for running optimization processes across all collections.
+    # Note: Each optimization thread will also use `max_indexing_threads` for index building.
+    # So total number of threads used for optimization will be `max_optimization_threads * max_indexing_threads`
+    max_optimization_threads: 1
 
   optimizers:
     # The minimal fraction of deleted vectors in a segment, required to perform segment optimization
@@ -66,7 +70,7 @@ storage:
     # Interval between forced flushes.
     flush_interval_sec: 5
     
-    # Max number of threads, which can be used for optimization.
+    # Max number of threads, which can be used for optimization per collection.
     max_optimization_threads: 1
 
   # Default parameters of HNSW Index. Could be overridden for each collection individually

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -93,6 +93,7 @@ fn batch_search_bench(c: &mut Criterion) {
             "test_collection".to_string(),
             storage_dir.path(),
             shared_config,
+            handle.clone(),
         ))
         .unwrap();
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -95,7 +95,7 @@ pub struct Collection {
     // Search runtime handle.
     search_runtime: Handle,
     // Optimizer runtime handle.
-    optimizer_runtime: Handle,
+    update_runtime: Handle,
 }
 
 impl Collection {
@@ -115,7 +115,7 @@ impl Collection {
         on_replica_failure: OnPeerFailure,
         request_shard_transfer: RequestShardTransfer,
         search_runtime: Option<Handle>,
-        optimizer_runtime: Option<Handle>,
+        update_runtime: Option<Handle>,
     ) -> Result<Self, CollectionError> {
         let start_time = std::time::Instant::now();
 
@@ -136,7 +136,7 @@ impl Collection {
                 path,
                 shared_config.clone(),
                 channel_service.clone(),
-                optimizer_runtime.clone().unwrap_or_else(Handle::current),
+                update_runtime.clone().unwrap_or_else(Handle::current),
             )
             .await;
 
@@ -172,7 +172,7 @@ impl Collection {
             is_initialized: Arc::new(Default::default()),
             updates_lock: RwLock::new(()),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
-            optimizer_runtime: optimizer_runtime.unwrap_or_else(Handle::current),
+            update_runtime: update_runtime.unwrap_or_else(Handle::current),
         })
     }
 
@@ -209,7 +209,7 @@ impl Collection {
         on_replica_failure: replica_set::OnPeerFailure,
         request_shard_transfer: RequestShardTransfer,
         search_runtime: Option<Handle>,
-        optimizer_runtime: Option<Handle>,
+        update_runtime: Option<Handle>,
     ) -> Self {
         let start_time = std::time::Instant::now();
         let stored_version = CollectionVersion::load(path)
@@ -257,7 +257,7 @@ impl Collection {
                 channel_service.clone(),
                 on_replica_failure.clone(),
                 this_peer_id,
-                optimizer_runtime.clone().unwrap_or_else(Handle::current),
+                update_runtime.clone().unwrap_or_else(Handle::current),
             )
             .await;
 
@@ -279,7 +279,7 @@ impl Collection {
             is_initialized: Arc::new(Default::default()),
             updates_lock: RwLock::new(()),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
-            optimizer_runtime: optimizer_runtime.unwrap_or_else(Handle::current),
+            update_runtime: update_runtime.unwrap_or_else(Handle::current),
         }
     }
 
@@ -655,7 +655,7 @@ impl Collection {
                 self.name(),
                 &replica_set.shard_path,
                 self.config.clone(),
-                self.optimizer_runtime.clone(),
+                self.update_runtime.clone(),
             )
             .await?;
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -2,7 +2,6 @@ use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 
@@ -19,7 +18,7 @@ use segment::types::{
     SegmentType,
 };
 use tokio::fs::{copy, create_dir_all, remove_dir_all};
-use tokio::runtime::{self, Runtime};
+use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, Mutex, RwLock as TokioRwLock};
 
@@ -50,7 +49,6 @@ pub struct LocalShard {
     pub(super) config: Arc<TokioRwLock<CollectionConfig>>,
     pub(super) wal: LockedWal,
     pub(super) update_handler: Arc<Mutex<UpdateHandler>>,
-    pub(super) runtime_handle: Option<Runtime>,
     pub(super) update_sender: ArcSwap<Sender<UpdateSignal>>,
     pub(super) path: PathBuf,
     before_drop_called: bool,
@@ -94,42 +92,21 @@ impl LocalShard {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        id: ShardId,
-        collection_id: CollectionId,
         segment_holder: SegmentHolder,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
         wal: SerdeWal<CollectionUpdateOperations>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         shard_path: &Path,
+        optimizer_runtime: Handle,
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = shared_config.read().await;
-        let mut optimize_runtime_builder = runtime::Builder::new_multi_thread();
-
-        optimize_runtime_builder
-            .worker_threads(3)
-            .enable_time()
-            .thread_name_fn(move || {
-                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let optimizer_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("collection-{collection_id}-shard-{id}-optimizer-{optimizer_id}")
-            });
-
-        if config.optimizer_config.max_optimization_threads > 0 {
-            // panics if val is not larger than 0.
-            optimize_runtime_builder
-                .max_blocking_threads(config.optimizer_config.max_optimization_threads);
-        }
-
-        let optimize_runtime = optimize_runtime_builder.build().unwrap();
-
         let locked_wal = Arc::new(ParkingMutex::new(wal));
 
         let mut update_handler = UpdateHandler::new(
             optimizers.clone(),
-            optimize_runtime.handle().clone(),
+            optimizer_runtime.clone(),
             segment_holder.clone(),
             locked_wal.clone(),
             config.optimizer_config.flush_interval_sec,
@@ -146,7 +123,6 @@ impl LocalShard {
             config: shared_config,
             wal: locked_wal,
             update_handler: Arc::new(Mutex::new(update_handler)),
-            runtime_handle: Some(optimize_runtime),
             update_sender: ArcSwap::from_pointee(update_sender),
             path: shard_path.to_owned(),
             before_drop_called: false,
@@ -164,6 +140,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
+        optimizer_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         let collection_config = shared_config.read().await;
 
@@ -238,13 +215,12 @@ impl LocalShard {
         drop(collection_config); // release `shared_config` from borrow checker
 
         let collection = LocalShard::new(
-            id,
-            collection_id.clone(),
             segment_holder,
             shared_config,
             wal,
             optimizers,
             shard_path,
+            optimizer_runtime,
         )
         .await;
 
@@ -270,10 +246,18 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
+        optimizer_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file
         let local_shard_config = ShardConfig::new_local();
-        let shard = Self::build(id, collection_id, shard_path, shared_config).await?;
+        let shard = Self::build(
+            id,
+            collection_id,
+            shard_path,
+            shared_config,
+            optimizer_runtime,
+        )
+        .await?;
         local_shard_config.save(shard_path)?;
         Ok(shard)
     }
@@ -284,6 +268,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
+        optimizer_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         let config = shared_config.read().await;
 
@@ -361,13 +346,12 @@ impl LocalShard {
         drop(config); // release `shared_config` from borrow checker
 
         let collection = LocalShard::new(
-            id,
-            collection_id,
             segment_holder,
             shared_config,
             wal,
             optimizers,
             shard_path,
+            optimizer_runtime,
         )
         .await;
 
@@ -446,23 +430,6 @@ impl LocalShard {
 
         if let Err(err) = self.wait_update_workers_stop().await {
             log::warn!("Update workers failed with: {}", err);
-        }
-
-        match self.runtime_handle.take() {
-            None => {}
-            Some(handle) => {
-                // The drop could be called from the tokio context, e.g. from perform_collection_operation method.
-                // Calling remove from there would lead to the following error in a new version of tokio:
-                // "Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context."
-                // So the workaround for move out the runtime handler and drop it in the separate thread.
-                // The proper solution is to reconsider the collection to be an owner of the runtime
-
-                let thread_handler = thread::Builder::new()
-                    .name("collection_drop".to_string())
-                    .spawn(move || drop(handle))
-                    .unwrap();
-                thread_handler.join().unwrap();
-            }
         }
 
         self.before_drop_called = true;

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -98,7 +98,7 @@ impl LocalShard {
         wal: SerdeWal<CollectionUpdateOperations>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         shard_path: &Path,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = shared_config.read().await;
@@ -106,7 +106,7 @@ impl LocalShard {
 
         let mut update_handler = UpdateHandler::new(
             optimizers.clone(),
-            optimizer_runtime.clone(),
+            update_runtime.clone(),
             segment_holder.clone(),
             locked_wal.clone(),
             config.optimizer_config.flush_interval_sec,
@@ -140,7 +140,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         let collection_config = shared_config.read().await;
 
@@ -220,7 +220,7 @@ impl LocalShard {
             wal,
             optimizers,
             shard_path,
-            optimizer_runtime,
+            update_runtime,
         )
         .await;
 
@@ -246,18 +246,12 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file
         let local_shard_config = ShardConfig::new_local();
-        let shard = Self::build(
-            id,
-            collection_id,
-            shard_path,
-            shared_config,
-            optimizer_runtime,
-        )
-        .await?;
+        let shard =
+            Self::build(id, collection_id, shard_path, shared_config, update_runtime).await?;
         local_shard_config.save(shard_path)?;
         Ok(shard)
     }
@@ -268,7 +262,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         let config = shared_config.read().await;
 
@@ -351,7 +345,7 @@ impl LocalShard {
             wal,
             optimizers,
             shard_path,
-            optimizer_runtime,
+            update_runtime,
         )
         .await;
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -118,6 +118,7 @@ pub struct ShardReplicaSet {
     channel_service: ChannelService,
     collection_id: CollectionId,
     collection_config: Arc<RwLock<CollectionConfig>>,
+    optimizer_runtime: Handle,
 }
 
 impl ShardReplicaSet {
@@ -188,6 +189,7 @@ impl ShardReplicaSet {
         collection_path: &Path,
         shared_config: Arc<RwLock<CollectionConfig>>,
         channel_service: ChannelService,
+        optimizer_runtime: Handle,
     ) -> CollectionResult<Self> {
         let shard_path = create_shard_dir(collection_path, shard_id).await?;
         let local = if local {
@@ -196,6 +198,7 @@ impl ShardReplicaSet {
                 collection_id.clone(),
                 &shard_path,
                 shared_config.clone(),
+                optimizer_runtime.clone(),
             )
             .await?;
             Some(Local(shard))
@@ -240,6 +243,7 @@ impl ShardReplicaSet {
             channel_service,
             collection_id,
             collection_config: shared_config,
+            optimizer_runtime,
         })
     }
 
@@ -342,6 +346,7 @@ impl ShardReplicaSet {
                         self.collection_id.clone(),
                         &self.shard_path,
                         self.collection_config.clone(),
+                        self.optimizer_runtime.clone(),
                     )
                     .await?,
                 ))
@@ -363,6 +368,7 @@ impl ShardReplicaSet {
     ///
     /// WARN: This method intended to be used only on the initial start of the node.
     /// It does not implement any logic to recover from a failure. Will panic if there is a failure.
+    #[allow(clippy::too_many_arguments)]
     pub async fn load(
         shard_id: ShardId,
         collection_id: CollectionId,
@@ -371,6 +377,7 @@ impl ShardReplicaSet {
         channel_service: ChannelService,
         on_peer_failure: OnPeerFailure,
         this_peer_id: PeerId,
+        optimizer_runtime: Handle,
     ) -> Self {
         let replica_state: SaveOnDisk<ReplicaSetState> =
             SaveOnDisk::load_or_init(shard_path.join(REPLICA_STATE_FILE)).unwrap();
@@ -404,6 +411,7 @@ impl ShardReplicaSet {
                 collection_id.clone(),
                 shard_path,
                 shared_config.clone(),
+                optimizer_runtime.clone(),
             )
             .await
             .map_err(|e| {
@@ -428,6 +436,7 @@ impl ShardReplicaSet {
             channel_service,
             collection_id,
             collection_config: shared_config,
+            optimizer_runtime,
         }
     }
 
@@ -500,6 +509,7 @@ impl ShardReplicaSet {
                     self.collection_id.clone(),
                     &self.shard_path,
                     self.collection_config.clone(),
+                    self.optimizer_runtime.clone(),
                 )
                 .await?;
                 match state {
@@ -729,6 +739,7 @@ impl ShardReplicaSet {
                 self.collection_id.clone(),
                 &self.shard_path,
                 self.collection_config.clone(),
+                self.optimizer_runtime.clone(),
             )
             .await?;
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -118,7 +118,7 @@ pub struct ShardReplicaSet {
     channel_service: ChannelService,
     collection_id: CollectionId,
     collection_config: Arc<RwLock<CollectionConfig>>,
-    optimizer_runtime: Handle,
+    update_runtime: Handle,
 }
 
 impl ShardReplicaSet {
@@ -189,7 +189,7 @@ impl ShardReplicaSet {
         collection_path: &Path,
         shared_config: Arc<RwLock<CollectionConfig>>,
         channel_service: ChannelService,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> CollectionResult<Self> {
         let shard_path = create_shard_dir(collection_path, shard_id).await?;
         let local = if local {
@@ -198,7 +198,7 @@ impl ShardReplicaSet {
                 collection_id.clone(),
                 &shard_path,
                 shared_config.clone(),
-                optimizer_runtime.clone(),
+                update_runtime.clone(),
             )
             .await?;
             Some(Local(shard))
@@ -243,7 +243,7 @@ impl ShardReplicaSet {
             channel_service,
             collection_id,
             collection_config: shared_config,
-            optimizer_runtime,
+            update_runtime,
         })
     }
 
@@ -346,7 +346,7 @@ impl ShardReplicaSet {
                         self.collection_id.clone(),
                         &self.shard_path,
                         self.collection_config.clone(),
-                        self.optimizer_runtime.clone(),
+                        self.update_runtime.clone(),
                     )
                     .await?,
                 ))
@@ -377,7 +377,7 @@ impl ShardReplicaSet {
         channel_service: ChannelService,
         on_peer_failure: OnPeerFailure,
         this_peer_id: PeerId,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) -> Self {
         let replica_state: SaveOnDisk<ReplicaSetState> =
             SaveOnDisk::load_or_init(shard_path.join(REPLICA_STATE_FILE)).unwrap();
@@ -411,7 +411,7 @@ impl ShardReplicaSet {
                 collection_id.clone(),
                 shard_path,
                 shared_config.clone(),
-                optimizer_runtime.clone(),
+                update_runtime.clone(),
             )
             .await
             .map_err(|e| {
@@ -436,7 +436,7 @@ impl ShardReplicaSet {
             channel_service,
             collection_id,
             collection_config: shared_config,
-            optimizer_runtime,
+            update_runtime,
         }
     }
 
@@ -509,7 +509,7 @@ impl ShardReplicaSet {
                     self.collection_id.clone(),
                     &self.shard_path,
                     self.collection_config.clone(),
-                    self.optimizer_runtime.clone(),
+                    self.update_runtime.clone(),
                 )
                 .await?;
                 match state {
@@ -739,7 +739,7 @@ impl ShardReplicaSet {
                 self.collection_id.clone(),
                 &self.shard_path,
                 self.collection_config.clone(),
-                self.optimizer_runtime.clone(),
+                self.update_runtime.clone(),
             )
             .await?;
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -211,7 +211,7 @@ impl ShardHolder {
         channel_service: ChannelService,
         on_peer_failure: OnPeerFailure,
         this_peer_id: PeerId,
-        optimizer_runtime: Handle,
+        update_runtime: Handle,
     ) {
         let shard_number = shared_collection_config
             .read()
@@ -232,7 +232,7 @@ impl ShardHolder {
                     channel_service.clone(),
                     on_peer_failure.clone(),
                     this_peer_id,
-                    optimizer_runtime.clone(),
+                    update_runtime.clone(),
                 )
                 .await;
 
@@ -244,7 +244,7 @@ impl ShardHolder {
                             collection_id.clone(),
                             &path,
                             shared_collection_config.clone(),
-                            optimizer_runtime.clone(),
+                            update_runtime.clone(),
                         )
                         .await
                         .unwrap();
@@ -265,7 +265,7 @@ impl ShardHolder {
                             collection_id.clone(),
                             &path,
                             shared_collection_config.clone(),
-                            optimizer_runtime.clone(),
+                            update_runtime.clone(),
                         )
                         .await
                         .unwrap();

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use tokio::runtime::Handle;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::config::CollectionConfig;
@@ -201,6 +202,7 @@ impl ShardHolder {
         self.shards.is_empty()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn load_shards(
         &mut self,
         collection_path: &Path,
@@ -209,6 +211,7 @@ impl ShardHolder {
         channel_service: ChannelService,
         on_peer_failure: OnPeerFailure,
         this_peer_id: PeerId,
+        optimizer_runtime: Handle,
     ) {
         let shard_number = shared_collection_config
             .read()
@@ -229,6 +232,7 @@ impl ShardHolder {
                     channel_service.clone(),
                     on_peer_failure.clone(),
                     this_peer_id,
+                    optimizer_runtime.clone(),
                 )
                 .await;
 
@@ -240,6 +244,7 @@ impl ShardHolder {
                             collection_id.clone(),
                             &path,
                             shared_collection_config.clone(),
+                            optimizer_runtime.clone(),
                         )
                         .await
                         .unwrap();
@@ -260,6 +265,7 @@ impl ShardHolder {
                             collection_id.clone(),
                             &path,
                             shared_collection_config.clone(),
+                            optimizer_runtime.clone(),
                         )
                         .await
                         .unwrap();

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -82,6 +82,7 @@ async fn test_snapshot_collection() {
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         None,
+        None,
     )
     .await
     .unwrap();
@@ -107,6 +108,7 @@ async fn test_snapshot_collection() {
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
         None,
     )
     .await;

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -98,6 +98,7 @@ pub async fn new_local_collection(
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         None,
+        None,
     )
     .await;
 
@@ -127,6 +128,7 @@ pub async fn load_local_collection(
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        None,
         None,
     )
     .await

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -66,6 +66,7 @@ pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: StorageConfig,
     search_runtime: Runtime,
+    optimizer_runtime: Runtime,
     collection_management_runtime: Runtime,
     alias_persistence: RwLock<AliasPersistence>,
     pub this_peer_id: PeerId,
@@ -81,6 +82,7 @@ impl TableOfContent {
     pub fn new(
         storage_config: &StorageConfig,
         search_runtime: Runtime,
+        optimizer_runtime: Runtime,
         channel_service: ChannelService,
         this_peer_id: PeerId,
         consensus_proposal_sender: Option<OperationSender>,
@@ -145,6 +147,7 @@ impl TableOfContent {
                     collection_name.clone(),
                 ),
                 Some(search_runtime.handle().clone()),
+                Some(optimizer_runtime.handle().clone()),
             ));
 
             collections.insert(collection_name, collection);
@@ -156,6 +159,7 @@ impl TableOfContent {
             collections: Arc::new(RwLock::new(collections)),
             storage_config: storage_config.clone(),
             search_runtime,
+            optimizer_runtime,
             alias_persistence: RwLock::new(alias_persistence),
             collection_management_runtime,
             this_peer_id,
@@ -346,6 +350,7 @@ impl TableOfContent {
                 collection_name.to_string(),
             ),
             Some(self.search_runtime.handle().clone()),
+            Some(self.optimizer_runtime.handle().clone()),
         )
         .await?;
 
@@ -1249,6 +1254,7 @@ impl TableOfContent {
                                 id.to_string(),
                             ),
                             Some(self.search_runtime.handle().clone()),
+                            Some(self.optimizer_runtime.handle().clone()),
                         )
                         .await?;
                         collections.validate_collection_not_exists(id).await?;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -66,7 +66,7 @@ pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: StorageConfig,
     search_runtime: Runtime,
-    optimizer_runtime: Runtime,
+    update_runtime: Runtime,
     collection_management_runtime: Runtime,
     alias_persistence: RwLock<AliasPersistence>,
     pub this_peer_id: PeerId,
@@ -82,7 +82,7 @@ impl TableOfContent {
     pub fn new(
         storage_config: &StorageConfig,
         search_runtime: Runtime,
-        optimizer_runtime: Runtime,
+        update_runtime: Runtime,
         channel_service: ChannelService,
         this_peer_id: PeerId,
         consensus_proposal_sender: Option<OperationSender>,
@@ -147,7 +147,7 @@ impl TableOfContent {
                     collection_name.clone(),
                 ),
                 Some(search_runtime.handle().clone()),
-                Some(optimizer_runtime.handle().clone()),
+                Some(update_runtime.handle().clone()),
             ));
 
             collections.insert(collection_name, collection);
@@ -159,7 +159,7 @@ impl TableOfContent {
             collections: Arc::new(RwLock::new(collections)),
             storage_config: storage_config.clone(),
             search_runtime,
-            optimizer_runtime,
+            update_runtime,
             alias_persistence: RwLock::new(alias_persistence),
             collection_management_runtime,
             this_peer_id,
@@ -350,7 +350,7 @@ impl TableOfContent {
                 collection_name.to_string(),
             ),
             Some(self.search_runtime.handle().clone()),
-            Some(self.optimizer_runtime.handle().clone()),
+            Some(self.update_runtime.handle().clone()),
         )
         .await?;
 
@@ -1254,7 +1254,7 @@ impl TableOfContent {
                                 id.to_string(),
                             ),
                             Some(self.search_runtime.handle().clone()),
-                            Some(self.optimizer_runtime.handle().clone()),
+                            Some(self.update_runtime.handle().clone()),
                         )
                         .await?;
                         collections.validate_collection_not_exists(id).await?;

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -13,9 +13,15 @@ use tonic::transport::Uri;
 
 pub type PeerAddressById = HashMap<PeerId, Uri>;
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PerformanceConfig {
     pub max_search_threads: usize,
+    #[serde(default = "default_max_optimization_threads")]
+    pub max_optimization_threads: usize,
+}
+
+fn default_max_optimization_threads() -> usize {
+    1
 }
 
 /// Global configuration of the storage, loaded on the service launch, default stored in ./config

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -51,15 +51,18 @@ mod tests {
             mmap_advice: madvise::Advice::Random,
         };
 
-        let runtime = Runtime::new().unwrap();
-        let handle = runtime.handle().clone();
+        let search_runtime = Runtime::new().unwrap();
+        let handle = search_runtime.handle().clone();
+
+        let optimizer_runtime = Runtime::new().unwrap();
 
         let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
         let propose_operation_sender = OperationSender::new(propose_sender);
 
         let toc = Arc::new(TableOfContent::new(
             &config,
-            runtime,
+            search_runtime,
+            optimizer_runtime,
             Default::default(),
             0,
             Some(propose_operation_sender),

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -46,6 +46,7 @@ mod tests {
             wal: Default::default(),
             performance: PerformanceConfig {
                 max_search_threads: 1,
+                max_optimization_threads: 1,
             },
             hnsw_index: Default::default(),
             mmap_advice: madvise::Advice::Random,

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -55,7 +55,7 @@ mod tests {
         let search_runtime = Runtime::new().unwrap();
         let handle = search_runtime.handle().clone();
 
-        let optimizer_runtime = Runtime::new().unwrap();
+        let update_runtime = Runtime::new().unwrap();
 
         let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
         let propose_operation_sender = OperationSender::new(propose_sender);
@@ -63,7 +63,7 @@ mod tests {
         let toc = Arc::new(TableOfContent::new(
             &config,
             search_runtime,
-            optimizer_runtime,
+            update_runtime,
             Default::default(),
             0,
             Some(propose_operation_sender),

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -30,6 +30,24 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
         .build()
 }
 
+pub fn create_optimizer_runtime(max_optimization_threads: usize) -> std::io::Result<Runtime> {
+    let mut optimize_runtime_builder = runtime::Builder::new_multi_thread();
+
+    optimize_runtime_builder
+        .enable_time()
+        .thread_name_fn(move || {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let optimizer_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("optimizer-{optimizer_id}")
+        });
+
+    if max_optimization_threads > 0 {
+        // panics if val is not larger than 0.
+        optimize_runtime_builder.max_blocking_threads(max_optimization_threads);
+    }
+    optimize_runtime_builder.build()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -30,10 +30,10 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
         .build()
 }
 
-pub fn create_optimizer_runtime(max_optimization_threads: usize) -> std::io::Result<Runtime> {
-    let mut optimize_runtime_builder = runtime::Builder::new_multi_thread();
+pub fn create_update_runtime(max_optimization_threads: usize) -> std::io::Result<Runtime> {
+    let mut update_runtime_builder = runtime::Builder::new_multi_thread();
 
-    optimize_runtime_builder
+    update_runtime_builder
         .enable_time()
         .thread_name_fn(move || {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
@@ -43,9 +43,9 @@ pub fn create_optimizer_runtime(max_optimization_threads: usize) -> std::io::Res
 
     if max_optimization_threads > 0 {
         // panics if val is not larger than 0.
-        optimize_runtime_builder.max_blocking_threads(max_optimization_threads);
+        update_runtime_builder.max_blocking_threads(max_optimization_threads);
     }
-    optimize_runtime_builder.build()
+    update_runtime_builder.build()
 }
 
 #[cfg(test)]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -866,15 +866,20 @@ mod tests {
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
         env_logger::init();
-        let runtime = crate::create_search_runtime(settings.storage.performance.max_search_threads)
-            .expect("Can't create runtime.");
+        let search_runtime =
+            crate::create_search_runtime(settings.storage.performance.max_search_threads)
+                .expect("Can't create search runtime.");
+        let optimizer_runtime =
+            crate::create_optimizer_runtime(settings.storage.performance.max_search_threads)
+                .expect("Can't create optimizer runtime.");
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         let persistent_state =
             Persistent::load_or_init(&settings.storage.storage_path, true).unwrap();
         let operation_sender = OperationSender::new(propose_sender);
         let toc = TableOfContent::new(
             &settings.storage,
-            runtime,
+            search_runtime,
+            optimizer_runtime,
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -869,8 +869,8 @@ mod tests {
         let search_runtime =
             crate::create_search_runtime(settings.storage.performance.max_search_threads)
                 .expect("Can't create search runtime.");
-        let optimizer_runtime =
-            crate::create_optimizer_runtime(settings.storage.performance.max_search_threads)
+        let update_runtime =
+            crate::create_update_runtime(settings.storage.performance.max_search_threads)
                 .expect("Can't create optimizer runtime.");
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         let persistent_state =
@@ -879,7 +879,7 @@ mod tests {
         let toc = TableOfContent::new(
             &settings.storage,
             search_runtime,
-            optimizer_runtime,
+            update_runtime,
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn main() -> anyhow::Result<()> {
     let search_runtime_handle = search_runtime.handle().clone();
 
     let optimizer_runtime =
-        create_optimizer_runtime(settings.storage.optimizers.max_optimization_threads)
+        create_optimizer_runtime(settings.storage.performance.max_optimization_threads)
             .expect("Can't optimizer create runtime.");
 
     // Create a signal sender and receiver. It is used to communicate with the consensus thread.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use storage::dispatcher::Dispatcher;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
-use crate::common::helpers::create_search_runtime;
+use crate::common::helpers::{create_optimizer_runtime, create_search_runtime};
 use crate::common::telemetry::TelemetryCollector;
 use crate::greeting::welcome;
 use crate::migrations::single_to_cluster::handle_existing_collections;
@@ -125,9 +125,13 @@ fn main() -> anyhow::Result<()> {
 
     // Create and own search runtime out of the scope of async context to ensure correct
     // destruction of it
-    let runtime = create_search_runtime(settings.storage.performance.max_search_threads)
-        .expect("Can't create runtime.");
-    let runtime_handle = runtime.handle().clone();
+    let search_runtime = create_search_runtime(settings.storage.performance.max_search_threads)
+        .expect("Can't search create runtime.");
+    let search_runtime_handle = search_runtime.handle().clone();
+
+    let optimizer_runtime =
+        create_optimizer_runtime(settings.storage.optimizers.max_optimization_threads)
+            .expect("Can't optimizer create runtime.");
 
     // Create a signal sender and receiver. It is used to communicate with the consensus thread.
     let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
@@ -165,14 +169,15 @@ fn main() -> anyhow::Result<()> {
     // It is a main entry point for the storage.
     let toc = TableOfContent::new(
         &settings.storage,
-        runtime,
+        search_runtime,
+        optimizer_runtime,
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
     );
 
     // Here we load all stored collections.
-    runtime_handle.block_on(async {
+    search_runtime_handle.block_on(async {
         for collection in toc.all_collections().await {
             log::debug!("Loaded collection: {}", collection);
         }
@@ -233,7 +238,7 @@ fn main() -> anyhow::Result<()> {
 
         let toc_arc_clone = toc_arc.clone();
         let consensus_state_clone = consensus_state.clone();
-        let _cancel_transfer_handle = runtime_handle.spawn(async move {
+        let _cancel_transfer_handle = search_runtime_handle.spawn(async move {
             consensus_state_clone.is_leader_established.await_ready();
             match toc_arc_clone
                 .cancel_outgoing_all_transfers("Source peer restarted")
@@ -249,14 +254,14 @@ fn main() -> anyhow::Result<()> {
         });
 
         let collections_to_recover_in_consensus = if is_new_deployment {
-            let existing_collections = runtime_handle.block_on(toc_arc.all_collections());
+            let existing_collections = search_runtime_handle.block_on(toc_arc.all_collections());
             existing_collections
         } else {
             restored_collections
         };
 
         if !collections_to_recover_in_consensus.is_empty() {
-            runtime_handle.spawn(handle_existing_collections(
+            search_runtime_handle.spawn(handle_existing_collections(
                 toc_arc.clone(),
                 consensus_state.clone(),
                 dispatcher_arc.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use storage::dispatcher::Dispatcher;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
-use crate::common::helpers::{create_optimizer_runtime, create_search_runtime};
+use crate::common::helpers::{create_search_runtime, create_update_runtime};
 use crate::common::telemetry::TelemetryCollector;
 use crate::greeting::welcome;
 use crate::migrations::single_to_cluster::handle_existing_collections;
@@ -129,8 +129,8 @@ fn main() -> anyhow::Result<()> {
         .expect("Can't search create runtime.");
     let search_runtime_handle = search_runtime.handle().clone();
 
-    let optimizer_runtime =
-        create_optimizer_runtime(settings.storage.performance.max_optimization_threads)
+    let update_runtime =
+        create_update_runtime(settings.storage.performance.max_optimization_threads)
             .expect("Can't optimizer create runtime.");
 
     // Create a signal sender and receiver. It is used to communicate with the consensus thread.
@@ -170,7 +170,7 @@ fn main() -> anyhow::Result<()> {
     let toc = TableOfContent::new(
         &settings.storage,
         search_runtime,
-        optimizer_runtime,
+        update_runtime,
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),


### PR DESCRIPTION
This PR replaces the per-collection optimizer runtime with one global runtime, similar to what we do for the search runtime.
