### PR TITLE
Add optional `tracing` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "parking_lot",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1682,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e123d9ae7c02966b4d892e550bdc32164f05853cd40ab570650ad600596a8a"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1855,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0ddd025eccd8a2fff9865e82ef4c8ce00c4a67709036847d95cf3ccffd07a8"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -2286,6 +2349,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2728,12 @@ dependencies = [
  "dlv-list",
  "hashbrown",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3047,6 +3148,7 @@ dependencies = [
  "collection",
  "colored",
  "config",
+ "console-subscriber",
  "constant_time_eq 0.2.5",
  "env_logger",
  "futures",
@@ -3082,6 +3184,9 @@ dependencies = [
  "tonic",
  "tower",
  "tower-layer",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-tracy",
  "uuid",
  "validator",
  "wal",
@@ -3295,6 +3400,15 @@ checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -3632,6 +3746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,6 +3993,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4184,6 +4313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4422,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
 ]
 
@@ -4481,6 +4621,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-tracy"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c48ef3e655220d4e43a6be44aa84f078c3004357251cab45f9cc15551a593e"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d99f5fc382239d08b6bf05bb6206a585bfdb988c878f2499081d0f285ef7819"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4618,6 +4820,12 @@ dependencies = [
  "proc-macro2",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -4846,6 +5054,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ default-run = "qdrant"
 default = ["web", "parking_lot"]
 web = ["actix-web"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
+tracing-log = ["tracing", "tracing/log"]
+console = ["console-subscriber"]
+console-subscriber = ["tracing", "tracing-subscriber", "dep:console-subscriber"]
+tracy = ["tracing-tracy"]
+tracing-tracy = ["tracing", "tracing-subscriber", "dep:tracing-tracy"]
+tokio-tracing = ["tokio/tracing"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"
@@ -75,6 +81,12 @@ storage = { path = "lib/storage" }
 api = { path = "lib/api" }
 actix-multipart = "0.6.0"
 constant_time_eq = "0.2.5"
+
+# Profiling
+tracing = { version = "0.1", features = ["async-await"], optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
+console-subscriber = { version = "0.1", default-features = false, features = ["parking_lot"], optional = true }
+tracing-tracy = { version = "0.10.2", features = ["ondemand"], optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -150,7 +150,7 @@ that can be enabled with optional features.
 - `tokio-tracing` feature explicitly enables [`Tokio` crate tracing][tokio-tracing]
   - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
   - this is required (and enabled automatically) by the `console` feature
-  - but you can enable it explicitly with the `tracy` feature, to see `Tokio` traces in [`Tracy`] profiler
+  - but you can enable it explicitly with the `tracy` feature, to see Tokio traces in [`Tracy`] profiler
 - `tracing` feature simply enables optional [`tracing`] crate dependency (without any integrations)
   - this is required (and enabled automatically) by all of the above features
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -179,7 +179,7 @@ fn some_other_function() {
 [`tracing`]: https://docs.rs/tracing/latest/tracing/
 [`Tracy`]: https://github.com/wolfpld/tracy
 [`tokio-console`]: https://docs.rs/tokio-console/latest/tokio_console/
-[`tokio-tracing`]: https://docs.rs/tokio/latest/tokio/#unstable-features
+[tokio-tracing]: https://docs.rs/tokio/latest/tokio/#unstable-features
 
 ## API changes
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -135,6 +135,44 @@ Use [pprof](https://github.com/google/pprof) and the following command to genera
 
 ![call-graph example](./imgs/call-graph-profile.png)
 
+### Real-time profiling
+
+Qdrant have basic [`Tracy`] and [`tokio-console`] profilers integration that can be enabled with optional features.
+
+- `tracy` feature enables [`Tracy`] integration
+- `console` feature enables [`tokio-console`] integration
+  - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
+  - by default [`tokio-console`] binds to `127.0.0.1:6669`
+  - if you want to connect [`tokio-console`] to Qdrant instance running inside a Docker container
+    or on remote server, you can define `TOKIO_CONSOLE_BIND` when running Qdrant to override it
+    (e.g., `TOKIO_CONSOLE_BIND=0.0.0.0:6669` to listen on all interfaces)
+- `tokio-tracing` feature explicitly enables [`Tokio` crate tracing][tokio-tracing]
+  - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
+  - this is required (and enabled automatically) by the `console` feature
+  - but you can enable it explicitly with the `tracy` feature, to see `Tokio` traces in [`Tracy`] profiler
+
+Qdrant code is **not** instrumented by default, so you'll have to manually add `#[tracing::instrument]` attributes
+on functions and methods that you want to profile.
+
+```rust
+// `tracing` crate is an *optional* dependency, so if you want the code to compile even when `tracing`
+// feature is disabled, you'll have to use `#[cfg_attr(...)]`...
+//
+// See https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute
+#[cfg_attr(feature = "tracing", tracing::instrument)]
+fn my_function(some_parameter: String) {
+    // ...
+}
+
+// ...or if you just want to do some quick-and-dirty profiling, you use `#[tracing::instrument]`
+// directly, just don't forget to add `--features tracing` when running `cargo` or add `tracing`
+// to default features in `Cargo.toml`
+#[tracing::instrument]
+fn some_other_function() {
+    // ...
+}
+```
+
 ## API changes
 
 ### REST

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -137,9 +137,10 @@ Use [pprof](https://github.com/google/pprof) and the following command to genera
 
 ### Real-time profiling
 
-Qdrant have basic [`Tracy`] and [`tokio-console`] profilers integration that can be enabled with optional features.
+Qdrant have basic [`tracing`] support with [`Tracy`] profiler and [`tokio-console`] integrations
+that can be enabled with optional features.
 
-- `tracy` feature enables [`Tracy`] integration
+- `tracy` feature enables [`Tracy`] profiler integration
 - `console` feature enables [`tokio-console`] integration
   - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
   - by default [`tokio-console`] binds to `127.0.0.1:6669`
@@ -150,13 +151,15 @@ Qdrant have basic [`Tracy`] and [`tokio-console`] profilers integration that can
   - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
   - this is required (and enabled automatically) by the `console` feature
   - but you can enable it explicitly with the `tracy` feature, to see `Tokio` traces in [`Tracy`] profiler
+- `tracing` feature simply enables optional [`tracing`] crate dependency (without any integrations)
+  - this is required (and enabled automatically) by all of the above features
 
 Qdrant code is **not** instrumented by default, so you'll have to manually add `#[tracing::instrument]` attributes
 on functions and methods that you want to profile.
 
 ```rust
-// `tracing` crate is an *optional* dependency, so if you want the code to compile even when `tracing`
-// feature is disabled, you'll have to use `#[cfg_attr(...)]`...
+// `tracing` crate is an *optional* dependency, so if you want the code to compile when `tracing`
+// feature is disabled, you have to use `#[cfg_attr(...)]`...
 //
 // See https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute
 #[cfg_attr(feature = "tracing", tracing::instrument)]
@@ -164,14 +167,19 @@ fn my_function(some_parameter: String) {
     // ...
 }
 
-// ...or if you just want to do some quick-and-dirty profiling, you use `#[tracing::instrument]`
-// directly, just don't forget to add `--features tracing` when running `cargo` or add `tracing`
-// to default features in `Cargo.toml`
+// ...or if you just want to do some quick-and-dirty profiling, you can use `#[tracing::instrument]`
+// directly, just don't forget to add `--features tracing` when running `cargo` (or add `tracing`
+// to default features in `Cargo.toml`)
 #[tracing::instrument]
 fn some_other_function() {
     // ...
 }
 ```
+
+[`tracing`]: https://docs.rs/tracing/latest/tracing/
+[`Tracy`]: https://github.com/wolfpld/tracy
+[`tokio-console`]: https://docs.rs/tokio-console/latest/tokio_console/
+[`tokio-tracing`]: https://docs.rs/tokio/latest/tokio/#unstable-features
 
 ## API changes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,26 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Use `console` and/or `tracy` features to enable both `tracing-subscriber` and the layer(s)
+    #[cfg(feature = "tracing-subscriber")]
+    {
+        use tracing_subscriber::prelude::*;
+
+        let reg = tracing_subscriber::registry();
+
+        // Use `console` feature to enable both `tracing-subscriber` and `console-subscriber`
+        #[cfg(feature = "console-subscriber")]
+        let reg = reg.with(console_subscriber::spawn());
+
+        // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
+        #[cfg(feature = "tracing-tracy")]
+        let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(
+            tracing_subscriber::filter::filter_fn(|metadata| metadata.is_span()),
+        ));
+
+        tracing::subscriber::set_global_default(reg)?;
+    }
+
     remove_started_file_indicator();
 
     let args = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,18 @@ fn main() -> anyhow::Result<()> {
         #[cfg(feature = "console-subscriber")]
         let reg = reg.with(console_subscriber::spawn());
 
+        // Note, that `console-subscriber` requires manually enabling
+        // `--cfg tokio_unstable` rust flags during compilation!
+        //
+        // Otherwise `console_subscriber::spawn` call panics!
+        //
+        // See https://docs.rs/tokio/latest/tokio/#unstable-features
+        #[cfg(all(feature = "console-subscriber", not(tokio_unstable)))]
+        eprintln!(
+            "`console-subscriber` requires manually enabling \
+             `--cfg tokio_unstable` rust flags during compilation!"
+        );
+
         // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
         #[cfg(feature = "tracing-tracy")]
         let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,37 +106,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    // Use `console` and/or `tracy` features to enable both `tracing-subscriber` and the layer(s)
-    #[cfg(feature = "tracing-subscriber")]
-    {
-        use tracing_subscriber::prelude::*;
-
-        let reg = tracing_subscriber::registry();
-
-        // Use `console` feature to enable both `tracing-subscriber` and `console-subscriber`
-        #[cfg(feature = "console-subscriber")]
-        let reg = reg.with(console_subscriber::spawn());
-
-        // Note, that `console-subscriber` requires manually enabling
-        // `--cfg tokio_unstable` rust flags during compilation!
-        //
-        // Otherwise `console_subscriber::spawn` call panics!
-        //
-        // See https://docs.rs/tokio/latest/tokio/#unstable-features
-        #[cfg(all(feature = "console-subscriber", not(tokio_unstable)))]
-        eprintln!(
-            "`console-subscriber` requires manually enabling \
-             `--cfg tokio_unstable` rust flags during compilation!"
-        );
-
-        // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
-        #[cfg(feature = "tracing-tracy")]
-        let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(
-            tracing_subscriber::filter::filter_fn(|metadata| metadata.is_span()),
-        ));
-
-        tracing::subscriber::set_global_default(reg)?;
-    }
+    setup_tracing();
 
     remove_started_file_indicator();
 
@@ -451,4 +421,38 @@ fn main() -> anyhow::Result<()> {
     drop(toc_arc);
     drop(settings);
     Ok(())
+}
+
+fn setup_tracing() {
+    // Use `console` and/or `tracy` features to enable both `tracing-subscriber` and the layer(s)
+    #[cfg(feature = "tracing-subscriber")]
+    {
+        use tracing_subscriber::prelude::*;
+
+        let reg = tracing_subscriber::registry();
+
+        // Use `console` feature to enable both `tracing-subscriber` and `console-subscriber`
+        #[cfg(feature = "console-subscriber")]
+        let reg = reg.with(console_subscriber::spawn());
+
+        // Note, that `console-subscriber` requires manually enabling
+        // `--cfg tokio_unstable` rust flags during compilation!
+        //
+        // Otherwise `console_subscriber::spawn` call panics!
+        //
+        // See https://docs.rs/tokio/latest/tokio/#unstable-features
+        #[cfg(all(feature = "console-subscriber", not(tokio_unstable)))]
+        eprintln!(
+            "`console-subscriber` requires manually enabling \
+             `--cfg tokio_unstable` rust flags during compilation!"
+        );
+
+        // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
+        #[cfg(feature = "tracing-tracy")]
+        let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(
+            tracing_subscriber::filter::filter_fn(|metadata| metadata.is_span()),
+        ));
+
+        tracing::subscriber::set_global_default(reg)?;
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod settings;
 mod snapshots;
 mod startup;
 mod tonic;
+mod tracing;
 
 use std::io::Error;
 use std::sync::Arc;
@@ -106,7 +107,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    setup_tracing();
+    tracing::setup()?;
 
     remove_started_file_indicator();
 
@@ -421,38 +422,4 @@ fn main() -> anyhow::Result<()> {
     drop(toc_arc);
     drop(settings);
     Ok(())
-}
-
-fn setup_tracing() {
-    // Use `console` and/or `tracy` features to enable both `tracing-subscriber` and the layer(s)
-    #[cfg(feature = "tracing-subscriber")]
-    {
-        use tracing_subscriber::prelude::*;
-
-        let reg = tracing_subscriber::registry();
-
-        // Use `console` feature to enable both `tracing-subscriber` and `console-subscriber`
-        #[cfg(feature = "console-subscriber")]
-        let reg = reg.with(console_subscriber::spawn());
-
-        // Note, that `console-subscriber` requires manually enabling
-        // `--cfg tokio_unstable` rust flags during compilation!
-        //
-        // Otherwise `console_subscriber::spawn` call panics!
-        //
-        // See https://docs.rs/tokio/latest/tokio/#unstable-features
-        #[cfg(all(feature = "console-subscriber", not(tokio_unstable)))]
-        eprintln!(
-            "`console-subscriber` requires manually enabling \
-             `--cfg tokio_unstable` rust flags during compilation!"
-        );
-
-        // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
-        #[cfg(feature = "tracing-tracy")]
-        let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(
-            tracing_subscriber::filter::filter_fn(|metadata| metadata.is_span()),
-        ));
-
-        tracing::subscriber::set_global_default(reg)?;
-    }
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,35 @@
+pub fn setup() -> anyhow::Result<()> {
+    // Use `console` and/or `tracy` features to enable both `tracing-subscriber` and the layer(s)
+    #[cfg(feature = "tracing-subscriber")]
+    {
+        use tracing_subscriber::prelude::*;
+
+        let reg = tracing_subscriber::registry();
+
+        // Use `console` feature to enable both `tracing-subscriber` and `console-subscriber`
+        #[cfg(feature = "console-subscriber")]
+        let reg = reg.with(console_subscriber::spawn());
+
+        // Note, that `console-subscriber` requires manually enabling
+        // `--cfg tokio_unstable` rust flags during compilation!
+        //
+        // Otherwise `console_subscriber::spawn` call panics!
+        //
+        // See https://docs.rs/tokio/latest/tokio/#unstable-features
+        #[cfg(all(feature = "console-subscriber", not(tokio_unstable)))]
+        eprintln!(
+            "`console-subscriber` requires manually enabling \
+             `--cfg tokio_unstable` rust flags during compilation!"
+        );
+
+        // Use `tracy` feature to enable both `tracing-subscriber` and `tracing-tracy`
+        #[cfg(feature = "tracing-tracy")]
+        let reg = reg.with(tracing_tracy::TracyLayer::new().with_filter(
+            tracing_subscriber::filter::filter_fn(|metadata| metadata.is_span()),
+        ));
+
+        tracing::subscriber::set_global_default(reg)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add an optional `tracing` support with basic `tokio-console` and `tracing` integration.

__TODO:__
- [x] add documentation
- [x] add explicit check for `--cfg tokio_unstable` RUSTFLAGS for `tokio-console` integration
  - (otherwise, it compiles fine, but panics at runtime, which is extremely annoying)