### PR TITLE
Remove decoding limit for external gRPC endpoints

### DIFF
--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -60,7 +60,6 @@ pub fn init(
         let points_service = PointsService::new(dispatcher.toc().clone());
         let snapshot_service = SnapshotsService::new(dispatcher.clone());
 
-        let max_request_size = settings.service.max_request_size_mb * 1024 * 1024;
         log::info!("Qdrant gRPC listening on {}", grpc_port);
 
         let mut server = Server::builder();
@@ -82,25 +81,25 @@ pub fn init(
                 QdrantServer::new(qdrant_service)
                     .send_compressed(CompressionEncoding::Gzip)
                     .accept_compressed(CompressionEncoding::Gzip)
-                    .max_decoding_message_size(max_request_size),
+                    .max_decoding_message_size(usize::MAX),
             )
             .add_service(
                 CollectionsServer::new(collections_service)
                     .send_compressed(CompressionEncoding::Gzip)
                     .accept_compressed(CompressionEncoding::Gzip)
-                    .max_decoding_message_size(max_request_size),
+                    .max_decoding_message_size(usize::MAX),
             )
             .add_service(
                 PointsServer::new(points_service)
                     .send_compressed(CompressionEncoding::Gzip)
                     .accept_compressed(CompressionEncoding::Gzip)
-                    .max_decoding_message_size(max_request_size),
+                    .max_decoding_message_size(usize::MAX),
             )
             .add_service(
                 SnapshotsServer::new(snapshot_service)
                     .send_compressed(CompressionEncoding::Gzip)
                     .accept_compressed(CompressionEncoding::Gzip)
-                    .max_decoding_message_size(max_request_size),
+                    .max_decoding_message_size(usize::MAX),
             )
             .serve_with_shutdown(socket, async {
                 signal::ctrl_c().await.unwrap();


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/1658

We decided to it would make more sense to not introduce any restriction on the gRPC payload size as it would be a breaking change in practice.

This PR gets us back to the previous behavior.