### PR TITLE
 add upload snapshot functionality using multipart request 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-multipart"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee489e3c01eae4d1c35b03c4493f71cb40d93f66b14558feb1b1a807671cc4e"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec592f234db8a253cf80531246a4407c8a70530423eea80688a6c5a44a110e7"
+dependencies = [
+ "darling",
+ "parse-size",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1162,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +2828,7 @@ version = "0.11.1"
 dependencies = [
  "actix-cors",
  "actix-files",
+ "actix-multipart",
  "actix-web",
  "anyhow",
  "api",
@@ -3433,6 +3519,15 @@ checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = [ "web", "parking_lot" ]
+default = ["web", "parking_lot"]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
@@ -68,6 +68,7 @@ segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }
 storage = { path = "lib/storage" }
 api = { path = "lib/api" }
+actix-multipart = "0.6.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1350,6 +1350,101 @@
         }
       }
     },
+    "/collections/{collection_name}/snapshots/upload": {
+      "post": {
+        "tags": [
+          "snapshots",
+          "collections"
+        ],
+        "summary": "Recover from an uploaded snapshot",
+        "description": "Recover local collection data from an uploaded snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.",
+        "operationId": "recover_from_uploaded_snapshot",
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Snapshot to recover from",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "snapshot": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/snapshots/recover": {
       "put": {
         "tags": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1377,6 +1377,15 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "description": "Defines source of truth for snapshot recovery",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/SnapshotPriority"
+            }
           }
         ],
         "requestBody": {

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -12,7 +12,7 @@ use crate::operations::types::CollectionResult;
 /// Defines source of truth for snapshot recovery
 /// `Snapshot` means - prefer snapshot data over the current state
 /// `Replica` means - prefer existing data over the snapshot
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SnapshotPriority {
     Snapshot,
@@ -32,15 +32,6 @@ pub struct SnapshotRecover {
     /// If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.
     #[serde(default)]
     pub priority: Option<SnapshotPriority>,
-}
-
-impl SnapshotRecover {
-    pub fn from_url(location: Url) -> Self {
-        Self {
-            location,
-            priority: Some(SnapshotPriority::default()),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -34,6 +34,15 @@ pub struct SnapshotRecover {
     pub priority: Option<SnapshotPriority>,
 }
 
+impl SnapshotRecover {
+    pub fn from_url(location: Url) -> Self {
+        Self {
+            location,
+            priority: Some(SnapshotPriority::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SnapshotDescription {
     pub name: String,

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -43,3 +43,4 @@ uuid = "1.3.0"
 url = "2.3.1"
 reqwest = { version = "0.11", features = ["stream", "rustls-tls"] }
 openssl = { version = "0.10", features = ["vendored"] }
+tempfile = "3.4.0"

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -3,6 +3,7 @@ use std::io::Error as IoError;
 
 use collection::operations::types::CollectionError;
 use segment::common::file_operations::FileStorageError;
+use tempfile::PersistError;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
@@ -226,6 +227,15 @@ impl From<tokio::task::JoinError> for StorageError {
     fn from(err: tokio::task::JoinError) -> Self {
         StorageError::ServiceError {
             description: format!("Tokio task join error: {err}"),
+            backtrace: Some(Backtrace::force_capture().to_string()),
+        }
+    }
+}
+
+impl From<PersistError> for StorageError {
+    fn from(err: PersistError) -> Self {
+        StorageError::ServiceError {
+            description: err.to_string(),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -235,7 +235,7 @@ impl From<tokio::task::JoinError> for StorageError {
 impl From<PersistError> for StorageError {
     fn from(err: PersistError) -> Self {
         StorageError::ServiceError {
-            description: err.to_string(),
+            description: format!("Persist error: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -22,6 +22,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: priority
+          in: query
+          description: "Defines source of truth for snapshot recovery"
+          required: false
+          schema:
+            $ref: "#/components/schemas/SnapshotPriority"
       requestBody:
         description: Snapshot to recover from
         content:

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -1,6 +1,38 @@
 #@ load("openapi.lib.yml", "response", "reference", "type", "array")
 
 paths:
+  /collections/{collection_name}/snapshots/upload:
+    post:
+      tags:
+        - snapshots
+        - collections
+      summary: Recover from an uploaded snapshot
+      description: Recover local collection data from an uploaded snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.
+      operationId: recover_from_uploaded_snapshot
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection
+          required: true
+          schema:
+            type: string
+        - name: wait
+          in: query
+          description: "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true."
+          required: false
+          schema:
+            type: boolean
+      requestBody:
+        description: Snapshot to recover from
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                snapshot:
+                  type: string
+                  format: binary
+      responses: #@ response(type("boolean"))
   /collections/{collection_name}/snapshots/recover:
     put:
       tags:

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -98,9 +98,7 @@ async fn upload_snapshot(
         collection_name,
         snapshot.file_name.unwrap()
     );
-    println!("saving file at: {path}");
     snapshot.file.persist(&path).unwrap();
-    println!("saved successfully, restoring");
     let snapshot_location = Url::from_file_path(format!("file://{path}")).unwrap();
     let snapshot_recover = SnapshotRecover::from_url(snapshot_location);
     let response = do_recover_from_snapshot(

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
+use actix_multipart::form::tempfile::TempFileConfig;
 use actix_web::middleware::{Compress, Condition, Logger};
 use actix_web::web::Data;
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
@@ -85,6 +86,7 @@ pub fn init(
                         .limit(settings.service.max_request_size_mb * 1024 * 1024)
                         .error_handler(json_error_handler),
                 ))
+                .app_data(TempFileConfig::default().directory(dispatcher_data.snapshots_path()))
                 .service(index)
                 .configure(config_collections_api)
                 .configure(config_snapshots_api)

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
 use actix_cors::Cors;
 use actix_multipart::form::tempfile::TempFileConfig;
+use actix_multipart::form::MultipartFormConfig;
 use actix_web::middleware::{Compress, Condition, Logger};
 use actix_web::web::Data;
 use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
@@ -87,6 +88,7 @@ pub fn init(
                         .error_handler(json_error_handler),
                 ))
                 .app_data(TempFileConfig::default().directory(dispatcher_data.snapshots_path()))
+                .app_data(MultipartFormConfig::default().total_limit(usize::MAX))
                 .service(index)
                 .configure(config_collections_api)
                 .configure(config_snapshots_api)

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -1,0 +1,160 @@
+import pathlib
+
+import requests
+from .fixtures import create_collection, upsert_random_points, random_vector, search
+from .utils import *
+from .assertions import assert_http_ok
+import time
+
+N_PEERS = 3
+N_SHARDS = 3
+COLLECTION_NAME = "test_collection"
+
+
+def create_snapshot(peer_api_uri):
+    r = requests.post(
+        f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots")
+    assert_http_ok(r)
+    return r.json()["result"]["name"]
+
+
+def get_peer_id(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["peer_id"]
+
+
+def get_local_shards(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["local_shards"]
+
+
+def get_remote_shards(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+    assert_http_ok(r)
+    return r.json()["result"]["remote_shards"]
+
+
+def recover_snapshot(peer_api_uri, snapshot_url):
+    r = requests.put(
+        f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/recover",
+        json={"location": snapshot_url},
+    )
+    assert_http_ok(r)
+    return r.json()["result"]
+
+
+def upload_snapshot(peer_api_uri, snapshot_path):
+    with open(snapshot_path, "rb") as f:
+        print(f"uploading {snapshot_path} to {peer_api_uri}")
+        snapshot_file = {"snapshot": f}
+        r = requests.post(
+            f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/upload",
+            files=snapshot_file,
+        )
+        assert_http_ok(r)
+        return r.json()["result"]
+
+
+def test_upload_snapshot_1(tmp_path: pathlib.Path):
+    recover_from_uploaded_snapshot(tmp_path, 1)
+
+
+def test_upload_snapshot_2(tmp_path: pathlib.Path):
+    recover_from_uploaded_snapshot(tmp_path, 2)
+
+
+def recover_from_uploaded_snapshot(tmp_path: pathlib.Path, n_replicas):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(
+        peer_api_uris[0], shard_number=N_SHARDS, replication_factor=n_replicas
+    )
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name="test_collection", peer_api_uris=peer_api_uris
+    )
+    upsert_random_points(peer_api_uris[0], 100)
+
+    query_city = "London"
+    query_vector = random_vector()
+
+    search_result = search(peer_api_uris[0], query_vector, query_city)
+    assert len(search_result) > 0
+
+    snapshot_name = create_snapshot(peer_api_uris[-1])
+    assert snapshot_name is not None
+
+    # move file
+    snapshot_path = Path(peer_dirs[-1]) / \
+        "snapshots" / COLLECTION_NAME / snapshot_name
+    assert snapshot_path.exists()
+
+    process_peer_id = get_peer_id(peer_api_uris[-1])
+    local_shards = get_local_shards(peer_api_uris[-1])
+
+    # Kill last peer
+    p = processes.pop()
+    p.kill()
+
+    # Remove last peer from cluster
+    res = requests.delete(
+        f"{peer_api_uris[0]}/cluster/peer/{process_peer_id}?force=true"
+    )
+    assert_http_ok(res)
+
+    new_peer_dir = make_peer_folder(tmp_path, N_PEERS + 1)
+    new_url = start_peer(
+        new_peer_dir, f"peer_snapshot_{N_PEERS + 1}.log", bootstrap_uri
+    )
+
+    # Wait node is up and synced
+    while True:
+        try:
+            res = requests.get(f"{new_url}/collections")
+        except requests.exceptions.ConnectionError:
+            time.sleep(1)
+            continue
+        if not res.ok:
+            time.sleep(1)  # Wait to node is up
+            continue
+        collections = set(
+            collection["name"] for collection in res.json()["result"]["collections"]
+        )
+        if COLLECTION_NAME not in collections:
+            time.sleep(1)  # Wait to sync with consensus
+            continue
+        break
+
+    # Recover snapshot
+    # All nodes share the same snapshot directory, so it is fine to use any
+
+    print(f"Recovering snapshot {snapshot_path} on {new_url}")
+    upload_snapshot(new_url, snapshot_path)
+
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=[new_url]
+    )
+
+    new_local_shards = get_local_shards(new_url)
+
+    new_local_shards = sorted(new_local_shards, key=lambda x: x["shard_id"])
+    local_shards = sorted(local_shards, key=lambda x: x["shard_id"])
+
+    assert len(new_local_shards) == len(local_shards)
+    for i in range(len(new_local_shards)):
+        assert new_local_shards[i] == local_shards[i]
+
+    new_search_result = search(new_url, query_vector, query_city)
+
+    assert len(new_search_result) == len(search_result)
+    for i in range(len(new_search_result)):
+        assert new_search_result[i] == search_result[i]
+
+    peer_0_remote_shards_new = get_remote_shards(peer_api_uris[0])
+    for shard in peer_0_remote_shards_new:
+        print("remote shard", shard)
+        assert shard["state"] == "Active"
+    assert len(peer_0_remote_shards_new) == 2 * n_replicas

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -36,15 +36,6 @@ def get_remote_shards(peer_api_uri):
     return r.json()["result"]["remote_shards"]
 
 
-def recover_snapshot(peer_api_uri, snapshot_url):
-    r = requests.put(
-        f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/recover",
-        json={"location": snapshot_url},
-    )
-    assert_http_ok(r)
-    return r.json()["result"]
-
-
 def upload_snapshot(peer_api_uri, snapshot_path):
     with open(snapshot_path, "rb") as f:
         print(f"uploading {snapshot_path} to {peer_api_uri}")


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

This PR is related to #1567
I added the upload functionality using _actix-multipart_ with as little changes as possible. I tried not to dive in too deep and make a bunch of changes in my first pull request without consulting the mentors first.

This solution is far from optimal. Off the top of my head, I think it can be improved by not having to write the snapshot file to disk and restore it from memory. This would require some changes in the recovery logic to make it work that way (didn't look thoroughly into that but I'm willing to, if it's suitable).

Also the use of a `tempfile` then persisting it to the disk makes it look like it's writing the file twice. I checked that by tracing the system-calls it makes and apparently it just renames the old file so no additional disk load. 

I couldn't test the patch since I can't run it in distributed mode, so any help regarding that is highly appreciated.