### PR TITLE
[REST] alias `with_vector` <-> `with_vectors`

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -182,7 +182,7 @@ pub struct ScrollRequest {
     /// Select which payload to return with the response. Default: All
     pub with_payload: Option<WithPayloadInterface>,
     /// Whether to return the point vector with the result?
-    #[serde(default)]
+    #[serde(default, alias = "with_vectors")]
     pub with_vector: WithVector,
 }
 
@@ -231,7 +231,7 @@ pub struct SearchRequest {
     /// Select which payload to return with the response. Default: None
     pub with_payload: Option<WithPayloadInterface>,
     /// Whether to return the point vector with the result?
-    #[serde(default)]
+    #[serde(default, alias = "with_vectors")]
     pub with_vector: Option<WithVector>,
     /// Define a minimal score threshold for the result.
     /// If defined, less similar results will not be returned.
@@ -254,7 +254,7 @@ pub struct PointRequest {
     /// Select which payload to return with the response. Default: All
     pub with_payload: Option<WithPayloadInterface>,
     /// Whether to return the point vector with the result?
-    #[serde(default)]
+    #[serde(default, alias = "with_vectors")]
     pub with_vector: WithVector,
 }
 
@@ -314,7 +314,7 @@ pub struct RecommendRequest {
     /// Select which payload to return with the response. Default: None
     pub with_payload: Option<WithPayloadInterface>,
     /// Whether to return the point vector with the result?
-    #[serde(default)]
+    #[serde(default, alias = "with_vectors")]
     pub with_vector: Option<WithVector>,
     /// Define a minimal score threshold for the result.
     /// If defined, less similar results will not be returned.


### PR DESCRIPTION
Makes alias for `with_vector` parameter, to enable the plural form (`with_vectors`) in REST API requests. 

Solves #1554 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
