### PR TITLE
fix: use `#[sealed_test]` for tests that rely on `RUN_MODE` environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,7 @@ dependencies = [
  "reqwest",
  "rusty-hook",
  "schemars",
+ "sealed_test",
  "segment",
  "serde",
  "serde_cbor",
@@ -3504,6 +3505,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty-forkfork"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce85af4dfa2fb0c0143121ab5e424c71ea693867357c9159b8777b59984c218"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rusty-hook"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +3608,28 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sealed_test"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a608d94641cc17fe203b102db2ae86d47a236630192f0244ddbbbb0044c0272"
+dependencies = [
+ "fs_extra",
+ "rusty-forkfork",
+ "sealed_test_derive",
+ "tempfile",
+]
+
+[[package]]
+name = "sealed_test_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b672e005ae58fef5da619d90b9f1c5b44b061890f4a371b3c96257a8a15e697"
+dependencies = [
+ "quote",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"
+sealed_test = "1.0.0"
 
 tempfile = "3.5.0"
 rusty-hook = "^0.11.2"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -256,6 +256,8 @@ pub fn max_web_workers(settings: &Settings) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use sealed_test::prelude::*;
+
     use super::*;
 
     /// Ensure we can successfully deserialize into [`Settings`] with just the default configuration.
@@ -271,8 +273,15 @@ mod tests {
             .expect("failed to validate default config");
     }
 
-    #[test]
+    #[sealed_test(files = ["config/config.yaml", "config/development.yaml"])]
     fn test_runtime_development_config() {
+        // `sealed_test` copies files into the same directory as the test runs in.
+        // We need them in a subdirectory.
+        std::fs::create_dir("config").expect("failed to create `config` subdirectory.");
+        std::fs::copy("config.yaml", "config/config.yaml").expect("failed to copy `config.yaml`.");
+        std::fs::copy("development.yaml", "config/development.yaml")
+            .expect("failed to copy `development.yaml`.");
+
         let key = "RUN_MODE";
         env::set_var(key, "development");
 
@@ -286,7 +295,7 @@ mod tests {
         assert!(config.found_config_files)
     }
 
-    #[test]
+    #[sealed_test]
     fn test_no_config_files() {
         let non_existing_config_path = "config/non_existing_config".to_string();
         env::remove_var("RUN_MODE");


### PR DESCRIPTION
closes #1803

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?
