### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -332,10 +332,12 @@ impl From<segment::types::WithPayloadInterface> for WithPayloadSelector {
 impl From<QuantizationSearchParams> for segment::types::QuantizationSearchParams {
     fn from(params: QuantizationSearchParams) -> Self {
         Self {
-            ignore: params.ignore.unwrap_or(default_quantization_ignore_value()),
+            ignore: params
+                .ignore
+                .unwrap_or_else(default_quantization_ignore_value),
             rescore: params
                 .rescore
-                .unwrap_or(default_quantization_rescore_value()),
+                .unwrap_or_else(default_quantization_rescore_value),
         }
     }
 }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -337,7 +337,7 @@ fn sampling_limit(
 /// Determines the effective ef limit value for the given parameters.
 fn effective_limit(limit: usize, ef_limit: usize, poisson_sampling: usize) -> usize {
     // Prefer the highest of poisson_sampling/ef_limit, but never be higher than limit
-    poisson_sampling.max(ef_limit).min(limit)
+    poisson_sampling.clamp(limit, ef_limit)
 }
 
 /// Process sequentially contiguous batches

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -207,7 +207,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let ignore_quantization = params
             .and_then(|p| p.quantization)
             .map(|q| q.ignore)
-            .unwrap_or(default_quantization_ignore_value());
+            .unwrap_or_else(default_quantization_ignore_value);
 
         let (raw_scorer, quantized) = if ignore_quantization {
             (
@@ -244,7 +244,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             let if_rescore = params
                 .and_then(|p| p.quantization)
                 .map(|q| q.rescore)
-                .unwrap_or(default_quantization_rescore_value());
+                .unwrap_or_else(default_quantization_rescore_value);
             if quantized && if_rescore {
                 let raw_scorer = new_raw_scorer(
                     vector.to_owned(),
@@ -290,7 +290,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let ignore_quantization = params
             .and_then(|p| p.quantization)
             .map(|q| q.ignore)
-            .unwrap_or(default_quantization_ignore_value());
+            .unwrap_or_else(default_quantization_ignore_value);
         if ignore_quantization {
             vectors
                 .iter()

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -64,7 +64,9 @@ pub fn do_save_uploaded_snapshot(
     collection_name: &str,
     snapshot: TempFile,
 ) -> std::result::Result<Url, StorageError> {
-    let filename = snapshot.file_name.unwrap_or(Uuid::new_v4().to_string());
+    let filename = snapshot
+        .file_name
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
     let path = StdPath::new(toc.snapshots_path())
         .join(collection_name)
         .join(filename);


### PR DESCRIPTION
- Prefer `unwrap_or_else` over `unwrap_or` as the later is always executed.
- Use `clamp`.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

