### PR TITLE
add init state to replica set

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5566,7 +5566,8 @@
         "enum": [
           "Active",
           "Dead",
-          "Partial"
+          "Partial",
+          "Initializing"
         ]
       },
       "RemoteShardInfo": {

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -331,8 +331,7 @@ impl Collection {
             let current_state = replica_set.peer_state(&peer_id);
             if current_state != from_state {
                 return Err(CollectionError::bad_input(format!(
-                    "Replica {} of shard {} has state {:?}, but expected {:?}",
-                    peer_id, shard_id, current_state, from_state
+                    "Replica {peer_id} of shard {shard_id} has state {current_state:?}, but expected {from_state:?}"
                 )));
             }
         }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -49,7 +49,6 @@ const READ_REMOTE_REPLICAS: u32 = 2;
 
 const REPLICA_STATE_FILE: &str = "replica_state.json";
 
-
 // Shard replication state machine:
 //
 //    │

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -14,7 +14,7 @@ use crate::operations::{OperationToShard, SplitByShard};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::local_shard::LocalShard;
-use crate::shards::replica_set::{OnPeerFailure, ReplicaState, ShardReplicaSet};
+use crate::shards::replica_set::{ChangePeerState, ReplicaState, ShardReplicaSet};
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{ShardConfig, ShardType};
 use crate::shards::shard_versioning::latest_shard_paths;
@@ -209,7 +209,7 @@ impl ShardHolder {
         collection_id: &CollectionId,
         shared_collection_config: Arc<RwLock<CollectionConfig>>,
         channel_service: ChannelService,
-        on_peer_failure: OnPeerFailure,
+        on_peer_failure: ChangePeerState,
         this_peer_id: PeerId,
         update_runtime: Handle,
     ) {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -11,7 +11,7 @@ use crate::operations::types::{VectorParams, VectorsConfig};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-use crate::shards::replica_set::OnPeerFailure;
+use crate::shards::replica_set::ChangePeerState;
 
 const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     deleted_threshold: 0.9,
@@ -24,7 +24,7 @@ const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     max_optimization_threads: 2,
 };
 
-pub fn dummy_on_replica_failure() -> OnPeerFailure {
+pub fn dummy_on_replica_failure() -> ChangePeerState {
     Arc::new(move |_peer_id, _shard_id| {})
 }
 

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -107,7 +107,7 @@ pub async fn new_local_collection(
     let local_shards = collection.get_local_shards().await;
     for shard_id in local_shards {
         collection
-            .set_shard_replica_state(shard_id, 0, ReplicaState::Active)
+            .set_shard_replica_state(shard_id, 0, ReplicaState::Active, None)
             .await?;
     }
     Ok(collection)

--- a/lib/collection/tests/common/mod.rs
+++ b/lib/collection/tests/common/mod.rs
@@ -10,7 +10,7 @@ use collection::operations::types::{CollectionError, VectorParams};
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
-use collection::shards::replica_set::{OnPeerFailure, ReplicaState};
+use collection::shards::replica_set::{ChangePeerState, ReplicaState};
 use collection::shards::CollectionId;
 use segment::types::Distance;
 
@@ -71,7 +71,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
     .unwrap()
 }
 
-pub fn dummy_on_replica_failure() -> OnPeerFailure {
+pub fn dummy_on_replica_failure() -> ChangePeerState {
     Arc::new(move |_peer_id, _shard_id| {})
 }
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -256,6 +256,13 @@ pub struct SetShardReplicaState {
     pub peer_id: PeerId,
     /// If `Active` then the replica is up to date and can receive updates and answer requests
     pub state: ReplicaState,
+    /// If `Some` then check that the replica is in this state before changing it
+    /// If `None` then the replica can be in any state
+    /// This is useful for example when we want to make sure
+    /// we only make transition from `Initializing` to `Active`, and not from `Dead` to `Active`.
+    /// If `from_state` does not match the current state of the replica, then the operation will be dismissed.
+    #[serde(default)]
+    pub from_state: Option<ReplicaState>,
 }
 
 /// Enumeration of all possible collection update operations

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -18,6 +18,7 @@ pub mod toc;
 
 pub mod consensus_ops {
     use collection::shards::replica_set::ReplicaState;
+    use collection::shards::replica_set::ReplicaState::Initializing;
     use collection::shards::shard::PeerId;
     use collection::shards::transfer::shard_transfer::ShardTransfer;
     use collection::shards::{replica_set, CollectionId};
@@ -72,6 +73,7 @@ pub mod consensus_ops {
             shard_id: u32,
             peer_id: PeerId,
             state: ReplicaState,
+            from_state: Option<ReplicaState>,
         ) -> Self {
             ConsensusOperations::CollectionMeta(
                 CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
@@ -79,6 +81,7 @@ pub mod consensus_ops {
                     shard_id,
                     peer_id,
                     state,
+                    from_state,
                 })
                 .into(),
             )
@@ -104,12 +107,19 @@ pub mod consensus_ops {
             )
         }
 
-        pub fn activate_replica(
+        /// Report that a replica was initialized
+        pub fn initialize_replica(
             collection_name: CollectionId,
             shard_id: u32,
             peer_id: PeerId,
         ) -> Self {
-            Self::set_replica_state(collection_name, shard_id, peer_id, ReplicaState::Active)
+            Self::set_replica_state(
+                collection_name,
+                shard_id,
+                peer_id,
+                ReplicaState::Active,
+                Some(Initializing),
+            )
         }
 
         pub fn deactivate_replica(
@@ -117,7 +127,7 @@ pub mod consensus_ops {
             shard_id: u32,
             peer_id: PeerId,
         ) -> Self {
-            Self::set_replica_state(collection_name, shard_id, peer_id, ReplicaState::Dead)
+            Self::set_replica_state(collection_name, shard_id, peer_id, ReplicaState::Dead, None)
         }
 
         pub fn start_transfer(collection_id: CollectionId, transfer: ShardTransfer) -> Self {

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -28,6 +28,7 @@ async fn activate_shard(
             peer_id,
             *shard_id,
             ReplicaState::Active,
+            None,
         )?;
     } else {
         log::debug!(
@@ -36,7 +37,7 @@ async fn activate_shard(
             &collection.name()
         );
         collection
-            .set_shard_replica_state(*shard_id, peer_id, ReplicaState::Active)
+            .set_shard_replica_state(*shard_id, peer_id, ReplicaState::Active, None)
             .await?;
     }
     Ok(())
@@ -122,6 +123,7 @@ pub async fn do_recover_from_snapshot(
                         this_peer_id,
                         *shard_id,
                         ReplicaState::Partial,
+                        None,
                     )?;
                 }
             }
@@ -202,6 +204,7 @@ pub async fn do_recover_from_snapshot(
                                     *peer_id,
                                     *shard_id,
                                     ReplicaState::Dead,
+                                    None,
                                 )?;
                             }
                         }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -66,7 +66,7 @@ impl Dispatcher {
                         // Expect all replicas to become active eventually
                         for (shard_id, peer_ids) in &shard_distribution.distribution {
                             for peer_id in peer_ids {
-                                expect_operations.push(ConsensusOperations::activate_replica(
+                                expect_operations.push(ConsensusOperations::initialize_replica(
                                     op.collection_name.clone(),
                                     *shard_id,
                                     *peer_id,

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -95,7 +95,6 @@ impl Dispatcher {
                 .propose_consensus_op_with_await(
                     ConsensusOperations::CollectionMeta(Box::new(op)),
                     wait_timeout,
-                    true,
                 )
                 .await?;
 

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -48,7 +48,6 @@ async fn remove_peer(
                 .propose_consensus_op_with_await(
                     ConsensusOperations::RemovePeer(peer_id),
                     params.timeout.map(std::time::Duration::from_secs),
-                    false,
                 )
                 .await
         }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -958,7 +958,7 @@ mod tests {
             .unwrap();
 
         // Then
-        assert_eq!(consensus_state.hard_state().commit, 5); // Collection + Nop + 2 of shard activations
+        assert_eq!(consensus_state.hard_state().commit, 4); // Collection + 2 of shard activations
         assert_eq!(toc_arc.all_collections_sync(), vec!["test"]);
     }
 }

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -80,6 +80,7 @@ pub async fn handle_existing_collections(
                             shard_id,
                             peer_id: this_peer_id,
                             state: ReplicaState::Active,
+                            from_state: None,
                         }),
                         None,
                     )

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -85,7 +85,6 @@ impl Raft for RaftService {
                     uri: uri.to_string(),
                 },
                 None,
-                true,
             )
             .await
             .map_err(|err| Status::internal(format!("Failed to add peer: {err}")))?;


### PR DESCRIPTION
The problem:

We create collection in Partial/Dead state to prevent premature access to shards which are not created yet (like node might be down and we don't want to send requests there until node reports that collection is created)

But: shard activation is managed by consensus and we can lose the proposal is leader is lost. In this case some shards are never activated and collection create API times out. That happened in the integration tests couple of times. 

Solution: What is we create a special state of the shard called `initializing`, which means, that is it just created. No shard should have this state, as if local state is there, it is already initialized. We can use this property to report activation during the local state sync.

---- 

Pros:

- collection create API should not timeout even if we catch the re-election

Cons:

- more complicated state. In theory, if user received collection creation timeout, they can just retry. Would need to update the integration test accordingly in this case 

