### PR TITLE
Add aggregated vector count to prometheus /metrics endpoint

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -110,6 +110,17 @@ impl MetricsProvider for CollectionsTelemetry {
                 .iter()
                 .filter(|p| matches!(p, CollectionTelemetryEnum::Aggregated(_)))
                 .count();
+            let aggregated_vector_count = collections
+                .iter()
+                .filter_map({
+                    |p| match p {
+                        CollectionTelemetryEnum::Aggregated(telemetry_data) => {
+                            Some(telemetry_data.vectors)
+                        }
+                        _ => None,
+                    }
+                })
+                .sum::<usize>();
             metrics.push(metric_family(
                 "collections_full_total",
                 "number of full collections",
@@ -121,6 +132,12 @@ impl MetricsProvider for CollectionsTelemetry {
                 "number of aggregated collections",
                 MetricType::GAUGE,
                 vec![gauge(aggregated_count as f64, &[])],
+            ));
+            metrics.push(metric_family(
+                "collections_aggregated_vector_total",
+                "total number of vectors in all collections",
+                MetricType::GAUGE,
+                vec![gauge(aggregated_vector_count as f64, &[])],
             ));
         }
     }


### PR DESCRIPTION
This is a partial implementation of #1583. Should the base branch be master or dev?

New to the codebase, figured observability would touch a couple of points.

This PR implements an aggregated total of all vectors across collections for Prometheus on /metrics.  I only implemented it on detail level 1. More would need some refactoring to avoid duplication on the aggregate telemetry itself. Consider this WIP. Would propose to scope it to vector count only to keep the PR small.

Couple considerations:
* Conceptually, why is there a need for the aggregated telemetry? From the code it still looks to dive into the collections. Future performance?
* Would love to add proper tests; are the integration tests ok for this?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
