### PR TITLE
[WIP] Nested object filter

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -21,10 +21,10 @@ use crate::grpc::qdrant::{
     with_vectors_selector, CollectionDescription, CollectionOperationResponse, Condition, Distance,
     FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoRadius, HasIdCondition, HealthCheckReply,
     HnswConfigDiff, IsEmptyCondition, ListCollectionsResponse, ListValue, Match, NamedVectors,
-    NestedFilter, PayloadExcludeSelector, PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo,
-    PayloadSchemaType, PointId, QuantizationConfig, QuantizationSearchParams, Range,
-    ScalarQuantization, ScoredPoint, SearchParams, Struct, TextIndexParams, TokenizerType, Value,
-    ValuesCount, Vector, Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
+    NestedFilter, PayloadExcludeSelector, PayloadIncludeSelector, PayloadIndexParams,
+    PayloadSchemaInfo, PayloadSchemaType, PointId, QuantizationConfig, QuantizationSearchParams,
+    Range, ScalarQuantization, ScoredPoint, SearchParams, Struct, TextIndexParams, TokenizerType,
+    Value, ValuesCount, Vector, Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
 };
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -342,6 +342,12 @@ message Filter {
   repeated Condition should = 1; // At least one of those conditions should match
   repeated Condition must = 2; // All conditions must match
   repeated Condition must_not = 3; // All conditions must NOT match
+  optional NestedFilter nested = 4; // Nested filter
+}
+
+message NestedFilter {
+  string path = 1; // Path to nested object
+  Filter filter = 2; // Filter condition
 }
 
 message Condition {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2303,6 +2303,19 @@ pub struct Filter {
     /// All conditions must NOT match
     #[prost(message, repeated, tag = "3")]
     pub must_not: ::prost::alloc::vec::Vec<Condition>,
+    /// Nested filter
+    #[prost(message, optional, boxed, tag = "4")]
+    pub nested: ::core::option::Option<::prost::alloc::boxed::Box<NestedFilter>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NestedFilter {
+    /// Path to nested object
+    #[prost(string, tag = "1")]
+    pub path: ::prost::alloc::string::String,
+    /// Filter condition
+    #[prost(message, optional, boxed, tag = "2")]
+    pub filter: ::core::option::Option<::prost::alloc::boxed::Box<Filter>>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -295,6 +295,7 @@ where
                 must_not: Some(vec![Condition::HasId(HasIdCondition {
                     has_id: reference_vectors_ids.iter().cloned().collect(),
                 })]),
+                nested: None, // TODO: support nested filters
             }),
             with_payload: request.with_payload.clone(),
             with_vector: request.with_vector.clone(),

--- a/lib/collection/tests/collection_test.rs
+++ b/lib/collection/tests/collection_test.rs
@@ -452,6 +452,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
         should: None,
         must: Some(vec![Condition::HasId(HasIdCondition::from(to_be_deleted))]),
         must_not: None,
+        nested: None,
     };
 
     let delete_points = CollectionUpdateOperations::PointOperation(

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -187,6 +187,7 @@ pub fn random_must_filter<R: Rng + ?Sized>(rnd_gen: &mut R, num_conditions: usiz
         should: None,
         must: Some(must_conditions),
         must_not: None,
+        nested: None,
     }
 }
 
@@ -218,6 +219,7 @@ pub fn random_filter<R: Rng + ?Sized>(rnd_gen: &mut R, total_conditions: usize) 
         should: should_conditions_opt,
         must: must_conditions_opt,
         must_not: None,
+        nested: None,
     }
 }
 
@@ -236,6 +238,7 @@ pub fn random_nested_filter<R: Rng + ?Sized>(rnd_gen: &mut R) -> Filter {
         should: Some(vec![condition]),
         must: None,
         must_not: None,
+        nested: None,
     }
 }
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -118,6 +118,14 @@ where
         }
     }
 
+    // TODO nested test
+    match &filter.nested {
+        None => {}
+        Some(nested_filter) => {
+            filter_estimations.push(estimate_filter(estimator, &nested_filter.filter, total))
+        }
+    }
+
     combine_must_estimations(&filter_estimations, total)
 }
 
@@ -253,6 +261,7 @@ mod tests {
                 test_condition("un-indexed".to_owned()),
             ]),
             must_not: None,
+            nested: None,
         };
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);
@@ -276,6 +285,7 @@ mod tests {
             ]),
             must: None,
             must_not: None,
+            nested: None,
         };
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);
@@ -295,6 +305,7 @@ mod tests {
             ]),
             must: None,
             must_not: None,
+            nested: None,
         };
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);
@@ -316,6 +327,7 @@ mod tests {
                         test_condition("size".to_owned()),
                     ]),
                     must_not: None,
+                    nested: None,
                 }),
                 Condition::Filter(Filter {
                     should: None,
@@ -324,12 +336,14 @@ mod tests {
                         test_condition("size".to_owned()),
                     ]),
                     must_not: None,
+                    nested: None,
                 }),
             ]),
             must: None,
             must_not: Some(vec![Condition::HasId(HasIdCondition {
                 has_id: HashSet::from_iter([1, 2, 3, 4, 5].into_iter().map(|x| x.into())),
             })]),
+            nested: None,
         };
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);
@@ -351,6 +365,7 @@ mod tests {
                         test_condition("size".to_owned()),
                     ]),
                     must_not: None,
+                    nested: None,
                 }),
                 Condition::Filter(Filter {
                     must: None,
@@ -359,11 +374,13 @@ mod tests {
                         test_condition("size".to_owned()),
                     ]),
                     must_not: None,
+                    nested: None,
                 }),
             ]),
             must_not: Some(vec![Condition::HasId(HasIdCondition {
                 has_id: HashSet::from_iter([1, 2, 3, 4, 5].into_iter().map(|x| x.into())),
             })]),
+            nested: None,
         };
 
         let estimation = estimate_filter(&test_estimator, &query, TOTAL);

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -15,12 +15,41 @@ pub struct OptimizedFilter<'a> {
     pub must: Option<Vec<OptimizedCondition<'a>>>,
     /// All conditions must NOT match
     pub must_not: Option<Vec<OptimizedCondition<'a>>>,
+    /// Nested object filter
+    pub nested: Option<Box<NestedOptimizedFilter<'a>>>,
+}
+
+pub struct NestedOptimizedFilter<'a> {
+    pub path: &'a str,
+    pub filter: OptimizedFilter<'a>,
 }
 
 pub fn check_optimized_filter(filter: &OptimizedFilter, point_id: PointOffsetType) -> bool {
     check_should(&filter.should, point_id)
         && check_must(&filter.must, point_id)
         && check_must_not(&filter.must_not, point_id)
+        && check_nested(&filter.nested, point_id)
+}
+
+fn check_nested(nested: &Option<Box<NestedOptimizedFilter>>, point_id: PointOffsetType) -> bool {
+    match nested {
+        None => true,
+        Some(nested) => {
+            // TODO so far only one level of nesting is supported on `must`
+            let _path = nested.path;
+            nested.filter.must.as_ref().map_or(true, |must| {
+                must.iter().any(|condition| match condition {
+                    OptimizedCondition::Filter(_filter) => {
+                        unreachable!("no nested filter in nested object filter");
+                    }
+                    OptimizedCondition::Checker(checker) => {
+                        eprintln!("nested condition checker");
+                        checker(point_id)
+                    }
+                })
+            })
+        }
+    }
 }
 
 fn check_condition(condition: &OptimizedCondition, point_id: PointOffsetType) -> bool {

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -44,6 +44,7 @@ pub fn optimize_filter<'a, F>(
     payload_provider: PayloadProvider,
     estimator: &F,
     total: usize,
+    nested_path: Option<&'a str>,
 ) -> (OptimizedFilter<'a>, CardinalityEstimation)
 where
     F: Fn(&Condition) -> CardinalityEstimation,
@@ -76,6 +77,7 @@ where
                     payload_provider.clone(),
                     estimator,
                     total,
+                    nested_path,
                 );
                 filter_estimations.push(estimation);
                 Some(optimized_conditions)
@@ -107,6 +109,7 @@ where
                 payload_provider.clone(),
                 estimator,
                 total,
+                Some(nested.path.as_ref()),
             );
             filter_estimations.push(estimation);
             let nested_optimized_filter = NestedOptimizedFilter {
@@ -130,6 +133,7 @@ fn convert_conditions<'a, F>(
     payload_provider: PayloadProvider,
     estimator: &F,
     total: usize,
+    nested_path: Option<&'a str>,
 ) -> Vec<(OptimizedCondition<'a>, CardinalityEstimation)>
 where
     F: Fn(&Condition) -> CardinalityEstimation,
@@ -145,6 +149,7 @@ where
                     payload_provider.clone(),
                     estimator,
                     total,
+                    nested_path,
                 );
                 (OptimizedCondition::Filter(optimized_filter), estimation)
             }
@@ -155,6 +160,7 @@ where
                     field_indexes,
                     payload_provider.clone(),
                     id_tracker,
+                    nested_path,
                 );
                 (OptimizedCondition::Checker(condition_checker), estimation)
             }
@@ -180,6 +186,7 @@ where
         payload_provider,
         estimator,
         total,
+        None,
     );
     // More probable conditions first
     converted.sort_by_key(|(_, estimation)| Reverse(estimation.exp));
@@ -195,6 +202,7 @@ fn optimize_must<'a, F>(
     payload_provider: PayloadProvider,
     estimator: &F,
     total: usize,
+    nested_path: Option<&'a str>,
 ) -> (Vec<OptimizedCondition<'a>>, CardinalityEstimation)
 where
     F: Fn(&Condition) -> CardinalityEstimation,
@@ -206,6 +214,7 @@ where
         payload_provider,
         estimator,
         total,
+        nested_path,
     );
     // Less probable conditions first
     converted.sort_by_key(|(_, estimation)| estimation.exp);
@@ -232,6 +241,7 @@ where
         payload_provider,
         estimator,
         total,
+        None,
     );
     // More probable conditions first, as it will be reverted
     converted.sort_by_key(|(_, estimation)| estimation.exp);

--- a/lib/segment/src/index/struct_filter_context.rs
+++ b/lib/segment/src/index/struct_filter_context.rs
@@ -29,6 +29,7 @@ impl<'a> StructFilterContext<'a> {
             payload_provider,
             estimator,
             total,
+            None,
         );
 
         Self { optimized_filter }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -341,8 +341,9 @@ impl PayloadIndex for StructPayloadIndex {
         query: &'a Filter,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-
+        eprintln!("query_point: {:?}", query);
         let query_cardinality = self.estimate_cardinality(query);
+        eprintln!("query_cardinality: {:?}", query_cardinality);
         return if query_cardinality.primary_clauses.is_empty() {
             let full_scan_iterator =
                 ArcAtomicRefCellIterator::new(self.id_tracker.clone(), |points_iterator| {

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -94,6 +94,7 @@ mod tests {
                 )),
             ]),
             must_not: None,
+            nested: None,
         };
 
         // Example:

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -87,7 +87,7 @@ where
 {
     let checker = |condition: &Condition| match condition {
         Condition::Field(field_condition) => {
-            check_field_condition(field_condition, get_payload().deref())
+            check_field_condition(field_condition, get_payload().deref(), None)
         }
         Condition::IsEmpty(is_empty) => check_is_empty_condition(is_empty, get_payload().deref()),
         Condition::HasId(has_id) => {
@@ -107,8 +107,16 @@ pub fn check_is_empty_condition(is_empty: &IsEmptyCondition, payload: &Payload) 
     payload.get_value(&is_empty.is_empty.key).is_empty()
 }
 
-pub fn check_field_condition(field_condition: &FieldCondition, payload: &Payload) -> bool {
-    let field_values = payload.get_value(&field_condition.key);
+pub fn check_field_condition(
+    field_condition: &FieldCondition,
+    payload: &Payload,
+    nested_path: Option<&str>,
+) -> bool {
+    let full_path = match nested_path {
+        None => field_condition.key.clone(),
+        Some(path) => format!("{}.{}", path, field_condition.key),
+    };
+    let field_values = payload.get_value(&full_path);
     eprintln!(
         "field_values: {:#?} for condition {:?}",
         field_values, field_condition

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -832,10 +832,12 @@ impl SegmentEntry for Segment {
                 .take(limit.unwrap_or(usize::MAX))
                 .collect(),
             Some(condition) => {
+                eprintln!("read_filtered: {:?}", condition);
                 let query_cardinality = {
                     let payload_index = self.payload_index.borrow();
                     payload_index.estimate_cardinality(condition)
                 };
+                eprintln!("query_cardinality: {:?}", query_cardinality);
 
                 // ToDo: Add telemetry for this heuristics
 
@@ -866,7 +868,7 @@ impl SegmentEntry for Segment {
                 // use `query cardinality` as a starting point.
                 let exp_index_checks = query_cardinality.max;
 
-                if exp_stream_checks > exp_index_checks {
+                if dbg!(exp_stream_checks > exp_index_checks) {
                     self.filtered_read_by_index(offset, limit, condition)
                 } else {
                     self.filtered_read_by_id_stream(offset, limit, condition)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1285,6 +1285,17 @@ pub struct Filter {
     pub must: Option<Vec<Condition>>,
     /// All conditions must NOT match
     pub must_not: Option<Vec<Condition>>,
+    /// Nested filters
+    pub nested: Option<Box<NestedFilter>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct NestedFilter {
+    pub path: String,
+    #[serde(flatten)]
+    pub filter: Filter,
 }
 
 impl Filter {
@@ -1293,6 +1304,7 @@ impl Filter {
             should: Some(vec![condition]),
             must: None,
             must_not: None,
+            nested: None,
         }
     }
 
@@ -1301,6 +1313,7 @@ impl Filter {
             should: None,
             must: Some(vec![condition]),
             must_not: None,
+            nested: None,
         }
     }
 
@@ -1309,6 +1322,7 @@ impl Filter {
             should: None,
             must: None,
             must_not: Some(vec![condition]),
+            nested: None,
         }
     }
 }
@@ -1351,6 +1365,7 @@ mod tests {
             ))]),
             must_not: None,
             should: None,
+            nested: None,
         };
         let json = serde_json::to_string_pretty(&filter).unwrap();
         eprintln!("{json}")
@@ -1523,6 +1538,37 @@ mod tests {
                 value: ValueVariants::Keyword("world".to_owned())
             })
         );
+    }
+
+    #[test]
+    fn test_parse_nested_filter_query() {
+        let query = r#"
+        {
+           "nested": {
+              "path": "country.cities[]",
+              "must": [
+                  {
+                      "key": "country.cities[].sightseeing",
+                      "values_count": {
+                          "gt": 2
+                      }
+                  }
+              ]
+            }
+        }
+        "#;
+        let result: Filter = serde_json::from_str(query).unwrap();
+        let nested_filter = result.nested.unwrap();
+        assert_eq!(nested_filter.path, "country.cities[]");
+        let musts = nested_filter.filter.must.unwrap();
+        assert_eq!(musts.len(), 1);
+        let condition = musts.get(0).unwrap();
+        match condition {
+            Condition::Field(field) => {
+                assert_eq!(field.key, "country.cities[].sightseeing");
+            }
+            _ => panic!("Condition expected"),
+        }
     }
 
     #[test]

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -416,6 +416,7 @@ mod tests {
                 should: None,
                 must: Some(vec![condition]),
                 must_not: None,
+                nested: None,
             };
 
             let plain_result = plain_segment

--- a/lib/segment/tests/segment_tests.rs
+++ b/lib/segment/tests/segment_tests.rs
@@ -44,6 +44,7 @@ mod tests {
             should: None,
             must: None,
             must_not: Some(vec![Condition::HasId(ids.into())]),
+            nested: None,
         };
 
         let res = segment
@@ -101,6 +102,7 @@ mod tests {
             should: None,
             must: None,
             must_not: Some(vec![Condition::HasId(ids.into())]),
+            nested: None,
         };
 
         let res = segment

--- a/openapi/tests/run_docker.sh
+++ b/openapi/tests/run_docker.sh
@@ -14,5 +14,5 @@ cd "$(dirname "$0")"
 
 trap clear_after_tests EXIT
 
-pytest -s openapi_integration/test_nested_payload_indexing.py
-#pytest -s
+#pytest -s openapi_integration/test_nested_payload_indexing.py
+pytest -s

--- a/openapi/tests/run_docker.sh
+++ b/openapi/tests/run_docker.sh
@@ -14,4 +14,5 @@ cd "$(dirname "$0")"
 
 trap clear_after_tests EXIT
 
-pytest -s
+pytest -s openapi_integration/test_nested_payload_indexing.py
+#pytest -s


### PR DESCRIPTION
Draft for supporting nested object filters to query nested payload objects independently.

E.g:

```json
{
  "filter": {
    "nested": {
      "path": "country.cities[]",
      "must": [
        {
          "key": "population",
          "range": {
            "gte": 9
          }
        },
        {
          "key": "sightseeing",
          "values_count": {
            "gt": 3
          }
        }
      ]
    }
  },
  "limit": 3
}
```