### PR TITLE
Wrap blocking `await_ready_for_timeout` call with `tokio::task::spawn_blocking`

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -587,10 +587,13 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     ) -> Result<bool, StorageError> {
         let wait_timeout = wait_timeout.unwrap_or(DEFAULT_META_OP_WAIT);
 
-        if !self
-            .is_leader_established
-            .await_ready_for_timeout(wait_timeout)
-        {
+        let is_leader_established = self.is_leader_established.clone();
+
+        let await_ready_for_timeout_future = tokio::task::spawn_blocking(move || {
+            is_leader_established.await_ready_for_timeout(wait_timeout)
+        });
+
+        if !await_ready_for_timeout_future.await.unwrap() {
             return Err(StorageError::service_error(format!(
                 "Failed to propose operation: leader is not established within {} secs",
                 wait_timeout.as_secs()

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -593,7 +593,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             is_leader_established.await_ready_for_timeout(wait_timeout)
         });
 
-        if !await_ready_for_timeout_future.await.unwrap() {
+        let is_leader_established = await_ready_for_timeout_future
+            .await
+            .map_err(|err| StorageError::service_error(err.to_string()))?;
+
+        if !is_leader_established {
             return Err(StorageError::service_error(format!(
                 "Failed to propose operation: leader is not established within {} secs",
                 wait_timeout.as_secs()


### PR DESCRIPTION
As it turned out, [blocking calls in async context is a much bigger deal, than one may think][tokio-blocking-bug]. Seems like we're hitting this bug, and this PR fixes it.

[tokio-blocking-bug]: https://github.com/tokio-rs/tokio/issues/4730