### PR TITLE
Set max_decoding_message_size to larger value following tonic 0.9.0

### DIFF
--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -60,6 +60,7 @@ pub fn init(
         let points_service = PointsService::new(dispatcher.toc().clone());
         let snapshot_service = SnapshotsService::new(dispatcher.toc().clone());
 
+        let max_request_size = settings.service.max_request_size_mb * 1024 * 1024;
         log::info!("Qdrant gRPC listening on {}", grpc_port);
 
         let mut server = Server::builder();
@@ -80,22 +81,26 @@ pub fn init(
             .add_service(
                 QdrantServer::new(qdrant_service)
                     .send_compressed(CompressionEncoding::Gzip)
-                    .accept_compressed(CompressionEncoding::Gzip),
+                    .accept_compressed(CompressionEncoding::Gzip)
+                    .max_decoding_message_size(max_request_size),
             )
             .add_service(
                 CollectionsServer::new(collections_service)
                     .send_compressed(CompressionEncoding::Gzip)
-                    .accept_compressed(CompressionEncoding::Gzip),
+                    .accept_compressed(CompressionEncoding::Gzip)
+                    .max_decoding_message_size(max_request_size),
             )
             .add_service(
                 PointsServer::new(points_service)
                     .send_compressed(CompressionEncoding::Gzip)
-                    .accept_compressed(CompressionEncoding::Gzip),
+                    .accept_compressed(CompressionEncoding::Gzip)
+                    .max_decoding_message_size(max_request_size),
             )
             .add_service(
                 SnapshotsServer::new(snapshot_service)
                     .send_compressed(CompressionEncoding::Gzip)
-                    .accept_compressed(CompressionEncoding::Gzip),
+                    .accept_compressed(CompressionEncoding::Gzip)
+                    .max_decoding_message_size(max_request_size),
             )
             .serve_with_shutdown(socket, async {
                 signal::ctrl_c().await.unwrap();
@@ -147,22 +152,26 @@ pub fn init_internal(
                 .add_service(
                     QdrantServer::new(qdrant_service)
                         .send_compressed(CompressionEncoding::Gzip)
-                        .accept_compressed(CompressionEncoding::Gzip),
+                        .accept_compressed(CompressionEncoding::Gzip)
+                        .max_decoding_message_size(usize::MAX),
                 )
                 .add_service(
                     CollectionsInternalServer::new(collections_internal_service)
                         .send_compressed(CompressionEncoding::Gzip)
-                        .accept_compressed(CompressionEncoding::Gzip),
+                        .accept_compressed(CompressionEncoding::Gzip)
+                        .max_decoding_message_size(usize::MAX),
                 )
                 .add_service(
                     PointsInternalServer::new(points_internal_service)
                         .send_compressed(CompressionEncoding::Gzip)
-                        .accept_compressed(CompressionEncoding::Gzip),
+                        .accept_compressed(CompressionEncoding::Gzip)
+                        .max_decoding_message_size(usize::MAX),
                 )
                 .add_service(
                     RaftServer::new(raft_service)
                         .send_compressed(CompressionEncoding::Gzip)
-                        .accept_compressed(CompressionEncoding::Gzip),
+                        .accept_compressed(CompressionEncoding::Gzip)
+                        .max_decoding_message_size(usize::MAX),
                 )
                 .serve_with_shutdown(socket, async {
                     signal::ctrl_c().await.unwrap();


### PR DESCRIPTION
Yesterday we merged a PR updating tonic to 0.9.0 https://github.com/qdrant/qdrant/pull/1636

I think we missed a potential issue with the breaking change mentioned in the release notes.

https://github.com/hyperium/tonic/blob/master/CHANGELOG.md#v090-2023-03-31

```
Default decoding message limit set to 4MiB by default.
```

It is a breaking change because there used to be no limits.

This could be an issue for users previously pushing gRPC payload larger than 4MB and for our internal gRPC API.

This PR proposes to set the limit to:

- `settings.service.max_request_size_mb` for the external gRPC API
- `usize::MAX` for the internal gRPC API
