### PR TITLE
Fix and test effective ef_limit with poisson sampling

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -336,13 +336,8 @@ fn sampling_limit(
 
 /// Determines the effective ef limit value for the given parameters.
 fn effective_limit(limit: usize, ef_limit: usize, poisson_sampling: usize) -> usize {
-    if poisson_sampling > limit {
-        // sampling cannot be greater than limit
-        limit
-    } else {
-        // sampling should not be less than ef_limit
-        poisson_sampling.max(ef_limit)
-    }
+    // Prefer the highest of poisson_sampling/ef_limit, but never be higher than limit
+    poisson_sampling.max(ef_limit).min(limit)
 }
 
 /// Process sequentially contiguous batches

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -329,15 +329,20 @@ fn sampling_limit(
     let poisson_sampling =
         find_search_sampling_over_point_distribution(limit as f64, segment_probability)
             .unwrap_or(limit);
-    let res = if poisson_sampling > limit {
+    let effective = effective_limit(limit, ef_limit.unwrap_or(0), poisson_sampling);
+    log::trace!("sampling: {effective}, poisson: {poisson_sampling} segment_probability: {segment_probability}, segment_points: {segment_points}, total_points: {total_points}");
+    effective
+}
+
+/// Determines the effective ef limit value for the given parameters.
+fn effective_limit(limit: usize, ef_limit: usize, poisson_sampling: usize) -> usize {
+    if poisson_sampling > limit {
         // sampling cannot be greater than limit
-        return limit;
+        limit
     } else {
         // sampling should not be less than ef_limit
-        poisson_sampling.max(ef_limit.unwrap_or(0))
-    };
-    log::trace!("sampling: {res}, poisson: {poisson_sampling} segment_probability: {segment_probability}, segment_points: {segment_points}, total_points: {total_points}");
-    res
+        poisson_sampling.max(ef_limit)
+    }
 }
 
 /// Process sequentially contiguous batches
@@ -628,5 +633,33 @@ mod tests {
     #[test]
     fn test_sampling_limit_high() {
         assert_eq!(sampling_limit(1000000, None, 464530, 35103551), 1000000);
+    }
+
+    /// Tests whether calculating the effective ef limit value is correct.
+    ///
+    /// Because there was confustion about what the effective value should be for some imput
+    /// combinations, we decided to write this tests to ensure correctness.
+    ///
+    /// See: <https://github.com/qdrant/qdrant/pull/1694>
+    #[test]
+    fn test_effective_limit() {
+        // Test cases to assert: (limit, ef_limit, poisson_sampling, effective)
+        let tests = [
+            (1000, 128, 150, 150),
+            (1000, 128, 110, 128),
+            (130, 128, 150, 130),
+            (130, 128, 110, 128),
+            (50, 128, 150, 50),
+            (50, 128, 110, 50),
+            (500, 1000, 300, 500),
+            (500, 400, 300, 400),
+            (1000, 0, 150, 150),
+            (1000, 0, 110, 110),
+        ];
+        tests.into_iter().for_each(|(limit, ef_limit, poisson_sampling, effective)| assert_eq!(
+            effective_limit(limit, ef_limit, poisson_sampling),
+            effective,
+            "effective limit for [limit: {limit}, ef_limit: {ef_limit}, poisson_sampling: {poisson_sampling}] must be {effective}",
+        ));
     }
 }


### PR DESCRIPTION
Fixes incorrect logic for choosing the effective ef_limit with poisson sampling when searching. This potentially improves search performance in some scenarios.

There was some confusion about what the effective `ef_limit` value should be for searching, this adds tests to ensure the logic for calculating it is correct. This showed a logic discrepancy which is now fixed.

Now, the lower limit is picked when `ef_limit` is larger than `limit`. This may result in a performance boost in some search configurations.

This table shows the difference for some input values. We used F1 before, this PR changes to F2:

![table](https://user-images.githubusercontent.com/856222/231181087-d1ffe3a2-443e-4ccb-a034-020063f3c2af.png)

*Via: https://docs.google.com/spreadsheets/d/16nJBXQ757tGjX0aOCSFNKuHiTYG2QtB2DQoVWb3enVo/edit*

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?