### PR TITLE
Merge remaining runtimes

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -94,7 +94,7 @@ pub struct Collection {
     updates_lock: RwLock<()>,
     // Search runtime handle.
     search_runtime: Handle,
-    // Optimizer runtime handle.
+    // Update runtime handle.
     update_runtime: Handle,
 }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -246,6 +246,7 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
+
         update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -246,7 +246,6 @@ impl LocalShard {
         collection_id: CollectionId,
         shard_path: &Path,
         shared_config: Arc<TokioRwLock<CollectionConfig>>,
-
         update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{create_dir_all, read_dir};
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use collection::collection::{Collection, RequestShardTransfer};
@@ -30,7 +30,7 @@ use collection::shards::transfer::shard_transfer::{
 use collection::shards::{replica_set, CollectionId};
 use collection::telemetry::CollectionTelemetry;
 use segment::types::ScoredPoint;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{RwLock, RwLockReadGuard};
 use uuid::Uuid;
 
@@ -67,7 +67,7 @@ pub struct TableOfContent {
     storage_config: StorageConfig,
     search_runtime: Runtime,
     update_runtime: Runtime,
-    collection_management_runtime: Runtime,
+    collection_management_runtime: Handle,
     alias_persistence: RwLock<AliasPersistence>,
     pub this_peer_id: PeerId,
     channel_service: ChannelService,
@@ -86,20 +86,11 @@ impl TableOfContent {
         channel_service: ChannelService,
         this_peer_id: PeerId,
         consensus_proposal_sender: Option<OperationSender>,
+        collection_management_runtime: Handle,
     ) -> Self {
         let snapshots_path = Path::new(&storage_config.snapshots_path.clone()).to_owned();
         create_dir_all(&snapshots_path).expect("Can't create Snapshots directory");
         let collections_path = Path::new(&storage_config.storage_path).join(COLLECTIONS_DIR);
-        let collection_management_runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_time()
-            .enable_io()
-            .thread_name_fn(|| {
-                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("toc-{}", id)
-            })
-            .build()
-            .unwrap();
         create_dir_all(&collections_path).expect("Can't create Collections directory");
         let collection_paths =
             read_dir(&collections_path).expect("Can't read Collections directory");

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -57,6 +57,8 @@ mod tests {
 
         let update_runtime = Runtime::new().unwrap();
 
+        let general_runtime = Runtime::new().unwrap();
+
         let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
         let propose_operation_sender = OperationSender::new(propose_sender);
 
@@ -64,10 +66,10 @@ mod tests {
             &config,
             search_runtime,
             update_runtime,
+            general_runtime,
             Default::default(),
             0,
             Some(propose_operation_sender),
-            handle.clone(),
         ));
         let dispatcher = Dispatcher::new(toc);
 

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -67,6 +67,7 @@ mod tests {
             Default::default(),
             0,
             Some(propose_operation_sender),
+            handle.clone(),
         ));
         let dispatcher = Dispatcher::new(toc);
 

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -48,6 +48,18 @@ pub fn create_update_runtime(max_optimization_threads: usize) -> std::io::Result
     update_runtime_builder.build()
 }
 
+pub fn create_general_purpose_runtime() -> std::io::Result<Runtime> {
+    runtime::Builder::new_multi_thread()
+        .enable_time()
+        .enable_io()
+        .thread_name_fn(|| {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("general-{}", id)
+        })
+        .build()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -37,8 +37,8 @@ pub fn create_update_runtime(max_optimization_threads: usize) -> std::io::Result
         .enable_time()
         .thread_name_fn(move || {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let optimizer_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("optimizer-{optimizer_id}")
+            let update_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("update-{update_id}")
         });
 
     if max_optimization_threads > 0 {
@@ -54,8 +54,8 @@ pub fn create_general_purpose_runtime() -> std::io::Result<Runtime> {
         .enable_io()
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("general-{}", id)
+            let general_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("general-{}", general_id)
         })
         .build()
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -867,7 +867,7 @@ mod tests {
                 .expect("Can't create search runtime.");
         let update_runtime =
             crate::create_update_runtime(settings.storage.performance.max_search_threads)
-                .expect("Can't create optimizer runtime.");
+                .expect("Can't create update runtime.");
         let handle = update_runtime.handle().clone(); // no general runtime here, reuse optimizer runtime as it is cheaper
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         let persistent_state =

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::thread::JoinHandle;
@@ -20,7 +19,7 @@ use storage::content_manager::consensus_ops::ConsensusOperations;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
 use storage::types::PeerAddressById;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::sleep;
 use tonic::transport::Uri;
@@ -47,7 +46,7 @@ pub struct Consensus {
     /// Receives proposals from peers and client for applying in consensus
     receiver: Receiver<Message>,
     /// Runtime for async message sending
-    runtime: Runtime,
+    runtime: Handle,
     /// Uri to some other known peer, used to join the consensus
     /// ToDo: Make if many
     bootstrap_uri: Option<Uri>,
@@ -70,6 +69,7 @@ impl Consensus {
         propose_receiver: mpsc::Receiver<ConsensusOperations>,
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
+        runtime: Handle,
     ) -> anyhow::Result<JoinHandle<std::io::Result<()>>> {
         let (mut consensus, message_sender) = Self::new(
             logger,
@@ -79,6 +79,7 @@ impl Consensus {
             p2p_port,
             config,
             channel_service,
+            runtime.clone(),
         )?;
 
         let state_ref_clone = state_ref.clone();
@@ -90,6 +91,7 @@ impl Consensus {
                     state_ref_clone.on_consensus_thread_err(err);
                 } else {
                     log::info!("Consensus stopped");
+                    state_ref_clone.on_consensus_stopped();
                     state_ref_clone.on_consensus_stopped();
                 }
             })?;
@@ -119,6 +121,7 @@ impl Consensus {
                     p2p_host,
                     p2p_port,
                     message_sender,
+                    runtime,
                 )
             })
             .unwrap();
@@ -136,6 +139,7 @@ impl Consensus {
         p2p_port: u16,
         config: ConsensusConfig,
         channel_service: ChannelService,
+        runtime: Handle,
     ) -> anyhow::Result<(Self, Sender<Message>)> {
         // raft will not return entries to the application smaller or equal to `applied`
         let last_applied = state_ref.last_applied_entry().unwrap_or_default();
@@ -155,14 +159,6 @@ impl Consensus {
             log::warn!("With current tick period of {}ms, operation commit time might exceed default wait timeout: {}ms",
                  config.tick_period_ms, op_wait.as_millis())
         }
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .thread_name_fn(|| {
-                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("consensus-tokio-rt-{}", id)
-            })
-            .enable_all()
-            .build()?;
         // bounded channel for backpressure
         let (sender, receiver) = tokio::sync::mpsc::channel(config.max_message_queue_size);
         // State might be initialized but the node might be shutdown without actually syncing or committing anything.
@@ -175,7 +171,7 @@ impl Consensus {
                 uri,
                 p2p_port,
                 &config,
-                &runtime,
+                runtime.clone(),
                 leader_established_in_ms,
             )
             .map_err(|err| anyhow!("Failed to initialize Consensus for new Raft state: {}", err))?;
@@ -218,7 +214,7 @@ impl Consensus {
         uri: Option<String>,
         p2p_port: u16,
         config: &ConsensusConfig,
-        runtime: &Runtime,
+        runtime: Handle,
         leader_established_in_ms: u64,
     ) -> anyhow::Result<()> {
         if let Some(bootstrap_peer) = bootstrap_peer {
@@ -872,6 +868,7 @@ mod tests {
         let update_runtime =
             crate::create_update_runtime(settings.storage.performance.max_search_threads)
                 .expect("Can't create optimizer runtime.");
+        let handle = update_runtime.handle().clone(); // no general runtime here, reuse optimizer runtime as it is cheaper
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         let persistent_state =
             Persistent::load_or_init(&settings.storage.storage_path, true).unwrap();
@@ -883,6 +880,7 @@ mod tests {
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),
+            handle.clone(),
         );
         let toc_arc = Arc::new(toc);
         let storage_path = toc_arc.storage_path();
@@ -903,6 +901,7 @@ mod tests {
             6335,
             ConsensusConfig::default(),
             ChannelService::default(),
+            handle.clone(),
         )
         .unwrap();
 
@@ -929,8 +928,7 @@ mod tests {
         // When
 
         // New runtime is used as timers need to be enabled.
-        tokio::runtime::Runtime::new()
-            .unwrap()
+        handle
             .block_on(
                 dispatcher.submit_collection_meta_op(
                     CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -852,6 +852,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::Consensus;
+    use crate::common::helpers::create_general_purpose_runtime;
     use crate::settings::ConsensusConfig;
 
     #[test]
@@ -868,7 +869,9 @@ mod tests {
         let update_runtime =
             crate::create_update_runtime(settings.storage.performance.max_search_threads)
                 .expect("Can't create update runtime.");
-        let handle = update_runtime.handle().clone(); // no general runtime here, reuse optimizer runtime as it is cheaper
+        let general_runtime =
+            create_general_purpose_runtime().expect("Can't create general purpose runtime.");
+        let handle = general_runtime.handle().clone();
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
         let persistent_state =
             Persistent::load_or_init(&settings.storage.storage_path, true).unwrap();
@@ -877,10 +880,10 @@ mod tests {
             &settings.storage,
             search_runtime,
             update_runtime,
+            general_runtime,
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),
-            handle.clone(),
         );
         let toc_arc = Arc::new(toc);
         let storage_path = toc_arc.storage_path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,9 @@ use storage::dispatcher::Dispatcher;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
-use crate::common::helpers::{create_search_runtime, create_update_runtime};
+use crate::common::helpers::{
+    create_general_purpose_runtime, create_update_runtime, create_search_runtime,
+};
 use crate::common::telemetry::TelemetryCollector;
 use crate::greeting::welcome;
 use crate::migrations::single_to_cluster::handle_existing_collections;
@@ -127,11 +129,14 @@ fn main() -> anyhow::Result<()> {
     // destruction of it
     let search_runtime = create_search_runtime(settings.storage.performance.max_search_threads)
         .expect("Can't search create runtime.");
-    let search_runtime_handle = search_runtime.handle().clone();
 
     let update_runtime =
         create_update_runtime(settings.storage.performance.max_optimization_threads)
             .expect("Can't optimizer create runtime.");
+
+    let general_runtime =
+        create_general_purpose_runtime().expect("Can't optimizer general purpose runtime.");
+    let runtime_handle = general_runtime.handle().clone();
 
     // Create a signal sender and receiver. It is used to communicate with the consensus thread.
     let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
@@ -174,10 +179,11 @@ fn main() -> anyhow::Result<()> {
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
+        runtime_handle.clone(),
     );
 
     // Here we load all stored collections.
-    search_runtime_handle.block_on(async {
+    runtime_handle.block_on(async {
         for collection in toc.all_collections().await {
             log::debug!("Loaded collection: {}", collection);
         }
@@ -231,6 +237,7 @@ fn main() -> anyhow::Result<()> {
             propose_receiver,
             tonic_telemetry_collector,
             toc_arc.clone(),
+            runtime_handle.clone(),
         )
         .expect("Can't initialize consensus");
 
@@ -238,7 +245,7 @@ fn main() -> anyhow::Result<()> {
 
         let toc_arc_clone = toc_arc.clone();
         let consensus_state_clone = consensus_state.clone();
-        let _cancel_transfer_handle = search_runtime_handle.spawn(async move {
+        let _cancel_transfer_handle = runtime_handle.spawn(async move {
             consensus_state_clone.is_leader_established.await_ready();
             match toc_arc_clone
                 .cancel_outgoing_all_transfers("Source peer restarted")
@@ -254,14 +261,14 @@ fn main() -> anyhow::Result<()> {
         });
 
         let collections_to_recover_in_consensus = if is_new_deployment {
-            let existing_collections = search_runtime_handle.block_on(toc_arc.all_collections());
+            let existing_collections = runtime_handle.block_on(toc_arc.all_collections());
             existing_collections
         } else {
             restored_collections
         };
 
         if !collections_to_recover_in_consensus.is_empty() {
-            search_runtime_handle.spawn(handle_existing_collections(
+            runtime_handle.spawn(handle_existing_collections(
                 toc_arc.clone(),
                 consensus_state.clone(),
                 dispatcher_arc.clone(),
@@ -304,6 +311,7 @@ fn main() -> anyhow::Result<()> {
                     tonic_telemetry_collector,
                     settings.service.host,
                     grpc_port,
+                    runtime_handle,
                 )
             })
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,10 +176,10 @@ fn main() -> anyhow::Result<()> {
         &settings.storage,
         search_runtime,
         update_runtime,
+        general_runtime,
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
-        runtime_handle.clone(),
     );
 
     // Here we load all stored collections.
@@ -356,6 +356,10 @@ fn main() -> anyhow::Result<()> {
     }
 
     for handle in handles.into_iter() {
+        log::debug!(
+            "Waiting for thread {} to finish",
+            handle.thread().name().unwrap()
+        );
         handle.join().expect("thread is not panicking")?;
     }
     drop(toc_arc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use storage::dispatcher::Dispatcher;
 use tikv_jemallocator::Jemalloc;
 
 use crate::common::helpers::{
-    create_general_purpose_runtime, create_update_runtime, create_search_runtime,
+    create_general_purpose_runtime, create_search_runtime, create_update_runtime,
 };
 use crate::common::telemetry::TelemetryCollector;
 use crate::greeting::welcome;


### PR DESCRIPTION
THis PR merges the remaining Tokio runtimes into a single global one named `general`.

The remaining runtimes were:
- tonic
- tonic-internal
- toc
- consensus-rt

![threads](https://user-images.githubusercontent.com/606963/214513922-69be2d2c-f595-46d7-8a4e-cf161ed09633.png)
