### PR TITLE
Add script to generate `docker-compose.yaml` for Qdrant cluster

### DIFF
--- a/docker-compose-gen.sh
+++ b/docker-compose-gen.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 declare NODES="${1:-5}"
 declare BASE_PORT="${2:-6330}"
 
-echo 'version: "3.7"'
-echo 'services:'
+cat <<-EOF
+version: "3.7"
+
+services:
+EOF
 
 for ((node=0; node<NODES; node++))
 do
@@ -19,7 +22,7 @@ do
 	then
 		declare COMMAND="./qdrant --uri 'http://$SERVICE_NAME:6335'"
 	else
-		declare COMMAND="bash -c \"sleep $((5 + node)) && ./qdrant --bootstrap 'http://qdrant_node_0:6335' --uri 'http://$SERVICE_NAME:6335'\""
+		declare COMMAND="bash -c \"sleep $((10 + node / 10 + RANDOM % 10)) && ./qdrant --bootstrap 'http://qdrant_node_0:6335' --uri 'http://$SERVICE_NAME:6335'\""
 	fi
 
 	cat <<-EOF

--- a/docker-compose-gen.sh
+++ b/docker-compose-gen.sh
@@ -39,6 +39,10 @@ do
 	    ports:
 	      - "$HTTP_PORT:6333"
 	      - "$GRPC_PORT:6334"
+	    deploy:
+	      resources:
+	        limits:
+	          cpus: 0.3
 
 	EOF
 done

--- a/docker-compose-gen.sh
+++ b/docker-compose-gen.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare NODES="${1:-5}"
+declare BASE_PORT="${2:-6330}"
+
+echo 'version: "3.7"'
+echo 'services:'
+
+for ((node=0; node<NODES; node++))
+do
+	declare SERVICE_NAME=qdrant_node_$node
+
+	declare HTTP_PORT=$((BASE_PORT + node * 10 + 3))
+	declare GRPC_PORT=$((BASE_PORT + node * 10 + 4))
+
+	if ((node == 0))
+	then
+		declare COMMAND="./qdrant --uri 'http://$SERVICE_NAME:6335'"
+	else
+		declare COMMAND="bash -c \"sleep $((5 + node)) && ./qdrant --bootstrap 'http://qdrant_node_0:6335' --uri 'http://$SERVICE_NAME:6335'\""
+	fi
+
+	cat <<-EOF
+	  $SERVICE_NAME:
+	    image: qdrant/qdrant:latest
+	    command: $COMMAND
+	    restart: always
+	    environment:
+	      - QDRANT__SERVICE__GRPC_PORT=6334
+	      - QDRANT__CLUSTER__ENABLED=true
+	      - QDRANT__CLUSTER__P2P__PORT=6335
+	      - QDRANT__CLUSTER__CONSENSUS__MAX_MESSAGE_QUEUE_SIZE=5000
+	      - QDRANT__LOG_LEVEL=debug,raft=info
+	    ports:
+	      - "$HTTP_PORT:6333"
+	      - "$GRPC_PORT:6334"
+
+	EOF
+done

--- a/docker-compose-gen.sh
+++ b/docker-compose-gen.sh
@@ -42,7 +42,7 @@ do
 	    deploy:
 	      resources:
 	        limits:
-	          cpus: 0.3
+	          cpus: "0.3"
 
 	EOF
 done

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1,5 +1,6 @@
 use std::backtrace::Backtrace;
 use std::collections::{BTreeMap, HashMap};
+use std::error::Error as _;
 use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1,6 +1,7 @@
 use std::backtrace::Backtrace;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as _;
+use std::fmt::Write as _;
 use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 
@@ -680,8 +681,8 @@ impl From<RequestError<tonic::Status>> for CollectionError {
                 let mut err = err.source();
 
                 while let Some(src) = err {
-                    msg += &format!(": {src}");
                     err = src.source();
+                    write!(&mut msg, ": {src}").unwrap(); // Writing into `String` never fails
                 }
 
                 CollectionError::service_error(msg)

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -674,7 +674,17 @@ impl From<RequestError<tonic::Status>> for CollectionError {
     fn from(err: RequestError<tonic::Status>) -> Self {
         match err {
             RequestError::FromClosure(status) => status.into(),
-            RequestError::Tonic(err) => CollectionError::service_error(format!("{err}")),
+            RequestError::Tonic(err) => {
+                let mut msg = err.to_string();
+                let mut err = err.source();
+
+                while let Some(src) = err {
+                    msg += &format!(": {src}");
+                    err = src.source();
+                }
+
+                CollectionError::service_error(msg)
+            }
         }
     }
 }

--- a/tools/generate_docker_compose_cluster.sh
+++ b/tools/generate_docker_compose_cluster.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Generate a docker-compose configuration for a cluster.
+#
+# Parameters:
+# - $1: number of nodes (default: 5)
+# - $2: base port (default: 6330)
+#
+# Example usage:
+# ./generate_docker_compose_cluster.sh 5 > docker-compose.yaml
+
 set -euo pipefail
 
 declare NODES="${1:-5}"


### PR DESCRIPTION
_Edited by @timvisee:_

This adds a script to generate a Docker compose configuration to easily start a small cluster in Docker.

I've been using this a few times, so I decided to make it ready to merge into our main repo.

Example usage:

```bash
./tools/generate_docker_compose_cluster.sh 5 > docker-compose.yaml

docker-compose up
```