### PR TITLE
Fix windows warning in CI

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -449,6 +449,7 @@ mod tests {
 
     const M: usize = 8;
 
+    #[cfg(not(windows))]
     fn parallel_graph_build<TMetric: Metric + Sync + Send, R>(
         num_vectors: usize,
         dim: usize,


### PR DESCRIPTION
Fix warning while windows tests:
```
warning: function `parallel_graph_build` is never used
   --> lib\segment\src\index\hnsw_index\graph_layers_builder.rs:452:8
    |
452 |     fn parallel_graph_build<TMetric: Metric + Sync + Send, R>(
    |        ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [ ] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
