### PR TITLE
Access payload key through nested Array

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -264,14 +264,10 @@ mod tests {
         // Check payload is preserved in optimized segment
         for &point_id in &segment_points_to_assign1 {
             assert!(segment_guard.has_point(point_id));
-            let payload = segment_guard
-                .payload(point_id)
-                .unwrap()
-                .get_value("color")
-                .unwrap()
-                .clone();
+            let payload = segment_guard.payload(point_id).unwrap();
+            let payload_color = &(*payload.get_value("color").first().unwrap()).clone();
 
-            match payload {
+            match payload_color {
                 Value::String(x) => assert_eq!(x, "red"),
                 _ => panic!(),
             }

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -219,14 +219,18 @@ mod tests {
 
                 assert!(payload.contains_key("key1"));
 
-                let payload_type = payload.get_value("key1").expect("No key key1");
+                let payload_type = payload
+                    .get_value("key1")
+                    .first()
+                    .cloned()
+                    .expect("No key key1");
 
                 match payload_type {
                     Value::String(x) => assert_eq!(x, "hello"),
                     _ => panic!("Wrong payload type"),
                 }
 
-                let payload_type_json = payload.get_value("key3");
+                let payload_type_json = payload.get_value("key3").first().cloned();
 
                 assert!(matches!(payload_type_json, Some(Value::Object(_))))
             }

--- a/lib/collection/tests/collection_restore_test.rs
+++ b/lib/collection/tests/collection_restore_test.rs
@@ -111,6 +111,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
         .as_ref()
         .expect("has payload")
         .get_value("k")
+        .first()
         .expect("has value")
     {
         Value::String(value) => assert_eq!("v1", value),
@@ -185,6 +186,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
         .as_ref()
         .expect("has payload")
         .get_value("k2")
+        .first()
         .expect("has value")
     {
         Value::String(value) => assert_eq!("v3", value),
@@ -226,6 +228,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
         .as_ref()
         .expect("has payload")
         .get_value("k3")
+        .first()
         .expect("has value")
     {
         Value::String(value) => assert_eq!("v4", value),

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -9,40 +9,181 @@ pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {
     (b + 1..=a).rev()
 }
 
+/// Parse array path and index from path
+///
+/// return Some((path, Some(index))) if path is an array path with index
+fn parse_array_path(path: &str) -> Option<(&str, Option<u32>)> {
+    // shortcut no array path
+    if !path.contains('[') || !path.ends_with(']') {
+        return None;
+    }
+    let mut path = path.split('[');
+    let element = path.next();
+    let index = path.next();
+    match (element, index) {
+        (Some(element), None) => Some((element, None)), // no index info
+        (Some(element), Some("]")) => Some((element, None)), // full array
+        (Some(element), Some(index)) => {
+            let trimmed_index = index.trim_matches(']');
+            // get numeric index
+            match trimmed_index.parse::<u32>() {
+                Ok(num_index) => Some((element, Some(num_index))),
+                Err(_) => None, // not a well formed path array
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Focus on array values references according to array path
+///
+/// Expects to be called with a path that is a path to an Array
+fn focus_array_path<'a>(
+    array_path: &str,
+    array_index: Option<u32>,
+    rest_path: Option<&str>,
+    value: &'a serde_json::Map<String, Value>,
+) -> Vec<&'a Value> {
+    match value.get(array_path) {
+        Some(Value::Array(array)) => {
+            let mut values = Vec::new();
+            for (i, value) in array.iter().enumerate() {
+                if let Value::Object(map) = value {
+                    if let Some(array_index) = array_index {
+                        if i == array_index as usize {
+                            match rest_path {
+                                Some(rest_path) => {
+                                    values.extend(get_value_from_json_map(rest_path, map))
+                                }
+                                None => values.push(value),
+                            }
+                        }
+                    } else {
+                        match rest_path {
+                            Some(rest_path) => {
+                                values.extend(get_value_from_json_map(rest_path, map))
+                            }
+                            None => values.push(value),
+                        }
+                    }
+                }
+            }
+            values
+        }
+        _ => vec![],
+    }
+}
+
+// TODO make TinyVec
 pub fn get_value_from_json_map<'a>(
     path: &str,
     value: &'a serde_json::Map<String, Value>,
-) -> Option<&'a Value> {
+) -> Vec<&'a Value> {
+    // check if leaf path element
     match path.split_once('.') {
-        Some((element, path)) => match value.get(element) {
-            Some(Value::Object(map)) => get_value_from_json_map(path, map),
-            Some(value) => match path.is_empty() {
-                true => Some(value),
-                false => None,
+        Some((element, path)) => {
+            // check if targeting array
+            match parse_array_path(element) {
+                Some((array_element_path, array_index)) => {
+                    focus_array_path(array_element_path, array_index, Some(path), value)
+                }
+                None => {
+                    // targeting object
+                    match value.get(element) {
+                        Some(Value::Object(map)) => get_value_from_json_map(path, map),
+                        Some(value) => match path.is_empty() {
+                            true => vec![value],
+                            false => vec![],
+                        },
+                        None => vec![],
+                    }
+                }
+            }
+        }
+        None => match parse_array_path(path) {
+            Some((array_element_path, array_index)) => {
+                focus_array_path(array_element_path, array_index, None, value)
+            }
+            None => match value.get(path) {
+                Some(value) => vec![value],
+                None => vec![],
             },
-            None => None,
         },
-        None => value.get(path),
     }
+}
+
+/// Delete array values according to array path
+///
+/// Expects to be called with a path that is a path to an Array
+fn delete_array_path(
+    array_path: &str,
+    array_index: Option<u32>,
+    rest_path: Option<&str>,
+    value: &mut serde_json::Map<String, Value>,
+) -> Option<Value> {
+    if let Some(Value::Array(array)) = value.get_mut(array_path) {
+        match rest_path {
+            None => {
+                // end of path - delete and collect
+                if let Some(array_index) = array_index {
+                    if array.len() > array_index as usize {
+                        return Some(array.remove(array_index as usize));
+                    }
+                } else {
+                    return Some(Value::Array(array.drain(..).collect()));
+                }
+            }
+            Some(rest_path) => {
+                // dig deeper
+                for (i, value) in array.iter_mut().enumerate() {
+                    if let Value::Object(map) = value {
+                        if let Some(array_index) = array_index {
+                            if i == array_index as usize {
+                                return remove_value_from_json_map(rest_path, map);
+                            }
+                        } else {
+                            return remove_value_from_json_map(rest_path, map);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 pub fn remove_value_from_json_map(
     path: &str,
     value: &mut serde_json::Map<String, Value>,
 ) -> Option<Value> {
+    // check if leaf path element
     match path.split_once('.') {
         Some((element, new_path)) => {
-            if new_path.is_empty() {
-                value.remove(element)
-            } else {
-                match value.get_mut(element) {
-                    None => None,
-                    Some(Value::Object(map)) => remove_value_from_json_map(new_path, map),
-                    Some(_value) => None,
+            // check if targeting array
+            match parse_array_path(element) {
+                Some((array_element_path, array_index)) => {
+                    delete_array_path(array_element_path, array_index, Some(path), value)
+                }
+                None => {
+                    // targeting object
+                    if new_path.is_empty() {
+                        value.remove(element)
+                    } else {
+                        match value.get_mut(element) {
+                            None => None,
+                            Some(Value::Object(map)) => remove_value_from_json_map(new_path, map),
+                            Some(_value) => None,
+                        }
+                    }
                 }
             }
         }
-        None => value.remove(path),
+        None => match parse_array_path(path) {
+            Some((array_element_path, array_index)) => {
+                delete_array_path(array_element_path, array_index, None, value)
+            }
+            None => value.remove(path),
+        },
     }
 }
 
@@ -57,4 +198,157 @@ pub fn transpose_map_into_named_vector(
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_nested_value_from_json_map() {
+        let map = serde_json::from_str::<serde_json::Map<String, Value>>(
+            r#"
+            {
+                "a": {
+                    "b": {
+                        "c": 1
+                    }
+                },
+                "d": 2
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_value_from_json_map("a.b", &map),
+            vec![&Value::Object(serde_json::Map::from_iter(vec![(
+                "c".to_string(),
+                Value::Number(1.into())
+            )]))]
+        );
+
+        // going deeper
+        assert_eq!(
+            get_value_from_json_map("a.b.c", &map),
+            vec![&Value::Number(1.into())]
+        );
+
+        // missing path
+        assert!(get_value_from_json_map("a.b.c.d", &map).is_empty());
+    }
+
+    #[test]
+    fn test_get_nested_array_value_from_json_map() {
+        let map = serde_json::from_str::<serde_json::Map<String, Value>>(
+            r#"
+            {
+                "a": {
+                    "b": [
+                        { "c": 1 },
+                        { "c": 2 },
+                        { "d": { "e": 3 } }
+                    ]
+                },
+                "f": 3
+            }
+            "#,
+        )
+        .unwrap();
+
+        // get JSON array
+        assert_eq!(
+            get_value_from_json_map("a.b", &map),
+            vec![&Value::Array(vec![
+                Value::Object(serde_json::Map::from_iter(vec![(
+                    "c".to_string(),
+                    Value::Number(1.into())
+                )])),
+                Value::Object(serde_json::Map::from_iter(vec![(
+                    "c".to_string(),
+                    Value::Number(2.into())
+                )])),
+                Value::Object(serde_json::Map::from_iter(vec![(
+                    "d".to_string(),
+                    Value::Object(serde_json::Map::from_iter(vec![(
+                        "e".to_string(),
+                        Value::Number(3.into())
+                    )]))
+                )]))
+            ])]
+        );
+
+        // a.b[] extract all elements from array
+        assert_eq!(
+            get_value_from_json_map("a.b[]", &map),
+            vec![
+                &Value::Object(serde_json::Map::from_iter(vec![(
+                    "c".to_string(),
+                    Value::Number(1.into())
+                )])),
+                &Value::Object(serde_json::Map::from_iter(vec![(
+                    "c".to_string(),
+                    Value::Number(2.into())
+                )])),
+                &Value::Object(serde_json::Map::from_iter(vec![(
+                    "d".to_string(),
+                    Value::Object(serde_json::Map::from_iter(vec![(
+                        "e".to_string(),
+                        Value::Number(3.into())
+                    )]))
+                )]))
+            ]
+        );
+
+        // project scalar field through array
+        assert_eq!(
+            get_value_from_json_map("a.b[].c", &map),
+            vec![&Value::Number(1.into()), &Value::Number(2.into())]
+        );
+
+        // project object field through array
+        assert_eq!(
+            get_value_from_json_map("a.b[].d", &map),
+            vec![&Value::Object(serde_json::Map::from_iter(vec![(
+                "e".to_string(),
+                Value::Number(3.into())
+            )]))]
+        );
+
+        // select scalar element from array
+        assert_eq!(
+            get_value_from_json_map("a.b[0]", &map),
+            vec![&Value::Object(serde_json::Map::from_iter(vec![(
+                "c".to_string(),
+                Value::Number(1.into())
+            )]))]
+        );
+
+        // select scalar element from array different index
+        assert_eq!(
+            get_value_from_json_map("a.b[1]", &map),
+            vec![&Value::Object(serde_json::Map::from_iter(vec![(
+                "c".to_string(),
+                Value::Number(2.into())
+            )]))]
+        );
+
+        // select object element from array
+        assert_eq!(
+            get_value_from_json_map("a.b[2]", &map),
+            vec![&Value::Object(serde_json::Map::from_iter(vec![(
+                "d".to_string(),
+                Value::Object(serde_json::Map::from_iter(vec![(
+                    "e".to_string(),
+                    Value::Number(3.into())
+                )]))
+            )]))]
+        );
+
+        // select out of bound index from array
+        assert!(get_value_from_json_map("a.b[3]", &map).is_empty());
+
+        // select bad index from array
+        assert!(get_value_from_json_map("a.b[z]", &map).is_empty());
+    }
 }

--- a/lib/segment/src/index/index_base.rs
+++ b/lib/segment/src/index/index_base.rs
@@ -89,7 +89,7 @@ pub trait PayloadIndex {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>>;
+    ) -> OperationResult<Vec<Value>>;
 
     /// Drop all payload of the point
     fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -161,7 +161,7 @@ impl PayloadIndex for PlainPayloadIndex {
         &mut self,
         _point_id: PointOffsetType,
         _key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         unreachable!()
     }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -181,6 +181,7 @@ impl StructPayloadIndex {
         }
 
         payload_storage.iter(|point_id, point_payload| {
+            // TODO handle more than first value
             let field_value_opt = point_payload.get_value(field).first().cloned();
             if let Some(field_value) = field_value_opt {
                 for field_index in field_indexes.iter_mut() {
@@ -424,6 +425,7 @@ impl PayloadIndex for StructPayloadIndex {
 
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         for (field, field_index) in &mut self.field_indexes {
+            // TODO handle more than first value
             if let Some(field_value) = payload.get_value(field).first() {
                 for index in field_index {
                     index.add_point(point_id, field_value)?;
@@ -441,7 +443,7 @@ impl PayloadIndex for StructPayloadIndex {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         if let Some(indexes) = self.field_indexes.get_mut(key) {
             for index in indexes {
                 index.remove_point(point_id)?;
@@ -491,6 +493,7 @@ impl PayloadIndex for StructPayloadIndex {
     ) -> OperationResult<Option<PayloadSchemaType>> {
         let mut schema = None;
         self.payload.borrow().iter(|_id, payload: &Payload| {
+            // TODO handle more than first value
             let field_value: Option<_> = payload.get_value(key).first().cloned();
             schema = field_value.and_then(infer_value_type);
             Ok(false)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -181,7 +181,7 @@ impl StructPayloadIndex {
         }
 
         payload_storage.iter(|point_id, point_payload| {
-            let field_value_opt = point_payload.get_value(field);
+            let field_value_opt = point_payload.get_value(field).first().cloned();
             if let Some(field_value) = field_value_opt {
                 for field_index in field_indexes.iter_mut() {
                     field_index.add_point(point_id, field_value)?;
@@ -424,7 +424,7 @@ impl PayloadIndex for StructPayloadIndex {
 
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         for (field, field_index) in &mut self.field_indexes {
-            if let Some(field_value) = payload.get_value(field) {
+            if let Some(field_value) = payload.get_value(field).first() {
                 for index in field_index {
                     index.add_point(point_id, field_value)?;
                 }
@@ -491,7 +491,7 @@ impl PayloadIndex for StructPayloadIndex {
     ) -> OperationResult<Option<PayloadSchemaType>> {
         let mut schema = None;
         self.payload.borrow().iter(|_id, payload: &Payload| {
-            let field_value = payload.get_value(key);
+            let field_value: Option<_> = payload.get_value(key).first().cloned();
             schema = field_value.and_then(infer_value_type);
             Ok(false)
         })?;

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -30,13 +30,13 @@ impl PayloadStorage for InMemoryPayloadStorage {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         match self.payload.get_mut(&point_id) {
             Some(payload) => {
                 let res = payload.remove(key);
                 Ok(res)
             }
-            None => Ok(None),
+            None => Ok(vec![]),
         }
     }
 

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -92,18 +92,18 @@ impl PayloadStorage for OnDiskPayloadStorage {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         let stored_payload = self.read_payload(point_id)?;
 
         match stored_payload {
             Some(mut payload) => {
                 let res = payload.remove(key);
-                if res.is_some() {
+                if !res.is_empty() {
                     self.update_storage(point_id, &payload)?;
                 }
                 Ok(res)
             }
-            None => Ok(None),
+            None => Ok(vec![]),
         }
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -24,7 +24,7 @@ pub trait PayloadStorage {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>>;
+    ) -> OperationResult<Vec<Value>>;
 
     /// Drop all payload of the point
     fn drop(&mut self, point_id: PointOffsetType) -> OperationResult<Option<Payload>>;

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -66,7 +66,7 @@ impl PayloadStorage for PayloadStorageEnum {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         match self {
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.delete(point_id, key),
             PayloadStorageEnum::SimplePayloadStorage(s) => s.delete(point_id, key),

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -93,6 +93,7 @@ where
 }
 
 pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) -> bool {
+    // TODO handle more than first value
     match payload.get_value(&is_empty.is_empty.key).first() {
         None => true,
         Some(value) => match value {
@@ -106,7 +107,7 @@ pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) 
 pub fn check_field_condition(field_condition: &FieldCondition, payload: &Payload) -> bool {
     payload
         .get_value(&field_condition.key)
-        .first()
+        .first()// TODO handle more than first value
         .map_or(false, |p| {
             let mut res = false;
             // ToDo: Convert onto iterator over checkers, so it would be impossible to forget a condition

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -107,7 +107,7 @@ pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) 
 pub fn check_field_condition(field_condition: &FieldCondition, payload: &Payload) -> bool {
     payload
         .get_value(&field_condition.key)
-        .first()// TODO handle more than first value
+        .first() // TODO handle more than first value
         .map_or(false, |p| {
             let mut res = false;
             // ToDo: Convert onto iterator over checkers, so it would be impossible to forget a condition

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -93,7 +93,7 @@ where
 }
 
 pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) -> bool {
-    match payload.get_value(&is_empty.is_empty.key) {
+    match payload.get_value(&is_empty.is_empty.key).first() {
         None => true,
         Some(value) => match value {
             Value::Null => true,
@@ -104,36 +104,39 @@ pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) 
 }
 
 pub fn check_field_condition(field_condition: &FieldCondition, payload: &Payload) -> bool {
-    payload.get_value(&field_condition.key).map_or(false, |p| {
-        let mut res = false;
-        // ToDo: Convert onto iterator over checkers, so it would be impossible to forget a condition
-        res = res
-            || field_condition
-                .r#match
-                .as_ref()
-                .map_or(false, |condition| condition.check(p));
-        res = res
-            || field_condition
-                .range
-                .as_ref()
-                .map_or(false, |condition| condition.check(p));
-        res = res
-            || field_condition
-                .geo_radius
-                .as_ref()
-                .map_or(false, |condition| condition.check(p));
-        res = res
-            || field_condition
-                .geo_bounding_box
-                .as_ref()
-                .map_or(false, |condition| condition.check(p));
-        res = res
-            || field_condition
-                .values_count
-                .as_ref()
-                .map_or(false, |condition| condition.check(p));
-        res
-    })
+    payload
+        .get_value(&field_condition.key)
+        .first()
+        .map_or(false, |p| {
+            let mut res = false;
+            // ToDo: Convert onto iterator over checkers, so it would be impossible to forget a condition
+            res = res
+                || field_condition
+                    .r#match
+                    .as_ref()
+                    .map_or(false, |condition| condition.check(p));
+            res = res
+                || field_condition
+                    .range
+                    .as_ref()
+                    .map_or(false, |condition| condition.check(p));
+            res = res
+                || field_condition
+                    .geo_radius
+                    .as_ref()
+                    .map_or(false, |condition| condition.check(p));
+            res = res
+                || field_condition
+                    .geo_bounding_box
+                    .as_ref()
+                    .map_or(false, |condition| condition.check(p));
+            res = res
+                || field_condition
+                    .values_count
+                    .as_ref()
+                    .map_or(false, |condition| condition.check(p));
+            res
+        })
 }
 
 pub struct SimpleConditionChecker {

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -33,16 +33,16 @@ impl PayloadStorage for SimplePayloadStorage {
         &mut self,
         point_id: PointOffsetType,
         key: PayloadKeyTypeRef,
-    ) -> OperationResult<Option<Value>> {
+    ) -> OperationResult<Vec<Value>> {
         match self.payload.get_mut(&point_id) {
             Some(payload) => {
                 let res = payload.remove(key);
-                if res.is_some() {
+                if !res.is_empty() {
                     self.update_storage(&point_id)?;
                 }
                 Ok(res)
             }
-            None => Ok(None),
+            None => Ok(vec![]),
         }
     }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -493,11 +493,11 @@ impl Payload {
     }
 
     pub fn get_value(&self, path: &str) -> Vec<&Value> {
-        utils::get_value_from_json_map(path, &self.0)
+        utils::get_value_from_json_map(path, &self.0).values()
     }
 
     pub fn remove(&mut self, path: &str) -> Vec<Value> {
-        utils::remove_value_from_json_map(path, &mut self.0)
+        utils::remove_value_from_json_map(path, &mut self.0).values()
     }
 
     pub fn len(&self) -> usize {
@@ -1582,26 +1582,26 @@ mod tests {
         "#,
         )
         .unwrap();
-        let removed = remove_value_from_json_map("b.c", &mut payload.0);
+        let removed = remove_value_from_json_map("b.c", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Number(123.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.f[1]", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.f[1]", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Number(2.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[0].j", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.i[0].j", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Number(1.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[].k", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.i[].k", &mut payload.0).values();
         assert_eq!(
             removed,
             vec![Value::Number(2.into()), Value::Number(4.into())]
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[]", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.i[]", &mut payload.0).values();
         assert_eq!(
             removed,
             vec![Value::Array(vec![
@@ -1614,11 +1614,11 @@ mod tests {
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.i", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Array(vec![])]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.f", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e.f", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Array(vec![1.into(), 3.into()])]);
         assert_ne!(payload, Default::default());
 
@@ -1634,11 +1634,11 @@ mod tests {
         assert!(removed.is_empty());
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("a", &mut payload.0);
+        let removed = remove_value_from_json_map("a", &mut payload.0).values();
         assert_eq!(removed, vec![Value::Number(1.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e", &mut payload.0);
+        let removed = remove_value_from_json_map("b.e", &mut payload.0).values();
         assert_eq!(
             removed,
             vec![Value::Object(serde_json::Map::from_iter(vec![
@@ -1649,7 +1649,7 @@ mod tests {
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b", &mut payload.0);
+        let removed = remove_value_from_json_map("b", &mut payload.0).values();
         assert_eq!(
             removed,
             vec![Value::Object(serde_json::Map::from_iter(vec![]))]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -496,9 +496,8 @@ impl Payload {
         utils::get_value_from_json_map(path, &self.0)
     }
 
-    pub fn remove(&mut self, path: &str) -> Option<Value> {
-        // TODO propagate vector of values
-        utils::remove_value_from_json_map(path, &mut self.0).pop()
+    pub fn remove(&mut self, path: &str) -> Vec<Value> {
+        utils::remove_value_from_json_map(path, &mut self.0)
     }
 
     pub fn len(&self) -> usize {

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -153,10 +153,7 @@ mod tests {
                 .borrow()
                 .search(&[&query], None, top, None);
 
-            assert!(
-                index_result == plain_result,
-                "Exact search is not equal to plain search"
-            );
+            assert_eq!(index_result, plain_result, "Exact search is not equal to plain search");
 
             let range_size = 40;
             let left_range = rnd.gen_range(0..400);
@@ -187,10 +184,7 @@ mod tests {
                 .borrow()
                 .search(&[&query], filter_query, top, None);
 
-            assert!(
-                index_result == plain_result,
-                "Exact search is not equal to plain search"
-            );
+            assert_eq!(index_result, plain_result, "Exact search is not equal to plain search");
         }
     }
 }

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -153,7 +153,10 @@ mod tests {
                 .borrow()
                 .search(&[&query], None, top, None);
 
-            assert_eq!(index_result, plain_result, "Exact search is not equal to plain search");
+            assert_eq!(
+                index_result, plain_result,
+                "Exact search is not equal to plain search"
+            );
 
             let range_size = 40;
             let left_range = rnd.gen_range(0..400);
@@ -184,7 +187,10 @@ mod tests {
                 .borrow()
                 .search(&[&query], filter_query, top, None);
 
-            assert_eq!(index_result, plain_result, "Exact search is not equal to plain search");
+            assert_eq!(
+                index_result, plain_result,
+                "Exact search is not equal to plain search"
+            );
         }
     }
 }


### PR DESCRIPTION
This PR updates the payload JSON addressing infrastructure to support nested access through arrays.

E.g:
- `a.b.c[]`
- `a.b.c[1]` 
- `a.b.c[].e`
- `a.b.c[1].e`

This affects both payload key lookups and deletions.

This change is not propagated fully to the indexers for the time being to keep the PR small.

Previously a path lookup would return an `Option<&Value>`, now it returns something akin to `Vec<&Value>`.

To avoid creating a lot of Vec with a single element, this PR introduces the `JsonPathTarget` abstraction. 