### PR TITLE
Add support for deleted vectors in segments

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -533,8 +533,8 @@ impl SegmentEntry for ProxySegment {
         }
     }
 
-    fn deleted_count(&self) -> usize {
-        self.write_segment.get().read().deleted_count()
+    fn deleted_point_count(&self) -> usize {
+        self.write_segment.get().read().deleted_point_count()
     }
 
     fn segment_type(&self) -> SegmentType {

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -80,10 +80,7 @@ impl VacuumOptimizer {
                 let is_not_special = read_segment.segment_type() != SegmentType::Special;
                 let is_littered = littered_ratio > self.deleted_threshold;
 
-                match is_big && is_not_special && is_littered {
-                    true => Some((*idx, littered_ratio)),
-                    false => None,
-                }
+                (is_big && is_not_special && is_littered).then_some((*idx, littered_ratio))
             })
             .max_by_key(|(_, ratio)| OrderedFloat(*ratio))
             .map(|(idx, _)| (idx, segments_read_guard.get(idx).unwrap().clone()))

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -17,7 +17,7 @@ use crate::collection_manager::optimizers::segment_optimizer::{
 };
 use crate::config::CollectionParams;
 
-/// Optimizer which looks for segments with hig amount of soft-deleted points.
+/// Optimizer which looks for segments with high amount of soft-deleted points.
 /// Used to free up space.
 pub struct VacuumOptimizer {
     deleted_threshold: f64,
@@ -74,7 +74,7 @@ impl VacuumOptimizer {
                 let segment_entry = segment.get();
                 let read_segment = segment_entry.read();
                 let littered_ratio =
-                    read_segment.deleted_count() as f64 / read_segment.points_count() as f64;
+                    read_segment.deleted_point_count() as f64 / read_segment.points_count() as f64;
 
                 let is_big = read_segment.points_count() >= self.min_vectors_number;
                 let is_not_special = read_segment.segment_type() != SegmentType::Special;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -64,7 +64,7 @@ fn benchmark_naive(c: &mut Criterion) {
             new_raw_scorer(
                 vector,
                 &borrowed_storage,
-                borrowed_id_tracker.deleted_bitvec(),
+                borrowed_id_tracker.deleted_bitslice(),
             )
             .peek_top_all(10)
         })
@@ -85,7 +85,7 @@ fn random_access_benchmark(c: &mut Criterion) {
     let scorer = new_raw_scorer(
         vector,
         &borrowed_storage,
-        borrowed_id_tracker.deleted_bitvec(),
+        borrowed_id_tracker.deleted_bitslice(),
     );
 
     let mut total_score = 0.;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -64,7 +64,7 @@ fn benchmark_naive(c: &mut Criterion) {
             new_raw_scorer(
                 vector,
                 &borrowed_storage,
-                borrowed_id_tracker.deleted_bitslice(),
+                borrowed_id_tracker.deleted_point_bitslice(),
             )
             .peek_top_all(10)
         })
@@ -85,7 +85,7 @@ fn random_access_benchmark(c: &mut Criterion) {
     let scorer = new_raw_scorer(
         vector,
         &borrowed_storage,
-        borrowed_id_tracker.deleted_bitslice(),
+        borrowed_id_tracker.deleted_point_bitslice(),
     );
 
     let mut total_score = 0.;

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -270,7 +270,7 @@ pub trait SegmentEntry {
     fn vector_dims(&self) -> HashMap<String, usize>;
 
     /// Number of vectors, marked as deleted
-    fn deleted_count(&self) -> usize;
+    fn deleted_point_count(&self) -> usize;
 
     /// Get segment type
     fn segment_type(&self) -> SegmentType;

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -1,15 +1,20 @@
 use std::marker::PhantomData;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
-use bitvec::prelude::BitVec;
+use bitvec::prelude::{BitSlice, BitVec};
 use rand::Rng;
 
+use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
+use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
-use crate::spaces::tools::peek_top_largest_iterable;
-use crate::types::{PointOffsetType, ScoreType};
+use crate::types::{Distance, PointOffsetType, QuantizationConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
-use crate::vector_storage::{RawScorer, ScoredPointOffset};
+use crate::vector_storage::quantized::quantized_vectors_base::QuantizedVectorsStorage;
+use crate::vector_storage::{raw_scorer_impl, RawScorer, VectorStorage, VectorStorageEnum};
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
     (0..size).map(|_| rnd_gen.gen_range(0.0..1.0)).collect()
@@ -25,84 +30,85 @@ impl FilterContext for FakeFilterContext {
 
 pub struct TestRawScorerProducer<TMetric: Metric> {
     pub vectors: ChunkedVectors<VectorElementType>,
-    pub deleted: BitVec,
+    pub deleted_points: BitVec,
+    pub deleted_vectors: BitVec,
     pub metric: PhantomData<TMetric>,
 }
 
-struct TestRawScorer<'a, TMetric: Metric> {
-    points_count: PointOffsetType,
-    query: Vec<VectorElementType>,
-    data: &'a TestRawScorerProducer<TMetric>,
-}
-
-impl<'a, TMetric> RawScorer for TestRawScorer<'a, TMetric>
-where
-    TMetric: Metric,
-{
-    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
-        let mut size: usize = 0;
-        for point_id in points.iter().copied() {
-            if self.data.deleted[point_id as usize] {
-                continue;
-            }
-            let other_vector = self.data.vectors.get(point_id);
-            scores[size] = ScoredPointOffset {
-                idx: point_id,
-                score: TMetric::similarity(&self.query, other_vector),
-            };
-
-            size += 1;
-            if size == scores.len() {
-                return size;
-            }
-        }
-        size
+impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
+    fn vector_dim(&self) -> usize {
+        self.vectors.get(0).len()
     }
 
-    fn check_vec(&self, point: PointOffsetType) -> bool {
-        point < self.points_count && !self.data.deleted[point as usize]
+    fn distance(&self) -> Distance {
+        TMetric::distance()
     }
 
-    fn score_point(&self, point: PointOffsetType) -> ScoreType {
-        let other_vector = self.data.vectors.get(point);
-        TMetric::similarity(&self.query, other_vector)
+    fn total_vector_count(&self) -> usize {
+        self.vectors.len()
     }
 
-    fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        let vector_a = self.data.vectors.get(point_a);
-        let vector_b = self.data.vectors.get(point_b);
-        TMetric::similarity(vector_a, vector_b)
+    fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
+        self.vectors.get(key)
     }
 
-    fn peek_top_iter(
-        &self,
-        points: &mut dyn Iterator<Item = PointOffsetType>,
-        top: usize,
-    ) -> Vec<ScoredPointOffset> {
-        let scores = points
-            .filter(|point_id| !self.data.deleted[*point_id as usize])
-            .map(|point_id| {
-                let other_vector = self.data.vectors.get(point_id);
-                ScoredPointOffset {
-                    idx: point_id,
-                    score: TMetric::similarity(&self.query, other_vector),
-                }
-            });
-        peek_top_largest_iterable(scores, top)
+    fn insert_vector(
+        &mut self,
+        key: PointOffsetType,
+        vector: &[VectorElementType],
+    ) -> OperationResult<()> {
+        self.vectors.insert(key, vector);
+        Ok(())
     }
 
-    fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
-        let scores = (0..self.points_count)
-            .filter(|point_id| self.check_vec(*point_id))
-            .map(|point_id| {
-                let point_id = point_id as PointOffsetType;
-                let other_vector = &self.data.vectors.get(point_id);
-                ScoredPointOffset {
-                    idx: point_id,
-                    score: TMetric::similarity(&self.query, other_vector),
-                }
-            });
-        peek_top_largest_iterable(scores, top)
+    fn update_from(
+        &mut self,
+        _other: &VectorStorageEnum,
+        _other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        todo!()
+    }
+
+    fn flusher(&self) -> Flusher {
+        Box::new(|| Ok(()))
+    }
+
+    fn quantize(
+        &mut self,
+        _data_path: &Path,
+        _quantization_config: &QuantizationConfig,
+    ) -> OperationResult<()> {
+        Ok(())
+    }
+
+    fn load_quantization(&mut self, _data_path: &Path) -> OperationResult<()> {
+        Ok(())
+    }
+
+    fn quantized_storage(&self) -> Option<&QuantizedVectorsStorage> {
+        None
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
+        self.deleted_vectors.set(key as usize, true);
+        Ok(())
+    }
+
+    fn is_deleted_vec(&self, key: PointOffsetType) -> bool {
+        self.deleted_vectors[key as usize]
+    }
+
+    fn deleted_vec_count(&self) -> usize {
+        self.deleted_vectors.count_ones()
+    }
+
+    fn deleted_vec_bitslice(&self) -> &BitSlice {
+        &self.deleted_vectors
     }
 }
 
@@ -122,18 +128,14 @@ where
         }
         TestRawScorerProducer::<TMetric> {
             vectors,
-            deleted: BitVec::repeat(false, num_vectors),
+            deleted_points: BitVec::repeat(false, num_vectors),
+            deleted_vectors: BitVec::repeat(false, num_vectors),
             metric: PhantomData,
         }
     }
 
     pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> Box<dyn RawScorer + '_> {
-        let points_count = self.vectors.len() as PointOffsetType;
         let query = TMetric::preprocess(&query).unwrap_or(query);
-        Box::new(TestRawScorer {
-            points_count,
-            query,
-            data: self,
-        })
+        raw_scorer_impl(query, self, self.deleted_vec_bitslice())
     }
 }

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -59,7 +59,7 @@ where
         size
     }
 
-    fn check_point(&self, point: PointOffsetType) -> bool {
+    fn check_vec(&self, point: PointOffsetType) -> bool {
         point < self.points_count && !self.data.deleted[point as usize]
     }
 
@@ -93,7 +93,7 @@ where
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
         let scores = (0..self.points_count)
-            .filter(|point_id| self.check_point(*point_id))
+            .filter(|point_id| self.check_vec(*point_id))
             .map(|point_id| {
                 let point_id = point_id as PointOffsetType;
                 let other_vector = &self.data.vectors.get(point_id);

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use bitvec::vec::BitVec;
+use bitvec::prelude::{BitSlice, BitVec};
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 
@@ -30,11 +30,9 @@ pub struct FixtureIdTracker {
 
 impl FixtureIdTracker {
     pub fn new(num_points: usize) -> Self {
-        let mut deleted = BitVec::with_capacity(num_points);
-        deleted.resize(num_points, false);
         Self {
             ids: (0..num_points).map(|x| x as PointOffsetType).collect(),
-            deleted,
+            deleted: BitVec::repeat(false, num_points),
         }
     }
 }
@@ -148,7 +146,7 @@ impl IdTracker for FixtureIdTracker {
         self.deleted[key]
     }
 
-    fn deleted_bitvec(&self) -> &BitVec {
+    fn deleted_bitslice(&self) -> &BitSlice {
         &self.deleted
     }
 }

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -138,7 +138,7 @@ impl IdTracker for FixtureIdTracker {
         Box::new(|| Ok(()))
     }
 
-    fn is_deleted(&self, key: PointOffsetType) -> bool {
+    fn is_deleted_point(&self, key: PointOffsetType) -> bool {
         let key = key as usize;
         if key >= self.deleted.len() {
             return true;
@@ -146,7 +146,7 @@ impl IdTracker for FixtureIdTracker {
         self.deleted[key]
     }
 
-    fn deleted_bitslice(&self) -> &BitSlice {
+    fn deleted_point_bitslice(&self) -> &BitSlice {
         &self.deleted
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -1,4 +1,4 @@
-use bitvec::vec::BitVec;
+use bitvec::prelude::BitSlice;
 use rand::Rng;
 
 use crate::common::Flusher;
@@ -62,7 +62,7 @@ pub trait IdTracker {
     /// Flush points versions to disk
     fn versions_flusher(&self) -> Flusher;
 
-    fn deleted_bitvec(&self) -> &BitVec;
+    fn deleted_bitslice(&self) -> &BitSlice;
 
     fn is_deleted(&self, internal_id: PointOffsetType) -> bool;
 

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -62,12 +62,16 @@ pub trait IdTracker {
     /// Flush points versions to disk
     fn versions_flusher(&self) -> Flusher;
 
-    fn deleted_bitslice(&self) -> &BitSlice;
+    /// Get [`BitSlice`] representation for deleted points with deletion flags
+    ///
+    /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
+    /// vectors in this segment.
+    fn deleted_point_bitslice(&self) -> &BitSlice;
 
-    fn is_deleted(&self, internal_id: PointOffsetType) -> bool;
+    fn is_deleted_point(&self, internal_id: PointOffsetType) -> bool;
 
-    // Number of deleted points
-    fn deleted_count(&self) -> usize {
+    /// Number of deleted points
+    fn deleted_point_count(&self) -> usize {
         self.internal_size() - self.points_count()
     }
 
@@ -78,7 +82,7 @@ pub trait IdTracker {
         Box::new(
             (0..total)
                 .map(move |_| rng.gen_range(0..total))
-                .filter(move |x| !self.is_deleted(*x)),
+                .filter(move |x| !self.is_deleted_point(*x)),
         )
     }
 }

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use bincode;
-use bitvec::vec::BitVec;
+use bitvec::prelude::{BitSlice, BitVec};
 use parking_lot::RwLock;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};
@@ -353,7 +353,7 @@ impl IdTracker for SimpleIdTracker {
         self.deleted[key]
     }
 
-    fn deleted_bitvec(&self) -> &BitVec {
+    fn deleted_bitslice(&self) -> &BitSlice {
         &self.deleted
     }
 }

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -345,7 +345,7 @@ impl IdTracker for SimpleIdTracker {
         self.versions_db_wrapper.flusher()
     }
 
-    fn is_deleted(&self, key: PointOffsetType) -> bool {
+    fn is_deleted_point(&self, key: PointOffsetType) -> bool {
         let key = key as usize;
         if key >= self.deleted.len() {
             return true;
@@ -353,7 +353,7 @@ impl IdTracker for SimpleIdTracker {
         self.deleted[key]
     }
 
-    fn deleted_bitslice(&self) -> &BitSlice {
+    fn deleted_point_bitslice(&self) -> &BitSlice {
         &self.deleted
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -201,7 +201,7 @@ impl<TGraphLinks: GraphLinks> GraphLayers<TGraphLinks> {
     ) -> Vec<ScoredPointOffset> {
         let entry_point = match self
             .entry_points
-            .get_entry_point(|point_id| points_scorer.check_point(point_id))
+            .get_entry_point(|point_id| points_scorer.check_vec(point_id))
         {
             None => return vec![],
             Some(ep) => ep,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -306,7 +306,7 @@ impl GraphLayersBuilder {
             .entry_points
             .lock()
             .new_point(point_id, level, |point_id| {
-                points_scorer.check_point(point_id)
+                points_scorer.check_vec(point_id)
             });
         match entry_point_opt {
             // New point is a new empty entry (for this filter, at least)

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -167,12 +167,12 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     let vector = vector_storage.get_vector(block_point_id).to_vec();
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
-                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitvec())
+                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitslice())
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),
                                 &vector_storage,
-                                id_tracker.deleted_bitvec(),
+                                id_tracker.deleted_bitslice(),
                             )
                         };
                     let block_condition_checker = BuildConditionChecker {
@@ -214,13 +214,13 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitvec(),
+                    id_tracker.deleted_bitslice(),
                 ),
                 false,
             )
         } else if let Some(quantized_storage) = vector_storage.quantized_storage() {
             (
-                quantized_storage.raw_scorer(vector, id_tracker.deleted_bitvec()),
+                quantized_storage.raw_scorer(vector, id_tracker.deleted_bitslice()),
                 true,
             )
         } else {
@@ -228,7 +228,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitvec(),
+                    id_tracker.deleted_bitslice(),
                 ),
                 false,
             )
@@ -249,7 +249,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let raw_scorer = new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitvec(),
+                    id_tracker.deleted_bitslice(),
                 );
                 search_result.iter_mut().for_each(|scored_point| {
                     scored_point.score = raw_scorer.score_point(scored_point.idx);
@@ -298,7 +298,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     new_raw_scorer(
                         vector.to_vec(),
                         &vector_storage,
-                        id_tracker.deleted_bitvec(),
+                        id_tracker.deleted_bitslice(),
                     )
                     .peek_top_iter(filtered_iter.as_mut(), top)
                 })
@@ -309,13 +309,13 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 .map(|vector| {
                     if let Some(quantized_storage) = vector_storage.quantized_storage() {
                         quantized_storage
-                            .raw_scorer(vector, id_tracker.deleted_bitvec())
+                            .raw_scorer(vector, id_tracker.deleted_bitslice())
                             .peek_top_iter(filtered_iter.as_mut(), top)
                     } else {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitvec(),
+                            id_tracker.deleted_bitslice(),
                         )
                         .peek_top_iter(filtered_iter.as_mut(), top)
                     }
@@ -347,7 +347,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                             new_raw_scorer(
                                 vector.to_vec(),
                                 &vector_storage,
-                                id_tracker.deleted_bitvec(),
+                                id_tracker.deleted_bitslice(),
                             )
                             .peek_top_all(top)
                         })
@@ -469,12 +469,12 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     let vector = vector_storage.get_vector(vector_id).to_vec();
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
-                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitvec())
+                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitslice())
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),
                                 &vector_storage,
-                                id_tracker.deleted_bitvec(),
+                                id_tracker.deleted_bitslice(),
                             )
                         };
                     let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -167,7 +167,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     let vector = vector_storage.get_vector(block_point_id).to_vec();
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
-                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitslice())
+                            quantized_storage.raw_scorer(
+                                &vector,
+                                id_tracker.deleted_bitslice(),
+                                vector_storage.deleted_bitslice(),
+                            )
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),
@@ -220,7 +224,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             )
         } else if let Some(quantized_storage) = vector_storage.quantized_storage() {
             (
-                quantized_storage.raw_scorer(vector, id_tracker.deleted_bitslice()),
+                quantized_storage.raw_scorer(
+                    vector,
+                    id_tracker.deleted_bitslice(),
+                    vector_storage.deleted_bitslice(),
+                ),
                 true,
             )
         } else {
@@ -309,7 +317,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 .map(|vector| {
                     if let Some(quantized_storage) = vector_storage.quantized_storage() {
                         quantized_storage
-                            .raw_scorer(vector, id_tracker.deleted_bitslice())
+                            .raw_scorer(
+                                vector,
+                                id_tracker.deleted_bitslice(),
+                                vector_storage.deleted_bitslice(),
+                            )
                             .peek_top_iter(filtered_iter.as_mut(), top)
                     } else {
                         new_raw_scorer(
@@ -469,7 +481,11 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     let vector = vector_storage.get_vector(vector_id).to_vec();
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
-                            quantized_storage.raw_scorer(&vector, id_tracker.deleted_bitslice())
+                            quantized_storage.raw_scorer(
+                                &vector,
+                                id_tracker.deleted_bitslice(),
+                                vector_storage.deleted_bitslice(),
+                            )
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -169,14 +169,14 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
                             quantized_storage.raw_scorer(
                                 &vector,
-                                id_tracker.deleted_bitslice(),
-                                vector_storage.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
+                                vector_storage.deleted_vec_bitslice(),
                             )
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),
                                 &vector_storage,
-                                id_tracker.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
                             )
                         };
                     let block_condition_checker = BuildConditionChecker {
@@ -218,7 +218,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitslice(),
+                    id_tracker.deleted_point_bitslice(),
                 ),
                 false,
             )
@@ -226,8 +226,8 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             (
                 quantized_storage.raw_scorer(
                     vector,
-                    id_tracker.deleted_bitslice(),
-                    vector_storage.deleted_bitslice(),
+                    id_tracker.deleted_point_bitslice(),
+                    vector_storage.deleted_vec_bitslice(),
                 ),
                 true,
             )
@@ -236,7 +236,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitslice(),
+                    id_tracker.deleted_point_bitslice(),
                 ),
                 false,
             )
@@ -257,7 +257,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 let raw_scorer = new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
-                    id_tracker.deleted_bitslice(),
+                    id_tracker.deleted_point_bitslice(),
                 );
                 search_result.iter_mut().for_each(|scored_point| {
                     scored_point.score = raw_scorer.score_point(scored_point.idx);
@@ -306,7 +306,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     new_raw_scorer(
                         vector.to_vec(),
                         &vector_storage,
-                        id_tracker.deleted_bitslice(),
+                        id_tracker.deleted_point_bitslice(),
                     )
                     .peek_top_iter(filtered_iter.as_mut(), top)
                 })
@@ -319,15 +319,15 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                         quantized_storage
                             .raw_scorer(
                                 vector,
-                                id_tracker.deleted_bitslice(),
-                                vector_storage.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
+                                vector_storage.deleted_vec_bitslice(),
                             )
                             .peek_top_iter(filtered_iter.as_mut(), top)
                     } else {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitslice(),
+                            id_tracker.deleted_point_bitslice(),
                         )
                         .peek_top_iter(filtered_iter.as_mut(), top)
                     }
@@ -359,7 +359,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                             new_raw_scorer(
                                 vector.to_vec(),
                                 &vector_storage,
-                                id_tracker.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
                             )
                             .peek_top_all(top)
                         })
@@ -483,14 +483,14 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
                             quantized_storage.raw_scorer(
                                 &vector,
-                                id_tracker.deleted_bitslice(),
-                                vector_storage.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
+                                vector_storage.deleted_vec_bitslice(),
                             )
                         } else {
                             new_raw_scorer(
                                 vector.to_owned(),
                                 &vector_storage,
-                                id_tracker.deleted_bitslice(),
+                                id_tracker.deleted_point_bitslice(),
                             )
                         };
                     let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), None);

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -20,14 +20,14 @@ impl<'a> FilteredScorer<'a> {
         }
     }
 
-    pub fn check_point(&self, point_id: PointOffsetType) -> bool {
+    pub fn check_vec(&self, point_id: PointOffsetType) -> bool {
         match self.filter_context {
-            None => self.raw_scorer.check_point(point_id),
-            Some(f) => f.check(point_id) && self.raw_scorer.check_point(point_id),
+            None => self.raw_scorer.check_vec(point_id),
+            Some(f) => f.check(point_id) && self.raw_scorer.check_vec(point_id),
         }
     }
 
-    /// Method filters and calculates scores for the given slice of points
+    /// Method filters and calculates scores for the given slice of points IDs
     ///
     /// For performance reasons this function mutates input values.
     /// For result slice allocation this function mutates self.

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -21,7 +21,7 @@ fn search_in_builder(
 ) -> Vec<ScoredPointOffset> {
     let entry_point = match builder
         .get_entry_points()
-        .get_entry_point(|point_id| points_scorer.check_point(point_id))
+        .get_entry_point(|point_id| points_scorer.check_vec(point_id))
     {
         None => return vec![],
         Some(ep) => ep,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -238,7 +238,7 @@ impl VectorIndex for PlainIndex {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitvec(),
+                            id_tracker.deleted_bitslice(),
                         )
                         .peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
                     })
@@ -254,7 +254,7 @@ impl VectorIndex for PlainIndex {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitvec(),
+                            id_tracker.deleted_bitslice(),
                         )
                         .peek_top_all(top)
                     })

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -238,7 +238,7 @@ impl VectorIndex for PlainIndex {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitslice(),
+                            id_tracker.deleted_point_bitslice(),
                         )
                         .peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
                     })
@@ -254,7 +254,7 @@ impl VectorIndex for PlainIndex {
                         new_raw_scorer(
                             vector.to_vec(),
                             &vector_storage,
-                            id_tracker.deleted_bitslice(),
+                            id_tracker.deleted_point_bitslice(),
                         )
                         .peek_top_all(top)
                     })

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -266,7 +266,7 @@ impl Segment {
     ) -> OperationResult<Option<Vec<VectorElementType>>> {
         check_vector_name(vector_name, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
-        if !self.id_tracker.borrow().is_deleted(point_offset) {
+        if !self.id_tracker.borrow().is_deleted_point(point_offset) {
             Ok(Some(
                 vector_data
                     .vector_storage
@@ -911,8 +911,8 @@ impl SegmentEntry for Segment {
         }
     }
 
-    fn deleted_count(&self) -> usize {
-        self.id_tracker.borrow().deleted_count()
+    fn deleted_point_count(&self) -> usize {
+        self.id_tracker.borrow().deleted_point_count()
     }
 
     fn segment_type(&self) -> SegmentType {
@@ -934,7 +934,7 @@ impl SegmentEntry for Segment {
             segment_type: self.segment_type,
             num_vectors: self.points_count() * self.vector_data.len(),
             num_points: self.points_count(),
-            num_deleted_vectors: self.deleted_count(),
+            num_deleted_vectors: self.deleted_point_count(),
             ram_usage_bytes: 0,  // ToDo: Implement
             disk_usage_bytes: 0, // ToDo: Implement
             is_appendable: self.appendable_flag,

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Write};
 use std::mem;
 use std::path::Path;
 
+use super::div_ceil;
 use crate::types::PointOffsetType;
 
 // chunk size in bytes
@@ -59,10 +60,8 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
     pub fn insert(&mut self, key: PointOffsetType, vector: &[T]) {
         let key = key as usize;
         self.len = max(self.len, key + 1);
-        self.chunks.resize(
-            (self.len + self.chunk_capacity - 1) / self.chunk_capacity,
-            vec![],
-        );
+        self.chunks
+            .resize(div_ceil(self.len, self.chunk_capacity), vec![]);
 
         let chunk_data = &mut self.chunks[key / self.chunk_capacity];
         let idx = (key % self.chunk_capacity) * self.dim;

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -59,9 +59,10 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
     pub fn insert(&mut self, key: PointOffsetType, vector: &[T]) {
         let key = key as usize;
         self.len = max(self.len, key + 1);
-        while self.chunks.len() * self.chunk_capacity < self.len {
-            self.chunks.push(vec![]);
-        }
+        self.chunks.resize(
+            (self.len + self.chunk_capacity - 1) / self.chunk_capacity,
+            vec![],
+        );
 
         let chunk_data = &mut self.chunks[key / self.chunk_capacity];
         let idx = (key % self.chunk_capacity) * self.dim;

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -146,6 +146,14 @@ impl VectorStorage for MemmapVectorStorage {
         }
         files
     }
+
+    fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
+        unimplemented!()
+    }
+
+    fn is_deleted(&self, key: PointOffsetType) -> bool {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -584,10 +584,11 @@ mod tests {
         let query = vec![0.5, 0.5, 0.5, 0.5];
 
         {
-            let scorer_quant = borrowed_storage
-                .quantized_storage()
-                .unwrap()
-                .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
+            let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
+                &query,
+                borrowed_id_tracker.deleted_bitslice(),
+                borrowed_storage.deleted_bitslice(),
+            );
             let scorer_orig = new_raw_scorer(
                 query.clone(),
                 &borrowed_storage,
@@ -607,10 +608,11 @@ mod tests {
         // test save-load
         borrowed_storage.load_quantization(dir.path()).unwrap();
 
-        let scorer_quant = borrowed_storage
-            .quantized_storage()
-            .unwrap()
-            .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
+        let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
+            &query,
+            borrowed_id_tracker.deleted_bitslice(),
+            borrowed_storage.deleted_bitslice(),
+        );
         let scorer_orig = new_raw_scorer(
             query,
             &borrowed_storage,

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use bitvec::slice::BitSlice;
+use bitvec::prelude::BitSlice;
 
 use super::quantized::quantized_vectors_base::QuantizedVectorsStorage;
 use super::VectorStorageEnum;
@@ -267,7 +267,7 @@ mod tests {
         let raw_scorer = new_raw_scorer(
             points[2].clone(),
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         );
         let res = raw_scorer.peek_top_all(2);
 
@@ -340,7 +340,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
@@ -361,7 +361,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
@@ -381,7 +381,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_all(5);
         assert!(closest.is_empty(), "must have no results, all deleted");
@@ -439,7 +439,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
@@ -501,7 +501,7 @@ mod tests {
         let scorer = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         );
 
         let mut res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
@@ -587,11 +587,11 @@ mod tests {
             let scorer_quant = borrowed_storage
                 .quantized_storage()
                 .unwrap()
-                .raw_scorer(&query, borrowed_id_tracker.deleted_bitvec());
+                .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
             let scorer_orig = new_raw_scorer(
                 query.clone(),
                 &borrowed_storage,
-                borrowed_id_tracker.deleted_bitvec(),
+                borrowed_id_tracker.deleted_bitslice(),
             );
             for i in 0..5 {
                 let quant = scorer_quant.score_point(i);
@@ -610,11 +610,11 @@ mod tests {
         let scorer_quant = borrowed_storage
             .quantized_storage()
             .unwrap()
-            .raw_scorer(&query, borrowed_id_tracker.deleted_bitvec());
+            .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
         let scorer_orig = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         );
 
         for i in 0..5 {

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use bitvec::slice::BitSlice;
 
 use super::quantized::quantized_vectors_base::QuantizedVectorsStorage;
 use super::VectorStorageEnum;
@@ -160,6 +161,10 @@ impl VectorStorage for MemmapVectorStorage {
 
     fn is_deleted(&self, key: PointOffsetType) -> bool {
         self.mmap_store.as_ref().unwrap().is_deleted(key)
+    }
+
+    fn deleted_bitslice(&self) -> &BitSlice {
+        self.mmap_store.as_ref().unwrap().deleted_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -125,7 +125,7 @@ impl VectorStorage for MemmapVectorStorage {
         let store = self.mmap_store.as_mut().unwrap();
         for id in deleted_ids {
             check_process_stopped(stopped)?;
-            store.delete(id)?;
+            store.delete(id);
         }
 
         Ok(start_index..end_index)
@@ -165,7 +165,8 @@ impl VectorStorage for MemmapVectorStorage {
     }
 
     fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
-        self.mmap_store.as_mut().unwrap().delete(key)
+        self.mmap_store.as_mut().unwrap().delete(key);
+        Ok(())
     }
 
     fn is_deleted(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -163,6 +163,10 @@ impl VectorStorage for MemmapVectorStorage {
         self.mmap_store.as_ref().unwrap().is_deleted(key)
     }
 
+    fn deleted_count(&self) -> usize {
+        self.mmap_store.as_ref().unwrap().deleted_count
+    }
+
     fn deleted_bitslice(&self) -> &BitSlice {
         self.mmap_store.as_ref().unwrap().deleted_bitslice()
     }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -19,9 +19,8 @@ use crate::vector_storage::mmap_vectors::MmapVectors;
 use crate::vector_storage::quantized::quantized_vectors_base::QuantizedVectors;
 use crate::vector_storage::VectorStorage;
 
-fn vf_to_u8<T>(v: &[T]) -> &[u8] {
-    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
-}
+pub const VECTORS_PATH: &str = "matrix.dat";
+pub const DELETED_PATH: &str = "deleted.dat";
 
 /// Stores all vectors in mem-mapped file
 ///
@@ -43,8 +42,8 @@ pub fn open_memmap_vector_storage(
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
     create_dir_all(path)?;
 
-    let vectors_path = path.join("matrix.dat");
-    let deleted_path = path.join("deleted.dat");
+    let vectors_path = path.join(VECTORS_PATH);
+    let deleted_path = path.join(DELETED_PATH);
     let mmap_store = MmapVectors::open(&vectors_path, &deleted_path, dim)?;
 
     Ok(Arc::new(AtomicRefCell::new(VectorStorageEnum::Memmap(
@@ -190,6 +189,10 @@ fn open_append<P: AsRef<Path>>(path: P) -> io::Result<File> {
         .append(true)
         .create(false)
         .open(path)
+}
+
+fn vf_to_u8<T>(v: &[T]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -1,6 +1,6 @@
 use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::{self, Write};
-use std::mem::size_of;
+use std::mem;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -195,7 +195,7 @@ fn open_append<P: AsRef<Path>>(path: P) -> io::Result<File> {
 }
 
 fn vf_to_u8<T>(v: &[T]) -> &[u8] {
-    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, mem::size_of_val(v)) }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -131,7 +131,10 @@ impl VectorStorage for MemmapVectorStorage {
     }
 
     fn flusher(&self) -> Flusher {
-        Box::new(|| Ok(()))
+        match &self.mmap_store {
+            Some(mmap_store) => mmap_store.flusher(),
+            None => Box::new(|| Ok(())),
+        }
     }
 
     fn quantize(

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use bitvec::slice::BitSlice;
 use memmap2::{Mmap, MmapMut, MmapOptions};
 
+use super::div_ceil;
 use crate::common::error_logging::LogError;
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
@@ -188,11 +189,6 @@ fn ensure_mmap_file_size(path: &Path, header: &[u8], size: Option<u64>) -> Opera
         }
     }
     Ok(())
-}
-
-#[inline]
-const fn div_ceil(a: usize, b: usize) -> usize {
-    (a / b) + (a % b > 0) as usize
 }
 
 /// Get start position of flags `BitSlice` in deleted mmap.

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -141,22 +141,20 @@ impl MmapVectors {
         self.raw_vector_offset(offset)
     }
 
-    pub fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
-        if !self.deleted_bitslice_mut().replace(key as usize, true) {
+    pub fn delete(&mut self, key: PointOffsetType) {
+        if self.num_vectors <= key as usize {
+            return;
+        }
+        if !self.deleted_bitslice.replace(key as usize, true) {
             self.deleted_count += 1;
         }
-        Ok(())
     }
 
     pub fn is_deleted(&self, key: PointOffsetType) -> bool {
-        self.deleted_bitslice()[key as usize]
+        self.deleted_bitslice[key as usize]
     }
 
     pub fn deleted_bitslice(&self) -> &BitSlice {
-        self.deleted_bitslice
-    }
-
-    pub fn deleted_bitslice_mut(&mut self) -> &mut BitSlice {
         self.deleted_bitslice
     }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -2,8 +2,10 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::mem::{size_of, transmute};
 use std::path::Path;
+use std::sync::Arc;
 
-use memmap2::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapMut, MmapOptions};
+use parking_lot::{RwLock, RwLockReadGuard};
 
 use crate::common::error_logging::LogError;
 use crate::data_types::vectors::VectorElementType;
@@ -13,14 +15,19 @@ use crate::types::{Distance, PointOffsetType, QuantizationConfig};
 use crate::vector_storage::quantized::quantized_vectors_base::QuantizedVectorsStorage;
 
 const HEADER_SIZE: usize = 4;
-const VECTORS_HEADER: &[u8; 4] = b"data";
+const VECTORS_HEADER: &[u8; HEADER_SIZE] = b"data";
+const DELETED_HEADER: &[u8; HEADER_SIZE] = b"drop";
 
 /// Mem-mapped file
 pub struct MmapVectors {
     pub dim: usize,
     pub num_vectors: usize,
+    /// Has an exact size to fit `num_vectors` of vectors.
     mmap: Mmap,
     pub quantized_vectors: Option<QuantizedVectorsStorage>,
+    /// Has an exact size to fit deleted flags for `num_vectors`.
+    deleted_mmap: Arc<RwLock<MmapMut>>,
+    pub deleted_count: usize,
 }
 
 fn open_read(path: &Path) -> OperationResult<Mmap> {
@@ -36,27 +43,70 @@ fn open_read(path: &Path) -> OperationResult<Mmap> {
     Ok(mmap)
 }
 
-fn ensure_mmap_file_exists(path: &Path, header: &[u8]) -> OperationResult<()> {
+fn open_write(path: &Path) -> OperationResult<MmapMut> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .open(path)?;
+
+    let mmap = unsafe { MmapMut::map_mut(&file)? };
+    madvise::madvise(&mmap, madvise::get_global())?;
+    Ok(mmap)
+}
+
+/// Ensure the given mmap file exists
+///
+/// # Arguments
+/// * `path`: path of the file.
+/// * `header`: header to set when the file is newly created.
+/// * `size_bytes`: grow the file to this number of bytes filled with zeroes>
+fn ensure_mmap_file_exists(
+    path: &Path,
+    header: &[u8],
+    size_bytes: Option<usize>,
+) -> OperationResult<()> {
     if path.exists() {
         return Ok(());
     }
     let mut file = File::create(path)?;
     file.write_all(header)?;
+    if let Some(size) = size_bytes {
+        file.write_all(&vec![0; size - HEADER_SIZE])?;
+    }
     Ok(())
 }
 
 impl MmapVectors {
-    pub fn open(vectors_path: &Path, dim: usize) -> OperationResult<Self> {
-        ensure_mmap_file_exists(vectors_path, VECTORS_HEADER).describe("Create mmap data file")?;
-
+    pub fn open(vectors_path: &Path, deleted_path: &Path, dim: usize) -> OperationResult<Self> {
+        // Allocate/open vectors mmap
+        ensure_mmap_file_exists(vectors_path, VECTORS_HEADER, None)
+            .describe("Create mmap data file")?;
         let mmap = open_read(vectors_path).describe("Open mmap for reading")?;
         let num_vectors = (mmap.len() - HEADER_SIZE) / dim / size_of::<VectorElementType>();
+
+        // Allocate/open deleted mmap
+        ensure_mmap_file_exists(
+            deleted_path,
+            DELETED_HEADER,
+            Some(num_vectors + HEADER_SIZE),
+        )
+        .describe("Create mmap data file")?;
+        let deleted_mmap = open_write(deleted_path).describe("Open mmap deleted for writing")?;
+        let deleted_count = deleted_mmap.as_ref().iter().filter(|b| b != &&0).count();
+        debug_assert_eq!(
+            num_vectors + HEADER_SIZE,
+            deleted_mmap.len(),
+            "deleted mmap file size must match number of mmap vectors",
+        );
 
         Ok(MmapVectors {
             dim,
             num_vectors,
             mmap,
             quantized_vectors: None,
+            deleted_mmap: Arc::new(RwLock::new(deleted_mmap)),
+            deleted_count,
         })
     }
 
@@ -117,5 +167,34 @@ impl MmapVectors {
     pub fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
         let offset = self.data_offset(key).unwrap();
         self.raw_vector_offset(offset)
+    }
+
+    pub fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
+        let i = key as usize;
+        debug_assert!(
+            i < self.num_vectors,
+            "key must always be in-bound of deleted mmap"
+        );
+
+        let mut deleted_mmap = self.deleted_mmap.write();
+        let flag = &mut deleted_mmap[HEADER_SIZE + i];
+        if *flag == 0 {
+            *flag = 1;
+            self.deleted_count += 1;
+        }
+        Ok(())
+    }
+
+    pub fn is_deleted(&self, key: PointOffsetType) -> bool {
+        Self::check_deleted(&self.deleted_mmap.read(), key)
+    }
+
+    #[inline]
+    pub fn check_deleted(mmap: &MmapMut, key: PointOffsetType) -> bool {
+        mmap[HEADER_SIZE + (key as usize)] != 0
+    }
+
+    pub fn read_deleted_map(&self) -> RwLockReadGuard<MmapMut> {
+        self.deleted_mmap.read()
     }
 }

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::pin::Pin;
 use std::slice;
 
-use bitvec::slice::BitSlice;
+use bitvec::prelude::BitSlice;
 use memmap2::{Mmap, MmapMut, MmapOptions};
 
 use super::div_ceil;

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::slice;
 
 use bitvec::prelude::BitSlice;
-use memmap2::{Advice, Mmap, MmapMut, MmapOptions};
+use memmap2::{Mmap, MmapMut, MmapOptions};
 
 use super::div_ceil;
 use crate::common::error_logging::LogError;
@@ -61,7 +61,7 @@ impl MmapVectors {
 
         // Advice kernel that we'll need this page soon so the kernel can prepare
         #[cfg(unix)]
-        if let Err(err) = deleted_mmap.advise(Advice::WillNeed) {
+        if let Err(err) = deleted_mmap.advise(memmap2::Advice::WillNeed) {
             log::error!("Failed to advice WillNeed for deleted flags: {}", err,);
         }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -108,8 +108,8 @@ impl MmapVectors {
         data_path: &Path,
         distance: Distance,
     ) -> OperationResult<()> {
-        self.lock_deleted_flags();
         if QuantizedVectorsStorage::check_exists(data_path) {
+            self.lock_deleted_flags();
             self.quantized_vectors =
                 Some(QuantizedVectorsStorage::load(data_path, true, distance)?);
         }

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -150,11 +150,15 @@ impl MmapVectors {
         }
     }
 
-    pub fn is_deleted(&self, key: PointOffsetType) -> bool {
+    pub fn is_deleted_vec(&self, key: PointOffsetType) -> bool {
         self.deleted[key as usize]
     }
 
-    pub fn deleted_bitslice(&self) -> &BitSlice {
+    /// Get [`BitSlice`] representation for deleted vectors with deletion flags
+    ///
+    /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
+    /// vectors in this segment.
+    pub fn deleted_vec_bitslice(&self) -> &BitSlice {
         self.deleted
     }
 

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -12,5 +12,5 @@ pub use vector_storage_base::*;
 // We can replace this by `div_ceil` from the standard library once it stabilizes.
 #[inline]
 const fn div_ceil(a: usize, b: usize) -> usize {
-    (a / b) + (a % b > 0) as usize
+    (a + b - 1) / b
 }

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -8,3 +8,9 @@ mod vector_storage_base;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;
+
+// We can replace this by `div_ceil` from the standard library once it stabilizes.
+#[inline]
+const fn div_ceil(a: usize, b: usize) -> usize {
+    (a / b) + (a % b > 0) as usize
+}

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -9,7 +9,19 @@ mod vector_storage_base;
 pub use raw_scorer::*;
 pub use vector_storage_base::*;
 
-// We can replace this by `div_ceil` from the standard library once it stabilizes.
+/// Calculates the quotient of self and rhs, rounding the result towards positive infinity.
+///
+/// # Panics
+///
+/// This function will panic if rhs is zero.
+///
+/// # Overflow behavior
+///
+/// On overflow, this function will panic if overflow checks are enabled (default in debug mode)
+/// and wrap if overflow checks are disabled (default in release mode).
+// Can be replaced with stdlib once it stabilizes:
+// - <https://github.com/rust-lang/rust/issues/88581>
+// - <https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil>
 #[inline]
 const fn div_ceil(a: usize, b: usize) -> usize {
     (a + b - 1) / b

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use bitvec::prelude::BitVec;
+use bitvec::prelude::BitSlice;
 use serde::{Deserialize, Serialize};
 
 use crate::common::file_operations::{atomic_save_json, read_json};
@@ -40,7 +40,7 @@ pub trait QuantizedVectors: Send + Sync {
     fn raw_scorer<'a>(
         &'a self,
         query: &[VectorElementType],
-        deleted: &'a BitVec,
+        deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a>;
 
     fn save_to(&self, path: &Path) -> OperationResult<()>;
@@ -53,7 +53,7 @@ impl QuantizedVectors for QuantizedVectorsStorage {
     fn raw_scorer<'a>(
         &'a self,
         query: &[VectorElementType],
-        deleted: &'a BitVec,
+        deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a> {
         match &self.storage_impl {
             QuantizedVectorStorageImpl::ScalarRam(storage) => storage.raw_scorer(query, deleted),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -41,6 +41,7 @@ pub trait QuantizedVectors: Send + Sync {
         &'a self,
         query: &[VectorElementType],
         deleted: &'a BitSlice,
+        vec_deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a>;
 
     fn save_to(&self, path: &Path) -> OperationResult<()>;
@@ -54,10 +55,15 @@ impl QuantizedVectors for QuantizedVectorsStorage {
         &'a self,
         query: &[VectorElementType],
         deleted: &'a BitSlice,
+        vec_deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a> {
         match &self.storage_impl {
-            QuantizedVectorStorageImpl::ScalarRam(storage) => storage.raw_scorer(query, deleted),
-            QuantizedVectorStorageImpl::ScalarMmap(storage) => storage.raw_scorer(query, deleted),
+            QuantizedVectorStorageImpl::ScalarRam(storage) => {
+                storage.raw_scorer(query, deleted, vec_deleted)
+            }
+            QuantizedVectorStorageImpl::ScalarMmap(storage) => {
+                storage.raw_scorer(query, deleted, vec_deleted)
+            }
         }
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors_base.rs
@@ -40,7 +40,7 @@ pub trait QuantizedVectors: Send + Sync {
     fn raw_scorer<'a>(
         &'a self,
         query: &[VectorElementType],
-        deleted: &'a BitSlice,
+        point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a>;
 
@@ -54,15 +54,15 @@ impl QuantizedVectors for QuantizedVectorsStorage {
     fn raw_scorer<'a>(
         &'a self,
         query: &[VectorElementType],
-        deleted: &'a BitSlice,
+        point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a> {
         match &self.storage_impl {
             QuantizedVectorStorageImpl::ScalarRam(storage) => {
-                storage.raw_scorer(query, deleted, vec_deleted)
+                storage.raw_scorer(query, point_deleted, vec_deleted)
             }
             QuantizedVectorStorageImpl::ScalarMmap(storage) => {
-                storage.raw_scorer(query, deleted, vec_deleted)
+                storage.raw_scorer(query, point_deleted, vec_deleted)
             }
         }
     }

--- a/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
+++ b/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use bitvec::prelude::BitVec;
+use bitvec::prelude::BitSlice;
 use quantization::EncodedVectors;
 
 use crate::data_types::vectors::VectorElementType;
@@ -18,7 +18,7 @@ where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
     query: TEncodedQuery,
-    deleted: &'a BitVec,
+    deleted: &'a BitSlice,
     // Total number of vectors including deleted ones
     quantized_data: &'a TEncodedVectors,
 }
@@ -99,7 +99,7 @@ where
     fn raw_scorer<'a>(
         &'a self,
         query: &[VectorElementType],
-        deleted: &'a BitVec,
+        deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a> {
         let query = self
             .distance

--- a/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
+++ b/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
@@ -19,6 +19,7 @@ where
 {
     query: TEncodedQuery,
     deleted: &'a BitSlice,
+    vec_deleted: &'a BitSlice,
     // Total number of vectors including deleted ones
     quantized_data: &'a TEncodedVectors,
 }
@@ -47,7 +48,16 @@ where
     }
 
     fn check_point(&self, point: PointOffsetType) -> bool {
-        (point as usize) < self.deleted.len() && !self.deleted[point as usize]
+        !self
+            .deleted
+            .get(point as usize)
+            .map(|b| *b)
+            .unwrap_or(false)
+            && !self
+                .vec_deleted
+                .get(point as usize)
+                .map(|b| *b)
+                .unwrap_or(false)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
@@ -100,6 +110,7 @@ where
         &'a self,
         query: &[VectorElementType],
         deleted: &'a BitSlice,
+        vec_deleted: &'a BitSlice,
     ) -> Box<dyn RawScorer + 'a> {
         let query = self
             .distance
@@ -109,6 +120,7 @@ where
         Box::new(ScalarQuantizedRawScorer {
             query,
             deleted,
+            vec_deleted,
             quantized_data: &self.storage,
         })
     }

--- a/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
+++ b/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
@@ -34,7 +34,7 @@ where
     fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
         let mut size: usize = 0;
         for point_id in points.iter().copied() {
-            if !self.check_point(point_id) {
+            if !self.check_vec(point_id) {
                 continue;
             }
             scores[size] = ScoredPointOffset {
@@ -49,7 +49,7 @@ where
         size
     }
 
-    fn check_point(&self, point: PointOffsetType) -> bool {
+    fn check_vec(&self, point: PointOffsetType) -> bool {
         !self
             .point_deleted
             .get(point as usize)
@@ -75,7 +75,7 @@ where
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
     ) -> Vec<ScoredPointOffset> {
-        let scores = points.filter(|idx| self.check_point(*idx)).map(|idx| {
+        let scores = points.filter(|idx| self.check_vec(*idx)).map(|idx| {
             let score = self.score_point(idx);
             ScoredPointOffset { idx, score }
         });
@@ -84,7 +84,7 @@ where
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
         let scores = (0..self.point_deleted.len() as PointOffsetType)
-            .filter(|idx| self.check_point(*idx))
+            .filter(|idx| self.check_vec(*idx))
             .map(|idx| {
                 let score = self.score_point(idx);
                 ScoredPointOffset { idx, score }

--- a/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
+++ b/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
@@ -53,12 +53,14 @@ where
         !self
             .point_deleted
             .get(point as usize)
-            .map(|b| *b)
+            .as_deref()
+            .copied()
             .unwrap_or(false)
             && !self
                 .vec_deleted
                 .get(point as usize)
-                .map(|b| *b)
+                .as_deref()
+                .copied()
                 .unwrap_or(false)
     }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bitvec::slice::BitSlice;
+use bitvec::prelude::BitSlice;
 
 use super::{ScoredPointOffset, VectorStorage, VectorStorageEnum};
 use crate::data_types::vectors::VectorElementType;

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -39,7 +39,7 @@ pub struct RawScorerImpl<'a, TMetric: Metric, TVectorStorage: VectorStorage> {
     pub vector_storage: &'a TVectorStorage,
     /// [`BitSlice`] defining flags for deleted points (and thus these vectors).
     pub point_deleted: &'a BitSlice,
-    /// [`BitSlice`] defining flags for deleted vectors.
+    /// [`BitSlice`] defining flags for deleted vectors in this segment.
     pub vec_deleted: &'a BitSlice,
     pub metric: PhantomData<TMetric>,
 }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -61,7 +61,7 @@ fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
     point_deleted: &'a BitSlice,
 ) -> Box<dyn RawScorer + 'a> {
     let points_count = vector_storage.total_vector_count() as PointOffsetType;
-    let vec_deleted = vector_storage.deleted_bitslice();
+    let vec_deleted = vector_storage.deleted_vec_bitslice();
     match vector_storage.distance() {
         Distance::Cosine => Box::new(RawScorerImpl::<'a, CosineMetric, TVectorStorage> {
             points_count,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -58,7 +58,7 @@ pub fn new_raw_scorer<'a>(
     }
 }
 
-fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
+pub fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
     vector: Vec<VectorElementType>,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -123,14 +123,12 @@ where
             && !self
                 .point_deleted
                 .get(point as usize)
-                .as_deref()
-                .copied()
+                .map(|x| *x)
                 .unwrap_or(false)
             && !self
                 .vec_deleted
                 .get(point as usize)
-                .as_deref()
-                .copied()
+                .map(|x| *x)
                 .unwrap_or(false)
     }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -123,12 +123,14 @@ where
             && !self
                 .point_deleted
                 .get(point as usize)
-                .map(|b| *b)
+                .as_deref()
+                .copied()
                 .unwrap_or(false)
             && !self
                 .vec_deleted
                 .get(point as usize)
-                .map(|b| *b)
+                .as_deref()
+                .copied()
                 .unwrap_or(false)
     }
 

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -544,10 +544,11 @@ mod tests {
         let query = vec![0.5, 0.5, 0.5, 0.5];
 
         {
-            let scorer_quant = borrowed_storage
-                .quantized_storage()
-                .unwrap()
-                .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
+            let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
+                &query,
+                borrowed_id_tracker.deleted_bitslice(),
+                borrowed_storage.deleted_bitslice(),
+            );
             let scorer_orig = new_raw_scorer(
                 query.clone(),
                 &borrowed_storage,
@@ -567,10 +568,11 @@ mod tests {
         // test save-load
         borrowed_storage.load_quantization(dir.path()).unwrap();
 
-        let scorer_quant = borrowed_storage
-            .quantized_storage()
-            .unwrap()
-            .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
+        let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
+            &query,
+            borrowed_id_tracker.deleted_bitslice(),
+            borrowed_storage.deleted_bitslice(),
+        );
         let scorer_orig = new_raw_scorer(
             query.clone(),
             &borrowed_storage,

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use bitvec::slice::BitSlice;
-use bitvec::vec::BitVec;
+use bitvec::prelude::{BitSlice, BitVec};
 use log::debug;
 use parking_lot::RwLock;
 use rocksdb::DB;
@@ -313,7 +312,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
@@ -334,7 +333,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
@@ -354,7 +353,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_all(5);
         assert!(closest.is_empty(), "must have no results, all deleted");
@@ -413,7 +412,7 @@ mod tests {
         let closest = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
@@ -460,7 +459,7 @@ mod tests {
         let closest = new_raw_scorer(
             query.clone(),
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         )
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
@@ -479,7 +478,7 @@ mod tests {
         let raw_scorer = new_raw_scorer(
             query,
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         );
         let closest = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
@@ -548,11 +547,11 @@ mod tests {
             let scorer_quant = borrowed_storage
                 .quantized_storage()
                 .unwrap()
-                .raw_scorer(&query, borrowed_id_tracker.deleted_bitvec());
+                .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
             let scorer_orig = new_raw_scorer(
                 query.clone(),
                 &borrowed_storage,
-                borrowed_id_tracker.deleted_bitvec(),
+                borrowed_id_tracker.deleted_bitslice(),
             );
             for i in 0..5 {
                 let quant = scorer_quant.score_point(i);
@@ -571,11 +570,11 @@ mod tests {
         let scorer_quant = borrowed_storage
             .quantized_storage()
             .unwrap()
-            .raw_scorer(&query, borrowed_id_tracker.deleted_bitvec());
+            .raw_scorer(&query, borrowed_id_tracker.deleted_bitslice());
         let scorer_orig = new_raw_scorer(
             query.clone(),
             &borrowed_storage,
-            borrowed_id_tracker.deleted_bitvec(),
+            borrowed_id_tracker.deleted_bitslice(),
         );
         for i in 0..5 {
             let quant = scorer_quant.score_point(i);

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -240,11 +240,11 @@ impl VectorStorage for SimpleVectorStorage {
 fn bitvec_set_deleted(bitvec: &mut BitVec, point_id: PointOffsetType, deleted: bool) -> bool {
     if bitvec.len() > point_id as usize {
         // Set deleted flag if bitvec is large enough
-        bitvec.replace(point_id as usize, deleted)
+        unsafe { bitvec.replace_unchecked(point_id as usize, deleted) }
     } else if deleted {
         // Bitvec is too small; we only need to grow and set flag if deleting
         bitvec.resize(point_id as usize + 1, false);
-        bitvec.set(point_id as usize, true);
+        unsafe { bitvec.set_unchecked(point_id as usize, true) };
         false
     } else {
         false

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -226,6 +226,10 @@ impl VectorStorage for SimpleVectorStorage {
         self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
     }
 
+    fn deleted_count(&self) -> usize {
+        self.deleted_count
+    }
+
     fn deleted_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
     }

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use bitvec::slice::BitSlice;
 use bitvec::vec::BitVec;
 use log::debug;
 use parking_lot::RwLock;
@@ -222,11 +223,11 @@ impl VectorStorage for SimpleVectorStorage {
     }
 
     fn is_deleted(&self, key: PointOffsetType) -> bool {
-        self.deleted
-            .get(key as usize)
-            .as_deref()
-            .copied()
-            .unwrap_or(false)
+        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+    }
+
+    fn deleted_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -83,6 +83,9 @@ pub trait VectorStorage {
     /// Check whether the vector at the given key is flagged as deleted.
     fn is_deleted(&self, key: PointOffsetType) -> bool;
 
+    /// Get number of deleted vectors.
+    fn deleted_count(&self) -> usize;
+
     /// Get [`BitSlice`] representation with deletion flags.
     ///
     /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
@@ -197,6 +200,13 @@ impl VectorStorage for VectorStorageEnum {
         match self {
             VectorStorageEnum::Simple(v) => v.is_deleted(key),
             VectorStorageEnum::Memmap(v) => v.is_deleted(key),
+        }
+    }
+
+    fn deleted_count(&self) -> usize {
+        match self {
+            VectorStorageEnum::Simple(v) => v.deleted_count(),
+            VectorStorageEnum::Memmap(v) => v.deleted_count(),
         }
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -75,6 +75,12 @@ pub trait VectorStorage {
     fn quantized_storage(&self) -> Option<&QuantizedVectorsStorage>;
 
     fn files(&self) -> Vec<PathBuf>;
+
+    /// Flag the vector by the given key as deleted.
+    fn delete(&mut self, key: PointOffsetType) -> OperationResult<()>;
+
+    /// Check whether the vector at the given key is flagged as deleted.
+    fn is_deleted(&self, key: PointOffsetType) -> bool;
 }
 
 pub enum VectorStorageEnum {
@@ -170,6 +176,20 @@ impl VectorStorage for VectorStorageEnum {
         match self {
             VectorStorageEnum::Simple(v) => v.files(),
             VectorStorageEnum::Memmap(v) => v.files(),
+        }
+    }
+
+    fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
+        match self {
+            VectorStorageEnum::Simple(v) => v.delete(key),
+            VectorStorageEnum::Memmap(v) => v.delete(key),
+        }
+    }
+
+    fn is_deleted(&self, key: PointOffsetType) -> bool {
+        match self {
+            VectorStorageEnum::Simple(v) => v.is_deleted(key),
+            VectorStorageEnum::Memmap(v) => v.is_deleted(key),
         }
     }
 }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use bitvec::slice::BitSlice;
+use bitvec::prelude::BitSlice;
 use ordered_float::OrderedFloat;
 
 use super::memmap_vector_storage::MemmapVectorStorage;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use bitvec::slice::BitSlice;
 use ordered_float::OrderedFloat;
 
 use super::memmap_vector_storage::MemmapVectorStorage;
@@ -81,6 +82,12 @@ pub trait VectorStorage {
 
     /// Check whether the vector at the given key is flagged as deleted.
     fn is_deleted(&self, key: PointOffsetType) -> bool;
+
+    /// Get [`BitSlice`] representation with deletion flags.
+    ///
+    /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
+    /// vectors in this segment.
+    fn deleted_bitslice(&self) -> &BitSlice;
 }
 
 pub enum VectorStorageEnum {
@@ -190,6 +197,13 @@ impl VectorStorage for VectorStorageEnum {
         match self {
             VectorStorageEnum::Simple(v) => v.is_deleted(key),
             VectorStorageEnum::Memmap(v) => v.is_deleted(key),
+        }
+    }
+
+    fn deleted_bitslice(&self) -> &BitSlice {
+        match self {
+            VectorStorageEnum::Simple(v) => v.deleted_bitslice(),
+            VectorStorageEnum::Memmap(v) => v.deleted_bitslice(),
         }
     }
 }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -77,20 +77,20 @@ pub trait VectorStorage {
 
     fn files(&self) -> Vec<PathBuf>;
 
-    /// Flag the vector by the given key as deleted.
-    fn delete(&mut self, key: PointOffsetType) -> OperationResult<()>;
+    /// Flag the vector by the given key as deleted
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()>;
 
-    /// Check whether the vector at the given key is flagged as deleted.
-    fn is_deleted(&self, key: PointOffsetType) -> bool;
+    /// Check whether the vector at the given key is flagged as deleted
+    fn is_deleted_vec(&self, key: PointOffsetType) -> bool;
 
-    /// Get number of deleted vectors.
-    fn deleted_count(&self) -> usize;
+    /// Get number of deleted vectors
+    fn deleted_vec_count(&self) -> usize;
 
-    /// Get [`BitSlice`] representation with deletion flags.
+    /// Get [`BitSlice`] representation for deleted vectors with deletion flags
     ///
     /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
     /// vectors in this segment.
-    fn deleted_bitslice(&self) -> &BitSlice;
+    fn deleted_vec_bitslice(&self) -> &BitSlice;
 }
 
 pub enum VectorStorageEnum {
@@ -189,31 +189,31 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn delete(&mut self, key: PointOffsetType) -> OperationResult<()> {
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
         match self {
-            VectorStorageEnum::Simple(v) => v.delete(key),
-            VectorStorageEnum::Memmap(v) => v.delete(key),
+            VectorStorageEnum::Simple(v) => v.delete_vec(key),
+            VectorStorageEnum::Memmap(v) => v.delete_vec(key),
         }
     }
 
-    fn is_deleted(&self, key: PointOffsetType) -> bool {
+    fn is_deleted_vec(&self, key: PointOffsetType) -> bool {
         match self {
-            VectorStorageEnum::Simple(v) => v.is_deleted(key),
-            VectorStorageEnum::Memmap(v) => v.is_deleted(key),
+            VectorStorageEnum::Simple(v) => v.is_deleted_vec(key),
+            VectorStorageEnum::Memmap(v) => v.is_deleted_vec(key),
         }
     }
 
-    fn deleted_count(&self) -> usize {
+    fn deleted_vec_count(&self) -> usize {
         match self {
-            VectorStorageEnum::Simple(v) => v.deleted_count(),
-            VectorStorageEnum::Memmap(v) => v.deleted_count(),
+            VectorStorageEnum::Simple(v) => v.deleted_vec_count(),
+            VectorStorageEnum::Memmap(v) => v.deleted_vec_count(),
         }
     }
 
-    fn deleted_bitslice(&self) -> &BitSlice {
+    fn deleted_vec_bitslice(&self) -> &BitSlice {
         match self {
-            VectorStorageEnum::Simple(v) => v.deleted_bitslice(),
-            VectorStorageEnum::Memmap(v) => v.deleted_bitslice(),
+            VectorStorageEnum::Simple(v) => v.deleted_vec_bitslice(),
+            VectorStorageEnum::Memmap(v) => v.deleted_vec_bitslice(),
         }
     }
 }


### PR DESCRIPTION
Part of <https://github.com/qdrant/qdrant/issues/1045>.

This implements logic in our storage bits to support optional named vectors in the future. I set a goal to keep things performant and relatively simple.

In a later PR I will expose this functionality in the external API so this can be used.

In short:
- Based upon earlier deleted flag bitvec implementation, but heavily improved
- Add bitvec with deleted flags in all storage types
- Use `BitSlice` everywhere to determine point/vector deletions, this unifies the deleted interface across all storage types, making stuff simpler
- In mmap segment, directly map `BitSlice` on top of a mmap file. So we don't need to load/store bitvecs, and we don't need multiple bitvecs, keeping things simple
- Add deleted vector support in raw scorer (regular and quantized)
- Add deleted vector support in HNSW graphs
- Add tests to cover deleted vectors in all storage types

Some performance tweaks:
- When using mmap storage with quantization, lock deleted flags backed by mmap file in physical RAM. This prevents page faults and keeps things fast (not supported on Windows)
- Advice kernel to load delete flags backed by mmap file early with `MADV_WILLNEED` for fast subsequent access (not supported on Windows)
- Use bitvec for deleted flags, rather than a byte per vector like before
- Reworked various internal bits to make some instantiation/loops more efficient

Follow-up steps (in other PRs):
- Make query planner aware of deleted vectors, optimize search for sparse segments
- Update vacuum optimizer to rebuild sparse segments
- Expose this functionality into internal/external API

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
