### PR TITLE
Add `message_timeout_ticks` parameter to consensus config

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -760,7 +760,9 @@ impl Consensus {
             .collect();
         let bootstrap_uri = self.bootstrap_uri.clone();
         let consensus_config_arc = Arc::new(self.config.clone());
-        let message_timeout = Duration::from_millis(consensus_config_arc.tick_period_ms * 2);
+        let message_timeout = Duration::from_millis(
+            consensus_config_arc.tick_period_ms * consensus_config_arc.message_timeout_ticks,
+        );
         let pool = self.channel_service.channel_pool.clone();
         let store = self.store();
         let tls_config = self.tls_config.clone();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -74,6 +74,7 @@ pub struct ConsensusConfig {
     #[serde(default = "default_bootstrap_timeout_sec")]
     #[validate(range(min = 1))]
     pub bootstrap_timeout_sec: u64,
+    #[validate(range(min = 1))]
     #[serde(default = "default_message_timeout_tics")]
     pub message_timeout_ticks: u64,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -74,6 +74,8 @@ pub struct ConsensusConfig {
     #[serde(default = "default_bootstrap_timeout_sec")]
     #[validate(range(min = 1))]
     pub bootstrap_timeout_sec: u64,
+    #[serde(default = "default_message_timeout_tics")]
+    pub message_timeout_ticks: u64,
 }
 
 impl Default for ConsensusConfig {
@@ -82,6 +84,7 @@ impl Default for ConsensusConfig {
             max_message_queue_size: default_max_message_queue_size(),
             tick_period_ms: default_tick_period_ms(),
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
+            message_timeout_ticks: default_message_timeout_tics(),
         }
     }
 }
@@ -172,6 +175,10 @@ fn default_max_message_queue_size() -> usize {
 
 fn default_connection_pool_size() -> usize {
     DEFAULT_POOL_SIZE
+}
+
+fn default_message_timeout_tics() -> u64 {
+    8
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -178,7 +178,7 @@ fn default_connection_pool_size() -> usize {
 }
 
 fn default_message_timeout_tics() -> u64 {
-    8
+    10
 }
 
 impl Settings {


### PR DESCRIPTION
- added `message_timeout_ticks` parameter to the consensus config
- and changed default message timeout to __10__ ticks instead of 2
  - 10 seems like a safe bet, as [by default re-election starts at `10 * heartbeat_tick` ticks][election-tick]
  - and [default `heartbeat-tick` is 2 ticks][heartbeat-tick]
  - (and here's [a min and max election tick][min-max-election-tick] for the reference)
  - but we can revert it back to 2 to be safe

The parameter is pretty useful for debugging, I've been using it a lot in the last few weeks, so at this point I'd just add it to the config.

[election-tick]: https://github.com/tikv/raft-rs/blob/10c6e9db6792b85c81784e44fc278f895d5f0ab0/src/config.rs#L108
[heartbeat-tick]: https://github.com/tikv/raft-rs/blob/10c6e9db6792b85c81784e44fc278f895d5f0ab0/src/config.rs#L105
[min-max-election-tick]: https://github.com/tikv/raft-rs/blob/10c6e9db6792b85c81784e44fc278f895d5f0ab0/src/config.rs#L138-L154