### PR TITLE
Fix recover snapshot peer

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1320,7 +1320,7 @@
           "collections"
         ],
         "summary": "Recover from a snapshot",
-        "description": "Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection.",
+        "description": "Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.",
         "operationId": "recover_from_snapshot",
         "parameters": [
           {
@@ -1330,6 +1330,15 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1443,7 +1443,12 @@ impl Collection {
     /// Restore collection from snapshot
     ///
     /// This method performs blocking IO.
-    pub fn restore_snapshot(snapshot_path: &Path, target_dir: &Path) -> CollectionResult<()> {
+    pub fn restore_snapshot(
+        snapshot_path: &Path,
+        target_dir: &Path,
+        this_peer_id: PeerId,
+        is_distributed: bool,
+    ) -> CollectionResult<()> {
         // decompress archive
         let archive_file = std::fs::File::open(snapshot_path)?;
         let mut ar = tar::Archive::new(archive_file);
@@ -1463,7 +1468,11 @@ impl Collection {
                     }
                     shard_config::ShardType::Temporary => {}
                     shard_config::ShardType::ReplicaSet { .. } => {
-                        ReplicaSetShard::restore_snapshot(&shard_path)?
+                        ReplicaSetShard::restore_snapshot(
+                            &shard_path,
+                            this_peer_id,
+                            is_distributed,
+                        )?
                     }
                 }
             } else {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -250,7 +250,7 @@ impl LocalShard {
         update_runtime: Handle,
     ) -> CollectionResult<LocalShard> {
         // initialize local shard config file
-        let local_shard_config = ShardConfig::new_local();
+        let local_shard_config = ShardConfig::new_replica_set();
         let shard =
             Self::build(id, collection_id, shard_path, shared_config, update_runtime).await?;
         local_shard_config.save(shard_path)?;

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use api::grpc::qdrant::collections_internal_client::CollectionsInternalClient;
@@ -37,7 +37,6 @@ use crate::shards::conversions::{
     internal_upsert_points, try_scored_point_from_grpc,
 };
 use crate::shards::shard::{PeerId, ShardId};
-use crate::shards::shard_config::ShardConfig;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::RemoteShardTelemetry;
 use crate::shards::CollectionId;
@@ -72,33 +71,8 @@ impl RemoteShard {
         }
     }
 
-    /// Initialize remote shard by persisting its info on the file system.
-    pub fn init(
-        id: ShardId,
-        collection_id: CollectionId,
-        peer_id: PeerId,
-        shard_path: PathBuf,
-        channel_service: ChannelService,
-    ) -> CollectionResult<Self> {
-        // initialize remote shard config file
-        let shard_config = ShardConfig::new_remote(peer_id);
-        shard_config.save(&shard_path)?;
-        Ok(RemoteShard::new(
-            id,
-            collection_id,
-            peer_id,
-            channel_service,
-        ))
-    }
-
     pub fn restore_snapshot(_snapshot_path: &Path) {
         // NO extra actions needed for remote shards
-    }
-
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
-        let shard_config = ShardConfig::new_remote(self.peer_id);
-        shard_config.save(target_path)?;
-        Ok(())
     }
 
     fn current_address(&self) -> CollectionResult<Uri> {

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -120,13 +120,6 @@ pub struct ReplicaSetState {
 }
 
 impl ReplicaSetState {
-    pub fn update_this_peer_id(&mut self, peer_id: PeerId) {
-        self.this_peer_id = peer_id;
-        self.peers
-            .remove(&peer_id)
-            .and_then(|state| self.peers.insert(peer_id, state));
-    }
-
     pub fn get_peer_state(&self, peer_id: &PeerId) -> Option<&ReplicaState> {
         self.peers.get(peer_id)
     }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -120,6 +120,13 @@ pub struct ReplicaSetState {
 }
 
 impl ReplicaSetState {
+    pub fn update_this_peer_id(&mut self, peer_id: PeerId) {
+        self.this_peer_id = peer_id;
+        self.peers
+            .remove(&peer_id)
+            .and_then(|state| self.peers.insert(peer_id, state));
+    }
+
     pub fn get_peer_state(&self, peer_id: &PeerId) -> Option<&ReplicaState> {
         self.peers.get(peer_id)
     }
@@ -959,9 +966,38 @@ impl ShardReplicaSet {
         }
     }
 
-    pub fn restore_snapshot(snapshot_path: &Path) -> CollectionResult<()> {
+    pub fn restore_snapshot(
+        snapshot_path: &Path,
+        this_peer_id: PeerId,
+        is_distributed: bool,
+    ) -> CollectionResult<()> {
         let replica_state: SaveOnDisk<ReplicaSetState> =
             SaveOnDisk::load_or_init(snapshot_path.join(REPLICA_STATE_FILE))?;
+
+        // If this shard have local data
+        let is_snapshot_local = replica_state.read().is_local;
+
+        if !is_distributed && !is_snapshot_local {
+            return Err(CollectionError::service_error(format!(
+                "Can't restore snapshot is local mode with missing data at shard: {}",
+                snapshot_path.display()
+            )));
+        }
+
+        replica_state.write(|state| {
+            state.this_peer_id = this_peer_id;
+            if is_distributed {
+                state
+                    .peers
+                    .remove(&this_peer_id)
+                    .and_then(|replica_state| state.peers.insert(this_peer_id, replica_state));
+            } else {
+                // In local mode we don't want any remote peers
+                state.peers.clear();
+                state.peers.insert(this_peer_id, ReplicaState::Active);
+            }
+        })?;
+
         if replica_state.read().is_local {
             LocalShard::restore_snapshot(snapshot_path)?;
         }

--- a/lib/collection/src/shards/shard_config.rs
+++ b/lib/collection/src/shards/shard_config.rs
@@ -10,9 +10,9 @@ pub const SHARD_CONFIG_FILE: &str = "shard_config.json";
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum ShardType {
-    Local,
-    Remote { peer_id: PeerId },
-    Temporary, // same as local, but not ready yet
+    Local,                      // Deprecated
+    Remote { peer_id: PeerId }, // Deprecated
+    Temporary,                  // Deprecated
     ReplicaSet,
 }
 
@@ -30,21 +30,6 @@ impl ShardConfig {
         Self {
             r#type: ShardType::ReplicaSet,
         }
-    }
-
-    pub fn new_remote(peer_id: PeerId) -> Self {
-        let r#type = ShardType::Remote { peer_id };
-        Self { r#type }
-    }
-
-    pub fn new_local() -> Self {
-        let r#type = ShardType::Local;
-        Self { r#type }
-    }
-
-    pub fn new_temp() -> Self {
-        let r#type = ShardType::Temporary;
-        Self { r#type }
     }
 
     pub fn load(shard_path: &Path) -> CollectionResult<Option<Self>> {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -95,13 +95,24 @@ async fn test_snapshot_collection() {
         .await
         .unwrap();
 
-    Collection::restore_snapshot(
-        &snapshots_path.path().join(snapshot_description.name),
+    // Do not recover in local mode if some shards are remote
+    assert!(Collection::restore_snapshot(
+        &snapshots_path.path().join(&snapshot_description.name),
         recover_dir.path(),
         0,
         false,
     )
-    .unwrap();
+    .is_err());
+
+    if let Err(err) = Collection::restore_snapshot(
+        &snapshots_path.path().join(snapshot_description.name),
+        recover_dir.path(),
+        0,
+        true,
+    ) {
+        collection.before_drop().await;
+        panic!("Failed to restore snapshot: {err}")
+    }
 
     let mut recovered_collection = Collection::load(
         collection_name_rec,

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -98,6 +98,8 @@ async fn test_snapshot_collection() {
     Collection::restore_snapshot(
         &snapshots_path.path().join(snapshot_description.name),
         recover_dir.path(),
+        0,
+        false,
     )
     .unwrap();
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,3 +1,4 @@
+use collection::config::CollectionConfig;
 use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff,
 };
@@ -283,4 +284,23 @@ pub enum CollectionMetaOperations {
     TransferShard(CollectionId, ShardTransferOperations),
     SetShardReplicaState(SetShardReplicaState),
     Nop { token: usize }, // Empty operation
+}
+
+/// Use config of the existing collection to generate a create collection operation
+/// for the new collection
+impl From<CollectionConfig> for CreateCollection {
+    fn from(value: CollectionConfig) -> Self {
+        Self {
+            vectors: value.params.vectors,
+            shard_number: Some(value.params.shard_number.get()),
+            replication_factor: Some(value.params.replication_factor.get()),
+            write_consistency_factor: Some(value.params.write_consistency_factor.get()),
+            on_disk_payload: Some(value.params.on_disk_payload),
+            hnsw_config: Some(value.hnsw_config.into()),
+            wal_config: Some(value.wal_config.into()),
+            optimizers_config: Some(value.optimizer_config.into()),
+            init_from: None,
+            quantization_config: value.quantization_config,
+        }
+    }
 }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -36,7 +36,7 @@ pub struct Persistent {
     /// Last known cluster topology
     #[serde(with = "serialize_peer_addresses")]
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
-    pub this_peer_id: u64,
+    pub this_peer_id: PeerId,
     #[serde(skip)]
     pub path: PathBuf,
     /// Tracks if there are some unsaved changes due to the failure on save
@@ -146,7 +146,7 @@ impl Persistent {
         self.peer_address_by_id.read().clone()
     }
 
-    pub fn this_peer_id(&self) -> u64 {
+    pub fn this_peer_id(&self) -> PeerId {
         self.this_peer_id
     }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -8,7 +8,11 @@ use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::shard_config::ShardType;
 use collection::shards::shard_versioning::latest_shard_paths;
 
+use crate::content_manager::collection_meta_ops::{
+    CollectionMetaOperations, CreateCollectionOperation,
+};
 use crate::content_manager::snapshots::download::{download_snapshot, downloaded_snapshots_dir};
+use crate::dispatcher::Dispatcher;
 use crate::{StorageError, TableOfContent};
 
 async fn activate_shard(
@@ -44,13 +48,16 @@ async fn activate_shard(
 }
 
 pub async fn do_recover_from_snapshot(
-    toc: &TableOfContent,
+    dispatcher: &Dispatcher,
     collection_name: &str,
     source: SnapshotRecover,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location, priority } = source;
+    let toc = dispatcher.toc();
 
-    let collection = toc.get_collection(collection_name).await?;
+    let this_peer_id = toc.this_peer_id;
+
+    let is_distributed = toc.is_distributed();
 
     let snapshot_download_path = downloaded_snapshots_dir(toc.snapshots_path());
     tokio::fs::create_dir_all(&snapshot_download_path).await?;
@@ -85,11 +92,32 @@ pub async fn do_recover_from_snapshot(
     let tmp_collection_dir_clone = tmp_collection_dir.clone();
     let restoring = tokio::task::spawn_blocking(move || {
         // Unpack snapshot collection to the target folder
-        Collection::restore_snapshot(&snapshot_path, &tmp_collection_dir_clone)
+        Collection::restore_snapshot(
+            &snapshot_path,
+            &tmp_collection_dir_clone,
+            this_peer_id,
+            is_distributed,
+        )
     });
     restoring.await??;
 
     let snapshot_config = CollectionConfig::load(&tmp_collection_dir)?;
+
+    let collection = match toc.get_collection(collection_name).await.ok() {
+        Some(collection) => collection,
+        None => {
+            log::debug!("Collection {} does not exist, creating it", collection_name);
+            let operation =
+                CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
+                    collection_name.to_string(),
+                    snapshot_config.clone().into(),
+                ));
+            dispatcher
+                .submit_collection_meta_op(operation, None)
+                .await?;
+            toc.get_collection(collection_name).await?
+        }
+    };
 
     let state = collection.state().await;
 
@@ -110,8 +138,6 @@ pub async fn do_recover_from_snapshot(
     }
 
     // Deactivate collection local shards during recovery
-    let this_peer_id = toc.this_peer_id;
-
     for (shard_id, shard_info) in &state.shards {
         let local_shard_state = shard_info.replicas.get(&this_peer_id);
         match local_shard_state {

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -51,6 +51,25 @@ pub async fn do_recover_from_snapshot(
     dispatcher: &Dispatcher,
     collection_name: &str,
     source: SnapshotRecover,
+    wait: bool,
+) -> Result<bool, StorageError> {
+    let dispatch = dispatcher.clone();
+    let collection_name = collection_name.to_string();
+    let recovery =
+        tokio::spawn(
+            async move { _do_recover_from_snapshot(dispatch, &collection_name, source).await },
+        );
+    if wait {
+        Ok(recovery.await??)
+    } else {
+        Ok(true)
+    }
+}
+
+async fn _do_recover_from_snapshot(
+    dispatcher: Dispatcher,
+    collection_name: &str,
+    source: SnapshotRecover,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location, priority } = source;
     let toc = dispatcher.toc();

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -133,3 +133,12 @@ impl Deref for Dispatcher {
         self.toc.deref()
     }
 }
+
+impl Clone for Dispatcher {
+    fn clone(&self) -> Self {
+        Self {
+            toc: self.toc.clone(),
+            consensus_state: self.consensus_state.clone(),
+        }
+    }
+}

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -7,7 +7,7 @@ paths:
         - snapshots
         - collections
       summary: Recover from a snapshot
-      description: Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection.
+      description: Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.
       operationId: recover_from_snapshot
       parameters:
         - name: collection_name
@@ -16,6 +16,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: wait
+          in: query
+          description: "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true."
+          required: false
+          schema:
+            type: boolean
       requestBody:
         description: Snapshot to recover from
         content:

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -8,6 +8,7 @@ use storage::content_manager::snapshots::{
     do_list_full_snapshots, get_full_snapshot_path,
 };
 use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
 
 use crate::actix::helpers::{
     collection_into_actix_error, process_response, storage_into_actix_error,
@@ -65,7 +66,7 @@ async fn create_snapshot(
 
 #[put("/collections/{name}/snapshots/recover")]
 async fn recover_from_snapshot(
-    toc: web::Data<TableOfContent>,
+    dispatcher: web::Data<Dispatcher>,
     path: web::Path<String>,
     request: web::Json<SnapshotRecover>,
 ) -> impl Responder {
@@ -74,7 +75,7 @@ async fn recover_from_snapshot(
 
     let timing = Instant::now();
     let response =
-        do_recover_from_snapshot(toc.get_ref(), &collection_name, snapshot_recover).await;
+        do_recover_from_snapshot(dispatcher.get_ref(), &collection_name, snapshot_recover).await;
     process_response(response, timing)
 }
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,7 +1,10 @@
 use actix_files::NamedFile;
 use actix_web::rt::time::Instant;
+use actix_web::web::Query;
 use actix_web::{delete, get, post, put, web, Responder, Result};
 use collection::operations::snapshot_ops::SnapshotRecover;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use storage::content_manager::snapshots::recover::do_recover_from_snapshot;
 use storage::content_manager::snapshots::{
     do_create_full_snapshot, do_delete_collection_snapshot, do_delete_full_snapshot,
@@ -14,6 +17,11 @@ use crate::actix::helpers::{
     collection_into_actix_error, process_response, storage_into_actix_error,
 };
 use crate::common::collections::*;
+
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct SnapshottingParam {
+    pub wait: Option<bool>,
+}
 
 // Actix specific code
 pub async fn do_get_full_snapshot(toc: &TableOfContent, snapshot_name: &str) -> Result<NamedFile> {
@@ -69,13 +77,20 @@ async fn recover_from_snapshot(
     dispatcher: web::Data<Dispatcher>,
     path: web::Path<String>,
     request: web::Json<SnapshotRecover>,
+    params: Query<SnapshottingParam>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
     let snapshot_recover = request.into_inner();
+    let wait = params.wait.unwrap_or(true);
 
     let timing = Instant::now();
-    let response =
-        do_recover_from_snapshot(dispatcher.get_ref(), &collection_name, snapshot_recover).await;
+    let response = do_recover_from_snapshot(
+        dispatcher.get_ref(),
+        &collection_name,
+        snapshot_recover,
+        wait,
+    )
+    .await;
     process_response(response, timing)
 }
 

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -44,7 +44,7 @@ where
                 } => {
                     log::warn!("error processing request: {}", description);
                     if let Some(backtrace) = backtrace {
-                        log::warn!("backtrace: {}", backtrace);
+                        log::trace!("backtrace: {}", backtrace);
                     }
                     HttpResponse::InternalServerError()
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,8 @@ fn main() -> anyhow::Result<()> {
 
     segment::madvise::set_global(settings.storage.mmap_advice);
 
+    welcome();
+
     // Saved state of the consensus.
     let persistent_consensus_state =
         Persistent::load_or_init(&settings.storage.storage_path, args.bootstrap.is_none())?;
@@ -143,8 +145,6 @@ fn main() -> anyhow::Result<()> {
     } else {
         vec![]
     };
-
-    welcome();
 
     // Create and own search runtime out of the scope of async context to ensure correct
     // destruction of it


### PR DESCRIPTION
 - Allows to recover snapshots, taken in distributed mode, on local deployment.
 - Allows to recover snapshot even if collection does not exists
 - Allows to use `wait=false` during recovery, API will also tolerate disconnections now