### PR TITLE
Include last_queried in telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,6 +3611,7 @@ dependencies = [
  "atomicwrites",
  "bincode",
  "bitvec",
+ "chrono",
  "criterion",
  "fs_extra",
  "geo",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -50,6 +50,7 @@ semver = "1.0.17"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 quantization = { git = "https://github.com/qdrant/quantization.git" }
 validator = { version = "0.16", features = ["derive"] }
+chrono = "0.4.24"
 
 [[bench]]
 name = "vector_search"


### PR DESCRIPTION
Solves #1660

Adds a new `"last_queried"` field which displays the last time an operation was queried. This refers to the request time, rather than the response time.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

