### PR TITLE
allow to overwrite max number of cpus with env variable

### DIFF
--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use schemars::JsonSchema;
+use segment::common::cpu::get_num_cpus;
 use segment::types::HnswConfig;
 use serde::{Deserialize, Serialize};
 
@@ -76,7 +77,7 @@ impl OptimizersConfig {
 
     pub fn get_number_segments(&self) -> usize {
         if self.default_segment_number == 0 {
-            let num_cpus = num_cpus::get();
+            let num_cpus = get_num_cpus();
             // Do not configure less than 2 and more than 8 segments
             // until it is not explicitly requested
             num_cpus.clamp(2, 8)
@@ -89,7 +90,7 @@ impl OptimizersConfig {
         if let Some(max_segment_size) = self.max_segment_size {
             max_segment_size
         } else {
-            let num_cpus = num_cpus::get();
+            let num_cpus = get_num_cpus();
             num_cpus.saturating_mul(DEFAULT_MAX_SEGMENT_PER_CPU_KB)
         }
     }

--- a/lib/segment/src/common/cpu.rs
+++ b/lib/segment/src/common/cpu.rs
@@ -1,0 +1,15 @@
+/// Try to read number of CPUs from environment variable `QDRANT_NUM_CPUS`.
+/// If it is not set, use `num_cpus::get()`.
+pub fn get_num_cpus() -> usize {
+    match std::env::var("QDRANT_NUM_CPUS") {
+        Ok(val) => {
+            let num_cpus = val.parse::<usize>().unwrap_or(0);
+            if num_cpus > 0 {
+                num_cpus
+            } else {
+                num_cpus::get()
+            }
+        }
+        Err(_) => num_cpus::get(),
+    }
+}

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod anonymize;
 pub mod arc_atomic_ref_cell_iterator;
+pub mod cpu;
 pub mod error_logging;
 pub mod file_operations;
 pub mod operation_time_statistics;

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::common::cpu::get_num_cpus;
 use crate::common::file_operations::{atomic_save_json, read_json};
 use crate::entry::entry_point::OperationResult;
 
@@ -62,7 +63,7 @@ impl HnswGraphConfig {
         let max_threads = self.max_indexing_threads;
 
         if max_threads == 0 {
-            let num_cpu = num_cpus::get();
+            let num_cpu = get_num_cpus();
             std::cmp::max(1, num_cpu - 1)
         } else {
             max_threads

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use schemars::JsonSchema;
+use segment::common::cpu::get_num_cpus;
 use serde::{Deserialize, Serialize};
 use tokio::runtime;
 use tokio::runtime::Runtime;
@@ -15,7 +16,7 @@ pub fn create_search_runtime(max_search_threads: usize) -> std::io::Result<Runti
     let mut search_threads = max_search_threads;
 
     if search_threads == 0 {
-        let num_cpu = num_cpus::get();
+        let num_cpu = get_num_cpus();
         search_threads = std::cmp::max(1, num_cpu - 1);
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use config::{Config, ConfigError, Environment, File};
+use segment::common::cpu::get_num_cpus;
 use serde::Deserialize;
 use storage::types::StorageConfig;
 
@@ -152,7 +153,7 @@ pub fn max_web_workers(settings: &Settings) -> usize {
     let max_workers = settings.service.max_workers;
 
     if max_workers == Some(0) {
-        let num_cpu = num_cpus::get();
+        let num_cpu = get_num_cpus();
         std::cmp::max(1, num_cpu - 1)
     } else if max_workers.is_none() {
         settings.storage.performance.max_search_threads


### PR DESCRIPTION
There are several things, which depend on CPU number:
- default number of segments
- number of workers
- default number of indexing threads 

Use `QDRANT_NUM_CPUS` to re-redefine number used CPUs.

Useful in container env, where available cpus != system cpus.
 
