### PR TITLE
Fix connections flood bug

### DIFF
--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -843,10 +843,8 @@ impl ShardReplicaSet {
             max(factor, usize::try_from(self.read_remote_replicas).unwrap())
         };
 
-        let mut pending_operations: FuturesUnordered<_> = operations
-            .by_ref()
-            .take(required_reads)
-            .collect();
+        let mut pending_operations: FuturesUnordered<_> =
+            operations.by_ref().take(required_reads).collect();
 
         let mut responses = Vec::new();
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::ops::Deref;
@@ -834,9 +835,17 @@ impl ShardReplicaSet {
 
         let mut operations = local_operations.chain(remote_operations);
 
+        let required_reads = if active_local_count > 0 {
+            // If there is a local shard, we can ignore fan-out `read_remote_replicas` param,
+            // as we already know that the local peer is working.
+            factor
+        } else {
+            max(factor, usize::try_from(self.read_remote_replicas).unwrap())
+        };
+
         let mut pending_operations: FuturesUnordered<_> = operations
             .by_ref()
-            .take(factor + usize::try_from(self.read_remote_replicas).unwrap() - 1)
+            .take(required_reads)
             .collect();
 
         let mut responses = Vec::new();


### PR DESCRIPTION
Fixes extensive requests in `execute_and_resolve_read_operation` in case if local shard is present.

This issue was significantly affecting performance in case of replication_factor > 1 due to looping queries.