### PR TITLE
Fix `ForwardProxyShard::update` error handling

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -388,6 +388,8 @@ pub enum CollectionError {
         shards_failed: u32,
         first_err: Box<CollectionError>,
     },
+    #[error("Remote shard on {peer_id} failed during forward proxy operation: {error}")]
+    ForwardProxyError { peer_id: PeerId, error: Box<Self> },
 }
 
 impl CollectionError {
@@ -408,6 +410,20 @@ impl CollectionError {
 
     pub fn bad_shard_selection(description: String) -> CollectionError {
         CollectionError::BadShardSelection { description }
+    }
+
+    pub fn forward_proxy_error(peer_id: PeerId, error: impl Into<Self>) -> Self {
+        Self::ForwardProxyError {
+            peer_id,
+            error: Box::new(error.into()),
+        }
+    }
+
+    pub fn remote_peer_id(&self) -> Option<PeerId> {
+        match self {
+            Self::ForwardProxyError { peer_id, .. } => Some(*peer_id),
+            _ => None,
+        }
     }
 }
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1180,6 +1180,7 @@ impl ShardReplicaSet {
                     }
                     _ => {}
                 }
+
                 log::debug!(
                     "Deactivating peer {} because of failed update of shard {}:{}",
                     peer_id,
@@ -1323,7 +1324,12 @@ impl ShardReplicaSet {
                             .get()
                             .update(operation.clone(), wait)
                             .await
-                            .map_err(|err| (self.this_peer_id(), err))
+                            .map_err(|err| {
+                                let peer_id =
+                                    err.remote_peer_id().unwrap_or_else(|| self.this_peer_id());
+
+                                (peer_id, err)
+                            })
                     };
                     let remote_updates = join_all(remote_futures);
 

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -79,6 +79,9 @@ impl StorageError {
             CollectionError::BadShardSelection { .. } => StorageError::BadRequest {
                 description: overriding_description,
             },
+            CollectionError::ForwardProxyError { error, .. } => {
+                Self::from_inconsistent_shard_failure(*error, overriding_description)
+            }
         }
     }
 }
@@ -108,6 +111,10 @@ impl From<CollectionError> for StorageError {
             }
             CollectionError::BadShardSelection { description } => {
                 StorageError::BadRequest { description }
+            }
+            CollectionError::ForwardProxyError { error, .. } => {
+                let full_description = format!("{error}");
+                StorageError::from_inconsistent_shard_failure(*error, full_description)
             }
         }
     }


### PR DESCRIPTION
Currently, _any_ error during `ForwardProxyShard::update` (including error of _remote shard_) are treated as failure of the _local_ shard. This leads to local shard being (or, at best, _attempted_ to be) marked as dead if remote shard is faulty.

This PR attempts to fix this bug in the most trivial way.