### PR TITLE
Add ID generation/optional ID support to upsert endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,6 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ futures = "0.3.27"
 futures-util = "0.3.27"
 clap = { version = "4.1.11", features = ["derive"] }
 serde_cbor = { version = "0.11.2"}
-uuid = { version = "1.3", features = ["v4", "serde"] }
+uuid = { version = "1.3", features = ["v4", "serde", "fast-rng"] }
 sys-info = "0.9.1"
 
 config = "~0.13.3"

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1816,6 +1816,7 @@ The JSON representation for `Value` is a JSON value.
 | hnsw_ef | [uint64](#uint64) | optional | Params relevant to HNSW index. Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search. |
 | exact | [bool](#bool) | optional | Search without approximation. If set to true, search may run long but with exact results. |
 | quantization | [QuantizationSearchParams](#qdrant-QuantizationSearchParams) | optional | If set to true, search will ignore quantized vector data |
+| ignore_quantization | [bool](#bool) | optional | If set to true, search will ignore quantized vector data |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2252,7 +2252,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PointInsertOperations"
+                "$ref": "#/components/schemas/NewPointInsertOperations"
               }
             }
           }
@@ -5378,13 +5378,13 @@
           }
         }
       },
-      "PointInsertOperations": {
+      "NewPointInsertOperations": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/PointsBatch"
+            "$ref": "#/components/schemas/NewPointsBatch"
           },
           {
-            "$ref": "#/components/schemas/PointsList"
+            "$ref": "#/components/schemas/NewPointsList"
           }
         ]
       },
@@ -5415,15 +5415,22 @@
           }
         ]
       },
-      "PointStruct": {
+      "NewPointStruct": {
         "type": "object",
         "required": [
-          "id",
           "vector"
         ],
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
+            "description": "Point id (optional)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExtendedPointId"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "vector": {
             "$ref": "#/components/schemas/VectorStruct"
@@ -5441,23 +5448,32 @@
           }
         }
       },
-      "Batch": {
+      "NewBatch": {
         "type": "object",
         "required": [
-          "ids",
           "vectors"
         ],
         "properties": {
           "ids": {
+            "description": "Point ids (optional)",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            }
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ExtendedPointId"
+                },
+                {
+                  "nullable": true
+                }
+              ]
+            },
+            "nullable": true
           },
           "vectors": {
             "$ref": "#/components/schemas/BatchVectorStruct"
           },
           "payloads": {
+            "description": "Point payloads (optional)",
             "type": "array",
             "items": {
               "anyOf": [
@@ -5473,17 +5489,17 @@
           }
         }
       },
-      "PointsBatch": {
+      "NewPointsBatch": {
         "required": [
           "batch"
         ],
         "properties": {
           "batch": {
-            "$ref": "#/components/schemas/Batch"
+            "$ref": "#/components/schemas/NewBatch"
           }
         }
       },
-      "PointsList": {
+      "NewPointsList": {
         "type": "object",
         "required": [
           "points"
@@ -5492,7 +5508,7 @@
           "points": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PointStruct"
+              "$ref": "#/components/schemas/NewPointStruct"
             }
           }
         }

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -14,7 +14,7 @@ prost-types = "0.11.8"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 schemars = { version = "0.8.12", features = ["uuid1", "preserve_order"] }
-uuid = { version = "1.3", features = ["v4", "serde"] }
+uuid = { version = "1.3", features = ["v4", "serde", "fast-rng"] }
 tower = "0.4.13"
 tokio = "1.26.0"
 rand = "0.8.5"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -38,7 +38,7 @@ async-trait = "0.1.67"
 arc-swap = "1.6.0"
 tonic = { version = "0.8.3", features = ["gzip"] }
 tower = "0.4.13"
-uuid = { version = "1.3", features = ["v4", "serde"] }
+uuid = { version = "1.3", features = ["v4", "serde", "fast-rng"] }
 url = { version = "2", features = ["serde"] }
 
 segment = {path = "../segment"}

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -24,7 +24,7 @@ rayon = "1.7.0"
 num_cpus = "1.15"
 itertools = "0.10"
 rocksdb = { version = "0.20.1", default-features = false, features = [ "snappy" ] }
-uuid = { version = "1.3", features = ["v4", "serde"] }
+uuid = { version = "1.3", features = ["v4", "serde", "fast-rng"] }
 bincode = "1.3"
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_json = "~1.0"

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -198,4 +198,18 @@ impl BatchVectorStruct {
             }
         }
     }
+
+    pub fn len(&self) -> usize {
+        match self {
+            BatchVectorStruct::Single(v) => v.len(),
+            BatchVectorStruct::Multi(v) => v.values().next().map(|v| v.len()).unwrap_or(0),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            BatchVectorStruct::Single(_) => false,
+            BatchVectorStruct::Multi(v) => v.values().next().map(|v| v.is_empty()).unwrap_or(true),
+        }
+    }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -46,6 +46,13 @@ pub enum ExtendedPointId {
     Uuid(Uuid),
 }
 
+impl ExtendedPointId {
+    /// Generate secure random point ID (UUID).
+    pub fn random() -> Self {
+        Self::Uuid(Uuid::new_v4())
+    }
+}
+
 impl std::fmt::Display for ExtendedPointId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -39,7 +39,7 @@ collection = { path = "../collection" }
 api = { path = "../api" }
 futures = "0.3.27"
 anyhow = "1.0.70"
-uuid = "1.3.0"
+uuid = { version = "1.3", features = ["v4", "serde", "fast-rng"] }
 url = "2.3.1"
 reqwest = { version = "0.11", features = ["stream", "rustls-tls"] }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -69,7 +69,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PointInsertOperations"
+              $ref: "#/components/schemas/NewPointInsertOperations"
 
       parameters:
         - name: collection_name

--- a/openapi/tests/openapi_integration/helpers/helpers.py
+++ b/openapi/tests/openapi_integration/helpers/helpers.py
@@ -1,5 +1,6 @@
 import jsonschema
 import requests
+import uuid
 from schemathesis.models import APIOperation
 from schemathesis.specs.openapi.references import ConvertingResolver
 from schemathesis.specs.openapi.schemas import OpenApi30
@@ -81,3 +82,11 @@ def request_with_validation(
     operation.validate_response(response)
 
     return response
+
+
+def is_valid_uuid(val):
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False

--- a/openapi/tests/openapi_integration/test_optional_id.py
+++ b/openapi/tests/openapi_integration/test_optional_id.py
@@ -1,0 +1,142 @@
+import pytest
+import uuid
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation, is_valid_uuid
+
+collection_name = 'test_collection'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    basic_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_points_retrieve():
+    points_retrieve()
+
+
+def points_retrieve():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "vector": [0.23, 0.74, 0.02, 0.93],
+                    "payload": {"city": "Berlin"}
+                },
+                {
+                    "vector": [0.41, 0.24, 0.90, 0.20],
+                    "payload": {"city": ["Berlin", "London"]}
+                },
+                {
+                    "vector": [0.43, 0.86, 0.91, 0.64]
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "ids": [1, 2]
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 2
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    assert response.json()['result']['vectors_count'] == 9
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": [0.4, 0.2, 0.3, 0.8],
+            "limit": 4
+        }
+    )
+    assert response.ok
+    assert response.json()['result'][0]['id'] == 3
+    assert is_valid_uuid(response.json()['result'][1]['id'])
+    assert is_valid_uuid(response.json()['result'][2]['id'])
+    assert response.json()['result'][3]['id'] == 4
+    assert len(response.json()['result']) == 4
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "should": [
+                    {
+                        "key": "city",
+                        "match": {
+                            "value": "London"
+                        }
+                    }
+                ]
+            },
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 3  # only 3 London records in collection
+
+
+def test_points_unique():
+    points_unique()
+
+
+def points_unique():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                { "vector": [0.23, 0.74, 0.02, 0.93] },
+                { "vector": [0.23, 0.74, 0.02, 0.93] },
+                { "vector": [0.23, 0.74, 0.02, 0.93] },
+                { "vector": [0.41, 0.24, 0.90, 0.20] },
+                { "vector": [0.41, 0.24, 0.90, 0.20] },
+                { "vector": [0.41, 0.24, 0.90, 0.20] },
+                { "vector": [0.43, 0.86, 0.91, 0.64] },
+                { "vector": [0.43, 0.86, 0.91, 0.64] },
+                { "vector": [0.43, 0.86, 0.91, 0.64] }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    assert response.json()['result']['vectors_count'] == 15

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -2,7 +2,7 @@ use actix_web::rt::time::Instant;
 use actix_web::web::Query;
 use actix_web::{delete, post, put, web, Responder};
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
-use collection::operations::point_ops::{PointInsertOperations, PointsSelector, WriteOrdering};
+use collection::operations::point_ops::{NewPointInsertOperations, PointsSelector, WriteOrdering};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::toc::TableOfContent;
@@ -23,11 +23,11 @@ pub struct UpdateParam {
 pub async fn upsert_points(
     toc: web::Data<TableOfContent>,
     path: web::Path<String>,
-    operation: web::Json<PointInsertOperations>,
+    operation: web::Json<NewPointInsertOperations>,
     params: Query<UpdateParam>,
 ) -> impl Responder {
     let collection_name = path.into_inner();
-    let operation = operation.into_inner();
+    let operation = operation.into_inner().allocate_ids();
     let wait = params.wait.unwrap_or(false);
     let ordering = params.ordering.unwrap_or_default();
     let timing = Instant::now();

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -2,7 +2,7 @@ use api::grpc::models::CollectionsResponse;
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
-use collection::operations::point_ops::{PointInsertOperations, PointsSelector, WriteOrdering};
+use collection::operations::point_ops::{NewPointInsertOperations, PointsSelector, WriteOrdering};
 use collection::operations::snapshot_ops::{SnapshotDescription, SnapshotRecover};
 use collection::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
@@ -44,7 +44,7 @@ struct AllDefinitions {
     af: ChangeAliasesOperation,
     ag: CreateFieldIndex,
     ah: PointsSelector,
-    ai: PointInsertOperations,
+    ai: NewPointInsertOperations,
     aj: SetPayload,
     ak: DeletePayload,
     al: ClusterStatus,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -46,9 +46,10 @@ pub fn points_operation_response(
 
 pub async fn upsert(
     toc: &TableOfContent,
-    upsert_points: UpsertPoints,
+    mut upsert_points: UpsertPoints,
     shard_selection: Option<ShardId>,
 ) -> Result<Response<PointsOperationResponse>, Status> {
+    upsert_points.allocate_ids();
     let UpsertPoints {
         collection_name,
         wait,

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -72,7 +72,9 @@ curl -L -X PUT "http://$QDRANT_HOST/collections/test_collection/points?wait=true
         {"id": 3, "vector": [0.36, 0.55, 0.47, 0.94], "payload": {"city": ["Berlin", "Moscow"]}},
         {"id": 4, "vector": [0.18, 0.01, 0.85, 0.80], "payload": {"city": ["London", "Moscow"]}},
         {"id": "98a9a4b1-4ef2-46fb-8315-a97d874fe1d7", "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count": [0]}},
-        {"id": "f0e09527-b096-42a8-94e9-ea94d342b925", "vector": [0.35, 0.08, 0.11, 0.44]}
+        {"id": "f0e09527-b096-42a8-94e9-ea94d342b925", "vector": [0.35, 0.08, 0.11, 0.44]},
+        {"id": null, "vector": [0.24, 0.18, 0.22, 0.44], "payload": {"count": [0]}},
+        {"vector": [0.35, 0.08, 0.11, 0.44]}
       ]
     }' | jq
 
@@ -90,8 +92,8 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points" \
     }' | jq
 
 SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
-[[ "$SAVED_VECTORS_COUNT" == "6" ]] || {
-  echo 'check failed - 6 points expected'
+[[ "$SAVED_VECTORS_COUNT" == "8" ]] || {
+  echo 'check failed - 8 points expected'
   exit 1
 }
 

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -46,7 +46,9 @@ $docker_grpcurl -d '{
     {"id": { "num": 3 }, "vectors": {"vector": {"data": [0.36, 0.55, 0.47, 0.94]}}, "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "Moscow" }]}}}},
     {"id": { "num": 4 }, "vectors": {"vector": {"data": [0.18, 0.01, 0.85, 0.80]}}, "payload": {"city": {"list_value": {"values": [{ "string_value": "London" }, { "string_value": "Moscow" }]}}}},
     {"id": { "uuid": "98a9a4b1-4ef2-46fb-8315-a97d874fe1d7" }, "vectors": {"vector": {"data": [0.24, 0.18, 0.22, 0.44]}}, "payload": {"count":{"list_value": {"values": [{ "integer_value": 0 }]}}}},
-    {"id": { "uuid": "f0e09527-b096-42a8-94e9-ea94d342b925" }, "vectors": {"vector": {"data": [0.35, 0.08, 0.11, 0.44]}}}
+    {"id": { "uuid": "f0e09527-b096-42a8-94e9-ea94d342b925" }, "vectors": {"vector": {"data": [0.35, 0.08, 0.11, 0.44]}}},
+    {"id": null, "vectors": {"vector": {"data": [0.35, 0.08, 0.11, 0.44]}}},
+    {"vectors": {"vector": {"data": [0.35, 0.08, 0.11, 0.44]}}}
   ]
 }' $QDRANT_HOST qdrant.Points/Upsert
 


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/1424

This implements support for optional data point IDs on the upsert API and gRPC endpoints. A random UUID is picked if no `id` is defined.

With this, a client could PUT data with `"id": null` or with the `id` field omitted:

```bash
curl -L -X PUT 'http://localhost:6333/collections/test_collection/points' \
    -H 'Content-Type: application/json' \
    --data-raw '{
        "points": [
            {"id": 1, "vector": [0.05, 0.61, 0.76, 0.74], "payload": {"city": "Berlin" }},
            {"id": null, "vector": [0.19, 0.81, 0.75, 0.11], "payload": {"city": ["Berlin", "London"] }},
            {"vector": [0.35, 0.08, 0.11, 0.99]}
        ]
    }'
```

In this case the server will assign a random UUID to the last two data points.

I believe this can be implemented in two ways:
1. Modify `PointStruct`, `PointInsertOperations` and other internals everywhere to support an optional ID.
2. Add custom `PointStruct`, `PointInsertOperations` types to support optional IDs at API/gRPC endpoints.

I chose the second method. The first would require significant internal changes complicating things. The second method can catch the optional IDs right at the respective endpoints and assign a random ID there. Then normal upsert operation continues. This is possible because selecting a random UUID does not require an atomic operation or state. I added `NewPointStruct`, `NewBatch`, `NewPointInsertOperations` types for this.

I'm not sure if this is the correct approach so please comment on it, I'll leave this open for a bit. I'm very new to this codebase. Please let me know if I missed anything.

I've also enabled `fast-rng` for `uuid` globally for faster random ID generation, this pulls in `rand`.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
4. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
5. [x] Have you checked your code using ```cargo clippy``` command?

### Tasks:
- [x] Add support for optional IDs to point upsert API endpoint
- [x] Add support for optional IDs to point upsert gRPC endpoint
- [x] Update basic API test to add unidentified points
- [x] Update basic gRPC test to add unidentified points
- [x] Update OpenAPI specification
- [x] Update gRPC documentation

### Future tasks:
- Update qdrant/docs, note this in points upload documentation
- Update client implementations to reflect this change?