### PR TITLE
Remove collections_{full,aggregated}_total metric gauges

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -114,30 +114,6 @@ impl MetricsProvider for CollectionsTelemetry {
             MetricType::GAUGE,
             vec![gauge(vector_count as f64, &[])],
         ));
-
-        // Count collection types
-        if let Some(ref collections) = self.collections {
-            let full_count = collections
-                .iter()
-                .filter(|p| matches!(p, CollectionTelemetryEnum::Full(_)))
-                .count();
-            let aggregated_count = collections
-                .iter()
-                .filter(|p| matches!(p, CollectionTelemetryEnum::Aggregated(_)))
-                .count();
-            metrics.push(metric_family(
-                "collections_full_total",
-                "number of full collections",
-                MetricType::GAUGE,
-                vec![gauge(full_count as f64, &[])],
-            ));
-            metrics.push(metric_family(
-                "collections_aggregated_total",
-                "number of aggregated collections",
-                MetricType::GAUGE,
-                vec![gauge(aggregated_count as f64, &[])],
-            ));
-        }
     }
 }
 


### PR DESCRIPTION
This removes the `collections_{full,aggregated}_total` gauges from metrics. These were intended for telemetry, and are not useful for metrics.

More specifically, it removes these two:

```bash
# HELP collections_full_total number of full collections
# TYPE collections_full_total gauge
collections_full_total 0
# HELP collections_aggregated_total number of aggregated collections
# TYPE collections_aggregated_total gauge
collections_aggregated_total 2
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?