### PR TITLE
Use latest WAL 1a6bb8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,12 +1517,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
 dependencies = [
  "libc",
+ "rustix 0.35.13",
  "winapi",
 ]
 
@@ -2065,6 +2066,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
@@ -2086,7 +2093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
+ "io-lifetimes 1.0.3",
  "rustix 0.37.4",
  "windows-sys 0.45.0",
 ]
@@ -2214,6 +2221,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3400,13 +3413,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno 0.2.8",
+ "io-lifetimes 0.7.5",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno 0.2.8",
- "io-lifetimes",
+ "io-lifetimes 1.0.3",
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
@@ -3420,7 +3447,7 @@ checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
  "bitflags",
  "errno 0.3.0",
- "io-lifetimes",
+ "io-lifetimes 1.0.3",
  "libc",
  "linux-raw-sys 0.3.0",
  "windows-sys 0.45.0",
@@ -4540,18 +4567,19 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=7536f9e222d55cc53f7f7507a3028b0e303976cc#7536f9e222d55cc53f7f7507a3028b0e303976cc"
+source = "git+https://github.com/qdrant/wal.git?rev=1a6bb813611cd5549500eb03d7232c6b1d48df39#1a6bb813611cd5549500eb03d7232c6b1d48df39"
 dependencies = [
  "byteorder",
  "crc",
  "crossbeam-channel",
  "docopt",
  "env_logger",
- "fs2",
+ "fs4",
  "log",
  "memmap2",
  "rand 0.8.5",
  "rand_distr",
+ "rustix 0.36.5",
  "serde",
 ]
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "7536f9e222d55cc53f7f7507a3028b0e303976cc"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39"}
 ordered-float = "3.6"
 hashring = "0.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "7536f9e222d55cc53f7f7507a3028b0e303976cc" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39" }
 tokio = { version = "~1.27", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
Bump the latest WAL version to include external contribution to experiment with FreeBSD support https://github.com/qdrant/wal/pull/44