### PR TITLE
Enable on disk payload option by default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ storage:
   # It will be read from the disk every time it is requested.
   # This setting saves RAM by (slightly) increasing the response time.
   # Note: those payload values that are involved in filtering and are indexed - remain in RAM.
-  on_disk_payload: false
+  on_disk_payload: true
 
   # Write-ahead-log related configuration
   wal:


### PR DESCRIPTION
Payload often consumes a lot of RAM, thus it might be reasonable to store it on disk by default.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?