### PR TITLE
gRPC logging middleware

### DIFF
--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -60,8 +60,11 @@ where
                             Code::Ok => {
                                 log::trace!("gRPC {} Ok {:.6}", method_name, elapsed_sec);
                             }
-                            Code::Cancelled
-                            | Code::DeadlineExceeded
+                            Code::Cancelled => {
+                                // cluster mode generates a large amount of `stream error received: stream no longer needed`
+                                log::trace!("gRPC {} {:.6}", method_name, elapsed_sec);
+                            }
+                            Code::DeadlineExceeded
                             | Code::Aborted
                             | Code::OutOfRange
                             | Code::ResourceExhausted

--- a/src/tonic/logging_middleware.rs
+++ b/src/tonic/logging_middleware.rs
@@ -1,0 +1,95 @@
+use std::task::{Context, Poll};
+
+use futures_util::future::BoxFuture;
+use tonic::body::BoxBody;
+use tonic::codegen::http::Response;
+use tonic::Code;
+use tower::Service;
+use tower_layer::Layer;
+
+#[derive(Clone)]
+pub struct LoggingMiddleware<T> {
+    inner: T,
+}
+
+#[derive(Clone)]
+pub struct LoggingMiddlewareLayer;
+
+impl LoggingMiddlewareLayer {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<S> Service<tonic::codegen::http::Request<tonic::transport::Body>> for LoggingMiddleware<S>
+where
+    S: Service<tonic::codegen::http::Request<tonic::transport::Body>, Response = Response<BoxBody>>
+        + Clone,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<S::Response, S::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(
+        &mut self,
+        request: tonic::codegen::http::Request<tonic::transport::Body>,
+    ) -> Self::Future {
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        let method_name = request.uri().path().to_string();
+        let future = inner.call(request);
+        Box::pin(async move {
+            let response = future.await;
+            match response {
+                Err(error) => {
+                    log::error!("gGRPC request error {}", method_name);
+                    Err(error)
+                }
+                Ok(response_tonic) => {
+                    let grpc_status = tonic::Status::from_header_map(response_tonic.headers());
+                    if let Some(grpc_status) = grpc_status {
+                        match grpc_status.code() {
+                            Code::Ok
+                            | Code::Cancelled
+                            | Code::DeadlineExceeded
+                            | Code::Aborted
+                            | Code::OutOfRange
+                            | Code::ResourceExhausted
+                            | Code::NotFound
+                            | Code::InvalidArgument
+                            | Code::AlreadyExists
+                            | Code::FailedPrecondition
+                            | Code::PermissionDenied
+                            | Code::Unauthenticated => {} // no logging
+                            Code::Internal
+                            | Code::Unimplemented
+                            | Code::Unavailable
+                            | Code::DataLoss
+                            | Code::Unknown => log::error!(
+                                "gRPC request {} failed with {} {:?}",
+                                method_name,
+                                grpc_status.code(),
+                                grpc_status.message()
+                            ),
+                        };
+                    }
+                    Ok(response_tonic)
+                }
+            }
+        })
+    }
+}
+
+impl<S> Layer<S> for LoggingMiddlewareLayer {
+    type Service = LoggingMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        LoggingMiddleware { inner: service }
+    }
+}

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -1,5 +1,5 @@
 mod api;
-mod logging_middleware;
+mod logging;
 mod tonic_telemetry;
 
 use std::io;
@@ -75,7 +75,7 @@ pub fn init(
 
         // The stack of middleware that our service will be wrapped in
         let middleware_layer = tower::ServiceBuilder::new()
-            .layer(logging_middleware::LoggingMiddlewareLayer::new())
+            .layer(logging::LoggingMiddlewareLayer::new())
             .layer(tonic_telemetry::TonicTelemetryLayer::new(
                 telemetry_collector,
             ))
@@ -152,7 +152,7 @@ pub fn init_internal(
 
             // The stack of middleware that our service will be wrapped in
             let middleware_layer = tower::ServiceBuilder::new()
-                .layer(logging_middleware::LoggingMiddlewareLayer::new())
+                .layer(logging::LoggingMiddlewareLayer::new())
                 .layer(tonic_telemetry::TonicTelemetryLayer::new(
                     telemetry_collector,
                 ))

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod logging_middleware;
 mod tonic_telemetry;
 
 use std::io;
@@ -72,10 +73,16 @@ pub fn init(
                 .map_err(helpers::tonic_error_to_io_error)?;
         };
 
-        server
+        // The stack of middleware that our service will be wrapped in
+        let middleware_layer = tower::ServiceBuilder::new()
+            .layer(logging_middleware::LoggingMiddlewareLayer::new())
             .layer(tonic_telemetry::TonicTelemetryLayer::new(
                 telemetry_collector,
             ))
+            .into_inner();
+
+        server
+            .layer(middleware_layer)
             .add_service(
                 QdrantServer::new(qdrant_service)
                     .send_compressed(CompressionEncoding::Gzip)
@@ -143,10 +150,16 @@ pub fn init_internal(
                 server = server.tls_config(config)?;
             };
 
-            server
+            // The stack of middleware that our service will be wrapped in
+            let middleware_layer = tower::ServiceBuilder::new()
+                .layer(logging_middleware::LoggingMiddlewareLayer::new())
                 .layer(tonic_telemetry::TonicTelemetryLayer::new(
                     telemetry_collector,
                 ))
+                .into_inner();
+
+            server
+                .layer(middleware_layer)
                 .add_service(
                     QdrantServer::new(qdrant_service)
                         .send_compressed(CompressionEncoding::Gzip)


### PR DESCRIPTION
A common issue with the gRPC API is that is a blackbox in terms of error reporting.

Errors returned to the users are not logged in any way.

This PR adds a new Tower `LoggingMiddleware` for the internal and external gRPC APIs.

It was developed using [this example](https://github.com/hyperium/tonic/blob/master/examples/src/tower/server.rs) as reference.

E.g.

```
[2023-04-11T13:13:06.501Z ERROR qdrant::tonic::logging] gRPC /qdrant.Snapshots/Create failed with Internal error "Service internal error: Error while copy WAL \"./storage/snapshots_tmp/high-concurrency-17501009700520899966-2023-04-11-13-13-05.tmp/0\" No such file or directory (os error 2)" 0.311448
```