### PR TITLE
Refactor transport channel pool

### DIFF
--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -135,11 +135,7 @@ impl ChannelPool {
         connect_timeout: Duration,
         tls_config: Option<ClientTlsConfig>,
     ) -> Result<Self, TonicError> {
-        // TODO: Enable HTTP/2 keep-alive for *all* channels (e.g., move into `channel_builder`)?
-        let endpoint = channel_builder(uri, timeout, connect_timeout, tls_config)?
-            .http2_keep_alive_interval(Duration::from_millis(500))
-            .keep_alive_timeout(Duration::from_millis(500))
-            .keep_alive_while_idle(true);
+        let endpoint = channel_builder(uri, timeout, connect_timeout, tls_config)?;
 
         let (channel, service_discovery_sender) = Channel::balance_channel(16);
 
@@ -174,10 +170,12 @@ pub fn channel_builder(
     connect_timeout: Duration,
     tls_config: Option<ClientTlsConfig>,
 ) -> Result<Endpoint, TonicError> {
-    // TODO: Enable HTTP/2 keep-alive for *all* channels?
     let mut endpoint = Channel::builder(uri)
         .timeout(timeout)
-        .connect_timeout(connect_timeout);
+        .connect_timeout(connect_timeout)
+        .http2_keep_alive_interval(Duration::from_millis(500))
+        .keep_alive_timeout(Duration::from_millis(500))
+        .keep_alive_while_idle(true);
 
     if let Some(tls_config) = tls_config {
         endpoint = endpoint.tls_config(tls_config)?;

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -27,7 +27,7 @@ impl ChannelService {
     pub async fn remove_peer(&self, peer_id: PeerId) {
         let removed = self.id_to_address.write().remove(&peer_id);
         if let Some(uri) = removed {
-            self.channel_pool.drop_pool(&uri).await;
+            self.channel_pool.drop_channel_pool(&uri).await;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,11 +187,12 @@ fn main() -> anyhow::Result<()> {
         let tls_config = load_tls_client_config(&settings)?;
 
         channel_service.channel_pool = Arc::new(TransportChannelPool::new(
+            settings.cluster.p2p.connection_pool_size,
             p2p_grpc_timeout,
             connection_timeout,
-            settings.cluster.p2p.connection_pool_size,
             tls_config,
         ));
+
         channel_service.id_to_address = persistent_consensus_state.peer_address_by_id.clone();
     }
 

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -4,6 +4,7 @@ mod tonic_telemetry;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use ::api::grpc::models::VersionInfo;
 use ::api::grpc::qdrant::collections_internal_server::CollectionsInternalServer;
@@ -62,7 +63,9 @@ pub fn init(
 
         log::info!("Qdrant gRPC listening on {}", grpc_port);
 
-        let mut server = Server::builder();
+        let mut server = Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_millis(500)))
+            .http2_keepalive_timeout(Some(Duration::from_millis(500)));
 
         if settings.service.enable_tls {
             let tls_config = settings.tls()?;
@@ -133,7 +136,9 @@ pub fn init_internal(
 
         log::debug!("Qdrant internal gRPC listening on {}", internal_grpc_port);
 
-        let mut server = Server::builder();
+        let mut server = Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_millis(500)))
+            .http2_keepalive_timeout(Some(Duration::from_millis(500)));
 
         if let Some(config) = tls_config {
             server = server

--- a/tests/consensus_tests/docker-compose.yaml
+++ b/tests/consensus_tests/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
   qdrant_node_1:
     image: qdrant_consensus:latest
     environment:
+      - QDRANT__LOG_LEVEL=info,hyper::proto::h2::client=debug,tonic::transport::service::reconnect=debug
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
@@ -20,6 +21,7 @@ services:
   qdrant_node_follower:
     image: qdrant_consensus:latest
     environment:
+      - QDRANT__LOG_LEVEL=info,hyper::proto::h2::client=debug,tonic::transport::service::reconnect=debug
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
@@ -38,6 +40,7 @@ services:
   qdrant_node_follower_2:
     image: qdrant_consensus:latest
     environment:
+      - QDRANT__LOG_LEVEL=info,hyper::proto::h2::client=debug,tonic::transport::service::reconnect=debug
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
       - QDRANT__CLUSTER__P2P__PORT=6335
@@ -51,3 +54,10 @@ services:
 #      resources:
 #        limits:
 #          cpus: '0.03'
+
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 10.0.0.0/20

--- a/tests/consensus_tests/test_http2_keep_alive.sh
+++ b/tests/consensus_tests/test_http2_keep_alive.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# docker build ../../ --tag=qdrant_consensus
+docker compose up -d --force-recreate
+
+function cleanup {
+	docker compose down
+}
+
+trap cleanup EXIT
+
+# Wait for the service to start
+while [[ "$(curl -sS localhost:6533 -w ''%{http_code}'' -o /dev/null)" != "200" ]]
+do
+	sleep 1
+done
+
+# Pause `qdrant_node_follower_2` container, to trigger HTTP/2 keep-alive timeout
+docker container pause consensus_tests-qdrant_node_follower_2-1
+sleep 1
+
+# Check that there's a HTTP/2 keep-alive timeout log message in `qdrant_node_1` output
+declare ERROR='connection keep-alive timed out'
+
+if ! docker compose logs qdrant_node_1 | grep "$ERROR"
+then
+	echo "'$ERROR' log message not found in 'qdrant_node_1' logs" >&2
+	exit 1
+fi

--- a/tests/consensus_tests/test_ip_address_change.sh
+++ b/tests/consensus_tests/test_ip_address_change.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# docker build ../../ --tag=qdrant_consensus
+docker compose up -d --force-recreate
+
+function cleanup {
+    docker compose down
+}
+
+trap cleanup EXIT
+
+# Wait for the service to start
+while [[ "$(curl -sS localhost:6533 -w ''%{http_code}'' -o /dev/null)" != "200" ]]
+do
+    sleep 1
+done
+
+# Disconnect `qdrant_node_follower_2` container from the network
+docker network disconnect consensus_tests_default consensus_tests-qdrant_node_follower_2-1
+sleep 1
+
+# Reconnect `qdrant_node_follower_2` container with new IP address
+docker network connect consensus_tests_default consensus_tests-qdrant_node_follower_2-1 --alias qdrant_node_follower_2 --ip 10.0.0.5
+
+# Check that there's a DNS lookup error log message in `qdrant_node_1` output
+declare ERROR='dns error: failed to lookup address information: Name or service not known'
+
+if ! docker compose logs qdrant_node_1 | grep "$ERROR"
+then
+    echo "'$ERROR' log message not found in 'qdrant_node_1' logs" >&2
+    exit 1
+fi
+
+sleep 1
+
+# Check that `qdrant_node_follower_2` successfully reconnected to the cluster
+if ! curl -sS --fail-with-body localhost:6533/collections/test_collection \
+    -X PUT \
+    -H 'Content-Type: application/json' \
+    --data-raw '{"vectors": {"size": 4, "distance": "Cosine"}}'
+then
+    echo "Failed to send create collection request to 'qdrant_node_follower_2' node" >&2
+    exit 2
+fi


### PR DESCRIPTION
- utilize [`tonic::transport::Channel::balance_channel`] instead of explicit channel pool implementation
- remove `ChannelPool::fast_channel` and enable HTTP/2 keep-alive, which _should_ better serve `fast_channel`'s intended functionality
- remove "explicit" timeout, as [`tonic::Request::set_timeout`] _is_ enough (well, _should be_ enough):
  - [`tonic::transport::Channel` is a wrapper around `tonic::transport::service::Connection`][tonic-transport-channel]
  - `tonic::transport::service::Connection` is a `tower::Service` composed of a bunch of `tower::Layer`s, [one of which is `tonic::transport::service::GrpcTimeout`][tonic-transport-connection-new]...
  - ...[which _does_ apply the timeout from `tonic::Request` on the client side][grpc-timeout-layer] (in the linked code `self.server_timeout` is the timeout set with `tonic::Endpoint::timeout`, and `client_timeout` is the one set with `tonic::Request::set_timeout`)

__TODO:__
- [x] fix the last few `TODO`s in the code
- [x] test the code more thoroughly
- [x] implement an automated test for `fast_channel`/keep-alive
- [ ] fix the `test_triple_replication.py` test (it fails consistently, so it's probably something with the PR)

[`tonic::transport::Channel::balance_channel`]: https://docs.rs/tonic/latest/tonic/transport/struct.Channel.html#method.balance_channel
[`tonic::Request::set_timeout`]: https://docs.rs/tonic/latest/tonic/struct.Request.html#method.set_timeout
[tonic-transport-channel]: https://github.com/hyperium/tonic/blob/b3358dc6acf11ec800571735de1e1f1e449ec96a/tonic/src/transport/channel/mod.rs#L41-L71
[tonic-transport-connection-new]: https://github.com/hyperium/tonic/blob/b3358dc6acf11ec800571735de1e1f1e449ec96a/tonic/src/transport/service/connection.rs#L64
[grpc-timeout-layer]: https://github.com/hyperium/tonic/blob/b3358dc6acf11ec800571735de1e1f1e449ec96a/tonic/src/transport/service/grpc_timeout.rs#L50-L58