### PR TITLE
Fix possible double read on replica_state

### DIFF
--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -195,24 +195,12 @@ impl ShardReplicaSet {
 
     pub fn highest_alive_replica_peer_id(&self) -> Option<PeerId> {
         let read_lock = self.replica_state.read();
-        let peer_ids = read_lock
-            .peers
-            .iter()
-            .map(|(peer_id, _state)| peer_id)
-            .cloned()
-            .collect::<Vec<_>>();
+        let peer_ids = read_lock.peers.keys().cloned().collect::<Vec<_>>();
         drop(read_lock);
 
         peer_ids
             .into_iter()
-            .filter_map(|peer_id| {
-                // re-acquire replica_state read lock
-                if self.peer_is_active(&peer_id) {
-                    Some(peer_id)
-                } else {
-                    None
-                }
-            })
+            .filter(|peer_id| self.peer_is_active(peer_id)) // re-acquire replica_state read lock
             .max()
     }
 


### PR DESCRIPTION
Found using [lockbud](https://github.com/BurtonQin/lockbud) 

Docs from [RwLock](https://docs.rs/parking_lot/latest/parking_lot/type.RwLock.html)

```
This lock uses a task-fair locking policy which avoids both reader and writer starvation.
This means that readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock. 
Because of this, attempts to recursively acquire a read lock within a single thread may result in a deadlock.
```

Lockbud yields:

```
[2023-04-06T10:43:37Z WARN  lockbud::callbacks] [
      {
        "DoubleLock": {
          "bug_kind": "DoubleLock",
          "possibility": "Possibly",
          "diagnosis": {
            "first_lock_type": "ParkingLotRead(shards::replica_set::ReplicaSetState)",
            "first_lock_span": "lib/collection/src/shards/replica_set.rs:197:9: 198:20 (#0)",
            "second_lock_type": "ParkingLotRead(shards::replica_set::ReplicaSetState)",
            "second_lock_span": "lib/collection/src/shards/replica_set.rs:661:9: 661:34 (#0)",
            "callchains": [
              [
                [],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 208:19 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2967:9: 2967:30 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:3065:9: 3065:35 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2450:14: 2450:33 (#0)"
                ],
                [],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 208:19 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2967:9: 2967:30 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:3065:9: 3065:35 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2450:14: 2450:33 (#0)"
                ],
                [],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:36:28: 36:35 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 208:19 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2967:9: 2967:30 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:3065:9: 3065:35 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2450:14: 2450:33 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:85:9: 85:60 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2414:21: 2414:32 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:36:28: 36:35 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 208:19 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2967:9: 2967:30 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:3065:9: 3065:35 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2449:21: 2449:32 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:61:9: 61:40 (#0)"
                ],
                [],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2723:32: 2723:36 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:297:13: 297:35 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 208:19 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2967:9: 2967:30 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:3065:9: 3065:35 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2449:21: 2449:32 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/filter_map.rs:61:9: 61:40 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2729:9: 2729:36 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2238:21: 2238:32 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2723:32: 2723:36 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:297:13: 297:35 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 207:15 (#0)"
                ],
                [],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ],
              [
                [
                  "lib/collection/src/shards/replica_set.rs:197:9: 207:15 (#0)"
                ],
                [
                  "/home/agourlay/.rustup/toolchains/nightly-2022-10-06-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:946:9: 946:32 (#0)"
                ],
                [],
                [
                  "lib/collection/src/shards/replica_set.rs:202:20: 202:48 (#0)"
                ],
                [
                  "lib/collection/src/shards/replica_set.rs:645:9: 645:33 (#0)"
                ]
              ]
            ]
          },
          "explanation": "The first lock is not released when acquiring the second lock"
        }
      }
    ]
[2023-04-06T10:43:37Z WARN  lockbud::callbacks] crate collection contains doublelock: { probably: 0, possibly: 1 }, conflictlock: { probably: 0, possibly: 0 }, condvar_deadlock: { probably: 0, possibly: 0 }
```