### PR TITLE
Fix search one day bug

### DIFF
--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -113,7 +113,9 @@ where
     }
 
     fn check_point(&self, point: PointOffsetType) -> bool {
-        point < self.points_count && !self.deleted[point as usize]
+        point < self.points_count
+            && (point as usize) < self.deleted.len()
+            && !self.deleted[point as usize]
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {


### PR DESCRIPTION
After last changes in https://github.com/qdrant/qdrant/pull/1561 this bug arppeared: https://github.com/qdrant/qdrant/issues/1670

After investigation, there is quickfix for this bug.

Possible steps to reproduce:
1. Create collection
2. Upload 100 vectors
3. Delete LAST(!) 50 vectors
4. Restart Qdrant
5. Search something

Possible reason:
Before https://github.com/qdrant/qdrant/pull/1561 size of vector storage and deleted flags was equal. After changes, deleted flags are built from rocksdb and deleted flags can have different capacity and size that vector storage.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
7. [ ] Have you lint your code locally using ``cargo fmt`` command prior to submission?
8. [ ] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
