### PR TITLE
Fix collection recovery during Raft snapshot application

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1247,6 +1247,7 @@ impl TableOfContent {
     ) -> Result<(), StorageError> {
         self.general_runtime.block_on(async {
             let mut collections = self.collections.write().await;
+
             for (id, state) in &data.collections {
                 let collection_exists = collections.contains_key(id);
 
@@ -1333,9 +1334,10 @@ impl TableOfContent {
             for collection_name in collections.keys() {
                 if !data.collections.contains_key(collection_name) {
                     log::debug!(
-                        "Deleting collection {} because it is not part of the consensus snapshot",
-                        collection_name
+                        "Deleting collection {collection_name} \
+                         because it is not part of the consensus snapshot",
                     );
+
                     self.delete_collection(collection_name).await?;
                 }
             }
@@ -1345,6 +1347,7 @@ impl TableOfContent {
                 .write()
                 .await
                 .apply_state(data.aliases)?;
+
             Ok(())
         })
     }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1312,6 +1312,21 @@ impl TableOfContent {
                         log::error!("Can't apply state: single node mode");
                     }
                 }
+
+                // Mark local shards as dead (to initiate shard transfer),
+                // if collection has been created during snapshot application
+                if !collection_exists {
+                    for shard_id in collection.get_local_shards().await {
+                        collection
+                            .set_shard_replica_state(
+                                shard_id,
+                                self.this_peer_id,
+                                ReplicaState::Dead,
+                                None,
+                            )
+                            .await?;
+                    }
+                }
             }
 
             // Remove collections that are present locally but are not in the snapshot state


### PR DESCRIPTION
This is a continuation of #1451.

During testing @generall discovered, that if we:
- stop the node
- delete collection folder from the disk
- restart the node
- and call `/cluster/recover` on it

Then the collection won't be properly recovered:
- remote shards of recovered collection would be stuck in "Initializing" state
  - (until a state change is proposed through consensus, which may not happen for a long time)
- local shards of recovered collection would be empty, and recovered node won't request shard transfer automatically

This PR tries to fix both these issues.

__TODO:__
- [ ] refactor `test_collection_recovery.py` to test collection recovery
- [ ] investigate/test
  - [ ] if it's possible for a recovered node to happen to be the last active shard
         (which, kinda, prevents shard transfer to the node)
  - [ ] and what will happen in such case (e.g., can it lead to a data loss)