### PR TITLE
Add gRPC interface to update/delete optional named vectors

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -99,6 +99,7 @@
     - [PointId](#qdrant-PointId)
     - [PointStruct](#qdrant-PointStruct)
     - [PointStruct.PayloadEntry](#qdrant-PointStruct-PayloadEntry)
+    - [PointVectors](#qdrant-PointVectors)
     - [PointsIdsList](#qdrant-PointsIdsList)
     - [PointsOperationResponse](#qdrant-PointsOperationResponse)
     - [PointsSelector](#qdrant-PointsSelector)
@@ -1684,6 +1685,22 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-PointVectors"></a>
+
+### PointVectors
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [PointId](#qdrant-PointId) |  | ID to update vectors for |
+| vectors | [NamedVectors](#qdrant-NamedVectors) |  | Named vectors to update, leave others intact |
+
+
+
+
+
+
 <a name="qdrant-PointsIdsList"></a>
 
 ### PointsIdsList
@@ -2129,8 +2146,7 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | collection_name | [string](#string) |  | name of the collection |
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
-| id | [PointId](#qdrant-PointId) |  | ID to update vectors for |
-| vectors | [NamedVectors](#qdrant-NamedVectors) |  | Named vectors to update, leave others intact |
+| points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1347,7 +1347,7 @@ The JSON representation for `Value` is a JSON value.
 | collection_name | [string](#string) |  | name of the collection |
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
-| vector_names | [string](#string) | repeated | List of vector names to delete |
+| vectors | [VectorsSelector](#qdrant-VectorsSelector) |  | List of vector names to delete |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 
 
@@ -2129,8 +2129,8 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | collection_name | [string](#string) |  | name of the collection |
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
-| id | [PointId](#qdrant-PointId) |  |  |
-| vectors | [NamedVectors](#qdrant-NamedVectors) |  |  |
+| id | [PointId](#qdrant-PointId) |  | ID to update vectors for |
+| vectors | [NamedVectors](#qdrant-NamedVectors) |  | Named vectors to update, leave others intact |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -78,6 +78,7 @@
     - [CreateFieldIndexCollection](#qdrant-CreateFieldIndexCollection)
     - [DeleteFieldIndexCollection](#qdrant-DeleteFieldIndexCollection)
     - [DeletePayloadPoints](#qdrant-DeletePayloadPoints)
+    - [DeletePointVectors](#qdrant-DeletePointVectors)
     - [DeletePoints](#qdrant-DeletePoints)
     - [FieldCondition](#qdrant-FieldCondition)
     - [Filter](#qdrant-Filter)
@@ -123,6 +124,7 @@
     - [SearchResponse](#qdrant-SearchResponse)
     - [SetPayloadPoints](#qdrant-SetPayloadPoints)
     - [SetPayloadPoints.PayloadEntry](#qdrant-SetPayloadPoints-PayloadEntry)
+    - [UpdatePointVectors](#qdrant-UpdatePointVectors)
     - [UpdateResult](#qdrant-UpdateResult)
     - [UpsertPoints](#qdrant-UpsertPoints)
     - [ValuesCount](#qdrant-ValuesCount)
@@ -1334,6 +1336,25 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-DeletePointVectors"></a>
+
+### DeletePointVectors
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | name of the collection |
+| wait | [bool](#bool) | optional | Wait until the changes have been applied? |
+| points_selector | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
+| vector_names | [string](#string) | repeated | List of vector names to delete |
+| ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+
+
+
+
+
+
 <a name="qdrant-DeletePoints"></a>
 
 ### DeletePoints
@@ -2098,6 +2119,25 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-UpdatePointVectors"></a>
+
+### UpdatePointVectors
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection_name | [string](#string) |  | name of the collection |
+| wait | [bool](#bool) | optional | Wait until the changes have been applied? |
+| id | [PointId](#qdrant-PointId) |  |  |
+| vectors | [NamedVectors](#qdrant-NamedVectors) |  |  |
+| ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+
+
+
+
+
+
 <a name="qdrant-UpdateResult"></a>
 
 ### UpdateResult
@@ -2330,6 +2370,8 @@ The JSON representation for `Value` is a JSON value.
 | Upsert | [UpsertPoints](#qdrant-UpsertPoints) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Perform insert &#43; updates on points. If a point with a given ID already exists - it will be overwritten. |
 | Delete | [DeletePoints](#qdrant-DeletePoints) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Delete points |
 | Get | [GetPoints](#qdrant-GetPoints) | [GetResponse](#qdrant-GetResponse) | Retrieve points |
+| UpdateVectors | [UpdatePointVectors](#qdrant-UpdatePointVectors) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Update named vectors for point |
+| DeleteVectors | [DeletePointVectors](#qdrant-DeletePointVectors) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Delete named vectors for points |
 | SetPayload | [SetPayloadPoints](#qdrant-SetPayloadPoints) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Set payload for points |
 | OverwritePayload | [SetPayloadPoints](#qdrant-SetPayloadPoints) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Overwrite payload for points |
 | DeletePayload | [DeletePayloadPoints](#qdrant-DeletePayloadPoints) | [PointsOperationResponse](#qdrant-PointsOperationResponse) | Delete specified key payload for points |

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -129,7 +129,9 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpsertPoints.collection_name", "length(min = 1, max = 255)"),
             ("DeletePoints.collection_name", "length(min = 1, max = 255)"),
             ("UpdatePointVectors.collection_name", "length(min = 1, max = 255)"),
+            ("UpdatePointVectors.vectors", "custom(function = \"crate::grpc::validate::validate_named_vectors_not_empty\", message = \"must specify vectors to update\")"),
             ("DeletePointVectors.collection_name", "length(min = 1, max = 255)"),
+            ("DeletePointVectors.vector_names", "length(min = 1, message = \"must specify vector names to delete\")"),
             ("GetPoints.collection_name", "length(min = 1, max = 255)"),
             ("SetPayloadPoints.collection_name", "length(min = 1, max = 255)"),
             ("DeletePayloadPoints.collection_name", "length(min = 1, max = 255)"),
@@ -150,6 +152,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendBatchPoints.recommend_points", ""),
             ("CountPoints.collection_name", "length(min = 1, max = 255)"),
         ], &[])
+        .type_attribute("NamedVectors", "#[derive(serde::Serialize)]")
+        .type_attribute("Vector", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[
             ("UpsertPointsInternal.upsert_points", ""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -128,6 +128,8 @@ fn configure_validation(builder: Builder) -> Builder {
         .validates(&[
             ("UpsertPoints.collection_name", "length(min = 1, max = 255)"),
             ("DeletePoints.collection_name", "length(min = 1, max = 255)"),
+            ("UpdatePointVectors.collection_name", "length(min = 1, max = 255)"),
+            ("DeletePointVectors.collection_name", "length(min = 1, max = 255)"),
             ("GetPoints.collection_name", "length(min = 1, max = 255)"),
             ("SetPayloadPoints.collection_name", "length(min = 1, max = 255)"),
             ("DeletePayloadPoints.collection_name", "length(min = 1, max = 255)"),
@@ -152,6 +154,8 @@ fn configure_validation(builder: Builder) -> Builder {
         .validates(&[
             ("UpsertPointsInternal.upsert_points", ""),
             ("DeletePointsInternal.delete_points", ""),
+            ("UpdateVectorsInternal.update_vectors", ""),
+            ("DeleteVectorsInternal.delete_vectors", ""),
             ("SetPayloadPointsInternal.set_payload_points", ""),
             ("DeletePayloadPointsInternal.delete_payload_points", ""),
             ("ClearPayloadPointsInternal.clear_payload_points", ""),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -71,6 +71,22 @@ message GetPoints {
   optional ReadConsistency read_consistency = 6; // Options for specifying read consistency guarantees
 }
 
+message UpdatePointVectors {
+  string collection_name = 1; // name of the collection
+  optional bool wait = 2; // Wait until the changes have been applied?
+  PointId id = 3;
+  NamedVectors vectors = 4;
+  optional WriteOrdering ordering = 5; // Write ordering guarantees
+}
+
+message DeletePointVectors {
+  string collection_name = 1; // name of the collection
+  optional bool wait = 2; // Wait until the changes have been applied?
+  PointsSelector points_selector = 3; // Affected points
+  repeated string vector_names = 4; // List of vector names to delete
+  optional WriteOrdering ordering = 5; // Write ordering guarantees
+}
+
 message SetPayloadPoints {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -79,8 +79,8 @@ message UpdatePointVectors {
 }
 
 message PointVectors {
-  PointId id = 3; // ID to update vectors for
-  NamedVectors vectors = 4; // Named vectors to update, leave others intact
+  PointId id = 1; // ID to update vectors for
+  NamedVectors vectors = 2; // Named vectors to update, leave others intact
 }
 
 message DeletePointVectors {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -74,8 +74,8 @@ message GetPoints {
 message UpdatePointVectors {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
-  PointId id = 3;
-  NamedVectors vectors = 4;
+  PointId id = 3; // ID to update vectors for
+  NamedVectors vectors = 4; // Named vectors to update, leave others intact
   optional WriteOrdering ordering = 5; // Write ordering guarantees
 }
 
@@ -83,7 +83,7 @@ message DeletePointVectors {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
   PointsSelector points_selector = 3; // Affected points
-  repeated string vector_names = 4; // List of vector names to delete
+  VectorsSelector vectors = 4; // List of vector names to delete
   optional WriteOrdering ordering = 5; // Write ordering guarantees
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -74,9 +74,13 @@ message GetPoints {
 message UpdatePointVectors {
   string collection_name = 1; // name of the collection
   optional bool wait = 2; // Wait until the changes have been applied?
+  repeated PointVectors points = 3; // List of points and vectors to update
+  optional WriteOrdering ordering = 4; // Write ordering guarantees
+}
+
+message PointVectors {
   PointId id = 3; // ID to update vectors for
   NamedVectors vectors = 4; // Named vectors to update, leave others intact
-  optional WriteOrdering ordering = 5; // Write ordering guarantees
 }
 
 message DeletePointVectors {

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -10,6 +10,8 @@ service PointsInternal {
   rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}
   rpc Sync (SyncPointsInternal) returns (PointsOperationResponse) {}
   rpc Delete (DeletePointsInternal) returns (PointsOperationResponse) {}
+  rpc UpdateVectors (UpdateVectorsInternal) returns (PointsOperationResponse) {}
+  rpc DeleteVectors (DeleteVectorsInternal) returns (PointsOperationResponse) {}
   rpc SetPayload (SetPayloadPointsInternal) returns (PointsOperationResponse) {}
   rpc OverwritePayload (SetPayloadPointsInternal) returns (PointsOperationResponse) {}
   rpc DeletePayload (DeletePayloadPointsInternal) returns (PointsOperationResponse) {}
@@ -46,6 +48,16 @@ message UpsertPointsInternal {
 
 message DeletePointsInternal {
   DeletePoints delete_points = 1;
+  optional uint32 shard_id = 2;
+}
+
+message UpdateVectorsInternal {
+  UpdatePointVectors update_vectors = 1;
+  optional uint32 shard_id = 2;
+}
+
+message DeleteVectorsInternal {
+  DeletePointVectors delete_vectors = 1;
   optional uint32 shard_id = 2;
 }
 

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -20,6 +20,14 @@ service Points {
    */
   rpc Get (GetPoints) returns (GetResponse) {}
   /*
+  Update named vectors for point
+   */
+  rpc UpdateVectors (UpdatePointVectors) returns (PointsOperationResponse) {}
+  /*
+  Delete named vectors for points
+   */
+  rpc DeleteVectors (DeletePointVectors) returns (PointsOperationResponse) {}
+  /*
   Set payload for points
    */
   rpc SetPayload (SetPayloadPoints) returns (PointsOperationResponse) {}

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2428,6 +2428,7 @@ pub mod point_id {
         Uuid(::prost::alloc::string::String),
     }
 }
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
@@ -2504,6 +2505,12 @@ pub struct UpdatePointVectors {
     #[prost(message, optional, tag = "3")]
     pub id: ::core::option::Option<PointId>,
     #[prost(message, optional, tag = "4")]
+    #[validate(
+        custom(
+            function = "crate::grpc::validate::validate_named_vectors_not_empty",
+            message = "must specify vectors to update"
+        )
+    )]
     pub vectors: ::core::option::Option<NamedVectors>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "5")]
@@ -2525,6 +2532,7 @@ pub struct DeletePointVectors {
     pub points_selector: ::core::option::Option<PointsSelector>,
     /// List of vector names to delete
     #[prost(string, repeated, tag = "4")]
+    #[validate(length(min = 1, message = "must specify vector names to delete"))]
     pub vector_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "5")]
@@ -2668,6 +2676,7 @@ pub mod with_payload_selector {
         Exclude(super::PayloadExcludeSelector),
     }
 }
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedVectors {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2502,21 +2502,22 @@ pub struct UpdatePointVectors {
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
+    /// List of points and vectors to update
+    #[prost(message, repeated, tag = "3")]
+    pub points: ::prost::alloc::vec::Vec<PointVectors>,
+    /// Write ordering guarantees
+    #[prost(message, optional, tag = "4")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointVectors {
     /// ID to update vectors for
     #[prost(message, optional, tag = "3")]
     pub id: ::core::option::Option<PointId>,
     /// Named vectors to update, leave others intact
     #[prost(message, optional, tag = "4")]
-    #[validate(
-        custom(
-            function = "crate::grpc::validate::validate_named_vectors_not_empty",
-            message = "must specify vectors to update"
-        )
-    )]
     pub vectors: ::core::option::Option<NamedVectors>,
-    /// Write ordering guarantees
-    #[prost(message, optional, tag = "5")]
-    pub ordering: ::core::option::Option<WriteOrdering>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2502,8 +2502,10 @@ pub struct UpdatePointVectors {
     /// Wait until the changes have been applied?
     #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
+    /// ID to update vectors for
     #[prost(message, optional, tag = "3")]
     pub id: ::core::option::Option<PointId>,
+    /// Named vectors to update, leave others intact
     #[prost(message, optional, tag = "4")]
     #[validate(
         custom(
@@ -2531,9 +2533,8 @@ pub struct DeletePointVectors {
     #[prost(message, optional, tag = "3")]
     pub points_selector: ::core::option::Option<PointsSelector>,
     /// List of vector names to delete
-    #[prost(string, repeated, tag = "4")]
-    #[validate(length(min = 1, message = "must specify vector names to delete"))]
-    pub vector_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "4")]
+    pub vectors: ::core::option::Option<VectorsSelector>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "5")]
     pub ordering: ::core::option::Option<WriteOrdering>,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2513,10 +2513,10 @@ pub struct UpdatePointVectors {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointVectors {
     /// ID to update vectors for
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<PointId>,
     /// Named vectors to update, leave others intact
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag = "2")]
     pub vectors: ::core::option::Option<NamedVectors>,
 }
 #[derive(validator::Validate)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2493,6 +2493,46 @@ pub struct GetPoints {
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdatePointVectors {
+    /// name of the collection
+    #[prost(string, tag = "1")]
+    #[validate(length(min = 1, max = 255))]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Wait until the changes have been applied?
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    #[prost(message, optional, tag = "3")]
+    pub id: ::core::option::Option<PointId>,
+    #[prost(message, optional, tag = "4")]
+    pub vectors: ::core::option::Option<NamedVectors>,
+    /// Write ordering guarantees
+    #[prost(message, optional, tag = "5")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
+}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeletePointVectors {
+    /// name of the collection
+    #[prost(string, tag = "1")]
+    #[validate(length(min = 1, max = 255))]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Wait until the changes have been applied?
+    #[prost(bool, optional, tag = "2")]
+    pub wait: ::core::option::Option<bool>,
+    /// Affected points
+    #[prost(message, optional, tag = "3")]
+    pub points_selector: ::core::option::Option<PointsSelector>,
+    /// List of vector names to delete
+    #[prost(string, repeated, tag = "4")]
+    pub vector_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Write ordering guarantees
+    #[prost(message, optional, tag = "5")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
+}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPoints {
     /// name of the collection
     #[prost(string, tag = "1")]
@@ -3489,6 +3529,60 @@ pub mod points_client {
             self.inner.unary(req, path, codec).await
         }
         ///
+        /// Update named vectors for point
+        pub async fn update_vectors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdatePointVectors>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/UpdateVectors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "UpdateVectors"));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        /// Delete named vectors for points
+        pub async fn delete_vectors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeletePointVectors>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/DeleteVectors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "DeleteVectors"));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
         /// Set payload for points
         pub async fn set_payload(
             &mut self,
@@ -3821,6 +3915,24 @@ pub mod points_server {
             request: tonic::Request<super::GetPoints>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
         ///
+        /// Update named vectors for point
+        async fn update_vectors(
+            &self,
+            request: tonic::Request<super::UpdatePointVectors>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
+        ///
+        /// Delete named vectors for points
+        async fn delete_vectors(
+            &self,
+            request: tonic::Request<super::DeletePointVectors>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
+        ///
         /// Set payload for points
         async fn set_payload(
             &self,
@@ -4110,6 +4222,98 @@ pub mod points_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/UpdateVectors" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateVectorsSvc<T: Points>(pub Arc<T>);
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::UpdatePointVectors>
+                    for UpdateVectorsSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdatePointVectors>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).update_vectors(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateVectorsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/DeleteVectors" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteVectorsSvc<T: Points>(pub Arc<T>);
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::DeletePointVectors>
+                    for DeleteVectorsSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeletePointVectors>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).delete_vectors(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteVectorsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -4749,6 +4953,26 @@ pub struct DeletePointsInternal {
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateVectorsInternal {
+    #[prost(message, optional, tag = "1")]
+    #[validate]
+    pub update_vectors: ::core::option::Option<UpdatePointVectors>,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
+}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteVectorsInternal {
+    #[prost(message, optional, tag = "1")]
+    #[validate]
+    pub delete_vectors: ::core::option::Option<DeletePointVectors>,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
+}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetPayloadPointsInternal {
     #[prost(message, optional, tag = "1")]
     #[validate]
@@ -5021,6 +5245,56 @@ pub mod points_internal_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Delete"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn update_vectors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateVectorsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/UpdateVectors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.PointsInternal", "UpdateVectors"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn delete_vectors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteVectorsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/DeleteVectors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.PointsInternal", "DeleteVectors"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_payload(
@@ -5340,6 +5614,20 @@ pub mod points_internal_server {
             tonic::Response<super::PointsOperationResponse>,
             tonic::Status,
         >;
+        async fn update_vectors(
+            &self,
+            request: tonic::Request<super::UpdateVectorsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
+        async fn delete_vectors(
+            &self,
+            request: tonic::Request<super::DeleteVectorsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
@@ -5609,6 +5897,98 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/UpdateVectors" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateVectorsSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::UpdateVectorsInternal>
+                    for UpdateVectorsSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdateVectorsInternal>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).update_vectors(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateVectorsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/DeleteVectors" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteVectorsSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::DeleteVectorsInternal>
+                    for DeleteVectorsSvc<T> {
+                        type Response = super::PointsOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteVectorsInternal>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).delete_vectors(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteVectorsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use serde::Serialize;
 use validator::{Validate, ValidationError, ValidationErrors};
 
+use super::qdrant::NamedVectors;
+
 pub trait ValidateExt {
     fn validate(&self) -> Result<(), ValidationErrors>;
 }
@@ -166,6 +168,22 @@ where
     if let Some(max) = max {
         err.add_param(Cow::from("max"), &max);
     }
+    Err(err)
+}
+
+/// Validate the list of named vectors is not empty.
+pub fn validate_named_vectors_not_empty(
+    value: &Option<NamedVectors>,
+) -> Result<(), ValidationError> {
+    // If length is non-zero, we're good
+    if let Some(vectors) = value {
+        if !vectors.vectors.is_empty() {
+            return Ok(());
+        }
+    }
+
+    let mut err = ValidationError::new("length");
+    err.add_param(Cow::from("min"), &1);
     Err(err)
 }
 

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -176,10 +176,9 @@ pub fn validate_named_vectors_not_empty(
     value: &Option<NamedVectors>,
 ) -> Result<(), ValidationError> {
     // If length is non-zero, we're good
-    if let Some(vectors) = value {
-        if !vectors.vectors.is_empty() {
-            return Ok(());
-        }
+    match value {
+        Some(vectors) if !vectors.vectors.is_empty() => return Ok(()),
+        Some(_) | None => {}
     }
 
     let mut err = ValidationError::new("length");

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -54,6 +54,9 @@ impl CollectionUpdater {
             CollectionUpdateOperations::PointOperation(point_operation) => {
                 process_point_operation(segments, op_num, point_operation)
             }
+            CollectionUpdateOperations::VectorOperation(vector_operation) => {
+                process_vector_operation(segments, op_num, vector_operation)
+            }
             CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                 process_payload_operation(segments, op_num, payload_operation)
             }

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -314,6 +314,20 @@ impl SegmentEntry for ProxySegment {
         Ok(was_deleted || was_deleted_in_writable)
     }
 
+    fn update_vector(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vector_name: &str,
+        vector_data: &[VectorElementType],
+    ) -> OperationResult<bool> {
+        self.move_if_exists(op_num, point_id)?;
+        self.write_segment
+            .get()
+            .write()
+            .update_vector(op_num, point_id, vector_name, vector_data)
+    }
+
     fn delete_vector(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -314,18 +314,17 @@ impl SegmentEntry for ProxySegment {
         Ok(was_deleted || was_deleted_in_writable)
     }
 
-    fn update_vector(
+    fn update_vectors(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &str,
-        vector_data: &[VectorElementType],
+        vectors: NamedVectors,
     ) -> OperationResult<bool> {
         self.move_if_exists(op_num, point_id)?;
         self.write_segment
             .get()
             .write()
-            .update_vector(op_num, point_id, vector_name, vector_data)
+            .update_vectors(op_num, point_id, vectors)
     }
 
     fn delete_vector(

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -1,3 +1,5 @@
+//! A collection of functions for updating points and payloads stored in segments
+
 use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
@@ -13,9 +15,8 @@ use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
 use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::vector_ops::UpdateVectors;
 use crate::operations::FieldIndexOperations;
-
-/// A collection of functions for updating points and payloads stored in segments
 
 pub(crate) fn check_unprocessed_points(
     points: &[PointIdType],
@@ -49,6 +50,51 @@ pub(crate) fn delete_points(
             write_segment.delete_point(op_num, id)
         })
         .map_err(Into::into)
+}
+
+/// Update the specified named vectors of a point, keeping unspecified vectors intact.
+pub(crate) fn update_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    point: UpdateVectors,
+) -> CollectionResult<usize> {
+    let ids = [point.id];
+    let updated_points =
+        segments.apply_points_to_appendable(op_num, &ids, |id, write_segment| {
+            let vectors = point.vector.clone().into_all_vectors();
+            write_segment.update_vectors(op_num, id, vectors)
+        })?;
+    check_unprocessed_points(&ids, &updated_points)?;
+    Ok(updated_points.len())
+}
+
+/// Delete the given named vectors for the given points, keeping other vectors intact.
+pub(crate) fn delete_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: &[PointIdType],
+    vector_names: &[String],
+) -> CollectionResult<usize> {
+    segments
+        .apply_points(points, |id, _idx, write_segment| {
+            let mut res = true;
+            for name in vector_names {
+                res &= write_segment.delete_vector(op_num, id, name)?;
+            }
+            Ok(res)
+        })
+        .map_err(Into::into)
+}
+
+/// Delete the given named vectors for points matching the given filter, keeping otehr vectors intact.
+pub(crate) fn delete_vectors_by_filter(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    filter: &Filter,
+    vector_names: &[String],
+) -> CollectionResult<usize> {
+    let affected_points = points_by_filter(segments, filter)?;
+    delete_vectors(segments, op_num, &affected_points, vector_names)
 }
 
 pub(crate) fn overwrite_payload(

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -15,7 +15,7 @@ use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
 use crate::operations::types::{CollectionError, CollectionResult};
-use crate::operations::vector_ops::UpdateVectors;
+use crate::operations::vector_ops::{UpdateVectors, VectorOperations};
 use crate::operations::FieldIndexOperations;
 
 pub(crate) fn check_unprocessed_points(
@@ -445,6 +445,24 @@ pub(crate) fn process_point_operation(
                 &operation.points,
             )?;
             Ok(deleted + new + updated)
+        }
+    }
+}
+
+pub(crate) fn process_vector_operation(
+    segments: &RwLock<SegmentHolder>,
+    op_num: SeqNumberType,
+    vector_operation: VectorOperations,
+) -> CollectionResult<usize> {
+    match vector_operation {
+        VectorOperations::UpdateVectors(operation) => {
+            update_vectors(&segments.read(), op_num, operation)
+        }
+        VectorOperations::DeleteVectors(ids, vector_names) => {
+            delete_vectors(&segments.read(), op_num, &ids.points, &vector_names)
+        }
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
+            delete_vectors_by_filter(&segments.read(), op_num, &filter, &vector_names)
         }
     }
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -41,6 +41,7 @@ pub enum FieldIndexOperations {
 #[serde(untagged)]
 pub enum CollectionUpdateOperations {
     PointOperation(point_ops::PointOperations),
+    VectorOperation(vector_ops::VectorOperations),
     PayloadOperation(payload_ops::PayloadOps),
     FieldIndexOperation(FieldIndexOperations),
 }
@@ -100,6 +101,7 @@ impl Validate for CollectionUpdateOperations {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             CollectionUpdateOperations::PointOperation(operation) => operation.validate(),
+            CollectionUpdateOperations::VectorOperation(operation) => operation.validate(),
             CollectionUpdateOperations::PayloadOperation(operation) => operation.validate(),
             CollectionUpdateOperations::FieldIndexOperation(operation) => operation.validate(),
         }
@@ -146,6 +148,9 @@ impl SplitByShard for CollectionUpdateOperations {
             CollectionUpdateOperations::PointOperation(operation) => operation
                 .split_by_shard(ring)
                 .map(CollectionUpdateOperations::PointOperation),
+            CollectionUpdateOperations::VectorOperation(operation) => operation
+                .split_by_shard(ring)
+                .map(CollectionUpdateOperations::VectorOperation),
             CollectionUpdateOperations::PayloadOperation(operation) => operation
                 .split_by_shard(ring)
                 .map(CollectionUpdateOperations::PayloadOperation),
@@ -160,6 +165,9 @@ impl CollectionUpdateOperations {
     pub fn is_write_operation(&self) -> bool {
         match self {
             CollectionUpdateOperations::PointOperation(operation) => operation.is_write_operation(),
+            CollectionUpdateOperations::VectorOperation(operation) => {
+                operation.is_write_operation()
+            }
             CollectionUpdateOperations::PayloadOperation(operation) => {
                 operation.is_write_operation()
             }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -9,6 +9,7 @@ pub mod shared_storage_config;
 pub mod snapshot_ops;
 pub mod types;
 pub mod validation;
+pub mod vector_ops;
 
 use std::collections::HashMap;
 

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -1,9 +1,8 @@
 use segment::types::{Filter, PointIdType};
 
+use super::vector_ops;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::{point_ops, CollectionUpdateOperations};
-
-use super::vector_ops;
 
 /// Structure to define what part of the shard are affected by the operation
 pub enum OperationEffectArea {

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -69,7 +69,8 @@ impl EstimateOperationEffectArea for vector_ops::VectorOperations {
     fn estimate_effect_area(&self) -> OperationEffectArea {
         match self {
             vector_ops::VectorOperations::UpdateVectors(update_operation) => {
-                OperationEffectArea::Points(vec![update_operation.id])
+                let ids = update_operation.points.iter().map(|p| p.id).collect();
+                OperationEffectArea::Points(ids)
             }
             vector_ops::VectorOperations::DeleteVectors(ids, _) => {
                 OperationEffectArea::Points(ids.points.clone())

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -101,6 +101,12 @@ pub struct PointIdsList {
     pub points: Vec<PointIdType>,
 }
 
+impl From<Vec<PointIdType>> for PointIdsList {
+    fn from(points: Vec<PointIdType>) -> Self {
+        Self { points }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct FilterSelector {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -95,7 +95,7 @@ impl Batch {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct PointIdsList {
     pub points: Vec<PointIdType>,

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -1,0 +1,30 @@
+use std::collections::HashSet;
+
+use schemars::JsonSchema;
+use segment::data_types::vectors::VectorStruct;
+use segment::types::PointIdType;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+use super::point_ops::PointsSelector;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+pub struct UpdateVectors {
+    /// Point id
+    pub id: PointIdType,
+    /// Vectors
+    #[serde(alias = "vectors")]
+    pub vector: VectorStruct,
+}
+
+type VectorNameList = HashSet<String>;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct DeleteVectors {
+    /// Point selector
+    pub point_selector: PointsSelector,
+    /// Vectors
+    // TODO: validate cannot be empty?
+    #[serde(alias = "vectors")]
+    pub vector: VectorNameList,
+}

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -2,11 +2,14 @@ use std::collections::HashSet;
 
 use schemars::JsonSchema;
 use segment::data_types::vectors::VectorStruct;
-use segment::types::PointIdType;
+use segment::types::{Filter, PointIdType};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-use super::point_ops::PointsSelector;
+use super::point_ops::{PointIdsList, PointsSelector};
+use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
+use crate::hash_ring::HashRing;
+use crate::shards::shard::ShardId;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 pub struct UpdateVectors {
@@ -17,14 +20,66 @@ pub struct UpdateVectors {
     pub vector: VectorStruct,
 }
 
-type VectorNameList = HashSet<String>;
-
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct DeleteVectors {
     /// Point selector
     pub point_selector: PointsSelector,
     /// Vectors
-    // TODO: validate cannot be empty?
     #[serde(alias = "vectors")]
-    pub vector: VectorNameList,
+    #[validate(length(min = 1))]
+    pub vector: HashSet<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum VectorOperations {
+    /// Update vectors
+    UpdateVectors(UpdateVectors),
+    /// Delete vectors if exists
+    DeleteVectors(PointIdsList, Vec<String>),
+    /// Delete vectors by given filter criteria
+    DeleteVectorsByFilter(Filter, Vec<String>),
+}
+
+impl VectorOperations {
+    pub fn is_write_operation(&self) -> bool {
+        match self {
+            VectorOperations::UpdateVectors(_) => true,
+            VectorOperations::DeleteVectors(..) => false,
+            VectorOperations::DeleteVectorsByFilter(..) => false,
+        }
+    }
+}
+
+impl Validate for VectorOperations {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            VectorOperations::UpdateVectors(update_vectors) => update_vectors.validate(),
+            VectorOperations::DeleteVectors(..) => Ok(()),
+            VectorOperations::DeleteVectorsByFilter(..) => Ok(()),
+        }
+    }
+}
+
+impl SplitByShard for VectorOperations {
+    fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
+        match self {
+            VectorOperations::UpdateVectors(update_vectors) => {
+                let shard_id = point_to_shard(update_vectors.id, ring);
+                OperationToShard::by_shard([(
+                    shard_id,
+                    VectorOperations::UpdateVectors(update_vectors),
+                )])
+            }
+            VectorOperations::DeleteVectors(ids, vector_names) => {
+                split_iter_by_shard(ids.points, |id| *id, ring).map(|ids| {
+                    let points_ids_list = PointIdsList { points: ids };
+                    VectorOperations::DeleteVectors(points_ids_list, vector_names.clone())
+                })
+            }
+            by_filter @ VectorOperations::DeleteVectorsByFilter(..) => {
+                OperationToShard::to_all(by_filter)
+            }
+        }
+    }
 }

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -77,10 +77,8 @@ impl SplitByShard for VectorOperations {
                 )])
             }
             VectorOperations::DeleteVectors(ids, vector_names) => {
-                split_iter_by_shard(ids.points, |id| *id, ring).map(|ids| {
-                    let points_ids_list = PointIdsList { points: ids };
-                    VectorOperations::DeleteVectors(points_ids_list, vector_names.clone())
-                })
+                split_iter_by_shard(ids.points, |id| *id, ring)
+                    .map(|ids| VectorOperations::DeleteVectors(ids.into(), vector_names.clone()))
             }
             by_filter @ VectorOperations::DeleteVectorsByFilter(..) => {
                 OperationToShard::to_all(by_filter)

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -4,8 +4,10 @@ use api::grpc::qdrant::{
     ClearPayloadPoints, ClearPayloadPointsInternal, CreateFieldIndexCollection,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollection,
     DeleteFieldIndexCollectionInternal, DeletePayloadPoints, DeletePayloadPointsInternal,
-    DeletePoints, DeletePointsInternal, PointsIdsList, PointsSelector, SetPayloadPoints,
-    SetPayloadPointsInternal, SyncPoints, SyncPointsInternal, UpsertPoints, UpsertPointsInternal,
+    DeletePointVectors, DeletePoints, DeletePointsInternal, DeleteVectorsInternal, NamedVectors,
+    PointsIdsList, PointsSelector, SetPayloadPoints, SetPayloadPointsInternal, SyncPoints,
+    SyncPointsInternal, UpdatePointVectors, UpdateVectorsInternal, UpsertPoints,
+    UpsertPointsInternal,
 };
 use segment::types::{Filter, PayloadFieldSchema, PayloadSchemaParams, PointIdType, ScoredPoint};
 use tonic::Status;
@@ -14,6 +16,7 @@ use crate::operations::conversions::write_ordering_to_proto;
 use crate::operations::payload_ops::{DeletePayload, SetPayload};
 use crate::operations::point_ops::{PointInsertOperations, PointSyncOperation, WriteOrdering};
 use crate::operations::types::CollectionResult;
+use crate::operations::vector_ops::UpdateVectors;
 use crate::operations::CreateIndex;
 use crate::shards::shard::ShardId;
 
@@ -102,6 +105,78 @@ pub fn internal_delete_points_by_filter(
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
+            ordering: ordering.map(write_ordering_to_proto),
+        }),
+    }
+}
+
+pub fn internal_update_vectors(
+    shard_id: Option<ShardId>,
+    collection_name: String,
+    update_vectors: UpdateVectors,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> UpdateVectorsInternal {
+    UpdateVectorsInternal {
+        shard_id,
+        update_vectors: Some(UpdatePointVectors {
+            collection_name,
+            wait: Some(wait),
+            id: Some(update_vectors.id.into()),
+            vectors: Some(NamedVectors {
+                vectors: update_vectors
+                    .vector
+                    .into_all_vectors()
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_vec().into()))
+                    .collect(),
+            }),
+            ordering: ordering.map(write_ordering_to_proto),
+        }),
+    }
+}
+
+pub fn internal_delete_vectors(
+    shard_id: Option<ShardId>,
+    collection_name: String,
+    ids: Vec<PointIdType>,
+    vector_names: Vec<String>,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeleteVectorsInternal {
+    DeleteVectorsInternal {
+        shard_id,
+        delete_vectors: Some(DeletePointVectors {
+            collection_name,
+            wait: Some(wait),
+            points_selector: Some(PointsSelector {
+                points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
+                    ids: ids.into_iter().map(|id| id.into()).collect(),
+                })),
+            }),
+            vector_names,
+            ordering: ordering.map(write_ordering_to_proto),
+        }),
+    }
+}
+
+pub fn internal_delete_vectors_by_filter(
+    shard_id: Option<ShardId>,
+    collection_name: String,
+    filter: Filter,
+    vector_names: Vec<String>,
+    wait: bool,
+    ordering: Option<WriteOrdering>,
+) -> DeleteVectorsInternal {
+    DeleteVectorsInternal {
+        shard_id,
+        delete_vectors: Some(DeletePointVectors {
+            collection_name,
+            wait: Some(wait),
+            points_selector: Some(PointsSelector {
+                points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
+            }),
+            vector_names,
             ordering: ordering.map(write_ordering_to_proto),
         }),
     }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -7,7 +7,7 @@ use api::grpc::qdrant::{
     DeletePointVectors, DeletePoints, DeletePointsInternal, DeleteVectorsInternal, NamedVectors,
     PointsIdsList, PointsSelector, SetPayloadPoints, SetPayloadPointsInternal, SyncPoints,
     SyncPointsInternal, UpdatePointVectors, UpdateVectorsInternal, UpsertPoints,
-    UpsertPointsInternal,
+    UpsertPointsInternal, VectorsSelector,
 };
 use segment::types::{Filter, PayloadFieldSchema, PayloadSchemaParams, PointIdType, ScoredPoint};
 use tonic::Status;
@@ -154,7 +154,9 @@ pub fn internal_delete_vectors(
                     ids: ids.into_iter().map(|id| id.into()).collect(),
                 })),
             }),
-            vector_names,
+            vectors: Some(VectorsSelector {
+                names: vector_names,
+            }),
             ordering: ordering.map(write_ordering_to_proto),
         }),
     }
@@ -176,7 +178,9 @@ pub fn internal_delete_vectors_by_filter(
             points_selector: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
-            vector_names,
+            vectors: Some(VectorsSelector {
+                names: vector_names,
+            }),
             ordering: ordering.map(write_ordering_to_proto),
         }),
     }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -5,8 +5,8 @@ use api::grpc::qdrant::{
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollection,
     DeleteFieldIndexCollectionInternal, DeletePayloadPoints, DeletePayloadPointsInternal,
     DeletePointVectors, DeletePoints, DeletePointsInternal, DeleteVectorsInternal, NamedVectors,
-    PointsIdsList, PointsSelector, SetPayloadPoints, SetPayloadPointsInternal, SyncPoints,
-    SyncPointsInternal, UpdatePointVectors, UpdateVectorsInternal, UpsertPoints,
+    PointVectors, PointsIdsList, PointsSelector, SetPayloadPoints, SetPayloadPointsInternal,
+    SyncPoints, SyncPointsInternal, UpdatePointVectors, UpdateVectorsInternal, UpsertPoints,
     UpsertPointsInternal, VectorsSelector,
 };
 use segment::types::{Filter, PayloadFieldSchema, PayloadSchemaParams, PointIdType, ScoredPoint};
@@ -122,15 +122,21 @@ pub fn internal_update_vectors(
         update_vectors: Some(UpdatePointVectors {
             collection_name,
             wait: Some(wait),
-            id: Some(update_vectors.id.into()),
-            vectors: Some(NamedVectors {
-                vectors: update_vectors
-                    .vector
-                    .into_all_vectors()
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_vec().into()))
-                    .collect(),
-            }),
+            points: update_vectors
+                .points
+                .into_iter()
+                .map(|point| PointVectors {
+                    id: Some(point.id.into()),
+                    vectors: Some(NamedVectors {
+                        vectors: point
+                            .vector
+                            .into_all_vectors()
+                            .iter()
+                            .map(|(k, v)| (k.to_string(), v.to_vec().into()))
+                            .collect(),
+                    }),
+                })
+                .collect(),
             ordering: ordering.map(write_ordering_to_proto),
         }),
     }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -21,6 +21,9 @@ use tokio::runtime::Handle;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
+use super::conversions::{
+    internal_delete_vectors, internal_delete_vectors_by_filter, internal_update_vectors,
+};
 use crate::operations::conversions::try_record_from_grpc;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{PointOperations, WriteOrdering};
@@ -41,8 +44,6 @@ use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::RemoteShardTelemetry;
 use crate::shards::CollectionId;
-
-use super::conversions::{internal_update_vectors, internal_delete_vectors, internal_delete_vectors_by_filter};
 
 /// RemoteShard
 ///
@@ -234,7 +235,9 @@ impl RemoteShard {
                         ordering,
                     );
                     self.with_points_client(|mut client| async move {
-                        client.update_vectors(tonic::Request::new(request.clone())).await
+                        client
+                            .update_vectors(tonic::Request::new(request.clone()))
+                            .await
                     })
                     .await?
                     .into_inner()
@@ -246,10 +249,12 @@ impl RemoteShard {
                         ids.points,
                         vector_names.clone(),
                         wait,
-                        ordering
+                        ordering,
                     );
                     self.with_points_client(|mut client| async move {
-                        client.delete_vectors(tonic::Request::new(request.clone())).await
+                        client
+                            .delete_vectors(tonic::Request::new(request.clone()))
+                            .await
                     })
                     .await?
                     .into_inner()
@@ -264,7 +269,9 @@ impl RemoteShard {
                         ordering,
                     );
                     self.with_points_client(|mut client| async move {
-                        client.delete_vectors(tonic::Request::new(request.clone())).await
+                        client
+                            .delete_vectors(tonic::Request::new(request.clone()))
+                            .await
                     })
                     .await?
                     .into_inner()

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -219,12 +219,11 @@ pub trait SegmentEntry {
         point_id: PointIdType,
     ) -> OperationResult<bool>;
 
-    fn update_vector(
+    fn update_vectors(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &str,
-        vector_data: &[VectorElementType],
+        vectors: NamedVectors,
     ) -> OperationResult<bool>;
 
     fn delete_vector(

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -219,6 +219,14 @@ pub trait SegmentEntry {
         point_id: PointIdType,
     ) -> OperationResult<bool>;
 
+    fn update_vector(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vector_name: &str,
+        vector_data: &[VectorElementType],
+    ) -> OperationResult<bool>;
+
     fn delete_vector(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -814,8 +814,9 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
-            // Point does already not exist anymore
-            None => Ok(false),
+            None => Err(OperationError::PointIdError {
+                missed_point_id: point_id,
+            }),
             Some(internal_id) => {
                 self.handle_version_and_failure(op_num, Some(internal_id), |segment| {
                     segment.update_vectors(internal_id, vectors)?;
@@ -833,8 +834,9 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
-            // Point does already not exist anymore
-            None => Ok(false),
+            None => Err(OperationError::PointIdError {
+                missed_point_id: point_id,
+            }),
             Some(internal_id) => {
                 self.handle_version_and_failure(op_num, Some(internal_id), |segment| {
                     let vector_data = segment.vector_data.get(vector_name).ok_or(

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -87,9 +87,20 @@ pub struct VectorData {
 }
 
 impl Segment {
-    /// Change vector in-place.
-    /// WARN: Available for appendable segments only
-    fn update_vectors(
+    /// Replace vectors in-place
+    ///
+    /// This replaces all named vectors for this point with the given set of named vectors.
+    ///
+    /// - new named vectors are inserted
+    /// - existing named vectors are replaced
+    /// - existing named vectors not specified are deleted
+    ///
+    /// This differs with [`update_vectors`], because this deletes unspecified vectors.
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    fn replace_all_vectors(
         &mut self,
         internal_id: PointOffsetType,
         vectors: NamedVectors,
@@ -109,6 +120,35 @@ impl Segment {
                     vector_storage.delete_vector(internal_id)?;
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Update vectors in-place
+    ///
+    /// This updates all specified named vectors for this point with the given set of named vectors, leaving unspecified vectors untouched.
+    ///
+    /// - new named vectors are inserted
+    /// - existing named vectors are replaced
+    /// - existing named vectors not specified are untouched and kept as-is
+    ///
+    /// This differs with [`replace_all_vectors`], because this keeps unspecified vectors as-is.
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    fn update_vectors(
+        &mut self,
+        internal_id: PointOffsetType,
+        vectors: NamedVectors,
+    ) -> OperationResult<()> {
+        debug_assert!(self.is_appendable());
+        check_vectors_set(&vectors, &self.segment_config)?;
+        for (vector_name, new_vector) in vectors {
+            self.vector_data[vector_name.as_ref()]
+                .vector_storage
+                .borrow_mut()
+                .insert_vector(internal_id, new_vector.as_ref())?;
         }
         Ok(())
     }
@@ -730,7 +770,7 @@ impl SegmentEntry for Segment {
             }
 
             if let Some(existing_internal_id) = stored_internal_point {
-                segment.update_vectors(existing_internal_id, processed_vectors)?;
+                segment.replace_all_vectors(existing_internal_id, processed_vectors)?;
                 Ok((true, Some(existing_internal_id)))
             } else {
                 let new_index = segment.insert_new_vectors(point_id, processed_vectors)?;
@@ -772,22 +812,13 @@ impl SegmentEntry for Segment {
         point_id: PointIdType,
         vectors: NamedVectors,
     ) -> OperationResult<bool> {
-        // Ensure we can append, and that the given named vectors exist before we do anything
-        debug_assert!(self.is_appendable());
-        check_vectors_set(&vectors, &self.segment_config)?;
-
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
             // Point does already not exist anymore
             None => Ok(false),
             Some(internal_id) => {
                 self.handle_version_and_failure(op_num, Some(internal_id), |segment| {
-                    for (vector_name, new_vector) in vectors {
-                        segment.vector_data[vector_name.as_ref()]
-                            .vector_storage
-                            .borrow_mut()
-                            .insert_vector(internal_id, new_vector.as_ref())?;
-                    }
+                    segment.update_vectors(internal_id, vectors)?;
                     Ok((true, Some(internal_id)))
                 })
             }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -766,12 +766,11 @@ impl SegmentEntry for Segment {
         }
     }
 
-    fn update_vector(
+    fn update_vectors(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &str,
-        vector: &[VectorElementType],
+        vectors: NamedVectors,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
@@ -779,13 +778,7 @@ impl SegmentEntry for Segment {
             None => Ok(false),
             Some(internal_id) => {
                 self.handle_version_and_failure(op_num, Some(internal_id), |segment| {
-                    let vector_data = segment.vector_data.get(vector_name).ok_or(
-                        OperationError::VectorNameNotExists {
-                            received_name: vector_name.to_string(),
-                        },
-                    )?;
-                    let mut vector_storage = vector_data.vector_storage.borrow_mut();
-                    vector_storage.insert_vector(internal_id, vector)?;
+                    segment.update_vectors(internal_id, vectors)?;
                     Ok((true, Some(internal_id)))
                 })
             }

--- a/lib/segment/tests/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/disbalanced_vectors_test.rs
@@ -57,11 +57,6 @@ mod tests {
         }
 
         for i in 0..NUM_VECTORS_2 {
-            if i % 2 == 0 {
-                segment2
-                    .delete_point(2, (NUM_VECTORS_1 + i).into())
-                    .unwrap();
-            }
             if i % 3 == 0 {
                 segment2
                     .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector1")
@@ -73,6 +68,11 @@ mod tests {
             if i % 3 == 1 {
                 segment2
                     .delete_vector(2, (NUM_VECTORS_1 + i).into(), "vector2")
+                    .unwrap();
+            }
+            if i % 2 == 0 {
+                segment2
+                    .delete_point(2, (NUM_VECTORS_1 + i).into())
                     .unwrap();
             }
         }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 use api::grpc::qdrant::points_server::Points;
 use api::grpc::qdrant::{
     ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
-    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, GetPoints, GetResponse,
-    PointsOperationResponse, RecommendBatchPoints, RecommendBatchResponse, RecommendPoints,
-    RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse,
-    SearchPoints, SearchResponse, SetPayloadPoints, UpsertPoints,
+    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePointVectors, DeletePoints, GetPoints,
+    GetResponse, PointsOperationResponse, RecommendBatchPoints, RecommendBatchResponse,
+    RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchPoints,
+    SearchBatchResponse, SearchPoints, SearchResponse, SetPayloadPoints, UpdatePointVectors,
+    UpsertPoints,
 };
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
+use super::points_common::{delete_vectors, update_vectors};
 use super::validate;
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index, delete, delete_field_index, delete_payload, get,
@@ -49,6 +51,22 @@ impl Points for PointsService {
     async fn get(&self, request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
         validate(request.get_ref())?;
         get(self.toc.as_ref(), request.into_inner(), None).await
+    }
+
+    async fn update_vectors(
+        &self,
+        request: Request<UpdatePointVectors>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
+        update_vectors(self.toc.as_ref(), request.into_inner(), None).await
+    }
+
+    async fn delete_vectors(
+        &self,
+        request: Request<DeletePointVectors>,
+    ) -> Result<Response<PointsOperationResponse>, Status> {
+        validate(request.get_ref())?;
+        delete_vectors(self.toc.as_ref(), request.into_inner(), None).await
     }
 
     async fn set_payload(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -4,11 +4,11 @@ use api::grpc::conversions::proto_to_payloads;
 use api::grpc::qdrant::payload_index_params::IndexParams;
 use api::grpc::qdrant::{
     BatchResult, ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
-    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints, FieldType, GetPoints,
-    GetResponse, PayloadIndexParams, PointsOperationResponse,
+    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePointVectors, DeletePoints, FieldType,
+    GetPoints, GetResponse, PayloadIndexParams, PointsOperationResponse,
     ReadConsistency as ReadConsistencyGrpc, RecommendBatchResponse, RecommendPoints,
     RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchResponse, SearchPoints,
-    SearchResponse, SetPayloadPoints, SyncPoints, UpsertPoints,
+    SearchResponse, SetPayloadPoints, SyncPoints, UpdatePointVectors, UpsertPoints,
 };
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::conversions::write_ordering_from_proto;
@@ -20,8 +20,10 @@ use collection::operations::types::{
     default_exact_count, PointRequest, RecommendRequestBatch, ScrollRequest, SearchRequest,
     SearchRequestBatch,
 };
+use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use collection::operations::CollectionUpdateOperations;
 use collection::shards::shard::ShardId;
+use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::NamedVector;
 use segment::types::{PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType};
 use storage::content_manager::conversions::error_to_status;
@@ -30,8 +32,9 @@ use tonic::{Response, Status};
 
 use crate::common::points::{
     do_clear_payload, do_count_points, do_create_index, do_delete_index, do_delete_payload,
-    do_delete_points, do_get_points, do_overwrite_payload, do_scroll_points,
-    do_search_batch_points, do_search_points, do_set_payload, do_upsert_points, CreateFieldIndex,
+    do_delete_points, do_delete_vectors, do_get_points, do_overwrite_payload, do_scroll_points,
+    do_search_batch_points, do_search_points, do_set_payload, do_update_vectors, do_upsert_points,
+    CreateFieldIndex,
 };
 
 pub fn points_operation_response(
@@ -141,6 +144,95 @@ pub async fn delete(
         toc,
         &collection_name,
         points_selector,
+        shard_selection,
+        wait.unwrap_or(false),
+        write_ordering_from_proto(ordering)?,
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn update_vectors(
+    toc: &TableOfContent,
+    update_point_vectors: UpdatePointVectors,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let UpdatePointVectors {
+        collection_name,
+        wait,
+        id,
+        vectors,
+        ordering,
+    } = update_point_vectors;
+
+    let id = match id {
+        Some(id) => id.try_into()?,
+        None => return Err(Status::invalid_argument("id is expected")),
+    };
+    let vector = match vectors {
+        Some(vectors) => {
+            let vectors = vectors
+                .vectors
+                .into_iter()
+                .map(|(k, v)| (k, v.data))
+                .collect();
+            NamedVectors::from_map(vectors)
+        }
+        None => return Err(Status::invalid_argument("vectors is expected")),
+    };
+
+    let operation = UpdateVectors {
+        id,
+        vector: vector.into(),
+    };
+
+    let timing = Instant::now();
+    let result = do_update_vectors(
+        toc,
+        &collection_name,
+        operation,
+        shard_selection,
+        wait.unwrap_or(false),
+        write_ordering_from_proto(ordering)?,
+    )
+    .await
+    .map_err(error_to_status)?;
+
+    let response = points_operation_response(timing, result);
+    Ok(Response::new(response))
+}
+
+pub async fn delete_vectors(
+    toc: &TableOfContent,
+    delete_point_vectors: DeletePointVectors,
+    shard_selection: Option<ShardId>,
+) -> Result<Response<PointsOperationResponse>, Status> {
+    let DeletePointVectors {
+        collection_name,
+        wait,
+        points_selector,
+        vector_names,
+        ordering,
+    } = delete_point_vectors;
+
+    let point_selector = match points_selector {
+        Some(points_selector) => points_selector.try_into()?,
+        None => return Err(Status::invalid_argument("points_selector is expected")),
+    };
+
+    let operation = DeleteVectors {
+        point_selector,
+        vector: vector_names.into_iter().collect(),
+    };
+
+    let timing = Instant::now();
+    let result = do_delete_vectors(
+        toc,
+        &collection_name,
+        operation,
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -214,13 +214,17 @@ pub async fn delete_vectors(
         collection_name,
         wait,
         points_selector,
-        vector_names,
+        vectors,
         ordering,
     } = delete_point_vectors;
 
     let point_selector = match points_selector {
         Some(points_selector) => points_selector.try_into()?,
         None => return Err(Status::invalid_argument("points_selector is expected")),
+    };
+    let vector_names = match vectors {
+        Some(vectors) => vectors.names,
+        None => return Err(Status::invalid_argument("vectors is expected")),
     };
 
     let operation = DeleteVectors {


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/1835>. Continuation of <https://github.com/qdrant/qdrant/pull/1758>. Part of <https://github.com/qdrant/qdrant/issues/1045>.

This PR adds a public and internal gRPC interface for updating and deleting optional named vectors.

Sorry for the PR size. There's a lot of layers to go through from the public interface to the internal functions. That makes it hard to shrink it further. Though big, the PR is quite simple. I'd be happy to walk through this in a call.

The basic interface consists of two actions:

https://github.com/qdrant/qdrant/blob/e0649929fc05410756fb2fdf3c851c608f4b1096/lib/api/src/grpc/proto/points.proto#L74-L88

I'd like to ask to take a look at the following with extra care:
- the public API design ([rendered](https://github.com/qdrant/qdrant/blob/e0649929fc05410756fb2fdf3c851c608f4b1096/docs/grpc/docs.md)) (discussed in a call before)
- the functions mutating segments to update/delete vectors

These features will be added in a separate PR to not grow this any bigger:
  - REST interface (<https://github.com/qdrant/qdrant/pull/1836>)
  - Integration tests

I did some basic testing for this against the gRPC interface locally.

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/1835
- [x] Rebase on `dev`
- [x] Undraft PR

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?