### PR TITLE
add release binary action

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,20 @@
+name: release binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  upload-bins:
+    name: "Upload release binaries"
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: qdrant
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new Github action to create and upload binaries for Linux, Windows and Mac automatically when a Github release is created.