### PR TITLE
Wait for all shards to be active when testing collection recovery

### DIFF
--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -54,11 +54,11 @@ const REPLICA_STATE_FILE: &str = "replica_state.json";
 //    │    Collection Created
 //    │
 //    ▼
-//  ┌─────────────┐
-//  │             │
-//  │ Initilizing │
-//  │             │
-//  └──────┬──────┘
+//  ┌──────────────┐
+//  │              │
+//  │ Initializing │
+//  │              │
+//  └──────┬───────┘
 //         │  Report created    ┌───────────┐
 //         └────────────────────►           │
 //             Activate         │ Consensus │

--- a/tests/consensus_tests/test_collection_recovery.py
+++ b/tests/consensus_tests/test_collection_recovery.py
@@ -1,7 +1,6 @@
 import pathlib
 import shutil
 
-import requests
 from .fixtures import create_collection, upsert_random_points, random_vector, search
 from .utils import *
 from .assertions import assert_http_ok
@@ -42,7 +41,7 @@ def test_collection_recovery(tmp_path: pathlib.Path):
     # Recover Raft state
     recover_raft_state(peer_url)
 
-    # Wait for the Raft state to be recovered
+    # Wait for all shards to be active
     wait_for(all_collection_shards_are_active, peer_url, COLLECTION_NAME)
 
     # Check, that the collection is not empty on recovered node
@@ -52,17 +51,15 @@ def test_collection_recovery(tmp_path: pathlib.Path):
         assert shard["points_count"] > 0
 
 
-def get_collection_cluser_info(peer_url, collection_name):
-    r = request.get(f"{peer_url}/collections/{collection_name}/cluster")
-    return request_result(r)
-
 def recover_raft_state(peer_url):
     r = requests.post(f"{peer_url}/cluster/recover")
     return request_result(r)
 
+
 def request_result(resp):
     assert_http_ok(resp)
     return resp.json()["result"]
+
 
 def collection_exists(peer_url, collection_name):
     try:
@@ -72,6 +69,7 @@ def collection_exists(peer_url, collection_name):
 
     return True
 
+
 def all_collection_shards_are_active(peer_url, collection_name):
     try:
         info = get_collection_cluster_info(peer_url, collection_name)
@@ -79,8 +77,9 @@ def all_collection_shards_are_active(peer_url, collection_name):
         return False
 
     remote_shards = info["remote_shards"]
+    local_shards = info["local_shards"]
 
     if len(remote_shards) == 0:
         return False
 
-    return all(map(lambda shard: shard["state"] == "Active", remote_shards))
+    return all(map(lambda shard: shard["state"] == "Active", local_shards + remote_shards))


### PR DESCRIPTION
This PR tackles the flaky test `consensus//test_collection_recovery.py`

This test fails quite often on our CI ([e.g,](https://github.com/qdrant/qdrant/actions/runs/4285965943/jobs/7464917615#step:10:140))

```
FAILED tests/consensus_tests/test_collection_recovery.py::test_collection_recovery - assert 0 > 0
```

It fails also pretty often locally for me.

My understanding is that the test expects the shard to be up to date once its remote shards are active.

However, it is possible that the local shards are not yet ready.

```
Local shards: [{'shard_id': 0, 'points_count': 0, 'state': 'Partial'}]
```

I propose to wait for both remote and local shards to be active before querying the number of points.
