### PR TITLE
Disable indexing and memmap with `0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /benches/search-points/target
 /.idea
+/.vscode
 /storage
 /snapshots
 /consensus_test_logs

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,12 +68,15 @@ storage:
     # Segments larger than this threshold will be stored as read-only memmaped file.
     # To enable memmap storage, lower the threshold
     # Note: 1Kb = 1 vector of size 256
-    # If not set, mmap will not be used.
+    # To explicitly disable mmap optimization, set to `0`.
+    # If not set, will be disabled by default.
     memmap_threshold_kb: null
 
     # Maximum size (in KiloBytes) of vectors allowed for plain index.
     # Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
     # Note: 1Kb = 1 vector of size 256
+    # To explicitly disable vector indexing, set to `0`.
+    # If not set, the default value will be used.
     indexing_threshold_kb: 20000
 
     # Interval between forced flushes.

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -637,8 +637,18 @@ It is recommended to select the default number of segments as a factor of the nu
 | max_segment_size | [uint64](#uint64) | optional | Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.
 
 If indexation speed has more priority for you - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 |
-| memmap_threshold | [uint64](#uint64) | optional | Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as a read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256 |
-| indexing_threshold | [uint64](#uint64) | optional | Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md Note: 1Kb = 1 vector of size 256 |
+| memmap_threshold | [uint64](#uint64) | optional | Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.
+
+To enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+
+Note: 1Kb = 1 vector of size 256 |
+| indexing_threshold | [uint64](#uint64) | optional | Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on &lt;https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md&gt;.
+
+Recommendend minimum value is `1000`.
+
+When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+
+Note: 1kB = 1 vector of size 256. |
 | flush_interval_sec | [uint64](#uint64) | optional | Interval between forced flushes. |
 | max_optimization_threads | [uint64](#uint64) | optional | Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used |
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -634,19 +634,21 @@
 - Amount of stored points. - Current write RPS.
 
 It is recommended to select the default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads. |
-| max_segment_size | [uint64](#uint64) | optional | Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.
+| max_segment_size | [uint64](#uint64) | optional | Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.
 
-If indexation speed has more priority for you - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 |
+If indexing speed is more important - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs. |
 | memmap_threshold | [uint64](#uint64) | optional | Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.
 
-To enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+
+To disable memmap storage, set this to `0`.
 
 Note: 1Kb = 1 vector of size 256 |
-| indexing_threshold | [uint64](#uint64) | optional | Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on &lt;https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md&gt;.
+| indexing_threshold | [uint64](#uint64) | optional | Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
 
-Recommendend minimum value is `1000`.
+Default value is 20,000, based on &lt;https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md&gt;.
 
-When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+To disable vector indexing, set to `0`.
 
 Note: 1kB = 1 vector of size 256. |
 | flush_interval_sec | [uint64](#uint64) | optional | Interval between forced flushes. |

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4040,7 +4040,7 @@
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nTo enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.\n\nNote: 1Kb = 1 vector of size 256 If not set, mmap will not be used.",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -4048,7 +4048,7 @@
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nRecommendend minimum value is `1000`.\n\nWhen set to `0`, plain index will be disabled. It will be treated as the largest value possible.\n\nNote: 1kB = 1 vector of size 256. If not set, the default 20,000 will be used.",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`. Internally it will use the largest threshold possible.\n\nNote: 1kB = 1 vector of size 256.",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -5328,14 +5328,14 @@
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nTo enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.\n\nNote: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 1000,
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nRecommendend minimum value is `1000`.\n\nWhen set to `0`, plain index will be disabled. It will be treated as the largest value possible.\n\nNote: 1kB = 1 vector of size 256.",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`. Internally it will use the largest threshold possible.\n\nNote: 1kB = 1 vector of size 256.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4048,7 +4048,7 @@
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`. Internally it will use the largest threshold possible.\n\nNote: 1kB = 1 vector of size 256.",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -5328,14 +5328,14 @@
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`.\n\nNote: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`. Internally it will use the largest threshold possible.\n\nNote: 1kB = 1 vector of size 256.",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5331,7 +5331,7 @@
             "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
-            "minimum": 1000,
+            "minimum": 0,
             "nullable": true
           },
           "indexing_threshold": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -3879,7 +3879,7 @@
             "nullable": true
           },
           "full_scan_threshold": {
-            "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
+            "description": "Minimal size (in kilobytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 1000,
@@ -4032,7 +4032,7 @@
             "minimum": 0
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs.",
+            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexing speed is more important - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs.",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -4040,18 +4040,19 @@
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256 If not set, mmap will not be used.",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nTo enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.\n\nNote: 1Kb = 1 vector of size 256 If not set, mmap will not be used.",
             "default": null,
             "type": "integer",
             "format": "uint",
-            "minimum": 1000,
+            "minimum": 0,
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md> Note: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nRecommendend minimum value is `1000`.\n\nWhen set to `0`, plain index will be disabled. It will be treated as the largest value possible.\n\nNote: 1kB = 1 vector of size 256. If not set, the default 20,000 will be used.",
+            "default": null,
             "type": "integer",
             "format": "uint",
-            "minimum": 1000,
+            "minimum": 0,
             "nullable": true
           },
           "flush_interval_sec": {
@@ -5320,24 +5321,24 @@
             "nullable": true
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this size (in KiloBytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
+            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "memmap_threshold": {
-            "description": "Maximum size (in KiloBytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file. To enable memmap storage, lower the threshold Note: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nTo enable memmap storage, lower the threshold. To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.\n\nNote: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 1000,
             "nullable": true
           },
           "indexing_threshold": {
-            "description": "Maximum size (in KiloBytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md> Note: 1Kb = 1 vector of size 256",
+            "description": "Maximum size (in kilobytes) of vectors allowed for plain index. Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nRecommendend minimum value is `1000`.\n\nWhen set to `0`, plain index will be disabled. It will be treated as the largest value possible.\n\nNote: 1kB = 1 vector of size 256.",
             "type": "integer",
             "format": "uint",
-            "minimum": 1000,
+            "minimum": 0,
             "nullable": true
           },
           "flush_interval_sec": {

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -103,8 +103,6 @@ fn configure_validation(builder: Builder) -> Builder {
             ("WalConfigDiff.wal_capacity_mb", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("OptimizersConfigDiff.deleted_threshold", "custom = \"crate::grpc::validate::validate_f64_range_1\""),
             ("OptimizersConfigDiff.vacuum_min_vector_number", "custom = \"crate::grpc::validate::validate_u64_range_min_100\""),
-            ("OptimizersConfigDiff.memmap_threshold", "custom = \"crate::grpc::validate::validate_u64_range_min_1000\""),
-            ("OptimizersConfigDiff.indexing_threshold", "custom = \"crate::grpc::validate::validate_u64_range_min_1000\""),
             ("VectorsConfig.config", ""),
             ("VectorParams.size", "range(min = 1)"),
             ("VectorParams.hnsw_config", ""),

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -129,26 +129,35 @@ message OptimizersConfigDiff {
   */
   optional uint64 default_segment_number = 3;
   /*
-  Do not create segments larger this size (in KiloBytes).
+  Do not create segments larger this size (in kilobytes).
   Large segments might require disproportionately long indexation times,
   therefore it makes sense to limit the size of segments.
-
-  If indexation speed has more priority for you - make this parameter lower.
+    
+  If indexing speed is more important - make this parameter lower.
   If search speed is more important - make this parameter higher.
   Note: 1Kb = 1 vector of size 256
+  If not set, will be automatically selected considering the number of available CPUs.
   */
   optional uint64 max_segment_size = 4;
   /*
-  Maximum size (in KiloBytes) of vectors to store in-memory per segment.
-  Segments larger than this threshold will be stored as a read-only memmaped file.
-  To enable memmap storage, lower the threshold
+  Maximum size (in kilobytes) of vectors to store in-memory per segment.
+  Segments larger than this threshold will be stored as read-only memmaped file.
+
+  To enable memmap storage, lower the threshold.
+  To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+
   Note: 1Kb = 1 vector of size 256
   */
   optional uint64 memmap_threshold = 5;
   /*
-  Maximum size (in KiloBytes) of vectors allowed for plain index.
-  Default value based on https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md
-  Note: 1Kb = 1 vector of size 256
+  Maximum size (in kilobytes) of vectors allowed for plain index.
+  Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+  
+  Recommendend minimum value is `1000`.
+  
+  When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+  
+  Note: 1kB = 1 vector of size 256.
   */
   optional uint64 indexing_threshold = 6;
   /*

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -145,7 +145,7 @@ message OptimizersConfigDiff {
 
   Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
 
-  To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
+  To disable memmap storage, set this to `0`.
 
   Note: 1Kb = 1 vector of size 256
   */
@@ -155,7 +155,7 @@ message OptimizersConfigDiff {
   
   Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
   
-  To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
+  To disable vector indexing, set to `0`.
   
   Note: 1kB = 1 vector of size 256.
   */

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -143,19 +143,19 @@ message OptimizersConfigDiff {
   Maximum size (in kilobytes) of vectors to store in-memory per segment.
   Segments larger than this threshold will be stored as read-only memmaped file.
 
-  To enable memmap storage, lower the threshold.
-  To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+  Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+
+  To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
 
   Note: 1Kb = 1 vector of size 256
   */
   optional uint64 memmap_threshold = 5;
   /*
-  Maximum size (in kilobytes) of vectors allowed for plain index.
-  Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+  Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
   
-  Recommendend minimum value is `1000`.
+  Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
   
-  When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+  To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
   
   Note: 1kB = 1 vector of size 256.
   */

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -162,32 +162,33 @@ pub struct OptimizersConfigDiff {
     #[prost(uint64, optional, tag = "3")]
     pub default_segment_number: ::core::option::Option<u64>,
     ///
-    /// Do not create segments larger this size (in KiloBytes).
+    /// Do not create segments larger this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///
-    /// If indexation speed has more priority for you - make this parameter lower.
+    /// If indexing speed is more important - make this parameter lower.
     /// If search speed is more important - make this parameter higher.
     /// Note: 1Kb = 1 vector of size 256
+    /// If not set, will be automatically selected considering the number of available CPUs.
     #[prost(uint64, optional, tag = "4")]
     pub max_segment_size: ::core::option::Option<u64>,
     ///
     /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
     ///
-    /// To enable memmap storage, lower the threshold.
-    /// To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+    /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+    ///
+    /// To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[prost(uint64, optional, tag = "5")]
     pub memmap_threshold: ::core::option::Option<u64>,
     ///
-    /// Maximum size (in kilobytes) of vectors allowed for plain index.
-    /// Default value based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
+    /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
     ///
-    /// Recommendend minimum value is `1000`.
+    /// Default value is 20,000, based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
     ///
-    /// When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+    /// To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[prost(uint64, optional, tag = "6")]
@@ -444,8 +445,10 @@ pub struct CollectionInfo {
     pub config: ::core::option::Option<CollectionConfig>,
     /// Collection data types
     #[prost(map = "string, message", tag = "8")]
-    pub payload_schema:
-        ::std::collections::HashMap<::prost::alloc::string::String, PayloadSchemaInfo>,
+    pub payload_schema: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        PayloadSchemaInfo,
+    >,
     /// number of points in the collection
     #[prost(uint64, tag = "9")]
     pub points_count: u64,
@@ -643,7 +646,9 @@ pub struct UpdateCollectionClusterSetupRequest {
         oneof = "update_collection_cluster_setup_request::Operation",
         tags = "2, 3, 4, 5"
     )]
-    pub operation: ::core::option::Option<update_collection_cluster_setup_request::Operation>,
+    pub operation: ::core::option::Option<
+        update_collection_cluster_setup_request::Operation,
+    >,
 }
 /// Nested message and enum types in `UpdateCollectionClusterSetupRequest`.
 pub mod update_collection_cluster_setup_request {
@@ -872,8 +877,8 @@ impl ReplicaState {
 /// Generated client implementations.
 pub mod collections_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct CollectionsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -917,8 +922,9 @@ pub mod collections_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             CollectionsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -958,19 +964,23 @@ pub mod collections_client {
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCollectionInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Get");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "Get"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Get"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -978,19 +988,23 @@ pub mod collections_client {
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListCollectionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListCollectionsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListCollectionsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/List");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "List"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "List"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -998,19 +1012,25 @@ pub mod collections_client {
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Create");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/Create",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "Create"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Create"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1018,19 +1038,25 @@ pub mod collections_client {
         pub async fn update(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Update");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/Update",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "Update"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Update"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1038,19 +1064,25 @@ pub mod collections_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Delete");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/Delete",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "Delete"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1058,16 +1090,23 @@ pub mod collections_client {
         pub async fn update_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ChangeAliases>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/UpdateAliases");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/UpdateAliases",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Collections", "UpdateAliases"));
@@ -1078,22 +1117,26 @@ pub mod collections_client {
         pub async fn list_collection_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListCollectionAliasesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAliasesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/qdrant.Collections/ListCollectionAliases");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/ListCollectionAliases",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "qdrant.Collections",
-                "ListCollectionAliases",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "ListCollectionAliases"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1101,16 +1144,23 @@ pub mod collections_client {
         pub async fn list_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAliasesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAliasesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/ListAliases");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/ListAliases",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Collections", "ListAliases"));
@@ -1121,22 +1171,26 @@ pub mod collections_client {
         pub async fn collection_cluster_info(
             &mut self,
             request: impl tonic::IntoRequest<super::CollectionClusterInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::CollectionClusterInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionClusterInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/qdrant.Collections/CollectionClusterInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/CollectionClusterInfo",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "qdrant.Collections",
-                "CollectionClusterInfo",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "CollectionClusterInfo"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1148,21 +1202,24 @@ pub mod collections_client {
             tonic::Response<super::UpdateCollectionClusterSetupResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/qdrant.Collections/UpdateCollectionClusterSetup",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "qdrant.Collections",
-                "UpdateCollectionClusterSetup",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("qdrant.Collections", "UpdateCollectionClusterSetup"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1179,55 +1236,82 @@ pub mod collections_server {
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCollectionInfoResponse>,
+            tonic::Status,
+        >;
         ///
         /// Get list name of all existing collections
         async fn list(
             &self,
             request: tonic::Request<super::ListCollectionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListCollectionsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListCollectionsResponse>,
+            tonic::Status,
+        >;
         ///
         /// Create new collection with given parameters
         async fn create(
             &self,
             request: tonic::Request<super::CreateCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Update parameters of the existing collection
         async fn update(
             &self,
             request: tonic::Request<super::UpdateCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Drop collection and all associated data
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteCollection>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Update Aliases of the existing collection
         async fn update_aliases(
             &self,
             request: tonic::Request<super::ChangeAliases>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Get list of all aliases for a collection
         async fn list_collection_aliases(
             &self,
             request: tonic::Request<super::ListCollectionAliasesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAliasesResponse>,
+            tonic::Status,
+        >;
         ///
         /// Get list of all aliases for all existing collections
         async fn list_aliases(
             &self,
             request: tonic::Request<super::ListAliasesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAliasesResponse>,
+            tonic::Status,
+        >;
         ///
         /// Get cluster information for a collection
         async fn collection_cluster_info(
             &self,
             request: tonic::Request<super::CollectionClusterInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::CollectionClusterInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionClusterInfoResponse>,
+            tonic::Status,
+        >;
         ///
         /// Update cluster setup for a collection
         async fn update_collection_cluster_setup(
@@ -1261,7 +1345,10 @@ pub mod collections_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1317,11 +1404,15 @@ pub mod collections_server {
                 "/qdrant.Collections/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections>
-                        tonic::server::UnaryService<super::GetCollectionInfoRequest> for GetSvc<T>
-                    {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::GetCollectionInfoRequest>
+                    for GetSvc<T> {
                         type Response = super::GetCollectionInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCollectionInfoRequest>,
@@ -1357,9 +1448,15 @@ pub mod collections_server {
                 "/qdrant.Collections/List" => {
                     #[allow(non_camel_case_types)]
                     struct ListSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::ListCollectionsRequest> for ListSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ListCollectionsRequest>
+                    for ListSvc<T> {
                         type Response = super::ListCollectionsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListCollectionsRequest>,
@@ -1395,9 +1492,15 @@ pub mod collections_server {
                 "/qdrant.Collections/Create" => {
                     #[allow(non_camel_case_types)]
                     struct CreateSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::CreateCollection> for CreateSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::CreateCollection>
+                    for CreateSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateCollection>,
@@ -1433,9 +1536,15 @@ pub mod collections_server {
                 "/qdrant.Collections/Update" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::UpdateCollection> for UpdateSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::UpdateCollection>
+                    for UpdateSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpdateCollection>,
@@ -1471,9 +1580,15 @@ pub mod collections_server {
                 "/qdrant.Collections/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::DeleteCollection> for DeleteSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::DeleteCollection>
+                    for DeleteSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteCollection>,
@@ -1509,15 +1624,23 @@ pub mod collections_server {
                 "/qdrant.Collections/UpdateAliases" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::ChangeAliases> for UpdateAliasesSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ChangeAliases>
+                    for UpdateAliasesSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ChangeAliases>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).update_aliases(request).await };
+                            let fut = async move {
+                                (*inner).update_aliases(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1547,19 +1670,23 @@ pub mod collections_server {
                 "/qdrant.Collections/ListCollectionAliases" => {
                     #[allow(non_camel_case_types)]
                     struct ListCollectionAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections>
-                        tonic::server::UnaryService<super::ListCollectionAliasesRequest>
-                        for ListCollectionAliasesSvc<T>
-                    {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ListCollectionAliasesRequest>
+                    for ListCollectionAliasesSvc<T> {
                         type Response = super::ListAliasesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListCollectionAliasesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { (*inner).list_collection_aliases(request).await };
+                            let fut = async move {
+                                (*inner).list_collection_aliases(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1589,15 +1716,23 @@ pub mod collections_server {
                 "/qdrant.Collections/ListAliases" => {
                     #[allow(non_camel_case_types)]
                     struct ListAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections> tonic::server::UnaryService<super::ListAliasesRequest> for ListAliasesSvc<T> {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::ListAliasesRequest>
+                    for ListAliasesSvc<T> {
                         type Response = super::ListAliasesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListAliasesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).list_aliases(request).await };
+                            let fut = async move {
+                                (*inner).list_aliases(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1627,19 +1762,23 @@ pub mod collections_server {
                 "/qdrant.Collections/CollectionClusterInfo" => {
                     #[allow(non_camel_case_types)]
                     struct CollectionClusterInfoSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections>
-                        tonic::server::UnaryService<super::CollectionClusterInfoRequest>
-                        for CollectionClusterInfoSvc<T>
-                    {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::CollectionClusterInfoRequest>
+                    for CollectionClusterInfoSvc<T> {
                         type Response = super::CollectionClusterInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CollectionClusterInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { (*inner).collection_cluster_info(request).await };
+                            let fut = async move {
+                                (*inner).collection_cluster_info(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1669,15 +1808,21 @@ pub mod collections_server {
                 "/qdrant.Collections/UpdateCollectionClusterSetup" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateCollectionClusterSetupSvc<T: Collections>(pub Arc<T>);
-                    impl<T: Collections>
-                        tonic::server::UnaryService<super::UpdateCollectionClusterSetupRequest>
-                        for UpdateCollectionClusterSetupSvc<T>
-                    {
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<
+                        super::UpdateCollectionClusterSetupRequest,
+                    > for UpdateCollectionClusterSetupSvc<T> {
                         type Response = super::UpdateCollectionClusterSetupResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::UpdateCollectionClusterSetupRequest>,
+                            request: tonic::Request<
+                                super::UpdateCollectionClusterSetupRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -1709,14 +1854,18 @@ pub mod collections_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -1770,8 +1919,8 @@ pub struct InitiateShardTransferRequest {
 /// Generated client implementations.
 pub mod collections_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct CollectionsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1815,8 +1964,9 @@ pub mod collections_internal_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             CollectionsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1856,16 +2006,23 @@ pub mod collections_internal_client {
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequestInternal>,
-        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCollectionInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.CollectionsInternal/Get");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.CollectionsInternal/Get",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.CollectionsInternal", "Get"));
@@ -1876,16 +2033,23 @@ pub mod collections_internal_client {
         pub async fn initiate(
             &mut self,
             request: impl tonic::IntoRequest<super::InitiateShardTransferRequest>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.CollectionsInternal/Initiate");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.CollectionsInternal/Initiate",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.CollectionsInternal", "Initiate"));
@@ -1905,13 +2069,19 @@ pub mod collections_internal_server {
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequestInternal>,
-        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCollectionInfoResponse>,
+            tonic::Status,
+        >;
         ///
         /// Initiate shard transfer
         async fn initiate(
             &self,
             request: tonic::Request<super::InitiateShardTransferRequest>,
-        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct CollectionsInternalServer<T: CollectionsInternal> {
@@ -1936,7 +2106,10 @@ pub mod collections_internal_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1992,15 +2165,21 @@ pub mod collections_internal_server {
                 "/qdrant.CollectionsInternal/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: CollectionsInternal>(pub Arc<T>);
-                    impl<T: CollectionsInternal>
-                        tonic::server::UnaryService<super::GetCollectionInfoRequestInternal>
-                        for GetSvc<T>
-                    {
+                    impl<
+                        T: CollectionsInternal,
+                    > tonic::server::UnaryService<
+                        super::GetCollectionInfoRequestInternal,
+                    > for GetSvc<T> {
                         type Response = super::GetCollectionInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::GetCollectionInfoRequestInternal>,
+                            request: tonic::Request<
+                                super::GetCollectionInfoRequestInternal,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).get(request).await };
@@ -2033,12 +2212,15 @@ pub mod collections_internal_server {
                 "/qdrant.CollectionsInternal/Initiate" => {
                     #[allow(non_camel_case_types)]
                     struct InitiateSvc<T: CollectionsInternal>(pub Arc<T>);
-                    impl<T: CollectionsInternal>
-                        tonic::server::UnaryService<super::InitiateShardTransferRequest>
-                        for InitiateSvc<T>
-                    {
+                    impl<
+                        T: CollectionsInternal,
+                    > tonic::server::UnaryService<super::InitiateShardTransferRequest>
+                    for InitiateSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InitiateShardTransferRequest>,
@@ -2071,14 +2253,18 @@ pub mod collections_internal_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -2104,7 +2290,8 @@ pub mod collections_internal_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: CollectionsInternal> tonic::server::NamedService for CollectionsInternalServer<T> {
+    impl<T: CollectionsInternal> tonic::server::NamedService
+    for CollectionsInternalServer<T> {
         const NAME: &'static str = "qdrant.CollectionsInternal";
     }
 }
@@ -2985,7 +3172,9 @@ pub struct ValuesCount {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsSelector {
     #[prost(oneof = "points_selector::PointsSelectorOneOf", tags = "1, 2")]
-    pub points_selector_one_of: ::core::option::Option<points_selector::PointsSelectorOneOf>,
+    pub points_selector_one_of: ::core::option::Option<
+        points_selector::PointsSelectorOneOf,
+    >,
 }
 /// Nested message and enum types in `PointsSelector`.
 pub mod points_selector {
@@ -3155,8 +3344,8 @@ impl UpdateStatus {
 /// Generated client implementations.
 pub mod points_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PointsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -3200,8 +3389,9 @@ pub mod points_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             PointsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -3241,19 +3431,23 @@ pub mod points_client {
         pub async fn upsert(
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Upsert");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Upsert"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Upsert"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3261,19 +3455,23 @@ pub mod points_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Delete");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Delete"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3282,17 +3480,19 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoints>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Get");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Get"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Get"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3300,19 +3500,23 @@ pub mod points_client {
         pub async fn set_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/SetPayload");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "SetPayload"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "SetPayload"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3320,16 +3524,23 @@ pub mod points_client {
         pub async fn overwrite_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/OverwritePayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/OverwritePayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "OverwritePayload"));
@@ -3340,16 +3551,23 @@ pub mod points_client {
         pub async fn delete_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeletePayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/DeletePayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "DeletePayload"));
@@ -3360,16 +3578,23 @@ pub mod points_client {
         pub async fn clear_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/ClearPayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/ClearPayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "ClearPayload"));
@@ -3380,16 +3605,23 @@ pub mod points_client {
         pub async fn create_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollection>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/CreateFieldIndex");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/CreateFieldIndex",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "CreateFieldIndex"));
@@ -3400,16 +3632,23 @@ pub mod points_client {
         pub async fn delete_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollection>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeleteFieldIndex");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/DeleteFieldIndex",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "DeleteFieldIndex"));
@@ -3421,17 +3660,19 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPoints>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Search");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Search"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Search"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3439,19 +3680,25 @@ pub mod points_client {
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPoints>,
-        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SearchBatchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/SearchBatch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/SearchBatch",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "SearchBatch"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "SearchBatch"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3460,17 +3707,19 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ScrollPoints>,
         ) -> std::result::Result<tonic::Response<super::ScrollResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Scroll");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Scroll"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Scroll"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3478,18 +3727,23 @@ pub mod points_client {
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPoints>,
-        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Recommend");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Recommend"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Recommend"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3497,16 +3751,23 @@ pub mod points_client {
         pub async fn recommend_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendBatchPoints>,
-        ) -> std::result::Result<tonic::Response<super::RecommendBatchResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendBatchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/RecommendBatch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/RecommendBatch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "RecommendBatch"));
@@ -3518,17 +3779,19 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CountPoints>,
         ) -> std::result::Result<tonic::Response<super::CountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Count");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Points", "Count"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Count"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -3545,13 +3808,19 @@ pub mod points_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Delete points
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Retrieve points
         async fn get(
@@ -3563,37 +3832,55 @@ pub mod points_server {
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Overwrite payload for points
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Delete specified key payload for points
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Remove all payload for specified points
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPoints>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Create index for field in collection
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollection>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Delete field index for collection
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollection>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         ///
         /// Retrieve closest points based on vector similarity and given filtering conditions
         async fn search(
@@ -3605,7 +3892,10 @@ pub mod points_server {
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPoints>,
-        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SearchBatchResponse>,
+            tonic::Status,
+        >;
         ///
         /// Iterate over all or filtered points points
         async fn scroll(
@@ -3617,13 +3907,19 @@ pub mod points_server {
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPoints>,
-        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendResponse>,
+            tonic::Status,
+        >;
         ///
         /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         async fn recommend_batch(
             &self,
             request: tonic::Request<super::RecommendBatchPoints>,
-        ) -> std::result::Result<tonic::Response<super::RecommendBatchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendBatchResponse>,
+            tonic::Status,
+        >;
         ///
         /// Count points in collection with given filtering conditions
         async fn count(
@@ -3654,7 +3950,10 @@ pub mod points_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -3710,9 +4009,13 @@ pub mod points_server {
                 "/qdrant.Points/Upsert" => {
                     #[allow(non_camel_case_types)]
                     struct UpsertSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints> for UpsertSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints>
+                    for UpsertSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpsertPoints>,
@@ -3748,9 +4051,13 @@ pub mod points_server {
                 "/qdrant.Points/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::DeletePoints> for DeleteSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::DeletePoints>
+                    for DeleteSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePoints>,
@@ -3786,9 +4093,13 @@ pub mod points_server {
                 "/qdrant.Points/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::GetPoints> for GetSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::GetPoints>
+                    for GetSvc<T> {
                         type Response = super::GetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPoints>,
@@ -3824,9 +4135,13 @@ pub mod points_server {
                 "/qdrant.Points/SetPayload" => {
                     #[allow(non_camel_case_types)]
                     struct SetPayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints> for SetPayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints>
+                    for SetPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPoints>,
@@ -3862,15 +4177,21 @@ pub mod points_server {
                 "/qdrant.Points/OverwritePayload" => {
                     #[allow(non_camel_case_types)]
                     struct OverwritePayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints> for OverwritePayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints>
+                    for OverwritePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).overwrite_payload(request).await };
+                            let fut = async move {
+                                (*inner).overwrite_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3900,15 +4221,23 @@ pub mod points_server {
                 "/qdrant.Points/DeletePayload" => {
                     #[allow(non_camel_case_types)]
                     struct DeletePayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::DeletePayloadPoints> for DeletePayloadSvc<T> {
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::DeletePayloadPoints>
+                    for DeletePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delete_payload(request).await };
+                            let fut = async move {
+                                (*inner).delete_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3938,15 +4267,23 @@ pub mod points_server {
                 "/qdrant.Points/ClearPayload" => {
                     #[allow(non_camel_case_types)]
                     struct ClearPayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::ClearPayloadPoints> for ClearPayloadSvc<T> {
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::ClearPayloadPoints>
+                    for ClearPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ClearPayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).clear_payload(request).await };
+                            let fut = async move {
+                                (*inner).clear_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3976,17 +4313,23 @@ pub mod points_server {
                 "/qdrant.Points/CreateFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFieldIndexSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::CreateFieldIndexCollection>
-                        for CreateFieldIndexSvc<T>
-                    {
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::CreateFieldIndexCollection>
+                    for CreateFieldIndexSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateFieldIndexCollection>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).create_field_index(request).await };
+                            let fut = async move {
+                                (*inner).create_field_index(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -4016,17 +4359,23 @@ pub mod points_server {
                 "/qdrant.Points/DeleteFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFieldIndexSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::DeleteFieldIndexCollection>
-                        for DeleteFieldIndexSvc<T>
-                    {
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::DeleteFieldIndexCollection>
+                    for DeleteFieldIndexSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteFieldIndexCollection>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delete_field_index(request).await };
+                            let fut = async move {
+                                (*inner).delete_field_index(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -4056,9 +4405,13 @@ pub mod points_server {
                 "/qdrant.Points/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SearchPoints> for SearchSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SearchPoints>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchPoints>,
@@ -4094,15 +4447,21 @@ pub mod points_server {
                 "/qdrant.Points/SearchBatch" => {
                     #[allow(non_camel_case_types)]
                     struct SearchBatchSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SearchBatchPoints> for SearchBatchSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SearchBatchPoints>
+                    for SearchBatchSvc<T> {
                         type Response = super::SearchBatchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchBatchPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).search_batch(request).await };
+                            let fut = async move {
+                                (*inner).search_batch(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -4132,9 +4491,13 @@ pub mod points_server {
                 "/qdrant.Points/Scroll" => {
                     #[allow(non_camel_case_types)]
                     struct ScrollSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::ScrollPoints> for ScrollSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::ScrollPoints>
+                    for ScrollSvc<T> {
                         type Response = super::ScrollResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScrollPoints>,
@@ -4170,9 +4533,13 @@ pub mod points_server {
                 "/qdrant.Points/Recommend" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::RecommendPoints> for RecommendSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::RecommendPoints>
+                    for RecommendSvc<T> {
                         type Response = super::RecommendResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendPoints>,
@@ -4208,15 +4575,23 @@ pub mod points_server {
                 "/qdrant.Points/RecommendBatch" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendBatchSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::RecommendBatchPoints> for RecommendBatchSvc<T> {
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::RecommendBatchPoints>
+                    for RecommendBatchSvc<T> {
                         type Response = super::RecommendBatchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendBatchPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).recommend_batch(request).await };
+                            let fut = async move {
+                                (*inner).recommend_batch(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -4246,9 +4621,13 @@ pub mod points_server {
                 "/qdrant.Points/Count" => {
                     #[allow(non_camel_case_types)]
                     struct CountSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::CountPoints> for CountSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::CountPoints>
+                    for CountSvc<T> {
                         type Response = super::CountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CountPoints>,
@@ -4281,14 +4660,18 @@ pub mod points_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -4406,7 +4789,9 @@ pub struct ClearPayloadPointsInternal {
 pub struct CreateFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
     #[validate]
-    pub create_field_index_collection: ::core::option::Option<CreateFieldIndexCollection>,
+    pub create_field_index_collection: ::core::option::Option<
+        CreateFieldIndexCollection,
+    >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
@@ -4416,7 +4801,9 @@ pub struct CreateFieldIndexCollectionInternal {
 pub struct DeleteFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
     #[validate]
-    pub delete_field_index_collection: ::core::option::Option<DeleteFieldIndexCollection>,
+    pub delete_field_index_collection: ::core::option::Option<
+        DeleteFieldIndexCollection,
+    >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
@@ -4486,8 +4873,8 @@ pub struct CountPointsInternal {
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PointsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4531,8 +4918,9 @@ pub mod points_internal_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             PointsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4570,16 +4958,23 @@ pub mod points_internal_client {
         pub async fn upsert(
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Upsert");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Upsert",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Upsert"));
@@ -4588,16 +4983,23 @@ pub mod points_internal_client {
         pub async fn sync(
             &mut self,
             request: impl tonic::IntoRequest<super::SyncPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Sync");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Sync",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Sync"));
@@ -4606,16 +5008,23 @@ pub mod points_internal_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Delete");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Delete",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Delete"));
@@ -4624,16 +5033,23 @@ pub mod points_internal_client {
         pub async fn set_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/SetPayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/SetPayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "SetPayload"));
@@ -4642,17 +5058,23 @@ pub mod points_internal_client {
         pub async fn overwrite_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/OverwritePayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/OverwritePayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "OverwritePayload"));
@@ -4661,16 +5083,23 @@ pub mod points_internal_client {
         pub async fn delete_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/DeletePayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/DeletePayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "DeletePayload"));
@@ -4679,16 +5108,23 @@ pub mod points_internal_client {
         pub async fn clear_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/ClearPayload");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/ClearPayload",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "ClearPayload"));
@@ -4697,17 +5133,23 @@ pub mod points_internal_client {
         pub async fn create_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollectionInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/CreateFieldIndex");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/CreateFieldIndex",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "CreateFieldIndex"));
@@ -4716,17 +5158,23 @@ pub mod points_internal_client {
         pub async fn delete_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollectionInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/DeleteFieldIndex");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/DeleteFieldIndex",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "DeleteFieldIndex"));
@@ -4736,14 +5184,19 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Search");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Search",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Search"));
@@ -4752,16 +5205,23 @@ pub mod points_internal_client {
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SearchBatchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/SearchBatch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/SearchBatch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "SearchBatch"));
@@ -4771,14 +5231,19 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ScrollPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::ScrollResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Scroll");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Scroll",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Scroll"));
@@ -4788,14 +5253,19 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CountPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::CountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Count");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Count",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Count"));
@@ -4804,15 +5274,23 @@ pub mod points_internal_client {
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Recommend");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Recommend",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Recommend"));
@@ -4822,17 +5300,21 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Get");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Get",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -4847,39 +5329,66 @@ pub mod points_internal_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn sync(
             &self,
             request: tonic::Request<super::SyncPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
-        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponse>,
+            tonic::Status,
+        >;
         async fn search(
             &self,
             request: tonic::Request<super::SearchPointsInternal>,
@@ -4887,7 +5396,10 @@ pub mod points_internal_server {
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SearchBatchResponse>,
+            tonic::Status,
+        >;
         async fn scroll(
             &self,
             request: tonic::Request<super::ScrollPointsInternal>,
@@ -4899,7 +5411,10 @@ pub mod points_internal_server {
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPointsInternal>,
-        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RecommendResponse>,
+            tonic::Status,
+        >;
         async fn get(
             &self,
             request: tonic::Request<super::GetPointsInternal>,
@@ -4928,7 +5443,10 @@ pub mod points_internal_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4984,9 +5502,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Upsert" => {
                     #[allow(non_camel_case_types)]
                     struct UpsertSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::UpsertPointsInternal> for UpsertSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::UpsertPointsInternal>
+                    for UpsertSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpsertPointsInternal>,
@@ -5022,9 +5546,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::SyncPointsInternal> for SyncSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SyncPointsInternal>
+                    for SyncSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncPointsInternal>,
@@ -5060,9 +5590,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::DeletePointsInternal> for DeleteSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::DeletePointsInternal>
+                    for DeleteSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePointsInternal>,
@@ -5098,12 +5634,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/SetPayload" => {
                     #[allow(non_camel_case_types)]
                     struct SetPayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::SetPayloadPointsInternal>
-                        for SetPayloadSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SetPayloadPointsInternal>
+                    for SetPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPointsInternal>,
@@ -5139,18 +5678,23 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/OverwritePayload" => {
                     #[allow(non_camel_case_types)]
                     struct OverwritePayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::SetPayloadPointsInternal>
-                        for OverwritePayloadSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SetPayloadPointsInternal>
+                    for OverwritePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).overwrite_payload(request).await };
+                            let fut = async move {
+                                (*inner).overwrite_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5180,18 +5724,23 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/DeletePayload" => {
                     #[allow(non_camel_case_types)]
                     struct DeletePayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::DeletePayloadPointsInternal>
-                        for DeletePayloadSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::DeletePayloadPointsInternal>
+                    for DeletePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delete_payload(request).await };
+                            let fut = async move {
+                                (*inner).delete_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5221,18 +5770,23 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/ClearPayload" => {
                     #[allow(non_camel_case_types)]
                     struct ClearPayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::ClearPayloadPointsInternal>
-                        for ClearPayloadSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::ClearPayloadPointsInternal>
+                    for ClearPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ClearPayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).clear_payload(request).await };
+                            let fut = async move {
+                                (*inner).clear_payload(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5262,18 +5816,26 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/CreateFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::CreateFieldIndexCollectionInternal>
-                        for CreateFieldIndexSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<
+                        super::CreateFieldIndexCollectionInternal,
+                    > for CreateFieldIndexSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
+                            request: tonic::Request<
+                                super::CreateFieldIndexCollectionInternal,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).create_field_index(request).await };
+                            let fut = async move {
+                                (*inner).create_field_index(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5303,18 +5865,26 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/DeleteFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::DeleteFieldIndexCollectionInternal>
-                        for DeleteFieldIndexSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<
+                        super::DeleteFieldIndexCollectionInternal,
+                    > for DeleteFieldIndexSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
+                            request: tonic::Request<
+                                super::DeleteFieldIndexCollectionInternal,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delete_field_index(request).await };
+                            let fut = async move {
+                                (*inner).delete_field_index(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5344,9 +5914,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::SearchPointsInternal> for SearchSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SearchPointsInternal>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchPointsInternal>,
@@ -5382,18 +5958,23 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/SearchBatch" => {
                     #[allow(non_camel_case_types)]
                     struct SearchBatchSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::SearchBatchPointsInternal>
-                        for SearchBatchSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::SearchBatchPointsInternal>
+                    for SearchBatchSvc<T> {
                         type Response = super::SearchBatchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchBatchPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).search_batch(request).await };
+                            let fut = async move {
+                                (*inner).search_batch(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5423,9 +6004,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Scroll" => {
                     #[allow(non_camel_case_types)]
                     struct ScrollSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::ScrollPointsInternal> for ScrollSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::ScrollPointsInternal>
+                    for ScrollSvc<T> {
                         type Response = super::ScrollResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScrollPointsInternal>,
@@ -5461,9 +6048,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Count" => {
                     #[allow(non_camel_case_types)]
                     struct CountSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::CountPointsInternal> for CountSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::CountPointsInternal>
+                    for CountSvc<T> {
                         type Response = super::CountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CountPointsInternal>,
@@ -5499,12 +6092,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Recommend" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal>
-                        tonic::server::UnaryService<super::RecommendPointsInternal>
-                        for RecommendSvc<T>
-                    {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::RecommendPointsInternal>
+                    for RecommendSvc<T> {
                         type Response = super::RecommendResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendPointsInternal>,
@@ -5540,9 +6136,15 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<T: PointsInternal> tonic::server::UnaryService<super::GetPointsInternal> for GetSvc<T> {
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::GetPointsInternal>
+                    for GetSvc<T> {
                         type Response = super::GetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPointsInternal>,
@@ -5575,14 +6177,18 @@ pub mod points_internal_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -5662,8 +6268,8 @@ pub struct Uri {
 /// Generated client implementations.
 pub mod raft_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct RaftClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -5694,7 +6300,10 @@ pub mod raft_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> RaftClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> RaftClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -5704,8 +6313,9 @@ pub mod raft_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             RaftClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -5745,17 +6355,19 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RaftMessage>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/Send");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Raft", "Send"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Raft", "Send"));
             self.inner.unary(req, path, codec).await
         }
         /// Send to bootstrap peer
@@ -5764,17 +6376,19 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PeerId>,
         ) -> std::result::Result<tonic::Response<super::Uri>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/WhoIs");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Raft", "WhoIs"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Raft", "WhoIs"));
             self.inner.unary(req, path, codec).await
         }
         /// Send to bootstrap peer
@@ -5784,14 +6398,19 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::AddPeerToKnownMessage>,
         ) -> std::result::Result<tonic::Response<super::AllPeers>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/AddPeerToKnown");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Raft/AddPeerToKnown",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Raft", "AddPeerToKnown"));
@@ -5806,14 +6425,19 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PeerId>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/AddPeerAsParticipant");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Raft/AddPeerAsParticipant",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Raft", "AddPeerAsParticipant"));
@@ -5879,7 +6503,10 @@ pub mod raft_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -5935,9 +6562,13 @@ pub mod raft_server {
                 "/qdrant.Raft/Send" => {
                     #[allow(non_camel_case_types)]
                     struct SendSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::RaftMessage> for SendSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::RaftMessage>
+                    for SendSvc<T> {
                         type Response = ();
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftMessage>,
@@ -5973,10 +6604,17 @@ pub mod raft_server {
                 "/qdrant.Raft/WhoIs" => {
                     #[allow(non_camel_case_types)]
                     struct WhoIsSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::PeerId> for WhoIsSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::PeerId>
+                    for WhoIsSvc<T> {
                         type Response = super::Uri;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::PeerId>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::PeerId>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).who_is(request).await };
                             Box::pin(fut)
@@ -6008,15 +6646,23 @@ pub mod raft_server {
                 "/qdrant.Raft/AddPeerToKnown" => {
                     #[allow(non_camel_case_types)]
                     struct AddPeerToKnownSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::AddPeerToKnownMessage> for AddPeerToKnownSvc<T> {
+                    impl<
+                        T: Raft,
+                    > tonic::server::UnaryService<super::AddPeerToKnownMessage>
+                    for AddPeerToKnownSvc<T> {
                         type Response = super::AllPeers;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AddPeerToKnownMessage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).add_peer_to_known(request).await };
+                            let fut = async move {
+                                (*inner).add_peer_to_known(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -6046,13 +6692,21 @@ pub mod raft_server {
                 "/qdrant.Raft/AddPeerAsParticipant" => {
                     #[allow(non_camel_case_types)]
                     struct AddPeerAsParticipantSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::PeerId> for AddPeerAsParticipantSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::PeerId>
+                    for AddPeerAsParticipantSvc<T> {
                         type Response = ();
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::PeerId>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::PeerId>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { (*inner).add_peer_as_participant(request).await };
+                            let fut = async move {
+                                (*inner).add_peer_as_participant(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -6079,14 +6733,18 @@ pub mod raft_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -6205,8 +6863,8 @@ pub struct DeleteSnapshotResponse {
 /// Generated client implementations.
 pub mod snapshots_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SnapshotsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6250,8 +6908,9 @@ pub mod snapshots_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SnapshotsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6291,19 +6950,23 @@ pub mod snapshots_client {
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreateSnapshotResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Create");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Snapshots", "Create"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "Create"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6311,19 +6974,23 @@ pub mod snapshots_client {
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListSnapshotsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/List");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Snapshots", "List"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "List"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6331,19 +6998,23 @@ pub mod snapshots_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteSnapshotResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Delete");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Snapshots", "Delete"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6351,16 +7022,23 @@ pub mod snapshots_client {
         pub async fn create_full(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFullSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreateSnapshotResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/CreateFull");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Snapshots/CreateFull",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Snapshots", "CreateFull"));
@@ -6371,19 +7049,25 @@ pub mod snapshots_client {
         pub async fn list_full(
             &mut self,
             request: impl tonic::IntoRequest<super::ListFullSnapshotsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListSnapshotsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/ListFull");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Snapshots/ListFull",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Snapshots", "ListFull"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "ListFull"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6391,16 +7075,23 @@ pub mod snapshots_client {
         pub async fn delete_full(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFullSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteSnapshotResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/DeleteFull");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Snapshots/DeleteFull",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Snapshots", "DeleteFull"));
@@ -6420,37 +7111,55 @@ pub mod snapshots_server {
         async fn create(
             &self,
             request: tonic::Request<super::CreateSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreateSnapshotResponse>,
+            tonic::Status,
+        >;
         ///
         /// List collection snapshots
         async fn list(
             &self,
             request: tonic::Request<super::ListSnapshotsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListSnapshotsResponse>,
+            tonic::Status,
+        >;
         ///
         /// Delete collection snapshots
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteSnapshotResponse>,
+            tonic::Status,
+        >;
         ///
         /// Create full storage snapshot
         async fn create_full(
             &self,
             request: tonic::Request<super::CreateFullSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreateSnapshotResponse>,
+            tonic::Status,
+        >;
         ///
         /// List full storage snapshots
         async fn list_full(
             &self,
             request: tonic::Request<super::ListFullSnapshotsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListSnapshotsResponse>,
+            tonic::Status,
+        >;
         ///
         /// List full storage snapshots
         async fn delete_full(
             &self,
             request: tonic::Request<super::DeleteFullSnapshotRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteSnapshotResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SnapshotsServer<T: Snapshots> {
@@ -6475,7 +7184,10 @@ pub mod snapshots_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6531,9 +7243,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/Create" => {
                     #[allow(non_camel_case_types)]
                     struct CreateSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::CreateSnapshotRequest> for CreateSvc<T> {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::CreateSnapshotRequest>
+                    for CreateSvc<T> {
                         type Response = super::CreateSnapshotResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateSnapshotRequest>,
@@ -6569,9 +7287,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/List" => {
                     #[allow(non_camel_case_types)]
                     struct ListSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::ListSnapshotsRequest> for ListSvc<T> {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::ListSnapshotsRequest>
+                    for ListSvc<T> {
                         type Response = super::ListSnapshotsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListSnapshotsRequest>,
@@ -6607,9 +7331,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::DeleteSnapshotRequest> for DeleteSvc<T> {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::DeleteSnapshotRequest>
+                    for DeleteSvc<T> {
                         type Response = super::DeleteSnapshotResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteSnapshotRequest>,
@@ -6645,11 +7375,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/CreateFull" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::CreateFullSnapshotRequest>
-                        for CreateFullSvc<T>
-                    {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::CreateFullSnapshotRequest>
+                    for CreateFullSvc<T> {
                         type Response = super::CreateSnapshotResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateFullSnapshotRequest>,
@@ -6685,9 +7419,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/ListFull" => {
                     #[allow(non_camel_case_types)]
                     struct ListFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::ListFullSnapshotsRequest> for ListFullSvc<T> {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::ListFullSnapshotsRequest>
+                    for ListFullSvc<T> {
                         type Response = super::ListSnapshotsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListFullSnapshotsRequest>,
@@ -6723,11 +7463,15 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/DeleteFull" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<T: Snapshots> tonic::server::UnaryService<super::DeleteFullSnapshotRequest>
-                        for DeleteFullSvc<T>
-                    {
+                    impl<
+                        T: Snapshots,
+                    > tonic::server::UnaryService<super::DeleteFullSnapshotRequest>
+                    for DeleteFullSvc<T> {
                         type Response = super::DeleteSnapshotResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteFullSnapshotRequest>,
@@ -6760,14 +7504,18 @@ pub mod snapshots_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -6811,8 +7559,8 @@ pub struct HealthCheckReply {
 /// Generated client implementations.
 pub mod qdrant_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct QdrantClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6856,8 +7604,9 @@ pub mod qdrant_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             QdrantClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6895,18 +7644,25 @@ pub mod qdrant_client {
         pub async fn health_check(
             &mut self,
             request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> std::result::Result<tonic::Response<super::HealthCheckReply>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckReply>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/qdrant.Qdrant/HealthCheck");
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Qdrant/HealthCheck",
+            );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6921,7 +7677,10 @@ pub mod qdrant_server {
         async fn health_check(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> std::result::Result<tonic::Response<super::HealthCheckReply>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckReply>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct QdrantServer<T: Qdrant> {
@@ -6946,7 +7705,10 @@ pub mod qdrant_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7002,15 +7764,23 @@ pub mod qdrant_server {
                 "/qdrant.Qdrant/HealthCheck" => {
                     #[allow(non_camel_case_types)]
                     struct HealthCheckSvc<T: Qdrant>(pub Arc<T>);
-                    impl<T: Qdrant> tonic::server::UnaryService<super::HealthCheckRequest> for HealthCheckSvc<T> {
+                    impl<
+                        T: Qdrant,
+                    > tonic::server::UnaryService<super::HealthCheckRequest>
+                    for HealthCheckSvc<T> {
                         type Response = super::HealthCheckReply;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).health_check(request).await };
+                            let fut = async move {
+                                (*inner).health_check(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -7037,14 +7807,18 @@ pub mod qdrant_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -178,7 +178,7 @@ pub struct OptimizersConfigDiff {
     ///
     /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
     ///
-    /// To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
+    /// To disable memmap storage, set this to `0`.
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[prost(uint64, optional, tag = "5")]
@@ -188,7 +188,7 @@ pub struct OptimizersConfigDiff {
     ///
     /// Default value is 20,000, based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
     ///
-    /// To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
+    /// To disable vector indexing, set to `0`.
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[prost(uint64, optional, tag = "6")]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -172,19 +172,25 @@ pub struct OptimizersConfigDiff {
     #[prost(uint64, optional, tag = "4")]
     pub max_segment_size: ::core::option::Option<u64>,
     ///
-    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
-    /// Segments larger than this threshold will be stored as a read-only memmaped file.
-    /// To enable memmap storage, lower the threshold
+    /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
+    /// Segments larger than this threshold will be stored as read-only memmaped file.
+    ///
+    /// To enable memmap storage, lower the threshold.
+    /// To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+    ///
     /// Note: 1Kb = 1 vector of size 256
     #[prost(uint64, optional, tag = "5")]
-    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1000")]
     pub memmap_threshold: ::core::option::Option<u64>,
     ///
-    /// Maximum size (in KiloBytes) of vectors allowed for plain index.
-    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
-    /// Note: 1Kb = 1 vector of size 256
+    /// Maximum size (in kilobytes) of vectors allowed for plain index.
+    /// Default value based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
+    ///
+    /// Recommendend minimum value is `1000`.
+    ///
+    /// When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+    ///
+    /// Note: 1kB = 1 vector of size 256.
     #[prost(uint64, optional, tag = "6")]
-    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1000")]
     pub indexing_threshold: ::core::option::Option<u64>,
     ///
     /// Interval between forced flushes.
@@ -438,10 +444,8 @@ pub struct CollectionInfo {
     pub config: ::core::option::Option<CollectionConfig>,
     /// Collection data types
     #[prost(map = "string, message", tag = "8")]
-    pub payload_schema: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        PayloadSchemaInfo,
-    >,
+    pub payload_schema:
+        ::std::collections::HashMap<::prost::alloc::string::String, PayloadSchemaInfo>,
     /// number of points in the collection
     #[prost(uint64, tag = "9")]
     pub points_count: u64,
@@ -639,9 +643,7 @@ pub struct UpdateCollectionClusterSetupRequest {
         oneof = "update_collection_cluster_setup_request::Operation",
         tags = "2, 3, 4, 5"
     )]
-    pub operation: ::core::option::Option<
-        update_collection_cluster_setup_request::Operation,
-    >,
+    pub operation: ::core::option::Option<update_collection_cluster_setup_request::Operation>,
 }
 /// Nested message and enum types in `UpdateCollectionClusterSetupRequest`.
 pub mod update_collection_cluster_setup_request {
@@ -870,8 +872,8 @@ impl ReplicaState {
 /// Generated client implementations.
 pub mod collections_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct CollectionsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -915,9 +917,8 @@ pub mod collections_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             CollectionsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -957,23 +958,19 @@ pub mod collections_client {
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCollectionInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Get");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Get"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "Get"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -981,23 +978,19 @@ pub mod collections_client {
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListCollectionsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListCollectionsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListCollectionsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/List");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "List"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "List"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1005,25 +998,19 @@ pub mod collections_client {
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/Create",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Create");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Create"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "Create"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1031,25 +1018,19 @@ pub mod collections_client {
         pub async fn update(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/Update",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Update");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Update"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "Update"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1057,25 +1038,19 @@ pub mod collections_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/Delete",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/Delete");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Collections", "Delete"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1083,23 +1058,16 @@ pub mod collections_client {
         pub async fn update_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ChangeAliases>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/UpdateAliases",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/UpdateAliases");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Collections", "UpdateAliases"));
@@ -1110,26 +1078,22 @@ pub mod collections_client {
         pub async fn list_collection_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListCollectionAliasesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAliasesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/ListCollectionAliases",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/qdrant.Collections/ListCollectionAliases");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "ListCollectionAliases"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "qdrant.Collections",
+                "ListCollectionAliases",
+            ));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1137,23 +1101,16 @@ pub mod collections_client {
         pub async fn list_aliases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAliasesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAliasesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/ListAliases",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Collections/ListAliases");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Collections", "ListAliases"));
@@ -1164,26 +1121,22 @@ pub mod collections_client {
         pub async fn collection_cluster_info(
             &mut self,
             request: impl tonic::IntoRequest<super::CollectionClusterInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionClusterInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionClusterInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Collections/CollectionClusterInfo",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/qdrant.Collections/CollectionClusterInfo");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("qdrant.Collections", "CollectionClusterInfo"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "qdrant.Collections",
+                "CollectionClusterInfo",
+            ));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -1195,24 +1148,21 @@ pub mod collections_client {
             tonic::Response<super::UpdateCollectionClusterSetupResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/qdrant.Collections/UpdateCollectionClusterSetup",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("qdrant.Collections", "UpdateCollectionClusterSetup"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "qdrant.Collections",
+                "UpdateCollectionClusterSetup",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1229,82 +1179,55 @@ pub mod collections_server {
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCollectionInfoResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
         ///
         /// Get list name of all existing collections
         async fn list(
             &self,
             request: tonic::Request<super::ListCollectionsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListCollectionsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListCollectionsResponse>, tonic::Status>;
         ///
         /// Create new collection with given parameters
         async fn create(
             &self,
             request: tonic::Request<super::CreateCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
         /// Update parameters of the existing collection
         async fn update(
             &self,
             request: tonic::Request<super::UpdateCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
         /// Drop collection and all associated data
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
         /// Update Aliases of the existing collection
         async fn update_aliases(
             &self,
             request: tonic::Request<super::ChangeAliases>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
         ///
         /// Get list of all aliases for a collection
         async fn list_collection_aliases(
             &self,
             request: tonic::Request<super::ListCollectionAliasesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAliasesResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
         ///
         /// Get list of all aliases for all existing collections
         async fn list_aliases(
             &self,
             request: tonic::Request<super::ListAliasesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAliasesResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListAliasesResponse>, tonic::Status>;
         ///
         /// Get cluster information for a collection
         async fn collection_cluster_info(
             &self,
             request: tonic::Request<super::CollectionClusterInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionClusterInfoResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionClusterInfoResponse>, tonic::Status>;
         ///
         /// Update cluster setup for a collection
         async fn update_collection_cluster_setup(
@@ -1338,10 +1261,7 @@ pub mod collections_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1397,15 +1317,11 @@ pub mod collections_server {
                 "/qdrant.Collections/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::GetCollectionInfoRequest>
-                    for GetSvc<T> {
+                    impl<T: Collections>
+                        tonic::server::UnaryService<super::GetCollectionInfoRequest> for GetSvc<T>
+                    {
                         type Response = super::GetCollectionInfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCollectionInfoRequest>,
@@ -1441,15 +1357,9 @@ pub mod collections_server {
                 "/qdrant.Collections/List" => {
                     #[allow(non_camel_case_types)]
                     struct ListSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::ListCollectionsRequest>
-                    for ListSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::ListCollectionsRequest> for ListSvc<T> {
                         type Response = super::ListCollectionsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListCollectionsRequest>,
@@ -1485,15 +1395,9 @@ pub mod collections_server {
                 "/qdrant.Collections/Create" => {
                     #[allow(non_camel_case_types)]
                     struct CreateSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::CreateCollection>
-                    for CreateSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::CreateCollection> for CreateSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateCollection>,
@@ -1529,15 +1433,9 @@ pub mod collections_server {
                 "/qdrant.Collections/Update" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::UpdateCollection>
-                    for UpdateSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::UpdateCollection> for UpdateSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpdateCollection>,
@@ -1573,15 +1471,9 @@ pub mod collections_server {
                 "/qdrant.Collections/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::DeleteCollection>
-                    for DeleteSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::DeleteCollection> for DeleteSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteCollection>,
@@ -1617,23 +1509,15 @@ pub mod collections_server {
                 "/qdrant.Collections/UpdateAliases" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::ChangeAliases>
-                    for UpdateAliasesSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::ChangeAliases> for UpdateAliasesSvc<T> {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ChangeAliases>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).update_aliases(request).await
-                            };
+                            let fut = async move { (*inner).update_aliases(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1663,23 +1547,19 @@ pub mod collections_server {
                 "/qdrant.Collections/ListCollectionAliases" => {
                     #[allow(non_camel_case_types)]
                     struct ListCollectionAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::ListCollectionAliasesRequest>
-                    for ListCollectionAliasesSvc<T> {
+                    impl<T: Collections>
+                        tonic::server::UnaryService<super::ListCollectionAliasesRequest>
+                        for ListCollectionAliasesSvc<T>
+                    {
                         type Response = super::ListAliasesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListCollectionAliasesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).list_collection_aliases(request).await
-                            };
+                            let fut =
+                                async move { (*inner).list_collection_aliases(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1709,23 +1589,15 @@ pub mod collections_server {
                 "/qdrant.Collections/ListAliases" => {
                     #[allow(non_camel_case_types)]
                     struct ListAliasesSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::ListAliasesRequest>
-                    for ListAliasesSvc<T> {
+                    impl<T: Collections> tonic::server::UnaryService<super::ListAliasesRequest> for ListAliasesSvc<T> {
                         type Response = super::ListAliasesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListAliasesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).list_aliases(request).await
-                            };
+                            let fut = async move { (*inner).list_aliases(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1755,23 +1627,19 @@ pub mod collections_server {
                 "/qdrant.Collections/CollectionClusterInfo" => {
                     #[allow(non_camel_case_types)]
                     struct CollectionClusterInfoSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<super::CollectionClusterInfoRequest>
-                    for CollectionClusterInfoSvc<T> {
+                    impl<T: Collections>
+                        tonic::server::UnaryService<super::CollectionClusterInfoRequest>
+                        for CollectionClusterInfoSvc<T>
+                    {
                         type Response = super::CollectionClusterInfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CollectionClusterInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).collection_cluster_info(request).await
-                            };
+                            let fut =
+                                async move { (*inner).collection_cluster_info(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1801,21 +1669,15 @@ pub mod collections_server {
                 "/qdrant.Collections/UpdateCollectionClusterSetup" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateCollectionClusterSetupSvc<T: Collections>(pub Arc<T>);
-                    impl<
-                        T: Collections,
-                    > tonic::server::UnaryService<
-                        super::UpdateCollectionClusterSetupRequest,
-                    > for UpdateCollectionClusterSetupSvc<T> {
+                    impl<T: Collections>
+                        tonic::server::UnaryService<super::UpdateCollectionClusterSetupRequest>
+                        for UpdateCollectionClusterSetupSvc<T>
+                    {
                         type Response = super::UpdateCollectionClusterSetupResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::UpdateCollectionClusterSetupRequest,
-                            >,
+                            request: tonic::Request<super::UpdateCollectionClusterSetupRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -1847,18 +1709,14 @@ pub mod collections_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -1912,8 +1770,8 @@ pub struct InitiateShardTransferRequest {
 /// Generated client implementations.
 pub mod collections_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct CollectionsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1957,9 +1815,8 @@ pub mod collections_internal_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             CollectionsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1999,23 +1856,16 @@ pub mod collections_internal_client {
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCollectionInfoRequestInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCollectionInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.CollectionsInternal/Get",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.CollectionsInternal/Get");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.CollectionsInternal", "Get"));
@@ -2026,23 +1876,16 @@ pub mod collections_internal_client {
         pub async fn initiate(
             &mut self,
             request: impl tonic::IntoRequest<super::InitiateShardTransferRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.CollectionsInternal/Initiate",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.CollectionsInternal/Initiate");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.CollectionsInternal", "Initiate"));
@@ -2062,19 +1905,13 @@ pub mod collections_internal_server {
         async fn get(
             &self,
             request: tonic::Request<super::GetCollectionInfoRequestInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCollectionInfoResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetCollectionInfoResponse>, tonic::Status>;
         ///
         /// Initiate shard transfer
         async fn initiate(
             &self,
             request: tonic::Request<super::InitiateShardTransferRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CollectionOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CollectionOperationResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct CollectionsInternalServer<T: CollectionsInternal> {
@@ -2099,10 +1936,7 @@ pub mod collections_internal_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2158,21 +1992,15 @@ pub mod collections_internal_server {
                 "/qdrant.CollectionsInternal/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: CollectionsInternal>(pub Arc<T>);
-                    impl<
-                        T: CollectionsInternal,
-                    > tonic::server::UnaryService<
-                        super::GetCollectionInfoRequestInternal,
-                    > for GetSvc<T> {
+                    impl<T: CollectionsInternal>
+                        tonic::server::UnaryService<super::GetCollectionInfoRequestInternal>
+                        for GetSvc<T>
+                    {
                         type Response = super::GetCollectionInfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::GetCollectionInfoRequestInternal,
-                            >,
+                            request: tonic::Request<super::GetCollectionInfoRequestInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).get(request).await };
@@ -2205,15 +2033,12 @@ pub mod collections_internal_server {
                 "/qdrant.CollectionsInternal/Initiate" => {
                     #[allow(non_camel_case_types)]
                     struct InitiateSvc<T: CollectionsInternal>(pub Arc<T>);
-                    impl<
-                        T: CollectionsInternal,
-                    > tonic::server::UnaryService<super::InitiateShardTransferRequest>
-                    for InitiateSvc<T> {
+                    impl<T: CollectionsInternal>
+                        tonic::server::UnaryService<super::InitiateShardTransferRequest>
+                        for InitiateSvc<T>
+                    {
                         type Response = super::CollectionOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InitiateShardTransferRequest>,
@@ -2246,18 +2071,14 @@ pub mod collections_internal_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -2283,8 +2104,7 @@ pub mod collections_internal_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: CollectionsInternal> tonic::server::NamedService
-    for CollectionsInternalServer<T> {
+    impl<T: CollectionsInternal> tonic::server::NamedService for CollectionsInternalServer<T> {
         const NAME: &'static str = "qdrant.CollectionsInternal";
     }
 }
@@ -3165,9 +2985,7 @@ pub struct ValuesCount {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsSelector {
     #[prost(oneof = "points_selector::PointsSelectorOneOf", tags = "1, 2")]
-    pub points_selector_one_of: ::core::option::Option<
-        points_selector::PointsSelectorOneOf,
-    >,
+    pub points_selector_one_of: ::core::option::Option<points_selector::PointsSelectorOneOf>,
 }
 /// Nested message and enum types in `PointsSelector`.
 pub mod points_selector {
@@ -3337,8 +3155,8 @@ impl UpdateStatus {
 /// Generated client implementations.
 pub mod points_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct PointsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -3382,9 +3200,8 @@ pub mod points_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             PointsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -3424,23 +3241,19 @@ pub mod points_client {
         pub async fn upsert(
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Upsert");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Upsert"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Upsert"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3448,23 +3261,19 @@ pub mod points_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Delete");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Delete"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3473,19 +3282,17 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoints>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Get");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Get"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Get"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3493,23 +3300,19 @@ pub mod points_client {
         pub async fn set_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/SetPayload");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "SetPayload"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "SetPayload"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3517,23 +3320,16 @@ pub mod points_client {
         pub async fn overwrite_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/OverwritePayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/OverwritePayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "OverwritePayload"));
@@ -3544,23 +3340,16 @@ pub mod points_client {
         pub async fn delete_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/DeletePayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeletePayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "DeletePayload"));
@@ -3571,23 +3360,16 @@ pub mod points_client {
         pub async fn clear_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/ClearPayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/ClearPayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "ClearPayload"));
@@ -3598,23 +3380,16 @@ pub mod points_client {
         pub async fn create_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/CreateFieldIndex",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/CreateFieldIndex");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "CreateFieldIndex"));
@@ -3625,23 +3400,16 @@ pub mod points_client {
         pub async fn delete_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/DeleteFieldIndex",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/DeleteFieldIndex");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "DeleteFieldIndex"));
@@ -3653,19 +3421,17 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPoints>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Search");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Search"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Search"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3673,25 +3439,19 @@ pub mod points_client {
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::SearchBatchResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/SearchBatch",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/SearchBatch");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "SearchBatch"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "SearchBatch"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3700,19 +3460,17 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ScrollPoints>,
         ) -> std::result::Result<tonic::Response<super::ScrollResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Scroll");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Scroll"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Scroll"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3720,23 +3478,18 @@ pub mod points_client {
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Recommend");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Recommend"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Recommend"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -3744,23 +3497,16 @@ pub mod points_client {
         pub async fn recommend_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendBatchPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendBatchResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RecommendBatchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Points/RecommendBatch",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/RecommendBatch");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Points", "RecommendBatch"));
@@ -3772,19 +3518,17 @@ pub mod points_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CountPoints>,
         ) -> std::result::Result<tonic::Response<super::CountResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Count");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Count"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "Count"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -3801,19 +3545,13 @@ pub mod points_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Delete points
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Retrieve points
         async fn get(
@@ -3825,55 +3563,37 @@ pub mod points_server {
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Overwrite payload for points
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Delete specified key payload for points
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Remove all payload for specified points
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Create index for field in collection
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Delete field index for collection
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollection>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         ///
         /// Retrieve closest points based on vector similarity and given filtering conditions
         async fn search(
@@ -3885,10 +3605,7 @@ pub mod points_server {
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::SearchBatchResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>;
         ///
         /// Iterate over all or filtered points points
         async fn scroll(
@@ -3900,19 +3617,13 @@ pub mod points_server {
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
         ///
         /// Look for the points which are closer to stored positive examples and at the same time further to negative examples.
         async fn recommend_batch(
             &self,
             request: tonic::Request<super::RecommendBatchPoints>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendBatchResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RecommendBatchResponse>, tonic::Status>;
         ///
         /// Count points in collection with given filtering conditions
         async fn count(
@@ -3943,10 +3654,7 @@ pub mod points_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4002,13 +3710,9 @@ pub mod points_server {
                 "/qdrant.Points/Upsert" => {
                     #[allow(non_camel_case_types)]
                     struct UpsertSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints>
-                    for UpsertSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::UpsertPoints> for UpsertSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpsertPoints>,
@@ -4044,13 +3748,9 @@ pub mod points_server {
                 "/qdrant.Points/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::DeletePoints>
-                    for DeleteSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::DeletePoints> for DeleteSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePoints>,
@@ -4086,13 +3786,9 @@ pub mod points_server {
                 "/qdrant.Points/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::GetPoints>
-                    for GetSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::GetPoints> for GetSvc<T> {
                         type Response = super::GetResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPoints>,
@@ -4128,13 +3824,9 @@ pub mod points_server {
                 "/qdrant.Points/SetPayload" => {
                     #[allow(non_camel_case_types)]
                     struct SetPayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints>
-                    for SetPayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints> for SetPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPoints>,
@@ -4170,21 +3862,15 @@ pub mod points_server {
                 "/qdrant.Points/OverwritePayload" => {
                     #[allow(non_camel_case_types)]
                     struct OverwritePayloadSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints>
-                    for OverwritePayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SetPayloadPoints> for OverwritePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).overwrite_payload(request).await
-                            };
+                            let fut = async move { (*inner).overwrite_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4214,23 +3900,15 @@ pub mod points_server {
                 "/qdrant.Points/DeletePayload" => {
                     #[allow(non_camel_case_types)]
                     struct DeletePayloadSvc<T: Points>(pub Arc<T>);
-                    impl<
-                        T: Points,
-                    > tonic::server::UnaryService<super::DeletePayloadPoints>
-                    for DeletePayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::DeletePayloadPoints> for DeletePayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).delete_payload(request).await
-                            };
+                            let fut = async move { (*inner).delete_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4260,23 +3938,15 @@ pub mod points_server {
                 "/qdrant.Points/ClearPayload" => {
                     #[allow(non_camel_case_types)]
                     struct ClearPayloadSvc<T: Points>(pub Arc<T>);
-                    impl<
-                        T: Points,
-                    > tonic::server::UnaryService<super::ClearPayloadPoints>
-                    for ClearPayloadSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::ClearPayloadPoints> for ClearPayloadSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ClearPayloadPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).clear_payload(request).await
-                            };
+                            let fut = async move { (*inner).clear_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4306,23 +3976,17 @@ pub mod points_server {
                 "/qdrant.Points/CreateFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFieldIndexSvc<T: Points>(pub Arc<T>);
-                    impl<
-                        T: Points,
-                    > tonic::server::UnaryService<super::CreateFieldIndexCollection>
-                    for CreateFieldIndexSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::CreateFieldIndexCollection>
+                        for CreateFieldIndexSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateFieldIndexCollection>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).create_field_index(request).await
-                            };
+                            let fut = async move { (*inner).create_field_index(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4352,23 +4016,17 @@ pub mod points_server {
                 "/qdrant.Points/DeleteFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFieldIndexSvc<T: Points>(pub Arc<T>);
-                    impl<
-                        T: Points,
-                    > tonic::server::UnaryService<super::DeleteFieldIndexCollection>
-                    for DeleteFieldIndexSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::DeleteFieldIndexCollection>
+                        for DeleteFieldIndexSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteFieldIndexCollection>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).delete_field_index(request).await
-                            };
+                            let fut = async move { (*inner).delete_field_index(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4398,13 +4056,9 @@ pub mod points_server {
                 "/qdrant.Points/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SearchPoints>
-                    for SearchSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SearchPoints> for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchPoints>,
@@ -4440,21 +4094,15 @@ pub mod points_server {
                 "/qdrant.Points/SearchBatch" => {
                     #[allow(non_camel_case_types)]
                     struct SearchBatchSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::SearchBatchPoints>
-                    for SearchBatchSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::SearchBatchPoints> for SearchBatchSvc<T> {
                         type Response = super::SearchBatchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchBatchPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).search_batch(request).await
-                            };
+                            let fut = async move { (*inner).search_batch(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4484,13 +4132,9 @@ pub mod points_server {
                 "/qdrant.Points/Scroll" => {
                     #[allow(non_camel_case_types)]
                     struct ScrollSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::ScrollPoints>
-                    for ScrollSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::ScrollPoints> for ScrollSvc<T> {
                         type Response = super::ScrollResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScrollPoints>,
@@ -4526,13 +4170,9 @@ pub mod points_server {
                 "/qdrant.Points/Recommend" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::RecommendPoints>
-                    for RecommendSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::RecommendPoints> for RecommendSvc<T> {
                         type Response = super::RecommendResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendPoints>,
@@ -4568,23 +4208,15 @@ pub mod points_server {
                 "/qdrant.Points/RecommendBatch" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendBatchSvc<T: Points>(pub Arc<T>);
-                    impl<
-                        T: Points,
-                    > tonic::server::UnaryService<super::RecommendBatchPoints>
-                    for RecommendBatchSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::RecommendBatchPoints> for RecommendBatchSvc<T> {
                         type Response = super::RecommendBatchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendBatchPoints>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).recommend_batch(request).await
-                            };
+                            let fut = async move { (*inner).recommend_batch(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -4614,13 +4246,9 @@ pub mod points_server {
                 "/qdrant.Points/Count" => {
                     #[allow(non_camel_case_types)]
                     struct CountSvc<T: Points>(pub Arc<T>);
-                    impl<T: Points> tonic::server::UnaryService<super::CountPoints>
-                    for CountSvc<T> {
+                    impl<T: Points> tonic::server::UnaryService<super::CountPoints> for CountSvc<T> {
                         type Response = super::CountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CountPoints>,
@@ -4653,18 +4281,14 @@ pub mod points_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -4782,9 +4406,7 @@ pub struct ClearPayloadPointsInternal {
 pub struct CreateFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
     #[validate]
-    pub create_field_index_collection: ::core::option::Option<
-        CreateFieldIndexCollection,
-    >,
+    pub create_field_index_collection: ::core::option::Option<CreateFieldIndexCollection>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
@@ -4794,9 +4416,7 @@ pub struct CreateFieldIndexCollectionInternal {
 pub struct DeleteFieldIndexCollectionInternal {
     #[prost(message, optional, tag = "1")]
     #[validate]
-    pub delete_field_index_collection: ::core::option::Option<
-        DeleteFieldIndexCollection,
-    >,
+    pub delete_field_index_collection: ::core::option::Option<DeleteFieldIndexCollection>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
@@ -4866,8 +4486,8 @@ pub struct CountPointsInternal {
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct PointsInternalClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4911,9 +4531,8 @@ pub mod points_internal_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             PointsInternalClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4951,23 +4570,16 @@ pub mod points_internal_client {
         pub async fn upsert(
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Upsert",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Upsert");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Upsert"));
@@ -4976,23 +4588,16 @@ pub mod points_internal_client {
         pub async fn sync(
             &mut self,
             request: impl tonic::IntoRequest<super::SyncPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Sync",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Sync");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Sync"));
@@ -5001,23 +4606,16 @@ pub mod points_internal_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Delete",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Delete");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Delete"));
@@ -5026,23 +4624,16 @@ pub mod points_internal_client {
         pub async fn set_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/SetPayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/SetPayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "SetPayload"));
@@ -5051,23 +4642,17 @@ pub mod points_internal_client {
         pub async fn overwrite_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/OverwritePayload",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/OverwritePayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "OverwritePayload"));
@@ -5076,23 +4661,16 @@ pub mod points_internal_client {
         pub async fn delete_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/DeletePayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/DeletePayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "DeletePayload"));
@@ -5101,23 +4679,16 @@ pub mod points_internal_client {
         pub async fn clear_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/ClearPayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/ClearPayload");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "ClearPayload"));
@@ -5126,23 +4697,17 @@ pub mod points_internal_client {
         pub async fn create_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollectionInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/CreateFieldIndex",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/CreateFieldIndex");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "CreateFieldIndex"));
@@ -5151,23 +4716,17 @@ pub mod points_internal_client {
         pub async fn delete_field_index(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollectionInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/DeleteFieldIndex",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/DeleteFieldIndex");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "DeleteFieldIndex"));
@@ -5177,19 +4736,14 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Search",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Search");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Search"));
@@ -5198,23 +4752,16 @@ pub mod points_internal_client {
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::SearchBatchResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/SearchBatch",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/SearchBatch");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "SearchBatch"));
@@ -5224,19 +4771,14 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ScrollPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::ScrollResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Scroll",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Scroll");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Scroll"));
@@ -5246,19 +4788,14 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CountPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::CountResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Count",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Count");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Count"));
@@ -5267,23 +4804,15 @@ pub mod points_internal_client {
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Recommend",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Recommend");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.PointsInternal", "Recommend"));
@@ -5293,21 +4822,17 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.PointsInternal/Get",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/Get");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -5322,66 +4847,39 @@ pub mod points_internal_server {
         async fn upsert(
             &self,
             request: tonic::Request<super::UpsertPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn sync(
             &self,
             request: tonic::Request<super::SyncPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PointsOperationResponse>, tonic::Status>;
         async fn search(
             &self,
             request: tonic::Request<super::SearchPointsInternal>,
@@ -5389,10 +4887,7 @@ pub mod points_internal_server {
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::SearchBatchResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SearchBatchResponse>, tonic::Status>;
         async fn scroll(
             &self,
             request: tonic::Request<super::ScrollPointsInternal>,
@@ -5404,10 +4899,7 @@ pub mod points_internal_server {
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPointsInternal>,
-        ) -> std::result::Result<
-            tonic::Response<super::RecommendResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RecommendResponse>, tonic::Status>;
         async fn get(
             &self,
             request: tonic::Request<super::GetPointsInternal>,
@@ -5436,10 +4928,7 @@ pub mod points_internal_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -5495,15 +4984,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Upsert" => {
                     #[allow(non_camel_case_types)]
                     struct UpsertSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::UpsertPointsInternal>
-                    for UpsertSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::UpsertPointsInternal> for UpsertSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpsertPointsInternal>,
@@ -5539,15 +5022,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::SyncPointsInternal>
-                    for SyncSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::SyncPointsInternal> for SyncSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncPointsInternal>,
@@ -5583,15 +5060,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::DeletePointsInternal>
-                    for DeleteSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::DeletePointsInternal> for DeleteSvc<T> {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePointsInternal>,
@@ -5627,15 +5098,12 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/SetPayload" => {
                     #[allow(non_camel_case_types)]
                     struct SetPayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::SetPayloadPointsInternal>
-                    for SetPayloadSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::SetPayloadPointsInternal>
+                        for SetPayloadSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPointsInternal>,
@@ -5671,23 +5139,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/OverwritePayload" => {
                     #[allow(non_camel_case_types)]
                     struct OverwritePayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::SetPayloadPointsInternal>
-                    for OverwritePayloadSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::SetPayloadPointsInternal>
+                        for OverwritePayloadSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).overwrite_payload(request).await
-                            };
+                            let fut = async move { (*inner).overwrite_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5717,23 +5180,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/DeletePayload" => {
                     #[allow(non_camel_case_types)]
                     struct DeletePayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::DeletePayloadPointsInternal>
-                    for DeletePayloadSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::DeletePayloadPointsInternal>
+                        for DeletePayloadSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeletePayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).delete_payload(request).await
-                            };
+                            let fut = async move { (*inner).delete_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5763,23 +5221,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/ClearPayload" => {
                     #[allow(non_camel_case_types)]
                     struct ClearPayloadSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::ClearPayloadPointsInternal>
-                    for ClearPayloadSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::ClearPayloadPointsInternal>
+                        for ClearPayloadSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ClearPayloadPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).clear_payload(request).await
-                            };
+                            let fut = async move { (*inner).clear_payload(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5809,26 +5262,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/CreateFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<
-                        super::CreateFieldIndexCollectionInternal,
-                    > for CreateFieldIndexSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::CreateFieldIndexCollectionInternal>
+                        for CreateFieldIndexSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::CreateFieldIndexCollectionInternal,
-                            >,
+                            request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).create_field_index(request).await
-                            };
+                            let fut = async move { (*inner).create_field_index(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5858,26 +5303,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/DeleteFieldIndex" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFieldIndexSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<
-                        super::DeleteFieldIndexCollectionInternal,
-                    > for DeleteFieldIndexSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::DeleteFieldIndexCollectionInternal>
+                        for DeleteFieldIndexSvc<T>
+                    {
                         type Response = super::PointsOperationResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::DeleteFieldIndexCollectionInternal,
-                            >,
+                            request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).delete_field_index(request).await
-                            };
+                            let fut = async move { (*inner).delete_field_index(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5907,15 +5344,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::SearchPointsInternal>
-                    for SearchSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::SearchPointsInternal> for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchPointsInternal>,
@@ -5951,23 +5382,18 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/SearchBatch" => {
                     #[allow(non_camel_case_types)]
                     struct SearchBatchSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::SearchBatchPointsInternal>
-                    for SearchBatchSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::SearchBatchPointsInternal>
+                        for SearchBatchSvc<T>
+                    {
                         type Response = super::SearchBatchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchBatchPointsInternal>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).search_batch(request).await
-                            };
+                            let fut = async move { (*inner).search_batch(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -5997,15 +5423,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Scroll" => {
                     #[allow(non_camel_case_types)]
                     struct ScrollSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::ScrollPointsInternal>
-                    for ScrollSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::ScrollPointsInternal> for ScrollSvc<T> {
                         type Response = super::ScrollResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScrollPointsInternal>,
@@ -6041,15 +5461,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Count" => {
                     #[allow(non_camel_case_types)]
                     struct CountSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::CountPointsInternal>
-                    for CountSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::CountPointsInternal> for CountSvc<T> {
                         type Response = super::CountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CountPointsInternal>,
@@ -6085,15 +5499,12 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Recommend" => {
                     #[allow(non_camel_case_types)]
                     struct RecommendSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::RecommendPointsInternal>
-                    for RecommendSvc<T> {
+                    impl<T: PointsInternal>
+                        tonic::server::UnaryService<super::RecommendPointsInternal>
+                        for RecommendSvc<T>
+                    {
                         type Response = super::RecommendResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RecommendPointsInternal>,
@@ -6129,15 +5540,9 @@ pub mod points_internal_server {
                 "/qdrant.PointsInternal/Get" => {
                     #[allow(non_camel_case_types)]
                     struct GetSvc<T: PointsInternal>(pub Arc<T>);
-                    impl<
-                        T: PointsInternal,
-                    > tonic::server::UnaryService<super::GetPointsInternal>
-                    for GetSvc<T> {
+                    impl<T: PointsInternal> tonic::server::UnaryService<super::GetPointsInternal> for GetSvc<T> {
                         type Response = super::GetResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPointsInternal>,
@@ -6170,18 +5575,14 @@ pub mod points_internal_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -6261,8 +5662,8 @@ pub struct Uri {
 /// Generated client implementations.
 pub mod raft_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct RaftClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6293,10 +5694,7 @@ pub mod raft_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> RaftClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> RaftClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -6306,9 +5704,8 @@ pub mod raft_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             RaftClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6348,19 +5745,17 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RaftMessage>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/Send");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Raft", "Send"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Raft", "Send"));
             self.inner.unary(req, path, codec).await
         }
         /// Send to bootstrap peer
@@ -6369,19 +5764,17 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PeerId>,
         ) -> std::result::Result<tonic::Response<super::Uri>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/WhoIs");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Raft", "WhoIs"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Raft", "WhoIs"));
             self.inner.unary(req, path, codec).await
         }
         /// Send to bootstrap peer
@@ -6391,19 +5784,14 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::AddPeerToKnownMessage>,
         ) -> std::result::Result<tonic::Response<super::AllPeers>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Raft/AddPeerToKnown",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/AddPeerToKnown");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Raft", "AddPeerToKnown"));
@@ -6418,19 +5806,14 @@ pub mod raft_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PeerId>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Raft/AddPeerAsParticipant",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Raft/AddPeerAsParticipant");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Raft", "AddPeerAsParticipant"));
@@ -6496,10 +5879,7 @@ pub mod raft_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6555,13 +5935,9 @@ pub mod raft_server {
                 "/qdrant.Raft/Send" => {
                     #[allow(non_camel_case_types)]
                     struct SendSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::RaftMessage>
-                    for SendSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::RaftMessage> for SendSvc<T> {
                         type Response = ();
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftMessage>,
@@ -6597,17 +5973,10 @@ pub mod raft_server {
                 "/qdrant.Raft/WhoIs" => {
                     #[allow(non_camel_case_types)]
                     struct WhoIsSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::PeerId>
-                    for WhoIsSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::PeerId> for WhoIsSvc<T> {
                         type Response = super::Uri;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::PeerId>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::PeerId>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).who_is(request).await };
                             Box::pin(fut)
@@ -6639,23 +6008,15 @@ pub mod raft_server {
                 "/qdrant.Raft/AddPeerToKnown" => {
                     #[allow(non_camel_case_types)]
                     struct AddPeerToKnownSvc<T: Raft>(pub Arc<T>);
-                    impl<
-                        T: Raft,
-                    > tonic::server::UnaryService<super::AddPeerToKnownMessage>
-                    for AddPeerToKnownSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::AddPeerToKnownMessage> for AddPeerToKnownSvc<T> {
                         type Response = super::AllPeers;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AddPeerToKnownMessage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).add_peer_to_known(request).await
-                            };
+                            let fut = async move { (*inner).add_peer_to_known(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -6685,21 +6046,13 @@ pub mod raft_server {
                 "/qdrant.Raft/AddPeerAsParticipant" => {
                     #[allow(non_camel_case_types)]
                     struct AddPeerAsParticipantSvc<T: Raft>(pub Arc<T>);
-                    impl<T: Raft> tonic::server::UnaryService<super::PeerId>
-                    for AddPeerAsParticipantSvc<T> {
+                    impl<T: Raft> tonic::server::UnaryService<super::PeerId> for AddPeerAsParticipantSvc<T> {
                         type Response = ();
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::PeerId>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::PeerId>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).add_peer_as_participant(request).await
-                            };
+                            let fut =
+                                async move { (*inner).add_peer_as_participant(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -6726,18 +6079,14 @@ pub mod raft_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -6856,8 +6205,8 @@ pub struct DeleteSnapshotResponse {
 /// Generated client implementations.
 pub mod snapshots_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct SnapshotsClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6901,9 +6250,8 @@ pub mod snapshots_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             SnapshotsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6943,23 +6291,19 @@ pub mod snapshots_client {
         pub async fn create(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateSnapshotResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Create");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "Create"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Snapshots", "Create"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6967,23 +6311,19 @@ pub mod snapshots_client {
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListSnapshotsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/List");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "List"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Snapshots", "List"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -6991,23 +6331,19 @@ pub mod snapshots_client {
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::DeleteSnapshotResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/Delete");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "Delete"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Snapshots", "Delete"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -7015,23 +6351,16 @@ pub mod snapshots_client {
         pub async fn create_full(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFullSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateSnapshotResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Snapshots/CreateFull",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/CreateFull");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Snapshots", "CreateFull"));
@@ -7042,25 +6371,19 @@ pub mod snapshots_client {
         pub async fn list_full(
             &mut self,
             request: impl tonic::IntoRequest<super::ListFullSnapshotsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListSnapshotsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Snapshots/ListFull",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/ListFull");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Snapshots", "ListFull"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Snapshots", "ListFull"));
             self.inner.unary(req, path, codec).await
         }
         ///
@@ -7068,23 +6391,16 @@ pub mod snapshots_client {
         pub async fn delete_full(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFullSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::DeleteSnapshotResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Snapshots/DeleteFull",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Snapshots/DeleteFull");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("qdrant.Snapshots", "DeleteFull"));
@@ -7104,55 +6420,37 @@ pub mod snapshots_server {
         async fn create(
             &self,
             request: tonic::Request<super::CreateSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateSnapshotResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
         ///
         /// List collection snapshots
         async fn list(
             &self,
             request: tonic::Request<super::ListSnapshotsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListSnapshotsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
         ///
         /// Delete collection snapshots
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::DeleteSnapshotResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
         ///
         /// Create full storage snapshot
         async fn create_full(
             &self,
             request: tonic::Request<super::CreateFullSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateSnapshotResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreateSnapshotResponse>, tonic::Status>;
         ///
         /// List full storage snapshots
         async fn list_full(
             &self,
             request: tonic::Request<super::ListFullSnapshotsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListSnapshotsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status>;
         ///
         /// List full storage snapshots
         async fn delete_full(
             &self,
             request: tonic::Request<super::DeleteFullSnapshotRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::DeleteSnapshotResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::DeleteSnapshotResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SnapshotsServer<T: Snapshots> {
@@ -7177,10 +6475,7 @@ pub mod snapshots_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7236,15 +6531,9 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/Create" => {
                     #[allow(non_camel_case_types)]
                     struct CreateSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::CreateSnapshotRequest>
-                    for CreateSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::CreateSnapshotRequest> for CreateSvc<T> {
                         type Response = super::CreateSnapshotResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateSnapshotRequest>,
@@ -7280,15 +6569,9 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/List" => {
                     #[allow(non_camel_case_types)]
                     struct ListSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::ListSnapshotsRequest>
-                    for ListSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::ListSnapshotsRequest> for ListSvc<T> {
                         type Response = super::ListSnapshotsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListSnapshotsRequest>,
@@ -7324,15 +6607,9 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/Delete" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::DeleteSnapshotRequest>
-                    for DeleteSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::DeleteSnapshotRequest> for DeleteSvc<T> {
                         type Response = super::DeleteSnapshotResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteSnapshotRequest>,
@@ -7368,15 +6645,11 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/CreateFull" => {
                     #[allow(non_camel_case_types)]
                     struct CreateFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::CreateFullSnapshotRequest>
-                    for CreateFullSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::CreateFullSnapshotRequest>
+                        for CreateFullSvc<T>
+                    {
                         type Response = super::CreateSnapshotResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateFullSnapshotRequest>,
@@ -7412,15 +6685,9 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/ListFull" => {
                     #[allow(non_camel_case_types)]
                     struct ListFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::ListFullSnapshotsRequest>
-                    for ListFullSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::ListFullSnapshotsRequest> for ListFullSvc<T> {
                         type Response = super::ListSnapshotsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListFullSnapshotsRequest>,
@@ -7456,15 +6723,11 @@ pub mod snapshots_server {
                 "/qdrant.Snapshots/DeleteFull" => {
                     #[allow(non_camel_case_types)]
                     struct DeleteFullSvc<T: Snapshots>(pub Arc<T>);
-                    impl<
-                        T: Snapshots,
-                    > tonic::server::UnaryService<super::DeleteFullSnapshotRequest>
-                    for DeleteFullSvc<T> {
+                    impl<T: Snapshots> tonic::server::UnaryService<super::DeleteFullSnapshotRequest>
+                        for DeleteFullSvc<T>
+                    {
                         type Response = super::DeleteSnapshotResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeleteFullSnapshotRequest>,
@@ -7497,18 +6760,14 @@ pub mod snapshots_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -7552,8 +6811,8 @@ pub struct HealthCheckReply {
 /// Generated client implementations.
 pub mod qdrant_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct QdrantClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7597,9 +6856,8 @@ pub mod qdrant_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             QdrantClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7637,25 +6895,18 @@ pub mod qdrant_client {
         pub async fn health_check(
             &mut self,
             request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HealthCheckReply>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::HealthCheckReply>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Qdrant/HealthCheck",
-            );
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Qdrant/HealthCheck");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7670,10 +6921,7 @@ pub mod qdrant_server {
         async fn health_check(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HealthCheckReply>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::HealthCheckReply>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QdrantServer<T: Qdrant> {
@@ -7698,10 +6946,7 @@ pub mod qdrant_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7757,23 +7002,15 @@ pub mod qdrant_server {
                 "/qdrant.Qdrant/HealthCheck" => {
                     #[allow(non_camel_case_types)]
                     struct HealthCheckSvc<T: Qdrant>(pub Arc<T>);
-                    impl<
-                        T: Qdrant,
-                    > tonic::server::UnaryService<super::HealthCheckRequest>
-                    for HealthCheckSvc<T> {
+                    impl<T: Qdrant> tonic::server::UnaryService<super::HealthCheckRequest> for HealthCheckSvc<T> {
                         type Response = super::HealthCheckReply;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).health_check(request).await
-                            };
+                            let fut = async move { (*inner).health_check(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -7800,18 +7037,14 @@ pub mod qdrant_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -117,7 +117,6 @@ pub struct OptimizersConfigDiff {
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
-    #[validate(range(min = 1000))]
     pub memmap_threshold: Option<usize>,
     /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
     ///

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -43,7 +43,7 @@ pub struct HnswConfigDiff {
     #[validate(range(min = 4))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ef_construct: Option<usize>,
-    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// Minimal size (in kilobytes) of vectors for additional payload-based indexing.
     /// If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used -
     /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
     /// Note: 1Kb = 1 vector of size 256
@@ -99,7 +99,7 @@ pub struct OptimizersConfigDiff {
     /// so that each segment would be handled evenly by one of the threads
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: Option<usize>,
-    /// Do not create segments larger this size (in KiloBytes).
+    /// Do not create segments larger this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///
@@ -108,18 +108,25 @@ pub struct OptimizersConfigDiff {
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "max_segment_size_kb")]
     pub max_segment_size: Option<usize>,
-    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+    /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
-    /// To enable memmap storage, lower the threshold
+    ///
+    /// To enable memmap storage, lower the threshold.
+    /// To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+    ///
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
     #[validate(range(min = 1000))]
     pub memmap_threshold: Option<usize>,
-    /// Maximum size (in KiloBytes) of vectors allowed for plain index.
-    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>
-    /// Note: 1Kb = 1 vector of size 256
+    /// Maximum size (in kilobytes) of vectors allowed for plain index.
+    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+    ///
+    /// Recommendend minimum value is `1000`.
+    ///
+    /// When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+    ///
+    /// Note: 1kB = 1 vector of size 256.
     #[serde(alias = "indexing_threshold_kb")]
-    #[validate(range(min = 1000))]
     pub indexing_threshold: Option<usize>,
     /// Minimum interval between forced flushes.
     pub flush_interval_sec: Option<u64>,

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -111,19 +111,19 @@ pub struct OptimizersConfigDiff {
     /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
     ///
-    /// To enable memmap storage, lower the threshold.
-    /// To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
+    /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+    ///
+    /// To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
     #[validate(range(min = 1000))]
     pub memmap_threshold: Option<usize>,
-    /// Maximum size (in kilobytes) of vectors allowed for plain index.
-    /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
+    /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
     ///
-    /// Recommendend minimum value is `1000`.
+    /// Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
     ///
-    /// When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
+    /// To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[serde(alias = "indexing_threshold_kb")]

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -113,7 +113,7 @@ pub struct OptimizersConfigDiff {
     ///
     /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
     ///
-    /// To disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.
+    /// To disable memmap storage, set this to `0`.
     ///
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "memmap_threshold_kb")]
@@ -122,7 +122,7 @@ pub struct OptimizersConfigDiff {
     ///
     /// Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
     ///
-    /// To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
+    /// To disable vector indexing, set to `0`.
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[serde(alias = "indexing_threshold_kb")]

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -60,7 +60,7 @@ pub struct OptimizersConfig {
     ///
     /// Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
     ///
-    /// To disable vector indexing, set to `0`. Internally it will use the largest threshold possible.
+    /// To disable vector indexing, set to `0`.
     ///
     /// Note: 1kB = 1 vector of size 256.
     #[serde(alias = "indexing_threshold_kb")]

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -33,7 +33,7 @@ pub struct OptimizersConfig {
     /// so that each segment would be handled evenly by one of the threads.
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs.
     pub default_segment_number: usize,
-    /// Do not create segments larger this size (in KiloBytes).
+    /// Do not create segments larger this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///
@@ -44,29 +44,28 @@ pub struct OptimizersConfig {
     #[serde(alias = "max_segment_size_kb")]
     #[serde(default)]
     pub max_segment_size: Option<usize>,
-    /// Maximum size (in KiloBytes) of vectors to store in-memory per segment.
+    /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
     /// Segments larger than this threshold will be stored as read-only memmaped file.
-    /// 
+    ///
     /// To enable memmap storage, lower the threshold.
     /// To disable memmap storage entirely, set to `0`. It will be treated as the largest value possible.
-    /// 
+    ///
     /// Note: 1Kb = 1 vector of size 256
     /// If not set, mmap will not be used.
     #[serde(alias = "memmap_threshold_kb")]
     #[serde(default)]
-    #[validate(range(min = 1000))]
     pub memmap_threshold: Option<usize>,
     /// Maximum size (in kilobytes) of vectors allowed for plain index.
     /// Default value based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
-    /// 
-    /// Minimum value is `1000`.
-    /// 
+    ///
+    /// Recommendend minimum value is `1000`.
+    ///
     /// When set to `0`, plain index will be disabled. It will be treated as the largest value possible.
-    /// 
+    ///
     /// Note: 1kB = 1 vector of size 256.
     /// If not set, the default 20,000 will be used.
     #[serde(alias = "indexing_threshold_kb")]
-    #[validate(range(min = 1000))]
+    #[serde(default)]
     pub indexing_threshold: Option<usize>,
     /// Minimum interval between forced flushes.
     pub flush_interval_sec: u64,
@@ -121,13 +120,13 @@ pub fn build_optimizers(
     let temp_segments_path = shard_path.join("temp_segments");
 
     let indexing_threshold = match optimizers_config.indexing_threshold {
-        None => 20_000,         // default value
-        Some(0) => usize::MAX,  // disable plain index
+        None => 20_000,        // default value
+        Some(0) => usize::MAX, // disable plain index
         Some(custom) => custom,
     };
 
     let memmap_threshold = match optimizers_config.memmap_threshold {
-        None | Some(0) => usize::MAX, // disable memmap
+        None | Some(0) => usize::MAX, // default | disable memmap
         Some(custom) => custom,
     };
 

--- a/openapi/tests/openapi_integration/test_validation.py
+++ b/openapi/tests/openapi_integration/test_validation.py
@@ -44,15 +44,13 @@ def test_validation():
                 "distance": "Dot"
             },
             "optimizers_config": {
-                "memmap_threshold": 100,
-                "indexing_threshold": 100,
+                "max_optimization_threads": 0,
             },
         }
     )
     assert not response.ok
     assert 'Validation error' in response.json()["status"]["error"]
-    assert 'optimizers_config.memmap_threshold' in response.json()["status"]["error"]
-    assert 'optimizers_config.indexing_threshold' in response.json()["status"]["error"]
+    assert 'optimizers_config.max_optimization_threads' in response.json()["status"]["error"]
 
     # Illegal URL parameters must trigger a validation error
     response = request_with_validation(

--- a/openapi/tests/openapi_integration/test_validation.py
+++ b/openapi/tests/openapi_integration/test_validation.py
@@ -43,14 +43,14 @@ def test_validation():
                 "size": 4,
                 "distance": "Dot"
             },
-            "optimizers_config": {
-                "max_optimization_threads": 0,
-            },
+            "hnsw_config": {
+                "ef_construct": 0,
+            }
         }
     )
     assert not response.ok
     assert 'Validation error' in response.json()["status"]["error"]
-    assert 'optimizers_config.max_optimization_threads' in response.json()["status"]["error"]
+    assert 'hnsw_config.ef_construct' in response.json()["status"]["error"]
 
     # Illegal URL parameters must trigger a validation error
     response = request_with_validation(

--- a/openapi/tests/openapi_integration/test_vector_config.py
+++ b/openapi/tests/openapi_integration/test_vector_config.py
@@ -145,7 +145,7 @@ def test_retrieve_vector_specific_quantization():
     assert config['quantization_config']['scalar']['type'] == "int8"
     assert config['quantization_config']['scalar']['quantile'] == 0.5
 
-@pytest.mark.timeout(3)
+@pytest.mark.timeout(20)
 def test_disable_indexing():
     indexed_name = 'test_collection_indexed'
     unindexed_name = 'test_collection_unindexed'
@@ -170,7 +170,7 @@ def test_disable_indexing():
         )
         assert response.ok
     
-    amount_of_vectors = 10
+    amount_of_vectors = 100
     
     # Collection with indexing enabled
     create_collection(indexed_name, 10)

--- a/openapi/tests/openapi_integration/test_vector_config.py
+++ b/openapi/tests/openapi_integration/test_vector_config.py
@@ -1,4 +1,5 @@
 import random
+from time import sleep
 import pytest
 
 from .helpers.helpers import request_with_validation
@@ -144,7 +145,6 @@ def test_retrieve_vector_specific_quantization():
     assert config['quantization_config']['scalar']['type'] == "int8"
     assert config['quantization_config']['scalar']['quantile'] == 0.5
 
-@pytest.mark.skip(reason="Takes too long for a sanity test")
 def test_disable_indexing():
     indexed_name = 'test_collection_indexed'
     unindexed_name = 'test_collection_unindexed'
@@ -169,35 +169,37 @@ def test_disable_indexing():
         )
         assert response.ok
         
-    amount_of_vectors = 3000
+    amount_of_vectors = 10
     
     # Collection with indexing enabled
-    create_collection(indexed_name, 1000)
+    create_collection(indexed_name, 10)
     insert_vectors(indexed_name, amount_of_vectors)
     
     # Collection with indexing disabled
-    create_collection(unindexed_name, None)
+    create_collection(unindexed_name, 0)
     insert_vectors(unindexed_name, amount_of_vectors)
     
-    # Get info
+    # Get info indexed
+    sleep(0.5) # wait for indexing to finish
     response = request_with_validation(
         method='GET',
         api='/collections/{collection_name}',
         path_params={'collection_name': indexed_name},
     )
     assert response.ok
-    assert response.json()['result']['indexed_vectors_count'] > 0
-    assert response.json()['result']['vectors_count'] == amount_of_vectors
     
-    # Get info
+    assert response.json()['result']['vectors_count'] == amount_of_vectors
+    assert response.json()['result']['indexed_vectors_count'] > 0
+    
+    # Get info unindexed
     response = request_with_validation(
         method='GET',
         api='/collections/{collection_name}',
         path_params={'collection_name': unindexed_name},
     )
     assert response.ok
-    assert response.json()['result']['indexed_vectors_count'] == 0
     assert response.json()['result']['vectors_count'] == amount_of_vectors
+    assert response.json()['result']['indexed_vectors_count'] == 0
     
     # Cleanup
     drop_collection(collection_name=indexed_name)
@@ -209,19 +211,29 @@ def insert_vectors(collection_name='test_collection', count=2000, size=256):
     ids = [x for x in range(count)]
     vectors = [[random.random() for _ in range(size)] for _ in range(count)]
     
-    response = request_with_validation(
-        api='/collections/{collection_name}/points',
-        method='PUT',
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={
-            "batch": {
-                "ids": ids,
-                "vectors": vectors,
+    batch_size = 1000
+    start = 0
+    end = 0
+    while end < count:
+        end = min(end + batch_size, count)
+        
+        response = request_with_validation(
+            api='/collections/{collection_name}/points',
+            method='PUT',
+            path_params={'collection_name': collection_name},
+            query_params={'wait': 'true'},
+            body={
+                "batch": {
+                    "ids": ids[start:end],
+                    "vectors": vectors[start:end],
+                }
             }
-        }
-    )
-    assert response.ok
+        )
+        assert response.ok
+        
+        
+        start += batch_size
+        
     
     
     

--- a/openapi/tests/requirements-freeze.txt
+++ b/openapi/tests/requirements-freeze.txt
@@ -25,6 +25,7 @@ pyrate-limiter==2.10.0
 pyrsistent==0.19.3
 pytest==7.2.2
 pytest-subtests==0.7.0
+pytest-timeout==2.1.0
 PyYAML==6.0
 requests==2.28.1
 schemathesis==3.19.0

--- a/openapi/tests/requirements.txt
+++ b/openapi/tests/requirements.txt
@@ -1,3 +1,4 @@
 schemathesis~=3.19.0
 requests
 pytest==7.2.2
+pytest-timeout==2.1.0


### PR DESCRIPTION
Switching from `null` to `0` to signify *disable* on `indexing_threshold` and on `memmap_threshold`

follow-up to #1702: Previously we allowed `null` to *disable*, but the problem was that we cannot set these parameters to `null` using gRPC, we can only **not** set them, which is ambiguous for when the user wants to deliberately have the default or the disabled value. 
Using `0` fixes this problem.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using ``cargo fmt`` command prior to submission?
3. [x] Have you checked your code using ```cargo clippy``` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
