### PR TITLE
Forward write request according to write consistency

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -31,6 +31,7 @@ message SyncPoints {
   repeated PointStruct points = 3;
   optional PointId from_id = 4; // Start of the sync range
   optional PointId to_id = 5; // End of the sync range
+  optional WriteOrdering ordering = 6;
 }
 
 message SyncPointsInternal {

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -35,71 +35,71 @@ message SyncPoints {
 
 message SyncPointsInternal {
   SyncPoints sync_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message UpsertPointsInternal {
   UpsertPoints upsert_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message DeletePointsInternal {
   DeletePoints delete_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message SetPayloadPointsInternal {
   SetPayloadPoints set_payload_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message DeletePayloadPointsInternal {
   DeletePayloadPoints delete_payload_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message ClearPayloadPointsInternal {
   ClearPayloadPoints clear_payload_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message CreateFieldIndexCollectionInternal {
   CreateFieldIndexCollection create_field_index_collection = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message DeleteFieldIndexCollectionInternal {
   DeleteFieldIndexCollection delete_field_index_collection = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message SearchPointsInternal {
   SearchPoints search_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message SearchBatchPointsInternal {
   string collection_name = 1;
   repeated SearchPoints search_points = 2;
-  uint32 shard_id = 3;
+  optional uint32 shard_id = 3;
 }
 
 message ScrollPointsInternal {
   ScrollPoints scroll_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message RecommendPointsInternal {
   RecommendPoints recommend_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message GetPointsInternal {
   GetPoints get_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }
 
 message CountPointsInternal {
   CountPoints count_points = 1;
-  uint32 shard_id = 2;
+  optional uint32 shard_id = 2;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3594,48 +3594,48 @@ pub struct SyncPoints {
 pub struct SyncPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub sync_points: ::core::option::Option<SyncPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub upsert_points: ::core::option::Option<UpsertPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePointsInternal {
     #[prost(message, optional, tag = "1")]
     pub delete_points: ::core::option::Option<DeletePoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub delete_payload_points: ::core::option::Option<DeletePayloadPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub clear_payload_points: ::core::option::Option<ClearPayloadPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3644,8 +3644,8 @@ pub struct CreateFieldIndexCollectionInternal {
     pub create_field_index_collection: ::core::option::Option<
         CreateFieldIndexCollection,
     >,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3654,16 +3654,16 @@ pub struct DeleteFieldIndexCollectionInternal {
     pub delete_field_index_collection: ::core::option::Option<
         DeleteFieldIndexCollection,
     >,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub search_points: ::core::option::Option<SearchPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3672,40 +3672,40 @@ pub struct SearchBatchPointsInternal {
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
-    #[prost(uint32, tag = "3")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "3")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub scroll_points: ::core::option::Option<ScrollPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub recommend_points: ::core::option::Option<RecommendPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub get_points: ::core::option::Option<GetPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountPointsInternal {
     #[prost(message, optional, tag = "1")]
     pub count_points: ::core::option::Option<CountPoints>,
-    #[prost(uint32, tag = "2")]
-    pub shard_id: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
 }
 /// Generated client implementations.
 pub mod points_internal_client {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3588,6 +3588,8 @@ pub struct SyncPoints {
     /// End of the sync range
     #[prost(message, optional, tag = "5")]
     pub to_id: ::core::option::Option<PointId>,
+    #[prost(message, optional, tag = "6")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -25,6 +25,7 @@ use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
 use crate::operations::config_diff::{CollectionParamsDiff, DiffConfig, OptimizersConfigDiff};
+use crate::operations::point_ops::WriteOrdering;
 use crate::operations::snapshot_ops::{
     get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
 };
@@ -703,6 +704,7 @@ impl Collection {
         &self,
         operation: CollectionUpdateOperations,
         wait: bool,
+        ordering: WriteOrdering,
     ) -> CollectionResult<UpdateResult> {
         operation.validate()?;
         let _update_lock = self.updates_lock.read().await;
@@ -719,7 +721,9 @@ impl Collection {
 
             let shard_requests = shard_to_op
                 .into_iter()
-                .map(move |(replica_set, operation)| replica_set.update(operation, wait));
+                .map(move |(replica_set, operation)| {
+                    replica_set.update_with_consistency(operation, wait, ordering)
+                });
             join_all(shard_requests).await
         };
 

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -61,6 +61,26 @@ pub fn internal_upsert_points(
     })
 }
 
+pub fn external_upsert_points(
+    point_insert_operations: PointInsertOperations,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> CollectionResult<UpsertPoints> {
+    Ok(UpsertPoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        points: match point_insert_operations {
+            PointInsertOperations::PointsBatch(batch) => batch.try_into()?,
+            PointInsertOperations::PointsList(list) => list
+                .into_iter()
+                .map(|id| id.try_into())
+                .collect::<Result<Vec<_>, Status>>()?,
+        },
+        ordering: ordering.map(write_ordering_to_proto),
+    })
+}
+
 pub fn internal_delete_points(
     ids: Vec<PointIdType>,
     shard: &RemoteShard,
@@ -82,6 +102,25 @@ pub fn internal_delete_points(
     }
 }
 
+pub fn external_delete_points(
+    ids: Vec<PointIdType>,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeletePoints {
+    DeletePoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        points: Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
+                ids: ids.into_iter().map(|id| id.into()).collect(),
+            })),
+        }),
+
+        ordering: ordering.map(write_ordering_to_proto),
+    }
+}
+
 pub fn internal_delete_points_by_filter(
     filter: Filter,
     shard: &RemoteShard,
@@ -98,6 +137,22 @@ pub fn internal_delete_points_by_filter(
             }),
             ordering: ordering.map(write_ordering_to_proto),
         }),
+    }
+}
+
+pub fn external_delete_points_by_filter(
+    filter: Filter,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeletePoints {
+    DeletePoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        points: Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
+        }),
+        ordering: ordering.map(write_ordering_to_proto),
     }
 }
 
@@ -135,6 +190,37 @@ pub fn internal_set_payload(
     }
 }
 
+pub fn external_set_payload(
+    set_payload: SetPayload,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> SetPayloadPoints {
+    let mut selected_points = vec![];
+
+    let points_selector = if let Some(points) = set_payload.points {
+        selected_points = points.into_iter().map(|id| id.into()).collect();
+        Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
+                ids: selected_points.clone(),
+            })),
+        })
+    } else {
+        set_payload.filter.map(|filter| PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
+        })
+    };
+
+    SetPayloadPoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        payload: payload_to_proto(set_payload.payload),
+        points: selected_points, // ToDo: Deprecated
+        points_selector,
+        ordering: ordering.map(write_ordering_to_proto),
+    }
+}
+
 pub fn internal_delete_payload(
     delete_payload: DeletePayload,
     shard: &RemoteShard,
@@ -168,6 +254,36 @@ pub fn internal_delete_payload(
     }
 }
 
+pub fn external_delete_payload(
+    delete_payload: DeletePayload,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeletePayloadPoints {
+    let mut selected_points = vec![];
+    let points_selector = if let Some(points) = delete_payload.points {
+        selected_points = points.into_iter().map(|id| id.into()).collect();
+        Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
+                ids: selected_points.clone(),
+            })),
+        })
+    } else {
+        delete_payload.filter.map(|filter| PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
+        })
+    };
+
+    DeletePayloadPoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        keys: delete_payload.keys,
+        points: selected_points, // ToDo: Deprecated
+        points_selector,
+        ordering: ordering.map(write_ordering_to_proto),
+    }
+}
+
 pub fn internal_clear_payload(
     points: Vec<PointIdType>,
     shard: &RemoteShard,
@@ -189,6 +305,24 @@ pub fn internal_clear_payload(
     }
 }
 
+pub fn external_clear_payload(
+    points: Vec<PointIdType>,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> ClearPayloadPoints {
+    ClearPayloadPoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        points: Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
+                ids: points.into_iter().map(|id| id.into()).collect(),
+            })),
+        }),
+        ordering: ordering.map(write_ordering_to_proto),
+    }
+}
+
 pub fn internal_clear_payload_by_filter(
     filter: Filter,
     shard: &RemoteShard,
@@ -205,6 +339,22 @@ pub fn internal_clear_payload_by_filter(
             }),
             ordering: ordering.map(write_ordering_to_proto),
         }),
+    }
+}
+
+pub fn external_clear_payload_by_filter(
+    filter: Filter,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> ClearPayloadPoints {
+    ClearPayloadPoints {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        points: Some(PointsSelector {
+            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
+        }),
+        ordering: ordering.map(write_ordering_to_proto),
     }
 }
 
@@ -260,6 +410,55 @@ pub fn internal_create_index(
     }
 }
 
+pub fn external_create_index(
+    create_index: CreateIndex,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> CreateFieldIndexCollection {
+    let (field_type, field_index_params) = create_index
+        .field_schema
+        .map(|field_schema| match field_schema {
+            PayloadFieldSchema::FieldType(field_type) => (
+                match field_type {
+                    segment::types::PayloadSchemaType::Keyword => {
+                        api::grpc::qdrant::FieldType::Keyword as i32
+                    }
+                    segment::types::PayloadSchemaType::Integer => {
+                        api::grpc::qdrant::FieldType::Integer as i32
+                    }
+                    segment::types::PayloadSchemaType::Float => {
+                        api::grpc::qdrant::FieldType::Float as i32
+                    }
+                    segment::types::PayloadSchemaType::Geo => {
+                        api::grpc::qdrant::FieldType::Geo as i32
+                    }
+                    segment::types::PayloadSchemaType::Text => {
+                        api::grpc::qdrant::FieldType::Text as i32
+                    }
+                },
+                None,
+            ),
+            PayloadFieldSchema::FieldParams(field_params) => match field_params {
+                PayloadSchemaParams::Text(text_index_params) => (
+                    api::grpc::qdrant::FieldType::Text as i32,
+                    Some(text_index_params.into()),
+                ),
+            },
+        })
+        .map(|(field_type, field_params)| (Some(field_type), field_params))
+        .unwrap_or((None, None));
+
+    CreateFieldIndexCollection {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        field_name: create_index.field_name,
+        field_type,
+        field_index_params,
+        ordering: ordering.map(write_ordering_to_proto),
+    }
+}
+
 pub fn internal_delete_index(
     delete_index: String,
     shard: &RemoteShard,
@@ -274,5 +473,19 @@ pub fn internal_delete_index(
             field_name: delete_index,
             ordering: ordering.map(write_ordering_to_proto),
         }),
+    }
+}
+
+pub fn external_delete_index(
+    delete_index: String,
+    shard: &RemoteShard,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeleteFieldIndexCollection {
+    DeleteFieldIndexCollection {
+        collection_name: shard.collection_id.clone(),
+        wait: Some(wait),
+        field_name: delete_index,
+        ordering: ordering.map(write_ordering_to_proto),
     }
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -22,6 +22,7 @@ pub fn internal_sync_points(
     collection_name: String,
     points_sync_operation: PointSyncOperation,
     wait: bool,
+    ordering: Option<WriteOrdering>,
 ) -> CollectionResult<SyncPointsInternal> {
     Ok(SyncPointsInternal {
         shard_id,
@@ -35,6 +36,7 @@ pub fn internal_sync_points(
                 .collect::<Result<Vec<_>, Status>>()?,
             from_id: points_sync_operation.from_id.map(|x| x.into()),
             to_id: points_sync_operation.to_id.map(|x| x.into()),
+            ordering: ordering.map(write_ordering_to_proto),
         }),
     })
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -15,17 +15,18 @@ use crate::operations::payload_ops::{DeletePayload, SetPayload};
 use crate::operations::point_ops::{PointInsertOperations, PointSyncOperation, WriteOrdering};
 use crate::operations::types::CollectionResult;
 use crate::operations::CreateIndex;
-use crate::shards::remote_shard::RemoteShard;
+use crate::shards::shard::ShardId;
 
 pub fn internal_sync_points(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     points_sync_operation: PointSyncOperation,
-    shard: &RemoteShard,
     wait: bool,
 ) -> CollectionResult<SyncPointsInternal> {
     Ok(SyncPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         sync_points: Some(SyncPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: points_sync_operation
                 .points
@@ -39,15 +40,16 @@ pub fn internal_sync_points(
 }
 
 pub fn internal_upsert_points(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     point_insert_operations: PointInsertOperations,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpsertPointsInternal> {
     Ok(UpsertPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         upsert_points: Some(UpsertPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: match point_insert_operations {
                 PointInsertOperations::PointsBatch(batch) => batch.try_into()?,
@@ -61,36 +63,17 @@ pub fn internal_upsert_points(
     })
 }
 
-pub fn external_upsert_points(
-    point_insert_operations: PointInsertOperations,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> CollectionResult<UpsertPoints> {
-    Ok(UpsertPoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        points: match point_insert_operations {
-            PointInsertOperations::PointsBatch(batch) => batch.try_into()?,
-            PointInsertOperations::PointsList(list) => list
-                .into_iter()
-                .map(|id| id.try_into())
-                .collect::<Result<Vec<_>, Status>>()?,
-        },
-        ordering: ordering.map(write_ordering_to_proto),
-    })
-}
-
 pub fn internal_delete_points(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     ids: Vec<PointIdType>,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeletePointsInternal {
     DeletePointsInternal {
-        shard_id: shard.id,
+        shard_id,
         delete_points: Some(DeletePoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
@@ -102,35 +85,17 @@ pub fn internal_delete_points(
     }
 }
 
-pub fn external_delete_points(
-    ids: Vec<PointIdType>,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> DeletePoints {
-    DeletePoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        points: Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: ids.into_iter().map(|id| id.into()).collect(),
-            })),
-        }),
-
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_delete_points_by_filter(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     filter: Filter,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeletePointsInternal {
     DeletePointsInternal {
-        shard_id: shard.id,
+        shard_id,
         delete_points: Some(DeletePoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
@@ -140,25 +105,10 @@ pub fn internal_delete_points_by_filter(
     }
 }
 
-pub fn external_delete_points_by_filter(
-    filter: Filter,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> DeletePoints {
-    DeletePoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        points: Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
-        }),
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_set_payload(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     set_payload: SetPayload,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> SetPayloadPointsInternal {
@@ -178,9 +128,9 @@ pub fn internal_set_payload(
     };
 
     SetPayloadPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         set_payload_points: Some(SetPayloadPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             payload: payload_to_proto(set_payload.payload),
             points: selected_points, // ToDo: Deprecated
@@ -190,40 +140,10 @@ pub fn internal_set_payload(
     }
 }
 
-pub fn external_set_payload(
-    set_payload: SetPayload,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> SetPayloadPoints {
-    let mut selected_points = vec![];
-
-    let points_selector = if let Some(points) = set_payload.points {
-        selected_points = points.into_iter().map(|id| id.into()).collect();
-        Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: selected_points.clone(),
-            })),
-        })
-    } else {
-        set_payload.filter.map(|filter| PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
-        })
-    };
-
-    SetPayloadPoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        payload: payload_to_proto(set_payload.payload),
-        points: selected_points, // ToDo: Deprecated
-        points_selector,
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_delete_payload(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     delete_payload: DeletePayload,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeletePayloadPointsInternal {
@@ -242,9 +162,9 @@ pub fn internal_delete_payload(
     };
 
     DeletePayloadPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         delete_payload_points: Some(DeletePayloadPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             keys: delete_payload.keys,
             points: selected_points, // ToDo: Deprecated
@@ -254,46 +174,17 @@ pub fn internal_delete_payload(
     }
 }
 
-pub fn external_delete_payload(
-    delete_payload: DeletePayload,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> DeletePayloadPoints {
-    let mut selected_points = vec![];
-    let points_selector = if let Some(points) = delete_payload.points {
-        selected_points = points.into_iter().map(|id| id.into()).collect();
-        Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: selected_points.clone(),
-            })),
-        })
-    } else {
-        delete_payload.filter.map(|filter| PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
-        })
-    };
-
-    DeletePayloadPoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        keys: delete_payload.keys,
-        points: selected_points, // ToDo: Deprecated
-        points_selector,
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_clear_payload(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     points: Vec<PointIdType>,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         clear_payload_points: Some(ClearPayloadPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
@@ -305,34 +196,17 @@ pub fn internal_clear_payload(
     }
 }
 
-pub fn external_clear_payload(
-    points: Vec<PointIdType>,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> ClearPayloadPoints {
-    ClearPayloadPoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        points: Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
-                ids: points.into_iter().map(|id| id.into()).collect(),
-            })),
-        }),
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_clear_payload_by_filter(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     filter: Filter,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
-        shard_id: shard.id,
+        shard_id,
         clear_payload_points: Some(ClearPayloadPoints {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
@@ -342,25 +216,10 @@ pub fn internal_clear_payload_by_filter(
     }
 }
 
-pub fn external_clear_payload_by_filter(
-    filter: Filter,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> ClearPayloadPoints {
-    ClearPayloadPoints {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        points: Some(PointsSelector {
-            points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
-        }),
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_create_index(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     create_index: CreateIndex,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> CreateFieldIndexCollectionInternal {
@@ -398,9 +257,9 @@ pub fn internal_create_index(
         .unwrap_or((None, None));
 
     CreateFieldIndexCollectionInternal {
-        shard_id: shard.id,
+        shard_id,
         create_field_index_collection: Some(CreateFieldIndexCollection {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             field_name: create_index.field_name,
             field_type,
@@ -410,82 +269,20 @@ pub fn internal_create_index(
     }
 }
 
-pub fn external_create_index(
-    create_index: CreateIndex,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> CreateFieldIndexCollection {
-    let (field_type, field_index_params) = create_index
-        .field_schema
-        .map(|field_schema| match field_schema {
-            PayloadFieldSchema::FieldType(field_type) => (
-                match field_type {
-                    segment::types::PayloadSchemaType::Keyword => {
-                        api::grpc::qdrant::FieldType::Keyword as i32
-                    }
-                    segment::types::PayloadSchemaType::Integer => {
-                        api::grpc::qdrant::FieldType::Integer as i32
-                    }
-                    segment::types::PayloadSchemaType::Float => {
-                        api::grpc::qdrant::FieldType::Float as i32
-                    }
-                    segment::types::PayloadSchemaType::Geo => {
-                        api::grpc::qdrant::FieldType::Geo as i32
-                    }
-                    segment::types::PayloadSchemaType::Text => {
-                        api::grpc::qdrant::FieldType::Text as i32
-                    }
-                },
-                None,
-            ),
-            PayloadFieldSchema::FieldParams(field_params) => match field_params {
-                PayloadSchemaParams::Text(text_index_params) => (
-                    api::grpc::qdrant::FieldType::Text as i32,
-                    Some(text_index_params.into()),
-                ),
-            },
-        })
-        .map(|(field_type, field_params)| (Some(field_type), field_params))
-        .unwrap_or((None, None));
-
-    CreateFieldIndexCollection {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        field_name: create_index.field_name,
-        field_type,
-        field_index_params,
-        ordering: ordering.map(write_ordering_to_proto),
-    }
-}
-
 pub fn internal_delete_index(
+    shard_id: Option<ShardId>,
+    collection_name: String,
     delete_index: String,
-    shard: &RemoteShard,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeleteFieldIndexCollectionInternal {
     DeleteFieldIndexCollectionInternal {
-        shard_id: shard.id,
+        shard_id,
         delete_field_index_collection: Some(DeleteFieldIndexCollection {
-            collection_name: shard.collection_id.clone(),
+            collection_name,
             wait: Some(wait),
             field_name: delete_index,
             ordering: ordering.map(write_ordering_to_proto),
         }),
-    }
-}
-
-pub fn external_delete_index(
-    delete_index: String,
-    shard: &RemoteShard,
-    wait: bool,
-    ordering: Option<WriteOrdering>,
-) -> DeleteFieldIndexCollection {
-    DeleteFieldIndexCollection {
-        collection_name: shard.collection_id.clone(),
-        wait: Some(wait),
-        field_name: delete_index,
-        ordering: ordering.map(write_ordering_to_proto),
     }
 }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -142,11 +142,13 @@ impl ShardReplicaSet {
     }
 
     pub fn highest_replica_peer_id(&self) -> Option<PeerId> {
-        self.peers().keys().max().cloned()
+        self.replica_state.read().peers.keys().max().cloned()
     }
 
     pub fn highest_alive_replica_peer_id(&self) -> Option<PeerId> {
-        self.peers()
+        self.replica_state
+            .read()
+            .peers
             .iter()
             .filter_map(|(peer_id, _state)| {
                 if self.peer_is_active(peer_id) {
@@ -1082,7 +1084,7 @@ impl ShardReplicaSet {
     ) -> CollectionResult<UpdateResult> {
         match self.leader_peer_for_update(ordering) {
             None => Err(CollectionError::service_error(format!(
-                "Cannot update shard {}:{} because there are no active replicas",
+                "Cannot update shard {}:{} with {ordering:?} ordering because no leader could be selected",
                 self.collection_id, self.shard_id
             ))),
             Some(leader_peer) => {
@@ -1091,7 +1093,13 @@ impl ShardReplicaSet {
                     self.update(operation, wait).await
                 } else {
                     // forward the update to the designated leader
-                    self.forward_update(leader_peer, operation, wait).await
+                    self.forward_update(leader_peer, operation, wait)
+                        .await
+                        .map_err(|err| {
+                            CollectionError::service_error(format!(
+                                "Failed to apply update with {ordering:?} ordering via leader peer {leader_peer}: {err}"
+                            ))
+                        })
                 }
             }
         }
@@ -1325,5 +1333,94 @@ impl ShardReplicaSet {
             &remotes,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::{NonZeroU32, NonZeroU64};
+
+    use segment::types::Distance;
+    use tempfile::{Builder, TempDir};
+
+    use super::*;
+    use crate::config::*;
+    use crate::operations::types::{VectorParams, VectorsConfig};
+    use crate::optimizers_builder::OptimizersConfig;
+
+    const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
+        deleted_threshold: 0.9,
+        vacuum_min_vector_number: 1000,
+        default_segment_number: 2,
+        max_segment_size: None,
+        memmap_threshold: None,
+        indexing_threshold: 50_000,
+        flush_interval_sec: 30,
+        max_optimization_threads: 2,
+    };
+
+    pub fn dummy_on_replica_failure() -> OnPeerFailure {
+        Arc::new(move |_peer_id, _shard_id| {})
+    }
+
+    async fn new_shard_replica_set(collection_dir: &TempDir) -> ShardReplicaSet {
+        let update_runtime = Handle::current();
+        let wal_config = WalConfig {
+            wal_capacity_mb: 1,
+            wal_segments_ahead: 0,
+        };
+
+        let collection_params = CollectionParams {
+            vectors: VectorsConfig::Single(VectorParams {
+                size: NonZeroU64::new(4).unwrap(),
+                distance: Distance::Dot,
+            }),
+            shard_number: NonZeroU32::new(4).unwrap(),
+            replication_factor: NonZeroU32::new(3).unwrap(),
+            write_consistency_factor: NonZeroU32::new(2).unwrap(),
+            on_disk_payload: false,
+        };
+
+        let config = CollectionConfig {
+            params: collection_params,
+            optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+            wal_config,
+            hnsw_config: Default::default(),
+        };
+
+        let shared_config = Arc::new(RwLock::new(config.clone()));
+        let remotes = HashSet::from([2, 3, 4, 5]);
+        ShardReplicaSet::build(
+            1,
+            "test_collection".to_string(),
+            1,
+            false,
+            remotes,
+            dummy_on_replica_failure(),
+            collection_dir.path(),
+            shared_config,
+            Default::default(),
+            update_runtime,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_highest_replica_peer_id() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let rs = new_shard_replica_set(&collection_dir).await;
+
+        assert_eq!(rs.highest_replica_peer_id(), Some(5));
+        // at build time the replicas are all dead, they need to be activated
+        assert_eq!(rs.highest_alive_replica_peer_id(), None);
+
+        rs.set_replica_state(&1, ReplicaState::Active).unwrap();
+        rs.set_replica_state(&3, ReplicaState::Active).unwrap();
+        rs.set_replica_state(&4, ReplicaState::Active).unwrap();
+        rs.set_replica_state(&5, ReplicaState::Partial).unwrap();
+
+        assert_eq!(rs.highest_replica_peer_id(), Some(5));
+        assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));
     }
 }

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -1,4 +1,6 @@
-use collection::operations::point_ops::{Batch, PointInsertOperations, PointOperations};
+use collection::operations::point_ops::{
+    Batch, PointInsertOperations, PointOperations, WriteOrdering,
+};
 use collection::operations::types::ScrollRequest;
 use collection::operations::CollectionUpdateOperations;
 use itertools::Itertools;
@@ -39,7 +41,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
             })),
         );
         collection
-            .update_from_client(insert_points, true)
+            .update_from_client(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
         collection.before_drop().await;
@@ -74,7 +76,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
             })),
         );
         collection
-            .update_from_client(insert_points, true)
+            .update_from_client(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
         collection.before_drop().await;
@@ -142,7 +144,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
             })),
         );
         collection
-            .update_from_client(insert_points, true)
+            .update_from_client(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
         collection.before_drop().await;

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use collection::operations::payload_ops::{PayloadOps, SetPayload};
-use collection::operations::point_ops::{Batch, PointOperations, PointStruct};
+use collection::operations::point_ops::{Batch, PointOperations, PointStruct, WriteOrdering};
 use collection::operations::types::{
     CountRequest, PointRequest, RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus,
 };
@@ -48,7 +48,9 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
         .into(),
     );
 
-    let insert_result = collection.update_from_client(insert_points, true).await;
+    let insert_result = collection
+        .update_from_client(insert_points, true, WriteOrdering::default())
+        .await;
 
     match insert_result {
         Ok(res) => {
@@ -104,7 +106,9 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
         .into(),
     );
 
-    let insert_result = collection.update_from_client(insert_points, true).await;
+    let insert_result = collection
+        .update_from_client(insert_points, true, WriteOrdering::default())
+        .await;
 
     match insert_result {
         Ok(res) => {
@@ -189,7 +193,7 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
         );
 
         collection
-            .update_from_client(insert_points, true)
+            .update_from_client(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
 
@@ -203,7 +207,7 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
             }));
 
         collection
-            .update_from_client(assign_payload, true)
+            .update_from_client(assign_payload, true, WriteOrdering::default())
             .await
             .unwrap();
         collection.before_drop().await;
@@ -317,7 +321,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
     );
 
     collection
-        .update_from_client(insert_points, true)
+        .update_from_client(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
     let result = recommend_by(
@@ -373,7 +377,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
     ));
 
     collection
-        .update_from_client(insert_points, true)
+        .update_from_client(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 
@@ -426,7 +430,9 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         .into(),
     );
 
-    let insert_result = collection.update_from_client(insert_points, true).await;
+    let insert_result = collection
+        .update_from_client(insert_points, true, WriteOrdering::default())
+        .await;
 
     match insert_result {
         Ok(res) => {
@@ -447,7 +453,9 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         PointOperations::DeletePointsByFilter(delete_filter),
     );
 
-    let delete_result = collection.update_from_client(delete_points, true).await;
+    let delete_result = collection
+        .update_from_client(delete_points, true, WriteOrdering::default())
+        .await;
 
     match delete_result {
         Ok(res) => {

--- a/lib/collection/tests/multi_vec_test.rs
+++ b/lib/collection/tests/multi_vec_test.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
-use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
+use collection::operations::point_ops::{
+    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+};
 use collection::operations::types::{
     CollectionError, PointRequest, RecommendRequest, SearchRequest, VectorParams, VectorsConfig,
 };
@@ -104,7 +106,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         PointInsertOperations::PointsList(points),
     ));
     collection
-        .update_from_client(insert_points, true)
+        .update_from_client(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/collection/tests/pagination_test.rs
+++ b/lib/collection/tests/pagination_test.rs
@@ -1,4 +1,6 @@
-use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
+use collection::operations::point_ops::{
+    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+};
 use collection::operations::types::SearchRequest;
 use collection::operations::CollectionUpdateOperations;
 use segment::types::WithPayloadInterface;
@@ -35,7 +37,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         PointInsertOperations::PointsList(points),
     ));
     collection
-        .update_from_client(insert_points, true)
+        .update_from_client(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use collection::collection::Collection;
-use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
+use collection::operations::point_ops::{
+    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+};
 use collection::operations::types::{CollectionError, CollectionResult, ScrollRequest};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use collection::shards::replica_set::ReplicaState;
@@ -114,7 +116,7 @@ async fn replicate_shard_data(
             handle_get_collection(collections_read.get(target_collection_name))?;
 
         target_collection
-            .update_from_client(upsert_request, false)
+            .update_from_client(upsert_request, false, WriteOrdering::default())
             .await?;
 
         if offset.is_none() {
@@ -215,7 +217,9 @@ pub async fn transfer_indexes(
                 field_schema: Some(schema.try_into()?),
             }),
         );
-        target_collection.update_from_client(request, false).await?;
+        target_collection
+            .update_from_client(request, false, WriteOrdering::default())
+            .await?;
     }
 
     Ok(())

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -12,6 +12,7 @@ use collection::config::{
     CollectionParams,
 };
 use collection::operations::config_diff::DiffConfig;
+use collection::operations::point_ops::WriteOrdering;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
     AliasDescription, CollectionResult, CountRequest, CountResult, PointRequest, RecommendRequest,
@@ -1139,6 +1140,7 @@ impl TableOfContent {
         operation: CollectionUpdateOperations,
         shard_selection: Option<ShardId>,
         wait: bool,
+        ordering: WriteOrdering,
     ) -> Result<UpdateResult, StorageError> {
         let collection = self.get_collection(collection_name).await?;
         let result = match shard_selection {
@@ -1151,7 +1153,9 @@ impl TableOfContent {
                 if operation.is_write_operation() {
                     self.check_write_lock()?;
                 }
-                collection.update_from_client(operation, wait).await
+                collection
+                    .update_from_client(operation, wait, ordering)
+                    .await
             }
         };
         result.map_err(|err| err.into())

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -27,12 +27,18 @@ pub async fn do_upsert_points(
     operation: PointInsertOperations,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(operation));
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_delete_points(
@@ -41,7 +47,7 @@ pub async fn do_delete_points(
     points: PointsSelector,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let point_operation = match points {
         PointsSelector::PointIdsSelector(points) => {
@@ -52,8 +58,14 @@ pub async fn do_delete_points(
         }
     };
     let collection_operation = CollectionUpdateOperations::PointOperation(point_operation);
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_set_payload(
@@ -62,12 +74,18 @@ pub async fn do_set_payload(
     operation: SetPayload,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(operation));
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_overwrite_payload(
@@ -76,12 +94,18 @@ pub async fn do_overwrite_payload(
     operation: SetPayload,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PayloadOperation(PayloadOps::OverwritePayload(operation));
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_delete_payload(
@@ -90,12 +114,18 @@ pub async fn do_delete_payload(
     operation: DeletePayload,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation =
         CollectionUpdateOperations::PayloadOperation(PayloadOps::DeletePayload(operation));
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_clear_payload(
@@ -104,7 +134,7 @@ pub async fn do_clear_payload(
     points: PointsSelector,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let points_operation = match points {
         PointsSelector::PointIdsSelector(points) => PayloadOps::ClearPayload {
@@ -116,8 +146,14 @@ pub async fn do_clear_payload(
     };
 
     let collection_operation = CollectionUpdateOperations::PayloadOperation(points_operation);
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_create_index(
@@ -126,7 +162,7 @@ pub async fn do_create_index(
     operation: CreateFieldIndex,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
@@ -134,8 +170,14 @@ pub async fn do_create_index(
             field_schema: operation.field_schema,
         }),
     );
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_delete_index(
@@ -144,13 +186,19 @@ pub async fn do_delete_index(
     index_name: String,
     shard_selection: Option<ShardId>,
     wait: bool,
-    _ordering: WriteOrdering,
+    ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::DeleteIndex(index_name),
     );
-    toc.update(collection_name, collection_operation, shard_selection, wait)
-        .await
+    toc.update(
+        collection_name,
+        collection_operation,
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
 }
 
 pub async fn do_search_points(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -77,7 +77,7 @@ pub async fn upsert(
 pub async fn sync(
     toc: &TableOfContent,
     sync_points: SyncPoints,
-    shard_selection: ShardId,
+    shard_selection: Option<ShardId>,
 ) -> Result<Response<PointsOperationResponse>, Status> {
     let SyncPoints {
         collection_name,
@@ -105,7 +105,7 @@ pub async fn sync(
         .update(
             &collection_name,
             collection_operation,
-            Some(shard_selection),
+            shard_selection,
             wait.unwrap_or(false),
             WriteOrdering::default(),
         )

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
 use collection::operations::conversions::write_ordering_from_proto;
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointSyncOperation, PointsSelector, WriteOrdering,
+    PointInsertOperations, PointOperations, PointSyncOperation, PointsSelector,
 };
 use collection::operations::types::{
     default_exact_count, PointRequest, RecommendRequestBatch, ScrollRequest, SearchRequest,
@@ -85,6 +85,7 @@ pub async fn sync(
         points,
         from_id,
         to_id,
+        ordering,
     } = sync_points;
 
     let points = points
@@ -107,7 +108,7 @@ pub async fn sync(
             collection_operation,
             shard_selection,
             wait.unwrap_or(false),
-            WriteOrdering::default(),
+            write_ordering_from_proto(ordering)?,
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
 use collection::operations::conversions::write_ordering_from_proto;
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointSyncOperation, PointsSelector,
+    PointInsertOperations, PointOperations, PointSyncOperation, PointsSelector, WriteOrdering,
 };
 use collection::operations::types::{
     default_exact_count, PointRequest, RecommendRequestBatch, ScrollRequest, SearchRequest,
@@ -107,6 +107,7 @@ pub async fn sync(
             collection_operation,
             Some(shard_selection),
             wait.unwrap_or(false),
+            WriteOrdering::default(),
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -42,7 +42,7 @@ impl PointsInternal for PointsInternalService {
         let upsert_points =
             upsert_points.ok_or_else(|| Status::invalid_argument("UpsertPoints is missing"))?;
 
-        upsert(self.toc.as_ref(), upsert_points, Some(shard_id)).await
+        upsert(self.toc.as_ref(), upsert_points, shard_id).await
     }
 
     async fn delete(
@@ -57,7 +57,7 @@ impl PointsInternal for PointsInternalService {
         let delete_points =
             delete_points.ok_or_else(|| Status::invalid_argument("DeletePoints is missing"))?;
 
-        delete(self.toc.as_ref(), delete_points, Some(shard_id)).await
+        delete(self.toc.as_ref(), delete_points, shard_id).await
     }
 
     async fn set_payload(
@@ -72,7 +72,7 @@ impl PointsInternal for PointsInternalService {
         let set_payload_points = set_payload_points
             .ok_or_else(|| Status::invalid_argument("SetPayloadPoints is missing"))?;
 
-        set_payload(self.toc.as_ref(), set_payload_points, Some(shard_id)).await
+        set_payload(self.toc.as_ref(), set_payload_points, shard_id).await
     }
 
     async fn delete_payload(
@@ -87,7 +87,7 @@ impl PointsInternal for PointsInternalService {
         let delete_payload_points = delete_payload_points
             .ok_or_else(|| Status::invalid_argument("DeletePayloadPoints is missing"))?;
 
-        delete_payload(self.toc.as_ref(), delete_payload_points, Some(shard_id)).await
+        delete_payload(self.toc.as_ref(), delete_payload_points, shard_id).await
     }
 
     async fn clear_payload(
@@ -102,7 +102,7 @@ impl PointsInternal for PointsInternalService {
         let clear_payload_points = clear_payload_points
             .ok_or_else(|| Status::invalid_argument("ClearPayloadPoints is missing"))?;
 
-        clear_payload(self.toc.as_ref(), clear_payload_points, Some(shard_id)).await
+        clear_payload(self.toc.as_ref(), clear_payload_points, shard_id).await
     }
 
     async fn create_field_index(
@@ -117,12 +117,7 @@ impl PointsInternal for PointsInternalService {
         let create_field_index_collection = create_field_index_collection
             .ok_or_else(|| Status::invalid_argument("CreateFieldIndexCollection is missing"))?;
 
-        create_field_index(
-            self.toc.as_ref(),
-            create_field_index_collection,
-            Some(shard_id),
-        )
-        .await
+        create_field_index(self.toc.as_ref(), create_field_index_collection, shard_id).await
     }
 
     async fn delete_field_index(
@@ -137,12 +132,7 @@ impl PointsInternal for PointsInternalService {
         let delete_field_index_collection = delete_field_index_collection
             .ok_or_else(|| Status::invalid_argument("DeleteFieldIndexCollection is missing"))?;
 
-        delete_field_index(
-            self.toc.as_ref(),
-            delete_field_index_collection,
-            Some(shard_id),
-        )
-        .await
+        delete_field_index(self.toc.as_ref(), delete_field_index_collection, shard_id).await
     }
 
     async fn search(
@@ -157,7 +147,7 @@ impl PointsInternal for PointsInternalService {
         let search_points =
             search_points.ok_or_else(|| Status::invalid_argument("SearchPoints is missing"))?;
 
-        search(self.toc.as_ref(), search_points, Some(shard_id)).await
+        search(self.toc.as_ref(), search_points, shard_id).await
     }
 
     async fn search_batch(
@@ -170,13 +160,7 @@ impl PointsInternal for PointsInternalService {
             shard_id,
         } = request.into_inner();
 
-        search_batch(
-            self.toc.as_ref(),
-            collection_name,
-            search_points,
-            Some(shard_id),
-        )
-        .await
+        search_batch(self.toc.as_ref(), collection_name, search_points, shard_id).await
     }
 
     async fn recommend(
@@ -207,7 +191,7 @@ impl PointsInternal for PointsInternalService {
         let scroll_points =
             scroll_points.ok_or_else(|| Status::invalid_argument("ScrollPoints is missing"))?;
 
-        scroll(self.toc.as_ref(), scroll_points, Some(shard_id)).await
+        scroll(self.toc.as_ref(), scroll_points, shard_id).await
     }
 
     async fn get(
@@ -222,7 +206,7 @@ impl PointsInternal for PointsInternalService {
         let get_points =
             get_points.ok_or_else(|| Status::invalid_argument("GetPoints is missing"))?;
 
-        get(self.toc.as_ref(), get_points, Some(shard_id)).await
+        get(self.toc.as_ref(), get_points, shard_id).await
     }
 
     async fn count(
@@ -236,7 +220,7 @@ impl PointsInternal for PointsInternalService {
 
         let count_points =
             count_points.ok_or_else(|| Status::invalid_argument("CountPoints is missing"))?;
-        count(self.toc.as_ref(), count_points, Some(shard_id)).await
+        count(self.toc.as_ref(), count_points, shard_id).await
     }
 
     async fn sync(
@@ -264,7 +248,7 @@ impl PointsInternal for PointsInternalService {
         let set_payload_points = set_payload_points
             .ok_or_else(|| Status::invalid_argument("SetPayloadPoints is missing"))?;
 
-        overwrite_payload(self.toc.as_ref(), set_payload_points, Some(shard_id)).await
+        overwrite_payload(self.toc.as_ref(), set_payload_points, shard_id).await
     }
 }
 

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -3,17 +3,10 @@ import pathlib
 
 from .fixtures import upsert_random_points, create_collection
 from .utils import *
-from .assertions import assert_http_ok
 
 N_PEERS = 3
 N_SHARDS = 1
 N_REPLICA = 3
-
-
-def check_collection_cluster(peer_url, collection_name):
-    res = requests.get(f"{peer_url}/collections/{collection_name}/cluster", timeout=10)
-    assert_http_ok(res)
-    return res.json()["result"]['local_shards'][0]
 
 
 def update_points_in_loop(peer_url, collection_name):

--- a/tests/consensus_tests/test_two_follower_nodes_down.py
+++ b/tests/consensus_tests/test_two_follower_nodes_down.py
@@ -3,17 +3,10 @@ import pathlib
 
 from .fixtures import upsert_random_points, create_collection
 from .utils import *
-from .assertions import assert_http_ok
 
 N_PEERS = 3
 N_SHARDS = 1
 N_REPLICA = 3
-
-
-def check_collection_cluster(peer_url, collection_name):
-    res = requests.get(f"{peer_url}/collections/{collection_name}/cluster", timeout=10)
-    assert_http_ok(res)
-    return res.json()["result"]['local_shards'][0]
 
 
 def update_points_in_loop(peer_url, collection_name):

--- a/tests/consensus_tests/test_write_ordering.py
+++ b/tests/consensus_tests/test_write_ordering.py
@@ -1,0 +1,121 @@
+import multiprocessing
+import pathlib
+import time
+
+from .fixtures import create_collection
+from .utils import *
+from .assertions import assert_http_ok
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICA = 3
+
+
+# Test update write ordering guarantees.
+def test_write_ordering(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name="test_collection",
+        peer_api_uris=peer_api_uris
+    )
+
+    max_peer_url = fetch_highest_peer_id(peer_api_uris)
+    url_index = peer_api_uris.index(max_peer_url)
+
+    # Kill update leader peer
+    print(f"Stopping update leader peer with url {max_peer_url} at index {url_index}")
+    p = processes.pop(url_index)
+    p.kill()
+    peer_api_uris.pop(url_index)
+
+    # write ordering weak (will trigger the detection of dead replicas)
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true&ordering=weak", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                        "city": "Berlin",
+                        "country": "Germany",
+                    }
+                }
+            ]
+        })
+    assert_http_ok(r)
+
+    # Assert that there are dead replicas
+    wait_for_some_replicas_not_active(peer_api_uris[0], "test_collection")
+
+    # write ordering medium
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true&ordering=medium", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                        "city": "Dresden",
+                        "country": "Germany",
+                    }
+                }
+            ]
+        })
+
+    # fails as highest peer is dead
+    assert r.status_code == 500
+
+    # write ordering strong
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/test_collection/points?wait=true&ordering=strong", json={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                        "city": "Munich",
+                        "country": "Germany",
+                    }
+                }
+            ]
+        })
+    # succeeds as Strong selects an Alive peer
+    assert_http_ok(r)
+
+    # Restart peer
+    new_url = start_peer(peer_dirs[url_index], f"peer_{url_index}_restarted.log", bootstrap_uri)
+    peer_api_uris.append(new_url)
+
+    # Wait for peers to be online
+    wait_for_peer_online(new_url)
+    time.sleep(1)
+
+    timeout = 10
+    while True:
+        if timeout < 0:
+            raise Exception("Timeout waiting for all replicas to be active")
+
+        all_active = True
+        points_counts = set()
+        for peer_api_uri in peer_api_uris:
+            res = check_collection_cluster(peer_api_uri, "test_collection")
+            points_counts.add(res['points_count'])
+            if res['state'] != 'Active':
+                all_active = False
+
+        if all_active:
+            if len(points_counts) != 1:
+                for peer_api_uri in peer_api_uris:
+                    res = requests.post(f"{peer_api_uri}/collections/test_collection/points/count", json={"exact": True})
+                    print(res.json())
+
+                assert False, f"Points count is not equal on all peers: {points_counts}"
+            break
+
+        time.sleep(1)
+        timeout -= 1


### PR DESCRIPTION
Implements update forward according to write consistency.

The request is forwarded via the internal gRPC API without an explicit target `shard_id`  in order to be able to route the request to `update_from_client`.

