### PR TITLE
Improve metrics building performance, limit endpoints to whitelist

### DIFF
--- a/openapi/tests/openapi_integration/test_service.py
+++ b/openapi/tests/openapi_integration/test_service.py
@@ -1,0 +1,17 @@
+import pytest
+
+from .helpers.helpers import request_with_validation
+
+
+def test_metrics():
+    response = request_with_validation(
+        api='/metrics',
+        method="GET",
+    )
+    assert response.ok
+
+    # Probe some strings that must exist in the metrics output
+    assert '# HELP app_info information about qdrant server' in response.text
+    assert '# TYPE app_info counter' in response.text
+    assert 'app_info{name="qdrant",version="' in response.text
+    assert 'collections_total ' in response.text

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -51,8 +51,7 @@ async fn metrics(
         telemetry_data
     };
 
-    let metrics_data = MetricsData::from(telemetry_data);
-    HttpResponse::Ok().body(metrics_data.format_metrics())
+    HttpResponse::Ok().body(MetricsData::from(telemetry_data).format_metrics())
 }
 
 #[post("/locks")]

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -1,3 +1,4 @@
+use actix_web::http::header::ContentType;
 use actix_web::rt::time::Instant;
 use actix_web::web::Query;
 use actix_web::{get, post, web, HttpResponse, Responder};
@@ -55,7 +56,9 @@ async fn metrics(
         telemetry_data
     };
 
-    HttpResponse::Ok().body(MetricsData::from(telemetry_data).format_metrics())
+    HttpResponse::Ok()
+        .content_type(ContentType::plaintext())
+        .body(MetricsData::from(telemetry_data).format_metrics())
 }
 
 #[post("/locks")]

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -36,15 +36,19 @@ async fn telemetry(
     process_response(Ok(telemetry_data), timing)
 }
 
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct MetricsParam {
+    pub anonymize: Option<bool>,
+}
+
 #[get("/metrics")]
 async fn metrics(
     telemetry_collector: web::Data<Mutex<TelemetryCollector>>,
-    params: Query<TelemetryParam>,
+    params: Query<MetricsParam>,
 ) -> impl Responder {
     let anonymize = params.anonymize.unwrap_or(false);
-    let details_level = params.details_level.unwrap_or(0);
     let telemetry_collector = telemetry_collector.lock().await;
-    let telemetry_data = telemetry_collector.prepare_data(details_level).await;
+    let telemetry_data = telemetry_collector.prepare_data(0).await;
     let telemetry_data = if anonymize {
         telemetry_data.anonymize()
     } else {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -138,7 +138,7 @@ impl MetricsProvider for ClusterStatusTelemetry {
                 registry
             )
             .unwrap()
-            .inc_by(self.term);
+            .inc_by(self.commit);
             int_gauge!(
                 Opts::new(
                     "cluster_pending_operations_total",

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -14,6 +14,8 @@ use crate::common::telemetry_ops::requests_telemetry::{
 /// Whitelist for REST endpoints in metrics output.
 ///
 /// Contains selection of search, recommend and upsert endpoints.
+///
+/// This array *must* be sorted.
 const REST_ENDPOINT_WHITELIST: &[&str] = &[
     "/collections/{name}/index",
     "/collections/{name}/points",
@@ -27,6 +29,8 @@ const REST_ENDPOINT_WHITELIST: &[&str] = &[
 /// Whitelist for GRPC endpoints in metrics output.
 ///
 /// Contains selection of search, recommend and upsert endpoints.
+///
+/// This array *must* be sorted.
 const GRPC_ENDPOINT_WHITELIST: &[&str] = &[
     "/qdrant.Points/OverwritePayload",
     "/qdrant.Points/Recommend",

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -1,7 +1,5 @@
-use prometheus::{
-    register_gauge_with_registry as gauge, register_int_counter_with_registry as int_counter,
-    register_int_gauge_with_registry as int_gauge, Encoder, Opts, Registry, TextEncoder,
-};
+use prometheus::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
+use prometheus::TextEncoder;
 
 use crate::common::telemetry::TelemetryData;
 use crate::common::telemetry_ops::app_telemetry::AppBuildTelemetry;
@@ -15,62 +13,59 @@ use crate::common::telemetry_ops::requests_telemetry::{
 
 /// Encapsulates metrics data in Prometheus format.
 pub struct MetricsData {
-    registry: Registry,
+    metrics: Vec<MetricFamily>,
 }
 
 impl MetricsData {
-    pub fn format_metrics(&self) -> Vec<u8> {
-        let mut buffer = vec![];
-        TextEncoder::new()
-            .encode(&self.registry.gather(), &mut buffer)
-            .unwrap();
-        buffer
+    pub fn format_metrics(&self) -> String {
+        TextEncoder::new().encode_to_string(&self.metrics).unwrap()
     }
 }
 
 impl From<TelemetryData> for MetricsData {
     fn from(telemetry_data: TelemetryData) -> Self {
-        let registry = Registry::new();
-        telemetry_data.register_metrics(&registry);
-        Self { registry }
+        let mut metrics = vec![];
+        telemetry_data.add_metrics(&mut metrics);
+        Self { metrics }
     }
 }
 
 trait MetricsProvider {
-    /// Register and add object metrics to registry.
-    fn register_metrics(&self, registry: &Registry);
+    /// Add metrics definitions for this.
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>);
 }
 
 impl MetricsProvider for TelemetryData {
-    fn register_metrics(&self, registry: &Registry) {
-        self.app.register_metrics(registry);
-        self.collections.register_metrics(registry);
-        self.cluster.register_metrics(registry);
-        self.requests.register_metrics(registry);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        self.app.add_metrics(metrics);
+        self.collections.add_metrics(metrics);
+        self.cluster.add_metrics(metrics);
+        self.requests.add_metrics(metrics);
     }
 }
 
 impl MetricsProvider for AppBuildTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        int_counter!(
-            Opts::new("app_info", "information about qdrant server")
-                .const_label("name", &self.name)
-                .const_label("version", &self.version),
-            registry,
-        )
-        .unwrap()
-        .inc_by(1);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        metrics.push(metric_family(
+            "app_info",
+            "information about qdrant server",
+            MetricType::COUNTER,
+            vec![counter(
+                1.0,
+                &[("name", &self.name), ("version", &self.version)],
+            )],
+        ));
     }
 }
 
 impl MetricsProvider for CollectionsTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        int_gauge!(
-            Opts::new("collections_total", "number of collections"),
-            registry
-        )
-        .unwrap()
-        .set(self.number_of_collections as i64);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        metrics.push(metric_family(
+            "collections_total",
+            "number of collections",
+            MetricType::GAUGE,
+            vec![gauge(self.number_of_collections as f64, &[])],
+        ));
 
         // Count collection types
         if let Some(ref collections) = self.collections {
@@ -82,208 +77,243 @@ impl MetricsProvider for CollectionsTelemetry {
                 .iter()
                 .filter(|p| matches!(p, CollectionTelemetryEnum::Aggregated(_)))
                 .count();
-            int_gauge!(
-                Opts::new("collections_full_total", "number of full collections"),
-                registry
-            )
-            .unwrap()
-            .set(full_count as i64);
-            int_gauge!(
-                Opts::new(
-                    "collections_aggregated_total",
-                    "number of aggregated collections"
-                ),
-                registry
-            )
-            .unwrap()
-            .set(aggregated_count as i64);
+            metrics.push(metric_family(
+                "collections_full_total",
+                "number of full collections",
+                MetricType::GAUGE,
+                vec![gauge(full_count as f64, &[])],
+            ));
+            metrics.push(metric_family(
+                "collections_aggregated_total",
+                "number of aggregated collections",
+                MetricType::GAUGE,
+                vec![gauge(aggregated_count as f64, &[])],
+            ));
         }
     }
 }
 
 impl MetricsProvider for ClusterTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        int_gauge!(
-            Opts::new("cluster_enabled", "is cluster support enabled"),
-            registry
-        )
-        .unwrap()
-        .set(self.enabled as i64);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        metrics.push(metric_family(
+            "cluster_enabled",
+            "is cluster support enabled",
+            MetricType::COUNTER,
+            vec![counter(if self.enabled { 1.0 } else { 0.0 }, &[])],
+        ));
 
         if let Some(ref status) = self.status {
-            status.register_metrics(registry);
+            status.add_metrics(metrics);
         }
     }
 }
 
 impl MetricsProvider for ClusterStatusTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        int_gauge!(
-            Opts::new("cluster_peers_total", "total number of cluster peers"),
-            registry
-        )
-        .unwrap()
-        .set(self.number_of_peers as i64);
-        int_counter!(Opts::new("cluster_term", "current cluster term"), registry)
-            .unwrap()
-            .inc_by(self.term);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        metrics.push(metric_family(
+            "cluster_peers_total",
+            "total number of cluster peers",
+            MetricType::GAUGE,
+            vec![gauge(self.number_of_peers as f64, &[])],
+        ));
+        metrics.push(metric_family(
+            "cluster_term",
+            "current cluster term",
+            MetricType::COUNTER,
+            vec![counter(self.term as f64, &[])],
+        ));
 
         if let Some(ref peer_id) = self.peer_id.map(|p| p.to_string()) {
-            int_counter!(
-                Opts::new(
-                    "cluster_commit",
-                    "index of last committed (finalized) operation cluster peer is aware of"
-                )
-                .const_label("peer_id", peer_id),
-                registry
-            )
-            .unwrap()
-            .inc_by(self.commit);
-            int_gauge!(
-                Opts::new(
-                    "cluster_pending_operations_total",
-                    "total number of pending operations for cluster peer"
-                )
-                .const_label("peer_id", peer_id),
-                registry
-            )
-            .unwrap()
-            .set(self.pending_operations as i64);
-            int_gauge!(
-                Opts::new("cluster_voter", "is cluster peer a voter or learner")
-                    .const_label("peer_id", peer_id),
-                registry
-            )
-            .unwrap()
-            .set(self.is_voter as i64);
+            metrics.push(metric_family(
+                "cluster_commit",
+                "index of last committed (finalized) operation cluster peer is aware of",
+                MetricType::COUNTER,
+                vec![counter(self.commit as f64, &[("peer_id", peer_id)])],
+            ));
+            metrics.push(metric_family(
+                "cluster_pending_operations_total",
+                "total number of pending operations for cluster peer",
+                MetricType::GAUGE,
+                vec![gauge(self.pending_operations as f64, &[])],
+            ));
+            metrics.push(metric_family(
+                "cluster_voter",
+                "is cluster peer a voter or learner",
+                MetricType::GAUGE,
+                vec![gauge(if self.is_voter { 1.0 } else { 0.0 }, &[])],
+            ));
         }
     }
 }
 
 impl MetricsProvider for RequestsTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        self.rest.register_metrics(registry);
-        self.grpc.register_metrics(registry);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        self.rest.add_metrics(metrics);
+        self.grpc.add_metrics(metrics);
     }
 }
 
 impl MetricsProvider for WebApiTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        // Skip if there are no request stats
+        if self.responses.is_empty() || self.responses.iter().all(|r| r.1.is_empty()) {
+            return;
+        }
+
+        let (mut total, mut fail_total, mut avg_secs, mut min_secs, mut max_secs) =
+            (vec![], vec![], vec![], vec![], vec![]);
         for (endpoint, responses) in &self.responses {
             let (method, endpoint) = endpoint.split_once(' ').unwrap();
-            for (status, statistics) in responses {
-                int_counter!(
-                    Opts::new("rest_responses_total", "total number of responses")
-                        .const_label("method", method)
-                        .const_label("endpoint", endpoint)
-                        .const_label("status", status.to_string()),
-                    registry,
-                )
-                .unwrap()
-                .inc_by(statistics.count as u64);
-                int_counter!(
-                    Opts::new(
-                        "rest_responses_fail_total",
-                        "total number of failed responses",
-                    )
-                    .const_label("method", method)
-                    .const_label("endpoint", endpoint)
-                    .const_label("status", status.to_string()),
-                    registry,
-                )
-                .unwrap()
-                .inc_by(statistics.fail_count as u64);
-                gauge!(
-                    Opts::new(
-                        "rest_responses_avg_duration_seconds",
-                        "average response duratoin",
-                    )
-                    .const_label("method", method)
-                    .const_label("endpoint", endpoint)
-                    .const_label("status", status.to_string()),
-                    registry,
-                )
-                .unwrap()
-                .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-                gauge!(
-                    Opts::new(
-                        "rest_responses_min_duration_seconds",
-                        "minimum response duration",
-                    )
-                    .const_label("method", method)
-                    .const_label("endpoint", endpoint)
-                    .const_label("status", status.to_string()),
-                    registry,
-                )
-                .unwrap()
-                .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-                gauge!(
-                    Opts::new(
-                        "rest_responses_max_duration_seconds",
-                        "maximum response duration",
-                    )
-                    .const_label("method", method)
-                    .const_label("endpoint", endpoint)
-                    .const_label("status", status.to_string()),
-                    registry,
-                )
-                .unwrap()
-                .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+            for (status, stats) in responses {
+                let labels = [
+                    ("method", method),
+                    ("endpoint", endpoint),
+                    ("status", &status.to_string()),
+                ];
+                total.push(counter(stats.count as f64, &labels));
+                fail_total.push(counter(stats.fail_count as f64, &labels));
+                avg_secs.push(gauge(
+                    stats.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                    &labels,
+                ));
+                min_secs.push(gauge(
+                    stats.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                    &labels,
+                ));
+                max_secs.push(gauge(
+                    stats.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                    &labels,
+                ));
             }
         }
+
+        metrics.push(metric_family(
+            "rest_responses_total",
+            "total number of responses",
+            MetricType::COUNTER,
+            total,
+        ));
+        metrics.push(metric_family(
+            "rest_responses_fail_total",
+            "total number of failed responses",
+            MetricType::COUNTER,
+            fail_total,
+        ));
+        metrics.push(metric_family(
+            "rest_responses_avg_duration_seconds",
+            "average response duration",
+            MetricType::GAUGE,
+            avg_secs,
+        ));
+        metrics.push(metric_family(
+            "rest_responses_min_duration_seconds",
+            "minimum response duration",
+            MetricType::GAUGE,
+            min_secs,
+        ));
+        metrics.push(metric_family(
+            "rest_responses_max_duration_seconds",
+            "maximum response duration",
+            MetricType::GAUGE,
+            max_secs,
+        ));
     }
 }
 
 impl MetricsProvider for GrpcTelemetry {
-    fn register_metrics(&self, registry: &Registry) {
-        for (endpoint, statistics) in &self.responses {
-            int_counter!(
-                Opts::new("grpc_responses_total", "total number of responses")
-                    .const_label("endpoint", endpoint),
-                registry,
-            )
-            .unwrap()
-            .inc_by(statistics.count as u64);
-            int_counter!(
-                Opts::new(
-                    "grpc_responses_fail_total",
-                    "total number of failed responses",
-                )
-                .const_label("endpoint", endpoint),
-                registry,
-            )
-            .unwrap()
-            .inc_by(statistics.fail_count as u64);
-            gauge!(
-                Opts::new(
-                    "grpc_responses_avg_duration_seconds",
-                    "average response duratoin",
-                )
-                .const_label("endpoint", endpoint),
-                registry,
-            )
-            .unwrap()
-            .set(statistics.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-            gauge!(
-                Opts::new(
-                    "grpc_responses_min_duration_seconds",
-                    "minimum response duration",
-                )
-                .const_label("endpoint", endpoint),
-                registry,
-            )
-            .unwrap()
-            .set(statistics.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
-            gauge!(
-                Opts::new(
-                    "grpc_responses_max_duration_seconds",
-                    "maximum response duration",
-                )
-                .const_label("endpoint", endpoint),
-                registry,
-            )
-            .unwrap()
-            .set(statistics.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0);
+    fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        // Skip if there are no request stats
+        if self.responses.is_empty() {
+            return;
         }
+
+        let (mut total, mut fail_total, mut avg_secs, mut min_secs, mut max_secs) =
+            (vec![], vec![], vec![], vec![], vec![]);
+        for (endpoint, stats) in &self.responses {
+            let labels = [("endpoint", endpoint.as_str())];
+            total.push(counter(stats.count as f64, &labels));
+            fail_total.push(counter(stats.fail_count as f64, &labels));
+            avg_secs.push(gauge(
+                stats.avg_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                &labels,
+            ));
+            min_secs.push(gauge(
+                stats.min_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                &labels,
+            ));
+            max_secs.push(gauge(
+                stats.max_duration_micros.unwrap_or(0.0) as f64 / 1_000_000.0,
+                &labels,
+            ));
+        }
+
+        metrics.push(metric_family(
+            "grpc_responses_total",
+            "total number of responses",
+            MetricType::COUNTER,
+            total,
+        ));
+        metrics.push(metric_family(
+            "grpc_responses_fail_total",
+            "total number of failed responses",
+            MetricType::COUNTER,
+            fail_total,
+        ));
+        metrics.push(metric_family(
+            "grpc_responses_avg_duration_seconds",
+            "average response duration",
+            MetricType::GAUGE,
+            avg_secs,
+        ));
+        metrics.push(metric_family(
+            "grpc_responses_min_duration_seconds",
+            "minimum response duration",
+            MetricType::GAUGE,
+            min_secs,
+        ));
+        metrics.push(metric_family(
+            "grpc_responses_max_duration_seconds",
+            "maximum response duration",
+            MetricType::GAUGE,
+            max_secs,
+        ));
     }
+}
+
+fn metric_family(name: &str, help: &str, r#type: MetricType, metrics: Vec<Metric>) -> MetricFamily {
+    let mut metric_family = MetricFamily::default();
+    metric_family.set_name(name.into());
+    metric_family.set_help(help.into());
+    metric_family.set_field_type(r#type);
+    metric_family.set_metric(metrics);
+    metric_family
+}
+
+fn counter(value: f64, labels: &[(&str, &str)]) -> Metric {
+    let mut metric = Metric::default();
+    metric.set_label(labels.iter().map(|(n, v)| label_pair(n, v)).collect());
+    metric.set_counter({
+        let mut counter = Counter::default();
+        counter.set_value(value);
+        counter
+    });
+    metric
+}
+
+fn gauge(value: f64, labels: &[(&str, &str)]) -> Metric {
+    let mut metric = Metric::default();
+    metric.set_label(labels.iter().map(|(n, v)| label_pair(n, v)).collect());
+    metric.set_gauge({
+        let mut gauge = Gauge::default();
+        gauge.set_value(value);
+        gauge
+    });
+    metric
+}
+
+fn label_pair(name: &str, value: &str) -> LabelPair {
+    let mut label = LabelPair::default();
+    label.set_name(name.into());
+    label.set_value(value.into());
+    label
 }

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -138,7 +138,3 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search" 
       "vector": [0.2, 0.1, 0.9, 0.7],
       "top": 3
   }' | jq
-
-# metrics endpoint
-curl -L -X GET "http://$QDRANT_HOST/metrics" \
-  --fail -s | head -n3

--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -121,7 +121,6 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search/b
     ]
   }' | jq
 
-
 curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search" \
   --fail -s \
   -H 'Content-Type: application/json' \
@@ -139,3 +138,7 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/search" 
       "vector": [0.2, 0.1, 0.9, 0.7],
       "top": 3
   }' | jq
+
+# metrics endpoint
+curl -L -X GET "http://$QDRANT_HOST/metrics" \
+  --fail -s | head -n3


### PR DESCRIPTION
Improves #1541 with suggestions from https://github.com/qdrant/qdrant/pull/1541#issuecomment-1468037878.

This improves upon the existing metrics system. It now collects/formats the metrics output more efficiently.

It now uses a whitelist for endpoints to report only the most significant ones: a selection of search, recommend and upsert endpoints:

```rust
const REST_ENDPOINT_WHITELIST: &[&str] = &[
    "/collections/{name}/index",
    "/collections/{name}/points",
    "/collections/{name}/points/payload",
    "/collections/{name}/points/recommend",
    "/collections/{name}/points/recommend/batch",
    "/collections/{name}/points/search",
    "/collections/{name}/points/search/batch",
];
const GRPC_ENDPOINT_WHITELIST: &[&str] = &[
    "/qdrant.Points/OverwritePayload",
    "/qdrant.Points/Recommend",
    "/qdrant.Points/RecommendBatch",
    "/qdrant.Points/Search",
    "/qdrant.Points/SearchBatch",
    "/qdrant.Points/SetPayload",
    "/qdrant.Points/Upsert",
];
```

This also:
- limits timing output to HTTP 200
- sets `Content-Type` header for `/metrics`
- fixes incorrect value for cluster commit metric
- adds a basic OpenAPI test for `/metrics`

<details>
<summary>Click here for a snippet of output with whitelisting.</summary>

```bash
# HELP app_info information about qdrant server
# TYPE app_info counter
app_info{name="qdrant",version="0.11.1"} 1
# HELP collections_total number of collections
# TYPE collections_total gauge
collections_total 4
# HELP cluster_enabled is cluster support enabled
# TYPE cluster_enabled counter
cluster_enabled 0
# HELP rest_responses_total total number of responses
# TYPE rest_responses_total counter
rest_responses_total{method="PUT",endpoint="/collections/{name}/points",status="200"} 5
rest_responses_total{method="POST",endpoint="/collections/{name}/points/search/batch",status="200"} 5
rest_responses_total{method="POST",endpoint="/collections/{name}/points/search",status="200"} 10
rest_responses_total{method="PUT",endpoint="/collections/{name}/index",status="200"} 15
rest_responses_total{method="POST",endpoint="/collections/{name}/points",status="200"} 5
# HELP rest_responses_fail_total total number of failed responses
# TYPE rest_responses_fail_total counter
rest_responses_fail_total{method="PUT",endpoint="/collections/{name}/points",status="200"} 0
rest_responses_fail_total{method="POST",endpoint="/collections/{name}/points/search/batch",status="200"} 0
rest_responses_fail_total{method="POST",endpoint="/collections/{name}/points/search",status="200"} 0
rest_responses_fail_total{method="PUT",endpoint="/collections/{name}/index",status="200"} 0
rest_responses_fail_total{method="POST",endpoint="/collections/{name}/points",status="200"} 0
# HELP rest_responses_avg_duration_seconds average response duration
# TYPE rest_responses_avg_duration_seconds gauge
rest_responses_avg_duration_seconds{method="PUT",endpoint="/collections/{name}/points",status="200"} 0.008645599609375
rest_responses_avg_duration_seconds{method="POST",endpoint="/collections/{name}/points/search/batch",status="200"} 0.0003522000122070312
rest_responses_avg_duration_seconds{method="POST",endpoint="/collections/{name}/points/search",status="200"} 0.0004141000061035156
rest_responses_avg_duration_seconds{method="PUT",endpoint="/collections/{name}/index",status="200"} 0.0002236666717529297
rest_responses_avg_duration_seconds{method="POST",endpoint="/collections/{name}/points",status="200"} 0.000155
# HELP rest_responses_min_duration_seconds minimum response duration
# TYPE rest_responses_min_duration_seconds gauge
rest_responses_min_duration_seconds{method="PUT",endpoint="/collections/{name}/points",status="200"} 0.006217
rest_responses_min_duration_seconds{method="POST",endpoint="/collections/{name}/points/search/batch",status="200"} 0.000283
rest_responses_min_duration_seconds{method="POST",endpoint="/collections/{name}/points/search",status="200"} 0.000337
rest_responses_min_duration_seconds{method="PUT",endpoint="/collections/{name}/index",status="200"} 0.000145
rest_responses_min_duration_seconds{method="POST",endpoint="/collections/{name}/points",status="200"} 0.000142
# HELP rest_responses_max_duration_seconds maximum response duration
# TYPE rest_responses_max_duration_seconds gauge
rest_responses_max_duration_seconds{method="PUT",endpoint="/collections/{name}/points",status="200"} 0.012047
rest_responses_max_duration_seconds{method="POST",endpoint="/collections/{name}/points/search/batch",status="200"} 0.000429
rest_responses_max_duration_seconds{method="POST",endpoint="/collections/{name}/points/search",status="200"} 0.000577
rest_responses_max_duration_seconds{method="PUT",endpoint="/collections/{name}/index",status="200"} 0.00032
rest_responses_max_duration_seconds{method="POST",endpoint="/collections/{name}/points",status="200"} 0.00017
# HELP grpc_responses_total total number of responses
# TYPE grpc_responses_total counter
grpc_responses_total{endpoint="/qdrant.Points/Recommend"} 8
grpc_responses_total{endpoint="/qdrant.Points/Upsert"} 8
grpc_responses_total{endpoint="/qdrant.Points/Search"} 32
# HELP grpc_responses_fail_total total number of failed responses
# TYPE grpc_responses_fail_total counter
grpc_responses_fail_total{endpoint="/qdrant.Points/Recommend"} 0
grpc_responses_fail_total{endpoint="/qdrant.Points/Upsert"} 0
grpc_responses_fail_total{endpoint="/qdrant.Points/Search"} 0
# HELP grpc_responses_avg_duration_seconds average response duration
# TYPE grpc_responses_avg_duration_seconds gauge
grpc_responses_avg_duration_seconds{endpoint="/qdrant.Points/Recommend"} 0.0001723572998046875
grpc_responses_avg_duration_seconds{endpoint="/qdrant.Points/Upsert"} 0.001592212890625
grpc_responses_avg_duration_seconds{endpoint="/qdrant.Points/Search"} 0.0005532779541015625
# HELP grpc_responses_min_duration_seconds minimum response duration
# TYPE grpc_responses_min_duration_seconds gauge
grpc_responses_min_duration_seconds{endpoint="/qdrant.Points/Recommend"} 0.000151
grpc_responses_min_duration_seconds{endpoint="/qdrant.Points/Upsert"} 0.001379
grpc_responses_min_duration_seconds{endpoint="/qdrant.Points/Search"} 0.000419
# HELP grpc_responses_max_duration_seconds maximum response duration
# TYPE grpc_responses_max_duration_seconds gauge
grpc_responses_max_duration_seconds{endpoint="/qdrant.Points/Recommend"} 0.000292
grpc_responses_max_duration_seconds{endpoint="/qdrant.Points/Upsert"} 0.001893
grpc_responses_max_duration_seconds{endpoint="/qdrant.Points/Search"} 0.000765
```

</details>

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
