### PR TITLE
Quantization re scoring param

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -30,7 +30,9 @@
     - [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff)
     - [PayloadIndexParams](#qdrant-PayloadIndexParams)
     - [PayloadSchemaInfo](#qdrant-PayloadSchemaInfo)
+    - [QuantizationConfig](#qdrant-QuantizationConfig)
     - [RenameAlias](#qdrant-RenameAlias)
+    - [ScalarQuantization](#qdrant-ScalarQuantization)
     - [TextIndexParams](#qdrant-TextIndexParams)
     - [UpdateCollection](#qdrant-UpdateCollection)
     - [VectorParams](#qdrant-VectorParams)
@@ -42,6 +44,7 @@
     - [CollectionStatus](#qdrant-CollectionStatus)
     - [Distance](#qdrant-Distance)
     - [PayloadSchemaType](#qdrant-PayloadSchemaType)
+    - [QuantizationType](#qdrant-QuantizationType)
     - [TokenizerType](#qdrant-TokenizerType)
   
 - [collections_service.proto](#collections_service-proto)
@@ -87,6 +90,7 @@
     - [PointsIdsList](#qdrant-PointsIdsList)
     - [PointsOperationResponse](#qdrant-PointsOperationResponse)
     - [PointsSelector](#qdrant-PointsSelector)
+    - [QuantizationSearchParams](#qdrant-QuantizationSearchParams)
     - [Range](#qdrant-Range)
     - [ReadConsistency](#qdrant-ReadConsistency)
     - [RecommendBatchPoints](#qdrant-RecommendBatchPoints)
@@ -218,6 +222,7 @@
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) |  | Configuration of vector index |
 | optimizer_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) |  | Configuration of the optimizers |
 | wal_config | [WalConfigDiff](#qdrant-WalConfigDiff) |  | Configuration of the Write-Ahead-Log |
+| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of the vector quantization |
 
 
 
@@ -363,6 +368,7 @@
 | replication_factor | [uint32](#uint32) | optional | Number of replicas of each shard that network tries to maintain, default = 1 |
 | write_consistency_factor | [uint32](#uint32) | optional | How many replicas should apply the operation for us to consider it successful, default = 1 |
 | init_from_collection | [string](#string) | optional | Specify name of the other collection to copy data from |
+| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional |  |
 
 
 
@@ -594,6 +600,21 @@ If indexation speed have more priority for your - make this parameter lower. If 
 
 
 
+<a name="qdrant-QuantizationConfig"></a>
+
+### QuantizationConfig
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| scalar | [ScalarQuantization](#qdrant-ScalarQuantization) |  |  |
+
+
+
+
+
+
 <a name="qdrant-RenameAlias"></a>
 
 ### RenameAlias
@@ -604,6 +625,23 @@ If indexation speed have more priority for your - make this parameter lower. If 
 | ----- | ---- | ----- | ----------- |
 | old_alias_name | [string](#string) |  | Name of the alias to rename |
 | new_alias_name | [string](#string) |  | Name of the alias |
+
+
+
+
+
+
+<a name="qdrant-ScalarQuantization"></a>
+
+### ScalarQuantization
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [QuantizationType](#qdrant-QuantizationType) |  | Type of quantization |
+| quantile | [float](#float) | optional | Number of bits to use for quantization |
+| always_ram | [bool](#bool) | optional | If true - quantized vectors always will be stored in RAM, ignoring the config of main storage |
 
 
 
@@ -768,6 +806,18 @@ If indexation speed have more priority for your - make this parameter lower. If 
 | Float | 3 |  |
 | Geo | 4 |  |
 | Text | 5 |  |
+
+
+
+<a name="qdrant-QuantizationType"></a>
+
+### QuantizationType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UnknownQuantization | 0 |  |
+| Int8 | 1 |  |
 
 
 
@@ -1460,6 +1510,22 @@ The JSON representation for `Value` is JSON value.
 
 
 
+<a name="qdrant-QuantizationSearchParams"></a>
+
+### QuantizationSearchParams
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ignore | [bool](#bool) | optional | If set to true, search will ignore quantized vector data |
+| rescore | [bool](#bool) | optional | If true, use original vectors to re-score top-k results. Default is true. |
+
+
+
+
+
+
 <a name="qdrant-Range"></a>
 
 ### Range
@@ -1749,6 +1815,7 @@ The JSON representation for `Value` is JSON value.
 | ----- | ---- | ----- | ----------- |
 | hnsw_ef | [uint64](#uint64) | optional | Params relevant to HNSW index. Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search. |
 | exact | [bool](#bool) | optional | Search without approximation. If set to true, search may run long but with exact results. |
+| quantization | [QuantizationSearchParams](#qdrant-QuantizationSearchParams) | optional | If set to true, search will ignore quantized vector data |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4460,8 +4460,31 @@
             "default": false,
             "type": "boolean"
           },
-          "ignore_quantization": {
-            "description": "If set to true, search will ignore quantized vector data",
+          "quantization": {
+            "description": "Quantization params",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QuantizationSearchParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "QuantizationSearchParams": {
+        "description": "Additional parameters of the search",
+        "type": "object",
+        "properties": {
+          "ignore": {
+            "description": "If true, quantized vectors are ignored. Default is false.",
+            "default": false,
+            "type": "boolean"
+          },
+          "rescore": {
+            "description": "If true, use original vectors to re-score top-k results. Might require more time in case if original vectors are stored on disk. Default is false.",
             "default": false,
             "type": "boolean"
           }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -158,6 +158,18 @@ message WithVectorsSelector {
   }
 }
 
+message QuantizationSearchParams {
+  /*
+  If set to true, search will ignore quantized vector data
+   */
+  optional bool ignore = 1;
+
+  /*
+  If true, use original vectors to re-score top-k results. Default is true.
+   */
+  optional bool rescore = 2;
+}
+
 message SearchParams {
   /*
   Params relevant to HNSW index. Size of the beam in a beam-search.
@@ -173,7 +185,7 @@ message SearchParams {
   /*
   If set to true, search will ignore quantized vector data 
   */
-  optional bool ignore_quantization = 3;
+  optional QuantizationSearchParams quantization = 3;
 }
 
 message SearchPoints {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1988,6 +1988,18 @@ pub mod with_vectors_selector {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuantizationSearchParams {
+    ///
+    /// If set to true, search will ignore quantized vector data
+    #[prost(bool, optional, tag = "1")]
+    pub ignore: ::core::option::Option<bool>,
+    ///
+    /// If true, use original vectors to re-score top-k results. Default is true.
+    #[prost(bool, optional, tag = "2")]
+    pub rescore: ::core::option::Option<bool>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchParams {
     ///
     /// Params relevant to HNSW index. Size of the beam in a beam-search.
@@ -2000,8 +2012,8 @@ pub struct SearchParams {
     pub exact: ::core::option::Option<bool>,
     ///
     /// If set to true, search will ignore quantized vector data
-    #[prost(bool, optional, tag = "3")]
-    pub ignore_quantization: ::core::option::Option<bool>,
+    #[prost(message, optional, tag = "3")]
+    pub quantization: ::core::option::Option<QuantizationSearchParams>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -28,7 +28,10 @@ use crate::index::visited_pool::VisitedList;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
-use crate::types::{FieldCondition, Filter, HnswConfig, SearchParams, VECTOR_ELEMENT_SIZE};
+use crate::types::{
+    default_quantization_ignore_value, default_quantization_rescore_value, FieldCondition, Filter,
+    HnswConfig, QuantizationSearchParams, SearchParams, VECTOR_ELEMENT_SIZE,
+};
 use crate::vector_storage::{ScoredPointOffset, VectorStorage, VectorStorageEnum};
 
 const HNSW_USE_HEURISTIC: bool = true;
@@ -193,7 +196,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         let vector_storage = self.vector_storage.borrow();
         let vector_scorer = vector_storage.scorer();
-        let ignore_quantization = params.map(|p| p.ignore_quantization).unwrap_or(false);
+        let ignore_quantization = params
+            .and_then(|p| p.quantization)
+            .map(|q| q.ignore)
+            .unwrap_or(default_quantization_ignore_value());
         let (raw_scorer, quantized) = if ignore_quantization {
             (vector_scorer.raw_scorer(vector.to_owned()), false)
         } else if let Some(quantized_raw_scorer) = vector_scorer.quantized_raw_scorer(vector) {
@@ -209,7 +215,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         if let Some(graph) = &self.graph {
             let mut search_result = graph.search(top, ef, points_scorer);
-            if quantized {
+            let if_rescore = params
+                .and_then(|p| p.quantization)
+                .map(|q| q.rescore)
+                .unwrap_or(default_quantization_rescore_value());
+            if quantized && if_rescore {
                 let raw_scorer = vector_scorer.raw_scorer(vector.to_owned());
                 search_result.iter_mut().for_each(|scored_point| {
                     scored_point.score = raw_scorer.score_point(scored_point.idx);
@@ -246,7 +256,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let payload_index = self.payload_index.borrow();
         let vector_storage = self.vector_storage.borrow();
         let mut filtered_iter = payload_index.query_points(filter);
-        let ignore_quantization = params.map(|p| p.ignore_quantization).unwrap_or(false);
+        let ignore_quantization = params
+            .and_then(|p| p.quantization)
+            .map(|q| q.ignore)
+            .unwrap_or(false);
         if ignore_quantization {
             vectors
                 .iter()
@@ -304,7 +317,10 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 if exact {
                     let exact_params = params.map(|params| {
                         let mut params = *params;
-                        params.ignore_quantization = true; // disable quantization for exact search
+                        params.quantization = Some(QuantizationSearchParams {
+                            ignore: true,
+                            rescore: false,
+                        }); // disable quantization for exact search
                         params
                     });
                     let _timer =

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -259,7 +259,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let ignore_quantization = params
             .and_then(|p| p.quantization)
             .map(|q| q.ignore)
-            .unwrap_or(false);
+            .unwrap_or(default_quantization_ignore_value());
         if ignore_quantization {
             vectors
                 .iter()

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -256,6 +256,27 @@ pub struct SegmentInfo {
 /// Additional parameters of the search
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
+pub struct QuantizationSearchParams {
+    /// If true, quantized vectors are ignored. Default is false.
+    #[serde(default = "default_quantization_ignore_value")]
+    pub ignore: bool,
+
+    /// If true, use original vectors to re-score top-k results. Default is true.
+    #[serde(default = "default_quantization_rescore_value")]
+    pub rescore: bool,
+}
+
+pub fn default_quantization_ignore_value() -> bool {
+    true
+}
+
+pub fn default_quantization_rescore_value() -> bool {
+    false // ToDo, decide which one is better
+}
+
+/// Additional parameters of the search
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
 pub struct SearchParams {
     /// Params relevant to HNSW index
     /// /// Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search.
@@ -265,9 +286,9 @@ pub struct SearchParams {
     #[serde(default)]
     pub exact: bool,
 
-    /// If set to true, search will ignore quantized vector data
+    /// Quantization params
     #[serde(default)]
-    pub ignore_quantization: bool,
+    pub quantization: Option<QuantizationSearchParams>,
 }
 
 /// Vector index configuration of the segment

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -267,7 +267,7 @@ pub struct QuantizationSearchParams {
 }
 
 pub fn default_quantization_ignore_value() -> bool {
-    true
+    false
 }
 
 pub fn default_quantization_rescore_value() -> bool {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -261,7 +261,9 @@ pub struct QuantizationSearchParams {
     #[serde(default = "default_quantization_ignore_value")]
     pub ignore: bool,
 
-    /// If true, use original vectors to re-score top-k results. Default is true.
+    /// If true, use original vectors to re-score top-k results.
+    /// Might require more time in case if original vectors are stored on disk.
+    /// Default is false.
     #[serde(default = "default_quantization_rescore_value")]
     pub rescore: bool,
 }
@@ -271,7 +273,7 @@ pub fn default_quantization_ignore_value() -> bool {
 }
 
 pub fn default_quantization_rescore_value() -> bool {
-    false // ToDo, decide which one is better
+    false
 }
 
 /// Additional parameters of the search


### PR DESCRIPTION
After experiments on slow disks I found out that 
final re-scoring actually significantly affects the search RPS:
E.g.:
| Setup                            | RPS    | Precision |
|----------------------------------|--------|-----------|
| 4.5Gb(full) mem                       | 600    | 0.99      |
| 4.5Gb(full) + quant + rescore     | 1000   | 0.989     |
| 2Gb mem, on disk                 | 2      | 0.99      |
| 2Gb mem, quant + rescore         | 30     | 0.989     |
| 2Gb mem, quant + no-rescore      | 1200   | 0.974     |

depending on the case, different scenarios might be preferable. So I propose to make re-scoring an optional search param.