### PR TITLE
Add `/cluster/recover` API endpoint

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -254,6 +254,63 @@
         }
       }
     },
+    "/cluster/recover": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "Tries to recover current peer Raft state.",
+        "operationId": "recover_current_peer",
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/cluster/peer/{peer_id}": {
       "delete": {
         "tags": [

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -111,7 +111,7 @@ impl ConsensusOpWal {
                     // expected_wal_index = 10 - 1 = 9
                     // 10 < 11 + 1
                     if index < offset {
-                        return Err(StorageError::service_error(&format!(
+                        return Err(StorageError::service_error(format!(
                             "Wal index conflict, raft index: {index}, wal index: {current_index}, offset: {offset}"
                         )));
                     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -118,10 +118,18 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         }
     }
 
-    pub fn report_snapshot(&self, peer_id: u64, status: impl Into<SnapshotStatus>) {
-        let _ = self
-            .propose_sender
-            .send(ConsensusOperations::report_snapshot(peer_id, status));
+    pub fn report_snapshot(
+        &self,
+        peer_id: u64,
+        status: impl Into<SnapshotStatus>,
+    ) -> Result<(), StorageError> {
+        self.propose_sender
+            .send(ConsensusOperations::report_snapshot(peer_id, status))
+            .map_err(|err| {
+                StorageError::service_error(
+                    "failed to send ReportSnapshot message to consensus thread",
+                )
+            })
     }
 
     pub fn record_message_send_failure<E: Error>(&self, peer_address: &Uri, error: E) {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -468,10 +468,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     ) -> Result<Result<(), StorageError>, StorageError> {
         let meta = snapshot.get_metadata();
 
-        if raft::Storage::first_index(self)? > meta.index {
-            return Ok(Err(StorageError::service_error("Snapshot out of date")));
-        }
-
         let data: SnapshotData = snapshot.get_data().try_into()?;
         self.toc.apply_collections_snapshot(data.collections_data)?;
         self.wal.lock().clear()?;

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -125,7 +125,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     ) -> Result<(), StorageError> {
         self.propose_sender
             .send(ConsensusOperations::report_snapshot(peer_id, status))
-            .map_err(|err| {
+            .map_err(|_err| {
                 StorageError::service_error(
                     "failed to send ReportSnapshot message to consensus thread",
                 )
@@ -534,7 +534,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .await
             .map_err(
                 |_: Elapsed| {
-                    StorageError::service_error(&format!(
+                    StorageError::service_error(format!(
                         "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
                         wait_timeout.as_secs_f64()
                     ))
@@ -594,7 +594,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .is_leader_established
             .await_ready_for_timeout(wait_timeout)
         {
-            return Err(StorageError::service_error(&format!(
+            return Err(StorageError::service_error(format!(
                 "Failed to propose operation: leader is not established within {} secs",
                 wait_timeout.as_secs()
             )));

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -441,7 +441,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 Ok(false)
             }
 
-            ConsensusOperations::ReportSnapshot { .. } => unreachable!(),
+            ConsensusOperations::RequestSnapshot { .. }
+            | ConsensusOperations::ReportSnapshot { .. } => unreachable!(),
         };
 
         if let Some(on_apply) = on_apply {

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -24,9 +24,9 @@ pub enum StorageError {
 }
 
 impl StorageError {
-    pub fn service_error(description: &str) -> StorageError {
+    pub fn service_error(description: impl Into<String>) -> StorageError {
         StorageError::ServiceError {
-            description: description.to_string(),
+            description: description.into(),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -114,19 +114,19 @@ impl From<CollectionError> for StorageError {
 
 impl From<IoError> for StorageError {
     fn from(err: IoError) -> Self {
-        StorageError::service_error(&format!("{err}"))
+        StorageError::service_error(format!("{err}"))
     }
 }
 
 impl From<FileStorageError> for StorageError {
     fn from(err: FileStorageError) -> Self {
         match err {
-            FileStorageError::IoError { description } => StorageError::service_error(&description),
+            FileStorageError::IoError { description } => StorageError::service_error(description),
             FileStorageError::UserAtomicIoError => {
                 StorageError::service_error("Unknown atomic write error")
             }
             FileStorageError::GenericError { description } => {
-                StorageError::service_error(&description)
+                StorageError::service_error(description)
             }
         }
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -34,8 +34,15 @@ pub mod consensus_ops {
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
     pub enum ConsensusOperations {
         CollectionMeta(Box<CollectionMetaOperations>),
-        AddPeer { peer_id: PeerId, uri: String },
+        AddPeer {
+            peer_id: PeerId,
+            uri: String,
+        },
         RemovePeer(PeerId),
+        ReportSnapshot {
+            peer_id: PeerId,
+            status: SnapshotStatus,
+        },
     }
 
     impl TryFrom<&RaftEntry> for ConsensusOperations {
@@ -135,6 +142,37 @@ pub mod consensus_ops {
                 collection_id,
                 ShardTransferOperations::Start(transfer),
             )))
+        }
+
+        pub fn report_snapshot(peer_id: PeerId, status: impl Into<SnapshotStatus>) -> Self {
+            Self::ReportSnapshot {
+                peer_id,
+                status: status.into(),
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+    pub enum SnapshotStatus {
+        Finish,
+        Failure,
+    }
+
+    impl From<raft::SnapshotStatus> for SnapshotStatus {
+        fn from(status: raft::SnapshotStatus) -> Self {
+            match status {
+                raft::SnapshotStatus::Finish => Self::Finish,
+                raft::SnapshotStatus::Failure => Self::Failure,
+            }
+        }
+    }
+
+    impl From<SnapshotStatus> for raft::SnapshotStatus {
+        fn from(status: SnapshotStatus) -> Self {
+            match status {
+                SnapshotStatus::Finish => Self::Finish,
+                SnapshotStatus::Failure => Self::Failure,
+            }
         }
     }
 }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -39,6 +39,9 @@ pub mod consensus_ops {
             uri: String,
         },
         RemovePeer(PeerId),
+        RequestSnapshot {
+            request_index: Option<u64>,
+        },
         ReportSnapshot {
             peer_id: PeerId,
             status: SnapshotStatus,
@@ -142,6 +145,10 @@ pub mod consensus_ops {
                 collection_id,
                 ShardTransferOperations::Start(transfer),
             )))
+        }
+
+        pub fn request_snapshot(request_index: Option<u64>) -> Self {
+            Self::RequestSnapshot { request_index }
         }
 
         pub fn report_snapshot(peer_id: PeerId, status: impl Into<SnapshotStatus>) -> Self {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -556,6 +556,21 @@ impl TableOfContent {
         })
     }
 
+    pub fn request_snapshot(&self, request_index: Option<u64>) -> Result<(), StorageError> {
+        let sender = match &self.consensus_proposal_sender {
+            Some(sender) => sender,
+            None => {
+                return Err(StorageError::service_error(
+                    "Qdrant is running in standalone mode",
+                ))
+            }
+        };
+
+        sender.send(ConsensusOperations::request_snapshot(request_index))?;
+
+        Ok(())
+    }
+
     pub fn send_set_replica_state_proposal(
         &self,
         collection_name: String,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -193,7 +193,7 @@ impl TableOfContent {
         tokio::fs::create_dir_all(&snapshots_path)
             .await
             .map_err(|err| {
-                StorageError::service_error(&format!(
+                StorageError::service_error(format!(
                     "Can't create directory for snapshots {collection_name}. Error: {err}"
                 ))
             })?;
@@ -205,7 +205,7 @@ impl TableOfContent {
         let path = self.get_collection_path(collection_name);
 
         tokio::fs::create_dir_all(&path).await.map_err(|err| {
-            StorageError::service_error(&format!(
+            StorageError::service_error(format!(
                 "Can't create directory for collection {collection_name}. Error: {err}"
             ))
         })?;

--- a/openapi/openapi-cluster.ytt.yaml
+++ b/openapi/openapi-cluster.ytt.yaml
@@ -10,6 +10,14 @@ paths:
       operationId: cluster_status
       responses: #@ response(reference("ClusterStatus"))
 
+  /cluster/recover:
+    post:
+      tags:
+        - cluster
+      summary: Tries to recover current peer Raft state.
+      operationId: recover_current_peer
+      responses: #@ response(type("boolean"))
+
   /cluster/peer/{peer_id}:
     delete:
       tags:

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -69,5 +69,5 @@ async fn remove_peer(
 pub fn config_cluster_api(cfg: &mut web::ServiceConfig) {
     cfg.service(cluster_status)
         .service(remove_peer)
-        .service(request_snapshot);
+        .service(recover_current_peer);
 }

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -1,5 +1,5 @@
 use actix_web::rt::time::Instant;
-use actix_web::{delete, get, web, Responder};
+use actix_web::{delete, get, post, web, Responder};
 use serde::Deserialize;
 use storage::content_manager::consensus_ops::ConsensusOperations;
 use storage::content_manager::errors::StorageError;
@@ -16,17 +16,17 @@ struct QueryParams {
     timeout: Option<u64>,
 }
 
-#[actix_web::post("/cluster/request_snapshot")]
-async fn request_snapshot(toc: web::Data<TableOfContent>) -> impl Responder {
-    let timing = Instant::now();
-    process_response(toc.request_snapshot(None), timing)
-}
-
 #[get("/cluster")]
 async fn cluster_status(dispatcher: web::Data<Dispatcher>) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher.cluster_status();
     process_response(Ok(response), timing)
+}
+
+#[post("/cluster/recover")]
+async fn recover_current_peer(toc: web::Data<TableOfContent>) -> impl Responder {
+    let timing = Instant::now();
+    process_response(toc.request_snapshot(None).map(|_| true), timing)
 }
 
 #[delete("/cluster/peer/{peer_id}")]

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -3,6 +3,7 @@ use actix_web::{delete, get, web, Responder};
 use serde::Deserialize;
 use storage::content_manager::consensus_ops::ConsensusOperations;
 use storage::content_manager::errors::StorageError;
+use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 
 use crate::actix::helpers::process_response;
@@ -13,6 +14,12 @@ struct QueryParams {
     force: bool,
     #[serde(default)]
     timeout: Option<u64>,
+}
+
+#[actix_web::post("/cluster/request_snapshot")]
+async fn request_snapshot(toc: web::Data<TableOfContent>) -> impl Responder {
+    let timing = Instant::now();
+    process_response(toc.request_snapshot(None), timing)
 }
 
 #[get("/cluster")]
@@ -60,5 +67,7 @@ async fn remove_peer(
 
 // Configure services
 pub fn config_cluster_api(cfg: &mut web::ServiceConfig) {
-    cfg.service(cluster_status).service(remove_peer);
+    cfg.service(cluster_status)
+        .service(remove_peer)
+        .service(request_snapshot);
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -479,6 +479,11 @@ impl Consensus {
                         log::debug!("Proposing network configuration change: {:?}", change);
                         self.node.propose_conf_change(uri.into_bytes(), change)
                     }
+                    ConsensusOperations::RequestSnapshot { request_index } => {
+                        self.node.request_snapshot(
+                            request_index.unwrap_or_else(|| self.node.store().hard_state().commit),
+                        )
+                    }
                     ConsensusOperations::ReportSnapshot { peer_id, status } => {
                         self.node.report_snapshot(peer_id, status.into());
                         Ok(())

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -630,7 +630,7 @@ impl Consensus {
             // This is a snapshot, we need to apply the snapshot at first.
             log::debug!("Applying snapshot");
 
-            if let Err(err) = store.apply_snapshot(&ready.snapshot().clone()) {
+            if let Err(err) = store.apply_snapshot(&ready.snapshot().clone())? {
                 log::error!("Failed to apply snapshot: {err}");
             }
         }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -629,9 +629,10 @@ impl Consensus {
         if !ready.snapshot().is_empty() {
             // This is a snapshot, we need to apply the snapshot at first.
             log::debug!("Applying snapshot");
-            store
-                .apply_snapshot(&ready.snapshot().clone())
-                .map_err(|err| anyhow!("Failed to apply snapshot: {}", err))?
+
+            if let Err(err) = store.apply_snapshot(&ready.snapshot().clone()) {
+                log::error!("Failed to apply snapshot: {err}");
+            }
         }
         if !ready.entries().is_empty() {
             // Append entries to the Raft log.

--- a/tests/consensus_tests/test_collection_recovery.py
+++ b/tests/consensus_tests/test_collection_recovery.py
@@ -6,33 +6,95 @@ from .fixtures import create_collection, upsert_random_points, random_vector, se
 from .utils import *
 from .assertions import assert_http_ok
 
+N_PEERS = 3
 COLLECTION_NAME = "test_collection"
+N_POINTS = 100
 
-def test_recover_from_snapshot_1(tmp_path: pathlib.Path):
+
+def test_collection_recovery(tmp_path: pathlib.Path):
     assert_project_root()
 
-    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, N_PEERS)
 
-    create_collection(peer_api_uris[0])
-    wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)
-    upsert_random_points(peer_api_uris[0], 100)
+    create_collection(peer_urls[0])
+    wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_urls)
+    upsert_random_points(peer_urls[0], N_POINTS)
+
+    # Check that collection is not empty
+    info = get_collection_cluster_info(peer_urls[-1], COLLECTION_NAME)
+
+    for shard in info["local_shards"]:
+        assert shard["points_count"] > 0
 
     # Kill last peer
     processes.pop().kill()
 
     # Delete collection files from disk
-    collection_path = Path(peer_dirs[-1]) / "storage" / COLLECTION_NAME
+    collection_path = Path(peer_dirs[-1]) / "storage" / "collections" / COLLECTION_NAME
     assert collection_path.exists()
     shutil.rmtree(collection_path)
 
     # Restart the peer
-    peer_url = start_peer(peer_dirs[-1], f"peer_0_restarted.log", bootstrap_uri)
+    peer_url = start_peer(peer_dirs[-1], f"peer_0_restarted.log", bootstrap_url)
+
+    # Wait until node is up
+    time.sleep(2)
 
     # Recover Raft state
     recover_raft_state(peer_url)
 
-    assert False
+    # Wait for the Raft state to be recovered
+    time.sleep(2)
 
-def recover_raft_state(peer_api_uri):
-    r = requests.post(f"{peer_api_uri}/cluster/recover")
-    assert_http_ok(r)
+    # Check, that remote shards are broken on recovered node 🥲
+    info = get_collection_cluster_info(peer_url, COLLECTION_NAME)
+
+    for remote_shard in info["remote_shards"]:
+        assert remote_shard["state"] == "Initializing"
+
+    # Recover Raft state once again
+    recover_raft_state(peer_url)
+
+    # Wait for the Raft state to be recovered
+    time.sleep(2)
+
+    # Check that remote shards are "fixed" on twise recovered node
+    info = get_collection_cluster_info(peer_url, COLLECTION_NAME)
+
+    for remote_shard in info["remote_shards"]:
+        assert remote_shard["state"] == "Active"
+
+    # Check, that the collection is empty on recovered node
+    info = get_collection_cluster_info(peer_url, COLLECTION_NAME)
+
+    for shard in info["local_shards"]:
+        assert shard["points_count"] == 0
+
+
+def recover_raft_state(peer_url):
+    r = requests.post(f"{peer_url}/cluster/recover")
+    return request_result(r)
+
+def get_points(peer_url, collection_name, limit):
+    r = requests.post(
+        f"{peer_url}/collections/{collection_name}/points/scroll",
+        json={
+            "limit": limit,
+            "with_vector": True,
+            "with_payload": True,
+        }
+    )
+
+    return request_result(r)
+
+def get_collection_info(peer_url, collection_name):
+    r = requests.get(f"{peer_url}/collections/{collection_name}?consistency=1")
+    return request_result(r)
+
+def get_collection_cluser_info(peer_url, collection_name):
+    r = request.get(f"{peer_url}/collections/{collection_name}/cluster")
+    return request_result(r)
+
+def request_result(resp):
+    assert_http_ok(resp)
+    return resp.json()["result"]

--- a/tests/consensus_tests/test_collection_recovery.py
+++ b/tests/consensus_tests/test_collection_recovery.py
@@ -10,6 +10,7 @@ N_PEERS = 3
 COLLECTION_NAME = "test_collection"
 
 
+@pytest.mark.skip(reason="this test does not check anything useful, but simply documents current (i.e., broken) behavior")
 def test_collection_recovery(tmp_path: pathlib.Path):
     assert_project_root()
 

--- a/tests/consensus_tests/test_collection_recovery.py
+++ b/tests/consensus_tests/test_collection_recovery.py
@@ -1,0 +1,38 @@
+import pathlib
+import shutil
+
+import requests
+from .fixtures import create_collection, upsert_random_points, random_vector, search
+from .utils import *
+from .assertions import assert_http_ok
+
+COLLECTION_NAME = "test_collection"
+
+def test_recover_from_snapshot_1(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0])
+    wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)
+    upsert_random_points(peer_api_uris[0], 100)
+
+    # Kill last peer
+    processes.pop().kill()
+
+    # Delete collection files from disk
+    collection_path = Path(peer_dirs[-1]) / "storage" / COLLECTION_NAME
+    assert collection_path.exists()
+    shutil.rmtree(collection_path)
+
+    # Restart the peer
+    peer_url = start_peer(peer_dirs[-1], f"peer_0_restarted.log", bootstrap_uri)
+
+    # Recover Raft state
+    recover_raft_state(peer_url)
+
+    assert False
+
+def recover_raft_state(peer_api_uri):
+    r = requests.post(f"{peer_api_uri}/cluster/recover")
+    assert_http_ok(r)

--- a/tools/generate_openapi_models.sh
+++ b/tools/generate_openapi_models.sh
@@ -44,7 +44,7 @@ docker run --rm -v "${PWD}":/workdir mikefarah/yq eval-all '. as $item ireduce (
   ./openapi/openapi-main.yaml \
   ./openapi/models.yaml > ./openapi/openapi-merged.yaml
 
-docker run --rm -v "${PWD}"/openapi:/spec redocly/openapi-cli lint openapi-merged.yaml
+docker run --rm -v "${PWD}"/openapi:/spec redocly/openapi-cli:v1.0.0-beta.88 lint openapi-merged.yaml
 
 docker run --rm -i mikefarah/yq eval -o=json - <./openapi/openapi-merged.yaml | jq > ./openapi/openapi-merged.json
 


### PR DESCRIPTION
- Utilized `RawNode::report_snapshot`
  - Without `report_snapshot` call on the leader, the snapshot will, generally, be applied on the follower without any obvious errors, but any consensus operation after that simply won't work
- Make `apply_snapshot` error non-fatal, so that, e.g., an "outdated snapshot" error won't stop the entire consensus thread

Also made a few changes to be able to trigger `RawNode::request_snapshot`, some/all of which should be removed before merging.

__TODO:__
- It's not clear how to properly call `report_snapshot` in case some node requested multiple snapshots in a burst sequence.
  - E.g., there's no way to report a _particular_ snapshot. I'd assume it's just always applied to the "last requested" one?
  - Does this mean that some extra care have to be taken with `report_snapshot` calls? Will something bad happen if we call `report_snapshot` multiple times in a row?
  - `tikv`, however, seems to call `report_snapshot` _uncoditionally_ in (some?) situations when they are calling `report_unreachable`, so maybe it's fine as-is?
  - I guess the logic for that is "if the node is unavailable, then we can definitely consider the snapshot (if any) as failed".
- Right now, _any_ error during `apply_snapshot` made non-fatal, which may be _too_ lax.
  - It's (kinda) impossible to match on "outdated snapshot" error only...
  - ...but it _may_ have to be done eventually. :/
  - ___"Fixed" by changing `apply_snapshot` return type to `Result<Result<(), StorageError>, StorageError>`___
    - where "outer" result is a "fatal" error (to be propagated with `?` operator)
    - and "inner" result is a "local" error (to be logged-and-ignored)
