### PR TITLE
Fix Docker builds on M1/amd64 by making gcc-multilib optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ RUN echo "Building for $TARGETARCH, arch: $(bash target_arch.sh)"
 
 COPY --from=planner /qdrant/recipe.json recipe.json
 
-RUN apt-get update && apt-get install -y gcc-multilib && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler && rustup component add rustfmt
+RUN apt-get update \
+    && ( apt-get install -y gcc-multilib || echo "Warning: not installing gcc-multilib" ) \
+    && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler \
+    && rustup component add rustfmt
 
 
 RUN rustup target add $(bash target_arch.sh)


### PR DESCRIPTION
Building the Docker image on M1 hardware currently fails, because there is no `gcc-multilib` installation candidate on arm64, as reported by https://github.com/qdrant/qdrant/issues/1514. The `gcc-multilib` package is required for cross compilation (arm64 on amd64) and was introduced in https://github.com/qdrant/qdrant/pull/1000.

This PR makes the `gcc-multilib` package optional, to only install it when it is available on the current architecture. This ensures builds on M1 succeed, while cross compilation is still possible om amd64.

This is probably not ideal, but may be a nice middle ground. What do you think?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?