### PR TITLE
Fix divide by zero panic

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -439,7 +439,13 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             self.config.m,
             self.config.m0,
             self.config.ef_construct,
-            max(1, total_points / self.config.indexing_threshold * 10),
+            max(
+                1,
+                total_points
+                    .checked_div(self.config.indexing_threshold)
+                    .unwrap_or(0)
+                    * 10,
+            ),
             HNSW_USE_HEURISTIC,
         );
 


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/1435>.

A division by zero panic is possible with weird collection parameters.

Though it is unlikely users will see this I figured this is still a good change. It is not possible anymore to set these weird parameters through the API, but it is by changing the settings configuration.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?