### PR TITLE
Increase timeout for rejoin cluster test

### DIFF
--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -28,7 +28,7 @@ def upsert_random_points(peer_url, num, collection_name="test_collection", fail_
 
 
 def create_collection(peer_url, collection="test_collection", shard_number=1, replication_factor=1, timeout=10):
-    # Create collection in first peer
+    # Create collection in peer_url
     r_batch = requests.put(
         f"{peer_url}/collections/{collection}?timeout={timeout}", json={
             "vectors": {
@@ -42,7 +42,7 @@ def create_collection(peer_url, collection="test_collection", shard_number=1, re
 
 
 def drop_collection(peer_url, collection="test_collection", timeout=10):
-    # Create collection in first peer
+    # Delete collection in peer_url
     r_batch = requests.delete(
         f"{peer_url}/collections/{collection}?timeout={timeout}")
     assert_http_ok(r_batch)

--- a/tests/consensus_tests/test_cluster_rejoin.py
+++ b/tests/consensus_tests/test_cluster_rejoin.py
@@ -11,15 +11,14 @@ N_SHARDS = 3
 
 def test_rejoin_cluster(tmp_path: pathlib.Path):
     assert_project_root()
-
+    # Start cluster
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, port_seed=10000)
-
-    print("cluster started")
 
     create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA)
     wait_collection_exists_and_active_on_all_peers(collection_name="test_collection", peer_api_uris=peer_api_uris)
     upsert_random_points(peer_api_uris[0], 100)
 
+    # Stop last node
     p = processes.pop()
     p.kill()
 
@@ -29,16 +28,20 @@ def test_rejoin_cluster(tmp_path: pathlib.Path):
     # Assert that there are dead replicas
     wait_for_some_replicas_not_active(peer_api_uris[0], "test_collection")
 
+    # Repeatedly drop, re-create collection and add data to it to accumulate Raft log entries
     for i in range(0, 2):
         print(f"creating collection {i}")
-        drop_collection(peer_api_uris[0], timeout=3)
+        # Drop test_collection
+        drop_collection(peer_api_uris[0], "test_collection", timeout=5)
+        # Re-create test_collection
         create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
         # Collection might not be ready yet, we don't care
         upsert_random_points(peer_api_uris[0], 100)
-        print(f"after recovery end {i}")
+        print(f"before recovery end {i}")
         res = requests.get(f"{peer_api_uris[1]}/collections")
         print(res.json())
 
+    # Create new collection unknown to the dead node
     create_collection(
         peer_api_uris[0],
         "test_collection2",
@@ -47,15 +50,20 @@ def test_rejoin_cluster(tmp_path: pathlib.Path):
         timeout=3
     )
 
+    # Restart last node
     new_url = start_peer(peer_dirs[-1], f"peer_0_restarted.log", bootstrap_uri, port=20000)
 
     peer_api_uris[-1] = new_url
 
+    # Wait for restarted node to be up and ready
     wait_all_peers_up([new_url])
 
+    # Repeatedly drop, re-create collection and add data to it to accumulate Raft log entries
     for i in range(0, 5):
         print(f"after recovery start {i}")
-        drop_collection(peer_api_uris[0], timeout=3)
+        # Drop test_collection
+        drop_collection(peer_api_uris[0], "test_collection", timeout=5)
+        # Re-create test_collection
         create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
         upsert_random_points(peer_api_uris[0], 500, fail_on_error=False)
         print(f"after recovery end {i}")
@@ -63,4 +71,5 @@ def test_rejoin_cluster(tmp_path: pathlib.Path):
         print(res.json())
 
     wait_for_all_replicas_active(peer_api_uris[0], "test_collection2")
+    # Assert that the restarted node has recovered the new collection
     wait_for_all_replicas_active(new_url, "test_collection2")

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -258,6 +258,7 @@ def all_nodes_cluster_info_consistent(peer_api_uris: [str], expected_leader: str
             return False
     return True
 
+
 def all_nodes_respond(peer_api_uris: [str]) -> bool:
     for uri in peer_api_uris:
         try:
@@ -351,6 +352,7 @@ def wait_for_uniform_cluster_status(peer_api_uris: [str], expected_leader: str):
     except Exception as e:
         print_clusters_info(peer_api_uris)
         raise e
+
 
 def wait_all_peers_up(peer_api_uris: [str]):
     try:


### PR DESCRIPTION
This PR increases the timeout in the consensus rejoin cluster test following a failure on CI.

https://github.com/qdrant/qdrant/actions/runs/4501309023/jobs/7921564227?pr=1597

Checking the logs, it seems all nodes where making progress, I could not spot a clear issue.

Given that it is the first time this issue appears, I simply propose to raise the timeout for the `drop_collection` operations from 3 secs to 5 secs.