### PR TITLE
Oom fallback script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ RUN mkdir -p ${APP}
 
 COPY --from=builder /qdrant/qdrant ${APP}/qdrant
 COPY --from=builder /qdrant/config ${APP}/config
+COPY --from=builder /qdrant/tools/entrypoint.sh ${APP}/entrypoint.sh
 
 WORKDIR ${APP}
 
-CMD ["./qdrant"]
+CMD ["./entrypoint.sh"]

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -6,11 +6,12 @@ const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 10_000;
 /// Storage configuration shared between all collections.
 /// Represents a per-node configuration, which might be changes with restart.
 /// Vales of this struct are not persisted.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct SharedStorageConfig {
     pub update_queue_size: usize,
     pub node_type: NodeType,
     pub handle_collection_load_errors: bool,
+    pub recovery_mode: Option<String>,
 }
 
 impl Default for SharedStorageConfig {
@@ -19,6 +20,7 @@ impl Default for SharedStorageConfig {
             update_queue_size: DEFAULT_UPDATE_QUEUE_SIZE,
             node_type: Default::default(),
             handle_collection_load_errors: false,
+            recovery_mode: None,
         }
     }
 }
@@ -28,6 +30,7 @@ impl SharedStorageConfig {
         update_queue_size: Option<usize>,
         node_type: NodeType,
         handle_collection_load_errors: bool,
+        recovery_mode: Option<String>,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,
@@ -38,6 +41,7 @@ impl SharedStorageConfig {
             update_queue_size,
             node_type,
             handle_collection_load_errors,
+            recovery_mode,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -481,32 +481,36 @@ impl ShardReplicaSet {
         );
 
         let local = if replica_state.read().is_local {
-            let res = LocalShard::load(
-                shard_id,
-                collection_id.clone(),
-                shard_path,
-                collection_config.clone(),
-                shared_storage_config.clone(),
-                update_runtime.clone(),
-            )
-            .await;
+            let shard = if let Some(recovery_reason) = &shared_storage_config.recovery_mode {
+                Dummy(DummyShard::new(recovery_reason))
+            } else {
+                let res = LocalShard::load(
+                    shard_id,
+                    collection_id.clone(),
+                    shard_path,
+                    collection_config.clone(),
+                    shared_storage_config.clone(),
+                    update_runtime.clone(),
+                )
+                .await;
 
-            let shard = match res {
-                Ok(shard) => Local(shard),
-                Err(err) => {
-                    if !shared_storage_config.handle_collection_load_errors {
-                        panic!("Failed to load local shard {shard_path:?}: {err}")
-                    }
+                match res {
+                    Ok(shard) => Local(shard),
+                    Err(err) => {
+                        if !shared_storage_config.handle_collection_load_errors {
+                            panic!("Failed to load local shard {shard_path:?}: {err}")
+                        }
 
-                    log::error!(
-                        "Failed to load local shard {shard_path:?}, \
+                        log::error!(
+                            "Failed to load local shard {shard_path:?}, \
                          initializing \"dummy\" shard instead: \
                          {err}"
-                    );
+                        );
 
-                    Dummy(DummyShard::new(format!(
-                        "Failed to load local shard {shard_path:?}: {err}"
-                    )))
+                        Dummy(DummyShard::new(format!(
+                            "Failed to load local shard {shard_path:?}: {err}"
+                        )))
+                    }
                 }
             };
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -56,6 +56,11 @@ pub struct StorageConfig {
     pub update_queue_size: Option<usize>,
     #[serde(default)]
     pub handle_collection_load_errors: bool,
+    /// If provided - qdrant will start in recovery mode, which means that it will not accept any new data.
+    /// Only collection metadata will be available, and it will only process collection delete requests.
+    /// Provided value will be used error message for unavailable requests.
+    #[serde(default)]
+    pub recovery_mode: Option<String>,
 }
 
 impl StorageConfig {
@@ -64,6 +69,7 @@ impl StorageConfig {
             self.update_queue_size,
             self.node_type,
             self.handle_collection_load_errors,
+            self.recovery_mode.clone(),
         )
     }
 }

--- a/lib/storage/tests/alias_tests.rs
+++ b/lib/storage/tests/alias_tests.rs
@@ -53,6 +53,7 @@ fn test_alias_operation() {
         node_type: Default::default(),
         update_queue_size: Default::default(),
         handle_collection_load_errors: false,
+        recovery_mode: None,
     };
 
     let search_runtime = Runtime::new().unwrap();

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -6,6 +6,8 @@ use log::LevelFilter;
 
 use crate::common::error_reporting::ErrorReporter;
 
+const INITIALIZED_FILE: &str = ".qdrant-initialized";
+
 pub fn setup_logger(log_level: &str) {
     let is_info = log_level.to_ascii_uppercase() == "INFO";
     let mut log_builder = env_logger::Builder::new();
@@ -50,4 +52,22 @@ pub fn setup_panic_hook(reporting_enabled: bool, reporting_id: String) {
             ErrorReporter::report(message, &reporting_id, Some(&loc));
         }
     }));
+}
+
+/// Creates a file that indicates that the server has been started.
+/// This file is used to check if the server has been been successfully started before potential kill.
+pub fn touch_started_file_indicator() {
+    if let Err(err) = std::fs::write(INITIALIZED_FILE, "") {
+        log::warn!("Failed to create init file indicator: {}", err);
+    }
+}
+
+/// Removes a file that indicates that the server has been started.
+/// Use before server initialization to avoid false positives.
+pub fn remove_started_file_indicator() {
+    if std::path::Path::new(INITIALIZED_FILE).exists() {
+        if let Err(err) = std::fs::remove_file(INITIALIZED_FILE) {
+            log::warn!("Failed to remove init file indicator: {}", err);
+        }
+    }
 }

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Script to run qdrant in docker container and handle contingencies, like OOM.
+# The functioning logic is as follows:
+# - If recovery mode is allowed, we check if qdrant was killed during initialization or not.
+#   - If it was killed during initialization, we remove run qdrant in recovery mode
+#   - If it was killed after initialization, do nothing and restart container
+# - If recovery mode is not allowed, we just restart container
+
+./qdrant $@
+
+EXIT_CODE=$?
+
+QDRANT_ALLOW_RECOVERY_MODE=${QDRANT_ALLOW_RECOVERY_MODE:-false}
+
+# Check that recovery mode is allowed
+if [ "$QDRANT_ALLOW_RECOVERY_MODE" = true ]; then
+
+  IS_INITIALIZED_FILE='.qdrant-initialized'
+
+  RECOVERY_MESSAGE="Qdrant was killed during initialization. Most likely it's Out-of-Memory. \
+  Please check memory consumption, increase memory limit or remove some collections and restart"
+
+  # Check that qdrant was killed (exit code 137)
+  # Ideally, we want to catch only OOM, but it's not possible to distinguish it from random kill signal
+  if [ $EXIT_CODE -eq 137 ]; then
+    # Check that qdrant was initialized
+    # Qdrant creates IS_INITIALIZED_FILE file after initialization
+    # So if it doesn't exist, qdrant was killed during initialization
+    if [ ! -f "$IS_INITIALIZED_FILE" ]; then
+      QDRANT__STORAGE__RECOVERY_MODE="$RECOVERY_MESSAGE" ./qdrant $@
+      exit $?
+    fi
+  fi
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Alternative to internal handling of memory issue

Instead of handling OOM inside qdrant binary, we can use an external script, that can run Qdrant in recover mode if qdrant failed during initialization.

There are following scenarios to consider:

- default mode - if no flags are specified, operate as usual, fail as usual, no recovery what-so-ever
- OOM/kill after initialization - not necessary require a recovery mode, so we just exit
- Error during initialization, but not OOM (e.g. SIGINT) - exit as is, no changes
- OOM/kill during initialization + recovery allowed by flag - only in this case we want to start a recovery mode.

Recovery mode will load all shards as dummy, and will report configured error message.

No regular checks or percentage of available memory required. 