### PR TITLE
undo vector-related changes in estimate_cardinality

### DIFF
--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -31,7 +31,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += plain_index.query_points(&filter, None).count();
+            result_size += plain_index.query_points(&filter).count();
             query_count += 1;
         })
     });
@@ -47,7 +47,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points-large", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 1);
-            result_size += plain_index.query_points(&filter, None).count();
+            result_size += plain_index.query_points(&filter).count();
             query_count += 1;
         })
     });
@@ -97,7 +97,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     let mut query_count = 0;
 
     let filter = random_must_filter(&mut rng, 2);
-    let cardinality = struct_index.estimate_cardinality(&filter, None);
+    let cardinality = struct_index.estimate_cardinality(&filter);
 
     let indexed_fields = struct_index.indexed_fields();
 
@@ -107,7 +107,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     group.bench_function("struct-conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += struct_index.query_points(&filter, None).count();
+            result_size += struct_index.query_points(&filter).count();
             query_count += 1;
         })
     });

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -29,11 +29,7 @@ pub trait PayloadIndex {
     /// Estimate amount of points (min, max) which satisfies filtering condition.
     ///
     /// A best estimation of the number of available points should be given.
-    fn estimate_cardinality(
-        &self,
-        query: &Filter,
-        available_points: Option<usize>,
-    ) -> CardinalityEstimation;
+    fn estimate_cardinality(&self, query: &Filter) -> CardinalityEstimation;
 
     /// Return list of all point ids, which satisfy filtering criteria
     ///
@@ -41,7 +37,6 @@ pub trait PayloadIndex {
     fn query_points<'a>(
         &'a self,
         query: &'a Filter,
-        available_points: Option<usize>,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>;
 
     /// Return number of points, indexed by this field

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -10,6 +10,77 @@ use itertools::Itertools;
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::types::{Condition, Filter};
 
+/// Re-estimate cardinality based on number of available vectors
+/// Assuming that deleted vectors are not correlated with the filter
+///
+/// # Arguments
+///
+/// * `estimation` - cardinality estimations of number of points selected by payload filter
+/// * `available_vectors` - number of available vectors for the named vector storage
+/// * `total_vectors` - total number of points in the segment
+///
+/// # Result
+///
+/// * `CardinalityEstimation` - new cardinality estimation
+///
+/// # Example
+///
+/// ```
+/// use segment::index::field_index::CardinalityEstimation;
+/// let estimation = CardinalityEstimation {
+///    primary_clauses: vec![],
+///   min: 0,
+///   exp: 64,
+///   max: 100
+/// };
+///
+/// let new_estimation = segment::index::query_estimator::adjust_to_available_vectors(
+///     estimation,
+///     50,
+///     200
+/// );
+///
+/// assert_eq!(new_estimation.min, 0);
+/// assert_eq!(new_estimation.exp, 16);
+/// assert_eq!(new_estimation.max, 50);
+///
+/// ```
+pub fn adjust_to_available_vectors(
+    estimation: CardinalityEstimation,
+    available_vectors: usize,
+    available_points: usize,
+) -> CardinalityEstimation {
+    if available_points == 0 || available_vectors == 0 {
+        return CardinalityEstimation {
+            primary_clauses: estimation.primary_clauses,
+            min: 0,
+            exp: 0,
+            max: 0,
+        };
+    }
+
+    let number_of_deleted_vectors = available_points.saturating_sub(available_vectors);
+
+    // It is possible, all deleted vectors are selected in worst case
+    let min = estimation.min.saturating_sub(number_of_deleted_vectors);
+    // Another extreme case - all deleted vectors are not selected
+    let max = estimation.max.min(available_vectors);
+
+    let availability_prob = number_of_deleted_vectors as f64 / available_points as f64;
+
+    let exp = (estimation.exp as f64 * availability_prob).round() as usize;
+
+    debug_assert!(min <= exp);
+    debug_assert!(exp <= max);
+
+    CardinalityEstimation {
+        primary_clauses: estimation.primary_clauses,
+        min,
+        exp,
+        max,
+    }
+}
+
 pub fn combine_should_estimations(
     estimations: &[CardinalityEstimation],
     total: usize,

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -66,7 +66,7 @@ pub fn adjust_to_available_vectors(
     // Another extreme case - all deleted vectors are not selected
     let max = estimation.max.min(available_vectors);
 
-    let availability_prob = number_of_deleted_vectors as f64 / available_points as f64;
+    let availability_prob = available_vectors as f64 / available_points as f64;
 
     let exp = (estimation.exp as f64 * availability_prob).round() as usize;
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -524,7 +524,7 @@ impl Segment {
         let id_tracker = self.id_tracker.borrow();
 
         let ids_iterator = payload_index
-            .query_points(condition, None)
+            .query_points(condition)
             .filter_map(|internal_id| {
                 let external_id = id_tracker.external_id(internal_id);
                 match external_id {
@@ -921,7 +921,7 @@ impl SegmentEntry for Segment {
             Some(condition) => {
                 let query_cardinality = {
                     let payload_index = self.payload_index.borrow();
-                    payload_index.estimate_cardinality(condition, None)
+                    payload_index.estimate_cardinality(condition)
                 };
 
                 // ToDo: Add telemetry for this heuristics
@@ -996,7 +996,7 @@ impl SegmentEntry for Segment {
             }
             Some(filter) => {
                 let payload_index = self.payload_index.borrow();
-                payload_index.estimate_cardinality(filter, None)
+                payload_index.estimate_cardinality(filter)
             }
         }
     }

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -116,7 +116,7 @@ mod tests {
         for block in &blocks {
             let px = payload_index_ptr.borrow();
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter, None);
+            let points = px.query_points(&filter);
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -18,7 +18,6 @@ mod tests {
         PayloadSchemaType, PointOffsetType, Range, SearchParams, SegmentConfig, SeqNumberType,
         StorageType, VectorDataConfig,
     };
-    use segment::vector_storage::VectorStorage;
     use serde_json::json;
     use tempfile::Builder;
 
@@ -113,13 +112,11 @@ mod tests {
             );
         }
 
-        let vector_storage = vector_storage.borrow();
         let mut coverage: HashMap<PointOffsetType, usize> = Default::default();
         let px = payload_index_ptr.borrow();
-        let available_vecs = vector_storage.available_vector_count();
         for block in &blocks {
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter, Some(available_vecs));
+            let points = px.query_points(&filter);
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -260,17 +260,17 @@ mod tests {
         let estimation_struct = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter, None);
+            .estimate_cardinality(&filter);
 
         let estimation_plain = plain_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter, None);
+            .estimate_cardinality(&filter);
 
         let real_number = plain_segment
             .payload_index
             .borrow()
-            .query_points(&filter, None)
+            .query_points(&filter)
             .count();
 
         eprintln!("estimation_plain = {estimation_plain:#?}");
@@ -309,7 +309,7 @@ mod tests {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter, None);
+            .estimate_cardinality(&filter);
 
         let payload_index = struct_segment.payload_index.borrow();
         let filter_context = payload_index.filter_context(&filter);
@@ -371,7 +371,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter, None);
+                .estimate_cardinality(&query_filter);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -450,7 +450,7 @@ mod tests {
             let estimation = plain_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter, None);
+                .estimate_cardinality(&query_filter);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -474,7 +474,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter, None);
+                .estimate_cardinality(&query_filter);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -542,7 +542,7 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter, None);
+                .estimate_cardinality(&query_filter);
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");


### PR DESCRIPTION

Keep query cardinality abstraction separated from the concept of optional vectors.

There were an attempt to introduce the "available vertor" param into `estimate_cardinality`, but after some consideration I think it should be kept separately.

There is only one place, where we truly care about adjusting cardinality estimation to take removed vectors into account - the "query planner".

So instead of changing interface of `estimate_cardinality` and `query_points` we simply re-adjust estimation after it is computed in `estimate_cardinality`.



