### PR TITLE
Add `/metrics` endpoint for OpenTelemetry/Prometheus (#1494, #1541)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
 name = "proptest"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +2763,7 @@ dependencies = [
  "num_cpus",
  "openssl",
  "parking_lot",
+ "prometheus",
  "prost",
  "raft",
  "raft-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ num-traits = "0.2.15"
 tar = "0.4.38"
 reqwest = { version = "0.11", features = ["stream", "rustls-tls", "blocking"] }
 openssl = { version = "0.10", features = ["vendored"] }
+prometheus = { version = "0.13.3", default-features = false }
 
 # Consensus related crates
 raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -72,6 +72,43 @@
         }
       }
     },
+    "/metrics": {
+      "get": {
+        "summary": "Collect Prometheus metrics data",
+        "description": "Collect metrics data including app info, collections info, cluster info and statistics",
+        "operationId": "metrics",
+        "tags": [
+          "service"
+        ],
+        "parameters": [
+          {
+            "name": "anonymize",
+            "in": "query",
+            "description": "If true, anonymize result",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics data in Prometheus format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "# HELP app_info information about qdrant server\n# TYPE app_info counter\napp_info{name=\"qdrant\",version=\"0.11.1\"} 1\n# HELP cluster_enabled is cluster support enabled\n# TYPE cluster_enabled gauge\ncluster_enabled 0\n# HELP collections_total number of collections\n# TYPE collections_total gauge\ncollections_total 1\n"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error"
+          }
+        }
+      }
+    },
     "/locks": {
       "post": {
         "summary": "Set lock options",
@@ -5858,9 +5895,13 @@
       "AppBuildTelemetry": {
         "type": "object",
         "required": [
+          "name",
           "version"
         ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "version": {
             "type": "string"
           },

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -17,6 +17,40 @@ paths:
             type: boolean
       responses: #@ response(array(reference("TelemetryData")))
 
+  /metrics:
+    get:
+      summary: Collect Prometheus metrics data
+      description: Collect metrics data including app info, collections info, cluster info and statistics
+      operationId: metrics
+      tags:
+        - service
+      parameters:
+        - name: anonymize
+          in: query
+          description: "If true, anonymize result"
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Metrics data in Prometheus format
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: |
+                  # HELP app_info information about qdrant server
+                  # TYPE app_info counter
+                  app_info{name="qdrant",version="0.11.1"} 1
+                  # HELP cluster_enabled is cluster support enabled
+                  # TYPE cluster_enabled gauge
+                  cluster_enabled 0
+                  # HELP collections_total number of collections
+                  # TYPE collections_total gauge
+                  collections_total 1
+        '4XX':
+          description: error
+
   /locks:
     post:
       summary: Set lock options

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -1,6 +1,6 @@
 use actix_web::rt::time::Instant;
 use actix_web::web::Query;
-use actix_web::{get, post, web, Responder};
+use actix_web::{get, post, web, HttpResponse, Responder};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 
 use crate::actix::helpers::process_response;
 use crate::common::helpers::LocksOption;
+use crate::common::metrics::gather_metrics;
 use crate::common::telemetry::TelemetryCollector;
 
 #[derive(Deserialize, Serialize, JsonSchema)]
@@ -33,6 +34,23 @@ async fn telemetry(
         telemetry_data
     };
     process_response(Ok(telemetry_data), timing)
+}
+
+#[get("/metrics")]
+async fn metrics(
+    telemetry_collector: web::Data<Mutex<TelemetryCollector>>,
+    params: Query<TelemetryParam>,
+) -> impl Responder {
+    let anonymize = params.anonymize.unwrap_or(false);
+    let details_level = params.details_level.unwrap_or(0);
+    let telemetry_collector = telemetry_collector.lock().await;
+    let telemetry_data = telemetry_collector.prepare_data(details_level).await;
+    let telemetry_data = if anonymize {
+        telemetry_data.anonymize()
+    } else {
+        telemetry_data
+    };
+    HttpResponse::Ok().body(gather_metrics(&telemetry_data))
 }
 
 #[post("/locks")]
@@ -62,5 +80,8 @@ async fn get_locks(toc: web::Data<TableOfContent>) -> impl Responder {
 
 // Configure services
 pub fn config_service_api(cfg: &mut web::ServiceConfig) {
-    cfg.service(telemetry).service(put_locks).service(get_locks);
+    cfg.service(telemetry)
+        .service(metrics)
+        .service(put_locks)
+        .service(get_locks);
 }

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 
 use crate::actix::helpers::process_response;
 use crate::common::helpers::LocksOption;
-use crate::common::metrics::gather_metrics;
+use crate::common::metrics::MetricsData;
 use crate::common::telemetry::TelemetryCollector;
 
 #[derive(Deserialize, Serialize, JsonSchema)]
@@ -50,7 +50,9 @@ async fn metrics(
     } else {
         telemetry_data
     };
-    HttpResponse::Ok().body(gather_metrics(&telemetry_data))
+
+    let metrics_data = MetricsData::from(telemetry_data);
+    HttpResponse::Ok().body(metrics_data.format_metrics())
 }
 
 #[post("/locks")]

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -1,0 +1,143 @@
+pub use prometheus::{
+    register_gauge_with_registry as gauge, register_int_gauge_with_registry as int_gauge, Encoder,
+    Opts, Registry, TextEncoder,
+};
+
+use super::telemetry::TelemetryData;
+
+/// Gather and return metrics in Prometheus format.
+pub fn gather_metrics(telemetry_data: &TelemetryData) -> Vec<u8> {
+    let r = Registry::new();
+
+    int_gauge!(
+        Opts::new("app_info", "information about qdrant server")
+            .const_label("version", &telemetry_data.app.version),
+        r,
+    )
+    .unwrap()
+    .set(1);
+
+    int_gauge!(Opts::new("collections_total", "number of collections"), r)
+        .unwrap()
+        .set(telemetry_data.collections.number_of_collections as i64);
+
+    // REST request details
+    for (endpoint, responses) in &telemetry_data.requests.rest.responses {
+        let (method, endpoint) = endpoint.split_once(' ').unwrap();
+        for (status, statistics) in responses {
+            int_gauge!(
+                Opts::new("rest_responses_total", "total number of responses")
+                    .const_label("method", method)
+                    .const_label("endpoint", endpoint)
+                    .const_label("status", status.to_string()),
+                r,
+            )
+            .unwrap()
+            .set(statistics.count as i64);
+            int_gauge!(
+                Opts::new(
+                    "rest_responses_fail_total",
+                    "total number of failed responses",
+                )
+                .const_label("method", method)
+                .const_label("endpoint", endpoint)
+                .const_label("status", status.to_string()),
+                r,
+            )
+            .unwrap()
+            .set(statistics.fail_count as i64);
+            gauge!(
+                Opts::new(
+                    "rest_responses_avg_duration_seconds",
+                    "average response duratoin",
+                )
+                .const_label("method", method)
+                .const_label("endpoint", endpoint)
+                .const_label("status", status.to_string()),
+                r,
+            )
+            .unwrap()
+            .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+            gauge!(
+                Opts::new(
+                    "rest_responses_min_duration_seconds",
+                    "minimum response duration",
+                )
+                .const_label("method", method)
+                .const_label("endpoint", endpoint)
+                .const_label("status", status.to_string()),
+                r,
+            )
+            .unwrap()
+            .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+            gauge!(
+                Opts::new(
+                    "rest_responses_max_duration_seconds",
+                    "maximum response duration",
+                )
+                .const_label("method", method)
+                .const_label("endpoint", endpoint)
+                .const_label("status", status.to_string()),
+                r,
+            )
+            .unwrap()
+            .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+        }
+    }
+
+    // gRPC request details
+    for (endpoint, statistics) in &telemetry_data.requests.grpc.responses {
+        int_gauge!(
+            Opts::new("grpc_responses_total", "total number of responses")
+                .const_label("endpoint", endpoint),
+            r,
+        )
+        .unwrap()
+        .set(statistics.count as i64);
+        int_gauge!(
+            Opts::new(
+                "grpc_responses_fail_total",
+                "total number of failed responses",
+            )
+            .const_label("endpoint", endpoint),
+            r,
+        )
+        .unwrap()
+        .set(statistics.fail_count as i64);
+        gauge!(
+            Opts::new(
+                "grpc_responses_avg_duration_seconds",
+                "average response duratoin",
+            )
+            .const_label("endpoint", endpoint),
+            r,
+        )
+        .unwrap()
+        .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+        gauge!(
+            Opts::new(
+                "grpc_responses_min_duration_seconds",
+                "minimum response duration",
+            )
+            .const_label("endpoint", endpoint),
+            r,
+        )
+        .unwrap()
+        .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+        gauge!(
+            Opts::new(
+                "grpc_responses_max_duration_seconds",
+                "maximum response duration",
+            )
+            .const_label("endpoint", endpoint),
+            r,
+        )
+        .unwrap()
+        .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+    }
+
+    // Format metrics
+    let mut buffer = vec![];
+    TextEncoder::new().encode(&r.gather(), &mut buffer).unwrap();
+    buffer
+}

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -13,17 +13,27 @@ use crate::common::telemetry_ops::requests_telemetry::{
     GrpcTelemetry, RequestsTelemetry, WebApiTelemetry,
 };
 
-/// Gather and return metrics in Prometheus format.
-pub fn gather_metrics(telemetry_data: &TelemetryData) -> Vec<u8> {
-    let registry = Registry::new();
-    telemetry_data.register_metrics(&registry);
+/// Encapsulates metrics data in Prometheus format.
+pub struct MetricsData {
+    registry: Registry,
+}
 
-    // Format metrics
-    let mut buffer = vec![];
-    TextEncoder::new()
-        .encode(&registry.gather(), &mut buffer)
-        .unwrap();
-    buffer
+impl MetricsData {
+    pub fn format_metrics(&self) -> Vec<u8> {
+        let mut buffer = vec![];
+        TextEncoder::new()
+            .encode(&self.registry.gather(), &mut buffer)
+            .unwrap();
+        buffer
+    }
+}
+
+impl From<TelemetryData> for MetricsData {
+    fn from(telemetry_data: TelemetryData) -> Self {
+        let registry = Registry::new();
+        telemetry_data.register_metrics(&registry);
+        Self { registry }
+    }
 }
 
 trait MetricsProvider {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -1,143 +1,189 @@
-pub use prometheus::{
+use prometheus::{
     register_gauge_with_registry as gauge, register_int_gauge_with_registry as int_gauge, Encoder,
     Opts, Registry, TextEncoder,
 };
 
-use super::telemetry::TelemetryData;
+use crate::common::telemetry::TelemetryData;
+use crate::common::telemetry_ops::app_telemetry::AppBuildTelemetry;
+use crate::common::telemetry_ops::collections_telemetry::CollectionsTelemetry;
+use crate::common::telemetry_ops::requests_telemetry::{
+    GrpcTelemetry, RequestsTelemetry, WebApiTelemetry,
+};
 
 /// Gather and return metrics in Prometheus format.
 pub fn gather_metrics(telemetry_data: &TelemetryData) -> Vec<u8> {
-    let r = Registry::new();
+    let registry = Registry::new();
+    telemetry_data.register_metrics(&registry);
 
-    int_gauge!(
-        Opts::new("app_info", "information about qdrant server")
-            .const_label("version", &telemetry_data.app.version),
-        r,
-    )
-    .unwrap()
-    .set(1);
+    // Format metrics
+    let mut buffer = vec![];
+    TextEncoder::new()
+        .encode(&registry.gather(), &mut buffer)
+        .unwrap();
+    buffer
+}
 
-    int_gauge!(Opts::new("collections_total", "number of collections"), r)
+trait MetricsProvider {
+    /// Register and add object metrics to registry.
+    fn register_metrics(&self, registry: &Registry);
+}
+
+impl MetricsProvider for TelemetryData {
+    fn register_metrics(&self, registry: &Registry) {
+        self.app.register_metrics(registry);
+        self.collections.register_metrics(registry);
+        self.requests.register_metrics(registry);
+    }
+}
+
+impl MetricsProvider for AppBuildTelemetry {
+    fn register_metrics(&self, registry: &Registry) {
+        int_gauge!(
+            Opts::new("app_info", "information about qdrant server")
+                .const_label("name", &self.name)
+                .const_label("version", &self.version),
+            registry,
+        )
         .unwrap()
-        .set(telemetry_data.collections.number_of_collections as i64);
+        .set(1);
+    }
+}
 
-    // REST request details
-    for (endpoint, responses) in &telemetry_data.requests.rest.responses {
-        let (method, endpoint) = endpoint.split_once(' ').unwrap();
-        for (status, statistics) in responses {
-            int_gauge!(
-                Opts::new("rest_responses_total", "total number of responses")
+impl MetricsProvider for CollectionsTelemetry {
+    fn register_metrics(&self, registry: &Registry) {
+        int_gauge!(
+            Opts::new("collections_total", "number of collections"),
+            registry
+        )
+        .unwrap()
+        .set(self.number_of_collections as i64);
+    }
+}
+
+impl MetricsProvider for RequestsTelemetry {
+    fn register_metrics(&self, registry: &Registry) {
+        self.rest.register_metrics(registry);
+        self.grpc.register_metrics(registry);
+    }
+}
+
+impl MetricsProvider for WebApiTelemetry {
+    fn register_metrics(&self, registry: &Registry) {
+        for (endpoint, responses) in &self.responses {
+            let (method, endpoint) = endpoint.split_once(' ').unwrap();
+            for (status, statistics) in responses {
+                int_gauge!(
+                    Opts::new("rest_responses_total", "total number of responses")
+                        .const_label("method", method)
+                        .const_label("endpoint", endpoint)
+                        .const_label("status", status.to_string()),
+                    registry,
+                )
+                .unwrap()
+                .set(statistics.count as i64);
+                int_gauge!(
+                    Opts::new(
+                        "rest_responses_fail_total",
+                        "total number of failed responses",
+                    )
                     .const_label("method", method)
                     .const_label("endpoint", endpoint)
                     .const_label("status", status.to_string()),
-                r,
+                    registry,
+                )
+                .unwrap()
+                .set(statistics.fail_count as i64);
+                gauge!(
+                    Opts::new(
+                        "rest_responses_avg_duration_seconds",
+                        "average response duratoin",
+                    )
+                    .const_label("method", method)
+                    .const_label("endpoint", endpoint)
+                    .const_label("status", status.to_string()),
+                    registry,
+                )
+                .unwrap()
+                .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+                gauge!(
+                    Opts::new(
+                        "rest_responses_min_duration_seconds",
+                        "minimum response duration",
+                    )
+                    .const_label("method", method)
+                    .const_label("endpoint", endpoint)
+                    .const_label("status", status.to_string()),
+                    registry,
+                )
+                .unwrap()
+                .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+                gauge!(
+                    Opts::new(
+                        "rest_responses_max_duration_seconds",
+                        "maximum response duration",
+                    )
+                    .const_label("method", method)
+                    .const_label("endpoint", endpoint)
+                    .const_label("status", status.to_string()),
+                    registry,
+                )
+                .unwrap()
+                .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+            }
+        }
+    }
+}
+
+impl MetricsProvider for GrpcTelemetry {
+    fn register_metrics(&self, registry: &Registry) {
+        for (endpoint, statistics) in &self.responses {
+            int_gauge!(
+                Opts::new("grpc_responses_total", "total number of responses")
+                    .const_label("endpoint", endpoint),
+                registry,
             )
             .unwrap()
             .set(statistics.count as i64);
             int_gauge!(
                 Opts::new(
-                    "rest_responses_fail_total",
+                    "grpc_responses_fail_total",
                     "total number of failed responses",
                 )
-                .const_label("method", method)
-                .const_label("endpoint", endpoint)
-                .const_label("status", status.to_string()),
-                r,
+                .const_label("endpoint", endpoint),
+                registry,
             )
             .unwrap()
             .set(statistics.fail_count as i64);
             gauge!(
                 Opts::new(
-                    "rest_responses_avg_duration_seconds",
+                    "grpc_responses_avg_duration_seconds",
                     "average response duratoin",
                 )
-                .const_label("method", method)
-                .const_label("endpoint", endpoint)
-                .const_label("status", status.to_string()),
-                r,
+                .const_label("endpoint", endpoint),
+                registry,
             )
             .unwrap()
             .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
             gauge!(
                 Opts::new(
-                    "rest_responses_min_duration_seconds",
+                    "grpc_responses_min_duration_seconds",
                     "minimum response duration",
                 )
-                .const_label("method", method)
-                .const_label("endpoint", endpoint)
-                .const_label("status", status.to_string()),
-                r,
+                .const_label("endpoint", endpoint),
+                registry,
             )
             .unwrap()
             .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
             gauge!(
                 Opts::new(
-                    "rest_responses_max_duration_seconds",
+                    "grpc_responses_max_duration_seconds",
                     "maximum response duration",
                 )
-                .const_label("method", method)
-                .const_label("endpoint", endpoint)
-                .const_label("status", status.to_string()),
-                r,
+                .const_label("endpoint", endpoint),
+                registry,
             )
             .unwrap()
             .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
         }
     }
-
-    // gRPC request details
-    for (endpoint, statistics) in &telemetry_data.requests.grpc.responses {
-        int_gauge!(
-            Opts::new("grpc_responses_total", "total number of responses")
-                .const_label("endpoint", endpoint),
-            r,
-        )
-        .unwrap()
-        .set(statistics.count as i64);
-        int_gauge!(
-            Opts::new(
-                "grpc_responses_fail_total",
-                "total number of failed responses",
-            )
-            .const_label("endpoint", endpoint),
-            r,
-        )
-        .unwrap()
-        .set(statistics.fail_count as i64);
-        gauge!(
-            Opts::new(
-                "grpc_responses_avg_duration_seconds",
-                "average response duratoin",
-            )
-            .const_label("endpoint", endpoint),
-            r,
-        )
-        .unwrap()
-        .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-        gauge!(
-            Opts::new(
-                "grpc_responses_min_duration_seconds",
-                "minimum response duration",
-            )
-            .const_label("endpoint", endpoint),
-            r,
-        )
-        .unwrap()
-        .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-        gauge!(
-            Opts::new(
-                "grpc_responses_max_duration_seconds",
-                "maximum response duration",
-            )
-            .const_label("endpoint", endpoint),
-            r,
-        )
-        .unwrap()
-        .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-    }
-
-    // Format metrics
-    let mut buffer = vec![];
-    TextEncoder::new().encode(&r.gather(), &mut buffer).unwrap();
-    buffer
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod collections;
 pub mod error_reporting;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
+pub mod metrics;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod points;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -29,7 +29,7 @@ pub struct TelemetryData {
     id: String,
     pub(crate) app: AppBuildTelemetry,
     pub(crate) collections: CollectionsTelemetry,
-    cluster: ClusterTelemetry,
+    pub(crate) cluster: ClusterTelemetry,
     pub(crate) requests: RequestsTelemetry,
 }
 

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -27,10 +27,10 @@ pub struct TelemetryCollector {
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct TelemetryData {
     id: String,
-    app: AppBuildTelemetry,
-    collections: CollectionsTelemetry,
+    pub(crate) app: AppBuildTelemetry,
+    pub(crate) collections: CollectionsTelemetry,
     cluster: ClusterTelemetry,
-    requests: RequestsTelemetry,
+    pub(crate) requests: RequestsTelemetry,
 }
 
 impl Anonymize for TelemetryData {

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -24,8 +24,8 @@ pub struct RunningEnvironmentTelemetry {
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct AppBuildTelemetry {
-    name: String,
-    version: String,
+    pub name: String,
+    pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub features: Option<AppFeaturesTelemetry>,

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -24,6 +24,7 @@ pub struct RunningEnvironmentTelemetry {
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct AppBuildTelemetry {
+    name: String,
     version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -36,6 +37,7 @@ pub struct AppBuildTelemetry {
 impl AppBuildTelemetry {
     pub fn collect(level: usize) -> Self {
         AppBuildTelemetry {
+            name: env!("CARGO_PKG_NAME").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             features: if level > 0 {
                 Some(AppFeaturesTelemetry {
@@ -115,6 +117,7 @@ impl Anonymize for AppFeaturesTelemetry {
 impl Anonymize for AppBuildTelemetry {
     fn anonymize(&self) -> Self {
         AppBuildTelemetry {
+            name: self.name.clone(),
             version: self.version.clone(),
             features: self.features.anonymize(),
             system: self.system.anonymize(),

--- a/src/common/telemetry_ops/requests_telemetry.rs
+++ b/src/common/telemetry_ops/requests_telemetry.rs
@@ -14,13 +14,13 @@ pub type HttpStatusCode = u16;
 #[derive(Serialize, Deserialize, Clone, Default, Debug, JsonSchema)]
 pub struct WebApiTelemetry {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    responses: HashMap<String, HashMap<HttpStatusCode, OperationDurationStatistics>>,
+    pub responses: HashMap<String, HashMap<HttpStatusCode, OperationDurationStatistics>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, JsonSchema)]
 pub struct GrpcTelemetry {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    responses: HashMap<String, OperationDurationStatistics>,
+    pub responses: HashMap<String, OperationDurationStatistics>,
 }
 
 pub struct ActixTelemetryCollector {
@@ -149,8 +149,8 @@ impl WebApiTelemetry {
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct RequestsTelemetry {
-    rest: WebApiTelemetry,
-    grpc: GrpcTelemetry,
+    pub rest: WebApiTelemetry,
+    pub grpc: GrpcTelemetry,
 }
 
 impl RequestsTelemetry {


### PR DESCRIPTION
Fixes #1494

This adds a `/metrics` endpoint to facilitate OpenTelemetry/Prometheus tools. This is currently based upon, but differs in format to, the `/telemetry` endpoint.

The current `TelemetryData` struct is used as source for this data. Later, this can be extended or implemented separately.

Here you see reporting to Prometheus in action with a dummy load as it is currently being worked on:

![image](https://user-images.githubusercontent.com/856222/224074385-a05e2ce6-afa4-4d9b-8710-fdfb045c04bf.png)

---

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Tasks:
* [x] Add `/metrics` endpoint.
* [x] Provide basic Prometheus metrics based on telemetry data.
* [x] Add the rest of the metrics (such as collection details).
* [x] Update OpenAPI specification

### Future tasks:
- Mention `/metrics` in `qdrant/docs`