### PR TITLE
add listener shard state

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,12 @@ storage:
     # Number of WAL segments to create ahead of actual data requirement
     wal_segments_ahead: 0
 
+  # Normal node - receives all updates and answers all queries
+  node_type: "Normal"
+
+  # Listener node - receives all updates, but does not answer search/read queries
+  # Useful for setting up a dedicated backup node
+  # node_type: "Listener"
 
   performance:
     # Number of parallel threads used for search operations. If 0 - auto selection.

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -51,41 +51,41 @@ const READ_REMOTE_REPLICAS: u32 = 2;
 
 const REPLICA_STATE_FILE: &str = "replica_state.json";
 
-// Shard replication state machine:
-//
-//    │
 //    │    Collection Created
 //    │
 //    ▼
 //  ┌─────────────┐
 //  │             │
-//  │Initializing │
+//  │ Initilizing │
 //  │             │
-//  └─────┬─-─────┘
-//        │  Report created     ┌───────────┐
-//        └────────────────────►│           │
+//  └──────┬──────┘
+//         │  Report created    ┌───────────┐
+//         └────────────────────►           │
 //             Activate         │ Consensus │
-//        ┌─────────────────────│           │
+//        ┌─────────────────────┤           │
 //        │                     └───────────┘
-//  ┌─────▼───────┐
-//  │             │
-//  │ Active      ◄───────────┐
-//  │             │           │Transfer
-//  └──┬──────────┘           │Finished
-//     │                      │
-//     │               ┌──────┴────────┐
-//     │Update         │               │
-//     │Failure        │ Partial       ├───┐
-//     │               │               │   │
-//     │               └───────▲───────┘   │
-//     │                       │           │Transfer
-//  ┌──▼──────────┐            │           │Failed/Cancelled
-//  │             │ Transfer   │           │
-//  │ Dead        ├────────────┘           │
-//  │             │ Started                │
-//  └──▲──────────┘                        │
-//     │                                   │
-//     └───────────────────────────────────┘
+//  ┌─────▼───────┐   User Promote           ┌──────────┐
+//  │             ◄──────────────────────────►          │
+//  │ Active      │                          │ Listener │
+//  │             ◄───────────┐              │          │
+//  └──┬──────────┘           │Transfer      └──┬───────┘
+//     │                      │Finished         │
+//     │               ┌──────┴────────┐        │Update
+//     │Update         │               │        │Failure
+//     │Failure        │ Partial       ├───┐    │
+//     │               │               │   │    │
+//     │               └───────▲───────┘   │    │
+//     │                       │           │    │
+//  ┌──▼──────────┐ Transfer   │           │    │
+//  │             │ Started    │           │    │
+//  │ Dead        ├────────────┘           │    │
+//  │             │                        │    │
+//  └─▲───────▲───┘        Transfer        │    │
+//    │       │            Failed/Cancelled│    │
+//    │       └────────────────────────────┘    │
+//    │                                         │
+//    └─────────────────────────────────────────┘
+//
 
 /// State of the single shard within a replica set.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq, Eq, Hash, Clone, Copy)]
@@ -99,6 +99,9 @@ pub enum ReplicaState {
     Partial,
     // Collection is being created
     Initializing,
+    // A shard which receives data, but is not used for search
+    // Useful for backup shards
+    Listener,
 }
 
 /// Represents a change in replica set, due to scaling of `replication_factor`
@@ -598,6 +601,12 @@ impl ShardReplicaSet {
                         self.set_local(local_shard, Some(ReplicaState::Initializing))
                             .await?;
                     }
+                    ReplicaState::Listener => {
+                        // Same as `Active`, we report a failure to consensus
+                        self.set_local(local_shard, Some(ReplicaState::Listener))
+                            .await?;
+                        self.notify_peer_failure(peer_id);
+                    }
                 }
                 continue;
             }
@@ -631,6 +640,7 @@ impl ShardReplicaSet {
             Some(ReplicaState::Partial) => true,
             Some(ReplicaState::Initializing) => true,
             Some(ReplicaState::Dead) => false,
+            Some(ReplicaState::Listener) => true,
             None => false,
         };
         res && !self.is_locally_disabled(peer_id)
@@ -1057,6 +1067,9 @@ impl ShardReplicaSet {
                 }
                 Some(ReplicaState::Initializing) => {
                     Ok(Some(local_shard.get().update(operation, wait).await?))
+                }
+                Some(ReplicaState::Listener) => {
+                    Ok(Some(local_shard.get().update(operation, false).await?))
                 }
                 Some(ReplicaState::Dead) | None => Ok(None),
             }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -9,7 +9,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
-use crate::operations::types::{CollectionError, CollectionResult, ShardTransferInfo};
+use crate::operations::types::{CollectionResult, ShardTransferInfo};
 use crate::operations::{OperationToShard, SplitByShard};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
@@ -152,20 +152,6 @@ impl ShardHolder {
             .filter(|transfer| transfer.from == *peer_id || transfer.to == *peer_id)
             .cloned()
             .collect()
-    }
-
-    pub fn set_shard_replica_state(
-        &self,
-        shard_id: ShardId,
-        peer_id: PeerId,
-        active: ReplicaState,
-    ) -> CollectionResult<()> {
-        let replica_set = self
-            .get_shard(&shard_id)
-            .ok_or_else(|| CollectionError::NotFound {
-                what: format!("Shard {shard_id}"),
-            })?;
-        replica_set.set_replica_state(&peer_id, active)
     }
 
     pub fn target_shard(

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -24,6 +24,17 @@ fn default_max_optimization_threads() -> usize {
     1
 }
 
+#[derive(Clone, Debug, Deserialize, Default)]
+pub enum NodeType {
+    /// Regular node, participates in the cluster
+    #[default]
+    Normal,
+    /// Node that does only receive data, but is not used for search/read operations
+    /// This is useful for nodes that are only used for writing data
+    /// and backup purposes
+    Listener,
+}
+
 /// Global configuration of the storage, loaded on the service launch, default stored in ./config
 #[derive(Clone, Debug, Deserialize)]
 pub struct StorageConfig {
@@ -38,6 +49,8 @@ pub struct StorageConfig {
     pub hnsw_index: HnswConfig,
     #[serde(default = "default_mmap_advice")]
     pub mmap_advice: madvise::Advice,
+    #[serde(default)]
+    pub node_type: NodeType,
 }
 
 fn default_snapshots_path() -> String {

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -50,6 +50,7 @@ mod tests {
             },
             hnsw_index: Default::default(),
             mmap_advice: madvise::Advice::Random,
+            node_type: Default::default(),
         };
 
         let search_runtime = Runtime::new().unwrap();

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -48,7 +48,7 @@ def drop_collection(peer_url, collection="test_collection", timeout=10):
     assert_http_ok(r_batch)
 
 
-def search(peer_url, vector, city):
+def search(peer_url, vector, city, collection="test_collection"):
     q = {
         "vector": vector,
         "top": 10,
@@ -63,6 +63,6 @@ def search(peer_url, vector, city):
             ]
         }
     }
-    r_search = requests.post(f"{peer_url}/collections/test_collection/points/search", json=q)
+    r_search = requests.post(f"{peer_url}/collections/{collection}/points/search", json=q)
     assert_http_ok(r_search)
     return r_search.json()["result"]

--- a/tests/consensus_tests/test_listener_node.py
+++ b/tests/consensus_tests/test_listener_node.py
@@ -24,8 +24,11 @@ def get_states(peer_api_uri: str, collection_name: str):
         all_shard_states.append(shard['state'])
 
     return all_shard_states
+
+
 def has_listener_shard(peer_api_uri: str, collection_name: str):
     return 'Listener' in get_states(peer_api_uri, collection_name)
+
 
 def has_no_listener_shard(peer_api_uri: str, collection_name: str):
     return 'Listener' not in get_states(peer_api_uri, collection_name)
@@ -105,5 +108,3 @@ def test_listener_node(tmp_path: pathlib.Path):
     res2 = search(peer_api_uris[0], query_vector, city="London", collection=COLLECTION_NAME)
 
     assert res1 == res2
-
-

--- a/tests/consensus_tests/test_listener_node.py
+++ b/tests/consensus_tests/test_listener_node.py
@@ -1,0 +1,109 @@
+import logging
+import pathlib
+
+from .fixtures import create_collection, upsert_random_points, search, random_vector
+from .utils import *
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICAS = 3
+COLLECTION_NAME = "test_collection"
+
+
+def get_states(peer_api_uri: str, collection_name: str):
+    res = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster", timeout=10)
+    assert_http_ok(res)
+    cluster = res.json()["result"]
+    all_shard_states = []
+    for shard in cluster['local_shards']:
+        all_shard_states.append(shard['state'])
+    for shard in cluster['remote_shards']:
+        all_shard_states.append(shard['state'])
+
+    return all_shard_states
+def has_listener_shard(peer_api_uri: str, collection_name: str):
+    return 'Listener' in get_states(peer_api_uri, collection_name)
+
+def has_no_listener_shard(peer_api_uri: str, collection_name: str):
+    return 'Listener' not in get_states(peer_api_uri, collection_name)
+
+
+def wait_listener_node(peer_api_uri: str, collection_name: str):
+    try:
+        wait_for(has_listener_shard, peer_api_uri, collection_name)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+def wait_no_listener_node(peer_api_uri: str, collection_name: str):
+    try:
+        wait_for(has_no_listener_shard, peer_api_uri, collection_name)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+
+def test_listener_node(tmp_path: pathlib.Path):
+
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
+
+    upsert_random_points(peer_api_uris[0], 100)
+
+    p = processes.pop()
+    p.kill()
+
+    peer_api_uris.pop()
+
+    peer_api_uris.append(
+        start_peer(
+            peer_dirs[-1],
+            f"peer_0_{N_PEERS}_restart.log",
+            bootstrap_uri,
+            port=20000,
+            extra_env={
+                "QDRANT__STORAGE__NODE_TYPE": "Listener",
+            }
+        )
+    )
+
+    for peer_api_uri in peer_api_uris:
+        wait_listener_node(peer_api_uri, COLLECTION_NAME)
+
+    upsert_random_points(peer_api_uris[0], 100)
+
+    query_vector = random_vector()
+    res1 = search(peer_api_uris[0], query_vector, city="London", collection=COLLECTION_NAME)
+
+    p = processes.pop()
+    p.kill()
+
+    peer_api_uris.pop()
+
+    peer_api_uris.append(
+        start_peer(
+            peer_dirs[-1],
+            f"peer_0_{N_PEERS}_restart_again.log",
+            bootstrap_uri,
+            port=20000,
+            extra_env={
+                "QDRANT__STORAGE__NODE_TYPE": "Normal",
+            }
+        )
+    )
+
+    for peer_api_uri in peer_api_uris:
+        wait_no_listener_node(peer_api_uri, COLLECTION_NAME)
+
+    res2 = search(peer_api_uris[0], query_vector, city="London", collection=COLLECTION_NAME)
+
+    assert res1 == res2
+
+

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -72,11 +72,16 @@ def init_pytest_log_folder() -> str:
 
 
 # Starts a peer and returns its api_uri
-def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None) -> str:
+def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, extra_env=None) -> str:
+    if extra_env is None:
+        extra_env = {}
     p2p_port = get_port() if port is None else port + 0
     grpc_port = get_port() if port is None else port + 1
     http_port = get_port() if port is None else port + 2
-    env = get_env(p2p_port, grpc_port, http_port)
+    env = {
+        **get_env(p2p_port, grpc_port, http_port),
+        **extra_env
+    }
     test_log_folder = init_pytest_log_folder()
     log_file = open(f"{test_log_folder}/{log_file}", "w")
     print(f"Starting follower peer with bootstrap uri {bootstrap_uri},"


### PR DESCRIPTION
- A new shard state for backup-oriented nodes
- If shard is in a listener state - it will accept write requests with wait=false
- Search requests are not sent to listener node
- There is a new values in config - `node_type`. If node type = Listener, add shards on this node will be requested to convert  into listening  shards