### PR TITLE
Try to fix dying shards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=1a6bb813611cd5549500eb03d7232c6b1d48df39#1a6bb813611cd5549500eb03d7232c6b1d48df39"
+source = "git+https://github.com/qdrant/wal.git?rev=9fe5a0c97c148152adacca0df238be6b1bf7d704#9fe5a0c97c148152adacca0df238be6b1bf7d704"
 dependencies = [
  "byteorder",
  "crc",
@@ -4580,7 +4580,7 @@ dependencies = [
  "memmap2",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.36.5",
+ "rustix 0.35.13",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "chrono",
  "env_logger",
  "log",
+ "parking_lot",
  "prost",
  "prost-types",
  "rand 0.8.5",

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN cargo chef cook --release --target $(bash target_arch.sh) --recipe-path reci
 
 COPY . .
 
+ARG CARGO_PROFILE_RELEASE_LTO
+ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO:-'fat'}
+
 # Build actual target here
 RUN cargo build --release --target $(bash target_arch.sh) --bin qdrant
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN cargo chef cook --release --target $(bash target_arch.sh) --recipe-path reci
 
 COPY . .
 
-ARG CARGO_PROFILE_RELEASE_LTO
-ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO:-'fat'}
 
 # Build actual target here
 RUN cargo build --release --target $(bash target_arch.sh) --bin qdrant

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -20,8 +20,12 @@ tokio = "1.27.0"
 rand = "0.8.5"
 chrono = { version = "~0.4", features = ["serde"] }
 thiserror = "1.0"
+parking_lot = "0.12"
 
 segment = {path = "../segment"}
 
 [build-dependencies]
 tonic-build = { version = "0.9.1", features = ["prost"] }
+
+[dev-dependencies]
+tokio = { version = "~1.27", features = ["full"] }

--- a/lib/api/src/grpc/dynamic_channel_pool.rs
+++ b/lib/api/src/grpc/dynamic_channel_pool.rs
@@ -1,0 +1,83 @@
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tonic::transport::{Channel, ClientTlsConfig, Error as TonicError, Uri};
+
+use crate::grpc::dynamic_pool::{CountedItem, DynamicPool};
+
+pub async fn make_grpc_channel(
+    timeout: Duration,
+    connection_timeout: Duration,
+    uri: Uri,
+    tls_config: Option<ClientTlsConfig>,
+) -> Result<Channel, TonicError> {
+    let mut endpoint = Channel::builder(uri)
+        .timeout(timeout)
+        .connect_timeout(connection_timeout)
+        .keep_alive_while_idle(true);
+    if let Some(config) = tls_config {
+        endpoint = endpoint.tls_config(config)?;
+    }
+    // `connect` is using the `Reconnect` network service internally to handle dropped connections
+    endpoint.connect().await
+}
+
+pub struct DynamicChannelPool {
+    pool: Mutex<DynamicPool<Channel>>,
+    init_at: Instant,
+    uri: Uri,
+    timeout: Duration,
+    connection_timeout: Duration,
+    tls_config: Option<ClientTlsConfig>,
+}
+
+impl DynamicChannelPool {
+    pub async fn new(
+        uri: Uri,
+        timeout: Duration,
+        connection_timeout: Duration,
+        tls_config: Option<ClientTlsConfig>,
+        usage_per_channel: usize,
+        min_channels: usize,
+    ) -> Result<Self, TonicError> {
+        let mut channels = Vec::with_capacity(min_channels);
+        for _ in 0..min_channels {
+            let channel =
+                make_grpc_channel(timeout, connection_timeout, uri.clone(), tls_config.clone())
+                    .await?;
+            channels.push(channel);
+        }
+
+        let pool = DynamicPool::new(channels, usage_per_channel, min_channels);
+        Ok(Self {
+            pool: Mutex::new(pool),
+            init_at: Instant::now(),
+            uri,
+            timeout,
+            connection_timeout,
+            tls_config,
+        })
+    }
+
+    pub fn init_at(&self) -> Instant {
+        self.init_at
+    }
+
+    pub async fn choose(&self) -> Result<CountedItem<Channel>, TonicError> {
+        let channel = self.pool.lock().choose();
+        let channel = match channel {
+            None => {
+                let channel = make_grpc_channel(
+                    self.timeout,
+                    self.connection_timeout,
+                    self.uri.clone(),
+                    self.tls_config.clone(),
+                )
+                .await?;
+                self.pool.lock().add(channel)
+            }
+            Some(channel) => channel,
+        };
+        Ok(channel)
+    }
+}

--- a/lib/api/src/grpc/dynamic_channel_pool.rs
+++ b/lib/api/src/grpc/dynamic_channel_pool.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
@@ -30,8 +29,6 @@ pub struct DynamicChannelPool {
     timeout: Duration,
     connection_timeout: Duration,
     tls_config: Option<ClientTlsConfig>,
-    // Timestamp of the last successful connection.
-    last_success: AtomicUsize,
 }
 
 impl DynamicChannelPool {
@@ -52,7 +49,6 @@ impl DynamicChannelPool {
         }
 
         let init_at = Instant::now();
-        let last_success_since = Instant::now().duration_since(init_at).as_millis() as usize;
 
         let pool = DynamicPool::new(channels, usage_per_channel, min_channels);
         Ok(Self {
@@ -62,7 +58,6 @@ impl DynamicChannelPool {
             timeout,
             connection_timeout,
             tls_config,
-            last_success: AtomicUsize::new(last_success_since),
         })
     }
 
@@ -88,15 +83,7 @@ impl DynamicChannelPool {
         Ok(channel)
     }
 
-    pub fn set_last_success(&self) {
-        let last_success_since = Instant::now().duration_since(self.init_at).as_millis() as usize;
-        self.last_success
-            .store(last_success_since, Ordering::Relaxed);
-    }
-
-    pub fn last_success_age(&self) -> Duration {
-        let last_success_since = self.last_success.load(Ordering::Relaxed);
-        let last_success = self.init_at + Duration::from_millis(last_success_since as u64);
-        Instant::now().duration_since(last_success)
+    pub fn drop_channel(&self, channel: CountedItem<Channel>) {
+        self.pool.lock().drop_item(channel);
     }
 }

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -114,7 +114,7 @@ impl<T: Clone> DynamicPool<T> {
 
     // Returns None if current capacity is not enough
     pub fn choose(&mut self) -> Option<CountedItem<T>> {
-        if self.items.is_empty() {
+        if self.items.len() < self.min_items {
             return None;
         }
 

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -135,9 +135,10 @@ impl<T: Clone> DynamicPool<T> {
             return None;
         }
 
-        let current_usage_capacity = self.items.len() * self.max_usage_per_item;
+        let current_usage_capacity = self.items.len().saturating_mul(self.max_usage_per_item);
 
-        if current_usage_capacity.saturating_sub(total_usage) > self.max_usage_per_item * 2
+        if current_usage_capacity.saturating_sub(total_usage)
+            > self.max_usage_per_item.saturating_mul(2)
             && self.items.len() > self.min_items
         {
             // We have too many items, and we have enough capacity to remove some of them

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -114,7 +114,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(
             rand::random::<u64>() % 100 + 1,
         ))
-            .await;
+        .await;
         item.item()
             .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
         drop(item);

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -1,0 +1,195 @@
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+pub struct DynamicPool<T: Clone> {
+    items: Vec<T>,
+    // How many items are currently in use
+    usage: Vec<Arc<AtomicUsize>>,
+    // How many times one item can be used
+    max_usage_per_item: usize,
+    // Minimal number of items in the pool
+    min_items: usize,
+}
+
+pub struct CountedItem<T: Clone> {
+    item: T,
+    counter: Arc<AtomicUsize>,
+}
+
+impl<T: Clone> CountedItem<T> {
+    fn new(item: T, counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self { item, counter }
+    }
+
+    pub fn item(&self) -> &T {
+        &self.item
+    }
+
+    pub fn item_mut(&mut self) -> &mut T {
+        &mut self.item
+    }
+}
+
+impl<T: Clone> Drop for CountedItem<T> {
+    fn drop(&mut self) {
+        self.counter
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl<T: Clone> DynamicPool<T> {
+    pub fn new(items: Vec<T>, max_usage_per_item: usize, min_items: usize) -> Self {
+        debug_assert!(max_usage_per_item > 0);
+        debug_assert!(items.len() >= min_items);
+        let usages = items
+            .iter()
+            .map(|_| Arc::new(AtomicUsize::new(0)))
+            .collect();
+        Self {
+            items,
+            usage: usages,
+            max_usage_per_item,
+            min_items,
+        }
+    }
+
+    pub fn add(&mut self, item: T) -> CountedItem<T> {
+        self.items.push(item.clone());
+        let usage = Arc::new(AtomicUsize::new(0));
+        self.usage.push(usage.clone());
+        CountedItem::new(item, usage)
+    }
+
+    // Returns None if current capacity is not enough
+    pub fn choose(&mut self) -> Option<CountedItem<T>> {
+        let mut total_usage = 0;
+        let mut min_usage = std::usize::MAX;
+        let mut min_usage_idx = 0;
+        for (idx, usage) in self
+            .usage
+            .iter()
+            .enumerate()
+            .map(|(id, usage)| (id, usage.load(std::sync::atomic::Ordering::SeqCst)))
+        {
+            total_usage += usage;
+            if usage < min_usage {
+                min_usage = usage;
+                min_usage_idx = idx;
+            }
+        }
+
+        if min_usage >= self.max_usage_per_item {
+            // All items are used too much, we can not use any of them.
+            // Return None to indicate that we need to add a new item
+            return None;
+        }
+
+        let current_usage_capacity = self.items.len() * self.max_usage_per_item;
+
+        if current_usage_capacity.saturating_sub(total_usage) > self.max_usage_per_item * 2
+            && self.items.len() > self.min_items
+        {
+            // We have too many items, and we have enough capacity to remove some of them
+            let item = self.items.remove(min_usage_idx);
+            let usage = self.usage.remove(min_usage_idx);
+            return Some(CountedItem::new(item, usage));
+        }
+
+        Some(CountedItem::new(
+            self.items[min_usage_idx].clone(),
+            self.usage[min_usage_idx].clone(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn use_item(item: CountedItem<Arc<AtomicUsize>>) {
+        item.item()
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // Sleep for 1-100 ms
+        tokio::time::sleep(std::time::Duration::from_millis(
+            rand::random::<u64>() % 100 + 1,
+        ))
+            .await;
+        item.item()
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        drop(item);
+    }
+
+    #[test]
+    fn test_dynamic_pool() {
+        let items = vec![Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0))];
+
+        let mut pool = DynamicPool::new(items, 5, 2);
+
+        let mut items = vec![];
+
+        for _ in 0..17 {
+            let item = match pool.choose() {
+                None => pool.add(Arc::new(AtomicUsize::new(0))),
+                Some(it) => it,
+            };
+
+            item.item()
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            items.push(item);
+        }
+
+        assert_eq!(pool.items.len(), 4);
+
+        for _ in 0..10 {
+            items.pop();
+        }
+
+        for usage in pool.usage.iter() {
+            println!("{}", usage.load(std::sync::atomic::Ordering::SeqCst));
+        }
+
+        assert!(pool.choose().is_some());
+
+        assert_eq!(pool.items.len(), 3);
+    }
+
+    #[test]
+    fn test_dynamic_pool_with_runtime() {
+        let items = vec![Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0))];
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+
+        let mut pool = DynamicPool::new(items, 5, 2);
+
+        let mut handles = vec![];
+        for _ in 0..1000 {
+            let item = match pool.choose() {
+                None => pool.add(Arc::new(AtomicUsize::new(0))),
+                Some(it) => it,
+            };
+
+            let handle = runtime.spawn(async move { use_item(item).await });
+
+            handles.push(handle);
+
+            // Sleep for 3 ms with std
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        runtime.block_on(async move {
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+
+        pool.items.iter().for_each(|item| {
+            assert_eq!(item.load(std::sync::atomic::Ordering::SeqCst), 0);
+        });
+
+        pool.usage.iter().for_each(|usage| {
+            assert_eq!(usage.load(std::sync::atomic::Ordering::SeqCst), 0);
+        });
+
+        assert!(pool.items.len() < 50);
+    }
+}

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -24,11 +24,11 @@ impl<T: Clone> ItemWithStats<T> {
 
 pub struct DynamicPool<T: Clone> {
     items: HashMap<u64, Arc<ItemWithStats<T>>>,
-    // How many times one item can be used
+    /// How many times one item can be used
     max_usage_per_item: usize,
-    // Minimal number of items in the pool
+    /// Minimal number of items in the pool
     min_items: usize,
-    // Instant when the pool was created
+    /// Instant when the pool was created
     init_at: Instant,
 }
 

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -5,9 +5,9 @@ pub mod models;
 #[allow(clippy::all)]
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 pub mod qdrant;
-pub mod transport_channel_pool;
-pub mod dynamic_pool;
 pub mod dynamic_channel_pool;
+pub mod dynamic_pool;
+pub mod transport_channel_pool;
 
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -6,6 +6,8 @@ pub mod models;
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 pub mod qdrant;
 pub mod transport_channel_pool;
+pub mod dynamic_pool;
+pub mod dynamic_channel_pool;
 
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -12,7 +12,7 @@ use crate::grpc::dynamic_pool::CountedItem;
 use crate::grpc::qdrant::qdrant_client::QdrantClient;
 use crate::grpc::qdrant::HealthCheckRequest;
 
-const MAX_CONNECTIONS_PER_CHANNEL: usize = 32;
+const MAX_CONNECTIONS_PER_CHANNEL: usize = 16;
 
 const DEFAULT_GRPC_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::num::NonZeroUsize;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tokio::select;
 use tonic::transport::{Channel, ClientTlsConfig, Error as TonicError, Uri};
@@ -13,6 +13,8 @@ use crate::grpc::qdrant::qdrant_client::QdrantClient;
 use crate::grpc::qdrant::HealthCheckRequest;
 
 const MAX_CONNECTIONS_PER_CHANNEL: usize = 16;
+const DEFAULT_RETRIES: usize = 10;
+const DEFAULT_BACKOFF: Duration = Duration::from_millis(100);
 
 const DEFAULT_GRPC_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
@@ -68,21 +70,25 @@ impl TransportChannelPool {
         }
     }
 
+    async fn _init_pool_for_uri(&self, uri: Uri) -> Result<DynamicChannelPool, TonicError> {
+        DynamicChannelPool::new(
+            uri,
+            self.grpc_timeout,
+            self.connection_timeout,
+            self.tls_config.clone(),
+            MAX_CONNECTIONS_PER_CHANNEL,
+            self.pool_size.get(),
+        )
+        .await
+    }
+
     /// Initialize a pool for the URI and return a clone of the first channel.
     /// Does not fail if the pool already exist.
     async fn init_pool_for_uri(&self, uri: Uri) -> Result<CountedItem<Channel>, TonicError> {
         let mut guard = self.uri_to_pool.write().await;
         match guard.get_mut(&uri) {
             None => {
-                let channels = DynamicChannelPool::new(
-                    uri.clone(),
-                    self.grpc_timeout,
-                    self.connection_timeout,
-                    self.tls_config.clone(),
-                    MAX_CONNECTIONS_PER_CHANNEL,
-                    self.pool_size.get(),
-                )
-                .await?;
+                let channels = self._init_pool_for_uri(uri.clone()).await?;
                 let channel = channels.choose().await?;
                 guard.insert(uri, channels);
                 Ok(channel)
@@ -94,6 +100,13 @@ impl TransportChannelPool {
     pub async fn drop_pool(&self, uri: &Uri) {
         let mut guard = self.uri_to_pool.write().await;
         guard.remove(uri);
+    }
+
+    pub async fn recreate_pool(&self, uri: &Uri) -> Result<(), TonicError> {
+        let mut guard = self.uri_to_pool.write().await;
+        guard.remove(uri);
+        guard.insert(uri.clone(), self._init_pool_for_uri(uri.clone()).await?);
+        Ok(())
     }
 
     async fn get_pooled_channel(
@@ -117,9 +130,16 @@ impl TransportChannelPool {
         }
     }
 
-    async fn get_created_at(&self, uri: &Uri) -> Option<Instant> {
+    async fn set_last_success(&self, uri: &Uri) {
         let guard = self.uri_to_pool.read().await;
-        guard.get(uri).map(|channels| channels.init_at())
+        if let Some(channels) = guard.get(uri) {
+            channels.set_last_success();
+        }
+    }
+
+    pub async fn last_success_age(&self, uri: &Uri) -> Option<Duration> {
+        let guard = self.uri_to_pool.read().await;
+        guard.get(uri).map(|channels| channels.last_success_age())
     }
 
     /// Checks if the channel is still alive.
@@ -157,43 +177,98 @@ impl TransportChannelPool {
         uri: &Uri,
         f: impl Fn(Channel) -> O,
         timeout: Option<Duration>,
+        retries: usize,
     ) -> Result<T, RequestError<Status>> {
-        let channel = self.get_or_create_pooled_channel(uri).await?;
-        let max_timeout = timeout.unwrap_or_else(|| self.grpc_timeout + self.connection_timeout);
+        let mut retries_left = retries;
+        let mut attempt = 0;
 
-        let result: Result<T, Status> = select! {
-            res = f(channel.item().clone()) => {
-                res
-            }
-            res = self.check_connectability(uri) => {
-               Err(res)
-            }
-            _res = tokio::time::sleep(max_timeout) => {
-                Err(Status::deadline_exceeded(format!("Timeout {}ms reached for uri: {}", max_timeout.as_millis(), uri)))
-            }
-        };
+        loop {
+            let channel = self.get_or_create_pooled_channel(uri).await?;
+            let max_timeout =
+                timeout.unwrap_or_else(|| self.grpc_timeout + self.connection_timeout);
 
-        // Reconnect on failure to handle the case with domain name change.
-        match result {
-            Ok(res) => Ok(res),
-            Err(err) => match err.code() {
-                Code::Internal | Code::Unavailable | Code::Cancelled | Code::DeadlineExceeded => {
-                    let channel_uptime = Instant::now().duration_since(
-                        self.get_created_at(uri).await.unwrap_or_else(Instant::now),
-                    );
-                    if channel_uptime > CHANNEL_TTL {
-                        log::debug!("dropping channel pool for uri: {}", uri);
-                        self.drop_pool(uri).await;
-                        let channel = self.get_or_create_pooled_channel(uri).await?;
-                        f(channel.item().clone())
-                            .await
-                            .map_err(RequestError::FromClosure)
-                    } else {
-                        Err(err).map_err(RequestError::FromClosure)
-                    }
+            let result: Result<T, Status> = select! {
+                res = f(channel.item().clone()) => {
+                    res
                 }
-                _ => Err(RequestError::FromClosure(err)),
-            },
+                res = self.check_connectability(uri) => {
+                   Err(res)
+                }
+                _res = tokio::time::sleep(max_timeout) => {
+                    Err(Status::deadline_exceeded(format!("Timeout {}ms reached for uri: {}", max_timeout.as_millis(), uri)))
+                }
+            };
+
+            let res = match result {
+                Ok(res) => {
+                    self.set_last_success(uri).await;
+                    return Ok(res);
+                }
+                Err(err) => match err.code() {
+                    Code::Internal
+                    | Code::Unavailable
+                    | Code::Cancelled
+                    | Code::DeadlineExceeded => {
+                        // Possible situations:
+                        // - Server is frozen and will never respond.
+                        // - Server is overloaded and will respond in a while.
+                        // - Server is overloaded and will respond in a while,
+                        //     but we can't wait for this request any longer.
+                        // - Server is broken and will never respond correctly.
+
+                        // Actions:
+                        //   - check if channels require reconnect
+                        //   - check if backoff is possible
+                        //   - return error or retry
+                        let last_success_age = self.last_success_age(uri).await;
+                        match last_success_age {
+                            None => {
+                                // Pool doesn't exist, that is possible if the peer was removed from the cluster
+                                // we can simply return the error
+                                return Err(RequestError::FromClosure(err));
+                            }
+                            Some(success_age) => {
+                                if success_age > CHANNEL_TTL {
+                                    // There were no successful requests for a long time, we can try to reconnect
+                                    // It might be possible that server died and changed its ip address
+                                    self.recreate_pool(uri).await?;
+                                }
+                            }
+                        };
+
+                        if retries_left > 0 {
+                            // We can try to make one more attempt
+                            if err.code() == Code::DeadlineExceeded || err.code() == Code::Internal
+                            {
+                                // We can't wait for the request any longer, last attempt no backoff
+                                retries_left = 0;
+                                continue;
+                            }
+
+                            // Calculate backoff
+                            let backoff = DEFAULT_BACKOFF * 2u32.pow(attempt as u32)
+                                + Duration::from_millis(rand::random::<u64>() % 100);
+
+                            if backoff > max_timeout {
+                                // We can't wait for the request any longer, return the error as is
+                                return Err(RequestError::FromClosure(err));
+                            }
+
+                            // Wait for the backoff
+                            tokio::time::sleep(backoff).await;
+                            // Try again
+                            retries_left -= 1;
+                            attempt += 1;
+                            continue;
+                        } else {
+                            // We can't make more attempts, return the error
+                            return Err(RequestError::FromClosure(err));
+                        }
+                    }
+                    _ => Err(RequestError::FromClosure(err)),
+                },
+            };
+            return res;
         }
     }
 
@@ -203,6 +278,7 @@ impl TransportChannelPool {
         uri: &Uri,
         f: impl Fn(Channel) -> O,
     ) -> Result<T, RequestError<Status>> {
-        self.with_channel_timeout(uri, f, None).await
+        self.with_channel_timeout(uri, f, None, DEFAULT_RETRIES)
+            .await
     }
 }

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -169,8 +169,7 @@ impl TransportChannelPool {
                Err(res)
             }
             _res = tokio::time::sleep(max_timeout) => {
-                log::debug!("Timeout reached for uri: {}", uri);
-                Err(Status::deadline_exceeded("Timeout exceeded"))
+                Err(Status::deadline_exceeded(format!("Timeout {}ms reached for uri: {}", max_timeout.as_millis(), uri)))
             }
         };
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "9fe5a0c97c148152adacca0df238be6b1bf7d704"}
 ordered-float = "3.6"
 hashring = "0.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1390,7 +1390,11 @@ impl Collection {
                 let shard_snapshot_path =
                     versioned_shard_path(&snapshot_path_with_tmp_extension, *shard_id, 0);
                 create_dir_all(&shard_snapshot_path).await?;
-                replica_set.create_snapshot(&shard_snapshot_path).await?;
+                // If node is listener, we can save whatever currently is in the storage
+                let save_wal = self.shared_storage_config.node_type != NodeType::Listener;
+                replica_set
+                    .create_snapshot(&shard_snapshot_path, save_wal)
+                    .await?;
             }
         }
 

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -1,7 +1,7 @@
 use crate::operations::types::NodeType;
 
 const DEFAULT_UPDATE_QUEUE_SIZE: usize = 100;
-const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 5000;
+const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 10_000;
 
 /// Storage configuration shared between all collections.
 /// Represents a per-node configuration, which might be changes with restart.

--- a/lib/collection/src/shards/collection_shard_distribution.rs
+++ b/lib/collection/src/shards/collection_shard_distribution.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::collection_state::ShardInfo;
 use crate::shards::shard::{PeerId, ShardId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CollectionShardDistribution {
     pub shards: HashMap<ShardId, HashSet<PeerId>>,
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -120,8 +120,14 @@ impl ForwardProxyShard {
     }
 
     /// Forward `create_snapshot` to `wrapped_shard`
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
-        self.wrapped_shard.create_snapshot(target_path).await
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .create_snapshot(target_path, save_wal)
+            .await
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -62,8 +62,14 @@ impl ProxyShard {
     }
 
     /// Forward `create_snapshot` to `wrapped_shard`
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
-        self.wrapped_shard.create_snapshot(target_path).await
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .create_snapshot(target_path, save_wal)
+            .await
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -999,11 +999,15 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
         let local_read = self.local.read().await;
 
         if let Some(local) = &*local_read {
-            local.create_snapshot(target_path).await?
+            local.create_snapshot(target_path, save_wal).await?
         }
 
         self.replica_state
@@ -1298,6 +1302,7 @@ impl ShardReplicaSet {
         let all_res: Vec<Result<_, _>> = {
             let local = self.local.read().await;
             let remotes = self.remotes.read().await;
+            let this_peer_id = self.this_peer_id();
 
             // target all remote peers that can receive updates
             let active_remote_shards: Vec<_> = remotes
@@ -1307,13 +1312,12 @@ impl ShardReplicaSet {
 
             // local is defined AND the peer itself can receive updates
             let local_is_updatable =
-                local.is_some() && self.peer_is_active_or_pending(&self.this_peer_id());
+                local.is_some() && self.peer_is_active_or_pending(&this_peer_id);
 
             if active_remote_shards.is_empty() && !local_is_updatable {
                 return Err(CollectionError::service_error(format!(
                     "The replica set for shard {} on peer {} has no active replica",
-                    self.shard_id,
-                    self.this_peer_id()
+                    self.shard_id, this_peer_id
                 )));
             }
 
@@ -1329,15 +1333,21 @@ impl ShardReplicaSet {
             }
 
             match local.deref() {
-                Some(local) if self.peer_is_active_or_pending(&self.this_peer_id()) => {
+                Some(local) if self.peer_is_active_or_pending(&this_peer_id) => {
+                    let local_wait =
+                        if self.peer_state(&this_peer_id) == Some(ReplicaState::Listener) {
+                            false
+                        } else {
+                            wait
+                        };
+
                     let local_update = async move {
                         local
                             .get()
-                            .update(operation.clone(), wait)
+                            .update(operation.clone(), local_wait)
                             .await
                             .map_err(|err| {
-                                let peer_id =
-                                    err.remote_peer_id().unwrap_or_else(|| self.this_peer_id());
+                                let peer_id = err.remote_peer_id().unwrap_or(this_peer_id);
 
                                 (peer_id, err)
                             })

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1204,8 +1204,8 @@ impl ShardReplicaSet {
         locally_disabled.remove(&peer_id_to_remove);
 
         if active_peers.len() == 1 {
-            let last_peer = active_peers.into_iter().next().unwrap();
-            locally_disabled.remove(&last_peer);
+            let last_peer = active_peers.first().unwrap();
+            locally_disabled.remove(last_peer);
         }
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -58,11 +58,17 @@ impl Shard {
         telemetry
     }
 
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
         match self {
-            Shard::Local(local_shard) => local_shard.create_snapshot(target_path).await,
-            Shard::Proxy(proxy_shard) => proxy_shard.create_snapshot(target_path).await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.create_snapshot(target_path).await,
+            Shard::Local(local_shard) => local_shard.create_snapshot(target_path, save_wal).await,
+            Shard::Proxy(proxy_shard) => proxy_shard.create_snapshot(target_path, save_wal).await,
+            Shard::ForwardProxy(proxy_shard) => {
+                proxy_shard.create_snapshot(target_path, save_wal).await
+            }
         }
     }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
 use std::thread::JoinHandle;
+use parking_lot::Mutex;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
 use std::thread::JoinHandle;
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
 use std::thread::JoinHandle;
-use parking_lot::Mutex;
 
+use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -3,8 +3,6 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
 use std::thread::JoinHandle;
-
-use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/lib/collection/tests/snapshot_recovery_test.rs
+++ b/lib/collection/tests/snapshot_recovery_test.rs
@@ -1,0 +1,186 @@
+use std::num::{NonZeroU32, NonZeroU64};
+use std::sync::Arc;
+
+use collection::collection::Collection;
+use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::operations::point_ops::{
+    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+};
+use collection::operations::shared_storage_config::SharedStorageConfig;
+use collection::operations::types::{NodeType, SearchRequest, VectorParams, VectorsConfig};
+use collection::operations::CollectionUpdateOperations;
+use collection::shards::channel_service::ChannelService;
+use collection::shards::collection_shard_distribution::CollectionShardDistribution;
+use collection::shards::replica_set::ReplicaState;
+use segment::types::{Distance, WithPayloadInterface, WithVector};
+use tempfile::Builder;
+
+use crate::common::{
+    dummy_on_replica_failure, dummy_request_shard_transfer, TEST_OPTIMIZERS_CONFIG,
+};
+
+mod common;
+
+async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParams {
+            size: NonZeroU64::new(4).unwrap(),
+            distance: Distance::Dot,
+        }),
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        on_disk_payload: false,
+    };
+
+    let config = CollectionConfig {
+        params: collection_params,
+        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+    };
+
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let recover_dir = Builder::new()
+        .prefix("test_collection_rec")
+        .tempdir()
+        .unwrap();
+    let collection_name = "test".to_string();
+    let collection_name_rec = "test_rec".to_string();
+
+    let storage_config: SharedStorageConfig = SharedStorageConfig {
+        node_type,
+        ..Default::default()
+    };
+
+    let this_peer_id = 0;
+    let shard_distribution = CollectionShardDistribution::all_local(
+        Some(config.params.shard_number.into()),
+        this_peer_id,
+    );
+
+    let mut collection = Collection::new(
+        collection_name,
+        this_peer_id,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        Arc::new(storage_config),
+        shard_distribution,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let local_shards = collection.get_local_shards().await;
+    for shard_id in local_shards {
+        collection
+            .set_shard_replica_state(shard_id, 0, ReplicaState::Active, None)
+            .await
+            .unwrap();
+    }
+
+    // Upload 1000 random vectors to the collection
+    let mut points = Vec::new();
+    for i in 0..100 {
+        points.push(PointStruct {
+            id: i.into(),
+            vector: vec![i as f32, 0.0, 0.0, 0.0].into(),
+            payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
+        });
+    }
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperations::PointsList(points),
+    ));
+    collection
+        .update_from_client(insert_points, true, WriteOrdering::default())
+        .await
+        .unwrap();
+
+    // Take a snapshot
+    let snapshots_tmp_dir = collection_dir.path().join("snapshots_tmp");
+    std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
+    let snapshot_description = collection
+        .create_snapshot(&snapshots_tmp_dir, 0)
+        .await
+        .unwrap();
+
+    if let Err(err) = Collection::restore_snapshot(
+        &snapshots_path.path().join(snapshot_description.name),
+        recover_dir.path(),
+        0,
+        false,
+    ) {
+        collection.before_drop().await;
+        panic!("Failed to restore snapshot: {err}")
+    }
+
+    let mut recovered_collection = Collection::load(
+        collection_name_rec,
+        this_peer_id,
+        recover_dir.path(),
+        snapshots_path.path(),
+        Default::default(),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        None,
+        None,
+    )
+    .await;
+
+    let query_vector = vec![1.0, 0.0, 0.0, 0.0];
+
+    let full_search_request = SearchRequest {
+        vector: query_vector.clone().into(),
+        filter: None,
+        limit: 100,
+        offset: 0,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: Some(WithVector::Bool(true)),
+        params: None,
+        score_threshold: None,
+    };
+
+    let reference_result = collection
+        .search(full_search_request.clone(), None, None)
+        .await
+        .unwrap();
+
+    let recovered_result = recovered_collection
+        .search(full_search_request, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(reference_result.len(), recovered_result.len());
+
+    for (reference, recovered) in reference_result.iter().zip(recovered_result.iter()) {
+        assert_eq!(reference.id, recovered.id);
+        assert_eq!(reference.payload, recovered.payload);
+        assert_eq!(reference.vector, recovered.vector);
+    }
+
+    collection.before_drop().await;
+    recovered_collection.before_drop().await;
+}
+
+#[tokio::test]
+async fn test_snapshot_and_recover_collection_normal() {
+    _test_snapshot_and_recover_collection(NodeType::Normal).await;
+}
+
+#[tokio::test]
+async fn test_snapshot_and_recover_collection_listener() {
+    _test_snapshot_and_recover_collection(NodeType::Listener).await;
+}

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -58,7 +58,7 @@ impl SegmentBuilder {
                 "Segment building error: created segment not found",
             )),
             Some(self_segment) => {
-                self_segment.version = cmp::max(self_segment.version(), other.version());
+                self_segment.version = Some(cmp::max(self_segment.version(), other.version()));
 
                 let other_id_tracker = other.id_tracker.borrow();
                 let other_vector_storages: HashMap<_, _> = other

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -60,7 +60,7 @@ pub fn get_vector_index_path(segment_path: &Path, vector_name: &str) -> PathBuf 
 }
 
 fn create_segment(
-    version: SeqNumberType,
+    version: Option<SeqNumberType>,
     segment_path: &Path,
     config: &SegmentConfig,
 ) -> OperationResult<Segment> {
@@ -238,7 +238,7 @@ pub fn build_segment(path: &Path, config: &SegmentConfig) -> OperationResult<Seg
 
     std::fs::create_dir_all(&segment_path)?;
 
-    let segment = create_segment(0, &segment_path, config)?;
+    let segment = create_segment(None, &segment_path, config)?;
     segment.save_current_state()?;
 
     // Version is the last file to save, as it will be used to check if segment was built correctly.
@@ -286,7 +286,7 @@ fn load_segment_state_v3(segment_path: &Path) -> OperationResult<SegmentState> {
                 distance: state.config.distance,
             };
             SegmentState {
-                version: state.version,
+                version: Some(state.version),
                 config: SegmentConfig {
                     vector_data: HashMap::from([(DEFAULT_VECTOR_NAME.to_owned(), vector_data)]),
                     index: state.config.index,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -502,7 +502,7 @@ pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 20_000;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentState {
-    pub version: SeqNumberType,
+    pub version: Option<SeqNumberType>,
     pub config: SegmentConfig,
 }
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "9fe5a0c97c148152adacca0df238be6b1bf7d704" }
 tokio = { version = "~1.27", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1253,10 +1253,6 @@ impl TableOfContent {
         wait: bool,
         ordering: WriteOrdering,
     ) -> Result<UpdateResult, StorageError> {
-        let _rate_limit = match &self.update_rate_limiter {
-            None => None,
-            Some(rate_limiter) => Some(rate_limiter.acquire().await),
-        };
         let collection = self.get_collection(collection_name).await?;
         let result = match shard_selection {
             Some(shard_selection) => {
@@ -1265,6 +1261,10 @@ impl TableOfContent {
                     .await
             }
             None => {
+                let _rate_limit = match &self.update_rate_limiter {
+                    None => None,
+                    Some(rate_limiter) => Some(rate_limiter.acquire().await),
+                };
                 if operation.is_write_operation() {
                     self.check_write_lock()?;
                 }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fs::{create_dir_all, read_dir};
 use std::num::NonZeroU32;
@@ -31,9 +32,10 @@ use collection::shards::transfer::shard_transfer::{
 };
 use collection::shards::{replica_set, CollectionId};
 use collection::telemetry::CollectionTelemetry;
+use segment::common::cpu::get_num_cpus;
 use segment::types::ScoredPoint;
 use tokio::runtime::Runtime;
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::{RwLock, RwLockReadGuard, Semaphore};
 use uuid::Uuid;
 
 use super::collection_meta_ops::{
@@ -77,6 +79,12 @@ pub struct TableOfContent {
     consensus_proposal_sender: Option<OperationSender>,
     is_write_locked: AtomicBool,
     lock_error_message: parking_lot::Mutex<Option<String>>,
+    /// Prevent DDoS of too many concurrent updates in distributed mode.
+    /// One external update usually triggers multiple internal updates, which breaks internal
+    /// timings. For example, the health check timing and consensus timing.
+    ///
+    /// If not defined - no rate limiting is applied.
+    update_rate_limiter: Option<Semaphore>,
 }
 
 impl TableOfContent {
@@ -148,6 +156,25 @@ impl TableOfContent {
         let alias_path = Path::new(&storage_config.storage_path).join(ALIASES_PATH);
         let alias_persistence =
             AliasPersistence::open(alias_path).expect("Can't open database by the provided config");
+
+        let rate_limiter = match storage_config.performance.update_rate_limit {
+            Some(limit) => Some(Semaphore::new(limit)),
+            None => {
+                if consensus_proposal_sender.is_some() {
+                    // Auto adjust the rate limit in distributed mode.
+                    // Select number of working threads as a guess.
+                    let limit = max(get_num_cpus(), 2);
+                    log::debug!(
+                        "Auto adjusting update rate limit to {} parallel update requests",
+                        limit
+                    );
+                    Some(Semaphore::new(limit))
+                } else {
+                    None
+                }
+            }
+        };
+
         TableOfContent {
             collections: Arc::new(RwLock::new(collections)),
             storage_config: Arc::new(storage_config.clone()),
@@ -160,6 +187,7 @@ impl TableOfContent {
             consensus_proposal_sender,
             is_write_locked: AtomicBool::new(false),
             lock_error_message: parking_lot::Mutex::new(None),
+            update_rate_limiter: rate_limiter,
         }
     }
 
@@ -1225,6 +1253,10 @@ impl TableOfContent {
         wait: bool,
         ordering: WriteOrdering,
     ) -> Result<UpdateResult, StorageError> {
+        let _rate_limit = match &self.update_rate_limiter {
+            None => None,
+            Some(rate_limiter) => Some(rate_limiter.acquire().await),
+        };
         let collection = self.get_collection(collection_name).await?;
         let result = match shard_selection {
             Some(shard_selection) => {

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -21,8 +21,7 @@ pub struct PerformanceConfig {
     pub max_search_threads: usize,
     #[serde(default = "default_max_optimization_threads")]
     pub max_optimization_threads: usize,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_rate_limit: Option<usize>,
 }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -21,6 +21,9 @@ pub struct PerformanceConfig {
     pub max_search_threads: usize,
     #[serde(default = "default_max_optimization_threads")]
     pub max_optimization_threads: usize,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_rate_limit: Option<usize>,
 }
 
 fn default_max_optimization_threads() -> usize {

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -45,6 +45,7 @@ fn test_alias_operation() {
         performance: PerformanceConfig {
             max_search_threads: 1,
             max_optimization_threads: 1,
+            update_rate_limit: None,
         },
         hnsw_index: Default::default(),
         quantization: None,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -874,6 +874,7 @@ async fn send_message(
                 client.send(request).await
             },
             Some(timeout),
+            0,
         )
         .await;
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -6,6 +6,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context};
+use api::grpc::dynamic_channel_pool::make_grpc_channel;
 use api::grpc::qdrant::raft_client::RaftClient;
 use api::grpc::qdrant::{AllPeers, PeerId as GrpcPeerId, RaftMessage as GrpcRaftMessage};
 use api::grpc::transport_channel_pool::TransportChannelPool;
@@ -281,7 +282,7 @@ impl Consensus {
         tls_config: Option<ClientTlsConfig>,
     ) -> anyhow::Result<AllPeers> {
         // Use dedicated transport channel for bootstrapping because of specific timeout
-        let channel = TransportChannelPool::make_channel(
+        let channel = make_grpc_channel(
             Duration::from_secs(config.bootstrap_timeout_sec),
             Duration::from_secs(config.bootstrap_timeout_sec),
             cluster_uri,
@@ -830,7 +831,7 @@ async fn who_is(
         bootstrap_uri.ok_or_else(|| anyhow::anyhow!("No bootstrap uri supplied"))?;
     let bootstrap_timeout = Duration::from_secs(config.bootstrap_timeout_sec);
     // Use dedicated transport channel for who_is because of specific timeout
-    let channel = TransportChannelPool::make_channel(
+    let channel = make_grpc_channel(
         bootstrap_timeout,
         bootstrap_timeout,
         bootstrap_uri,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,8 @@
 use std::{env, io};
 
+use api::grpc::transport_channel_pool::{
+    DEFAULT_CONNECT_TIMEOUT, DEFAULT_GRPC_TIMEOUT, DEFAULT_POOL_SIZE,
+};
 use collection::operations::validation;
 use config::{Config, ConfigError, Environment, File};
 use segment::common::cpu::get_num_cpus;
@@ -145,11 +148,11 @@ fn default_log_level() -> String {
 }
 
 fn default_timeout_ms() -> u64 {
-    1000 * 60
+    DEFAULT_GRPC_TIMEOUT.as_millis() as u64
 }
 
 fn default_connection_timeout_ms() -> u64 {
-    2000
+    DEFAULT_CONNECT_TIMEOUT.as_millis() as u64
 }
 
 fn default_tick_period_ms() -> u64 {
@@ -166,7 +169,7 @@ fn default_max_message_queue_size() -> usize {
 }
 
 fn default_connection_pool_size() -> usize {
-    2
+    DEFAULT_POOL_SIZE
 }
 
 impl Settings {


### PR DESCRIPTION
Globally there are 2 types of reasons why high concurrency benchmarks break stuff:

- DDoS-effect - one external request creates multiple internal. The load affects even health-check requests (both - manual and http2-keepalive. Messed-up internal timings create a wave of failures - shard transfer slows everything down - new requests are failing on all nodes before the consensus is able to react. As the result - all nodes are marked as failed.
- Shard failure might create an inconsistency in data, if `weak` ordering is used. Inconsistency can break incoming stream of changes, unless stronger ordering pattern isn't used. More info: https://qdrant.tech/documentation/distributed_deployment/#write-ordering

---

This PR aimed to fix the first part of the problem: prevent peer failing even under the high concurrent load.

To do so:

- redesign channel pool, now it have statistics of each channel usage and last success time. Channel is disposed only if there were no successful requests for a TTL, failure of the single channel doesn't kill all channels
- Configurable retry with randomized exponential back-off
- Liveness checks uses same channel pool 
- Channel pool can dynamically scale with usage (not actually used)
- **Rate limiter** on update requests  limits number of parallel internal processing. In theory and with limitied amount of test runs it seems that it prevents most problems with health-check timeouts
- Fix handling of locally disabled node - prevent situation where all nodes are declared as failed

