### PR TITLE
Add support for TLS certificate rotation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -193,6 +193,8 @@ tls:
   # Required if cluster.p2p.enable_tls is true.
   ca_cert: ./tls/cacert.pem
 
-  # TTL to re-load certificate from disk. Useful for certificate rotations
+  # TTL to re-load certificate from disk. Useful for certificate rotations,
+  # Only works for HTTPS endpoints, gRPC endpoints (including intra-cluster communication)
+  # doesn't support certificate re-load
   cert_ttl: 3600
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -192,3 +192,7 @@ tls:
   #
   # Required if cluster.p2p.enable_tls is true.
   ca_cert: ./tls/cacert.pem
+
+  # TTL to re-load certificate from disk. Useful for certificate rotations
+  cert_ttl: 3600
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -193,7 +193,7 @@ tls:
   # Required if cluster.p2p.enable_tls is true.
   ca_cert: ./tls/cacert.pem
 
-  # TTL to re-load certificate from disk. Useful for certificate rotations,
+  # TTL, in seconds, to re-load certificate from disk. Useful for certificate rotations,
   # Only works for HTTPS endpoints, gRPC endpoints (including intra-cluster communication)
   # doesn't support certificate re-load
   cert_ttl: 3600

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -21,7 +21,7 @@ struct SslContextHolder {
 }
 
 impl SslContextHolder {
-    pub fn new(
+    fn new(
         tls_config: &TlsConfig,
         verify_client_cert: bool,
         refresh_interval: Duration,
@@ -36,7 +36,7 @@ impl SslContextHolder {
         })
     }
 
-    pub fn try_get_ssl_context(&self) -> Option<&SslContext> {
+    fn try_get_ssl_context(&self) -> Option<&SslContext> {
         if self.last_updated.elapsed() < self.refresh_interval {
             Some(&self.ssl_context)
         } else {
@@ -44,7 +44,7 @@ impl SslContextHolder {
         }
     }
 
-    pub fn refresh_and_get_ssl_context(&mut self) -> Result<&SslContext, ()> {
+    fn refresh_and_get_ssl_context(&mut self) -> Result<&SslContext, ()> {
         if self.last_updated.elapsed() < self.refresh_interval {
             Ok(&self.ssl_context)
         } else {

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::time::{Duration, Instant};
+
+use openssl::error::ErrorStack;
+use openssl::ssl::{
+    SniError, SslAcceptor, SslAcceptorBuilder, SslContext, SslContextBuilder, SslFiletype,
+    SslMethod, SslVerifyMode,
+};
+use openssl::x509::store::X509StoreBuilder;
+use openssl::x509::X509;
+use parking_lot::RwLock;
+
+use crate::settings::{Settings, TlsConfig};
+
+struct SslContextHolder {
+    ssl_context: SslContext,
+    tls_config: TlsConfig,
+    verify_client_cert: bool,
+    refresh_interval: Duration,
+    last_updated: Instant,
+}
+
+impl SslContextHolder {
+    pub fn new(
+        tls_config: &TlsConfig,
+        verify_client_cert: bool,
+        refresh_interval: Duration,
+    ) -> Result<SslContextHolder, ErrorStack> {
+        let ssl_context = build_ssl_context(&tls_config, verify_client_cert)?;
+        Ok(SslContextHolder {
+            ssl_context,
+            tls_config: tls_config.clone(),
+            verify_client_cert,
+            refresh_interval,
+            last_updated: Instant::now(),
+        })
+    }
+
+    pub fn try_get_ssl_context(&self) -> Option<&SslContext> {
+        if self.last_updated.elapsed() < self.refresh_interval {
+            Some(&self.ssl_context)
+        } else {
+            None
+        }
+    }
+
+    pub fn refresh_and_get_ssl_context(&mut self) -> Result<&SslContext, ()> {
+        if self.last_updated.elapsed() < self.refresh_interval {
+            Ok(&self.ssl_context)
+        } else {
+            self.refresh()?;
+            Ok(&self.ssl_context)
+        }
+    }
+
+    fn refresh(&mut self) -> Result<(), ()> {
+        log::info!("Refreshing TLS certificates for actix!");
+        match build_ssl_context(&self.tls_config, self.verify_client_cert) {
+            Ok(ssl_context) => {
+                self.ssl_context = ssl_context;
+                Ok(())
+            }
+            Err(_err) => Err(())
+        }
+    }
+}
+
+pub fn build_ssl_acceptor(settings: &Settings) -> std::io::Result<SslAcceptorBuilder> {
+    let mut acceptor = SslAcceptor::mozilla_modern_v5(SslMethod::tls())?;
+
+    let tls_config = settings
+        .tls
+        .clone()
+        .ok_or_else(Settings::tls_config_is_undefined_error)?;
+
+    let verify_client_cert = settings.service.verify_https_client_certificate;
+    let ssl_context_holder = RwLock::new(SslContextHolder::new(
+        &tls_config,
+        verify_client_cert,
+        Duration::from_secs(tls_config.cert_ttl),
+    )?);
+
+    // Use set_servername_callback to implement dynamic certificate loading and refresh
+    acceptor.set_servername_callback(move |ssl, _alert| -> Result<(), SniError> {
+        let mut should_refresh = true;
+        {
+            let reader = ssl_context_holder.read();
+            if let Some(ssl_context) = reader.try_get_ssl_context() {
+                should_refresh = false;
+                ssl.set_ssl_context(&ssl_context).map_err(|error_stack| {
+                    log::error!("Failed to set SSL context: {}", error_stack);
+                    SniError::ALERT_FATAL
+                })?;
+            }
+        }
+
+        if should_refresh {
+            let mut writer = ssl_context_holder.write();
+            let ssl_context = writer
+                .refresh_and_get_ssl_context()
+                .map_err(|_refresh_error| {
+                    log::error!("Failed to refresh certificates!");
+                    SniError::ALERT_FATAL
+                })?;
+            ssl.set_ssl_context(&ssl_context).map_err(|error_stack| {
+                log::error!("Failed to set SSL context: {}", error_stack);
+                SniError::ALERT_FATAL
+            })?;
+        }
+        Ok(())
+    });
+    Ok(acceptor)
+}
+
+fn build_ssl_context(
+    tls_config: &TlsConfig,
+    verify_client_cert: bool,
+) -> Result<SslContext, ErrorStack> {
+    let mut ssl_context_builder = SslContextBuilder::new(SslMethod::tls_server())?;
+    // Server TLS config
+    ssl_context_builder.set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
+    ssl_context_builder.set_certificate_chain_file(&tls_config.cert)?;
+    ssl_context_builder.check_private_key()?;
+
+    // Verify client TLS certification
+    if verify_client_cert {
+        let client_ca =
+            fs::read_to_string(&tls_config.ca_cert).expect("Failed to load CA certificate");
+        let client_ca = X509::from_pem(client_ca.as_bytes())?;
+
+        let mut x509_client_store_builder = X509StoreBuilder::new()?;
+        x509_client_store_builder.add_cert(client_ca)?;
+        let client_cert_store = x509_client_store_builder.build();
+        ssl_context_builder.set_verify_cert_store(client_cert_store)?;
+        ssl_context_builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+    }
+    Ok(ssl_context_builder.build())
+}

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -60,7 +60,7 @@ impl SslContextHolder {
                 self.ssl_context = ssl_context;
                 Ok(())
             }
-            Err(_err) => Err(())
+            Err(_err) => Err(()),
         }
     }
 }

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -76,11 +76,9 @@ pub fn build_ssl_acceptor(settings: &Settings) -> std::io::Result<SslAcceptorBui
 
     // Use set_servername_callback to implement dynamic certificate loading and refresh
     acceptor.set_servername_callback(move |ssl, _alert| -> Result<(), SniError> {
-        let mut should_refresh = true;
         {
             let reader = ssl_context_holder.read();
             if let Some(ssl_context) = reader.try_get_ssl_context() {
-                should_refresh = false;
                 ssl.set_ssl_context(ssl_context).map_err(|error_stack| {
                     log::error!("Failed to set SSL context: {}", error_stack);
                     SniError::ALERT_FATAL

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -26,7 +26,7 @@ impl SslContextHolder {
         verify_client_cert: bool,
         refresh_interval: Duration,
     ) -> Result<SslContextHolder, ErrorStack> {
-        let ssl_context = build_ssl_context(&tls_config, verify_client_cert)?;
+        let ssl_context = build_ssl_context(tls_config, verify_client_cert)?;
         Ok(SslContextHolder {
             ssl_context,
             tls_config: tls_config.clone(),
@@ -87,7 +87,7 @@ pub fn build_ssl_acceptor(settings: &Settings) -> std::io::Result<SslAcceptorBui
             let reader = ssl_context_holder.read();
             if let Some(ssl_context) = reader.try_get_ssl_context() {
                 should_refresh = false;
-                ssl.set_ssl_context(&ssl_context).map_err(|error_stack| {
+                ssl.set_ssl_context(ssl_context).map_err(|error_stack| {
                     log::error!("Failed to set SSL context: {}", error_stack);
                     SniError::ALERT_FATAL
                 })?;
@@ -102,7 +102,7 @@ pub fn build_ssl_acceptor(settings: &Settings) -> std::io::Result<SslAcceptorBui
                     log::error!("Failed to refresh certificates!");
                     SniError::ALERT_FATAL
                 })?;
-            ssl.set_ssl_context(&ssl_context).map_err(|error_stack| {
+            ssl.set_ssl_context(ssl_context).map_err(|error_stack| {
                 log::error!("Failed to set SSL context: {}", error_stack);
                 SniError::ALERT_FATAL
             })?;

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -37,11 +37,7 @@ impl SslContextHolder {
     }
 
     fn try_get_ssl_context(&self) -> Option<&SslContext> {
-        if self.last_updated.elapsed() < self.refresh_interval {
-            Some(&self.ssl_context)
-        } else {
-            None
-        }
+        (self.last_updated.elapsed() < self.refresh_interval).then_some(&self.ssl_context)
     }
 
     fn get_ssl_context_or_refresh(&mut self) -> Result<&SslContext, ()> {

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -17,6 +17,7 @@ use actix_web::{error, get, web, App, HttpRequest, HttpResponse, HttpServer, Res
 use collection::operations::validation;
 use storage::dispatcher::Dispatcher;
 
+use self::certificate_helpers::build_ssl_acceptor;
 use crate::actix::api::cluster_api::config_cluster_api;
 use crate::actix::api::collections_api::config_collections_api;
 use crate::actix::api::count_api::count_points;
@@ -29,8 +30,6 @@ use crate::actix::api::update_api::config_update_api;
 use crate::actix::api_key::ApiKey;
 use crate::common::telemetry::TelemetryCollector;
 use crate::settings::{max_web_workers, Settings};
-
-use self::certificate_helpers::{build_ssl_acceptor};
 
 #[get("/")]
 pub async fn index() -> impl Responder {

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -1,8 +1,8 @@
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod actix_telemetry;
-pub(crate) mod api;
+pub mod api;
 pub mod api_key;
-pub mod certificate_helpers;
+mod certificate_helpers;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -194,9 +194,9 @@ fn default_message_timeout_tics() -> u64 {
     10
 }
 
-fn default_tls_cert_ttl() -> u64 {
-    // Default one day
-    60 * 60 * 24
+const fn default_tls_cert_ttl() -> u64 {
+    // Default one hour
+    3600
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -98,6 +98,8 @@ pub struct TlsConfig {
     pub cert: String,
     pub key: String,
     pub ca_cert: String,
+    #[serde(default = "default_tls_cert_ttl")]
+    pub cert_ttl: u64,
 }
 
 #[derive(Debug, Deserialize, Clone, Validate)]
@@ -190,6 +192,11 @@ fn default_connection_pool_size() -> usize {
 
 fn default_message_timeout_tics() -> u64 {
     10
+}
+
+fn default_tls_cert_ttl() -> u64 {
+    // Default one day
+    60 * 60 * 24
 }
 
 impl Settings {


### PR DESCRIPTION
## What's in this PR:
 - Use OpenSSL's `set_servername_callback` to implement certificate re-load for actix
 - Caching the SSL context in memory so that we don't load certificates whenever we have a new connection. Instead, a TTL mechanism controls the re-load from disk

Idea comes from @PaulFurtado . Thanks for suggesting this change. 

### Why is it useful:
Certificate reload is important to enable users to swap certificates while the server is running. This is particularly useful for HTTPS endpoints because usually it is handled by a certificate manager (like in Kubernetes), and the certificate have a very short TTL

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?
