### PR TITLE
doc: added steps to install Qdrant in local dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,48 @@ Make sure to mount it as a volume, otherwise docker will drop it with the contai
 
 Now Qdrant should be accessible at [localhost:6333](http://localhost:6333/).
 
+
+### Local development
+#### Linux/Debian
+To run Qdrant on local development environment you need to install below:
+- Install Rust, follow: [install rust](https://www.rust-lang.org/tools/install)
+- Install `rustfmt` toolchain for Rust 
+    ```shell
+    rustup component add rustfmt
+    ```
+- Install dependencies:
+    ```shell
+    sudo apt-get update -y 
+    sudo apt-get upgrade -y
+    sudo apt-get install -y curl unzip gcc-multilib \
+        clang cmake jq \
+        g++-9-aarch64-linux-gnu \
+        gcc-9-aarch64-linux-gnu
+    ```
+- Install `protoc` from source
+    ```shell
+    PROTOC_VERSION=22.2
+
+    # curl `proto` source file 
+    curl -LO https://github.com/protocolbuffers/protobuf/releases//download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip
+
+    unzip protoc-$PROTOC_VERSION-linux-x86_64.zip -d $HOME/.local
+
+    export PATH="$PATH:$HOME/.local/bin"
+
+    # remove source file if not needed
+    rm protoc-protoc-$PROTOC_VERSION-linux-x86_64.zip
+    
+    # check insalled `protoc` version
+    protoc --version
+    ```
+- Build and run the app
+    ```shell
+    cargo build --release --bin qdrant
+
+    ./target/release/qdrant
+    ```
+
 ## Docs 📓
 
 * The best place to start is [Quick Start Guide](https://github.com/qdrant/qdrant/blob/master/QUICK_START.md)

--- a/README.md
+++ b/README.md
@@ -199,47 +199,6 @@ Make sure to mount it as a volume, otherwise docker will drop it with the contai
 Now Qdrant should be accessible at [localhost:6333](http://localhost:6333/).
 
 
-### Local development
-#### Linux/Debian
-To run Qdrant on local development environment you need to install below:
-- Install Rust, follow: [install rust](https://www.rust-lang.org/tools/install)
-- Install `rustfmt` toolchain for Rust 
-    ```shell
-    rustup component add rustfmt
-    ```
-- Install dependencies:
-    ```shell
-    sudo apt-get update -y 
-    sudo apt-get upgrade -y
-    sudo apt-get install -y curl unzip gcc-multilib \
-        clang cmake jq \
-        g++-9-aarch64-linux-gnu \
-        gcc-9-aarch64-linux-gnu
-    ```
-- Install `protoc` from source
-    ```shell
-    PROTOC_VERSION=22.2
-
-    # curl `proto` source file 
-    curl -LO https://github.com/protocolbuffers/protobuf/releases//download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip
-
-    unzip protoc-$PROTOC_VERSION-linux-x86_64.zip -d $HOME/.local
-
-    export PATH="$PATH:$HOME/.local/bin"
-
-    # remove source file if not needed
-    rm protoc-protoc-$PROTOC_VERSION-linux-x86_64.zip
-    
-    # check insalled `protoc` version
-    protoc --version
-    ```
-- Build and run the app
-    ```shell
-    cargo build --release --bin qdrant
-
-    ./target/release/qdrant
-    ```
-
 ## Docs 📓
 
 * The best place to start is [Quick Start Guide](https://github.com/qdrant/qdrant/blob/master/QUICK_START.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,85 @@
 # Developer's guide to Qdrant
 
 
+## Build Qdrant
+
+### Docker 🐳
+
+Build your own from source
+
+```bash
+docker build . --tag=qdrant/qdrant
+```
+
+Or use latest pre-built image from [DockerHub](https://hub.docker.com/r/qdrant/qdrant)
+
+```bash
+docker pull qdrant/qdrant
+```
+
+To run the container, use the command:
+
+```bash
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+And once you need a fine-grained setup, you can also define a storage path and custom configuration:
+
+```bash
+docker run -p 6333:6333 \
+    -v $(pwd)/path/to/data:/qdrant/storage \
+    -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
+    qdrant/qdrant
+```
+
+* `/qdrant/storage` - is a place where Qdrant persists all your data. 
+Make sure to mount it as a volume, otherwise docker will drop it with the container. 
+* `/qdrant/config/production.yaml` - is the file with engine configuration. You can override any value from the [reference config](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) 
+
+Now Qdrant should be accessible at [localhost:6333](http://localhost:6333/).
+
+
+### Local development
+#### Linux/Debian
+To run Qdrant on local development environment you need to install below:
+- Install Rust, follow: [install rust](https://www.rust-lang.org/tools/install)
+- Install `rustfmt` toolchain for Rust 
+    ```shell
+    rustup component add rustfmt
+    ```
+- Install dependencies:
+    ```shell
+    sudo apt-get update -y 
+    sudo apt-get upgrade -y
+    sudo apt-get install -y curl unzip gcc-multilib \
+        clang cmake jq \
+        g++-9-aarch64-linux-gnu \
+        gcc-9-aarch64-linux-gnu
+    ```
+- Install `protoc` from source
+    ```shell
+    PROTOC_VERSION=22.2
+
+    # curl `proto` source file 
+    curl -LO https://github.com/protocolbuffers/protobuf/releases//download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip
+
+    unzip protoc-$PROTOC_VERSION-linux-x86_64.zip -d $HOME/.local
+
+    export PATH="$PATH:$HOME/.local/bin"
+
+    # remove source file if not needed
+    rm protoc-protoc-$PROTOC_VERSION-linux-x86_64.zip
+    
+    # check insalled `protoc` version
+    protoc --version
+    ```
+- Build and run the app
+    ```shell
+    cargo build --release --bin qdrant
+
+    ./target/release/qdrant
+    ```
+
 ## Profiling
 
 There are several benchmarks implemented in Qdrant. Benchmarks are not included in CI/CD and might take some time to execute.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,7 +69,7 @@ To run Qdrant on local development environment you need to install below:
     export PATH="$PATH:$HOME/.local/bin"
 
     # remove source file if not needed
-    rm protoc-protoc-$PROTOC_VERSION-linux-x86_64.zip
+    rm protoc-$PROTOC_VERSION-linux-x86_64.zip
     
     # check insalled `protoc` version
     protoc --version


### PR DESCRIPTION
### Documentation changes

After many trials to build and run Qdrant in my local machine and Gitpod, I preferred to add a guidance for how to prepare local development environment to build and run Qdrant.

I did test on below:
- My VM on KVM
```shell
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.2 LTS
Release:	22.04
Codename:	jammy
```
- Gitpod session
```shell
$  lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.6 LTS
Release:        20.04
Codename:       focal
```
