### PR TITLE
Add validation to gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "tonic-build",
  "tower",
  "uuid",
+ "validator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ clap = { version = "4.2.1", features = ["derive"] }
 serde_cbor = { version = "0.11.2"}
 uuid = { version = "1.3", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-validator = { version = "0.16", features = ["derive"] }
-actix-web-validator = "5.0.1"
 
 config = "~0.13.3"
 
@@ -58,6 +56,8 @@ tar = "0.4.38"
 reqwest = { version = "0.11", features = ["stream", "rustls-tls", "blocking"] }
 openssl = { version = "0.10", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
+validator = { version = "0.16", features = ["derive"] }
+actix-web-validator = "5.0.1"
 
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ clap = { version = "4.2.1", features = ["derive"] }
 serde_cbor = { version = "0.11.2"}
 uuid = { version = "1.3", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-actix-web-validator = "5.0.1"
 validator = { version = "0.16", features = ["derive"] }
+actix-web-validator = "5.0.1"
 
 config = "~0.13.3"
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8.5"
 chrono = { version = "~0.4", features = ["serde"] }
 thiserror = "1.0"
 parking_lot = "0.12"
+validator = { version = "0.16", features = ["derive"] }
 
 segment = {path = "../segment"}
 

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -7,7 +7,13 @@ fn main() -> std::io::Result<()> {
         .compile(
             &["src/grpc/proto/qdrant.proto"], // proto entry point
             &["src/grpc/proto"], // specify the root location to search proto dependencies
-        )
+        )?;
+
+    // Append trait imports to generated gRPC output
+    // TODO: find a better way to do this?
+    append_file("src/grpc/qdrant.rs", "use super::validate::ValidateExt;");
+
+    Ok(())
 }
 
 trait BuilderExt {
@@ -44,6 +50,21 @@ impl BuilderExt for Builder {
             c.field_validate(path, constraint)
         })
     }
+}
+
+fn append_file(path: &str, line: &str) {
+    use std::fs::OpenOptions;
+    use std::io::prelude::*;
+
+    writeln!(
+        OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(path)
+            .unwrap(),
+        "{line}",
+    )
+    .expect("failed to append to generated file");
 }
 
 #[rustfmt::skip]

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -70,8 +70,8 @@ fn append_file(path: &str, line: &str) {
 #[rustfmt::skip]
 fn configure_validation(builder: Builder) -> Builder {
     builder
+        // API: collections_api.rs
         .derive_validates(&[
-            // collections_api.rs
             "GetCollectionInfoRequest",
             "ListCollectionsRequest",
             "CreateCollection",
@@ -83,7 +83,27 @@ fn configure_validation(builder: Builder) -> Builder {
             "ChangeAliases",
             "ListCollectionAliasesRequest",
             "ListAliasesRequest",
-            // points_api.rs
+        ])
+        .field_validates(&[
+            ("GetCollectionInfoRequest.collection_name", "length(min = 1)"),
+            ("CreateCollection.hnsw_config", ""),
+            // TODO: ("HnswConfigDiff.m", "range(min = 4, max = 10_000)"),
+            // TODO: ("HnswConfigDiff.ef_construct", "range(min = 4)"),
+            ("UpdateCollection.collection_name", "length(min = 1)"),
+            ("UpdateCollection.optimizers_config", ""),
+            // TODO: ("OptimizersConfigDiff.deleted_threshold", "range(min = 0.0, max = 1.0)"),
+            // TODO: ("OptimizersConfigDiff.vacuum_min_vector_number", "range(min = 100)"),
+            // TODO: ("OptimizersConfigDiff.memmap_threshold", "range(min = 1000)"),
+            // TODO: ("OptimizersConfigDiff.indexing_threshold", "range(min = 1000)"),
+            // TODO: ("UpdateCollection.timeout", "range(min = 1)"),
+            ("UpdateCollection.params", ""),
+            ("DeleteCollection.collection_name", "length(min = 1)"),
+            // TODO: ("DeleteCollection.timeout", "range(min = 1)"),
+            // TODO: ("ChangeAliases.timeout", "range(min = 1)"),
+            ("ListCollectionAliasesRequest.collection_name", "length(min = 1)"),
+        ])
+        // API: points_api.rs
+        .derive_validates(&[
             "UpsertPoints",
             "DeletePoints",
             "GetPoints",
@@ -101,24 +121,6 @@ fn configure_validation(builder: Builder) -> Builder {
             "SyncPoints",
         ])
         .field_validates(&[
-            // collections_api.rs
-            ("GetCollectionInfoRequest.collection_name", "length(min = 1)"),
-            ("CreateCollection.hnsw_config", ""),
-            // TODO: ("HnswConfigDiff.m", "range(min = 4, max = 10_000)"),
-            // TODO: ("HnswConfigDiff.ef_construct", "range(min = 4)"),
-            ("UpdateCollection.collection_name", "length(min = 1)"),
-            ("UpdateCollection.optimizers_config", ""),
-            // TODO: ("OptimizersConfigDiff.deleted_threshold", "range(min = 0.0, max = 1.0)"),
-            // TODO: ("OptimizersConfigDiff.vacuum_min_vector_number", "range(min = 100)"),
-            // TODO: ("OptimizersConfigDiff.memmap_threshold", "range(min = 1000)"),
-            // TODO: ("OptimizersConfigDiff.indexing_threshold", "range(min = 1000)"),
-            // TODO: ("UpdateCollection.timeout", "range(min = 1)"),
-            ("UpdateCollection.params", ""),
-            ("DeleteCollection.collection_name", "length(min = 1)"),
-            // TODO: ("DeleteCollection.timeout", "range(min = 1)"),
-            // TODO: ("ChangeAliases.timeout", "range(min = 1)"),
-            ("ListCollectionAliasesRequest.collection_name", "length(min = 1)"),
-            // points_api.rs
             ("UpsertPoints.collection_name", "length(min = 1)"),
             ("DeletePoints.collection_name", "length(min = 1)"),
             ("GetPoints.collection_name", "length(min = 1)"),
@@ -142,5 +144,29 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendBatchPoints.recommend_points", ""),
             ("CountPoints.collection_name", "length(min = 1)"),
             ("SyncPoints.collection_name", "length(min = 1)"),
+        ])
+        // API: raft_api.rs
+        .derive_validates(&[
+            "AddPeerToKnownMessage",
+        ])
+        .field_validates(&[
+            // TODO: ("AddPeerToKnownMessage.uri", "length(min = 1)"),
+            // TODO: ("AddPeerToKnownMessage.port", "range(min = 1)"),
+        ])
+        // API: snapshots_api.rs
+        .derive_validates(&[
+            "CreateSnapshotRequest",
+            "ListSnapshotsRequest",
+            "DeleteSnapshotRequest",
+            "CreateFullSnapshotRequest",
+            "ListFullSnapshotsRequest",
+            "DeleteFullSnapshotRequest",
+        ])
+        .field_validates(&[
+            ("CreateSnapshotRequest.collection_name", "length(min = 1)"),
+            ("ListSnapshotsRequest.collection_name", "length(min = 1)"),
+            ("DeleteSnapshotsRequest.collection_name", "length(min = 1)"),
+            ("DeleteSnapshotsRequest.snapshot_name", "length(min = 1)"),
+            ("DeleteFullSnapshotsRequest.snapshot_name", "length(min = 1)"),
         ])
 }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -99,6 +99,11 @@ fn configure_validation(builder: Builder) -> Builder {
             "ChangeAliases",
             "ListAliasesRequest",
         ])
+        // Service: collections_internal.proto
+        .validates(&[
+            ("GetCollectionInfoRequestInternal.get_collection_info_request", ""),
+            ("InitiateShardTransferRequest.collection_name", "length(min = 1)"),
+        ], &[])
         // Service: points.proto
         .validates(&[
             ("UpsertPoints.collection_name", "length(min = 1)"),
@@ -122,6 +127,26 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendBatchPoints.collection_name", "length(min = 1)"),
             ("RecommendBatchPoints.recommend_points", ""),
             ("CountPoints.collection_name", "length(min = 1)"),
+        ], &[])
+        // Service: points_internal_service.proto
+        .validates(&[
+            ("UpsertPointsInternal.upsert_points", ""),
+            ("DeletePointsInternal.delete_points", ""),
+            ("SetPayloadPointsInternal.set_payload_points", ""),
+            ("DeletePayloadPointsInternal.delete_payload_points", ""),
+            ("ClearPayloadPointsInternal.clear_payload_points", ""),
+            ("CreateFieldIndexCollectionInternal.create_field_index_collection", ""),
+            ("DeleteFieldIndexCollectionInternal.delete_field_index_collection", ""),
+            ("SearchPointsInternal.search_points", ""),
+            ("SearchBatchPointsInternal.collection_name", "length(min = 1)"),
+            ("SearchBatchPointsInternal.search_points", ""),
+            ("RecommendPointsInternal.recommend_points", ""),
+            ("ScrollPointsInternal.scroll_points", ""),
+            ("GetPointsInternal.get_points", ""),
+            ("CountPointsInternal.count_points", ""),
+            ("SyncPointsInternal.sync_points", ""),
+            ("SetPayloadPointsInternal.set_payload_points", ""),
+            ("SyncPoints.collection_name", "length(min = 1)"),
         ], &[])
         // Service: raft_service.proto
         .validates(&[

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -71,6 +71,18 @@ fn append_file(path: &str, line: &str) {
 fn configure_validation(builder: Builder) -> Builder {
     builder
         .derive_validates(&[
+            // collections_api.rs
+            "GetCollectionInfoRequest",
+            "ListCollectionsRequest",
+            "CreateCollection",
+            "HnswConfigDiff",
+            "UpdateCollection",
+            "OptimizersConfigDiff",
+            "CollectionParamsDiff",
+            "DeleteCollection",
+            "ChangeAliases",
+            "ListCollectionAliasesRequest",
+            "ListAliasesRequest",
             // points_api.rs
             "UpsertPoints",
             "DeletePoints",
@@ -86,8 +98,26 @@ fn configure_validation(builder: Builder) -> Builder {
             "RecommendPoints",
             "RecommendBatchPoints",
             "CountPoints",
+            "SyncPoints",
         ])
         .field_validates(&[
+            // collections_api.rs
+            ("GetCollectionInfoRequest.collection_name", "length(min = 1)"),
+            ("CreateCollection.hnsw_config", ""),
+            // TODO: ("HnswConfigDiff.m", "range(min = 4, max = 10_000)"),
+            // TODO: ("HnswConfigDiff.ef_construct", "range(min = 4)"),
+            ("UpdateCollection.collection_name", "length(min = 1)"),
+            ("UpdateCollection.optimizers_config", ""),
+            // TODO: ("OptimizersConfigDiff.deleted_threshold", "range(min = 0.0, max = 1.0)"),
+            // TODO: ("OptimizersConfigDiff.vacuum_min_vector_number", "range(min = 100)"),
+            // TODO: ("OptimizersConfigDiff.memmap_threshold", "range(min = 1000)"),
+            // TODO: ("OptimizersConfigDiff.indexing_threshold", "range(min = 1000)"),
+            // TODO: ("UpdateCollection.timeout", "range(min = 1)"),
+            ("UpdateCollection.params", ""),
+            ("DeleteCollection.collection_name", "length(min = 1)"),
+            // TODO: ("DeleteCollection.timeout", "range(min = 1)"),
+            // TODO: ("ChangeAliases.timeout", "range(min = 1)"),
+            ("ListCollectionAliasesRequest.collection_name", "length(min = 1)"),
             // points_api.rs
             ("UpsertPoints.collection_name", "length(min = 1)"),
             ("DeletePoints.collection_name", "length(min = 1)"),
@@ -101,15 +131,16 @@ fn configure_validation(builder: Builder) -> Builder {
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
             ("SearchPoints.collection_name", "length(min = 1)"),
             ("SearchPoints.limit", "range(min = 1)"),
-            // ("SearchPoints.vector_name", "length(min = 1)"),
+            // TODO: ("SearchPoints.vector_name", "length(min = 1)"),
             ("SearchBatchPoints.collection_name", "length(min = 1)"),
-            // ("SearchBatchPoints.search_points", ""),
+            ("SearchBatchPoints.search_points", ""),
             ("ScrollPoints.collection_name", "length(min = 1)"),
-            // ("ScrollPoints.limit", "range(min = 1)"),
+            // TODO: ("ScrollPoints.limit", "range(min = 1)"),
             ("RecommendPoints.collection_name", "length(min = 1)"),
             ("RecommendPoints.limit", "range(min = 1)"),
             ("RecommendBatchPoints.collection_name", "length(min = 1)"),
-            // ("RecommendBatchPoints.recommend_points", ""),
+            ("RecommendBatchPoints.recommend_points", ""),
             ("CountPoints.collection_name", "length(min = 1)"),
+            ("SyncPoints.collection_name", "length(min = 1)"),
         ])
 }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -1,8 +1,94 @@
+use tonic_build::Builder;
+
 fn main() -> std::io::Result<()> {
     tonic_build::configure()
+        .configure_validation()
         .out_dir("src/grpc/") // saves generated structures at this location
         .compile(
             &["src/grpc/proto/qdrant.proto"], // proto entry point
             &["src/grpc/proto"], // specify the root location to search proto dependencies
         )
+}
+
+trait BuilderExt {
+    fn configure_validation(self) -> Self;
+    fn derive_validate(self, path: &str) -> Self;
+    fn derive_validates(self, paths: &[&str]) -> Self;
+    fn field_validate(self, path: &str, constraint: &str) -> Self;
+    fn field_validates(self, paths: &[(&str, &str)]) -> Self;
+}
+
+impl BuilderExt for Builder {
+    fn configure_validation(self) -> Self {
+        configure_validation(self)
+    }
+
+    fn derive_validate(self, path: &str) -> Self {
+        self.type_attribute(path, "#[derive(validator::Validate)]")
+    }
+
+    fn derive_validates(self, paths: &[&str]) -> Self {
+        paths.iter().fold(self, |c, path| c.derive_validate(path))
+    }
+
+    fn field_validate(self, path: &str, constraint: &str) -> Self {
+        if constraint.is_empty() {
+            self.field_attribute(path, "#[validate]")
+        } else {
+            self.field_attribute(path, format!("#[validate({constraint})]"))
+        }
+    }
+
+    fn field_validates(self, fields: &[(&str, &str)]) -> Self {
+        fields.iter().fold(self, |c, (path, constraint)| {
+            c.field_validate(path, constraint)
+        })
+    }
+}
+
+#[rustfmt::skip]
+fn configure_validation(builder: Builder) -> Builder {
+    builder
+        .derive_validates(&[
+            // points_api.rs
+            "UpsertPoints",
+            "DeletePoints",
+            "GetPoints",
+            "SetPayloadPoints",
+            "DeletePayloadPoints",
+            "ClearPayloadPoints",
+            "CreateFieldIndexCollection",
+            "DeleteFieldIndexCollection",
+            "SearchPoints",
+            "SearchBatchPoints",
+            "ScrollPoints",
+            "RecommendPoints",
+            "RecommendBatchPoints",
+            "CountPoints",
+        ])
+        .field_validates(&[
+            // points_api.rs
+            ("UpsertPoints.collection_name", "length(min = 1)"),
+            ("DeletePoints.collection_name", "length(min = 1)"),
+            ("GetPoints.collection_name", "length(min = 1)"),
+            ("SetPayloadPoints.collection_name", "length(min = 1)"),
+            ("DeletePayloadPoints.collection_name", "length(min = 1)"),
+            ("ClearPayloadPoints.collection_name", "length(min = 1)"),
+            ("CreateFieldIndexCollection.collection_name", "length(min = 1)"),
+            ("CreateFieldIndexCollection.field_name", "length(min = 1)"),
+            ("DeleteFieldIndexCollection.collection_name", "length(min = 1)"),
+            ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
+            ("SearchPoints.collection_name", "length(min = 1)"),
+            ("SearchPoints.limit", "range(min = 1)"),
+            // ("SearchPoints.vector_name", "length(min = 1)"),
+            ("SearchBatchPoints.collection_name", "length(min = 1)"),
+            // ("SearchBatchPoints.search_points", ""),
+            ("ScrollPoints.collection_name", "length(min = 1)"),
+            // ("ScrollPoints.limit", "range(min = 1)"),
+            ("RecommendPoints.collection_name", "length(min = 1)"),
+            ("RecommendPoints.limit", "range(min = 1)"),
+            ("RecommendBatchPoints.collection_name", "length(min = 1)"),
+            // ("RecommendBatchPoints.recommend_points", ""),
+            ("CountPoints.collection_name", "length(min = 1)"),
+        ])
 }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -79,20 +79,20 @@ fn configure_validation(builder: Builder) -> Builder {
     builder
         // Service: collections.proto
         .validates(&[
-            ("GetCollectionInfoRequest.collection_name", "length(min = 1)"),
-            ("CreateCollection.collection_name", "length(min = 1)"),
+            ("GetCollectionInfoRequest.collection_name", "length(min = 1, max = 255)"),
+            ("CreateCollection.collection_name", "length(min = 1, max = 255)"),
             ("CreateCollection.hnsw_config", ""),
             ("CreateCollection.wal_config", ""),
             ("CreateCollection.optimizers_config", ""),
             ("CreateCollection.vectors_config", ""),
-            ("UpdateCollection.collection_name", "length(min = 1)"),
+            ("UpdateCollection.collection_name", "length(min = 1, max = 255)"),
             ("UpdateCollection.optimizers_config", ""),
             ("UpdateCollection.params", ""),
             ("UpdateCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
-            ("DeleteCollection.collection_name", "length(min = 1)"),
+            ("DeleteCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("ChangeAliases.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
-            ("ListCollectionAliasesRequest.collection_name", "length(min = 1)"),
+            ("ListCollectionAliasesRequest.collection_name", "length(min = 1, max = 255)"),
             ("HnswConfigDiff.m", "custom = \"crate::grpc::validate::validate_u64_range_min_4_max_10000\""),
             ("HnswConfigDiff.ef_construct", "custom = \"crate::grpc::validate::validate_u64_range_min_4\""),
             ("WalConfigDiff.wal_capacity_mb", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
@@ -111,31 +111,31 @@ fn configure_validation(builder: Builder) -> Builder {
         // Service: collections_internal.proto
         .validates(&[
             ("GetCollectionInfoRequestInternal.get_collection_info_request", ""),
-            ("InitiateShardTransferRequest.collection_name", "length(min = 1)"),
+            ("InitiateShardTransferRequest.collection_name", "length(min = 1, max = 255)"),
         ], &[])
         // Service: points.proto
         .validates(&[
-            ("UpsertPoints.collection_name", "length(min = 1)"),
-            ("DeletePoints.collection_name", "length(min = 1)"),
-            ("GetPoints.collection_name", "length(min = 1)"),
-            ("SetPayloadPoints.collection_name", "length(min = 1)"),
-            ("DeletePayloadPoints.collection_name", "length(min = 1)"),
-            ("ClearPayloadPoints.collection_name", "length(min = 1)"),
-            ("CreateFieldIndexCollection.collection_name", "length(min = 1)"),
+            ("UpsertPoints.collection_name", "length(min = 1, max = 255)"),
+            ("DeletePoints.collection_name", "length(min = 1, max = 255)"),
+            ("GetPoints.collection_name", "length(min = 1, max = 255)"),
+            ("SetPayloadPoints.collection_name", "length(min = 1, max = 255)"),
+            ("DeletePayloadPoints.collection_name", "length(min = 1, max = 255)"),
+            ("ClearPayloadPoints.collection_name", "length(min = 1, max = 255)"),
+            ("CreateFieldIndexCollection.collection_name", "length(min = 1, max = 255)"),
             ("CreateFieldIndexCollection.field_name", "length(min = 1)"),
-            ("DeleteFieldIndexCollection.collection_name", "length(min = 1)"),
+            ("DeleteFieldIndexCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
-            ("SearchPoints.collection_name", "length(min = 1)"),
+            ("SearchPoints.collection_name", "length(min = 1, max = 255)"),
             ("SearchPoints.limit", "range(min = 1)"),
             ("SearchPoints.vector_name", "custom = \"crate::grpc::validate::validate_not_empty\""),
-            ("SearchBatchPoints.collection_name", "length(min = 1)"),
+            ("SearchBatchPoints.collection_name", "length(min = 1, max = 255)"),
             ("SearchBatchPoints.search_points", ""),
-            ("ScrollPoints.collection_name", "length(min = 1)"),
+            ("ScrollPoints.collection_name", "length(min = 1, max = 255)"),
             ("ScrollPoints.limit", "custom = \"crate::grpc::validate::validate_u32_range_min_1\""),
-            ("RecommendPoints.collection_name", "length(min = 1)"),
-            ("RecommendBatchPoints.collection_name", "length(min = 1)"),
+            ("RecommendPoints.collection_name", "length(min = 1, max = 255)"),
+            ("RecommendBatchPoints.collection_name", "length(min = 1, max = 255)"),
             ("RecommendBatchPoints.recommend_points", ""),
-            ("CountPoints.collection_name", "length(min = 1)"),
+            ("CountPoints.collection_name", "length(min = 1, max = 255)"),
         ], &[])
         // Service: points_internal_service.proto
         .validates(&[
@@ -147,14 +147,14 @@ fn configure_validation(builder: Builder) -> Builder {
             ("CreateFieldIndexCollectionInternal.create_field_index_collection", ""),
             ("DeleteFieldIndexCollectionInternal.delete_field_index_collection", ""),
             ("SearchPointsInternal.search_points", ""),
-            ("SearchBatchPointsInternal.collection_name", "length(min = 1)"),
+            ("SearchBatchPointsInternal.collection_name", "length(min = 1, max = 255)"),
             ("SearchBatchPointsInternal.search_points", ""),
             ("RecommendPointsInternal.recommend_points", ""),
             ("ScrollPointsInternal.scroll_points", ""),
             ("GetPointsInternal.get_points", ""),
             ("CountPointsInternal.count_points", ""),
             ("SyncPointsInternal.sync_points", ""),
-            ("SyncPoints.collection_name", "length(min = 1)"),
+            ("SyncPoints.collection_name", "length(min = 1, max = 255)"),
         ], &[])
         // Service: raft_service.proto
         .validates(&[
@@ -163,9 +163,9 @@ fn configure_validation(builder: Builder) -> Builder {
         ], &[])
         // Service: snapshot_service.proto
         .validates(&[
-            ("CreateSnapshotRequest.collection_name", "length(min = 1)"),
-            ("ListSnapshotsRequest.collection_name", "length(min = 1)"),
-            ("DeleteSnapshotRequest.collection_name", "length(min = 1)"),
+            ("CreateSnapshotRequest.collection_name", "length(min = 1, max = 255)"),
+            ("ListSnapshotsRequest.collection_name", "length(min = 1, max = 255)"),
+            ("DeleteSnapshotRequest.collection_name", "length(min = 1, max = 255)"),
             ("DeleteSnapshotRequest.snapshot_name", "length(min = 1)"),
             ("DeleteFullSnapshotRequest.snapshot_name", "length(min = 1)"),
         ], &[

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -129,7 +129,6 @@ fn configure_validation(builder: Builder) -> Builder {
             ("ScrollPoints.collection_name", "length(min = 1)"),
             // TODO: ("ScrollPoints.limit", "range(min = 1)"),
             ("RecommendPoints.collection_name", "length(min = 1)"),
-            ("RecommendPoints.limit", "range(min = 1)"),
             ("RecommendBatchPoints.collection_name", "length(min = 1)"),
             ("RecommendBatchPoints.recommend_points", ""),
             ("CountPoints.collection_name", "length(min = 1)"),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -5,7 +5,7 @@ fn main() -> std::io::Result<()> {
     tonic_build::configure()
         // Because we want to attach all validation rules to the generated gRPC types, we must do
         // so by extending the builder. This is ugly, but better than manually implementing
-        // `Validation` for all these types. This seems to be the best approach. The line below
+        // `Validation` for all these types and seems to be the best approach. The line below
         // configures all attributes.
         .configure_validation()
         .out_dir("src/grpc/") // saves generated structures at this location

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -88,28 +88,24 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdateCollection.collection_name", "length(min = 1)"),
             ("UpdateCollection.optimizers_config", ""),
             ("UpdateCollection.params", ""),
-            // Validate: ("UpdateCollection.timeout", "range(min = 1)"),
+            ("UpdateCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("DeleteCollection.collection_name", "length(min = 1)"),
-            // Validate: ("DeleteCollection.timeout", "range(min = 1)"),
-            // Validate: ("ChangeAliases.timeout", "range(min = 1)"),
+            ("DeleteCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
+            ("ChangeAliases.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("ListCollectionAliasesRequest.collection_name", "length(min = 1)"),
-            // Validate: ("HnswConfigDiff.m", "range(min = 4, max = 10_000)"),
-            // Validate: ("HnswConfigDiff.ef_construct", "range(min = 4)"),
-            // Validate: ("WalConfigDiff.wal_capacity_mb", "range(min = 1)"),
-            // Validate: ("OptimizersConfigDiff.deleted_threshold", "range(min = 0.0, max = 1.0)"),
-            // Validate: ("OptimizersConfigDiff.vacuum_min_vector_number", "range(min = 100)"),
-            // Validate: ("OptimizersConfigDiff.memmap_threshold", "range(min = 1000)"),
-            // Validate: ("OptimizersConfigDiff.indexing_threshold", "range(min = 1000)"),
+            ("HnswConfigDiff.m", "custom = \"crate::grpc::validate::validate_u64_range_min_4_max_10000\""),
+            ("HnswConfigDiff.ef_construct", "custom = \"crate::grpc::validate::validate_u64_range_min_4\""),
+            ("WalConfigDiff.wal_capacity_mb", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
+            ("OptimizersConfigDiff.deleted_threshold", "custom = \"crate::grpc::validate::validate_f64_range_1\""),
+            ("OptimizersConfigDiff.vacuum_min_vector_number", "custom = \"crate::grpc::validate::validate_u64_range_min_100\""),
+            ("OptimizersConfigDiff.memmap_threshold", "custom = \"crate::grpc::validate::validate_u64_range_min_1000\""),
+            ("OptimizersConfigDiff.indexing_threshold", "custom = \"crate::grpc::validate::validate_u64_range_min_1000\""),
             ("VectorsConfig.config", ""),
             ("VectorParams.size", "range(min = 1)"),
             ("VectorParamsMap.map", ""),
         ], &[
             "ListCollectionsRequest",
-            "HnswConfigDiff",
-            "WalConfigDiff",
-            "OptimizersConfigDiff",
             "CollectionParamsDiff",
-            "ChangeAliases",
             "ListAliasesRequest",
         ])
         // Service: collections_internal.proto
@@ -131,11 +127,11 @@ fn configure_validation(builder: Builder) -> Builder {
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
             ("SearchPoints.collection_name", "length(min = 1)"),
             ("SearchPoints.limit", "range(min = 1)"),
-            // Validate: ("SearchPoints.vector_name", "length(min = 1)"),
+            ("SearchPoints.vector_name", "custom = \"crate::grpc::validate::validate_not_empty\""),
             ("SearchBatchPoints.collection_name", "length(min = 1)"),
             ("SearchBatchPoints.search_points", ""),
             ("ScrollPoints.collection_name", "length(min = 1)"),
-            // Validate: ("ScrollPoints.limit", "range(min = 1)"),
+            ("ScrollPoints.limit", "custom = \"crate::grpc::validate::validate_u32_range_min_1\""),
             ("RecommendPoints.collection_name", "length(min = 1)"),
             ("RecommendBatchPoints.collection_name", "length(min = 1)"),
             ("RecommendBatchPoints.recommend_points", ""),
@@ -162,11 +158,9 @@ fn configure_validation(builder: Builder) -> Builder {
         ], &[])
         // Service: raft_service.proto
         .validates(&[
-            // Validate: ("AddPeerToKnownMessage.uri", "length(min = 1)"),
-            // Validate: ("AddPeerToKnownMessage.port", "range(min = 1)"),
-        ], &[
-            "AddPeerToKnownMessage",
-        ])
+            ("AddPeerToKnownMessage.uri", "custom = \"crate::grpc::validate::validate_not_empty\""),
+            ("AddPeerToKnownMessage.port", "custom = \"crate::grpc::validate::validate_u32_range_min_1\""),
+        ], &[])
         // Service: snapshot_service.proto
         .validates(&[
             ("CreateSnapshotRequest.collection_name", "length(min = 1)"),

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -8,6 +8,7 @@ pub mod qdrant;
 pub mod dynamic_channel_pool;
 pub mod dynamic_pool;
 pub mod transport_channel_pool;
+pub mod validate;
 
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -31,13 +31,16 @@ pub mod vectors_config {
         ParamsMap(super::VectorParamsMap),
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListCollectionsRequest {}
@@ -74,6 +77,7 @@ pub struct OptimizerStatus {
     #[prost(string, tag = "2")]
     pub error: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HnswConfigDiff {
@@ -115,6 +119,7 @@ pub struct WalConfigDiff {
     #[prost(uint64, optional, tag = "2")]
     pub wal_segments_ahead: ::core::option::Option<u64>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizersConfigDiff {
@@ -197,6 +202,7 @@ pub mod quantization_config {
         Scalar(super::ScalarQuantization),
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollection {
@@ -205,6 +211,7 @@ pub struct CreateCollection {
     pub collection_name: ::prost::alloc::string::String,
     /// Configuration of vector index
     #[prost(message, optional, tag = "4")]
+    #[validate]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
     /// Configuration of the Write-Ahead-Log
     #[prost(message, optional, tag = "5")]
@@ -236,27 +243,33 @@ pub struct CreateCollection {
     #[prost(message, optional, tag = "14")]
     pub quantization_config: ::core::option::Option<QuantizationConfig>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// New configuration parameters for the collection
     #[prost(message, optional, tag = "2")]
+    #[validate]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "3")]
     pub timeout: ::core::option::Option<u64>,
     /// New configuration parameters for the collection
     #[prost(message, optional, tag = "4")]
+    #[validate]
     pub params: ::core::option::Option<CollectionParamsDiff>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "2")]
@@ -291,6 +304,7 @@ pub struct CollectionParams {
     #[prost(uint32, optional, tag = "7")]
     pub write_consistency_factor: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionParamsDiff {
@@ -396,6 +410,7 @@ pub struct CollectionInfo {
     #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChangeAliases {
@@ -452,14 +467,17 @@ pub struct DeleteAlias {
     #[prost(string, tag = "1")]
     pub alias_name: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListAliasesRequest {}
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListCollectionAliasesRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2360,6 +2378,7 @@ pub struct SearchBatchPoints {
     #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
+    #[validate]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "3")]
@@ -2455,6 +2474,7 @@ pub struct RecommendBatchPoints {
     #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
+    #[validate]
     pub recommend_points: ::prost::alloc::vec::Vec<RecommendPoints>,
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "3")]
@@ -4296,11 +4316,13 @@ pub mod points_server {
         const NAME: &'static str = "qdrant.Points";
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2438,7 +2438,6 @@ pub struct RecommendPoints {
     pub filter: ::core::option::Option<Filter>,
     /// Max number of result
     #[prost(uint64, tag = "5")]
-    #[validate(range(min = 1))]
     pub limit: u64,
     /// Options for specifying which payload to include or not
     #[prost(message, optional, tag = "7")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -90,10 +90,12 @@ pub struct HnswConfigDiff {
     ///
     /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
     #[prost(uint64, optional, tag = "1")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_4_max_10000")]
     pub m: ::core::option::Option<u64>,
     ///
     /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
     #[prost(uint64, optional, tag = "2")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_4")]
     pub ef_construct: ::core::option::Option<u64>,
     ///
     /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
@@ -121,6 +123,7 @@ pub struct HnswConfigDiff {
 pub struct WalConfigDiff {
     /// Size of a single WAL block file
     #[prost(uint64, optional, tag = "1")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub wal_capacity_mb: ::core::option::Option<u64>,
     /// Number of segments to create in advance
     #[prost(uint64, optional, tag = "2")]
@@ -133,10 +136,12 @@ pub struct OptimizersConfigDiff {
     ///
     /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
     #[prost(double, optional, tag = "1")]
+    #[validate(custom = "crate::grpc::validate::validate_f64_range_1")]
     pub deleted_threshold: ::core::option::Option<f64>,
     ///
     /// The minimal number of vectors in a segment, required to perform segment optimization
     #[prost(uint64, optional, tag = "2")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_100")]
     pub vacuum_min_vector_number: ::core::option::Option<u64>,
     ///
     /// Target amount of segments the optimizer will try to keep.
@@ -165,12 +170,14 @@ pub struct OptimizersConfigDiff {
     /// To enable memmap storage, lower the threshold
     /// Note: 1Kb = 1 vector of size 256
     #[prost(uint64, optional, tag = "5")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1000")]
     pub memmap_threshold: ::core::option::Option<u64>,
     ///
     /// Maximum size (in KiloBytes) of vectors allowed for plain index.
     /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
     /// Note: 1Kb = 1 vector of size 256
     #[prost(uint64, optional, tag = "6")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1000")]
     pub indexing_threshold: ::core::option::Option<u64>,
     ///
     /// Interval between forced flushes.
@@ -268,6 +275,7 @@ pub struct UpdateCollection {
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "3")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub timeout: ::core::option::Option<u64>,
     /// New configuration parameters for the collection
     #[prost(message, optional, tag = "4")]
@@ -284,6 +292,7 @@ pub struct DeleteCollection {
     pub collection_name: ::prost::alloc::string::String,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "2")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub timeout: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -430,6 +439,7 @@ pub struct ChangeAliases {
     pub actions: ::prost::alloc::vec::Vec<AliasOperations>,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "2")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub timeout: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2375,6 +2385,7 @@ pub struct SearchPoints {
     pub offset: ::core::option::Option<u64>,
     /// Which vector to use for search, if not specified - use default vector
     #[prost(string, optional, tag = "10")]
+    #[validate(custom = "crate::grpc::validate::validate_not_empty")]
     pub vector_name: ::core::option::Option<::prost::alloc::string::String>,
     /// Options for specifying which vectors to include into response
     #[prost(message, optional, tag = "11")]
@@ -2413,6 +2424,7 @@ pub struct ScrollPoints {
     pub offset: ::core::option::Option<PointId>,
     /// Max number of result
     #[prost(uint32, optional, tag = "4")]
+    #[validate(custom = "crate::grpc::validate::validate_u32_range_min_1")]
     pub limit: ::core::option::Option<u32>,
     /// Options for specifying which payload to include or not
     #[prost(message, optional, tag = "6")]
@@ -5873,8 +5885,10 @@ pub struct Peer {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddPeerToKnownMessage {
     #[prost(string, optional, tag = "1")]
+    #[validate(custom = "crate::grpc::validate::validate_not_empty")]
     pub uri: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(uint32, optional, tag = "2")]
+    #[validate(custom = "crate::grpc::validate::validate_u32_range_min_1")]
     pub port: ::core::option::Option<u32>,
     #[prost(uint64, tag = "3")]
     pub id: u64,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4315,13 +4315,11 @@ pub mod points_server {
         const NAME: &'static str = "qdrant.Points";
     }
 }
-#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5826,6 +5826,7 @@ pub struct Peer {
     #[prost(uint64, tag = "2")]
     pub id: u64,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddPeerToKnownMessage {
@@ -6357,12 +6358,15 @@ pub mod raft_server {
         const NAME: &'static str = "qdrant.Raft";
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateFullSnapshotRequest {}
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListFullSnapshotsRequest {}
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteFullSnapshotRequest {
@@ -6370,20 +6374,25 @@ pub struct DeleteFullSnapshotRequest {
     #[prost(string, tag = "1")]
     pub snapshot_name: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSnapshotsRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteSnapshotRequest {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -43,7 +43,7 @@ pub mod vectors_config {
 pub struct GetCollectionInfoRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(validator::Validate)]
@@ -222,7 +222,7 @@ pub mod quantization_config {
 pub struct CreateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Configuration of vector index
     #[prost(message, optional, tag = "4")]
@@ -267,7 +267,7 @@ pub struct CreateCollection {
 pub struct UpdateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// New configuration parameters for the collection
     #[prost(message, optional, tag = "2")]
@@ -288,7 +288,7 @@ pub struct UpdateCollection {
 pub struct DeleteCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "2")]
@@ -498,7 +498,7 @@ pub struct ListAliasesRequest {}
 pub struct ListCollectionAliasesRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1550,7 +1550,7 @@ pub struct GetCollectionInfoRequestInternal {
 pub struct InitiateShardTransferRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Id of the temporary shard
     #[prost(uint32, tag = "2")]
@@ -2087,7 +2087,7 @@ pub struct Vector {
 pub struct UpsertPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2104,7 +2104,7 @@ pub struct UpsertPoints {
 pub struct DeletePoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2122,7 +2122,7 @@ pub struct DeletePoints {
 pub struct GetPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// List of points to retrieve
     #[prost(message, repeated, tag = "2")]
@@ -2143,7 +2143,7 @@ pub struct GetPoints {
 pub struct SetPayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2164,7 +2164,7 @@ pub struct SetPayloadPoints {
 pub struct DeletePayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2185,7 +2185,7 @@ pub struct DeletePayloadPoints {
 pub struct ClearPayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2203,7 +2203,7 @@ pub struct ClearPayloadPoints {
 pub struct CreateFieldIndexCollection {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2228,7 +2228,7 @@ pub struct CreateFieldIndexCollection {
 pub struct DeleteFieldIndexCollection {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2359,7 +2359,7 @@ pub struct SearchParams {
 pub struct SearchPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// vector
     #[prost(float, repeated, tag = "2")]
@@ -2400,7 +2400,7 @@ pub struct SearchPoints {
 pub struct SearchBatchPoints {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     #[validate]
@@ -2414,7 +2414,7 @@ pub struct SearchBatchPoints {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPoints {
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
     #[prost(message, optional, tag = "2")]
@@ -2451,7 +2451,7 @@ pub struct LookupLocation {
 pub struct RecommendPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Look for vectors closest to those
     #[prost(message, repeated, tag = "2")]
@@ -2496,7 +2496,7 @@ pub struct RecommendPoints {
 pub struct RecommendBatchPoints {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     #[validate]
@@ -2511,7 +2511,7 @@ pub struct RecommendBatchPoints {
 pub struct CountPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
     #[prost(message, optional, tag = "2")]
@@ -4347,7 +4347,7 @@ pub mod points_server {
 pub struct SyncPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -4462,7 +4462,7 @@ pub struct SearchPointsInternal {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchPointsInternal {
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     #[validate]
@@ -6437,7 +6437,7 @@ pub struct DeleteFullSnapshotRequest {
 pub struct CreateSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(validator::Validate)]
@@ -6446,7 +6446,7 @@ pub struct CreateSnapshotRequest {
 pub struct ListSnapshotsRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(validator::Validate)]
@@ -6455,7 +6455,7 @@ pub struct ListSnapshotsRequest {
 pub struct DeleteSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
     /// Name of the collection snapshot
     #[prost(string, tag = "2")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1514,6 +1514,7 @@ pub mod collections_server {
         const NAME: &'static str = "qdrant.Collections";
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoRequestInternal {
@@ -1522,11 +1523,13 @@ pub struct GetCollectionInfoRequestInternal {
     #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitiateShardTransferRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Id of the temporary shard
     #[prost(uint32, tag = "2")]
@@ -4315,11 +4318,13 @@ pub mod points_server {
         const NAME: &'static str = "qdrant.Points";
     }
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -4335,120 +4340,150 @@ pub struct SyncPoints {
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub sync_points: ::core::option::Option<SyncPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub upsert_points: ::core::option::Option<UpsertPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub delete_points: ::core::option::Option<DeletePoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
+    #[validate]
     pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub delete_payload_points: ::core::option::Option<DeletePayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub clear_payload_points: ::core::option::Option<ClearPayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub create_field_index_collection: ::core::option::Option<
         CreateFieldIndexCollection,
     >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub delete_field_index_collection: ::core::option::Option<
         DeleteFieldIndexCollection,
     >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub search_points: ::core::option::Option<SearchPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchPointsInternal {
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
+    #[validate]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
     #[prost(uint32, optional, tag = "3")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub scroll_points: ::core::option::Option<ScrollPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub recommend_points: ::core::option::Option<RecommendPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub get_points: ::core::option::Option<GetPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountPointsInternal {
     #[prost(message, optional, tag = "1")]
+    #[validate]
     pub count_points: ::core::option::Option<CountPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1,23 +1,29 @@
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorParams {
     /// Size of the vectors
     #[prost(uint64, tag = "1")]
+    #[validate(range(min = 1))]
     pub size: u64,
     /// Distance function used for comparing vectors
     #[prost(enumeration = "Distance", tag = "2")]
     pub distance: i32,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorParamsMap {
     #[prost(map = "string, message", tag = "1")]
+    #[validate]
     pub map: ::std::collections::HashMap<::prost::alloc::string::String, VectorParams>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorsConfig {
     #[prost(oneof = "vectors_config::Config", tags = "1, 2")]
+    #[validate]
     pub config: ::core::option::Option<vectors_config::Config>,
 }
 /// Nested message and enum types in `VectorsConfig`.
@@ -109,6 +115,7 @@ pub struct HnswConfigDiff {
     #[prost(uint64, optional, tag = "6")]
     pub payload_m: ::core::option::Option<u64>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WalConfigDiff {
@@ -208,6 +215,7 @@ pub mod quantization_config {
 pub struct CreateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Configuration of vector index
     #[prost(message, optional, tag = "4")]
@@ -215,9 +223,11 @@ pub struct CreateCollection {
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
     /// Configuration of the Write-Ahead-Log
     #[prost(message, optional, tag = "5")]
+    #[validate]
     pub wal_config: ::core::option::Option<WalConfigDiff>,
     /// Configuration of the optimizers
     #[prost(message, optional, tag = "6")]
+    #[validate]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
     /// Number of shards in the collection, default = 1
     #[prost(uint32, optional, tag = "7")]
@@ -230,6 +240,7 @@ pub struct CreateCollection {
     pub timeout: ::core::option::Option<u64>,
     /// Configuration for vectors
     #[prost(message, optional, tag = "10")]
+    #[validate]
     pub vectors_config: ::core::option::Option<VectorsConfig>,
     /// Number of replicas of each shard that network tries to maintain, default = 1
     #[prost(uint32, optional, tag = "11")]
@@ -4375,7 +4386,6 @@ pub struct DeletePointsInternal {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
-    #[validate]
     #[validate]
     pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
     #[prost(uint32, optional, tag = "2")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7398,3 +7398,4 @@ pub mod qdrant_server {
         const NAME: &'static str = "qdrant.Qdrant";
     }
 }
+use super::validate::ValidateExt;

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6372,6 +6372,7 @@ pub struct ListFullSnapshotsRequest {}
 pub struct DeleteFullSnapshotRequest {
     /// Name of the full snapshot
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub snapshot_name: ::prost::alloc::string::String,
 }
 #[derive(validator::Validate)]
@@ -6398,9 +6399,11 @@ pub struct ListSnapshotsRequest {
 pub struct DeleteSnapshotRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Name of the collection snapshot
     #[prost(string, tag = "2")]
+    #[validate(length(min = 1))]
     pub snapshot_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2039,11 +2039,13 @@ pub struct Vector {
     #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpsertPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2054,11 +2056,13 @@ pub struct UpsertPoints {
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2070,11 +2074,13 @@ pub struct DeletePoints {
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// List of points to retrieve
     #[prost(message, repeated, tag = "2")]
@@ -2089,11 +2095,13 @@ pub struct GetPoints {
     #[prost(message, optional, tag = "6")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2108,11 +2116,13 @@ pub struct SetPayloadPoints {
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeletePayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2127,11 +2137,13 @@ pub struct DeletePayloadPoints {
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearPayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
@@ -2143,17 +2155,20 @@ pub struct ClearPayloadPoints {
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateFieldIndexCollection {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Field name to index
     #[prost(string, tag = "3")]
+    #[validate(length(min = 1))]
     pub field_name: ::prost::alloc::string::String,
     /// Field type.
     #[prost(enumeration = "FieldType", optional, tag = "4")]
@@ -2165,17 +2180,20 @@ pub struct CreateFieldIndexCollection {
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteFieldIndexCollection {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     /// Field name to delete
     #[prost(string, tag = "3")]
+    #[validate(length(min = 1))]
     pub field_name: ::prost::alloc::string::String,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
@@ -2293,11 +2311,13 @@ pub struct SearchParams {
     #[prost(message, optional, tag = "3")]
     pub quantization: ::core::option::Option<QuantizationSearchParams>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// vector
     #[prost(float, repeated, tag = "2")]
@@ -2307,6 +2327,7 @@ pub struct SearchPoints {
     pub filter: ::core::option::Option<Filter>,
     /// Max number of result
     #[prost(uint64, tag = "4")]
+    #[validate(range(min = 1))]
     pub limit: u64,
     /// Options for specifying which payload to include or not
     #[prost(message, optional, tag = "6")]
@@ -2330,11 +2351,13 @@ pub struct SearchPoints {
     #[prost(message, optional, tag = "12")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchBatchPoints {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub search_points: ::prost::alloc::vec::Vec<SearchPoints>,
@@ -2342,10 +2365,12 @@ pub struct SearchBatchPoints {
     #[prost(message, optional, tag = "3")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollPoints {
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
     #[prost(message, optional, tag = "2")]
@@ -2375,11 +2400,13 @@ pub struct LookupLocation {
     #[prost(string, optional, tag = "2")]
     pub vector_name: ::core::option::Option<::prost::alloc::string::String>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Look for vectors closest to those
     #[prost(message, repeated, tag = "2")]
@@ -2392,6 +2419,7 @@ pub struct RecommendPoints {
     pub filter: ::core::option::Option<Filter>,
     /// Max number of result
     #[prost(uint64, tag = "5")]
+    #[validate(range(min = 1))]
     pub limit: u64,
     /// Options for specifying which payload to include or not
     #[prost(message, optional, tag = "7")]
@@ -2418,11 +2446,13 @@ pub struct RecommendPoints {
     #[prost(message, optional, tag = "14")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendBatchPoints {
     /// Name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub recommend_points: ::prost::alloc::vec::Vec<RecommendPoints>,
@@ -2430,11 +2460,13 @@ pub struct RecommendBatchPoints {
     #[prost(message, optional, tag = "3")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CountPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
+    #[validate(length(min = 1))]
     pub collection_name: ::prost::alloc::string::String,
     /// Filter conditions - return only those points that satisfy the specified conditions
     #[prost(message, optional, tag = "2")]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,31 +1,13 @@
-use validator::{HasLen, Validate, ValidationErrors};
+use validator::{Validate, ValidationErrors};
 
 pub trait ValidateExt {
     fn validate(&self) -> Result<(), ValidationErrors>;
 }
 
 impl Validate for dyn ValidateExt {
+    #[inline]
     fn validate(&self) -> Result<(), ValidationErrors> {
         ValidateExt::validate(self)
-    }
-}
-
-pub trait HasLenExt {
-    fn length(&self) -> u64;
-}
-
-impl HasLen for dyn HasLenExt {
-    fn length(&self) -> u64 {
-        HasLenExt::length(self)
-    }
-}
-
-impl<V> ValidateExt for &::core::option::Option<V>
-where
-    V: Validate,
-{
-    fn validate(&self) -> Result<(), ValidationErrors> {
-        self.as_ref().map(Validate::validate).unwrap_or(Ok(()))
     }
 }
 
@@ -33,14 +15,19 @@ impl<V> ValidateExt for ::core::option::Option<V>
 where
     V: Validate,
 {
+    #[inline]
     fn validate(&self) -> Result<(), ValidationErrors> {
-        self.as_ref().map(Validate::validate).unwrap_or(Ok(()))
+        (&self).validate()
     }
 }
 
-impl HasLenExt for ::prost::alloc::string::String {
-    fn length(&self) -> u64 {
-        HasLen::length(self)
+impl<V> ValidateExt for &::core::option::Option<V>
+where
+    V: Validate,
+{
+    #[inline]
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        self.as_ref().map(Validate::validate).unwrap_or(Ok(()))
     }
 }
 
@@ -48,6 +35,7 @@ impl<V> ValidateExt for Vec<V>
 where
     V: Validate,
 {
+    #[inline]
     fn validate(&self) -> Result<(), ValidationErrors> {
         let errors = self
             .iter()

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -82,11 +82,7 @@ impl Validate for crate::grpc::qdrant::vectors_config::Config {
 /// Validate that `value` is a non-empty string or `None`.
 pub fn validate_not_empty(value: &Option<String>) -> Result<(), ValidationError> {
     match value {
-        Some(value) if value.is_empty() => {
-            let mut err = ValidationError::new("not_empty");
-            err.add_param(Cow::from("value"), &value);
-            Err(err)
-        }
+        Some(value) if value.is_empty() => Err(ValidationError::new("not_empty")),
         _ => Ok(()),
     }
 }
@@ -150,7 +146,6 @@ where
     }
 
     let mut err = ValidationError::new("range");
-    err.add_param(Cow::from("value"), &value);
     if let Some(min) = min {
         err.add_param(Cow::from("min"), &min);
     }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -154,3 +154,81 @@ where
     }
     Err(err)
 }
+
+#[cfg(test)]
+mod tests {
+    use validator::Validate;
+
+    use crate::grpc::qdrant::{CreateCollection, CreateFieldIndexCollection, SearchPoints};
+
+    #[test]
+    fn test_good_request() {
+        let bad_request = CreateCollection {
+            collection_name: "test_collection".into(),
+            timeout: Some(10),
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_ok(),
+            "good collection request should not error on validation"
+        );
+    }
+
+    #[test]
+    fn test_bad_collection_request() {
+        let bad_request = CreateCollection {
+            collection_name: "".into(),
+            timeout: Some(0),
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_err(),
+            "bad collection request should error on validation"
+        );
+    }
+
+    #[test]
+    fn test_bad_index_request() {
+        let bad_request = CreateFieldIndexCollection {
+            collection_name: "".into(),
+            field_name: "".into(),
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_err(),
+            "bad index request should error on validation"
+        );
+    }
+
+    #[test]
+    fn test_bad_search_request() {
+        let bad_request = SearchPoints {
+            collection_name: "".into(),
+            limit: 0,
+            vector_name: Some("".into()),
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_err(),
+            "bad search request should error on validation"
+        );
+
+        let bad_request = SearchPoints {
+            limit: 0,
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_err(),
+            "bad search request should error on validation"
+        );
+
+        let bad_request = SearchPoints {
+            vector_name: Some("".into()),
+            ..Default::default()
+        };
+        assert!(
+            bad_request.validate().is_err(),
+            "bad search request should error on validation"
+        );
+    }
+}

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -87,42 +87,42 @@ pub fn validate_not_empty(value: &Option<String>) -> Result<(), ValidationError>
     }
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
+/// Validate the value is in `[1, ]` or `None`.
 pub fn validate_u64_range_min_1(value: &Option<u64>) -> Result<(), ValidationError> {
     validate_range_generic(value, Some(1), None)
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
-pub fn validate_u64_range_min_100(value: &Option<u64>) -> Result<(), ValidationError> {
-    validate_range_generic(value, Some(100), None)
-}
-
-/// Validate that the range of `value` is at least 1 or `None`.
-pub fn validate_u64_range_min_1000(value: &Option<u64>) -> Result<(), ValidationError> {
-    validate_range_generic(value, Some(1000), None)
-}
-
-/// Validate that the range of `value` is at least 1 or `None`.
+/// Validate the value is in `[1, ]` or `None`.
 pub fn validate_u32_range_min_1(value: &Option<u32>) -> Result<(), ValidationError> {
     validate_range_generic(value, Some(1), None)
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
-pub fn validate_u64_range_min_4_max_10000(value: &Option<u64>) -> Result<(), ValidationError> {
-    validate_range_generic(value, Some(4), Some(10_000))
+/// Validate the value is in `[100, ]` or `None`.
+pub fn validate_u64_range_min_100(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(100), None)
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
+/// Validate the value is in `[1000, ]` or `None`.
+pub fn validate_u64_range_min_1000(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(1000), None)
+}
+
+/// Validate the value is in `[4, ]` or `None`.
 pub fn validate_u64_range_min_4(value: &Option<u64>) -> Result<(), ValidationError> {
     validate_range_generic(value, Some(4), None)
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
+/// Validate the value is in `[4, 10000]` or `None`.
+pub fn validate_u64_range_min_4_max_10000(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(4), Some(10_000))
+}
+
+/// Validate the value is in `[0.0, 1.0]` or `None`.
 pub fn validate_f64_range_1(value: &Option<f64>) -> Result<(), ValidationError> {
     validate_range_generic(value, Some(0.0), Some(1.0))
 }
 
-/// Validate that the range of `value` is at least 1 or `None`.
+/// Validate the value is in `[min, max]` or `None`.
 #[inline]
 pub fn validate_range_generic<N>(
     value: &Option<N>,

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
-use validator::{Validate, ValidationErrors};
+use serde::Serialize;
+use validator::{Validate, ValidationError, ValidationErrors};
 
 pub trait ValidateExt {
     fn validate(&self) -> Result<(), ValidationErrors>;
@@ -75,4 +77,85 @@ impl Validate for crate::grpc::qdrant::vectors_config::Config {
             Config::ParamsMap(params_map) => params_map.validate(),
         }
     }
+}
+
+/// Validate that `value` is a non-empty string or `None`.
+pub fn validate_not_empty(value: &Option<String>) -> Result<(), ValidationError> {
+    match value {
+        Some(value) if value.is_empty() => {
+            let mut err = ValidationError::new("not_empty");
+            err.add_param(Cow::from("value"), &value);
+            Err(err)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u64_range_min_1(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(1), None)
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u64_range_min_100(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(100), None)
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u64_range_min_1000(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(1000), None)
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u32_range_min_1(value: &Option<u32>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(1), None)
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u64_range_min_4_max_10000(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(4), Some(10_000))
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_u64_range_min_4(value: &Option<u64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(4), None)
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+pub fn validate_f64_range_1(value: &Option<f64>) -> Result<(), ValidationError> {
+    validate_range_generic(value, Some(0.0), Some(1.0))
+}
+
+/// Validate that the range of `value` is at least 1 or `None`.
+#[inline]
+pub fn validate_range_generic<N>(
+    value: &Option<N>,
+    min: Option<N>,
+    max: Option<N>,
+) -> Result<(), ValidationError>
+where
+    N: PartialOrd + Serialize,
+{
+    // If value is None we're good
+    let value = match value {
+        Some(value) => value,
+        None => return Ok(()),
+    };
+
+    // If value is within bounds we're good
+    if min.as_ref().map(|min| value >= min).unwrap_or(true)
+        && max.as_ref().map(|max| value <= max).unwrap_or(true)
+    {
+        return Ok(());
+    }
+
+    let mut err = ValidationError::new("range");
+    err.add_param(Cow::from("value"), &value);
+    if let Some(min) = min {
+        err.add_param(Cow::from("min"), &min);
+    }
+    if let Some(max) = max {
+        err.add_param(Cow::from("max"), &max);
+    }
+    Err(err)
 }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,0 +1,61 @@
+use validator::{HasLen, Validate, ValidationErrors};
+
+pub trait ValidateExt {
+    fn validate(&self) -> Result<(), ValidationErrors>;
+}
+
+impl Validate for dyn ValidateExt {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        ValidateExt::validate(self)
+    }
+}
+
+pub trait HasLenExt {
+    fn length(&self) -> u64;
+}
+
+impl HasLen for dyn HasLenExt {
+    fn length(&self) -> u64 {
+        HasLenExt::length(self)
+    }
+}
+
+impl<V> ValidateExt for &::core::option::Option<V>
+where
+    V: Validate,
+{
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        self.as_ref().map(Validate::validate).unwrap_or(Ok(()))
+    }
+}
+
+impl<V> ValidateExt for ::core::option::Option<V>
+where
+    V: Validate,
+{
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        self.as_ref().map(Validate::validate).unwrap_or(Ok(()))
+    }
+}
+
+impl HasLenExt for ::prost::alloc::string::String {
+    fn length(&self) -> u64 {
+        HasLen::length(self)
+    }
+}
+
+impl<V> ValidateExt for Vec<V>
+where
+    V: Validate,
+{
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let errors = self
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.validate().err().map(|err| (i, err)))
+            .fold(ValidationErrors::new(), |a, (_i, b)| {
+                ValidationErrors::merge(Err(a), "", Err(b)).unwrap_err()
+            });
+        errors.errors().is_empty().then_some(()).ok_or(errors)
+    }
+}

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -40,8 +40,8 @@ tonic = { version = "0.9.1", features = ["gzip", "tls"] }
 tower = "0.4.13"
 uuid = { version = "1.3", features = ["v4", "serde"] }
 url = { version = "2", features = ["serde"] }
-actix-web-validator = "5.0.1"
 validator = { version = "0.16", features = ["derive"] }
+actix-web-validator = "5.0.1"
 
 segment = {path = "../segment"}
 api = {path = "../api"}

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -12,9 +12,10 @@ pub fn warn_validation_errors(description: &str, errs: &ValidationErrors) {
 }
 
 /// Label the given validation errors in a single string.
-pub fn label_errors(label: &str, errs: &ValidationErrors) -> String {
+pub fn label_errors(label: impl AsRef<str>, errs: &ValidationErrors) -> String {
     format!(
-        "{label}: [{}]",
+        "{}: [{}]",
+        label.as_ref(),
         describe_errors(errs)
             .into_iter()
             .map(|(field, err)| format!("{field}: {err}"))
@@ -26,7 +27,7 @@ pub fn label_errors(label: &str, errs: &ValidationErrors) -> String {
 /// Describe the given validation errors.
 ///
 /// Returns a list of error messages for fields: `(field, message)`
-pub fn describe_errors(errs: &ValidationErrors) -> Vec<(String, String)> {
+fn describe_errors(errs: &ValidationErrors) -> Vec<(String, String)> {
     flatten_errors(errs)
         .into_iter()
         .map(|(_, name, err)| (name, describe_error(err)))

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -77,6 +77,10 @@ fn describe_error(
                 None => msg,
             }
         }
+        "not_empty" => match params.get("value") {
+            Some(value) => format!("value {value} invalid, must not be empty"),
+            None => err.to_string(),
+        },
         // Undescribed error codes
         _ => err.to_string(),
     }

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -11,6 +11,18 @@ pub fn warn_validation_errors(description: &str, errs: &ValidationErrors) {
         .for_each(|(key, msg)| log::warn!("- {key}: {}", msg));
 }
 
+/// Label the given validation errors in a single string.
+pub fn label_errors(label: &str, errs: &ValidationErrors) -> String {
+    format!(
+        "{label}: [{}]",
+        describe_errors(errs)
+            .into_iter()
+            .map(|(field, err)| format!("{field}: {err}"))
+            .collect::<Vec<_>>()
+            .join("; ")
+    )
+}
+
 /// Describe the given validation errors.
 ///
 /// Returns a list of error messages for fields: `(field, message)`

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -123,7 +123,7 @@ fn validation_error_handler(
     // Nicely describe deserialization and validation errors
     let msg = match &err {
         actix_web_validator::Error::Validate(errs) => {
-            validation::label_errors(&format!("Validation error in {name}"), errs)
+            validation::label_errors(format!("Validation error in {name}"), errs)
         }
         actix_web_validator::Error::Deserialize(err) => {
             format!(

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -123,14 +123,7 @@ fn validation_error_handler(
     // Nicely describe deserialization and validation errors
     let msg = match &err {
         actix_web_validator::Error::Validate(errs) => {
-            format!(
-                "Validation error in {name}: [{}]",
-                validation::describe_errors(errs)
-                    .into_iter()
-                    .map(|(field, err)| format!("{field}: {err}"))
-                    .collect::<Vec<_>>()
-                    .join("; ")
-            )
+            validation::label_errors(&format!("Validation error in {name}"), errs)
         }
         actix_web_validator::Error::Deserialize(err) => {
             format!(

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -12,6 +12,7 @@ use storage::content_manager::conversions::error_to_status;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
+use super::validate;
 use crate::common::collections::*;
 use crate::tonic::api::collections_common::get;
 
@@ -102,13 +103,16 @@ impl Collections for CollectionsService {
         &self,
         request: Request<GetCollectionInfoRequest>,
     ) -> Result<Response<GetCollectionInfoResponse>, Status> {
+        validate(request.get_ref())?;
         get(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn list(
         &self,
-        _request: Request<ListCollectionsRequest>,
+        request: Request<ListCollectionsRequest>,
     ) -> Result<Response<ListCollectionsResponse>, Status> {
+        validate(request.get_ref())?;
+
         let timing = Instant::now();
         let result = do_list_collections(&self.dispatcher).await;
 
@@ -120,6 +124,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<CreateCollection>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        validate(request.get_ref())?;
         self.perform_operation(request).await
     }
 
@@ -127,6 +132,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<UpdateCollection>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        validate(request.get_ref())?;
         self.perform_operation(request).await
     }
 
@@ -134,6 +140,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<DeleteCollection>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        validate(request.get_ref())?;
         self.perform_operation(request).await
     }
 
@@ -141,6 +148,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<ChangeAliases>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        validate(request.get_ref())?;
         self.perform_operation(request).await
     }
 
@@ -148,6 +156,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<ListCollectionAliasesRequest>,
     ) -> Result<Response<ListAliasesResponse>, Status> {
+        validate(request.get_ref())?;
         self.list_collection_aliases(request).await
     }
 
@@ -155,6 +164,7 @@ impl Collections for CollectionsService {
         &self,
         request: Request<ListAliasesRequest>,
     ) -> Result<Response<ListAliasesResponse>, Status> {
+        validate(request.get_ref())?;
         self.list_aliases(request).await
     }
 }

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -112,7 +112,6 @@ impl Collections for CollectionsService {
         request: Request<ListCollectionsRequest>,
     ) -> Result<Response<ListCollectionsResponse>, Status> {
         validate(request.get_ref())?;
-
         let timing = Instant::now();
         let result = do_list_collections(&self.dispatcher).await;
 

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -35,9 +35,9 @@ impl CollectionsService {
                 Error = Status,
             >,
     {
+        let timing = Instant::now();
         let operation = request.into_inner();
         let wait_timeout = operation.wait_timeout();
-        let timing = Instant::now();
         let result = self
             .dispatcher
             .submit_collection_meta_op(operation.try_into()?, wait_timeout)

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -10,6 +10,7 @@ use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
+use super::validate_and_log;
 use crate::tonic::api::collections_common::get;
 
 pub struct CollectionsInternalService {
@@ -28,6 +29,7 @@ impl CollectionsInternal for CollectionsInternalService {
         &self,
         request: Request<GetCollectionInfoRequestInternal>,
     ) -> Result<Response<GetCollectionInfoResponse>, Status> {
+        validate_and_log(request.get_ref());
         let GetCollectionInfoRequestInternal {
             get_collection_info_request,
             shard_id,
@@ -48,6 +50,7 @@ impl CollectionsInternal for CollectionsInternalService {
         &self,
         request: Request<InitiateShardTransferRequest>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let timing = Instant::now();
         let InitiateShardTransferRequest {
             collection_name,

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -6,3 +6,14 @@ mod points_common;
 pub mod points_internal_api;
 pub mod raft_api;
 pub mod snapshots_api;
+
+use tonic::Status;
+use validator::Validate;
+
+/// Validate the given request. Returns validation error on failure.
+fn validate(request: &dyn Validate) -> Result<(), Status> {
+    // TODO: nicely format once <https://github.com/qdrant/qdrant/pull/1463/files> is merged
+    request
+        .validate()
+        .map_err(|err| Status::invalid_argument(format!("Validation error in body: {}", err)))
+}

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -11,9 +11,18 @@ use collection::operations::validation;
 use tonic::Status;
 use validator::Validate;
 
-/// Validate the given request. Returns validation error on failure.
+/// Validate the given request and fail on error.
+///
+/// Returns validation error on failure.
 fn validate(request: &dyn Validate) -> Result<(), Status> {
     request.validate().map_err(|ref err| {
         Status::invalid_argument(validation::label_errors("Validation error in body", err))
     })
+}
+
+/// Validate the given request. Returns validation error on failure.
+fn validate_and_log(request: &dyn Validate) {
+    if let Err(ref err) = request.validate() {
+        validation::warn_validation_errors("Internal gRPC", err);
+    }
 }

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -7,13 +7,13 @@ pub mod points_internal_api;
 pub mod raft_api;
 pub mod snapshots_api;
 
+use collection::operations::validation;
 use tonic::Status;
 use validator::Validate;
 
 /// Validate the given request. Returns validation error on failure.
 fn validate(request: &dyn Validate) -> Result<(), Status> {
-    // TODO: nicely format once <https://github.com/qdrant/qdrant/pull/1463/files> is merged
-    request
-        .validate()
-        .map_err(|err| Status::invalid_argument(format!("Validation error in body: {}", err)))
+    request.validate().map_err(|ref err| {
+        Status::invalid_argument(validation::label_errors("Validation error in body", err))
+    })
 }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -170,12 +170,3 @@ impl Points for PointsService {
         count(self.toc.as_ref(), request.into_inner(), None).await
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_grpc() {
-        // For running build from IDE
-        eprintln!("hello");
-    }
-}

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -11,6 +11,7 @@ use api::grpc::qdrant::{
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
+use super::validate;
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
     overwrite_payload, recommend, recommend_batch, scroll, search, search_batch, set_payload,
@@ -33,6 +34,7 @@ impl Points for PointsService {
         &self,
         request: Request<UpsertPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         upsert(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -40,10 +42,12 @@ impl Points for PointsService {
         &self,
         request: Request<DeletePoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         delete(self.toc.as_ref(), request.into_inner(), None).await
     }
 
     async fn get(&self, request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
+        validate(request.get_ref())?;
         get(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -51,6 +55,7 @@ impl Points for PointsService {
         &self,
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         set_payload(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -58,6 +63,7 @@ impl Points for PointsService {
         &self,
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         overwrite_payload(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -65,6 +71,7 @@ impl Points for PointsService {
         &self,
         request: Request<DeletePayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         delete_payload(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -72,6 +79,7 @@ impl Points for PointsService {
         &self,
         request: Request<ClearPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         clear_payload(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -79,6 +87,7 @@ impl Points for PointsService {
         &self,
         request: Request<CreateFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         create_field_index(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -86,6 +95,7 @@ impl Points for PointsService {
         &self,
         request: Request<DeleteFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
         delete_field_index(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -93,6 +103,7 @@ impl Points for PointsService {
         &self,
         request: Request<SearchPoints>,
     ) -> Result<Response<SearchResponse>, Status> {
+        validate(request.get_ref())?;
         search(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -100,6 +111,7 @@ impl Points for PointsService {
         &self,
         request: Request<SearchBatchPoints>,
     ) -> Result<Response<SearchBatchResponse>, Status> {
+        validate(request.get_ref())?;
         let SearchBatchPoints {
             collection_name,
             search_points,
@@ -119,6 +131,7 @@ impl Points for PointsService {
         &self,
         request: Request<ScrollPoints>,
     ) -> Result<Response<ScrollResponse>, Status> {
+        validate(request.get_ref())?;
         scroll(self.toc.as_ref(), request.into_inner(), None).await
     }
 
@@ -126,6 +139,7 @@ impl Points for PointsService {
         &self,
         request: Request<RecommendPoints>,
     ) -> Result<Response<RecommendResponse>, Status> {
+        validate(request.get_ref())?;
         recommend(self.toc.as_ref(), request.into_inner()).await
     }
 
@@ -133,6 +147,7 @@ impl Points for PointsService {
         &self,
         request: Request<RecommendBatchPoints>,
     ) -> Result<Response<RecommendBatchResponse>, Status> {
+        validate(request.get_ref())?;
         let RecommendBatchPoints {
             collection_name,
             recommend_points,
@@ -151,6 +166,7 @@ impl Points for PointsService {
         &self,
         request: Request<CountPoints>,
     ) -> Result<Response<CountResponse>, Status> {
+        validate(request.get_ref())?;
         count(self.toc.as_ref(), request.into_inner(), None).await
     }
 }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -288,12 +288,3 @@ impl PointsInternal for PointsInternalService {
         overwrite_payload(self.toc.as_ref(), set_payload_points, shard_id).await
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_grpc() {
-        // For running build from IDE
-        eprintln!("hello");
-    }
-}

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -12,6 +12,7 @@ use api::grpc::qdrant::{
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
+use super::validate_and_log;
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
     overwrite_payload, recommend, scroll, search, search_batch, set_payload, sync, upsert,
@@ -34,6 +35,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<UpsertPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let UpsertPointsInternal {
             upsert_points,
             shard_id,
@@ -49,6 +51,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<DeletePointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let DeletePointsInternal {
             delete_points,
             shard_id,
@@ -64,6 +67,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,
@@ -79,6 +83,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<DeletePayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let DeletePayloadPointsInternal {
             delete_payload_points,
             shard_id,
@@ -94,6 +99,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<ClearPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let ClearPayloadPointsInternal {
             clear_payload_points,
             shard_id,
@@ -109,6 +115,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<CreateFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let CreateFieldIndexCollectionInternal {
             create_field_index_collection,
             shard_id,
@@ -124,6 +131,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<DeleteFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let DeleteFieldIndexCollectionInternal {
             delete_field_index_collection,
             shard_id,
@@ -139,6 +147,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<SearchPointsInternal>,
     ) -> Result<Response<SearchResponse>, Status> {
+        validate_and_log(request.get_ref());
         let SearchPointsInternal {
             search_points,
             shard_id,
@@ -156,6 +165,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<SearchBatchPointsInternal>,
     ) -> Result<Response<SearchBatchResponse>, Status> {
+        validate_and_log(request.get_ref());
         let SearchBatchPointsInternal {
             collection_name,
             search_points,
@@ -182,6 +192,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<RecommendPointsInternal>,
     ) -> Result<Response<RecommendResponse>, Status> {
+        validate_and_log(request.get_ref());
         let RecommendPointsInternal {
             recommend_points,
             ..  // shard_id - is not used in internal API,
@@ -200,6 +211,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<ScrollPointsInternal>,
     ) -> Result<Response<ScrollResponse>, Status> {
+        validate_and_log(request.get_ref());
         let ScrollPointsInternal {
             scroll_points,
             shard_id,
@@ -217,6 +229,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<GetPointsInternal>,
     ) -> Result<Response<GetResponse>, Status> {
+        validate_and_log(request.get_ref());
         let GetPointsInternal {
             get_points,
             shard_id,
@@ -234,6 +247,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<CountPointsInternal>,
     ) -> Result<Response<CountResponse>, Status> {
+        validate_and_log(request.get_ref());
         let CountPointsInternal {
             count_points,
             shard_id,
@@ -248,6 +262,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let SyncPointsInternal {
             sync_points,
             shard_id,
@@ -261,6 +276,7 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate_and_log(request.get_ref());
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,

--- a/src/tonic/api/raft_api.rs
+++ b/src/tonic/api/raft_api.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc::Sender;
 use tonic::transport::Uri;
 use tonic::{async_trait, Request, Response, Status};
 
+use super::validate;
 use crate::consensus;
 
 pub struct RaftService {
@@ -57,6 +58,7 @@ impl Raft for RaftService {
         &self,
         request: tonic::Request<AddPeerToKnownMessage>,
     ) -> Result<tonic::Response<AllPeers>, tonic::Status> {
+        validate(request.get_ref())?;
         let peer = request.get_ref();
         let uri_string = if let Some(uri) = &peer.uri {
             uri.clone()

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -15,6 +15,7 @@ use storage::content_manager::snapshots::{
 use storage::dispatcher::Dispatcher;
 use tonic::{async_trait, Request, Response, Status};
 
+use super::validate;
 use crate::common::collections::{do_create_snapshot, do_list_snapshots};
 
 pub struct SnapshotsService {
@@ -33,6 +34,7 @@ impl Snapshots for SnapshotsService {
         &self,
         request: Request<CreateSnapshotRequest>,
     ) -> Result<Response<CreateSnapshotResponse>, Status> {
+        validate(request.get_ref())?;
         let collection_name = request.into_inner().collection_name;
         let timing = Instant::now();
         let dispatcher = self.dispatcher.clone();
@@ -49,6 +51,7 @@ impl Snapshots for SnapshotsService {
         &self,
         request: Request<ListSnapshotsRequest>,
     ) -> Result<Response<ListSnapshotsResponse>, Status> {
+        validate(request.get_ref())?;
         let collection_name = request.into_inner().collection_name;
 
         let timing = Instant::now();
@@ -65,6 +68,7 @@ impl Snapshots for SnapshotsService {
         &self,
         request: Request<DeleteSnapshotRequest>,
     ) -> Result<Response<DeleteSnapshotResponse>, Status> {
+        validate(request.get_ref())?;
         let DeleteSnapshotRequest {
             collection_name,
             snapshot_name,
@@ -81,8 +85,9 @@ impl Snapshots for SnapshotsService {
 
     async fn create_full(
         &self,
-        _request: Request<CreateFullSnapshotRequest>,
+        request: Request<CreateFullSnapshotRequest>,
     ) -> Result<Response<CreateSnapshotResponse>, Status> {
+        validate(request.get_ref())?;
         let timing = Instant::now();
         let response = do_create_full_snapshot(&self.dispatcher, true)
             .await
@@ -95,8 +100,9 @@ impl Snapshots for SnapshotsService {
 
     async fn list_full(
         &self,
-        _request: Request<ListFullSnapshotsRequest>,
+        request: Request<ListFullSnapshotsRequest>,
     ) -> Result<Response<ListSnapshotsResponse>, Status> {
+        validate(request.get_ref())?;
         let timing = Instant::now();
         let snapshots = do_list_full_snapshots(&self.dispatcher)
             .await
@@ -111,6 +117,7 @@ impl Snapshots for SnapshotsService {
         &self,
         request: Request<DeleteFullSnapshotRequest>,
     ) -> Result<Response<DeleteSnapshotResponse>, Status> {
+        validate(request.get_ref())?;
         let snapshot_name = request.into_inner().snapshot_name;
         let timing = Instant::now();
         let _response = do_delete_full_snapshot(&self.dispatcher, &snapshot_name, true)


### PR DESCRIPTION
Extends <https://github.com/qdrant/qdrant/pull/1463>.

This adds validation to gRPC request bodies. Both the external (public) and internal gRPC APIs are validated.

#### External validation
The external API now returns an  [`INVALID_ARGUMENT`](https://docs.rs/tonic/0.9.1/tonic/struct.Status.html#method.invalid_argument) error on validation failure with a message describing why validation failed.

For example:

```bash
$ docker run --rm --network=host -v /home/timvisee/git/qdrant/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto -d '{
   "collection_name": "",
   "vectors_config": {
      "params": {
        "size": 0,
        "distance": "Dot"
      }
   }
}' localhost:6334 qdrant.Collections/Create
ERROR:
  Code: InvalidArgument
  Message: Validation error in body: [collection_name: value "" invalid, must be at least 1 characters; vectors_config.config.size: value 0 invalid, must be 1.0 or larger]

```

#### Internal validation
If validation for the internal API fails, it doesn't error. Instead it shows a warning in the log to prevent critical internal communication from breaking at runtime.

For example:

![image](https://user-images.githubusercontent.com/856222/229572753-ce8849cc-dd38-4f14-bfa4-d4a7d5152672.png)

#### Definitions

The definitions for these validations are defined here:

https://github.com/qdrant/qdrant/blob/b0349e20a4e35dd802caa68d7b81c587ef8d9ea2/lib/api/build.rs#L81-L174

It is done this way because the gRPC stuff is code generated. Sadly this is a bit messy, but after some discussion with other team members we couldn't think of a better way to do this.

Pulling these definitions from REST structs and translating them for gRPC is not an option because the naming and types differ wildly. Doing this would require a lot of logic and edge case handling, which isn't better than doing it in the above way.

### Tasks:
- [x] Check whether we can pull the validation definitions from the REST structs?
  _Answer: not possible, differ too much in naming and types._
- [x] Attach validation rules to gRPC structs
- [x] Validate bodies for external gRPC endpoints and error on failure.
- [x] Respond with pretty errors.
- [x] Validate bodies for internal gRPC endpoints and warn in the log on failure.
- [x] Implement custom validators for special gRPC types.
- [x] Link to validation definitions in this issue.
- [ ] Improve internal custom validation logic (requires https://github.com/Keats/validator/issues/247)
- [x] Cleanup.
- [x] Add validation test.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?