### PR TITLE
Simplify quantization configuration, remove obsolete config nesting

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3979,22 +3979,20 @@
         }
       },
       "QuantizationConfig": {
-        "anyOf": [
+        "oneOf": [
           {
-            "$ref": "#/components/schemas/ScalarQuantization"
+            "type": "object",
+            "required": [
+              "scalar"
+            ],
+            "properties": {
+              "scalar": {
+                "$ref": "#/components/schemas/ScalarQuantizationConfig"
+              }
+            },
+            "additionalProperties": false
           }
         ]
-      },
-      "ScalarQuantization": {
-        "type": "object",
-        "required": [
-          "scalar"
-        ],
-        "properties": {
-          "scalar": {
-            "$ref": "#/components/schemas/ScalarQuantizationConfig"
-          }
-        }
       },
       "ScalarQuantizationConfig": {
         "type": "object",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -499,9 +499,7 @@ impl TryFrom<PointId> for segment::types::PointIdType {
 impl From<segment::types::QuantizationConfig> for QuantizationConfig {
     fn from(value: segment::types::QuantizationConfig) -> Self {
         match value {
-            segment::types::QuantizationConfig::Scalar(segment::types::ScalarQuantization {
-                scalar: config,
-            }) => Self {
+            segment::types::QuantizationConfig::Scalar(config) => Self {
                 quantization: Some(super::qdrant::quantization_config::Quantization::Scalar(
                     ScalarQuantization {
                         r#type: match config.r#type {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Formatter;
+use std::hash::{Hash, Hasher};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -362,12 +363,6 @@ pub struct ScalarQuantizationConfig {
     pub always_ram: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
-pub struct ScalarQuantization {
-    #[validate]
-    pub scalar: ScalarQuantizationConfig,
-}
-
 impl PartialEq for ScalarQuantizationConfig {
     fn eq(&self, other: &Self) -> bool {
         self.quantile == other.quantile
@@ -376,8 +371,8 @@ impl PartialEq for ScalarQuantizationConfig {
     }
 }
 
-impl std::hash::Hash for ScalarQuantizationConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl Hash for ScalarQuantizationConfig {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.always_ram.hash(state);
         self.r#type.hash(state);
     }
@@ -387,9 +382,8 @@ impl Eq for ScalarQuantizationConfig {}
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
-#[serde(untagged)]
 pub enum QuantizationConfig {
-    Scalar(ScalarQuantization),
+    Scalar(ScalarQuantizationConfig),
 }
 
 impl Validate for QuantizationConfig {
@@ -402,7 +396,7 @@ impl Validate for QuantizationConfig {
 
 impl From<ScalarQuantizationConfig> for QuantizationConfig {
     fn from(config: ScalarQuantizationConfig) -> Self {
-        QuantizationConfig::Scalar(ScalarQuantization { scalar: config })
+        QuantizationConfig::Scalar(config)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::common::file_operations::{atomic_save_json, read_json};
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
-use crate::types::{Distance, QuantizationConfig, ScalarQuantization, ScalarQuantizationConfig};
+use crate::types::{Distance, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::quantized::scalar_quantized::ScalarQuantizedVectors;
 use crate::vector_storage::quantized::scalar_quantized_mmap_storage::{
@@ -117,9 +117,7 @@ impl QuantizedVectorsStorage {
         let vector_parameters = Self::construct_vector_parameters(distance, dim, count);
 
         let quantized_storage = match quantization_config {
-            QuantizationConfig::Scalar(ScalarQuantization {
-                scalar: scalar_config,
-            }) => {
+            QuantizationConfig::Scalar(scalar_config) => {
                 let in_ram =
                     Self::check_use_ram_quantization_storage(scalar_config, on_disk_vector_storage);
                 if in_ram {
@@ -170,9 +168,7 @@ impl QuantizedVectorsStorage {
     ) -> OperationResult<Self> {
         let config: QuantizedVectorsConfig = read_json(&data_path.join(QUANTIZED_CONFIG_PATH))?;
         let quantized_store = match &config.quantization_config {
-            QuantizationConfig::Scalar(ScalarQuantization {
-                scalar: scalar_u8_config,
-            }) => {
+            QuantizationConfig::Scalar(scalar_u8_config) => {
                 let is_ram = Self::check_use_ram_quantization_storage(
                     scalar_u8_config,
                     on_disk_vector_storage,


### PR DESCRIPTION
This removes a level of nesting form the quantization configuration. It keeps the JSON representation and storage format intact.

More specifically, it pulls out the `ScalarQuantization` struct:

```rust
QuantizationConfig::Scalar(ScalarQuantization { scalar: config })
// to
QuantizationConfig::Scalar(config)
```

If there is a good reason to do it this way, please close this PR.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?