### PR TITLE
Update to Raft-rs 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,8 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 [[package]]
 name = "raft"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?rev=5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7#5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12688b23a649902762d4c11d854d73c49c9b93138f2de16403ef9f571ad5bae"
 dependencies = [
  "fxhash",
  "getset",
@@ -2852,7 +2853,8 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?rev=5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7#5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
 dependencies = [
  "lazy_static",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,11 @@ openssl = { version = "0.10", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
 
 # Consensus related crates
-raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }
+raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
 prost = "0.11.8"
-raft-proto = {  git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false}
+raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false}
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -30,7 +30,7 @@ chrono = { version = "~0.4", features = ["serde"] }
 
 # Consensus related
 atomicwrites = { version = "0.4.0" }
-raft = { git = "https://github.com/tikv/raft-rs", rev = "5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7", features = ["prost-codec"], default-features = false }
+raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 prost = { version = "0.11.8" } # version of prost used by raft
 serde_cbor = { version = "0.11.2" }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -449,8 +449,9 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 Ok(false)
             }
 
-            ConsensusOperations::RequestSnapshot { .. }
-            | ConsensusOperations::ReportSnapshot { .. } => unreachable!(),
+            ConsensusOperations::RequestSnapshot | ConsensusOperations::ReportSnapshot { .. } => {
+                unreachable!()
+            }
         };
 
         if let Some(on_apply) = on_apply {

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -40,7 +40,7 @@ pub mod consensus_ops {
         },
         RemovePeer(PeerId),
         RequestSnapshot {
-            request_index: Option<u64>,
+            request_index: Option<u64>, // TODO: param is not used, kept for compatibility
         },
         ReportSnapshot {
             peer_id: PeerId,

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -39,9 +39,7 @@ pub mod consensus_ops {
             uri: String,
         },
         RemovePeer(PeerId),
-        RequestSnapshot {
-            request_index: Option<u64>, // TODO: param is not used, kept for compatibility
-        },
+        RequestSnapshot,
         ReportSnapshot {
             peer_id: PeerId,
             status: SnapshotStatus,
@@ -147,8 +145,8 @@ pub mod consensus_ops {
             )))
         }
 
-        pub fn request_snapshot(request_index: Option<u64>) -> Self {
-            Self::RequestSnapshot { request_index }
+        pub fn request_snapshot() -> Self {
+            Self::RequestSnapshot
         }
 
         pub fn report_snapshot(peer_id: PeerId, status: impl Into<SnapshotStatus>) -> Self {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -576,7 +576,7 @@ impl TableOfContent {
         })
     }
 
-    pub fn request_snapshot(&self, request_index: Option<u64>) -> Result<(), StorageError> {
+    pub fn request_snapshot(&self) -> Result<(), StorageError> {
         let sender = match &self.consensus_proposal_sender {
             Some(sender) => sender,
             None => {
@@ -586,7 +586,7 @@ impl TableOfContent {
             }
         };
 
-        sender.send(ConsensusOperations::request_snapshot(request_index))?;
+        sender.send(ConsensusOperations::request_snapshot())?;
 
         Ok(())
     }

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -26,7 +26,7 @@ async fn cluster_status(dispatcher: web::Data<Dispatcher>) -> impl Responder {
 #[post("/cluster/recover")]
 async fn recover_current_peer(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();
-    process_response(toc.request_snapshot(None).map(|_| true), timing)
+    process_response(toc.request_snapshot().map(|_| true), timing)
 }
 
 #[delete("/cluster/peer/{peer_id}")]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -479,9 +479,7 @@ impl Consensus {
                         log::debug!("Proposing network configuration change: {:?}", change);
                         self.node.propose_conf_change(uri.into_bytes(), change)
                     }
-                    ConsensusOperations::RequestSnapshot { request_index: _ } => {
-                        self.node.request_snapshot()
-                    }
+                    ConsensusOperations::RequestSnapshot => self.node.request_snapshot(),
                     ConsensusOperations::ReportSnapshot { peer_id, status } => {
                         self.node.report_snapshot(peer_id, status.into());
                         Ok(())

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -479,10 +479,8 @@ impl Consensus {
                         log::debug!("Proposing network configuration change: {:?}", change);
                         self.node.propose_conf_change(uri.into_bytes(), change)
                     }
-                    ConsensusOperations::RequestSnapshot { request_index } => {
-                        self.node.request_snapshot(
-                            request_index.unwrap_or_else(|| self.node.store().hard_state().commit),
-                        )
+                    ConsensusOperations::RequestSnapshot { request_index: _ } => {
+                        self.node.request_snapshot()
                     }
                     ConsensusOperations::ReportSnapshot { peer_id, status } => {
                         self.node.report_snapshot(peer_id, status.into());


### PR DESCRIPTION
We have been depending on a non released `raft-rs` version to enable updating Tonic and Prost https://github.com/qdrant/qdrant/pull/1285

A new version has been released containing our changes https://github.com/tikv/raft-rs/releases/tag/v0.7.0

This PR changes the dependency configuration to depend on the new version instead of a specific commit hash.

There is a change impacting us regarding requesting snapshots https://github.com/tikv/raft-rs/pull/499