### PR TITLE
Add CI job to enforce generated OpenAPI and gRPC file consistency

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,9 +93,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install minimal stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: gRPC file consistency check
         run: ./tests/grpc_consistency_check.sh
-        shell: bash
       - name: OpenAPI file consistency check
         run: ./tests/openapi_consistency_check.sh
-        shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,6 +93,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: gRPC file consistency check
+        run: ./tests/grpc_consistency_check.sh
+        shell: bash
       - name: OpenAPI file consistency check
         run: ./tests/openapi_consistency_check.sh
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Run integration tests
         run: ./tests/integration-tests.sh
         shell: bash
-
   test-consensus:
 
     runs-on: ubuntu-latest
@@ -88,3 +87,12 @@ jobs:
       - name: Run integration tests
         run: ./test_tls.sh
         working-directory: ./tests/tls
+
+  test-consistency:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: OpenAPI file consistency check
+        run: ./tests/openapi_consistency_check.sh
+        shell: bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,6 +142,7 @@ Use [pprof](https://github.com/google/pprof) and the following command to genera
 Qdrant uses the [openapi](https://spec.openapis.org/oas/latest.html) specification to document its API.
 
 This means changes to the API must be followed by changes to the specification.
+This is enforced by CI.
 
 Here is a quick step-by-step guide:
 

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -7,13 +7,18 @@ cd "$(dirname "$0")/../"
 
 # Keep current version of file to check
 cp ./lib/api/src/grpc/{,.repo.}qdrant.rs
+cp ./docs/grpc/{,.repo.}docs.md
 
 # Regenerate gRPC files
 touch ./lib/api/src/grpc/proto/.build-trigger.proto
 cargo build --package api
 
+# Regenerate gRPC docs
+./tools/generate_grpc_docs.sh
+
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./lib/api/src/grpc/{,.repo.}qdrant.rs
+if diff -Zwa ./lib/api/src/grpc/{,.repo.}qdrant.rs \
+&& diff -Zwa ./docs/grpc/{,.repo.}docs.md
 then
     set +x
     echo "No diff found."
@@ -25,4 +30,4 @@ else
 fi
 
 # Cleanup
-rm -f ./lib/api/src/grpc/{.repo.qdrant.rs,proto/.build-trigger.proto}
+rm -f ./lib/api/src/grpc/{.repo.qdrant.rs,proto/.build-trigger.proto} ./docs/grpc/.repo.docs.md

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -6,13 +6,14 @@ set -ex
 cd "$(dirname "$0")/../"
 
 # Keep current version of files to check
-cp ./lib/api/src/grpc/qdrant.rs ./lib/api/src/grpc/.repo.qdrant.rs
+cp ./lib/api/src/grpc/{,.repo.}qdrant.rs
 
 # Regenerate gRPC files
+touch ./lib/api/src/grpc/proto/.build-trigger.proto
 cargo build --manifest-path lib/api/Cargo.toml
 
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./lib/api/src/grpc/qdrant.rs ./lib/api/src/grpc/.repo.qdrant.rs
+if diff -Zwa ./lib/api/src/grpc/{,.repo.}qdrant.rs
 then
     set +x
     echo "No diff found."
@@ -24,4 +25,4 @@ else
 fi
 
 # Cleanup
-rm -f ./lib/api/src/grpc/.repo.qdrant.rs
+rm -f ./lib/api/src/grpc/{.repo.qdrant.rs,proto/.build-trigger.proto}

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -6,8 +6,8 @@ set -ex
 cd "$(dirname "$0")/../"
 
 # Keep current version of file to check
-cp ./lib/api/src/grpc/{,.repo.}qdrant.rs
-cp ./docs/grpc/{,.repo.}docs.md
+cp ./lib/api/src/grpc/{,.diff.}qdrant.rs
+cp ./docs/grpc/{,.diff.}docs.md
 
 # Regenerate gRPC files
 touch ./lib/api/src/grpc/proto/.build-trigger.proto
@@ -17,8 +17,8 @@ cargo build --package api
 ./tools/generate_grpc_docs.sh
 
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./lib/api/src/grpc/{,.repo.}qdrant.rs \
-&& diff -Zwa ./docs/grpc/{,.repo.}docs.md
+if diff -Zwa ./lib/api/src/grpc/{,.diff.}qdrant.rs \
+&& diff -Zwa ./docs/grpc/{,.diff.}docs.md
 then
     set +x
     echo "No diff found."
@@ -30,4 +30,4 @@ else
 fi
 
 # Cleanup
-rm -f ./lib/api/src/grpc/{.repo.qdrant.rs,proto/.build-trigger.proto} ./docs/grpc/.repo.docs.md
+rm -f ./lib/api/src/grpc/{.diff.qdrant.rs,proto/.build-trigger.proto} ./docs/grpc/.diff.docs.md

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -5,7 +5,7 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-# Keep current version of files to check
+# Keep current version of file to check
 cp ./lib/api/src/grpc/{,.repo.}qdrant.rs
 
 # Regenerate gRPC files

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+# Ensure current path is project root
+cd "$(dirname "$0")/../"
+
+# Keep current version of files to check
+cp ./lib/api/src/grpc/qdrant.rs ./lib/api/src/grpc/.repo.qdrant.rs
+
+# Regenerate gRPC files
+cargo build --manifest-path lib/api/Cargo.toml
+
+# Ensure generated files are the same as files in this repository
+if diff -Zwa ./lib/api/src/grpc/qdrant.rs ./lib/api/src/grpc/.repo.qdrant.rs
+then
+    set +x
+    echo "No diff found."
+else
+    set +x
+    echo "ERROR: Generated gRPC file is not consistent with files in this repository, see diff above."
+    echo "ERROR: See: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#grpc"
+    exit 1
+fi
+
+# Cleanup
+rm -f ./lib/api/src/grpc/.repo.qdrant.rs

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -10,7 +10,7 @@ cp ./lib/api/src/grpc/{,.repo.}qdrant.rs
 
 # Regenerate gRPC files
 touch ./lib/api/src/grpc/proto/.build-trigger.proto
-cargo build --manifest-path lib/api/Cargo.toml
+cargo build --package api
 
 # Ensure generated files are the same as files in this repository
 if diff -Zwa ./lib/api/src/grpc/{,.repo.}qdrant.rs

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+# Some gRPC files in this repository are generated and based upon other
+# sources. When these sources change, the generated files must be generated
+# (and committed) again. It is the task of the contributing user to do this
+# properly.
+#
+# This tests makes sure the generated gRPC files are consistent with its
+# sources. If this fails, you probably have to generate the gRPC files again.
+#
+# Read more here: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#grpc
 
 set -ex
 

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -6,17 +6,17 @@ set -ex
 cd "$(dirname "$0")/../"
 
 # Keep current version of files to check
-cp ./openapi/openapi-merged.yaml ./openapi/.repo.openapi-merged.yaml
-cp ./openapi/openapi-merged.json ./openapi/.repo.openapi-merged.json
-cp ./docs/redoc/master/openapi.json ./docs/redoc/master/.repo.openapi.json
+cp ./openapi/{,.repo.}openapi-merged.yaml
+cp ./openapi/{,.repo.}openapi-merged.json
+cp ./docs/redoc/master/{,.repo.}openapi.json
 
 # Regenerate OpenAPI files
 tools/generate_openapi_models.sh
 
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./openapi/openapi-merged.yaml ./openapi/.repo.openapi-merged.yaml \
-&& diff -Zwa ./openapi/openapi-merged.json ./openapi/.repo.openapi-merged.json \
-&& diff -Zwa ./docs/redoc/master/openapi.json ./docs/redoc/master/.repo.openapi.json
+if diff -Zwa ./openapi/{,.repo.}openapi-merged.yaml \
+&& diff -Zwa ./openapi/{,.repo.}openapi-merged.json \
+&& diff -Zwa ./docs/redoc/master/{,.repo.}openapi.json
 then
     set +x
     echo "No diffs found."

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+# Some OpenAPI files in this repository are generated and based upon other
+# sources. When these sources change, the generated files must be generated
+# (and committed) again. It is the task of the contributing user to do this
+# properly.
+#
+# This tests makes sure the generated OpenAPI files are consistent with its
+# sources. If this fails, you probably have to generate the OpenAPI files again.
+#
+# Read more here: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#rest
 
 set -ex
 

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# Ensure current path is project root
+cd "$(dirname "$0")/../"
+
+# Keep current version of files to check
+cp ./openapi/openapi-merged.yaml ./openapi/.repo.openapi-merged.yaml
+cp ./openapi/openapi-merged.json ./openapi/.repo.openapi-merged.json
+cp ./docs/redoc/master/openapi.json ./docs/redoc/master/.repo.openapi.json
+
+# Regenerate OpenAPI files
+tools/generate_openapi_models.sh
+
+# Ensure generated files are the same as files in this repository
+if diff -Zwa ./openapi/openapi-merged.yaml ./openapi/.repo.openapi-merged.yaml \
+&& diff -Zwa ./openapi/openapi-merged.json ./openapi/.repo.openapi-merged.json \
+&& diff -Zwa ./docs/redoc/master/openapi.json ./docs/redoc/master/.repo.openapi.json
+then
+    set +x
+    echo "No diffs found."
+else
+    set +x
+    echo "ERROR: Generated OpenAPI files are not consistent with files in this repository, see diff above."
+    echo "ERROR: See: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#rest"
+    exit 1
+fi
+
+# Cleanup
+rm -f ./openapi/.repo.openapi-merged.{json,yaml} ./docs/redoc/master/.repo.openapi.json

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -5,18 +5,14 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-# Keep current version of files to check
-cp ./openapi/{,.repo.}openapi-merged.yaml
-cp ./openapi/{,.repo.}openapi-merged.json
+# Keep current version of file to check
 cp ./docs/redoc/master/{,.repo.}openapi.json
 
 # Regenerate OpenAPI files
 tools/generate_openapi_models.sh
 
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./openapi/{,.repo.}openapi-merged.yaml \
-&& diff -Zwa ./openapi/{,.repo.}openapi-merged.json \
-&& diff -Zwa ./docs/redoc/master/{,.repo.}openapi.json
+if diff -Zwa ./docs/redoc/master/{,.repo.}openapi.json
 then
     set +x
     echo "No diffs found."
@@ -28,4 +24,4 @@ else
 fi
 
 # Cleanup
-rm -f ./openapi/.repo.openapi-merged.{json,yaml} ./docs/redoc/master/.repo.openapi.json
+rm -f ./docs/redoc/master/.repo.openapi.json

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -6,13 +6,13 @@ set -ex
 cd "$(dirname "$0")/../"
 
 # Keep current version of file to check
-cp ./docs/redoc/master/{,.repo.}openapi.json
+cp ./docs/redoc/master/{,.diff.}openapi.json
 
 # Regenerate OpenAPI files
 tools/generate_openapi_models.sh
 
 # Ensure generated files are the same as files in this repository
-if diff -Zwa ./docs/redoc/master/{,.repo.}openapi.json
+if diff -Zwa ./docs/redoc/master/{,.diff.}openapi.json
 then
     set +x
     echo "No diffs found."
@@ -24,4 +24,4 @@ else
 fi
 
 # Cleanup
-rm -f ./docs/redoc/master/.repo.openapi.json
+rm -f ./docs/redoc/master/.diff.openapi.json


### PR DESCRIPTION
_Discussed [here](https://github.com/qdrant/qdrant/pull/1665#issuecomment-1497309003)._

This adds a CI job to ensure generated OpenAPI and gRPC files are consistent with their sources.

This hopefully prevents issues in the future where OpenAPI or gRPC files are accidentally not updated.

For example, if OpenAPI files are not up-to-date with their sources it will error with:

```
+ diff -Zwa ./openapi/openapi-merged.yaml ./openapi/.repo.openapi-merged.yaml
+ diff -Zwa ./openapi/openapi-merged.json ./openapi/.repo.openapi-merged.json
3678c3678
<             "minimum": 0
---
>             "minimum": 5
3915c3915
<             "format": "uint",
---
>             "format": "double",
+ set +x
ERROR: Generated OpenAPI files are not consistent with files in this repository, see diff above.
ERROR: See: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#rest
```

Or with gRPC `qdrant.rs`:

```
+ diff -Zwa ./lib/api/src/grpc/qdrant.rs ./lib/api/src/grpc/.repo.qdrant.rs
37a38
>     /// This should not be here!
+ set +x
ERROR: Generated gRPC file is not consistent with files in this repository, see diff above.
ERROR: See: https://github.com/qdrant/qdrant/blob/master/docs/DEVELOPMENT.md#grpc
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?