### PR TITLE
Make query planner aware of deleted points and vectors

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -286,10 +286,19 @@ impl SegmentsSearcher {
                             WithVector::Selector(vector_names) => {
                                 let mut selected_vectors = NamedVectors::default();
                                 for vector_name in vector_names {
-                                    selected_vectors.insert(
-                                        vector_name.clone(),
-                                        segment.vector(vector_name, id)?,
-                                    );
+                                    let vector_opt = segment.vector(vector_name, id)?;
+                                    match vector_opt {
+                                        Some(vector) => {
+                                            selected_vectors.insert(vector_name.clone(), vector);
+                                        }
+                                        None => {
+                                            // ToDo: Allow to return partial result
+                                            return Err(OperationError::service_error(format!(
+                                                "Vector {} not found for point {}",
+                                                vector_name, id
+                                            )));
+                                        }
+                                    }
                                 }
                                 Some(selected_vectors.into())
                             }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -427,7 +427,7 @@ pub fn suggest_peer_to_remove_replica(
         }
     });
 
-    candidates.into_iter().next().map(|(peer_id, _, _)| peer_id)
+    candidates.first().map(|(peer_id, _, _)| *peer_id)
 }
 
 pub fn spawn_transfer_task<T, F>(

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -31,7 +31,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter, None).count();
             query_count += 1;
         })
     });
@@ -47,7 +47,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points-large", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 1);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter, None).count();
             query_count += 1;
         })
     });
@@ -97,7 +97,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     let mut query_count = 0;
 
     let filter = random_must_filter(&mut rng, 2);
-    let cardinality = struct_index.estimate_cardinality(&filter);
+    let cardinality = struct_index.estimate_cardinality(&filter, None);
 
     let indexed_fields = struct_index.indexed_fields();
 
@@ -107,7 +107,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     group.bench_function("struct-conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += struct_index.query_points(&filter).count();
+            result_size += struct_index.query_points(&filter, None).count();
             query_count += 1;
         })
     });

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -35,13 +35,5 @@ pub fn check_vectors_set(
         }
     }
 
-    for vector_name in segment_config.vector_data.keys() {
-        if !vectors.contains_key(vector_name) {
-            return Err(OperationError::MissedVectorName {
-                received_name: vector_name.to_owned(),
-            });
-        }
-    }
-
     Ok(())
 }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -89,6 +89,10 @@ impl<'a> NamedVectors<'a> {
     pub fn iter(&self) -> impl Iterator<Item = (&str, &[VectorElementType])> {
         self.map.iter().map(|(k, v)| (k.as_ref(), v.as_ref()))
     }
+
+    pub fn get(&self, key: &str) -> Option<&[VectorElementType]> {
+        self.map.get(key).map(|v| v.as_ref())
+    }
 }
 
 impl<'a> IntoIterator for NamedVectors<'a> {

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -196,6 +196,13 @@ pub trait SegmentEntry {
         point_id: PointIdType,
     ) -> OperationResult<bool>;
 
+    fn delete_vector(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vector_name: &str,
+    ) -> OperationResult<bool>;
+
     fn set_payload(
         &mut self,
         op_num: SeqNumberType,
@@ -227,7 +234,7 @@ pub trait SegmentEntry {
         &self,
         vector_name: &str,
         point_id: PointIdType,
-    ) -> OperationResult<Vec<VectorElementType>>;
+    ) -> OperationResult<Option<Vec<VectorElementType>>>;
 
     fn all_vectors(&self, point_id: PointIdType) -> OperationResult<NamedVectors>;
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -250,6 +250,8 @@ pub trait SegmentEntry {
     fn has_point(&self, point_id: PointIdType) -> bool;
 
     /// Return number of vectors in this segment
+    ///
+    /// - Includes soft deleted points
     fn points_count(&self) -> usize;
 
     /// Estimate points count in this segment for given filter.

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -94,9 +94,8 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
         vec![]
     }
 
-    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
-        self.deleted_vectors.set(key as usize, true);
-        Ok(())
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<bool> {
+        Ok(!self.deleted_vectors.replace(key as usize, true))
     }
 
     fn is_deleted_vec(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -53,6 +53,23 @@ pub trait IdTracker {
     /// Iterate over all non-removed internal ids (offsets)
     fn iter_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_>;
 
+    /// Iterate over internal IDs (offsets)
+    ///
+    /// - excludes removed points
+    /// - excludes flagged items from `deleted_bitslice`
+    fn iter_ids_exluding<'a>(
+        &'a self,
+        exclude_bitslice: &'a BitSlice,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        Box::new(self.iter_ids().filter(|point| {
+            !exclude_bitslice
+                .get(*point as usize)
+                .as_deref()
+                .copied()
+                .unwrap_or(false)
+        }))
+    }
+
     /// Total number of internal ids (offsets), including removed ones
     fn internal_size(&self) -> usize;
 

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -56,7 +56,7 @@ pub trait IdTracker {
     /// Iterate over internal IDs (offsets)
     ///
     /// - excludes removed points
-    /// - excludes flagged items from `deleted_bitslice`
+    /// - excludes flagged items from `exclude_bitslice`
     fn iter_ids_exluding<'a>(
         &'a self,
         exclude_bitslice: &'a BitSlice,

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -106,11 +106,12 @@ pub trait IdTracker {
             (0..total)
                 .map(move |_| rng.gen_range(0..total))
                 .filter(move |x| {
-                    // Check if point or vector is deleted
-                    !self.is_deleted_point(*x)
-                        && !deleted_vec_bitslice
-                            .and_then(|d| d.get(*x as usize).as_deref().copied())
-                            .unwrap_or(false)
+                    // Check for deleted vector first, as that is more likely
+                    !deleted_vec_bitslice
+                        .and_then(|d| d.get(*x as usize).as_deref().copied())
+                        .unwrap_or(false)
+                    // Also check point deletion for integrity
+                    && !self.is_deleted_point(*x)
                 }),
         )
     }

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -92,14 +92,26 @@ pub trait IdTracker {
         self.internal_size() - self.points_count()
     }
 
-    /// Iterator over `n` random ids which are not deleted
-    fn sample_ids(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+    /// Iterator over `n` random IDs which are not deleted
+    ///
+    /// A [`BitSlice`] of deleted vectors may optionally be given to also consider deleted named
+    /// vectors.
+    fn sample_ids<'a>(
+        &'a self,
+        deleted_vec_bitslice: Option<&'a BitSlice>,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
         let total = self.internal_size() as PointOffsetType;
         let mut rng = rand::thread_rng();
         Box::new(
             (0..total)
                 .map(move |_| rng.gen_range(0..total))
-                .filter(move |x| !self.is_deleted_point(*x)),
+                .filter(move |x| {
+                    // Check if point or vector is deleted
+                    !self.is_deleted_point(*x)
+                        && !deleted_vec_bitslice
+                            .and_then(|d| d.get(*x as usize).as_deref().copied())
+                            .unwrap_or(false)
+                }),
         )
     }
 }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -81,10 +81,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 
     pub fn match_cardinality(&self, value: &N) -> CardinalityEstimation {
-        let values_count = match self.map.get(value) {
-            None => 0,
-            Some(points) => points.len(),
-        };
+        let values_count = self.map.get(value).map(|p| p.len()).unwrap_or(0);
 
         CardinalityEstimation {
             primary_clauses: vec![],

--- a/lib/segment/src/index/field_index/stat_tools.rs
+++ b/lib/segment/src/index/field_index/stat_tools.rs
@@ -1,9 +1,9 @@
 use std::f64::consts::{E, PI};
 
 /// This function estimates how many real points were selected with the filter.
-/// It is assumed that each real point has, on average, X values in correspondence.
-/// As a response to the execution of the query it is possible to establish only the number of matched associated values.
-///
+/// It is assumed that each real point has, on average, X values in correspondence. As a response
+/// to the execution of the query it is possible to establish only the number of matched associated
+/// values.
 ///
 /// # Arguments
 ///

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -17,11 +17,7 @@ pub struct HnswGraphConfig {
     pub ef_construct: usize,
     /// Number of neighbours to search on construction
     pub ef: usize,
-    /// Minimal number of vectors to perform indexing
-    ///
-    /// Note: this is number of vectors, not KiloBytes.
-    pub indexing_threshold: usize,
-    /// We prefer a full scan search upto this number of vectors.
+    /// We prefer a full scan search upto (excluding) this number of vectors.
     ///
     /// Note: this is number of vectors, not KiloBytes.
     #[serde(alias = "indexing_threshold")]
@@ -38,7 +34,6 @@ impl HnswGraphConfig {
     pub fn new(
         m: usize,
         ef_construct: usize,
-        indexing_threshold: usize,
         full_scan_threshold: usize,
         max_indexing_threads: usize,
         payload_m: Option<usize>,
@@ -48,7 +43,6 @@ impl HnswGraphConfig {
             m0: m * 2,
             ef_construct,
             ef: ef_construct,
-            indexing_threshold,
             full_scan_threshold,
             max_indexing_threads,
             payload_m,

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -18,7 +18,14 @@ pub struct HnswGraphConfig {
     /// Number of neighbours to search on construction
     pub ef: usize,
     /// Minimal number of vectors to perform indexing
+    ///
+    /// Note: this is number of vectors, not KiloBytes.
     pub indexing_threshold: usize,
+    /// We prefer a full scan search upto this number of vectors.
+    ///
+    /// Note: this is number of vectors, not KiloBytes.
+    #[serde(alias = "indexing_threshold")]
+    pub full_scan_threshold: usize,
     #[serde(default)]
     pub max_indexing_threads: usize,
     #[serde(default)]
@@ -32,6 +39,7 @@ impl HnswGraphConfig {
         m: usize,
         ef_construct: usize,
         indexing_threshold: usize,
+        full_scan_threshold: usize,
         max_indexing_threads: usize,
         payload_m: Option<usize>,
     ) -> Self {
@@ -41,6 +49,7 @@ impl HnswGraphConfig {
             ef_construct,
             ef: ef_construct,
             indexing_threshold,
+            full_scan_threshold,
             max_indexing_threads,
             payload_m,
             payload_m0: payload_m.map(|v| v * 2),

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -440,10 +440,10 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 // Fast cardinality estimation is not enough, do sample estimation of cardinality
                 let id_tracker = self.id_tracker.borrow();
                 if sample_check_cardinality(
-                    id_tracker.sample_ids(),
+                    id_tracker.sample_ids(Some(vector_storage.deleted_vec_bitslice())),
                     |idx| filter_context.check(idx),
                     self.config.indexing_threshold,
-                    id_tracker.points_count(),
+                    vector_storage.available_vector_count(),
                 ) {
                     // if cardinality is high enough - use HNSW index
                     let _timer =

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -144,7 +144,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let vector_storage = self.vector_storage.borrow();
         let id_tracker = self.id_tracker.borrow();
 
-        let points_to_index: Vec<_> = payload_index.query_points(&filter).collect();
+        let points_to_index: Vec<_> = payload_index
+            .query_points(&filter, Some(&vector_storage))
+            .collect();
 
         for block_point_id in points_to_index.iter().copied() {
             block_filter_list.check_and_update_visited(block_point_id);
@@ -294,7 +296,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let payload_index = self.payload_index.borrow();
         let vector_storage = self.vector_storage.borrow();
         let id_tracker = self.id_tracker.borrow();
-        let mut filtered_iter = payload_index.query_points(filter);
+        let mut filtered_iter = payload_index.query_points(filter, Some(&vector_storage));
         let ignore_quantization = params
             .and_then(|p| p.quantization)
             .map(|q| q.ignore)
@@ -395,7 +397,9 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 }
 
                 let payload_index = self.payload_index.borrow();
-                let query_cardinality = payload_index.estimate_cardinality(query_filter);
+                let vector_storage = self.vector_storage.borrow();
+                let query_cardinality =
+                    payload_index.estimate_cardinality(query_filter, Some(&vector_storage));
 
                 // debug!("query_cardinality: {:#?}", query_cardinality);
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -364,17 +364,14 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                         .estimate_available_vector_count(id_tracker.deleted_point_count());
                     vector_count < self.config.full_scan_threshold
                 };
-                let duration_aggregator = if exact {
-                    &self.searches_telemetry.exact_unfiltered
-                } else if plain_search {
-                    &self.searches_telemetry.unfiltered_plain
-                } else {
-                    &self.searches_telemetry.unfiltered_hnsw
-                };
 
                 // Do plain or graph search
                 if plain_search {
-                    let _timer = ScopeDurationMeasurer::new(duration_aggregator);
+                    let _timer = ScopeDurationMeasurer::new(if plain_search {
+                        &self.searches_telemetry.unfiltered_plain
+                    } else {
+                        &self.searches_telemetry.exact_unfiltered
+                    });
                     vectors
                         .iter()
                         .map(|vector| {
@@ -387,7 +384,8 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                         })
                         .collect()
                 } else {
-                    let _timer = ScopeDurationMeasurer::new(duration_aggregator);
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_hnsw);
                     self.search_vectors_with_graph(vectors, None, top, params)
                 }
             }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -11,6 +11,7 @@ use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
     PointOffsetType,
 };
+use crate::vector_storage::VectorStorageEnum;
 
 pub trait PayloadIndex {
     /// Get indexed fields
@@ -27,12 +28,23 @@ pub trait PayloadIndex {
     fn drop_index(&mut self, field: PayloadKeyTypeRef) -> OperationResult<()>;
 
     /// Estimate amount of points (min, max) which satisfies filtering condition.
-    fn estimate_cardinality(&self, query: &Filter) -> CardinalityEstimation;
+    ///
+    /// The vector storage that is searched must be provided to properly estimate the number of
+    /// points with deletions in this context.
+    fn estimate_cardinality(
+        &self,
+        query: &Filter,
+        vector_storage: Option<&VectorStorageEnum>,
+    ) -> CardinalityEstimation;
 
     /// Return list of all point ids, which satisfy filtering criteria
+    ///
+    /// The vector storage that is searched must be provided to properly estimate the number of
+    /// points with deletions in this context.
     fn query_points<'a>(
         &'a self,
         query: &'a Filter,
+        vector_storage: Option<&VectorStorageEnum>,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>;
 
     /// Return number of points, indexed by this field

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -11,7 +11,6 @@ use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
     PointOffsetType,
 };
-use crate::vector_storage::VectorStorageEnum;
 
 pub trait PayloadIndex {
     /// Get indexed fields
@@ -29,22 +28,20 @@ pub trait PayloadIndex {
 
     /// Estimate amount of points (min, max) which satisfies filtering condition.
     ///
-    /// The vector storage that is searched must be provided to properly estimate the number of
-    /// points with deletions in this context.
+    /// A best estimation of the number of available points should be given.
     fn estimate_cardinality(
         &self,
         query: &Filter,
-        vector_storage: Option<&VectorStorageEnum>,
+        available_points: Option<usize>,
     ) -> CardinalityEstimation;
 
     /// Return list of all point ids, which satisfy filtering criteria
     ///
-    /// The vector storage that is searched must be provided to properly estimate the number of
-    /// points with deletions in this context.
+    /// A best estimation of the number of available points should be given.
     fn query_points<'a>(
         &'a self,
         query: &'a Filter,
-        vector_storage: Option<&VectorStorageEnum>,
+        available_points: Option<usize>,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>;
 
     /// Return number of points, indexed by this field

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -110,7 +110,10 @@ impl PayloadIndex for PlainPayloadIndex {
         vector_storage: Option<&VectorStorageEnum>,
     ) -> CardinalityEstimation {
         let available_points = vector_storage
-            .map(|vs| vs.available_vector_count())
+            .map(|vs| {
+                let id_tracker = self.id_tracker.borrow();
+                vs.estimate_available_vector_count(id_tracker.deleted_point_count())
+            })
             .unwrap_or_else(|| self.id_tracker.borrow().points_count());
         CardinalityEstimation {
             primary_clauses: vec![],

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -26,7 +26,7 @@ use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
     PointOffsetType, SearchParams,
 };
-use crate::vector_storage::{new_raw_scorer, ScoredPointOffset, VectorStorageEnum};
+use crate::vector_storage::{new_raw_scorer, ScoredPointOffset, VectorStorage, VectorStorageEnum};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///
@@ -104,19 +104,26 @@ impl PayloadIndex for PlainPayloadIndex {
         self.save_config()
     }
 
-    fn estimate_cardinality(&self, _query: &Filter) -> CardinalityEstimation {
-        let total_points = self.id_tracker.borrow().points_count();
+    fn estimate_cardinality(
+        &self,
+        _query: &Filter,
+        vector_storage: Option<&VectorStorageEnum>,
+    ) -> CardinalityEstimation {
+        let available_points = vector_storage
+            .map(|vs| vs.available_vector_count())
+            .unwrap_or_else(|| self.id_tracker.borrow().points_count());
         CardinalityEstimation {
             primary_clauses: vec![],
             min: 0,
-            exp: total_points / 2,
-            max: total_points,
+            exp: available_points / 2,
+            max: available_points,
         }
     }
 
     fn query_points<'a>(
         &'a self,
         query: &'a Filter,
+        _vector_storage: Option<&VectorStorageEnum>,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         let filter_context = self.filter_context(query);
         Box::new(ArcAtomicRefCellIterator::new(
@@ -231,7 +238,9 @@ impl VectorIndex for PlainIndex {
                 let payload_index = self.payload_index.borrow();
                 let vector_storage = self.vector_storage.borrow();
                 let id_tracker = self.id_tracker.borrow();
-                let filtered_ids_vec: Vec<_> = payload_index.query_points(filter).collect();
+                let filtered_ids_vec: Vec<_> = payload_index
+                    .query_points(filter, Some(&vector_storage))
+                    .collect();
                 vectors
                     .iter()
                     .map(|vector| {

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -237,10 +237,9 @@ impl VectorIndex for PlainIndex {
                 let id_tracker = self.id_tracker.borrow();
                 let payload_index = self.payload_index.borrow();
                 let vector_storage = self.vector_storage.borrow();
-                let available_points = vector_storage
-                    .estimate_available_vector_count(id_tracker.deleted_point_count());
+                let available_vecs = vector_storage.available_vec_count();
                 let filtered_ids_vec: Vec<_> = payload_index
-                    .query_points(filter, Some(available_points))
+                    .query_points(filter, Some(available_vecs))
                     .collect();
                 vectors
                     .iter()

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -363,7 +363,10 @@ impl PayloadIndex for StructPayloadIndex {
     ) -> CardinalityEstimation {
         // Prefer available points versus total, because we can only search available points
         let available_points = vector_storage
-            .map(|vs| vs.available_vector_count())
+            .map(|vs| {
+                let id_tracker = self.id_tracker.borrow();
+                vs.estimate_available_vector_count(id_tracker.deleted_point_count())
+            })
             .unwrap_or_else(|| self.total_points());
 
         let estimator = |condition: &Condition| self.condition_cardinality(condition);

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -475,7 +475,7 @@ impl Segment {
         let id_tracker = self.id_tracker.borrow();
 
         let ids_iterator = payload_index
-            .query_points(condition)
+            .query_points(condition, None)
             .filter_map(|internal_id| {
                 let external_id = id_tracker.external_id(internal_id);
                 match external_id {
@@ -835,7 +835,7 @@ impl SegmentEntry for Segment {
             Some(condition) => {
                 let query_cardinality = {
                     let payload_index = self.payload_index.borrow();
-                    payload_index.estimate_cardinality(condition)
+                    payload_index.estimate_cardinality(condition, None)
                 };
 
                 // ToDo: Add telemetry for this heuristics
@@ -906,7 +906,7 @@ impl SegmentEntry for Segment {
             }
             Some(filter) => {
                 let payload_index = self.payload_index.borrow();
-                payload_index.estimate_cardinality(filter)
+                payload_index.estimate_cardinality(filter, None)
             }
         }
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -96,13 +96,52 @@ impl Segment {
     ) -> OperationResult<()> {
         debug_assert!(self.is_appendable());
         check_vectors_set(&vectors, &self.segment_config)?;
-        for (vector_name, vector) in vectors {
-            let vector_name: &str = &vector_name;
-            let vector_data = &self.vector_data[vector_name];
-            let mut vector_storage = vector_data.vector_storage.borrow_mut();
-            vector_storage.insert_vector(internal_id, &vector)?;
+        for (vector_name, vector_data) in self.vector_data.iter_mut() {
+            let vector = vectors.get(vector_name);
+            match vector {
+                Some(vector) => {
+                    let mut vector_storage = vector_data.vector_storage.borrow_mut();
+                    vector_storage.insert_vector(internal_id, vector)?;
+                }
+                None => {
+                    // No vector provided, so we remove it
+                    let mut vector_storage = vector_data.vector_storage.borrow_mut();
+                    vector_storage.delete_vec(internal_id)?;
+                }
+            }
         }
         Ok(())
+    }
+
+    /// Insert new vectors into the segment
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    fn insert_new_vectors(
+        &mut self,
+        point_id: PointIdType,
+        vectors: NamedVectors,
+    ) -> OperationResult<PointOffsetType> {
+        debug_assert!(self.is_appendable());
+        let new_index = self.id_tracker.borrow().internal_size() as PointOffsetType;
+        check_vectors_set(&vectors, &self.segment_config)?;
+        for (vector_name, vector_data) in self.vector_data.iter_mut() {
+            let vector_opt = vectors.get(vector_name);
+            let mut vector_storage = vector_data.vector_storage.borrow_mut();
+            match vector_opt {
+                None => {
+                    let dim = vector_storage.vector_dim();
+                    vector_storage.insert_vector(new_index, &vec![1.0; dim])?;
+                    vector_storage.delete_vec(new_index)?;
+                }
+                Some(vec) => {
+                    vector_storage.insert_vector(new_index, vec)?;
+                }
+            }
+        }
+        self.id_tracker.borrow_mut().set_link(point_id, new_index)?;
+        Ok(new_index)
     }
 
     /// Operation wrapped, which handles previous and new errors in the segment,
@@ -266,7 +305,11 @@ impl Segment {
     ) -> OperationResult<Option<Vec<VectorElementType>>> {
         check_vector_name(vector_name, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
-        if !self.id_tracker.borrow().is_deleted_point(point_offset) {
+        let is_vector_deleted = vector_data
+            .vector_storage
+            .borrow()
+            .is_deleted_vec(point_offset);
+        if !is_vector_deleted && !self.id_tracker.borrow().is_deleted_point(point_offset) {
             Ok(Some(
                 vector_data
                     .vector_storage
@@ -285,14 +328,20 @@ impl Segment {
     ) -> OperationResult<NamedVectors> {
         let mut vectors = NamedVectors::default();
         for (vector_name, vector_data) in &self.vector_data {
-            vectors.insert(
-                vector_name.clone(),
-                vector_data
-                    .vector_storage
-                    .borrow()
-                    .get_vector(point_offset)
-                    .to_vec(),
-            );
+            let is_vector_deleted = vector_data
+                .vector_storage
+                .borrow()
+                .is_deleted_vec(point_offset);
+            if !is_vector_deleted {
+                vectors.insert(
+                    vector_name.clone(),
+                    vector_data
+                        .vector_storage
+                        .borrow()
+                        .get_vector(point_offset)
+                        .to_vec(),
+                );
+            }
         }
         Ok(vectors)
     }
@@ -672,19 +721,7 @@ impl SegmentEntry for Segment {
                 segment.update_vector(existing_internal_id, processed_vectors)?;
                 Ok((true, Some(existing_internal_id)))
             } else {
-                let new_index = segment.id_tracker.borrow().internal_size() as PointOffsetType;
-
-                for (vector_name, processed_vector) in processed_vectors {
-                    let vector_name: &str = &vector_name;
-                    segment.vector_data[vector_name]
-                        .vector_storage
-                        .borrow_mut()
-                        .insert_vector(new_index, &processed_vector)?;
-                }
-                segment
-                    .id_tracker
-                    .borrow_mut()
-                    .set_link(point_id, new_index)?;
+                let new_index = segment.insert_new_vectors(point_id, processed_vectors)?;
                 Ok((false, Some(new_index)))
             }
         })
@@ -712,6 +749,31 @@ impl SegmentEntry for Segment {
                     }
 
                     Ok((true, Some(internal_id)))
+                })
+            }
+        }
+    }
+
+    fn delete_vector(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vector_name: &str,
+    ) -> OperationResult<bool> {
+        let internal_id = self.id_tracker.borrow().internal_id(point_id);
+        match internal_id {
+            // Point does already not exist anymore
+            None => Ok(false),
+            Some(internal_id) => {
+                self.handle_version_and_failure(op_num, Some(internal_id), |segment| {
+                    let vector_data = segment.vector_data.get(vector_name).ok_or(
+                        OperationError::VectorNameNotExists {
+                            received_name: vector_name.to_string(),
+                        },
+                    )?;
+                    let mut vector_storage = vector_data.vector_storage.borrow_mut();
+                    let is_deleted = vector_storage.delete_vec(internal_id)?;
+                    Ok((is_deleted, Some(internal_id)))
                 })
             }
         }
@@ -801,23 +863,18 @@ impl SegmentEntry for Segment {
         &self,
         vector_name: &str,
         point_id: PointIdType,
-    ) -> OperationResult<Vec<VectorElementType>> {
+    ) -> OperationResult<Option<Vec<VectorElementType>>> {
         let internal_id = self.lookup_internal_id(point_id)?;
         let vector_opt = self.vector_by_offset(vector_name, internal_id)?;
-        if let Some(vector) = vector_opt {
-            Ok(vector)
-        } else {
-            let segment_path = self.current_path.display();
-            Err(OperationError::service_error(format!(
-                "Vector {vector_name} not found at offset {internal_id} for point {point_id}, segment {segment_path}",
-            )))
-        }
+        Ok(vector_opt)
     }
 
     fn all_vectors(&self, point_id: PointIdType) -> OperationResult<NamedVectors> {
         let mut result = NamedVectors::default();
         for vector_name in self.vector_data.keys() {
-            result.insert(vector_name.clone(), self.vector(vector_name, point_id)?);
+            if let Some(vec) = self.vector(vector_name, point_id)? {
+                result.insert(vector_name.clone(), vec);
+            }
         }
         Ok(result)
     }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -149,11 +149,18 @@ impl SegmentBuilder {
                                 let existing_version =
                                     id_tracker.internal_version(existing_internal_id).unwrap();
                                 if existing_version < other_version {
-                                    // Other version is the newest, remove the existing one and replace
+                                    // Other version is the newest, reassign point to new internal ID
                                     id_tracker.drop(external_id)?;
                                     id_tracker.set_link(external_id, new_internal_id)?;
                                     id_tracker
                                         .set_internal_version(new_internal_id, other_version)?;
+
+                                    // Propagate deletes, delete all vectors for old internal ID
+                                    for vector_storage in vector_storages.values_mut() {
+                                        vector_storage.delete_vec(old_internal_id)?;
+                                    }
+
+                                    // Reassign payload point to new internal ID
                                     payload_index.drop(existing_internal_id)?;
                                     payload_index.assign(
                                         new_internal_id,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -98,8 +98,7 @@ impl SegmentBuilder {
                             "Cannot update from other segment because if missing vector name {vector_name}"
                         ))),
                     };
-                    let mut other_ids = other_id_tracker
-                        .iter_ids_exluding(other_vector_storage.deleted_vec_bitslice());
+                    let mut other_ids = other_id_tracker.iter_ids();
                     let internal_range = vector_storage.update_from(
                         other_vector_storage,
                         &mut other_ids,

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -102,7 +102,7 @@ impl VectorStorage for MemmapVectorStorage {
             vectors_file.write_all(raw_bites)?;
             end_index += 1;
 
-            // Remember deleted IDs so we can flush these later
+            // Remember deleted IDs so we can propagate deletions later
             if other.is_deleted_vec(id) {
                 deleted_ids.push((start_index + id) as PointOffsetType);
             }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -166,9 +166,8 @@ impl VectorStorage for MemmapVectorStorage {
         files
     }
 
-    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
-        self.mmap_store.as_mut().unwrap().delete(key);
-        Ok(())
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<bool> {
+        Ok(self.mmap_store.as_mut().unwrap().delete(key))
     }
 
     fn is_deleted_vec(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -154,13 +154,16 @@ impl MmapVectors {
         self.raw_vector_offset(offset)
     }
 
-    pub fn delete(&mut self, key: PointOffsetType) {
+    pub fn delete(&mut self, key: PointOffsetType) -> bool {
         if self.num_vectors <= key as usize {
-            return;
+            return false;
         }
-        if !self.deleted.replace(key as usize, true) {
+
+        let is_deleted = !self.deleted.replace(key as usize, true);
+        if is_deleted {
             self.deleted_count += 1;
         }
+        is_deleted
     }
 
     pub fn is_deleted_vec(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
+++ b/lib/segment/src/vector_storage/quantized/scalar_quantized.rs
@@ -50,18 +50,20 @@ where
     }
 
     fn check_vec(&self, point: PointOffsetType) -> bool {
+        // Deleted points propagate to vectors; check vector deletion for possible early return
         !self
+            .vec_deleted
+            .get(point as usize)
+            .as_deref()
+            .copied()
+            .unwrap_or(false)
+        // Additionally check point deletion for integrity if delete propagation to vector failed
+        && !self
             .point_deleted
             .get(point as usize)
             .as_deref()
             .copied()
             .unwrap_or(false)
-            && !self
-                .vec_deleted
-                .get(point as usize)
-                .as_deref()
-                .copied()
-                .unwrap_or(false)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -120,13 +120,15 @@ where
 
     fn check_vec(&self, point: PointOffsetType) -> bool {
         point < self.points_count
+            // Deleted points propagate to vectors; check vector deletion for possible early return
             && !self
-                .point_deleted
+                .vec_deleted
                 .get(point as usize)
                 .map(|x| *x)
                 .unwrap_or(false)
+            // Additionally check point deletion for integrity if delete propagation to vector failed
             && !self
-                .vec_deleted
+                .point_deleted
                 .get(point as usize)
                 .map(|x| *x)
                 .unwrap_or(false)

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -170,7 +170,7 @@ impl VectorStorage for SimpleVectorStorage {
             let other_vector = other.get_vector(point_id);
             let new_id = self.vectors.push(other_vector);
             self.set_deleted(new_id, other_deleted);
-            self.update_stored(new_id, false, Some(other_vector))?;
+            self.update_stored(new_id, other_deleted, Some(other_vector))?;
         }
         let end_index = self.vectors.len() as PointOffsetType;
         Ok(start_index..end_index)

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -93,9 +93,9 @@ pub fn open_simple_vector_storage(
 impl SimpleVectorStorage {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
-    fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) {
+    fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
         if self.vectors.len() <= key as usize {
-            return;
+            return false;
         }
         let previous = bitvec_set_deleted(&mut self.deleted, key, deleted);
         if !previous && deleted {
@@ -103,6 +103,7 @@ impl SimpleVectorStorage {
         } else if previous && !deleted {
             self.deleted_count -= 1;
         }
+        previous
     }
 
     fn update_stored(
@@ -218,10 +219,12 @@ impl VectorStorage for SimpleVectorStorage {
         }
     }
 
-    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
-        self.set_deleted(key, true);
-        self.update_stored(key, true, None)?;
-        Ok(())
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<bool> {
+        let is_deleted = !self.set_deleted(key, true);
+        if is_deleted {
+            self.update_stored(key, true, None)?;
+        }
+        Ok(is_deleted)
     }
 
     fn is_deleted_vec(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -45,6 +45,14 @@ pub trait VectorStorage {
     /// Number of vectors, marked as deleted but still stored
     fn total_vector_count(&self) -> usize;
 
+    /// Number of available vectors
+    ///
+    /// - excludes soft deleted vectors, which are still stored
+    fn available_vector_count(&self) -> usize {
+        debug_assert!(self.deleted_vec_count() <= self.total_vector_count());
+        self.total_vector_count() - self.deleted_vec_count()
+    }
+
     /// Number of all stored vectors including deleted
     fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType];
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -90,7 +90,8 @@ pub trait VectorStorage {
     fn files(&self) -> Vec<PathBuf>;
 
     /// Flag the vector by the given key as deleted
-    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()>;
+    /// Returns true if the vector was not deleted before and is now deleted
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<bool>;
 
     /// Check whether the vector at the given key is flagged as deleted
     fn is_deleted_vec(&self, key: PointOffsetType) -> bool;
@@ -212,7 +213,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<()> {
+    fn delete_vec(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         match self {
             VectorStorageEnum::Simple(v) => v.delete_vec(key),
             VectorStorageEnum::Memmap(v) => v.delete_vec(key),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -48,9 +48,34 @@ pub trait VectorStorage {
     /// Number of available vectors
     ///
     /// - excludes soft deleted vectors, which are still stored
+    /// - this does not consider deleted points
     fn available_vector_count(&self) -> usize {
-        debug_assert!(self.deleted_vec_count() <= self.total_vector_count());
-        self.total_vector_count() - self.deleted_vec_count()
+        let total = self.total_vector_count();
+        let deleted_vecs = self.deleted_vec_count();
+        debug_assert!(deleted_vecs <= total);
+        total - deleted_vecs
+    }
+
+    /// Estimate number of available vectors, considering deleted points and vectors
+    ///
+    /// We don't know the true number of available vectors. Vectors can be soft deleted in two
+    /// places: as point or as vector. These deletions may overlap. Calculating the true number of
+    /// available vectors is expensive as it would require to iterate over all points.
+    ///
+    /// This estimation assumes that 20% of deleted points and vectors overlap. This percentage is
+    /// arbitrary, but reflects an almost-worst scenario.
+    ///
+    /// - excludes soft deleted points, which are still stored
+    /// - excludes soft deleted vectors, which are still stored
+    /// - assumes these deletions have 20% overlap
+    fn estimate_available_vector_count(&self, deleted_points: usize) -> usize {
+        let total = self.total_vector_count();
+        let deleted_vecs = self.deleted_vec_count();
+        debug_assert!(deleted_points <= total);
+        debug_assert!(deleted_vecs <= total);
+        let overlap = deleted_vecs.min(deleted_points) / 5;
+        let deleted = deleted_points + deleted_vecs - overlap;
+        total.saturating_sub(deleted)
     }
 
     /// Number of all stored vectors including deleted

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -45,17 +45,6 @@ pub trait VectorStorage {
     /// Number of vectors, marked as deleted but still stored
     fn total_vector_count(&self) -> usize;
 
-    /// Number of available vectors
-    ///
-    /// - excludes soft deleted vectors, which are still stored
-    /// - this does not consider deleted points
-    fn available_vector_count(&self) -> usize {
-        let total = self.total_vector_count();
-        let deleted_vecs = self.deleted_vec_count();
-        debug_assert!(deleted_vecs <= total);
-        total - deleted_vecs
-    }
-
     /// Estimate number of available vectors, considering deleted points and vectors
     ///
     /// We don't know the true number of available vectors. Vectors can be soft deleted in two

--- a/lib/segment/tests/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/disbalanced_vectors_test.rs
@@ -1,0 +1,107 @@
+mod fixtures;
+
+const NUM_VECTORS_1: u64 = 300;
+const NUM_VECTORS_2: u64 = 500;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use segment::data_types::named_vectors::NamedVectors;
+    use segment::entry::entry_point::SegmentEntry;
+    use segment::segment::Segment;
+    use segment::segment_constructor::segment_builder::SegmentBuilder;
+    use segment::segment_constructor::simple_segment_constructor::build_multivec_segment;
+    use segment::types::Distance;
+    use tempfile::Builder;
+
+    use super::*;
+
+    #[test]
+    fn test_rebuild_with_removed_vectors() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+        let stopped = AtomicBool::new(false);
+
+        let mut segment1 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
+        let mut segment2 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
+
+        for i in 0..NUM_VECTORS_1 {
+            segment1
+                .upsert_vector(
+                    1,
+                    i.into(),
+                    &NamedVectors::from([
+                        ("vector1".to_string(), vec![i as f32, 0., 0., 0.]),
+                        ("vector2".to_string(), vec![0., i as f32, 0., 0., 0., 0.]),
+                    ]),
+                )
+                .unwrap();
+        }
+
+        for i in 0..NUM_VECTORS_2 {
+            let vectors = if i % 5 == 0 {
+                NamedVectors::from([("vector1".to_string(), vec![0., 0., i as f32, 0.])])
+            } else {
+                NamedVectors::from([
+                    ("vector1".to_string(), vec![0., 0., i as f32, 0.]),
+                    ("vector2".to_string(), vec![0., 0., 0., i as f32, 0., 0.]),
+                ])
+            };
+
+            segment2
+                .upsert_vector(1, (NUM_VECTORS_1 + i).into(), &vectors)
+                .unwrap();
+        }
+
+        for i in 0..NUM_VECTORS_2 {
+            if i % 2 == 0 {
+                segment2
+                    .delete_point(2, (NUM_VECTORS_1 + i).into())
+                    .unwrap();
+            }
+            if i % 3 == 0 {
+                segment2
+                    .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector1")
+                    .unwrap();
+                segment2
+                    .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2")
+                    .unwrap();
+            }
+            if i % 3 == 1 {
+                segment2
+                    .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2")
+                    .unwrap();
+            }
+        }
+
+        for i in 0..20 {
+            if i % 2 == 0 {
+                continue;
+            }
+            let idx = NUM_VECTORS_1 + i;
+            let vec = segment2.all_vectors(idx.into()).unwrap();
+            eprintln!("vec[{}] = {:?}", idx, vec);
+        }
+
+        let mut builder =
+            SegmentBuilder::new(dir.path(), temp_dir.path(), &segment1.segment_config).unwrap();
+
+        builder.update_from(&segment1, &stopped).unwrap();
+        builder.update_from(&segment2, &stopped).unwrap();
+
+        let merged_segment: Segment = builder.build(&stopped).unwrap();
+
+        eprintln!("-------------------");
+
+        for i in 0..20 {
+            if i % 2 == 0 {
+                continue;
+            }
+            let idx = NUM_VECTORS_1 + i;
+            let vec = merged_segment.all_vectors(idx.into()).unwrap();
+            eprintln!("vec[{}] = {:?}", idx, vec);
+        }
+    }
+}

--- a/lib/segment/tests/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/disbalanced_vectors_test.rs
@@ -13,8 +13,8 @@ mod tests {
     use segment::segment_constructor::segment_builder::SegmentBuilder;
     use segment::segment_constructor::simple_segment_constructor::build_multivec_segment;
     use segment::types::Distance;
-    use tempfile::Builder;
     use segment::vector_storage::VectorStorage;
+    use tempfile::Builder;
 
     use super::*;
 
@@ -98,10 +98,25 @@ mod tests {
 
         let merged_points_count = merged_segment.points_count();
 
-        assert_eq!(merged_points_count, (NUM_VECTORS_1 + NUM_VECTORS_2 / 2) as usize);
+        assert_eq!(
+            merged_points_count,
+            (NUM_VECTORS_1 + NUM_VECTORS_2 / 2) as usize
+        );
 
-        let vec1_count = merged_segment.vector_data.get("vector1").unwrap().vector_storage.borrow().available_vec_count();
-        let vec2_count = merged_segment.vector_data.get("vector2").unwrap().vector_storage.borrow().available_vec_count();
+        let vec1_count = merged_segment
+            .vector_data
+            .get("vector1")
+            .unwrap()
+            .vector_storage
+            .borrow()
+            .available_vec_count();
+        let vec2_count = merged_segment
+            .vector_data
+            .get("vector2")
+            .unwrap()
+            .vector_storage
+            .borrow()
+            .available_vec_count();
 
         assert_ne!(vec1_count, vec2_count);
 

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -116,7 +116,7 @@ mod tests {
         for block in &blocks {
             let px = payload_index_ptr.borrow();
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter);
+            let points = px.query_points(&filter, None);
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -85,12 +85,11 @@ mod tests {
             payload_m: None,
         };
 
+        let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
         let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
             hnsw_dir.path(),
             segment.id_tracker.clone(),
-            segment.vector_data[DEFAULT_VECTOR_NAME]
-                .vector_storage
-                .clone(),
+            vector_storage.clone(),
             payload_index_ptr.clone(),
             hnsw_config,
         )
@@ -117,7 +116,7 @@ mod tests {
         for block in &blocks {
             let px = payload_index_ptr.borrow();
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter);
+            let points = px.query_points(&filter, Some(&vector_storage.borrow()));
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -113,15 +113,13 @@ mod tests {
             );
         }
 
-        let id_tracker = segment.id_tracker.borrow();
         let vector_storage = vector_storage.borrow();
         let mut coverage: HashMap<PointOffsetType, usize> = Default::default();
+        let px = payload_index_ptr.borrow();
+        let available_vecs = vector_storage.available_vec_count();
         for block in &blocks {
-            let px = payload_index_ptr.borrow();
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let available_points =
-                vector_storage.estimate_available_vector_count(id_tracker.deleted_point_count());
-            let points = px.query_points(&filter, Some(available_points));
+            let points = px.query_points(&filter, Some(available_vecs));
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -260,17 +260,17 @@ mod tests {
         let estimation_struct = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter, None);
 
         let estimation_plain = plain_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter, None);
 
         let real_number = plain_segment
             .payload_index
             .borrow()
-            .query_points(&filter)
+            .query_points(&filter, None)
             .count();
 
         eprintln!("estimation_plain = {estimation_plain:#?}");
@@ -309,7 +309,7 @@ mod tests {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter, None);
 
         let payload_index = struct_segment.payload_index.borrow();
         let filter_context = payload_index.filter_context(&filter);
@@ -371,7 +371,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter, None);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -450,7 +450,7 @@ mod tests {
             let estimation = plain_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter, None);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -474,7 +474,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter, None);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -542,7 +542,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter, None);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");

--- a/lib/segment/tests/segment_tests.rs
+++ b/lib/segment/tests/segment_tests.rs
@@ -133,20 +133,29 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let mut segment = build_segment_3(dir.path());
 
-        let result = segment.upsert_vector(
-            6,
-            6.into(),
-            &NamedVectors::from([
-                ("vector2".to_owned(), vec![10.]),
-                ("vector3".to_owned(), vec![5., 6., 7., 8.]),
-            ]),
-        );
+        let exists = segment
+            .upsert_vector(
+                7,
+                1.into(),
+                &NamedVectors::from([
+                    ("vector2".to_owned(), vec![10.]),
+                    ("vector3".to_owned(), vec![5., 6., 7., 8.]),
+                ]),
+            )
+            .unwrap();
+        assert!(exists, "this partial vector should overwrite existing");
 
-        if let Err(OperationError::MissedVectorName { received_name }) = result {
-            assert!(received_name == "vector1");
-        } else {
-            panic!("wrong upsert result")
-        }
+        let exists = segment
+            .upsert_vector(
+                8,
+                6.into(),
+                &NamedVectors::from([
+                    ("vector2".to_owned(), vec![10.]),
+                    ("vector3".to_owned(), vec![5., 6., 7., 8.]),
+                ]),
+            )
+            .unwrap();
+        assert!(!exists, "this partial vector should not existing");
     }
 
     #[test]


### PR DESCRIPTION
Continuation of <https://github.com/qdrant/qdrant/pull/1724>. Part of <https://github.com/qdrant/qdrant/issues/1045>.

This updates the query planner to make it aware of deleted points and vectors.

In short:
- estimates the number of deleted vectors in a vector storage instance
- makes cardinality calculations aware of deleted vectors
- for unfiltered HNSW searches it may fall back to a full scan if there are a lot of deleted vectors

This plays with query cardinality/estimations. I'm not entirely sure I implemented these changes correctly. I hope any incorrectness/problems come up with code review.

Note that this does not touch the optimizers. That will be done in a separate PR.

### Tasks:

- [x] Merge <https://github.com/qdrant/qdrant/pull/1724>
- [x] ~Rebase~ onto `dev` (merged due to disjoint history)
- [x] Target this PR to `dev` branch

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
