### PR TITLE
Fix metrics vector count

### DIFF
--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -15,6 +15,21 @@ pub struct CollectionTelemetry {
     pub transfers: Vec<ShardTransferInfo>,
 }
 
+impl CollectionTelemetry {
+    pub fn count_vectors(&self) -> usize {
+        self.shards
+            .iter()
+            // TODO: improve this?
+            .filter_map(|shard| {
+                shard
+                    .local
+                    .as_ref()
+                    .map(|x| x.segments.iter().map(|s| s.info.num_vectors).sum::<usize>())
+            })
+            .sum::<usize>()
+    }
+}
+
 impl Anonymize for CollectionTelemetry {
     fn anonymize(&self) -> Self {
         Self {

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -19,14 +19,10 @@ impl CollectionTelemetry {
     pub fn count_vectors(&self) -> usize {
         self.shards
             .iter()
-            // TODO: improve this?
-            .filter_map(|shard| {
-                shard
-                    .local
-                    .as_ref()
-                    .map(|x| x.segments.iter().map(|s| s.info.num_vectors).sum::<usize>())
-            })
-            .sum::<usize>()
+            .flat_map(|shard| shard.local.as_ref())
+            .flat_map(|x| x.segments.iter())
+            .map(|s| s.info.num_vectors)
+            .sum()
     }
 }
 

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -49,7 +49,7 @@ async fn metrics(
 ) -> impl Responder {
     let anonymize = params.anonymize.unwrap_or(false);
     let telemetry_collector = telemetry_collector.lock().await;
-    let telemetry_data = telemetry_collector.prepare_data(0).await;
+    let telemetry_data = telemetry_collector.prepare_data(1).await;
     let telemetry_data = if anonymize {
         telemetry_data.anonymize()
     } else {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -93,13 +93,13 @@ impl MetricsProvider for AppBuildTelemetry {
 
 impl MetricsProvider for CollectionsTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
-        let aggregated_vector_count = self
+        let vector_count = self
             .collections
             .iter()
             .flatten()
             .map(|p| match p {
                 CollectionTelemetryEnum::Aggregated(a) => a.vectors,
-                CollectionTelemetryEnum::Full(_) => 0,
+                CollectionTelemetryEnum::Full(c) => c.count_vectors(),
             })
             .sum::<usize>();
         metrics.push(metric_family(
@@ -109,10 +109,10 @@ impl MetricsProvider for CollectionsTelemetry {
             vec![gauge(self.number_of_collections as f64, &[])],
         ));
         metrics.push(metric_family(
-            "collections_aggregated_vector_total",
+            "collections_vector_total",
             "total number of vectors in all collections",
             MetricType::GAUGE,
-            vec![gauge(aggregated_vector_count as f64, &[])],
+            vec![gauge(vector_count as f64, &[])],
         ));
 
         // Count collection types

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -29,17 +29,6 @@ pub struct CollectionsTelemetry {
 
 impl From<CollectionTelemetry> for CollectionsAggregatedTelemetry {
     fn from(telemetry: CollectionTelemetry) -> Self {
-        let number_of_vectors = telemetry
-            .shards
-            .iter()
-            .filter_map(|shard| {
-                shard
-                    .local
-                    .as_ref()
-                    .map(|x| x.segments.iter().map(|s| s.info.num_vectors).sum::<usize>())
-            })
-            .sum::<usize>();
-
         let optimizers_status = telemetry
             .shards
             .iter()
@@ -48,7 +37,7 @@ impl From<CollectionTelemetry> for CollectionsAggregatedTelemetry {
             .unwrap_or(OptimizersStatus::Ok);
 
         CollectionsAggregatedTelemetry {
-            vectors: number_of_vectors,
+            vectors: telemetry.count_vectors(),
             optimizers_status,
             params: telemetry.config.params,
         }


### PR DESCRIPTION
This fixes an issue where vectors were not counted properly in the `/metrics` output introduced in <https://github.com/qdrant/qdrant/pull/1598>.

It now successfully outputs:

```bash
# HELP collections_vector_total total number of vectors in all collections
# TYPE collections_vector_total gauge
collections_vector_total 100028
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?