### PR TITLE
Increase drop data timeout to accomodate larger segments

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -19,7 +19,7 @@ use crate::operations::types::CollectionError;
 pub type SegmentId = usize;
 
 const DROP_SPIN_TIMEOUT: Duration = Duration::from_millis(10);
-const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(10);
+const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Object, which unifies the access to different types of segments, but still allows to
 /// access the original type of the segment if it is required for more efficient operations.


### PR DESCRIPTION
This PR is a workaround for https://github.com/qdrant/qdrant/issues/1573

I tried reproducing the issue with a similar setup
- 36M vectors
- memmap_threshold=250000
- toggling the indexing on and off

I was not able to get the same error, I have however some supporting data.

While running the tests, I would be logging the time spent to acquire and unwrap the segment as the last owner.

Most of the time I would get values around 100ms but from time to time, I'd get really high values.

The highest witnessed were 5954ms and 2414ms which are pretty close to the 10 sec max wait time.

For the time being, I propose to increase the max wait time to 1 minute to accommodate large segments. 