### PR TITLE
Use mutual TLS for peer-to-peer connection

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -82,10 +82,12 @@ pub fn create_general_purpose_runtime() -> io::Result<Runtime> {
 /// Load client TLS configuration.
 pub fn load_tls_client_config(settings: &Settings) -> io::Result<Option<ClientTlsConfig>> {
     if settings.cluster.p2p.enable_tls {
-        let pem = fs::read_to_string(&settings.tls()?.ca_cert)?;
-        let cert = Certificate::from_pem(pem);
-        let tls_config = ClientTlsConfig::new().ca_certificate(cert);
-        Ok(Some(tls_config))
+        let tls_config = &settings.tls()?;
+        Ok(Some(
+            ClientTlsConfig::new()
+                .identity(load_identity(&tls_config)?)
+                .ca_certificate(load_ca_certificate(&tls_config)?),
+        ))
     } else {
         Ok(None)
     }
@@ -93,12 +95,20 @@ pub fn load_tls_client_config(settings: &Settings) -> io::Result<Option<ClientTl
 
 /// Load server TLS configuration.
 pub fn load_tls_server_config(tls_config: &TlsConfig) -> io::Result<ServerTlsConfig> {
+    Ok(ServerTlsConfig::new()
+        .identity(load_identity(tls_config)?)
+        .client_ca_root(load_ca_certificate(tls_config)?))
+}
+
+fn load_identity(tls_config: &TlsConfig) -> io::Result<Identity> {
     let cert = fs::read_to_string(&tls_config.cert)?;
     let key = fs::read_to_string(&tls_config.key)?;
+    Ok(Identity::from_pem(cert, key))
+}
 
-    let ident = Identity::from_pem(cert, key);
-
-    Ok(ServerTlsConfig::new().identity(ident))
+fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
+    let pem = fs::read_to_string(&tls_config.ca_cert)?;
+    Ok(Certificate::from_pem(pem))
 }
 
 pub fn tonic_error_to_io_error(err: tonic::transport::Error) -> io::Error {


### PR DESCRIPTION
## Changes
 - Do certificate verification in a mutual TLS fashion (using CA to verify the certificate from the client / server)
   - Before it is just the client verifying the validity of server certificate.  Malicious user can pretend to be a client and connect to the cluster because the client certificate is never validated
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
