### PR TITLE
Handle ties scores in test assertions

### DIFF
--- a/lib/segment/tests/utils/mod.rs
+++ b/lib/segment/tests/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod scored_point_ties;

--- a/lib/segment/tests/utils/scored_point_ties.rs
+++ b/lib/segment/tests/utils/scored_point_ties.rs
@@ -1,0 +1,42 @@
+use std::cmp::Ordering;
+
+use ordered_float::OrderedFloat;
+use segment::types::ScoredPoint;
+
+// Newtype to provide alternative comparator for ScoredPoint which breaks ties by id
+pub struct ScoredPointTies {
+    pub scored_point: ScoredPoint,
+}
+
+impl From<ScoredPoint> for ScoredPointTies {
+    fn from(scored_point: ScoredPoint) -> Self {
+        ScoredPointTies { scored_point }
+    }
+}
+
+impl Ord for ScoredPointTies {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let res =
+            OrderedFloat(self.scored_point.score).cmp(&OrderedFloat(other.scored_point.score));
+        // for identical scores, we fallback to sorting by ids to have a stable output
+        if res == Ordering::Equal {
+            self.scored_point.id.cmp(&other.scored_point.id)
+        } else {
+            res
+        }
+    }
+}
+
+impl PartialOrd for ScoredPointTies {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for ScoredPointTies {}
+
+impl PartialEq for ScoredPointTies {
+    fn eq(&self, other: &Self) -> bool {
+        self.scored_point == other.scored_point
+    }
+}


### PR DESCRIPTION
This PR tackles the flaky test described in https://github.com/qdrant/qdrant/issues/534

The root issue is that the current test assertion does not handle the case where points have identical scores but with different positions.

To fix the issue, this PR introduces test infrastructure to provide a deterministic sort of scored points by breaking ties on point id.