### PR TITLE
Fix potential panic in clamp function with high ef_limit value

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -329,8 +329,13 @@ fn sampling_limit(
     let poisson_sampling =
         find_search_sampling_over_point_distribution(limit as f64, segment_probability)
             .unwrap_or(limit);
-    // Sampling cannot be greater than limit, cannot be less than ef_limit
-    let res = poisson_sampling.clamp(ef_limit.unwrap_or(0), limit);
+    let res = if poisson_sampling > limit {
+        // sampling cannot be greater than limit
+        return limit;
+    } else {
+        // sampling should not be less than ef_limit
+        poisson_sampling.max(ef_limit.unwrap_or(0))
+    };
     log::trace!("sampling: {res}, poisson: {poisson_sampling} segment_probability: {segment_probability}, segment_points: {segment_points}, total_points: {total_points}");
     res
 }


### PR DESCRIPTION
This fixes a potential panic in `clamp` when a high `ef_limit` value is used when searching.

The usage of `clamp` was introduced in ([#1675](https://github.com/qdrant/qdrant/commit/b7c1ecfd5f75bba775ed031a8ab855298d72ab1d#diff-cb0e9997c84d55ebb0f87b7fe719a65fb2f66b1dcb1d003e99939df680b27307R333)) to simplify the logic, but it likely introduced this nasty side effect.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?