### PR TITLE
ability to save snapshot without locking wal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=a0ed4ebd79899471b49fcceb2537e1d6890ca869#a0ed4ebd79899471b49fcceb2537e1d6890ca869"
+source = "git+https://github.com/qdrant/wal.git?rev=9fe5a0c97c148152adacca0df238be6b1bf7d704#9fe5a0c97c148152adacca0df238be6b1bf7d704"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=1a6bb813611cd5549500eb03d7232c6b1d48df39#1a6bb813611cd5549500eb03d7232c6b1d48df39"
+source = "git+https://github.com/qdrant/wal.git?rev=a0ed4ebd79899471b49fcceb2537e1d6890ca869#a0ed4ebd79899471b49fcceb2537e1d6890ca869"
 dependencies = [
  "byteorder",
  "crc",
@@ -4580,7 +4580,7 @@ dependencies = [
  "memmap2",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.36.5",
+ "rustix 0.35.13",
  "serde",
 ]
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a0ed4ebd79899471b49fcceb2537e1d6890ca869"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "9fe5a0c97c148152adacca0df238be6b1bf7d704"}
 ordered-float = "3.6"
 hashring = "0.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "a0ed4ebd79899471b49fcceb2537e1d6890ca869"}
 ordered-float = "3.6"
 hashring = "0.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1390,7 +1390,11 @@ impl Collection {
                 let shard_snapshot_path =
                     versioned_shard_path(&snapshot_path_with_tmp_extension, *shard_id, 0);
                 create_dir_all(&shard_snapshot_path).await?;
-                replica_set.create_snapshot(&shard_snapshot_path).await?;
+                // If node is listener, we can save whatever currently is in the storage
+                let save_wal = self.shared_storage_config.node_type != NodeType::Listener;
+                replica_set
+                    .create_snapshot(&shard_snapshot_path, save_wal)
+                    .await?;
             }
         }
 

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -1,7 +1,7 @@
 use crate::operations::types::NodeType;
 
 const DEFAULT_UPDATE_QUEUE_SIZE: usize = 100;
-const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 5000;
+const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 10_000;
 
 /// Storage configuration shared between all collections.
 /// Represents a per-node configuration, which might be changes with restart.

--- a/lib/collection/src/shards/collection_shard_distribution.rs
+++ b/lib/collection/src/shards/collection_shard_distribution.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::collection_state::ShardInfo;
 use crate::shards::shard::{PeerId, ShardId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CollectionShardDistribution {
     pub shards: HashMap<ShardId, HashSet<PeerId>>,
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -120,8 +120,14 @@ impl ForwardProxyShard {
     }
 
     /// Forward `create_snapshot` to `wrapped_shard`
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
-        self.wrapped_shard.create_snapshot(target_path).await
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .create_snapshot(target_path, save_wal)
+            .await
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -533,8 +533,19 @@ impl LocalShard {
             (wal_guard.segment_capacity(), wal_guard.last_index())
         };
 
+        let target_path = Self::wal_path(snapshot_shard_path);
+
+        // Create directory if it does not exist
+        std::fs::create_dir_all(&target_path).map_err(|err| {
+            CollectionError::service_error(format!(
+                "Can not crate directory {}: {}",
+                target_path.display(),
+                err
+            ))
+        })?;
+
         Wal::generate_empty_wal_starting_at_index(
-            snapshot_shard_path,
+            target_path,
             &WalOptions {
                 segment_capacity,
                 segment_queue_len: 0,

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -20,7 +20,8 @@ use segment::types::{
 use tokio::fs::{copy, create_dir_all, remove_dir_all};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
-use tokio::sync::{mpsc, Mutex, RwLock as TokioRwLock};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock as TokioRwLock};
+use wal::{Wal, WalOptions};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
@@ -157,7 +158,7 @@ impl LocalShard {
 
         let wal: SerdeWal<CollectionUpdateOperations> = SerdeWal::new(
             wal_path.to_str().unwrap(),
-            &(&collection_config_read.wal_config).into(),
+            (&collection_config_read.wal_config).into(),
         )
         .map_err(|e| CollectionError::service_error(format!("Wal error: {e}")))?;
 
@@ -345,7 +346,7 @@ impl LocalShard {
         }
 
         let wal: SerdeWal<CollectionUpdateOperations> =
-            SerdeWal::new(wal_path.to_str().unwrap(), &(&config.wal_config).into())?;
+            SerdeWal::new(wal_path.to_str().unwrap(), (&config.wal_config).into())?;
 
         let optimizers = build_optimizers(
             shard_path,
@@ -478,7 +479,11 @@ impl LocalShard {
     }
 
     /// create snapshot for local shard into `target_path`
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
         let snapshot_shard_path = target_path;
 
         // snapshot all shard's segment
@@ -489,14 +494,28 @@ impl LocalShard {
         let wal = self.wal.clone();
         let snapshot_shard_path_owned = snapshot_shard_path.to_owned();
 
+        if !save_wal {
+            // If we are not saving WAL, we still need to make sure that all submitted by this point
+            // updates have made it to the segments. So we use the Plunger to achieve that.
+            // It will notify us when all submitted updates so far have been processed.
+            let (tx, rx) = oneshot::channel();
+            let plunger = UpdateSignal::Plunger(tx);
+            self.update_sender.load().send(plunger).await?;
+            rx.await?;
+        }
+
         tokio::task::spawn_blocking(move || {
             let segments_read = segments.read();
 
             // Do not change segments while snapshotting
             segments_read.snapshot_all_segments(&snapshot_segments_shard_path)?;
 
-            // snapshot all shard's WAL
-            Self::snapshot_wal(wal, &snapshot_shard_path_owned)
+            if save_wal {
+                // snapshot all shard's WAL
+                Self::snapshot_wal(wal, &snapshot_shard_path_owned)
+            } else {
+                Self::snapshot_empty_wal(wal, &snapshot_shard_path_owned)
+            }
         })
         .await??;
 
@@ -505,6 +524,26 @@ impl LocalShard {
         let target_shard_config_path = snapshot_shard_path.join(SHARD_CONFIG_FILE);
         copy(&shard_config_path, &target_shard_config_path).await?;
         Ok(())
+    }
+
+    /// Create empty WAL which is compatible with currently stored data
+    pub fn snapshot_empty_wal(wal: LockedWal, snapshot_shard_path: &Path) -> CollectionResult<()> {
+        let (segment_capacity, latest_op_num) = {
+            let wal_guard = wal.lock();
+            (wal_guard.segment_capacity(), wal_guard.last_index())
+        };
+
+        Wal::generate_empty_wal_starting_at_index(
+            snapshot_shard_path,
+            &WalOptions {
+                segment_capacity,
+                segment_queue_len: 0,
+            },
+            latest_op_num,
+        )
+        .map_err(|err| {
+            CollectionError::service_error(format!("Error while create empty WAL: {err}"))
+        })
     }
 
     /// snapshot WAL

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -62,8 +62,14 @@ impl ProxyShard {
     }
 
     /// Forward `create_snapshot` to `wrapped_shard`
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
-        self.wrapped_shard.create_snapshot(target_path).await
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .create_snapshot(target_path, save_wal)
+            .await
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -999,11 +999,15 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
         let local_read = self.local.read().await;
 
         if let Some(local) = &*local_read {
-            local.create_snapshot(target_path).await?
+            local.create_snapshot(target_path, save_wal).await?
         }
 
         self.replica_state

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -58,11 +58,17 @@ impl Shard {
         telemetry
     }
 
-    pub async fn create_snapshot(&self, target_path: &Path) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
         match self {
-            Shard::Local(local_shard) => local_shard.create_snapshot(target_path).await,
-            Shard::Proxy(proxy_shard) => proxy_shard.create_snapshot(target_path).await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.create_snapshot(target_path).await,
+            Shard::Local(local_shard) => local_shard.create_snapshot(target_path, save_wal).await,
+            Shard::Proxy(proxy_shard) => proxy_shard.create_snapshot(target_path, save_wal).await,
+            Shard::ForwardProxy(proxy_shard) => {
+                proxy_shard.create_snapshot(target_path, save_wal).await
+            }
         }
     }
 

--- a/lib/collection/tests/snapshot_recovery_test.rs
+++ b/lib/collection/tests/snapshot_recovery_test.rs
@@ -1,0 +1,186 @@
+use std::num::{NonZeroU32, NonZeroU64};
+use std::sync::Arc;
+
+use collection::collection::Collection;
+use collection::config::{CollectionConfig, CollectionParams, WalConfig};
+use collection::operations::point_ops::{
+    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+};
+use collection::operations::shared_storage_config::SharedStorageConfig;
+use collection::operations::types::{NodeType, SearchRequest, VectorParams, VectorsConfig};
+use collection::operations::CollectionUpdateOperations;
+use collection::shards::channel_service::ChannelService;
+use collection::shards::collection_shard_distribution::CollectionShardDistribution;
+use collection::shards::replica_set::ReplicaState;
+use segment::types::{Distance, WithPayloadInterface, WithVector};
+use tempfile::Builder;
+
+use crate::common::{
+    dummy_on_replica_failure, dummy_request_shard_transfer, TEST_OPTIMIZERS_CONFIG,
+};
+
+mod common;
+
+async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParams {
+            size: NonZeroU64::new(4).unwrap(),
+            distance: Distance::Dot,
+        }),
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        on_disk_payload: false,
+    };
+
+    let config = CollectionConfig {
+        params: collection_params,
+        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+    };
+
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let recover_dir = Builder::new()
+        .prefix("test_collection_rec")
+        .tempdir()
+        .unwrap();
+    let collection_name = "test".to_string();
+    let collection_name_rec = "test_rec".to_string();
+
+    let storage_config: SharedStorageConfig = SharedStorageConfig {
+        node_type,
+        ..Default::default()
+    };
+
+    let this_peer_id = 0;
+    let shard_distribution = CollectionShardDistribution::all_local(
+        Some(config.params.shard_number.into()),
+        this_peer_id,
+    );
+
+    let mut collection = Collection::new(
+        collection_name,
+        this_peer_id,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        Arc::new(storage_config),
+        shard_distribution,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let local_shards = collection.get_local_shards().await;
+    for shard_id in local_shards {
+        collection
+            .set_shard_replica_state(shard_id, 0, ReplicaState::Active, None)
+            .await
+            .unwrap();
+    }
+
+    // Upload 1000 random vectors to the collection
+    let mut points = Vec::new();
+    for i in 0..100 {
+        points.push(PointStruct {
+            id: i.into(),
+            vector: vec![i as f32, 0.0, 0.0, 0.0].into(),
+            payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
+        });
+    }
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperations::PointsList(points),
+    ));
+    collection
+        .update_from_client(insert_points, true, WriteOrdering::default())
+        .await
+        .unwrap();
+
+    // Take a snapshot
+    let snapshots_tmp_dir = collection_dir.path().join("snapshots_tmp");
+    std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
+    let snapshot_description = collection
+        .create_snapshot(&snapshots_tmp_dir, 0)
+        .await
+        .unwrap();
+
+    if let Err(err) = Collection::restore_snapshot(
+        &snapshots_path.path().join(snapshot_description.name),
+        recover_dir.path(),
+        0,
+        false,
+    ) {
+        collection.before_drop().await;
+        panic!("Failed to restore snapshot: {err}")
+    }
+
+    let mut recovered_collection = Collection::load(
+        collection_name_rec,
+        this_peer_id,
+        recover_dir.path(),
+        snapshots_path.path(),
+        Default::default(),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        None,
+        None,
+    )
+    .await;
+
+    let query_vector = vec![1.0, 0.0, 0.0, 0.0];
+
+    let full_search_request = SearchRequest {
+        vector: query_vector.clone().into(),
+        filter: None,
+        limit: 100,
+        offset: 0,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: Some(WithVector::Bool(true)),
+        params: None,
+        score_threshold: None,
+    };
+
+    let reference_result = collection
+        .search(full_search_request.clone(), None, None)
+        .await
+        .unwrap();
+
+    let recovered_result = recovered_collection
+        .search(full_search_request, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(reference_result.len(), recovered_result.len());
+
+    for (reference, recovered) in reference_result.iter().zip(recovered_result.iter()) {
+        assert_eq!(reference.id, recovered.id);
+        assert_eq!(reference.payload, recovered.payload);
+        assert_eq!(reference.vector, recovered.vector);
+    }
+
+    collection.before_drop().await;
+    recovered_collection.before_drop().await;
+}
+
+#[tokio::test]
+async fn test_snapshot_and_recover_collection_normal() {
+    _test_snapshot_and_recover_collection(NodeType::Normal).await;
+}
+
+#[tokio::test]
+async fn test_snapshot_and_recover_collection_listener() {
+    _test_snapshot_and_recover_collection(NodeType::Listener).await;
+}

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -58,7 +58,7 @@ impl SegmentBuilder {
                 "Segment building error: created segment not found",
             )),
             Some(self_segment) => {
-                self_segment.version = cmp::max(self_segment.version(), other.version());
+                self_segment.version = Some(cmp::max(self_segment.version(), other.version()));
 
                 let other_id_tracker = other.id_tracker.borrow();
                 let other_vector_storages: HashMap<_, _> = other

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -60,7 +60,7 @@ pub fn get_vector_index_path(segment_path: &Path, vector_name: &str) -> PathBuf 
 }
 
 fn create_segment(
-    version: SeqNumberType,
+    version: Option<SeqNumberType>,
     segment_path: &Path,
     config: &SegmentConfig,
 ) -> OperationResult<Segment> {
@@ -238,7 +238,7 @@ pub fn build_segment(path: &Path, config: &SegmentConfig) -> OperationResult<Seg
 
     std::fs::create_dir_all(&segment_path)?;
 
-    let segment = create_segment(0, &segment_path, config)?;
+    let segment = create_segment(None, &segment_path, config)?;
     segment.save_current_state()?;
 
     // Version is the last file to save, as it will be used to check if segment was built correctly.
@@ -286,7 +286,7 @@ fn load_segment_state_v3(segment_path: &Path) -> OperationResult<SegmentState> {
                 distance: state.config.distance,
             };
             SegmentState {
-                version: state.version,
+                version: Some(state.version),
                 config: SegmentConfig {
                     vector_data: HashMap::from([(DEFAULT_VECTOR_NAME.to_owned(), vector_data)]),
                     index: state.config.index,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -502,7 +502,7 @@ pub const DEFAULT_FULL_SCAN_THRESHOLD: usize = 20_000;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentState {
-    pub version: SeqNumberType,
+    pub version: Option<SeqNumberType>,
     pub config: SegmentConfig,
 }
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a0ed4ebd79899471b49fcceb2537e1d6890ca869" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "9fe5a0c97c148152adacca0df238be6b1bf7d704" }
 tokio = { version = "~1.27", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "1a6bb813611cd5549500eb03d7232c6b1d48df39" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "a0ed4ebd79899471b49fcceb2537e1d6890ca869" }
 tokio = { version = "~1.27", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
Use combination of Plunger + empty WAL to be able to make a snapshot without ever locking WAL

Plunger ensures that all changes (available at the point of snapshotting) will make into storage, so the WAL will not be required.