### PR TITLE
ensure segment flushing order + extend logging

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -391,6 +391,20 @@ impl<'s> SegmentHolder {
         Ok(read_points)
     }
 
+    /// Defines flush ordering for segments.
+    ///
+    /// Flush appendable segments first, then non-appendable.
+    /// This is done to ensure that all data, transferred from non-appendable segments to appendable segments
+    /// is persisted, before marking records in non-appendable segments as removed.
+    fn segment_flush_ordering(&self) -> impl Iterator<Item = SegmentId> {
+        let appendable_segments = self.appendable_segments();
+        let non_appendable_segments = self.non_appendable_segments();
+
+        appendable_segments
+            .into_iter()
+            .chain(non_appendable_segments.into_iter())
+    }
+
     /// Flushes all segments and returns maximum version to persist
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.
@@ -400,17 +414,7 @@ impl<'s> SegmentHolder {
         let mut min_unsaved_version: SeqNumberType = SeqNumberType::MAX;
         let mut has_unsaved = false;
 
-        let appendable_segments = self.appendable_segments();
-        let non_appendable_segments = self.non_appendable_segments();
-
-        // Flush appendable segments first, then non-appendable.
-        // This is done to ensure that all data, transferred from non-appendable segments to appendable segments
-        // is persisted, before marking records in non-appendable segments as removed.
-        let flush_ordering = appendable_segments
-            .into_iter()
-            .chain(non_appendable_segments.into_iter());
-
-        for segment_id in flush_ordering {
+        for segment_id in self.segment_flush_ordering() {
             let segment = self.segments.get(&segment_id).unwrap();
             let segment_lock = segment.get();
             let read_segment = segment_lock.read();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -197,19 +197,18 @@ impl<'s> SegmentHolder {
         self.segments.get(&id)
     }
 
-    pub fn appendable_ids(&self) -> Vec<SegmentId> {
-        self.segments
-            .iter()
-            .filter(|(_, x)| x.get().read().is_appendable())
-            .map(|(id, _)| id)
-            .cloned()
-            .collect()
-    }
-
     pub fn appendable_segments(&self) -> Vec<SegmentId> {
         self.segments
             .iter()
             .filter(|(_idx, seg)| seg.get().read().is_appendable())
+            .map(|(idx, _seg)| *idx)
+            .collect()
+    }
+
+    pub fn non_appendable_segments(&self) -> Vec<SegmentId> {
+        self.segments
+            .iter()
+            .filter(|(_idx, seg)| !seg.get().read().is_appendable())
             .map(|(idx, _seg)| *idx)
             .collect()
     }
@@ -400,7 +399,19 @@ impl<'s> SegmentHolder {
         let mut max_persisted_version: SeqNumberType = SeqNumberType::MIN;
         let mut min_unsaved_version: SeqNumberType = SeqNumberType::MAX;
         let mut has_unsaved = false;
-        for segment in self.segments.values() {
+
+        let appendable_segments = self.appendable_segments();
+        let non_appendable_segments = self.non_appendable_segments();
+
+        // Flush appendable segments first, then non-appendable.
+        // This is done to ensure that all data, transferred from non-appendable segments to appendable segments
+        // is persisted, before marking records in non-appendable segments as removed.
+        let flush_ordering = appendable_segments
+            .into_iter()
+            .chain(non_appendable_segments.into_iter());
+
+        for segment_id in flush_ordering {
+            let segment = self.segments.get(&segment_id).unwrap();
             let segment_lock = segment.get();
             let read_segment = segment_lock.read();
             let segment_version = read_segment.version();

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -378,10 +378,14 @@ impl LocalShard {
         // ToDo: Start from minimal applied version
         for (op_num, update) in wal.read_all() {
             // Panic only in case of internal error. If wrong formatting - skip
-            if let Err(CollectionError::ServiceError { error, .. }) =
+            if let Err(CollectionError::ServiceError { error, backtrace }) =
                 CollectionUpdater::update(segments, op_num, update)
             {
-                panic!("Can't apply WAL operation: {error}")
+                if let Some(backtrace) = backtrace {
+                    log::error!("Backtrace: {}", backtrace);
+                }
+                let path = self.path.display();
+                panic!("Can't apply WAL operation: {error}, collection: {collection_id}, shard: {path}, op_num: {op_num}");
             }
             bar.inc(1);
         }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -783,8 +783,9 @@ impl SegmentEntry for Segment {
         if let Some(vector) = vector_opt {
             Ok(vector)
         } else {
+            let segment_path = self.current_path.display();
             Err(OperationError::service_error(format!(
-                "Vector {vector_name} not found at offset {internal_id}"
+                "Vector {vector_name} not found at offset {internal_id} for point {point_id}, segment {segment_path}",
             )))
         }
     }


### PR DESCRIPTION
Enforce flush priority for appendable segments:

It is important to flush appendable segments first and non-appendable later, because on update we move data from non-appendable to appendable, and we want to make sure that data is moved before we flush delete flag on the source segment