### PR TITLE
[WIP] Quantum quantization

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -514,7 +514,9 @@ impl From<segment::types::QuantizationConfig> for QuantizationConfig {
                     },
                 )),
             },
-            _ => {todo!()}
+            _ => {
+                todo!()
+            }
         }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -514,6 +514,7 @@ impl From<segment::types::QuantizationConfig> for QuantizationConfig {
                     },
                 )),
             },
+            _ => {todo!()}
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -380,7 +380,6 @@ impl std::hash::Hash for ScalarQuantizationConfig {
 
 impl Eq for ScalarQuantizationConfig {}
 
-
 type Tensor = Vec<Vec<i64>>;
 
 /// This Configuration enables vector quantization using the
@@ -410,11 +409,10 @@ type Tensor = Vec<Vec<i64>>;
 ///
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
-pub struct  QuantumQuantization {
+pub struct QuantumQuantization {
     entanglement: Tensor,
     number_of_qubits: usize,
 }
-
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -380,11 +380,48 @@ impl std::hash::Hash for ScalarQuantizationConfig {
 
 impl Eq for ScalarQuantizationConfig {}
 
+
+type Tensor = Vec<Vec<i64>>;
+
+/// This Configuration enables vector quantization using the
+/// spin-based quantum entanglement algorithm.
+///
+/// The algorithm is described in the paper: https://arxiv.org/abs/2003.08934
+/// Overall process:
+/// 1. Generate a random quantum state
+/// 2. Encode the vector into the quantum state
+/// 3. Measure the quantum state
+/// 4. Decode the measurement into a vector
+///
+/// The algorithm is based on the following assumptions:
+/// 1. The quantum state is a good approximation of the vector
+/// 2. We have at least as many qubits as the vector dimension
+/// 3. The vector is dense
+/// 4. The vector is normalized
+///
+/// Expected performance:
+///
+/// The algorithm is expected to be faster than the scalar quantization.
+/// Given a vector of dimension `d` and `n` qubits, the algorithm is expected to be
+/// `O(d * n)` in time and `O(d)` in space.
+///
+/// Disclaimer:
+///     This algorithm is an April Fool's joke.
+///
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub struct  QuantumQuantization {
+    entanglement: Tensor,
+    number_of_qubits: usize,
+}
+
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum QuantizationConfig {
     Scalar(ScalarQuantization),
+    Quantum(QuantumQuantization),
 }
 
 impl From<ScalarQuantizationConfig> for QuantizationConfig {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -141,7 +141,9 @@ impl QuantizedVectorsStorage {
                     QuantizedVectorStorageImpl::ScalarMmap(storage)
                 }
             }
-            _ => { todo!() }
+            _ => {
+                todo!()
+            }
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -194,7 +196,9 @@ impl QuantizedVectorsStorage {
                     QuantizedVectorStorageImpl::ScalarMmap(storage)
                 }
             }
-            _ => { todo!() }
+            _ => {
+                todo!()
+            }
         };
 
         Ok(QuantizedVectorsStorage {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -141,6 +141,7 @@ impl QuantizedVectorsStorage {
                     QuantizedVectorStorageImpl::ScalarMmap(storage)
                 }
             }
+            _ => { todo!() }
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -193,6 +194,7 @@ impl QuantizedVectorsStorage {
                     QuantizedVectorStorageImpl::ScalarMmap(storage)
                 }
             }
+            _ => { todo!() }
         };
 
         Ok(QuantizedVectorsStorage {


### PR DESCRIPTION
This PR enables configuration for Quantum Quantization.

The main ideas:

- Encode f32 element of the vector into QBit.
- It is important to introduce assert statement for the number of allowed entangled Qbits, as it should be >= size of the vector
- As Qbits are holding all possible vectors within, I propose to disable MMAP option for this type of quantization
- Implementation details are described [here](https://www.youtube.com/watch?v=dQw4w9WgXcQ)

ToDo:

- CI\CD most likely will fail for this PR, as GitHub doesn't provide required architecture
- Docker file should be updated in a separate PR, to enable `arm-to-qtm6` cross-compilation
- Probably, it will require us to switch to `nightly` Rust version in future, as not all quantum dates are stabilized yet in release branch


