### PR TITLE
Disable test_task_stop on Windows

### DIFF
--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -74,6 +74,9 @@ mod tests {
         n
     }
 
+    // Test is disabled on Windows because it is flaky there
+    // https://github.com/qdrant/qdrant/issues/1442
+    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn test_task_stop() {
         let handle = spawn_stoppable(long_task);


### PR DESCRIPTION
Disable test for the release until we figure out the flakiness on Windows.

Tracked with https://github.com/qdrant/qdrant/issues/1442

Will need to be cherry-picked to master 