### PR TITLE
Name rayon hnsw threads for clarity

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -320,6 +320,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         );
 
         let pool = rayon::ThreadPoolBuilder::new()
+            .thread_name(|idx| format!("hnsw-build-{}", idx))
             .num_threads(self.config.max_rayon_threads())
             .build()?;
 


### PR DESCRIPTION
This PR names properly the Rayon thread performing the hnsw build.

This clarify the fact that this operation does not actually takes place on the optimizer runtime.