### PR TITLE
Clippy rust 1.67

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -486,7 +486,7 @@ impl TryFrom<PointId> for segment::types::PointIdType {
             Some(PointIdOptions::Uuid(uui_str)) => Uuid::parse_str(&uui_str)
                 .map(segment::types::PointIdType::Uuid)
                 .map_err(|_err| {
-                    Status::invalid_argument(format!("Unable to parse UUID: {}", uui_str))
+                    Status::invalid_argument(format!("Unable to parse UUID: {uui_str}"))
                 }),
             _ => Err(Status::invalid_argument(
                 "No ID options provided".to_string(),

--- a/lib/collection/benches/prof.rs
+++ b/lib/collection/benches/prof.rs
@@ -64,7 +64,7 @@ impl<'a> Profiler for FlamegraphProfiler<'a> {
         std::fs::create_dir_all(benchmark_dir).unwrap();
         let pprof_path = benchmark_dir.join("profile.pb");
         let flamegraph_path = benchmark_dir.join("flamegraph.svg");
-        eprintln!("\nflamegraph_path = {:#?}", flamegraph_path);
+        eprintln!("\nflamegraph_path = {flamegraph_path:#?}");
         let flamegraph_file = File::create(&flamegraph_path)
             .expect("File system error while creating flamegraph.svg");
         let mut options = pprof::flamegraph::Options::default();

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1095,9 +1095,7 @@ impl Collection {
 
                     if peers.len() == 1 {
                         return Err(CollectionError::BadRequest {
-                            description: format!(
-                                "Shard {shard_id} must have at least one replica"
-                            ),
+                            description: format!("Shard {shard_id} must have at least one replica"),
                         });
                     }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -229,7 +229,7 @@ impl Collection {
             if Self::can_upgrade_storage(&stored_version, &app_version) {
                 log::info!("Migrating collection {stored_version} -> {app_version}");
                 CollectionVersion::save(path)
-                    .unwrap_or_else(|err| panic!("Can't save collection version {}", err));
+                    .unwrap_or_else(|err| panic!("Can't save collection version {err}"));
             } else {
                 log::error!("Cannot upgrade version {stored_version} to {app_version}.");
                 panic!("Cannot upgrade version {stored_version} to {app_version}. Try to use older version of Qdrant first.");
@@ -694,8 +694,7 @@ impl Collection {
             Ok(res)
         } else {
             Err(CollectionError::service_error(format!(
-                "No target shard {} found for update",
-                shard_selection
+                "No target shard {shard_selection} found for update"
             )))
         }
     }
@@ -1089,8 +1088,7 @@ impl Collection {
                     if !peers.contains_key(&peer_id) {
                         return Err(CollectionError::BadRequest {
                             description: format!(
-                                "Peer {} has no replica of shard {}",
-                                peer_id, shard_id
+                                "Peer {peer_id} has no replica of shard {shard_id}"
                             ),
                         });
                     }
@@ -1098,8 +1096,7 @@ impl Collection {
                     if peers.len() == 1 {
                         return Err(CollectionError::BadRequest {
                             description: format!(
-                                "Shard {} must have at least one replica",
-                                shard_id
+                                "Shard {shard_id} must have at least one replica"
                             ),
                         });
                     }
@@ -1311,7 +1308,7 @@ impl Collection {
         let snapshot_path = self.snapshots_path.join(snapshot_name);
         if !snapshot_path.exists() {
             return Err(CollectionError::NotFound {
-                what: format!("Snapshot {}", snapshot_name),
+                what: format!("Snapshot {snapshot_name}"),
             });
         }
         Ok(snapshot_path)

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -781,7 +781,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_result = {:#?}", search_result);
+        eprintln!("search_result = {search_result:#?}");
 
         let mut seen_points: HashSet<PointIdType> = Default::default();
         for res in search_result {
@@ -848,7 +848,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_result = {:#?}", search_result);
+        eprintln!("search_result = {search_result:#?}");
 
         let search_batch_result = proxy_segment
             .search_batch(
@@ -862,7 +862,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_batch_result = {:#?}", search_batch_result);
+        eprintln!("search_batch_result = {search_batch_result:#?}");
 
         assert!(!search_result.is_empty());
         assert_eq!(search_result, search_batch_result[0].clone())
@@ -901,7 +901,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_result = {:#?}", search_result);
+        eprintln!("search_result = {search_result:#?}");
 
         let search_batch_result = proxy_segment
             .search_batch(
@@ -915,7 +915,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_batch_result = {:#?}", search_batch_result);
+        eprintln!("search_batch_result = {search_batch_result:#?}");
 
         assert!(!search_result.is_empty());
         assert_eq!(search_result, search_batch_result[0].clone())
@@ -965,7 +965,7 @@ mod tests {
             all_single_results.push(res);
         }
 
-        eprintln!("search_result = {:#?}", all_single_results);
+        eprintln!("search_result = {all_single_results:#?}");
 
         let search_batch_result = proxy_segment
             .search_batch(
@@ -979,7 +979,7 @@ mod tests {
             )
             .unwrap();
 
-        eprintln!("search_batch_result = {:#?}", search_batch_result);
+        eprintln!("search_batch_result = {search_batch_result:#?}");
 
         assert_eq!(all_single_results, search_batch_result)
     }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -480,7 +480,7 @@ mod tests {
         let suggested_to_optimize =
             index_optimizer.check_condition(locked_holder.clone(), &excluded_ids);
         assert!(suggested_to_optimize.contains(&large_segment_id));
-        eprintln!("suggested_to_optimize = {:#?}", suggested_to_optimize);
+        eprintln!("suggested_to_optimize = {suggested_to_optimize:#?}");
         index_optimizer
             .optimize(locked_holder.clone(), suggested_to_optimize, &stopped)
             .unwrap();

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -264,7 +264,7 @@ impl SegmentsSearcher {
 
         segments.read().read_points(points, |id, segment| {
             let version = segment.point_version(id).ok_or_else(|| {
-                OperationError::service_error(format!("No version for point {}", id))
+                OperationError::service_error(format!("No version for point {id}"))
             })?;
             // If this point was not found yet or this segment have later version
             if !point_version.contains_key(&id) || point_version[&id] < version {

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -90,7 +90,7 @@ fn test_update_proxy_segments() {
 
     for i in 1..10 {
         let idx = 100 * i + 1;
-        assert!(all_ids.contains(&idx.into()), "Not found {}", idx)
+        assert!(all_ids.contains(&idx.into()), "Not found {idx}")
     }
 }
 
@@ -163,19 +163,19 @@ fn test_move_points_to_copy_on_write() {
         .clone();
     let id_mapper = copy_on_write_segment_read.id_tracker.clone();
 
-    eprintln!("copy_on_write_points = {:#?}", copy_on_write_points);
+    eprintln!("copy_on_write_points = {copy_on_write_points:#?}");
 
     for idx in copy_on_write_points {
         let internal = id_mapper.borrow().internal_id(idx).unwrap();
-        eprintln!("{} -> {}", idx, internal);
+        eprintln!("{idx} -> {internal}");
     }
 
     let internal_ids = vector_storage.borrow().iter_ids().collect_vec();
 
-    eprintln!("internal_ids = {:#?}", internal_ids);
+    eprintln!("internal_ids = {internal_ids:#?}");
 
     for idx in internal_ids {
         let external = id_mapper.borrow().external_id(idx).unwrap();
-        eprintln!("{} -> {}", idx, external);
+        eprintln!("{idx} -> {external}");
     }
 }

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -93,7 +93,7 @@ fn test_aggregation_of_batch_search_results() {
 
     let top_results = aggregator.into_topk();
 
-    eprintln!("top_results = {:#?}", top_results);
+    eprintln!("top_results = {top_results:#?}");
 
     assert_eq!(top_results.len(), 2);
     assert_eq!(top_results[0].len(), 12);

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -111,7 +111,7 @@ impl CollectionConfig {
         let af = AtomicFile::new(&config_path, AllowOverwrite);
         let state_bytes = serde_json::to_vec(self).unwrap();
         af.write(|f| f.write_all(&state_bytes)).map_err(|err| {
-            CollectionError::service_error(format!("Can't write {:?}, error: {}", config_path, err))
+            CollectionError::service_error(format!("Can't write {config_path:?}, error: {err}"))
         })?;
         Ok(())
     }

--- a/lib/collection/src/operations/consistency_params.rs
+++ b/lib/collection/src/operations/consistency_params.rs
@@ -80,7 +80,7 @@ mod tests {
     fn test_read_consistency_deserialization() {
         let consistency = ReadConsistency::Type(ReadConsistencyType::Majority);
         let json = serde_json::to_string(&consistency).unwrap();
-        println!("{}", json);
+        println!("{json}");
 
         let json = "2";
         let consistency: ReadConsistency = serde_json::from_str(json).unwrap();
@@ -111,6 +111,6 @@ mod tests {
 
         let schema = schema_for!(ReadConsistency);
         let schema_str = serde_json::to_string_pretty(&schema).unwrap();
-        println!("{}", schema_str)
+        println!("{schema_str}")
     }
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -178,6 +178,6 @@ mod tests {
             });
 
         let json = serde_json::to_string_pretty(&op).unwrap();
-        println!("{}", json)
+        println!("{json}")
     }
 }

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -191,7 +191,7 @@ mod tests {
         };
         let raw_cbor = serde_cbor::to_vec(&obj1).unwrap();
         let obj2 = serde_cbor::from_slice::<TextSelectorOpt>(&raw_cbor).unwrap();
-        eprintln!("obj2 = {:#?}", obj2);
+        eprintln!("obj2 = {obj2:#?}");
         assert_eq!(obj1.points, obj2.points.unwrap());
     }
 

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -158,7 +158,7 @@ impl JsonSchema for PointInsertOperations {
 
         let get_obj_schema = |field: String, schema_name: String| {
             let schema_ref = Schema::Object(SchemaObject {
-                reference: Some(format!("{}{}", def_path, schema_name)),
+                reference: Some(format!("{def_path}{schema_name}")),
                 ..Default::default()
             });
             Schema::Object(SchemaObject {
@@ -179,7 +179,7 @@ impl JsonSchema for PointInsertOperations {
         definitions.insert(PointsList::schema_name(), proxy_b_schema);
 
         let proxy_a_ref = Schema::Object(SchemaObject {
-            reference: Some(format!("{}{}", def_path, proxy_a_name)),
+            reference: Some(format!("{def_path}{proxy_a_name}")),
             ..Default::default()
         });
 
@@ -238,8 +238,7 @@ impl Validate for PointInsertOperations {
         let bad_input_error = |ids_len: usize, vectors_len: usize| {
             Err(CollectionError::BadInput {
                 description: format!(
-                    "Amount of ids ({}) and vectors ({}) does not match",
-                    ids_len, vectors_len,
+                    "Amount of ids ({ids_len}) and vectors ({vectors_len}) does not match",
                 ),
             })
         };

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -411,7 +411,7 @@ impl CollectionError {
 impl From<SystemTimeError> for CollectionError {
     fn from(error: SystemTimeError) -> CollectionError {
         CollectionError::ServiceError {
-            error: format!("System time error: {}", error),
+            error: format!("System time error: {error}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -430,13 +430,13 @@ impl From<OperationError> for CollectionError {
     fn from(err: OperationError) -> Self {
         match err {
             OperationError::WrongVector { .. } => Self::BadInput {
-                description: format!("{}", err),
+                description: format!("{err}"),
             },
             OperationError::VectorNameNotExists { .. } => Self::BadInput {
-                description: format!("{}", err),
+                description: format!("{err}"),
             },
             OperationError::MissedVectorName { .. } => Self::BadInput {
-                description: format!("{}", err),
+                description: format!("{err}"),
             },
             OperationError::PointIdError { missed_point_id } => {
                 Self::PointNotFound { missed_point_id }
@@ -449,11 +449,11 @@ impl From<OperationError> for CollectionError {
                 backtrace,
             },
             OperationError::TypeError { .. } => Self::BadInput {
-                description: format!("{}", err),
+                description: format!("{err}"),
             },
             OperationError::Cancelled { description } => Self::Cancelled { description },
             OperationError::TypeInferenceError { .. } => Self::BadInput {
-                description: format!("{}", err),
+                description: format!("{err}"),
             },
         }
     }
@@ -462,7 +462,7 @@ impl From<OperationError> for CollectionError {
 impl From<OneshotRecvError> for CollectionError {
     fn from(err: OneshotRecvError) -> Self {
         Self::ServiceError {
-            error: format!("{}", err),
+            error: format!("{err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -471,7 +471,7 @@ impl From<OneshotRecvError> for CollectionError {
 impl From<JoinError> for CollectionError {
     fn from(err: JoinError) -> Self {
         Self::ServiceError {
-            error: format!("{}", err),
+            error: format!("{err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -480,7 +480,7 @@ impl From<JoinError> for CollectionError {
 impl From<WalError> for CollectionError {
     fn from(err: WalError) -> Self {
         Self::ServiceError {
-            error: format!("{}", err),
+            error: format!("{err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -489,7 +489,7 @@ impl From<WalError> for CollectionError {
 impl<T> From<SendError<T>> for CollectionError {
     fn from(err: SendError<T>) -> Self {
         Self::ServiceError {
-            error: format!("Can't reach one of the workers: {}", err),
+            error: format!("Can't reach one of the workers: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -498,7 +498,7 @@ impl<T> From<SendError<T>> for CollectionError {
 impl From<JsonError> for CollectionError {
     fn from(err: JsonError) -> Self {
         CollectionError::ServiceError {
-            error: format!("Json error: {}", err),
+            error: format!("Json error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -507,7 +507,7 @@ impl From<JsonError> for CollectionError {
 impl From<io::Error> for CollectionError {
     fn from(err: io::Error) -> Self {
         CollectionError::ServiceError {
-            error: format!("File IO error: {}", err),
+            error: format!("File IO error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -516,7 +516,7 @@ impl From<io::Error> for CollectionError {
 impl From<tonic::transport::Error> for CollectionError {
     fn from(err: tonic::transport::Error) -> Self {
         CollectionError::ServiceError {
-            error: format!("Tonic transport error: {}", err),
+            error: format!("Tonic transport error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -525,7 +525,7 @@ impl From<tonic::transport::Error> for CollectionError {
 impl From<InvalidUri> for CollectionError {
     fn from(err: InvalidUri) -> Self {
         CollectionError::ServiceError {
-            error: format!("Invalid URI error: {}", err),
+            error: format!("Invalid URI error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -535,20 +535,20 @@ impl From<tonic::Status> for CollectionError {
     fn from(err: tonic::Status) -> Self {
         match err.code() {
             tonic::Code::InvalidArgument => CollectionError::BadInput {
-                description: format!("InvalidArgument: {}", err),
+                description: format!("InvalidArgument: {err}"),
             },
             tonic::Code::AlreadyExists => CollectionError::BadInput {
-                description: format!("AlreadyExists: {}", err),
+                description: format!("AlreadyExists: {err}"),
             },
             tonic::Code::NotFound => CollectionError::NotFound {
-                what: format!("{}", err),
+                what: format!("{err}"),
             },
             tonic::Code::Internal => CollectionError::ServiceError {
-                error: format!("Internal error: {}", err),
+                error: format!("Internal error: {err}"),
                 backtrace: Some(Backtrace::force_capture().to_string()),
             },
             other => CollectionError::ServiceError {
-                error: format!("Tonic status error: {}", other),
+                error: format!("Tonic status error: {other}"),
                 backtrace: Some(Backtrace::force_capture().to_string()),
             },
         }
@@ -558,7 +558,7 @@ impl From<tonic::Status> for CollectionError {
 impl<Guard> From<std::sync::PoisonError<Guard>> for CollectionError {
     fn from(err: std::sync::PoisonError<Guard>) -> Self {
         CollectionError::ServiceError {
-            error: format!("Mutex lock poisoned: {}", err),
+            error: format!("Mutex lock poisoned: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -584,7 +584,7 @@ impl From<RequestError<tonic::Status>> for CollectionError {
     fn from(err: RequestError<tonic::Status>) -> Self {
         match err {
             RequestError::FromClosure(status) => status.into(),
-            RequestError::Tonic(err) => CollectionError::service_error(format!("{}", err)),
+            RequestError::Tonic(err) => CollectionError::service_error(format!("{err}")),
         }
     }
 }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -192,7 +192,7 @@ where
                     }
                     None => {
                         return Err(CollectionError::NotFound {
-                            what: format!("Collection {}", name),
+                            what: format!("Collection {name}"),
                         })
                     }
                 }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -394,7 +394,7 @@ impl ShardReplicaSet {
                     rs.this_peer_id = this_peer_id;
                 })
                 .map_err(|e| {
-                    panic!("Failed to update replica state in {:?}: {}", shard_path, e);
+                    panic!("Failed to update replica state in {shard_path:?}: {e}");
                 })
                 .unwrap();
         }
@@ -416,7 +416,7 @@ impl ShardReplicaSet {
             )
             .await
             .map_err(|e| {
-                panic!("Failed to load local shard {:?}: {}", shard_path, e);
+                panic!("Failed to load local shard {shard_path:?}: {e}");
             })
             .unwrap();
             Some(Local(shard))

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -285,7 +285,7 @@ impl ShardHolder {
                 if require_migration {
                     ShardConfig::new_replica_set()
                         .save(&path)
-                        .map_err(|e| panic!("Failed to save shard config {:?}: {}", path, e))
+                        .map_err(|e| panic!("Failed to save shard config {path:?}: {e}"))
                         .unwrap();
                 }
                 self.add_shard(shard_id, replica_set);

--- a/lib/collection/src/shards/shard_versioning.rs
+++ b/lib/collection/src/shards/shard_versioning.rs
@@ -22,7 +22,7 @@ async fn shards_versions(
 
             let file_name = file_name_opt.unwrap();
 
-            if file_name.starts_with(&format!("{shard_id}-", shard_id = shard_id)) {
+            if file_name.starts_with(&format!("{shard_id}-")) {
                 let version_opt = file_name
                     .split('-')
                     .nth(1)
@@ -33,7 +33,7 @@ async fn shards_versions(
                 }
                 let version = version_opt.unwrap();
                 all_versions.push((version, path.clone()));
-            } else if file_name == format!("{shard_id}", shard_id = shard_id) {
+            } else if file_name == format!("{shard_id}") {
                 let version = 0;
                 all_versions.push((version, path.clone()));
             }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -71,8 +71,7 @@ async fn transfer_batches(
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(
-                "Shard {} is not a forward proxy shard",
-                shard_id
+                "Shard {shard_id} is not a forward proxy shard"
             )));
         }
     }
@@ -101,8 +100,7 @@ async fn transfer_batches(
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(
-                "Shard {} is not found",
-                shard_id
+                "Shard {shard_id} is not found"
             )));
         }
     }
@@ -218,8 +216,7 @@ pub async fn transfer_shard(
             replica_set.proxify_local(remote_shard).await?;
         } else {
             return Err(CollectionError::service_error(format!(
-                "Shard {} cannot be proxied because it does not exist",
-                shard_id
+                "Shard {shard_id} cannot be proxied because it does not exist"
             )));
         }
     };

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -99,9 +99,7 @@ async fn test_cancel_optimization() {
     let optimization_res = join_all(join_handles).await;
 
     let actual_optimization_duration = now.elapsed().as_millis();
-    eprintln!(
-        "actual_optimization_duration = {actual_optimization_duration:#?} ms"
-    );
+    eprintln!("actual_optimization_duration = {actual_optimization_duration:#?} ms");
 
     for res in optimization_res {
         let was_finished = res.expect("Should be no errors during optimization");

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -100,8 +100,7 @@ async fn test_cancel_optimization() {
 
     let actual_optimization_duration = now.elapsed().as_millis();
     eprintln!(
-        "actual_optimization_duration = {:#?} ms",
-        actual_optimization_duration
+        "actual_optimization_duration = {actual_optimization_duration:#?} ms"
     );
 
     for res in optimization_res {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -235,7 +235,7 @@ impl UpdateHandler {
                                     // so the best available action here is to stop whole
                                     // optimization thread and log the error
                                     log::error!("Optimization error: {}", error);
-                                    panic!("Optimization error: {}", error);
+                                    panic!("Optimization error: {error}");
                                 }
                             },
                         }
@@ -392,8 +392,7 @@ impl UpdateHandler {
                 segments
                     .write()
                     .report_optimizer_error(WalError::WriteWalError(format!(
-                        "WAL flush error: {:?}",
-                        err
+                        "WAL flush error: {err:?}"
                     )));
                 continue;
             }

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -58,7 +58,7 @@ pub struct SerdeWal<R> {
 impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn new(dir: &str, wal_options: &WalOptions) -> Result<SerdeWal<R>> {
         let wal = Wal::with_options(dir, wal_options)
-            .map_err(|err| WalError::InitWalError(format!("{:?}", err)))?;
+            .map_err(|err| WalError::InitWalError(format!("{err:?}")))?;
         Ok(SerdeWal {
             record: PhantomData,
             wal,
@@ -71,7 +71,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         let binary_entity = serde_cbor::to_vec(&entity).unwrap();
         self.wal
             .append(&binary_entity)
-            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
+            .map_err(|err| WalError::WriteWalError(format!("{err:?}")))
     }
 
     pub fn read_all(&'s self) -> impl Iterator<Item = (u64, R)> + 's {
@@ -109,13 +109,13 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn ack(&mut self, until_index: u64) -> Result<()> {
         self.wal
             .prefix_truncate(until_index)
-            .map_err(|err| WalError::TruncateWalError(format!("{:?}", err)))
+            .map_err(|err| WalError::TruncateWalError(format!("{err:?}")))
     }
 
     pub fn flush(&mut self) -> Result<()> {
         self.wal
             .flush_open_segment()
-            .map_err(|err| WalError::WriteWalError(format!("{:?}", err)))
+            .map_err(|err| WalError::WriteWalError(format!("{err:?}")))
     }
 
     pub fn flush_async(&mut self) -> JoinHandle<std::io::Result<()>> {
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(metadata.size() as usize, wal_options.segment_capacity);
 
         for (_idx, rec) in serde_wal.read(0) {
-            println!("{:?}", rec);
+            println!("{rec:?}");
         }
 
         let record = TestRecord::Struct2(TestInternalStruct2 { a: 12, b: 13 });

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -54,7 +54,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
         Ok(res) => {
             assert_eq!(res.status, UpdateStatus::Completed)
         }
-        Err(err) => panic!("operation failed: {:?}", err),
+        Err(err) => panic!("operation failed: {err:?}"),
     }
 
     let search_request = SearchRequest {
@@ -76,7 +76,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
             assert_eq!(res[0].id, 2.into());
             assert!(res[0].payload.is_none());
         }
-        Err(err) => panic!("search failed: {:?}", err),
+        Err(err) => panic!("search failed: {err:?}"),
     }
     collection.before_drop().await;
 }
@@ -110,7 +110,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
         Ok(res) => {
             assert_eq!(res.status, UpdateStatus::Completed)
         }
-        Err(err) => panic!("operation failed: {:?}", err),
+        Err(err) => panic!("operation failed: {err:?}"),
     }
 
     let search_request = SearchRequest {
@@ -136,7 +136,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
                 _ => panic!("vector is not returned"),
             }
         }
-        Err(err) => panic!("search failed: {:?}", err),
+        Err(err) => panic!("search failed: {err:?}"),
     }
 
     let count_request = CountRequest {
@@ -432,7 +432,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         Ok(res) => {
             assert_eq!(res.status, UpdateStatus::Completed)
         }
-        Err(err) => panic!("operation failed: {:?}", err),
+        Err(err) => panic!("operation failed: {err:?}"),
     }
 
     // delete points with id (0, 3)
@@ -453,7 +453,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         Ok(res) => {
             assert_eq!(res.status, UpdateStatus::Completed)
         }
-        Err(err) => panic!("operation failed: {:?}", err),
+        Err(err) => panic!("operation failed: {err:?}"),
     }
 
     let result = collection

--- a/lib/collection/tests/multi_vec_test.rs
+++ b/lib/collection/tests/multi_vec_test.rs
@@ -154,8 +154,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
     assert!(
         matches!(result, Err(CollectionError::BadInput { .. })),
-        "{:?}",
-        result
+        "{result:?}"
     );
 
     let full_search_request = SearchRequest {
@@ -224,7 +223,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         Err(err) => match err {
             CollectionError::BadRequest { .. } => {}
             CollectionError::BadInput { .. } => {}
-            error => panic!("Unexpected error {}", error),
+            error => panic!("Unexpected error {error}"),
         },
     }
 

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -100,8 +100,8 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
 
     let indexed_fields = struct_index.indexed_fields();
 
-    eprintln!("cardinality = {:#?}", cardinality);
-    eprintln!("indexed_fields = {:#?}", indexed_fields);
+    eprintln!("cardinality = {cardinality:#?}");
+    eprintln!("indexed_fields = {indexed_fields:#?}");
 
     group.bench_function("struct-conditional-search-query-points", |b| {
         b.iter(|| {

--- a/lib/segment/benches/prof.rs
+++ b/lib/segment/benches/prof.rs
@@ -64,7 +64,7 @@ impl<'a> Profiler for FlamegraphProfiler<'a> {
         std::fs::create_dir_all(benchmark_dir).unwrap();
         let pprof_path = benchmark_dir.join("profile.pb");
         let flamegraph_path = benchmark_dir.join("flamegraph.svg");
-        eprintln!("\nflamegraph_path = {:#?}", flamegraph_path);
+        eprintln!("\nflamegraph_path = {flamegraph_path:#?}");
         let flamegraph_file = File::create(&flamegraph_path)
             .expect("File system error while creating flamegraph.svg");
         let mut options = pprof::flamegraph::Options::default();

--- a/lib/segment/benches/serde_formats.rs
+++ b/lib/segment/benches/serde_formats.rs
@@ -10,7 +10,7 @@ fn serde_formats_bench(c: &mut Criterion) {
 
     let payloads = (0..1000)
         .map(|x| {
-            let payload: Payload = json!({"val":format!("val_{}", x),}).into();
+            let payload: Payload = json!({"val":format!("val_{x}"),}).into();
             payload
         })
         .collect_vec();

--- a/lib/segment/src/common/file_operations.rs
+++ b/lib/segment/src/common/file_operations.rs
@@ -32,7 +32,7 @@ impl<E> From<AtomicIoError<E>> for FileStorageError {
     fn from(err: AtomicIoError<E>) -> Self {
         match err {
             AtomicIoError::Internal(io_err) => FileStorageError::IoError {
-                description: format!("{}", io_err),
+                description: format!("{io_err}"),
             },
             AtomicIoError::User(_atomic_io_err) => FileStorageError::UserAtomicIoError,
         }

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -122,9 +122,7 @@ impl DatabaseColumnWrapper {
         let db = self.database.read();
         let cf_handle = self.get_column_family(&db)?;
         db.put_cf_opt(cf_handle, key, value, &Self::get_write_options())
-            .map_err(|err| {
-                OperationError::service_error(format!("RocksDB put_cf error: {err}"))
-            })?;
+            .map_err(|err| OperationError::service_error(format!("RocksDB put_cf error: {err}")))?;
         Ok(())
     }
 

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -219,9 +219,9 @@ impl DatabaseColumnWrapper {
         write_options
     }
 
-    fn get_column_family<'a, 'b>(
+    fn get_column_family<'a>(
         &self,
-        db: &'a parking_lot::RwLockReadGuard<'b, DB>,
+        db: &'a parking_lot::RwLockReadGuard<'_, DB>,
     ) -> OperationResult<&'a ColumnFamily> {
         db.cf_handle(&self.column_name).ok_or_else(|| {
             OperationError::service_error(format!(

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -123,7 +123,7 @@ impl DatabaseColumnWrapper {
         let cf_handle = self.get_column_family(&db)?;
         db.put_cf_opt(cf_handle, key, value, &Self::get_write_options())
             .map_err(|err| {
-                OperationError::service_error(format!("RocksDB put_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB put_cf error: {err}"))
             })?;
         Ok(())
     }
@@ -137,7 +137,7 @@ impl DatabaseColumnWrapper {
         let result = db
             .get_pinned_cf(cf_handle, key)
             .map_err(|err| {
-                OperationError::service_error(format!("RocksDB get_pinned_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB get_pinned_cf error: {err}"))
             })?
             .map(|value| f(&value));
         Ok(result)
@@ -150,7 +150,7 @@ impl DatabaseColumnWrapper {
         let db = self.database.read();
         let cf_handle = self.get_column_family(&db)?;
         db.delete_cf(cf_handle, key).map_err(|err| {
-            OperationError::service_error(format!("RocksDB delete_cf error: {}", err))
+            OperationError::service_error(format!("RocksDB delete_cf error: {err}"))
         })?;
         Ok(())
     }
@@ -175,7 +175,7 @@ impl DatabaseColumnWrapper {
             })?;
 
             db.flush_cf(column_family).map_err(|err| {
-                OperationError::service_error(format!("RocksDB flush_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB flush_cf error: {err}"))
             })?;
             Ok(())
         })
@@ -186,7 +186,7 @@ impl DatabaseColumnWrapper {
         if db.cf_handle(&self.column_name).is_none() {
             db.create_cf(&self.column_name, &db_options())
                 .map_err(|err| {
-                    OperationError::service_error(format!("RocksDB create_cf error: {}", err))
+                    OperationError::service_error(format!("RocksDB create_cf error: {err}"))
                 })?;
         }
         Ok(())
@@ -201,7 +201,7 @@ impl DatabaseColumnWrapper {
         let mut db = self.database.write();
         if db.cf_handle(&self.column_name).is_some() {
             db.drop_cf(&self.column_name).map_err(|err| {
-                OperationError::service_error(format!("RocksDB drop_cf error: {}", err))
+                OperationError::service_error(format!("RocksDB drop_cf error: {err}"))
             })?;
         }
         Ok(())
@@ -242,8 +242,7 @@ impl<'a> DatabaseColumnIterator<'a> {
     pub fn new(db: &'a DB, column_name: &str) -> OperationResult<DatabaseColumnIterator<'a>> {
         let handle = db.cf_handle(column_name).ok_or_else(|| {
             OperationError::service_error(format!(
-                "RocksDB cf_handle error: Cannot find column family {}",
-                column_name
+                "RocksDB cf_handle error: Cannot find column family {column_name}"
             ))
         })?;
         let mut iter = db.raw_iterator_cf(&handle);

--- a/lib/segment/src/common/version.rs
+++ b/lib/segment/src/common/version.rs
@@ -34,8 +34,7 @@ pub trait StorageVersion {
         af.write(|f| f.write_all(current_version.as_bytes()))
             .map_err(|err| {
                 FileStorageError::generic_error(&format!(
-                    "Can't write {:?}, error: {}",
-                    version_file, err
+                    "Can't write {version_file:?}, error: {err}"
                 ))
             })
     }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -90,7 +90,7 @@ impl From<semver::Error> for OperationError {
 impl From<ThreadPoolBuildError> for OperationError {
     fn from(error: ThreadPoolBuildError) -> Self {
         OperationError::ServiceError {
-            description: format!("{}", error),
+            description: format!("{error}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -100,7 +100,7 @@ impl From<FileStorageError> for OperationError {
     fn from(err: FileStorageError) -> Self {
         match err {
             FileStorageError::IoError { description } => {
-                OperationError::service_error(format!("IO Error: {}", description))
+                OperationError::service_error(format!("IO Error: {description}"))
             }
             FileStorageError::UserAtomicIoError => {
                 OperationError::service_error("Unknown atomic write error")
@@ -114,7 +114,7 @@ impl From<FileStorageError> for OperationError {
 
 impl From<serde_cbor::Error> for OperationError {
     fn from(err: serde_cbor::Error) -> Self {
-        OperationError::service_error(format!("Failed to parse data: {}", err))
+        OperationError::service_error(format!("Failed to parse data: {err}"))
     }
 }
 
@@ -131,19 +131,19 @@ impl<E> From<AtomicIoError<E>> for OperationError {
 
 impl From<IoError> for OperationError {
     fn from(err: IoError) -> Self {
-        OperationError::service_error(format!("IO Error: {}", err))
+        OperationError::service_error(format!("IO Error: {err}"))
     }
 }
 
 impl From<serde_json::Error> for OperationError {
     fn from(err: serde_json::Error) -> Self {
-        OperationError::service_error(format!("Json error: {}", err))
+        OperationError::service_error(format!("Json error: {err}"))
     }
 }
 
 impl From<fs_extra::error::Error> for OperationError {
     fn from(err: fs_extra::error::Error) -> Self {
-        OperationError::service_error(format!("File system error: {}", err))
+        OperationError::service_error(format!("File system error: {err}"))
     }
 }
 

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -59,7 +59,7 @@ pub fn random_adj<R: Rng + ?Sized>(rnd_gen: &mut R) -> String {
 pub fn random_keyword<R: Rng + ?Sized>(rnd_gen: &mut R) -> String {
     let random_adj = ADJECTIVE.choose(rnd_gen).unwrap();
     let random_noun = NOUN.choose(rnd_gen).unwrap();
-    format!("{} {}", random_adj, random_noun)
+    format!("{random_adj} {random_noun}")
 }
 
 pub fn random_keyword_payload<R: Rng + ?Sized>(

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -36,13 +36,13 @@ impl FullTextIndex {
 
     fn serialize_document(document: &Document) -> OperationResult<Vec<u8>> {
         serde_cbor::to_vec(document).map_err(|e| {
-            OperationError::service_error(format!("Failed to serialize document: {}", e))
+            OperationError::service_error(format!("Failed to serialize document: {e}"))
         })
     }
 
     fn deserialize_document(data: &[u8]) -> OperationResult<Document> {
         serde_cbor::from_slice(data).map_err(|e| {
-            OperationError::service_error(format!("Failed to deserialize document: {}", e))
+            OperationError::service_error(format!("Failed to deserialize document: {e}"))
         })
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
@@ -150,7 +150,7 @@ mod tests {
         let text = "hello, мир!";
         let mut tokens = Vec::new();
         PrefixTokenizer::tokenize(text, 1, 4, |token| tokens.push(token.to_owned()));
-        eprintln!("tokens = {:#?}", tokens);
+        eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
         assert_eq!(tokens.get(0), Some(&"h".to_owned()));
         assert_eq!(tokens.get(1), Some(&"he".to_owned()));
@@ -166,7 +166,7 @@ mod tests {
         let text = "hello, мир!";
         let mut tokens = Vec::new();
         PrefixTokenizer::tokenize_query(text, 4, |token| tokens.push(token.to_owned()));
-        eprintln!("tokens = {:#?}", tokens);
+        eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens.get(0), Some(&"hell".to_owned()));
         assert_eq!(tokens.get(1), Some(&"мир".to_owned()));
@@ -187,7 +187,7 @@ mod tests {
             },
             |token| tokens.push(token.to_owned()),
         );
-        eprintln!("tokens = {:#?}", tokens);
+        eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
         assert_eq!(tokens.get(0), Some(&"h".to_owned()));
         assert_eq!(tokens.get(1), Some(&"he".to_owned()));

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn long_overflow_distance() {
         let dist = Point::new(-179.999, 66.0).haversine_distance(&Point::new(179.999, 66.0));
-        eprintln!("dist` = {:#?}", dist);
+        eprintln!("dist` = {dist:#?}");
         assert_eq!(dist, 90.45422731917998);
         let dist = Point::new(0.99, 90.).haversine_distance(&Point::new(0.99, -90.0));
         assert_eq!(dist, 20015114.442035925);

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -109,7 +109,7 @@ impl GeoMapIndex {
     }
 
     fn encode_db_key(value: &str, idx: PointOffsetType) -> String {
-        format!("{}/{}", value, idx)
+        format!("{value}/{idx}")
     }
 
     fn decode_db_key(s: &str) -> OperationResult<(GeoHash, PointOffsetType)> {
@@ -302,7 +302,7 @@ impl GeoMapIndex {
         for added_point in values {
             let added_geo_hash: GeoHash = encode_max_precision(added_point.lon, added_point.lat)
                 .map_err(|e| {
-                    OperationError::service_error(format!("Malformed geo points: {}", e))
+                    OperationError::service_error(format!("Malformed geo points: {e}"))
                 })?;
 
             let key = Self::encode_db_key(&added_geo_hash, idx);
@@ -604,8 +604,8 @@ mod tests {
         let card = field_index.estimate_cardinality(&field_condition);
         let card = card.unwrap();
 
-        eprintln!("real_cardinality = {:#?}", real_cardinality);
-        eprintln!("card = {:#?}", card);
+        eprintln!("real_cardinality = {real_cardinality:#?}");
+        eprintln!("card = {card:#?}");
 
         assert!(card.min <= real_cardinality);
         assert!(card.max >= real_cardinality);

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -301,9 +301,7 @@ impl GeoMapIndex {
 
         for added_point in values {
             let added_geo_hash: GeoHash = encode_max_precision(added_point.lon, added_point.lat)
-                .map_err(|e| {
-                    OperationError::service_error(format!("Malformed geo points: {e}"))
-                })?;
+                .map_err(|e| OperationError::service_error(format!("Malformed geo points: {e}")))?;
 
             let key = Self::encode_db_key(&added_geo_hash, idx);
             let value = Self::encode_db_value(added_point);

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -887,7 +887,7 @@ mod tests {
         eprintln!("read_counter.get() = {:#?}", read_counter.get());
         eprintln!("histogram.borders.len() = {:#?}", histogram.borders.len());
         for border in histogram.borders.iter().take(5) {
-            eprintln!("border = {:?}", border);
+            eprintln!("border = {border:?}");
         }
         (histogram, points_index)
     }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -135,7 +135,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 
     fn encode_db_record(value: &N, idx: PointOffsetType) -> String {
-        format!("{}/{}", value, idx)
+        format!("{value}/{idx}")
     }
 
     fn decode_db_record(s: &str) -> OperationResult<(N, PointOffsetType)> {

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -576,7 +576,7 @@ mod tests {
             .unique()
             .collect_vec();
 
-        eprintln!("estimation = {:#?}", estimation);
+        eprintln!("estimation = {estimation:#?}");
         eprintln!("result.len() = {:#?}", result.len());
         assert!(estimation.min <= result.len());
         assert!(estimation.max >= result.len());

--- a/lib/segment/src/index/field_index/stat_tools.rs
+++ b/lib/segment/src/index/field_index/stat_tools.rs
@@ -109,22 +109,22 @@ mod tests {
     fn test_estimation_corner_cases() {
         let count = estimate_multi_value_selection_cardinality(10, 20, 20);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
         let count = estimate_multi_value_selection_cardinality(100, 100, 100);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
         let count = estimate_multi_value_selection_cardinality(100, 100, 50);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
         let count = estimate_multi_value_selection_cardinality(10, 10, 10);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
         let count = estimate_multi_value_selection_cardinality(1, 1, 1);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
         let count = estimate_multi_value_selection_cardinality(1, 1, 0);
         assert!(!count.is_nan());
-        eprintln!("count = {:#?}", count);
+        eprintln!("count = {count:#?}");
     }
 
     #[test]

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -237,8 +237,7 @@ where
             read_bin(graph_path)
         } else {
             Err(FileStorageError::generic_error(&format!(
-                "Links file does not exists: {:?}",
-                links_path
+                "Links file does not exists: {links_path:?}"
             )))
         };
 
@@ -433,8 +432,8 @@ mod tests {
             .map(|i| graph_layers.links.links(i as PointOffsetType, 0).len())
             .sum::<usize>();
 
-        eprintln!("total_links_0 = {:#?}", total_links_0);
-        eprintln!("num_vectors = {:#?}", num_vectors);
+        eprintln!("total_links_0 = {total_links_0:#?}");
+        eprintln!("num_vectors = {num_vectors:#?}");
         assert!(total_links_0 > 0);
         assert!(total_links_0 as f64 / num_vectors as f64 > M as f64);
 
@@ -484,8 +483,7 @@ mod tests {
         let mut file = File::create("graph.json").unwrap();
         file.write_all(
             format!(
-                "{{ \"graph\": {}, \n \"vectors\": {} }}",
-                graph_json, vectors_json
+                "{{ \"graph\": {graph_json}, \n \"vectors\": {vectors_json} }}"
             )
             .as_bytes(),
         )

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -482,10 +482,7 @@ mod tests {
 
         let mut file = File::create("graph.json").unwrap();
         file.write_all(
-            format!(
-                "{{ \"graph\": {graph_json}, \n \"vectors\": {vectors_json} }}"
-            )
-            .as_bytes(),
+            format!("{{ \"graph\": {graph_json}, \n \"vectors\": {vectors_json} }}").as_bytes(),
         )
         .unwrap();
     }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -575,8 +575,8 @@ mod tests {
 
         assert!(total_links_0 > 0);
 
-        eprintln!("total_links_0 = {:#?}", total_links_0);
-        eprintln!("num_vectors = {:#?}", num_vectors);
+        eprintln!("total_links_0 = {total_links_0:#?}");
+        eprintln!("num_vectors = {num_vectors:#?}");
 
         assert!(total_links_0 as f64 / num_vectors as f64 > M as f64);
 
@@ -658,8 +658,8 @@ mod tests {
 
         assert!(total_links_0 > 0);
 
-        eprintln!("total_links_0 = {:#?}", total_links_0);
-        eprintln!("num_vectors = {:#?}", num_vectors);
+        eprintln!("total_links_0 = {total_links_0:#?}");
+        eprintln!("num_vectors = {num_vectors:#?}");
 
         assert!(total_links_0 as f64 / num_vectors as f64 > M as f64);
 
@@ -716,7 +716,7 @@ mod tests {
             .unwrap();
 
         let num_points = graph_layers.links.num_points();
-        eprintln!("number_points = {:#?}", num_points);
+        eprintln!("number_points = {num_points:#?}");
 
         let max_layer = (0..NUM_VECTORS)
             .map(|i| graph_layers.links.point_level(i as PointOffsetType))
@@ -728,13 +728,13 @@ mod tests {
         let links910 = (0..layers910 + 1)
             .map(|i| graph_layers.links.links(910, i).to_vec())
             .collect::<Vec<_>>();
-        eprintln!("graph_layers.links_layers[910] = {:#?}", links910,);
+        eprintln!("graph_layers.links_layers[910] = {links910:#?}",);
 
         let total_edges: usize = (0..NUM_VECTORS)
             .map(|i| graph_layers.links.links(i as PointOffsetType, 0).len())
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
-        eprintln!("avg_connectivity = {:#?}", avg_connectivity);
+        eprintln!("avg_connectivity = {avg_connectivity:#?}");
     }
 
     #[test]
@@ -775,7 +775,7 @@ mod tests {
         );
 
         for x in selected_candidates.iter() {
-            eprintln!("selected_candidates = {}", x);
+            eprintln!("selected_candidates = {x}");
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -320,7 +320,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         );
 
         let pool = rayon::ThreadPoolBuilder::new()
-            .thread_name(|idx| format!("hnsw-build-{}", idx))
+            .thread_name(|idx| format!("hnsw-build-{idx}"))
             .num_threads(self.config.max_rayon_threads())
             .build()?;
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -219,7 +219,7 @@ mod tests {
                     has_id
                         .has_id
                         .iter()
-                        .map(|&x| format!("{}", x).parse().unwrap()) // hack to convert ID as "number"
+                        .map(|&x| format!("{x}").parse().unwrap()) // hack to convert ID as "number"
                         .collect(),
                 )],
                 min: has_id.has_id.len(),
@@ -299,7 +299,7 @@ mod tests {
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);
         assert_eq!(estimation.primary_clauses.len(), 0);
-        eprintln!("estimation = {:#?}", estimation);
+        eprintln!("estimation = {estimation:#?}");
         assert!(estimation.max <= TOTAL);
         assert!(estimation.exp <= estimation.max);
         assert!(estimation.min <= estimation.exp);
@@ -389,6 +389,6 @@ mod tests {
         }];
 
         let res = combine_must_estimations(&estimations, 10_000);
-        eprintln!("res = {:#?}", res);
+        eprintln!("res = {res:#?}");
     }
 }

--- a/lib/segment/src/index/query_optimization/payload_provider.rs
+++ b/lib/segment/src/index/query_optimization/payload_provider.rs
@@ -47,7 +47,7 @@ impl PayloadProvider {
             // Which may lead to slowdown and assumes a lot of changes.
             PayloadStorageEnum::OnDiskPayloadStorage(s) => s
                 .read_payload(point_id)
-                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {}", err))
+                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {err}"))
                 .map(|x| x.into()),
         };
 

--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -85,8 +85,7 @@ mod tests {
                 assert!(interval.1 < delta);
                 delta = interval.1;
                 eprintln!(
-                    "confidence_agresti_coull_interval({}, {}, {}) = {:#?}",
-                    i, positive, total, interval
+                    "confidence_agresti_coull_interval({i}, {positive}, {total}) = {interval:#?}"
                 );
             }
         }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -97,7 +97,7 @@ impl StructPayloadIndex {
     }
 
     fn get_field_index_path(path: &Path, field: PayloadKeyTypeRef) -> PathBuf {
-        Self::get_field_index_dir(path).join(format!("{}.idx", field))
+        Self::get_field_index_dir(path).join(format!("{field}.idx"))
     }
 
     fn load_all_fields(&mut self) -> OperationResult<()> {
@@ -147,7 +147,7 @@ impl StructPayloadIndex {
         };
 
         let db = open_db_with_existing_cf(path)
-            .map_err(|err| OperationError::service_error(format!("RocksDB open error: {}", err)))?;
+            .map_err(|err| OperationError::service_error(format!("RocksDB open error: {err}")))?;
 
         let mut index = StructPayloadIndex {
             payload,

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -170,7 +170,7 @@ mod tests {
             assert!(res.0.contains_key("location"));
             assert!(res.0.contains_key("name"));
 
-            eprintln!("res = {:#?}", res);
+            eprintln!("res = {res:#?}");
 
             let partial_payload: Payload =
                 serde_json::from_str(r#"{ "hobby": "vector search" }"#).unwrap();
@@ -185,7 +185,7 @@ mod tests {
             assert!(res.0.contains_key("hobby"));
             assert!(res.0.contains_key("name"));
 
-            eprintln!("res = {:#?}", res);
+            eprintln!("res = {res:#?}");
         }
     }
 }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -186,7 +186,7 @@ impl ConditionChecker for SimpleConditionChecker {
                             // Which may lead to slowdown and assumes a lot of changes.
                             s.read_payload(point_id)
                                 .unwrap_or_else(|err| {
-                                    panic!("Payload storage is corrupted: {}", err)
+                                    panic!("Payload storage is corrupted: {err}")
                                 })
                                 .map(|x| x.into())
                         }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -185,9 +185,7 @@ impl ConditionChecker for SimpleConditionChecker {
                             // Rewrite condition checking code to support error reporting.
                             // Which may lead to slowdown and assumes a lot of changes.
                             s.read_payload(point_id)
-                                .unwrap_or_else(|err| {
-                                    panic!("Payload storage is corrupted: {err}")
-                                })
+                                .unwrap_or_else(|err| panic!("Payload storage is corrupted: {err}"))
                                 .map(|x| x.into())
                         }
                     };

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1020,15 +1020,11 @@ impl SegmentEntry for Segment {
         let flush_op = move || {
             // Flush mapping first to prevent having orphan internal ids.
             id_tracker_mapping_flusher().map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to flush id_tracker mapping: {err}"
-                ))
+                OperationError::service_error(format!("Failed to flush id_tracker mapping: {err}"))
             })?;
             for vector_storage_flusher in vector_storage_flushers {
                 vector_storage_flusher().map_err(|err| {
-                    OperationError::service_error(format!(
-                        "Failed to flush vector_storage: {err}"
-                    ))
+                    OperationError::service_error(format!("Failed to flush vector_storage: {err}"))
                 })?;
             }
             payload_index_flusher().map_err(|err| {
@@ -1041,9 +1037,7 @@ impl SegmentEntry for Segment {
             //  by simply overriding data in vector and payload storages.
             // Once versions are saved - points are considered persisted.
             id_tracker_versions_flusher().map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to flush id_tracker versions: {err}"
-                ))
+                OperationError::service_error(format!("Failed to flush id_tracker versions: {err}"))
             })?;
             Self::save_state(&state, &current_path).map_err(|err| {
                 OperationError::service_error(format!("Failed to flush segment state: {err}"))

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -140,8 +140,7 @@ impl Segment {
             // fail if newer operation is attempted before proper recovery
             if *failed_version < op_num {
                 return Err(OperationError::service_error(format!(
-                    "Not recovered from previous error: {}",
-                    error
+                    "Not recovered from previous error: {error}"
                 )));
             } // else: Re-try operation
         }
@@ -409,8 +408,7 @@ impl Segment {
                 let point_offset = scored_point_offset.idx;
                 let point_version = id_tracker.internal_version(point_offset).ok_or_else(|| {
                     OperationError::service_error(format!(
-                        "Corrupter id_tracker, no version for point {}",
-                        point_id
+                        "Corrupter id_tracker, no version for point {point_id}"
                     ))
                 })?;
                 let payload = if with_payload.enable {
@@ -1023,20 +1021,18 @@ impl SegmentEntry for Segment {
             // Flush mapping first to prevent having orphan internal ids.
             id_tracker_mapping_flusher().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to flush id_tracker mapping: {}",
-                    err
+                    "Failed to flush id_tracker mapping: {err}"
                 ))
             })?;
             for vector_storage_flusher in vector_storage_flushers {
                 vector_storage_flusher().map_err(|err| {
                     OperationError::service_error(format!(
-                        "Failed to flush vector_storage: {}",
-                        err
+                        "Failed to flush vector_storage: {err}"
                     ))
                 })?;
             }
             payload_index_flusher().map_err(|err| {
-                OperationError::service_error(format!("Failed to flush payload_index: {}", err))
+                OperationError::service_error(format!("Failed to flush payload_index: {err}"))
             })?;
             // Id Tracker contains versions of points. We need to flush it after vector_storage and payload_index flush.
             // This is because vector_storage and payload_index flush are not atomic.
@@ -1046,12 +1042,11 @@ impl SegmentEntry for Segment {
             // Once versions are saved - points are considered persisted.
             id_tracker_versions_flusher().map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to flush id_tracker versions: {}",
-                    err
+                    "Failed to flush id_tracker versions: {err}"
                 ))
             })?;
             Self::save_state(&state, &current_path).map_err(|err| {
-                OperationError::service_error(format!("Failed to flush segment state: {}", err))
+                OperationError::service_error(format!("Failed to flush segment state: {err}"))
             })?;
             *persisted_version.lock() = state.version;
 
@@ -1388,7 +1383,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        eprintln!("search_result = {:#?}", search_result);
+        eprintln!("search_result = {search_result:#?}");
 
         let search_batch_result = segment
             .search_batch(
@@ -1401,7 +1396,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        eprintln!("search_batch_result = {:#?}", search_batch_result);
+        eprintln!("search_batch_result = {search_batch_result:#?}");
 
         assert!(!search_result.is_empty());
         assert_eq!(search_result, search_batch_result[0].clone())

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -93,8 +93,7 @@ impl SegmentBuilder {
                     let other_vector_storage = other_vector_storages.get(vector_name);
                     if other_vector_storage.is_none() {
                         return Err(OperationError::service_error(format!(
-                            "Cannot update from other segment because if missing vector name {}",
-                            vector_name
+                            "Cannot update from other segment because if missing vector name {vector_name}"
                         )));
                     }
                     let other_vector_storage = other_vector_storage.unwrap();

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -43,7 +43,7 @@ fn create_segment(
 ) -> OperationResult<Segment> {
     let get_vector_name_with_prefix = |prefix: &str, vector_name: &str| {
         if !vector_name.is_empty() {
-            format!("{}-{}", prefix, vector_name)
+            format!("{prefix}-{vector_name}")
         } else {
             prefix.to_owned()
         }
@@ -54,7 +54,7 @@ fn create_segment(
         .map(|vector_name| get_vector_name_with_prefix(DB_VECTOR_CF, vector_name))
         .collect();
     let database = open_db(segment_path, &vector_db_names)
-        .map_err(|err| OperationError::service_error(format!("RocksDB open error: {}", err)))?;
+        .map_err(|err| OperationError::service_error(format!("RocksDB open error: {err}")))?;
 
     let payload_storage = match config.payload_storage_type {
         PayloadStorageType::InMemory => sp(SimplePayloadStorage::open(database.clone())?.into()),
@@ -170,16 +170,14 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
 
         if stored_version > app_version {
             return Err(OperationError::service_error(format!(
-                "Data version {} is newer than application version {}. \
-                Please upgrade the application. Compatibility is not guaranteed.",
-                stored_version, app_version
+                "Data version {stored_version} is newer than application version {app_version}. \
+                Please upgrade the application. Compatibility is not guaranteed."
             )));
         }
 
         if stored_version.major == 0 && stored_version.minor < 3 {
             return Err(OperationError::service_error(format!(
-                "Segment version({}) is not compatible with current version({})",
-                stored_version, app_version
+                "Segment version({stored_version}) is not compatible with current version({app_version})"
             )));
         }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -50,8 +50,8 @@ pub enum ExtendedPointId {
 impl std::fmt::Display for ExtendedPointId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExtendedPointId::NumId(idx) => write!(f, "{}", idx),
-            ExtendedPointId::Uuid(uuid) => write!(f, "{}", uuid),
+            ExtendedPointId::NumId(idx) => write!(f, "{idx}"),
+            ExtendedPointId::Uuid(uuid) => write!(f, "{uuid}"),
         }
     }
 }
@@ -512,7 +512,7 @@ impl From<Value> for Payload {
     fn from(value: Value) -> Self {
         match value {
             Value::Object(map) => Payload(map),
-            _ => panic!("cannot convert from {:?}", value),
+            _ => panic!("cannot convert from {value:?}"),
         }
     }
 }
@@ -641,8 +641,7 @@ impl TryFrom<PayloadIndexInfo> for PayloadFieldSchema {
                 PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(params)),
             ),
             (data_type, Some(_)) => Err(format!(
-                "Payload field with type {:?} has unexpected params",
-                data_type
+                "Payload field with type {data_type:?} has unexpected params"
             )),
             (data_type, None) => Ok(PayloadFieldSchema::FieldType(data_type)),
         }
@@ -1205,8 +1204,8 @@ mod tests {
         let payload: Payload = json!({"payload_key":"payload_value"}).into();
         let raw = rmp_serde::to_vec(&payload).unwrap();
         let de_record: Payload = serde_cbor::from_slice(&raw).unwrap();
-        eprintln!("payload = {:#?}", payload);
-        eprintln!("de_record = {:#?}", de_record);
+        eprintln!("payload = {payload:#?}");
+        eprintln!("de_record = {de_record:#?}");
     }
 
     #[test]
@@ -1220,7 +1219,7 @@ mod tests {
             should: None,
         };
         let json = serde_json::to_string_pretty(&filter).unwrap();
-        println!("{}", json)
+        println!("{json}")
     }
 
     #[test]
@@ -1317,7 +1316,7 @@ mod tests {
         "#;
 
         let filter: Filter = serde_json::from_str(query1).unwrap();
-        println!("{:?}", filter);
+        println!("{filter:?}");
         let must = filter.must.unwrap();
         let _must_not = filter.must_not;
         assert_eq!(must.len(), 2);
@@ -1400,15 +1399,15 @@ mod tests {
     fn test_payload_parsing() {
         let ft = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
         let ft_json = serde_json::to_string(&ft).unwrap();
-        eprintln!("ft_json = {:?}", ft_json);
+        eprintln!("ft_json = {ft_json:?}");
 
         let ft = PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(Default::default()));
         let ft_json = serde_json::to_string(&ft).unwrap();
-        eprintln!("ft_json = {:?}", ft_json);
+        eprintln!("ft_json = {ft_json:?}");
 
         let query = r#""keyword""#;
         let field_type: PayloadSchemaType = serde_json::from_str(query).unwrap();
-        eprintln!("field_type = {:?}", field_type);
+        eprintln!("field_type = {field_type:?}");
     }
 }
 

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -456,7 +456,7 @@ mod tests {
         eprintln!("slice.len() = {:#?}", slice.len());
 
         for (idx, element) in slice.iter().enumerate() {
-            println!("slice[{}]  = {:?}", idx, element);
+            println!("slice[{idx}]  = {element:?}");
         }
     }
 }

--- a/lib/segment/tests/filtering_context_check.rs
+++ b/lib/segment/tests/filtering_context_check.rs
@@ -35,7 +35,7 @@ mod tests {
             let struct_result = (0..NUM_POINTS)
                 .filter(|point_id| struct_filter_context.check(*point_id as PointOffsetType))
                 .collect_vec();
-            assert_eq!(plain_result, struct_result, "filter: {:#?}", filter);
+            assert_eq!(plain_result, struct_result, "filter: {filter:#?}");
         }
     }
 }

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -177,7 +177,7 @@ mod tests {
                 hits += 1;
             }
         }
-        assert!(attempts - hits < 5, "hits: {} of {}", hits, attempts); // Not more than 5% failures
-        eprintln!("hits = {:#?} out of {}", hits, attempts);
+        assert!(attempts - hits < 5, "hits: {hits} of {attempts}"); // Not more than 5% failures
+        eprintln!("hits = {hits:#?} out of {attempts}");
     }
 }

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -159,9 +159,9 @@ mod tests {
             .query_points(&filter)
             .count();
 
-        eprintln!("estimation_plain = {:#?}", estimation_plain);
-        eprintln!("estimation_struct = {:#?}", estimation_struct);
-        eprintln!("real_number = {:#?}", real_number);
+        eprintln!("estimation_plain = {estimation_plain:#?}");
+        eprintln!("estimation_struct = {estimation_struct:#?}");
+        eprintln!("real_number = {real_number:#?}");
 
         assert!(estimation_plain.max >= real_number);
         assert!(estimation_plain.min <= real_number);
@@ -207,8 +207,8 @@ mod tests {
             .collect_vec()
             .len();
 
-        eprintln!("exact = {:#?}", exact);
-        eprintln!("estimation = {:#?}", estimation);
+        eprintln!("exact = {exact:#?}");
+        eprintln!("estimation = {estimation:#?}");
 
         assert!(exact <= estimation.max);
         assert!(exact >= estimation.min);
@@ -259,16 +259,15 @@ mod tests {
                 .borrow()
                 .estimate_cardinality(&query_filter);
 
-            assert!(estimation.min <= estimation.exp, "{:#?}", estimation);
-            assert!(estimation.exp <= estimation.max, "{:#?}", estimation);
+            assert!(estimation.min <= estimation.exp, "{estimation:#?}");
+            assert!(estimation.exp <= estimation.max, "{estimation:#?}");
             assert!(
                 estimation.max
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
                         .vector_count(),
-                "{:#?}",
-                estimation
+                "{estimation:#?}"
             );
 
             // warning: report flakiness at https://github.com/qdrant/qdrant/issues/534
@@ -276,7 +275,7 @@ mod tests {
                 .iter()
                 .zip(struct_result.iter())
                 .for_each(|(r1, r2)| {
-                    assert_eq!(r1.id, r2.id, "got different ScoredPoint {:?} and {:?} for\nquery vector {:?}\nquery filter {:?}\nplain result {:?}\nstruct result{:?}", r1, r2, query_vector, query_filter, plain_result, struct_result);
+                    assert_eq!(r1.id, r2.id, "got different ScoredPoint {r1:?} and {r2:?} for\nquery vector {query_vector:?}\nquery filter {query_filter:?}\nplain result {plain_result:?}\nstruct result{struct_result:?}");
                     assert!((r1.score - r2.score) < 0.0001)
                 });
         }
@@ -334,16 +333,15 @@ mod tests {
                 .borrow()
                 .estimate_cardinality(&query_filter);
 
-            assert!(estimation.min <= estimation.exp, "{:#?}", estimation);
-            assert!(estimation.exp <= estimation.max, "{:#?}", estimation);
+            assert!(estimation.min <= estimation.exp, "{estimation:#?}");
+            assert!(estimation.exp <= estimation.max, "{estimation:#?}");
             assert!(
                 estimation.max
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
                         .vector_count(),
-                "{:#?}",
-                estimation
+                "{estimation:#?}"
             );
 
             let struct_result = struct_segment
@@ -363,16 +361,15 @@ mod tests {
                 .borrow()
                 .estimate_cardinality(&query_filter);
 
-            assert!(estimation.min <= estimation.exp, "{:#?}", estimation);
-            assert!(estimation.exp <= estimation.max, "{:#?}", estimation);
+            assert!(estimation.min <= estimation.exp, "{estimation:#?}");
+            assert!(estimation.exp <= estimation.max, "{estimation:#?}");
             assert!(
                 estimation.max
                     <= struct_segment.vector_data[DEFAULT_VECTOR_NAME]
                         .vector_storage
                         .borrow()
                         .vector_count(),
-                "{:#?}",
-                estimation
+                "{estimation:#?}"
             );
 
             plain_result

--- a/lib/segment/tests/scroll_filtering_test.rs
+++ b/lib/segment/tests/scroll_filtering_test.rs
@@ -28,10 +28,7 @@ mod tests {
             let read_by_stream_res =
                 segment.filtered_read_by_id_stream(Some(random_offset.into()), Some(10), &filter);
 
-            assert_eq!(
-                read_by_index_res, read_by_stream_res,
-                "filter: {filter:#?}"
-            );
+            assert_eq!(read_by_index_res, read_by_stream_res, "filter: {filter:#?}");
         }
     }
 }

--- a/lib/segment/tests/scroll_filtering_test.rs
+++ b/lib/segment/tests/scroll_filtering_test.rs
@@ -30,8 +30,7 @@ mod tests {
 
             assert_eq!(
                 read_by_index_res, read_by_stream_res,
-                "filter: {:#?}",
-                filter
+                "filter: {filter:#?}"
             );
         }
     }

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -85,7 +85,7 @@ impl AliasPersistence {
     ) -> Result<(), StorageError> {
         match self.get(old_alias_name) {
             None => Err(StorageError::NotFound {
-                description: format!("Alias {} does not exists!", old_alias_name),
+                description: format!("Alias {old_alias_name} does not exists!"),
             }),
             Some(collection_name) => {
                 self.alias_mapping.0.remove(old_alias_name);

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -18,7 +18,7 @@ pub trait Checker {
     ) -> Result<(), StorageError> {
         if self.is_collection_exists(collection_name) {
             return Err(StorageError::BadInput {
-                description: format!("Collection `{}` already exists!", collection_name),
+                description: format!("Collection `{collection_name}` already exists!"),
             });
         }
         Ok(())
@@ -27,7 +27,7 @@ pub trait Checker {
     async fn validate_collection_exists(&self, collection_name: &str) -> Result<(), StorageError> {
         if !self.is_collection_exists(collection_name) {
             return Err(StorageError::NotFound {
-                description: format!("Collection `{}` doesn't exist!", collection_name),
+                description: format!("Collection `{collection_name}` doesn't exist!"),
             });
         }
         Ok(())

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -100,10 +100,7 @@ impl ConsensusOpWal {
                 // Example: 2 <= 0 + 1 + 1
                 debug_assert!(
                     index <= current_index + offset + 1,
-                    "Expected no index skip: {} <= {} + {}",
-                    index,
-                    current_index,
-                    offset
+                    "Expected no index skip: {index} <= {current_index} + {offset}"
                 );
 
                 if index < current_index + offset {
@@ -115,8 +112,7 @@ impl ConsensusOpWal {
                     // 10 < 11 + 1
                     if index < offset {
                         return Err(StorageError::service_error(&format!(
-                            "Wal index conflict, raft index: {}, wal index: {}, offset: {}",
-                            index, current_index, offset
+                            "Wal index conflict, raft index: {index}, wal index: {current_index}, offset: {offset}"
                         )));
                     }
                     log::debug!(

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -19,7 +19,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::BadRequest { .. } => tonic::Code::InvalidArgument,
         StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
     };
-    tonic::Status::new(error_code, format!("{}", error))
+    tonic::Status::new(error_code, format!("{error}"))
 }
 
 impl TryFrom<api::grpc::qdrant::CreateCollection> for CollectionMetaOperations {

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -42,8 +42,7 @@ async fn get_local_source_shards(
         let responsible_shard = match responsible_shard_opt {
             None => {
                 return Err(CollectionError::service_error(format!(
-                    "No active replica for shard {}, collection initialization is cancelled",
-                    shard_id
+                    "No active replica for shard {shard_id}, collection initialization is cancelled"
                 )));
             }
             Some(responsible_shard) => responsible_shard,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -114,7 +114,7 @@ impl From<CollectionError> for StorageError {
 
 impl From<IoError> for StorageError {
     fn from(err: IoError) -> Self {
-        StorageError::service_error(&format!("{}", err))
+        StorageError::service_error(&format!("{err}"))
     }
 }
 
@@ -135,7 +135,7 @@ impl From<FileStorageError> for StorageError {
 impl<Guard> From<std::sync::PoisonError<Guard>> for StorageError {
     fn from(err: std::sync::PoisonError<Guard>) -> Self {
         StorageError::ServiceError {
-            description: format!("Mutex lock poisoned: {}", err),
+            description: format!("Mutex lock poisoned: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -144,7 +144,7 @@ impl<Guard> From<std::sync::PoisonError<Guard>> for StorageError {
 impl<T> From<std::sync::mpsc::SendError<T>> for StorageError {
     fn from(err: std::sync::mpsc::SendError<T>) -> Self {
         StorageError::ServiceError {
-            description: format!("Channel closed: {}", err),
+            description: format!("Channel closed: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -153,7 +153,7 @@ impl<T> From<std::sync::mpsc::SendError<T>> for StorageError {
 impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
     fn from(err: tokio::sync::oneshot::error::RecvError) -> Self {
         StorageError::ServiceError {
-            description: format!("Channel sender dropped: {}", err),
+            description: format!("Channel sender dropped: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -162,7 +162,7 @@ impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
 impl From<serde_cbor::Error> for StorageError {
     fn from(err: serde_cbor::Error) -> Self {
         StorageError::ServiceError {
-            description: format!("cbor (de)serialization error: {}", err),
+            description: format!("cbor (de)serialization error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -171,7 +171,7 @@ impl From<serde_cbor::Error> for StorageError {
 impl From<prost::EncodeError> for StorageError {
     fn from(err: prost::EncodeError) -> Self {
         StorageError::ServiceError {
-            description: format!("prost encode error: {}", err),
+            description: format!("prost encode error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -180,7 +180,7 @@ impl From<prost::EncodeError> for StorageError {
 impl From<prost::DecodeError> for StorageError {
     fn from(err: prost::DecodeError) -> Self {
         StorageError::ServiceError {
-            description: format!("prost decode error: {}", err),
+            description: format!("prost decode error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -189,7 +189,7 @@ impl From<prost::DecodeError> for StorageError {
 impl From<raft::Error> for StorageError {
     fn from(err: raft::Error) -> Self {
         StorageError::ServiceError {
-            description: format!("Error in Raft consensus: {}", err),
+            description: format!("Error in Raft consensus: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -198,7 +198,7 @@ impl From<raft::Error> for StorageError {
 impl<E: std::fmt::Display> From<atomicwrites::Error<E>> for StorageError {
     fn from(err: atomicwrites::Error<E>) -> Self {
         StorageError::ServiceError {
-            description: format!("Failed to write file: {}", err),
+            description: format!("Failed to write file: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -207,7 +207,7 @@ impl<E: std::fmt::Display> From<atomicwrites::Error<E>> for StorageError {
 impl From<tonic::transport::Error> for StorageError {
     fn from(err: tonic::transport::Error) -> Self {
         StorageError::ServiceError {
-            description: format!("Tonic transport error: {}", err),
+            description: format!("Tonic transport error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -216,7 +216,7 @@ impl From<tonic::transport::Error> for StorageError {
 impl From<reqwest::Error> for StorageError {
     fn from(err: reqwest::Error) -> Self {
         StorageError::ServiceError {
-            description: format!("Http request error: {}", err),
+            description: format!("Http request error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }
@@ -225,7 +225,7 @@ impl From<reqwest::Error> for StorageError {
 impl From<tokio::task::JoinError> for StorageError {
     fn from(err: tokio::task::JoinError) -> Self {
         StorageError::ServiceError {
-            description: format!("Tokio task join error: {}", err),
+            description: format!("Tokio task join error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -57,8 +57,7 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
             let local_file_path = Path::new(url.path());
             if !local_file_path.exists() {
                 return Err(StorageError::bad_request(&format!(
-                    "Snapshot file {:?} does not exist",
-                    local_file_path
+                    "Snapshot file {local_file_path:?} does not exist"
                 )));
             }
             Ok(local_file_path.to_path_buf())

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -30,7 +30,7 @@ pub async fn get_full_snapshot_path(
     let snapshot_path = Path::new(toc.snapshots_path()).join(snapshot_name);
     if !snapshot_path.exists() {
         return Err(StorageError::NotFound {
-            description: format!("Full storage snapshot {} not found", snapshot_name),
+            description: format!("Full storage snapshot {snapshot_name} not found"),
         });
     }
     Ok(snapshot_path)

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -117,9 +117,7 @@ impl TableOfContent {
             let collection_snapshots_path =
                 Self::collection_snapshots_path(&snapshots_path, &collection_name);
             create_dir_all(&collection_snapshots_path).unwrap_or_else(|e| {
-                panic!(
-                    "Can't create a directory for snapshot of {collection_name}: {e}"
-                )
+                panic!("Can't create a directory for snapshot of {collection_name}: {e}")
             });
             log::info!("Loading collection: {}", collection_name);
             let collection = general_runtime.block_on(Collection::load(

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -118,8 +118,7 @@ impl TableOfContent {
                 Self::collection_snapshots_path(&snapshots_path, &collection_name);
             create_dir_all(&collection_snapshots_path).unwrap_or_else(|e| {
                 panic!(
-                    "Can't create a directory for snapshot of {}: {}",
-                    collection_name, e
+                    "Can't create a directory for snapshot of {collection_name}: {e}"
                 )
             });
             log::info!("Loading collection: {}", collection_name);
@@ -193,8 +192,7 @@ impl TableOfContent {
             .await
             .map_err(|err| {
                 StorageError::service_error(&format!(
-                    "Can't create directory for snapshots {}. Error: {}",
-                    collection_name, err
+                    "Can't create directory for snapshots {collection_name}. Error: {err}"
                 ))
             })?;
 
@@ -206,8 +204,7 @@ impl TableOfContent {
 
         tokio::fs::create_dir_all(&path).await.map_err(|err| {
             StorageError::service_error(&format!(
-                "Can't create directory for collection {}. Error: {}",
-                collection_name, err
+                "Can't create directory for collection {collection_name}. Error: {err}"
             ))
         })?;
 
@@ -378,7 +375,7 @@ impl TableOfContent {
         let collection_vectors_schema = collection.state().await.config.params.vectors;
         if &collection_vectors_schema != vectors {
             return Err(StorageError::BadInput {
-                description: format!("Cannot take data from collection with vectors schema {:?} to collection with vectors schema {:?}", collection_vectors_schema, vectors)
+                description: format!("Cannot take data from collection with vectors schema {collection_vectors_schema:?} to collection with vectors schema {vectors:?}")
             });
         }
         Ok(())

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -45,7 +45,7 @@ pub async fn get_point(
             Ok(x) => x,
             Err(_) => {
                 let error = Err(StorageError::BadInput {
-                    description: format!("Can not recognize \"{}\" as point id", point_id_str),
+                    description: format!("Can not recognize \"{point_id_str}\" as point id"),
                 });
                 return process_response(error, timing);
             }
@@ -57,7 +57,7 @@ pub async fn get_point(
     let response = match response {
         Ok(record) => match record {
             None => Err(StorageError::NotFound {
-                description: format!("Point with id {} does not exists!", point_id),
+                description: format!("Point with id {point_id} does not exists!"),
             }),
             Some(record) => Ok(record),
         },

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -14,11 +14,11 @@ pub fn collection_into_actix_error(err: CollectionError) -> Error {
 
 pub fn storage_into_actix_error(err: StorageError) -> Error {
     match err {
-        StorageError::BadInput { .. } => error::ErrorBadRequest(format!("{}", err)),
-        StorageError::NotFound { .. } => error::ErrorNotFound(format!("{}", err)),
-        StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{}", err)),
-        StorageError::BadRequest { .. } => error::ErrorBadRequest(format!("{}", err)),
-        StorageError::Locked { .. } => error::ErrorForbidden(format!("{}", err)),
+        StorageError::BadInput { .. } => error::ErrorBadRequest(format!("{err}")),
+        StorageError::NotFound { .. } => error::ErrorNotFound(format!("{err}")),
+        StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{err}")),
+        StorageError::BadRequest { .. } => error::ErrorBadRequest(format!("{err}")),
+        StorageError::Locked { .. } => error::ErrorForbidden(format!("{err}")),
     }
 }
 
@@ -33,7 +33,7 @@ where
             time: timing.elapsed().as_secs_f64(),
         }),
         Err(err) => {
-            let error_description = format!("{}", err);
+            let error_description = format!("{err}");
 
             let mut resp = match err {
                 StorageError::BadInput { .. } => HttpResponse::BadRequest(),

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -111,7 +111,7 @@ pub async fn do_update_collection_cluster(
             .contains_key(&peer_id);
         if !target_peer_exist {
             return Err(StorageError::BadRequest {
-                description: format!("Peer {} does not exist", peer_id),
+                description: format!("Peer {peer_id} does not exist"),
             });
         }
         Ok(())

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -26,7 +26,7 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
             let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("search-{}", id)
+            format!("search-{id}")
         })
         .build()
 }
@@ -56,7 +56,7 @@ pub fn create_general_purpose_runtime() -> std::io::Result<Runtime> {
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
             let general_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("general-{}", general_id)
+            format!("general-{general_id}")
         })
         .build()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,7 +374,7 @@ fn main() -> anyhow::Result<()> {
 
                 let mut error = format!("{} deadlocks detected\n", deadlocks.len());
                 for (i, threads) in deadlocks.iter().enumerate() {
-                    writeln!(error, "Deadlock #{}", i).expect("fail to writeln!");
+                    writeln!(error, "Deadlock #{i}").expect("fail to writeln!");
                     for t in threads {
                         writeln!(
                             error,

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -65,7 +65,7 @@ struct AllDefinitions {
 fn save_schema<T: JsonSchema>() {
     let schema = schema_for!(T);
     let schema_str = serde_json::to_string_pretty(&schema).unwrap();
-    println!("{}", schema_str)
+    println!("{schema_str}")
 }
 
 fn main() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -132,7 +132,7 @@ impl Settings {
             // Add in the current environment file
             // Default to 'development' env
             // Note that this file is _optional_
-            .add_source(File::with_name(&format!("config/{}", env)).required(false))
+            .add_source(File::with_name(&format!("config/{env}")).required(false))
             // Add in a local configuration file
             // This file shouldn't be checked in to git
             .add_source(File::with_name("config/local").required(false))

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -100,9 +100,7 @@ pub fn recover_full_snapshot(snapshot_path: &str, storage_dir: &str, force: bool
         AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
     for (alias, collection_name) in config_json.collections_aliases {
         if alias_persistence.get(&alias).is_some() && !force {
-            panic!(
-                "Alias {alias} already exists. Use --force-snapshot to overwrite it."
-            );
+            panic!("Alias {alias} already exists. Use --force-snapshot to overwrite it.");
         }
         alias_persistence.insert(alias, collection_name).unwrap();
     }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -25,17 +25,16 @@ pub fn recover_snapshots(mapping: &[String], force: bool, storage_dir: &str) -> 
         let mut split = snapshot_params.split(':');
         let path = split
             .next()
-            .unwrap_or_else(|| panic!("Snapshot path is missing: {}", snapshot_params));
+            .unwrap_or_else(|| panic!("Snapshot path is missing: {snapshot_params}"));
 
         let snapshot_path = Path::new(path);
         let collection_name = split
             .next()
-            .unwrap_or_else(|| panic!("Collection name is missing: {}", snapshot_params));
+            .unwrap_or_else(|| panic!("Collection name is missing: {snapshot_params}"));
         recovered_collections.push(collection_name.to_string());
         assert!(
             split.next().is_none(),
-            "Too many parts in snapshot mapping: {}",
-            snapshot_params
+            "Too many parts in snapshot mapping: {snapshot_params}"
         );
         info!("Recovering snapshot {} from {}", collection_name, path);
         // check if collection already exists
@@ -46,20 +45,19 @@ pub fn recover_snapshots(mapping: &[String], force: bool, storage_dir: &str) -> 
         if collection_path.exists() {
             if !force {
                 panic!(
-                    "Collection {} already exists. Use --force-snapshot to overwrite it.",
-                    collection_name
+                    "Collection {collection_name} already exists. Use --force-snapshot to overwrite it."
                 );
             }
             info!("Overwriting collection {}", collection_name);
         }
         let collection_temp_path = collection_path.with_extension("tmp");
         if let Err(err) = Collection::restore_snapshot(snapshot_path, &collection_temp_path) {
-            panic!("Failed to recover snapshot {}: {}", collection_name, err);
+            panic!("Failed to recover snapshot {collection_name}: {err}");
         }
         // Remove collection_path directory if exists
         if collection_path.exists() {
             if let Err(err) = remove_dir_all(&collection_path) {
-                panic!("Failed to remove collection {}: {}", collection_name, err);
+                panic!("Failed to remove collection {collection_name}: {err}");
             }
         }
         rename(&collection_temp_path, &collection_path).unwrap();
@@ -103,8 +101,7 @@ pub fn recover_full_snapshot(snapshot_path: &str, storage_dir: &str, force: bool
     for (alias, collection_name) in config_json.collections_aliases {
         if alias_persistence.get(&alias).is_some() && !force {
             panic!(
-                "Alias {} already exists. Use --force-snapshot to overwrite it.",
-                alias
+                "Alias {alias} already exists. Use --force-snapshot to overwrite it."
             );
         }
         alias_persistence.insert(alias, collection_name).unwrap();


### PR DESCRIPTION
The Clippy release for Rust 1.67 introduced new warnings.

The inlining of `format!` argument was done using `cargo clippy --fix --all`