### PR TITLE
chunked mmap and dynamic flags

### DIFF
--- a/lib/segment/src/common/mmap_ops.rs
+++ b/lib/segment/src/common/mmap_ops.rs
@@ -8,6 +8,17 @@ use memmap2::{Mmap, MmapMut, MmapOptions};
 use crate::entry::entry_point::OperationResult;
 use crate::madvise;
 
+pub fn create_and_ensure_length(path: &Path, length: usize) -> OperationResult<()> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(path)?;
+
+    file.set_len(length as u64)?;
+    Ok(())
+}
+
 pub fn open_read_mmap(path: &Path) -> OperationResult<Mmap> {
     let file = OpenOptions::new()
         .read(true)
@@ -43,20 +54,51 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v as *const T as *const u8, mem::size_of_val(v)) }
 }
 
-pub fn transmute_from_u8_to_array<T>(data: &[u8]) -> &[T] {
+pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert!(data.len() % size_of::<T>() == 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }
 }
 
-pub fn transmute_from_u8_to_mut_array<T>(data: &mut [u8]) -> &mut [T] {
+pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert!(data.len() % size_of::<T>() == 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_mut_ptr() as *mut T;
     unsafe { std::slice::from_raw_parts_mut(ptr, len) }
 }
 
-pub fn transmute_to_u8_array<T>(v: &[T]) -> &[u8] {
+pub fn transmute_to_u8_slice<T>(v: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, mem::size_of_val(v)) }
+}
+
+pub fn write_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: T) {
+    debug_assert!(offset + size_of::<T>() <= mmap.len());
+    let ptr = mmap.as_mut_ptr();
+    unsafe {
+        let byte_data = transmute_to_u8(&data);
+        std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
+    }
+}
+
+pub fn write_slice_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: &[T]) {
+    debug_assert!(offset + data.len() * size_of::<T>() <= mmap.len());
+    let ptr = mmap.as_mut_ptr();
+    unsafe {
+        let byte_data = transmute_to_u8_slice(data);
+        std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
+    }
+}
+
+pub fn read_from_mmap<T>(mmap: &MmapMut, offset: usize) -> &T {
+    debug_assert!(offset + size_of::<T>() <= mmap.len());
+    let ptr = mmap.as_ptr();
+    unsafe { &*(ptr.add(offset) as *const T) }
+}
+
+pub fn read_slice_from_mmap<T>(mmap: &MmapMut, offset: usize, len: usize) -> &[T] {
+    debug_assert!(offset + len * size_of::<T>() <= mmap.len());
+    let byte_len = len * size_of::<T>();
+    let slice = &mmap[offset..offset + byte_len];
+    transmute_from_u8_to_slice(slice)
 }

--- a/lib/segment/src/common/mmap_ops.rs
+++ b/lib/segment/src/common/mmap_ops.rs
@@ -1,0 +1,62 @@
+use std::fs::OpenOptions;
+use std::mem;
+use std::mem::size_of;
+use std::path::Path;
+
+use memmap2::{Mmap, MmapMut, MmapOptions};
+
+use crate::entry::entry_point::OperationResult;
+use crate::madvise;
+
+pub fn open_read_mmap(path: &Path) -> OperationResult<Mmap> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(false)
+        .append(true)
+        .create(true)
+        .open(path)?;
+
+    let mmap = unsafe { MmapOptions::new().map(&file)? };
+    madvise::madvise(&mmap, madvise::get_global())?;
+    Ok(mmap)
+}
+
+pub fn open_write_mmap(path: &Path) -> OperationResult<MmapMut> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .open(path)?;
+
+    let mmap = unsafe { MmapMut::map_mut(&file)? };
+    madvise::madvise(&mmap, madvise::get_global())?;
+    Ok(mmap)
+}
+
+pub fn transmute_from_u8<T>(data: &[u8]) -> &T {
+    debug_assert!(data.len() == size_of::<T>());
+    let ptr = data.as_ptr() as *const T;
+    unsafe { &*ptr }
+}
+
+pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v as *const T as *const u8, mem::size_of_val(v)) }
+}
+
+pub fn transmute_from_u8_to_array<T>(data: &[u8]) -> &[T] {
+    debug_assert!(data.len() % size_of::<T>() == 0);
+    let len = data.len() / size_of::<T>();
+    let ptr = data.as_ptr() as *const T;
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+pub fn transmute_from_u8_to_mut_array<T>(data: &mut [u8]) -> &mut [T] {
+    debug_assert!(data.len() % size_of::<T>() == 0);
+    let len = data.len() / size_of::<T>();
+    let ptr = data.as_mut_ptr() as *mut T;
+    unsafe { std::slice::from_raw_parts_mut(ptr, len) }
+}
+
+pub fn transmute_to_u8_array<T>(v: &[T]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, mem::size_of_val(v)) }
+}

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -3,6 +3,7 @@ pub mod arc_atomic_ref_cell_iterator;
 pub mod cpu;
 pub mod error_logging;
 pub mod file_operations;
+pub mod mmap_ops;
 pub mod operation_time_statistics;
 pub mod rocksdb_wrapper;
 pub mod utils;

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -59,25 +59,25 @@ fn get_reindex_slice<'a>(
 ) -> &'a [PointOffsetType] {
     let reindex_range = header.get_reindex_range();
     let reindex_byte_slice = &data[reindex_range];
-    mmap_ops::transmute_from_u8_to_array(reindex_byte_slice)
+    mmap_ops::transmute_from_u8_to_slice(reindex_byte_slice)
 }
 
 fn get_links_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a [PointOffsetType] {
     let links_range = header.get_links_range();
     let links_byte_slice = &data[links_range];
-    mmap_ops::transmute_from_u8_to_array(links_byte_slice)
+    mmap_ops::transmute_from_u8_to_slice(links_byte_slice)
 }
 
 fn get_offsets_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a [u64] {
     let offsets_range = header.get_offsets_range();
     let offsets_byte_slice = &data[offsets_range];
-    mmap_ops::transmute_from_u8_to_array(offsets_byte_slice)
+    mmap_ops::transmute_from_u8_to_slice(offsets_byte_slice)
 }
 
 fn get_level_offsets<'a>(data: &'a [u8], header: &GraphLinksFileHeader) -> &'a [u64] {
     let level_offsets_range = header.get_level_offsets_range();
     let level_offsets_byte_slice = &data[level_offsets_range];
-    mmap_ops::transmute_from_u8_to_array(level_offsets_byte_slice)
+    mmap_ops::transmute_from_u8_to_slice(level_offsets_byte_slice)
 }
 
 impl GraphLinksFileHeader {
@@ -87,7 +87,7 @@ impl GraphLinksFileHeader {
 
     pub fn serialize_bytes_to(&self, raw_data: &mut [u8]) {
         let byte_slice = &mut raw_data[0..Self::raw_size()];
-        let arr: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_array(byte_slice);
+        let arr: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_slice(byte_slice);
         arr[0] = self.point_count;
         arr[1] = self.levels_count;
         arr[2] = self.total_links_len;
@@ -96,7 +96,7 @@ impl GraphLinksFileHeader {
 
     pub fn deserialize_bytes_from(raw_data: &[u8]) -> GraphLinksFileHeader {
         let byte_slice = &raw_data[0..Self::raw_size()];
-        let arr: &[u64] = mmap_ops::transmute_from_u8_to_array(byte_slice);
+        let arr: &[u64] = mmap_ops::transmute_from_u8_to_slice(byte_slice);
         GraphLinksFileHeader {
             point_count: arr[0],
             levels_count: arr[1],
@@ -218,7 +218,7 @@ impl GraphLinksConverter {
             let reindex_range = header.get_reindex_range();
             let reindex_byte_slice = &mut bytes_data[reindex_range];
             let reindex_slice: &mut [PointOffsetType] =
-                mmap_ops::transmute_from_u8_to_mut_array(reindex_byte_slice);
+                mmap_ops::transmute_from_u8_to_mut_slice(reindex_byte_slice);
             reindex_slice.copy_from_slice(&self.reindex);
         }
 
@@ -231,8 +231,8 @@ impl GraphLinksConverter {
                 .as_mut()
                 .split_at_mut(links_range.len());
             let links_mmap: &mut [PointOffsetType] =
-                mmap_ops::transmute_from_u8_to_mut_array(links_mmap);
-            let offsets_mmap: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_array(offsets_mmap);
+                mmap_ops::transmute_from_u8_to_mut_slice(links_mmap);
+            let offsets_mmap: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_slice(offsets_mmap);
             offsets_mmap[0] = 0;
 
             let mut links_pos = 0;
@@ -253,7 +253,7 @@ impl GraphLinksConverter {
             let level_offsets_range = header.get_level_offsets_range();
             let level_offsets_byte_slice = &mut bytes_data[level_offsets_range];
             let level_offsets_slice: &mut [u64] =
-                mmap_ops::transmute_from_u8_to_mut_array(level_offsets_byte_slice);
+                mmap_ops::transmute_from_u8_to_mut_slice(level_offsets_byte_slice);
             level_offsets_slice.copy_from_slice(&level_offsets);
         }
     }

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -6,23 +6,12 @@ use std::path::{Path, PathBuf};
 
 use memmap2::{Mmap, MmapMut};
 
+use crate::common::mmap_ops;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::madvise;
 use crate::types::PointOffsetType;
 
 pub const MMAP_PANIC_MESSAGE: &str = "Mmap links are not loaded";
-
-fn transmute_from_u8<T>(data: &[u8]) -> &[T] {
-    let len = data.len() / size_of::<T>();
-    let ptr = data.as_ptr() as *const T;
-    unsafe { std::slice::from_raw_parts(ptr, len) }
-}
-
-fn transmute_from_u8_mut<T>(data: &mut [u8]) -> &mut [T] {
-    let len = data.len() / size_of::<T>();
-    let ptr = data.as_mut_ptr() as *mut T;
-    unsafe { std::slice::from_raw_parts_mut(ptr, len) }
-}
 
 /*
 Links data for whole graph layers.
@@ -70,25 +59,25 @@ fn get_reindex_slice<'a>(
 ) -> &'a [PointOffsetType] {
     let reindex_range = header.get_reindex_range();
     let reindex_byte_slice = &data[reindex_range];
-    transmute_from_u8(reindex_byte_slice)
+    mmap_ops::transmute_from_u8_to_array(reindex_byte_slice)
 }
 
 fn get_links_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a [PointOffsetType] {
     let links_range = header.get_links_range();
     let links_byte_slice = &data[links_range];
-    transmute_from_u8(links_byte_slice)
+    mmap_ops::transmute_from_u8_to_array(links_byte_slice)
 }
 
 fn get_offsets_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a [u64] {
     let offsets_range = header.get_offsets_range();
     let offsets_byte_slice = &data[offsets_range];
-    transmute_from_u8(offsets_byte_slice)
+    mmap_ops::transmute_from_u8_to_array(offsets_byte_slice)
 }
 
 fn get_level_offsets<'a>(data: &'a [u8], header: &GraphLinksFileHeader) -> &'a [u64] {
     let level_offsets_range = header.get_level_offsets_range();
     let level_offsets_byte_slice = &data[level_offsets_range];
-    transmute_from_u8(level_offsets_byte_slice)
+    mmap_ops::transmute_from_u8_to_array(level_offsets_byte_slice)
 }
 
 impl GraphLinksFileHeader {
@@ -98,7 +87,7 @@ impl GraphLinksFileHeader {
 
     pub fn serialize_bytes_to(&self, raw_data: &mut [u8]) {
         let byte_slice = &mut raw_data[0..Self::raw_size()];
-        let arr: &mut [u64] = transmute_from_u8_mut(byte_slice);
+        let arr: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_array(byte_slice);
         arr[0] = self.point_count;
         arr[1] = self.levels_count;
         arr[2] = self.total_links_len;
@@ -107,7 +96,7 @@ impl GraphLinksFileHeader {
 
     pub fn deserialize_bytes_from(raw_data: &[u8]) -> GraphLinksFileHeader {
         let byte_slice = &raw_data[0..Self::raw_size()];
-        let arr: &[u64] = transmute_from_u8(byte_slice);
+        let arr: &[u64] = mmap_ops::transmute_from_u8_to_array(byte_slice);
         GraphLinksFileHeader {
             point_count: arr[0],
             levels_count: arr[1],
@@ -228,7 +217,8 @@ impl GraphLinksConverter {
         {
             let reindex_range = header.get_reindex_range();
             let reindex_byte_slice = &mut bytes_data[reindex_range];
-            let reindex_slice: &mut [PointOffsetType] = transmute_from_u8_mut(reindex_byte_slice);
+            let reindex_slice: &mut [PointOffsetType] =
+                mmap_ops::transmute_from_u8_to_mut_array(reindex_byte_slice);
             reindex_slice.copy_from_slice(&self.reindex);
         }
 
@@ -240,8 +230,9 @@ impl GraphLinksConverter {
             let (links_mmap, offsets_mmap) = bytes_data[union_range]
                 .as_mut()
                 .split_at_mut(links_range.len());
-            let links_mmap: &mut [PointOffsetType] = transmute_from_u8_mut(links_mmap);
-            let offsets_mmap: &mut [u64] = transmute_from_u8_mut(offsets_mmap);
+            let links_mmap: &mut [PointOffsetType] =
+                mmap_ops::transmute_from_u8_to_mut_array(links_mmap);
+            let offsets_mmap: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_array(offsets_mmap);
             offsets_mmap[0] = 0;
 
             let mut links_pos = 0;
@@ -261,7 +252,8 @@ impl GraphLinksConverter {
         {
             let level_offsets_range = header.get_level_offsets_range();
             let level_offsets_byte_slice = &mut bytes_data[level_offsets_range];
-            let level_offsets_slice: &mut [u64] = transmute_from_u8_mut(level_offsets_byte_slice);
+            let level_offsets_slice: &mut [u64] =
+                mmap_ops::transmute_from_u8_to_mut_array(level_offsets_byte_slice);
             level_offsets_slice.copy_from_slice(&level_offsets);
         }
     }

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -7,12 +7,14 @@ use std::path::{Path, PathBuf};
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
 
-use crate::common::mmap_ops::{read_from_mmap, read_slice_from_mmap,
-                              write_slice_to_mmap, write_to_mmap,
+use crate::common::mmap_ops::{
+    read_from_mmap, read_slice_from_mmap, write_slice_to_mmap, write_to_mmap,
 };
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::types::PointOffsetType;
-use crate::vector_storage::chunked_utils::{create_chunk, MmapStatus, ensure_status_file, read_mmaps};
+use crate::vector_storage::chunked_utils::{
+    create_chunk, ensure_status_file, read_mmaps, MmapStatus,
+};
 
 #[cfg(test)]
 const DEFAULT_CHUNK_SIZE: usize = 512 * 1024; // 512Kb

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -1,20 +1,22 @@
+use std::cmp::max;
+use std::collections::HashMap;
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::Write;
 use std::marker::PhantomData;
-use std::mem::size_of;
 use std::path::{Path, PathBuf};
 
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
 
 use crate::common::mmap_ops::{
-    open_write_mmap, transmute_from_u8_to_array, transmute_to_u8, transmute_to_u8_array,
+    create_and_ensure_length, open_write_mmap, read_from_mmap, read_slice_from_mmap,
+    write_slice_to_mmap, write_to_mmap,
 };
-use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::types::PointOffsetType;
 
 #[cfg(test)]
-const DEFAULT_CHUNK_SIZE: usize = 4 * 1024 * 1024; // 4Mb
+const DEFAULT_CHUNK_SIZE: usize = 512 * 1024; // 512Kb
 
 #[cfg(not(test))]
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024 * 1024; // 128Mb
@@ -25,59 +27,33 @@ const STATUS_FILE_NAME: &str = "status.json";
 const MMAP_CHUNKS_PATTERN_START: &str = "chunk_";
 const MMAP_CHUNKS_PATTERN_END: &str = ".mmap";
 
-struct ChunkedMMapStatus {
+struct ChunkedMmapStatus {
     len: usize,
 }
 
 #[derive(Serialize, Deserialize)]
-struct ChunkedMMapConfig {
-    chunk_size: usize,
+struct ChunkedMmapConfig {
+    chunk_size_bytes: usize,
+    chunk_size_vectors: usize,
     dim: usize,
 }
 
-pub struct ChunkedMMapVectors<T> {
-    config: ChunkedMMapConfig,
-    status: ChunkedMMapStatus,
+pub struct ChunkedMmapVectors<T> {
+    config: ChunkedMmapConfig,
+    status: ChunkedMmapStatus,
     _phantom: PhantomData<T>,
     chunks: Vec<MmapMut>,
     status_mmap: MmapMut,
     directory: PathBuf,
 }
 
-impl ChunkedMMapVectors<VectorElementType> {
+impl<T: Copy + Clone + Default> ChunkedMmapVectors<T> {
     fn status_file(directory: &Path) -> PathBuf {
         directory.join(STATUS_FILE_NAME)
     }
 
-    fn write_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: T) {
-        debug_assert!(offset + size_of::<T>() <= mmap.len());
-        let ptr = mmap.as_mut_ptr();
-        unsafe {
-            let byte_data = transmute_to_u8(&data);
-            std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
-        }
-    }
-
-    fn write_array_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: &[T]) {
-        debug_assert!(offset + data.len() * size_of::<T>() <= mmap.len());
-        let ptr = mmap.as_mut_ptr();
-        unsafe {
-            let byte_data = transmute_to_u8_array(data);
-            std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
-        }
-    }
-
-    fn read_from_mmap<T>(mmap: &MmapMut, offset: usize) -> &T {
-        debug_assert!(offset + size_of::<T>() <= mmap.len());
-        let ptr = mmap.as_ptr();
-        unsafe { &*(ptr.add(offset) as *const T) }
-    }
-
-    fn read_array_from_mmap<T>(mmap: &MmapMut, offset: usize, len: usize) -> &[T] {
-        debug_assert!(offset + len * size_of::<T>() <= mmap.len());
-        let byte_len = len * size_of::<T>();
-        let slice = &mmap[offset..offset + byte_len];
-        transmute_from_u8_to_array(slice)
+    fn config_file(directory: &Path) -> PathBuf {
+        directory.join(CONFIG_FILE_NAME)
     }
 
     fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
@@ -85,14 +61,10 @@ impl ChunkedMMapVectors<VectorElementType> {
         if !status_file.exists() {
             {
                 let length = std::mem::size_of::<usize>() as u64;
-                let file = OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .open(&status_file)?;
-                file.set_len(length)?;
+                create_and_ensure_length(&status_file, length as usize)?;
             }
             let mut mmap = open_write_mmap(&status_file)?;
-            Self::write_to_mmap(&mut mmap, 0, 0usize);
+            write_to_mmap(&mut mmap, 0, 0usize);
             mmap.flush()?;
             Ok(mmap)
         } else {
@@ -100,23 +72,29 @@ impl ChunkedMMapVectors<VectorElementType> {
         }
     }
 
-    fn ensure_config(directory: &Path, dim: usize) -> OperationResult<ChunkedMMapConfig> {
-        let config_file = directory.join(CONFIG_FILE_NAME);
+    fn ensure_config(directory: &Path, dim: usize) -> OperationResult<ChunkedMmapConfig> {
+        let config_file = Self::config_file(directory);
         if !config_file.exists() {
-            let config = ChunkedMMapConfig {
-                chunk_size: DEFAULT_CHUNK_SIZE,
+            let chunk_size_bytes = DEFAULT_CHUNK_SIZE;
+            let vector_size_bytes = dim * std::mem::size_of::<T>();
+            let chunk_size_vectors = chunk_size_bytes / vector_size_bytes;
+            let corrected_chunk_size_bytes = chunk_size_vectors * vector_size_bytes;
+
+            let config = ChunkedMmapConfig {
+                chunk_size_bytes: corrected_chunk_size_bytes,
+                chunk_size_vectors,
                 dim,
             };
             let mut file = OpenOptions::new()
                 .create(true)
                 .write(true)
                 .open(&config_file)?;
-            serde_json::to_writer_pretty(&mut file, &config)?;
+            serde_json::to_writer(&mut file, &config)?;
             file.flush()?;
             Ok(config)
         } else {
             let file = std::fs::File::open(&config_file)?;
-            let config: ChunkedMMapConfig = serde_json::from_reader(file)?;
+            let config: ChunkedMmapConfig = serde_json::from_reader(file)?;
 
             if config.dim != dim {
                 return Err(OperationError::service_error(format!(
@@ -131,25 +109,44 @@ impl ChunkedMMapVectors<VectorElementType> {
         }
     }
 
-    fn check_mmap_file_name_pattern(file_name: &str) -> bool {
-        file_name.starts_with(MMAP_CHUNKS_PATTERN_START)
-            && file_name.ends_with(MMAP_CHUNKS_PATTERN_END)
+    /// Checks if the file name matches the pattern for mmap chunks
+    /// Return ID from the file name if it matches, None otherwise
+    fn check_mmap_file_name_pattern(file_name: &str) -> Option<usize> {
+        file_name
+            .strip_prefix(MMAP_CHUNKS_PATTERN_START)
+            .and_then(|file_name| file_name.strip_suffix(MMAP_CHUNKS_PATTERN_END))
+            .and_then(|file_name| file_name.parse::<usize>().ok())
     }
 
     fn read_mmaps(directory: &Path) -> OperationResult<Vec<MmapMut>> {
         let mut result = Vec::new();
+        let mut mmap_files: HashMap<usize, _> = HashMap::new();
         for entry in directory.read_dir()? {
             let entry = entry?;
             let path = entry.path();
-            if path.is_file()
-                && path
+            if path.is_file() {
+                let chunk_id = path
                     .file_name()
                     .and_then(|file_name| file_name.to_str())
-                    .map(Self::check_mmap_file_name_pattern)
-                    .unwrap_or(false)
-            {
-                result.push(open_write_mmap(&path)?);
+                    .and_then(Self::check_mmap_file_name_pattern);
+
+                if let Some(chunk_id) = chunk_id {
+                    mmap_files.insert(chunk_id, path);
+                }
             }
+        }
+
+        let num_chunks = mmap_files.len();
+        for chunk_id in 0..num_chunks {
+            let mmap_file = mmap_files.remove(&chunk_id).ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "Missing mmap chunk {} in {}",
+                    chunk_id,
+                    directory.display()
+                ))
+            })?;
+            let mmap = open_write_mmap(&mmap_file)?;
+            result.push(mmap);
         }
         Ok(result)
     }
@@ -157,8 +154,8 @@ impl ChunkedMMapVectors<VectorElementType> {
     pub fn open(directory: &Path, dim: usize) -> OperationResult<Self> {
         create_dir_all(directory)?;
         let status_mmap = Self::ensure_status_file(directory)?;
-        let len = *Self::read_from_mmap(&status_mmap, 0);
-        let status = ChunkedMMapStatus { len };
+        let len = *read_from_mmap(&status_mmap, 0);
+        let status = ChunkedMmapStatus { len };
         let config = Self::ensure_config(directory, dim)?;
         let chunks = Self::read_mmaps(directory)?;
 
@@ -172,24 +169,145 @@ impl ChunkedMMapVectors<VectorElementType> {
         };
         Ok(vectors)
     }
+
+    #[inline]
+    fn get_chunk_index(&self, key: usize) -> usize {
+        key / self.config.chunk_size_vectors
+    }
+
+    /// Returns the byte offset of the vector in the chunk
+    #[inline]
+    fn get_chunk_offset(&self, key: usize) -> usize {
+        let chunk_vector_idx = key % self.config.chunk_size_vectors;
+        chunk_vector_idx * self.config.dim * std::mem::size_of::<T>()
+    }
+
+    pub fn len(&self) -> usize {
+        self.status.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.status.len == 0
+    }
+
+    fn add_chunk(&mut self) -> OperationResult<()> {
+        let chunk_file_name = format!(
+            "{}{}{}",
+            MMAP_CHUNKS_PATTERN_START,
+            self.chunks.len(),
+            MMAP_CHUNKS_PATTERN_END
+        );
+        let chunk_file_path = self.directory.join(chunk_file_name);
+        create_and_ensure_length(&chunk_file_path, self.config.chunk_size_bytes)?;
+        self.chunks.push(open_write_mmap(&chunk_file_path)?);
+        Ok(())
+    }
+
+    pub fn insert(&mut self, key: PointOffsetType, vector: &[T]) -> OperationResult<()> {
+        let key = key as usize;
+        let chunk_idx = self.get_chunk_index(key);
+        let chunk_offset = self.get_chunk_offset(key);
+
+        // Ensure capacity
+        while chunk_idx >= self.chunks.len() {
+            self.add_chunk()?;
+        }
+
+        let chunk = &mut self.chunks[chunk_idx];
+
+        write_slice_to_mmap(chunk, chunk_offset, vector);
+
+        let new_len = max(self.status.len, key + 1);
+
+        if new_len > self.status.len {
+            write_to_mmap(&mut self.status_mmap, 0, new_len);
+            self.status.len = new_len;
+        }
+        Ok(())
+    }
+
+    pub fn push(&mut self, vector: &[T]) -> OperationResult<PointOffsetType> {
+        let new_id = self.status.len as PointOffsetType;
+        self.insert(new_id, vector)?;
+        Ok(new_id)
+    }
+
+    pub fn get<TKey>(&self, key: TKey) -> &[T]
+    where
+        TKey: num_traits::cast::AsPrimitive<usize>,
+    {
+        let key: usize = key.as_();
+        let chunk_idx = self.get_chunk_index(key);
+        let chunk_offset = self.get_chunk_offset(key);
+        let chunk = &self.chunks[chunk_idx];
+        read_slice_from_mmap(chunk, chunk_offset, self.config.dim)
+    }
+
+    pub fn flush(&mut self) -> OperationResult<()> {
+        for chunk in &mut self.chunks {
+            chunk.flush()?;
+        }
+        self.status_mmap.flush()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use rand::prelude::StdRng;
+    use rand::SeedableRng;
     use tempfile::Builder;
 
     use super::*;
+    use crate::data_types::vectors::VectorElementType;
+    use crate::fixtures::index_fixtures::random_vector;
 
     #[test]
     fn test_chunked_mmap() {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-        let dim = 512;
+        let dim = 500;
+        let num_vectors = 1000;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let mut vectors: Vec<_> = (0..num_vectors)
+            .map(|_| random_vector(&mut rng, dim))
+            .collect();
+
         {
-            let chunked_mmap = ChunkedMMapVectors::open(dir.path(), dim).unwrap();
+            let mut chunked_mmap: ChunkedMmapVectors<VectorElementType> =
+                ChunkedMmapVectors::open(dir.path(), dim).unwrap();
+
+            for vec in &vectors {
+                chunked_mmap.push(vec).unwrap();
+            }
+
+            vectors[0] = random_vector(&mut rng, dim);
+            vectors[150] = random_vector(&mut rng, dim);
+            vectors[44] = random_vector(&mut rng, dim);
+            vectors[999] = random_vector(&mut rng, dim);
+
+            chunked_mmap.insert(0, &vectors[0]).unwrap();
+            chunked_mmap.insert(150, &vectors[150]).unwrap();
+            chunked_mmap.insert(44, &vectors[44]).unwrap();
+            chunked_mmap.insert(999, &vectors[999]).unwrap();
+
+            chunked_mmap.flush().unwrap();
         }
 
         {
-            let chunked_mmap = ChunkedMMapVectors::open(dir.path(), dim).unwrap();
+            let chunked_mmap: ChunkedMmapVectors<VectorElementType> =
+                ChunkedMmapVectors::open(dir.path(), dim).unwrap();
+
+            assert_eq!(chunked_mmap.len(), vectors.len());
+
+            for (i, vec) in vectors.iter().enumerate() {
+                assert_eq!(
+                    chunked_mmap.get(i),
+                    vec,
+                    "Vectors at index {} are not equal",
+                    i
+                );
+            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -1,0 +1,195 @@
+use std::fs::{create_dir_all, OpenOptions};
+use std::io::Write;
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+
+use memmap2::MmapMut;
+use serde::{Deserialize, Serialize};
+
+use crate::common::mmap_ops::{
+    open_write_mmap, transmute_from_u8_to_array, transmute_to_u8, transmute_to_u8_array,
+};
+use crate::data_types::vectors::VectorElementType;
+use crate::entry::entry_point::{OperationError, OperationResult};
+
+#[cfg(test)]
+const DEFAULT_CHUNK_SIZE: usize = 4 * 1024 * 1024; // 4Mb
+
+#[cfg(not(test))]
+const DEFAULT_CHUNK_SIZE: usize = 128 * 1024 * 1024; // 128Mb
+
+const CONFIG_FILE_NAME: &str = "config.json";
+const STATUS_FILE_NAME: &str = "status.json";
+
+const MMAP_CHUNKS_PATTERN_START: &str = "chunk_";
+const MMAP_CHUNKS_PATTERN_END: &str = ".mmap";
+
+struct ChunkedMMapStatus {
+    len: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChunkedMMapConfig {
+    chunk_size: usize,
+    dim: usize,
+}
+
+pub struct ChunkedMMapVectors<T> {
+    config: ChunkedMMapConfig,
+    status: ChunkedMMapStatus,
+    _phantom: PhantomData<T>,
+    chunks: Vec<MmapMut>,
+    status_mmap: MmapMut,
+    directory: PathBuf,
+}
+
+impl ChunkedMMapVectors<VectorElementType> {
+    fn status_file(directory: &Path) -> PathBuf {
+        directory.join(STATUS_FILE_NAME)
+    }
+
+    fn write_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: T) {
+        debug_assert!(offset + size_of::<T>() <= mmap.len());
+        let ptr = mmap.as_mut_ptr();
+        unsafe {
+            let byte_data = transmute_to_u8(&data);
+            std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
+        }
+    }
+
+    fn write_array_to_mmap<T>(mmap: &mut MmapMut, offset: usize, data: &[T]) {
+        debug_assert!(offset + data.len() * size_of::<T>() <= mmap.len());
+        let ptr = mmap.as_mut_ptr();
+        unsafe {
+            let byte_data = transmute_to_u8_array(data);
+            std::ptr::copy_nonoverlapping(byte_data.as_ptr(), ptr.add(offset), byte_data.len());
+        }
+    }
+
+    fn read_from_mmap<T>(mmap: &MmapMut, offset: usize) -> &T {
+        debug_assert!(offset + size_of::<T>() <= mmap.len());
+        let ptr = mmap.as_ptr();
+        unsafe { &*(ptr.add(offset) as *const T) }
+    }
+
+    fn read_array_from_mmap<T>(mmap: &MmapMut, offset: usize, len: usize) -> &[T] {
+        debug_assert!(offset + len * size_of::<T>() <= mmap.len());
+        let byte_len = len * size_of::<T>();
+        let slice = &mmap[offset..offset + byte_len];
+        transmute_from_u8_to_array(slice)
+    }
+
+    fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
+        let status_file = Self::status_file(directory);
+        if !status_file.exists() {
+            {
+                let length = std::mem::size_of::<usize>() as u64;
+                let file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .open(&status_file)?;
+                file.set_len(length)?;
+            }
+            let mut mmap = open_write_mmap(&status_file)?;
+            Self::write_to_mmap(&mut mmap, 0, 0usize);
+            mmap.flush()?;
+            Ok(mmap)
+        } else {
+            open_write_mmap(&status_file)
+        }
+    }
+
+    fn ensure_config(directory: &Path, dim: usize) -> OperationResult<ChunkedMMapConfig> {
+        let config_file = directory.join(CONFIG_FILE_NAME);
+        if !config_file.exists() {
+            let config = ChunkedMMapConfig {
+                chunk_size: DEFAULT_CHUNK_SIZE,
+                dim,
+            };
+            let mut file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(&config_file)?;
+            serde_json::to_writer_pretty(&mut file, &config)?;
+            file.flush()?;
+            Ok(config)
+        } else {
+            let file = std::fs::File::open(&config_file)?;
+            let config: ChunkedMMapConfig = serde_json::from_reader(file)?;
+
+            if config.dim != dim {
+                return Err(OperationError::service_error(format!(
+                    "Wrong configuration in {}: expected {}, found {}",
+                    config_file.display(),
+                    config.dim,
+                    dim
+                )));
+            }
+
+            Ok(config)
+        }
+    }
+
+    fn check_mmap_file_name_pattern(file_name: &str) -> bool {
+        file_name.starts_with(MMAP_CHUNKS_PATTERN_START)
+            && file_name.ends_with(MMAP_CHUNKS_PATTERN_END)
+    }
+
+    fn read_mmaps(directory: &Path) -> OperationResult<Vec<MmapMut>> {
+        let mut result = Vec::new();
+        for entry in directory.read_dir()? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|file_name| file_name.to_str())
+                    .map(Self::check_mmap_file_name_pattern)
+                    .unwrap_or(false)
+            {
+                result.push(open_write_mmap(&path)?);
+            }
+        }
+        Ok(result)
+    }
+
+    pub fn open(directory: &Path, dim: usize) -> OperationResult<Self> {
+        create_dir_all(directory)?;
+        let status_mmap = Self::ensure_status_file(directory)?;
+        let len = *Self::read_from_mmap(&status_mmap, 0);
+        let status = ChunkedMMapStatus { len };
+        let config = Self::ensure_config(directory, dim)?;
+        let chunks = Self::read_mmaps(directory)?;
+
+        let vectors = Self {
+            config,
+            status,
+            _phantom: Default::default(),
+            chunks,
+            status_mmap,
+            directory: directory.to_owned(),
+        };
+        Ok(vectors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::Builder;
+
+    use super::*;
+
+    #[test]
+    fn test_chunked_mmap() {
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let dim = 512;
+        {
+            let chunked_mmap = ChunkedMMapVectors::open(dir.path(), dim).unwrap();
+        }
+
+        {
+            let chunked_mmap = ChunkedMMapVectors::open(dir.path(), dim).unwrap();
+        }
+    }
+}

--- a/lib/segment/src/vector_storage/chunked_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_utils.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use memmap2::MmapMut;
+use crate::common::mmap_ops::{
+    create_and_ensure_length, open_write_mmap, write_to_mmap,
+};
+use crate::entry::entry_point::{OperationError, OperationResult};
+
+const STATUS_FILE_NAME: &str = "status.json";
+
+const MMAP_CHUNKS_PATTERN_START: &str = "chunk_";
+const MMAP_CHUNKS_PATTERN_END: &str = ".mmap";
+
+pub struct MmapStatus {
+    pub len: usize,
+}
+
+fn status_file(directory: &Path) -> PathBuf {
+    directory.join(STATUS_FILE_NAME)
+}
+
+pub fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
+    let status_file = status_file(directory);
+    if !status_file.exists() {
+        {
+            let length = std::mem::size_of::<usize>() as u64;
+            create_and_ensure_length(&status_file, length as usize)?;
+        }
+        let mut mmap = open_write_mmap(&status_file)?;
+        write_to_mmap(&mut mmap, 0, 0usize);
+        mmap.flush()?;
+        Ok(mmap)
+    } else {
+        open_write_mmap(&status_file)
+    }
+}
+
+/// Checks if the file name matches the pattern for mmap chunks
+/// Return ID from the file name if it matches, None otherwise
+fn check_mmap_file_name_pattern(file_name: &str) -> Option<usize> {
+    file_name
+        .strip_prefix(MMAP_CHUNKS_PATTERN_START)
+        .and_then(|file_name| file_name.strip_suffix(MMAP_CHUNKS_PATTERN_END))
+        .and_then(|file_name| file_name.parse::<usize>().ok())
+}
+
+pub fn read_mmaps(directory: &Path) -> OperationResult<Vec<MmapMut>> {
+    let mut result = Vec::new();
+    let mut mmap_files: HashMap<usize, _> = HashMap::new();
+    for entry in directory.read_dir()? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            let chunk_id = path
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .and_then(check_mmap_file_name_pattern);
+
+            if let Some(chunk_id) = chunk_id {
+                mmap_files.insert(chunk_id, path);
+            }
+        }
+    }
+
+    let num_chunks = mmap_files.len();
+    for chunk_id in 0..num_chunks {
+        let mmap_file = mmap_files.remove(&chunk_id).ok_or_else(|| {
+            OperationError::service_error(format!(
+                "Missing mmap chunk {} in {}",
+                chunk_id,
+                directory.display()
+            ))
+        })?;
+        let mmap = open_write_mmap(&mmap_file)?;
+        result.push(mmap);
+    }
+    Ok(result)
+}
+
+pub fn create_chunk(
+    directory: &Path,
+    chunk_id: usize,
+    chunk_length_bytes: usize,
+) -> OperationResult<MmapMut> {
+    let chunk_file_name = format!(
+        "{}{}{}",
+        MMAP_CHUNKS_PATTERN_START, chunk_id, MMAP_CHUNKS_PATTERN_END
+    );
+    let chunk_file_path = directory.join(chunk_file_name);
+    create_and_ensure_length(&chunk_file_path, chunk_length_bytes)?;
+    open_write_mmap(&chunk_file_path)
+}

--- a/lib/segment/src/vector_storage/chunked_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_utils.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use memmap2::MmapMut;
-use crate::common::mmap_ops::{
-    create_and_ensure_length, open_write_mmap, write_to_mmap,
-};
+
+use crate::common::mmap_ops::{create_and_ensure_length, open_write_mmap, write_to_mmap};
 use crate::entry::entry_point::{OperationError, OperationResult};
 
 const STATUS_FILE_NAME: &str = "status.json";

--- a/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
@@ -1,0 +1,207 @@
+use std::cmp::max;
+use std::fs::create_dir_all;
+use std::path::{Path, PathBuf};
+
+use bitvec::prelude::BitSlice;
+use memmap2::MmapMut;
+
+use crate::common::error_logging::LogError;
+use crate::common::mmap_ops::{
+    create_and_ensure_length, open_write_mmap, read_from_mmap, write_to_mmap,
+};
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::vector_storage::chunked_utils::{ensure_status_file, MmapStatus};
+use crate::vector_storage::div_ceil;
+use crate::vector_storage::mmap_vectors::mmap_to_bitslice;
+
+#[cfg(test)]
+const MINIMAL_MMAP_SIZE: usize = 1024; // 1Kb
+
+#[cfg(not(test))]
+const MINIMAL_MMAP_SIZE: usize = 1 * 1024 * 1024; // 1Mb
+
+const FLAGS_FILE: &str = "flags.dat";
+
+pub struct DynamicMmapFlags {
+    status: MmapStatus,
+    _flags_mmap: Option<MmapMut>,
+    flags: Option<&'static mut BitSlice>,
+    status_mmap: MmapMut,
+    directory: PathBuf,
+}
+
+/// Based on the number of flags determines the size of the mmap file.
+fn mmap_capacity_bytes(len: usize) -> usize {
+    let number_of_bytes = div_ceil(len, 8);
+
+    max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
+}
+
+/// Based on the current length determines how many flags can fit into the mmap file without resizing it.
+fn mmap_max_current_size(len: usize) -> usize {
+    let mmap_capacity_bytes = mmap_capacity_bytes(len);
+    mmap_capacity_bytes * 8
+}
+
+impl DynamicMmapFlags {
+    fn mmap_file_path(directory: &Path) -> PathBuf {
+        directory.join(FLAGS_FILE)
+    }
+
+    pub fn open(directory: &Path) -> OperationResult<Self> {
+        create_dir_all(directory)?;
+        let status_mmap = ensure_status_file(directory)?;
+        let len = *read_from_mmap(&status_mmap, 0);
+
+        let status = MmapStatus { len };
+
+        let mut flags = Self {
+            status,
+            _flags_mmap: None,
+            flags: None,
+            status_mmap,
+            directory: directory.to_owned(),
+        };
+
+        flags.reopen_mmap(len)?;
+
+        Ok(flags)
+    }
+
+    pub fn reopen_mmap(&mut self, length: usize) -> OperationResult<()> {
+        self.flags.take(); // Drop the bit slice
+        self._flags_mmap.take(); // Drop the mmap
+        let capacity_bytes = mmap_capacity_bytes(length);
+        let mmap_path = Self::mmap_file_path(&self.directory);
+        create_and_ensure_length(&mmap_path, capacity_bytes)?;
+        let mut flags_mmap = open_write_mmap(&mmap_path).describe("Open mmap flags for writing")?;
+        #[cfg(unix)]
+        if let Err(err) = flags_mmap.advise(memmap2::Advice::WillNeed) {
+            log::error!("Failed to advise MADV_WILLNEED for deleted flags: {}", err,);
+        }
+        let flags = unsafe { mmap_to_bitslice(&mut flags_mmap, 0) };
+        self._flags_mmap = Some(flags_mmap);
+        self.flags = Some(flags);
+        Ok(())
+    }
+
+    /// Set the length of the vector to the given value.
+    /// If the vector is grown, the new elements will be set to `false`.
+    /// Errors if the vector is shrunk.
+    pub fn set_len(&mut self, new_len: usize) -> OperationResult<()> {
+        debug_assert!(new_len >= self.status.len);
+        if new_len == self.status.len {
+            return Ok(());
+        }
+
+        let current_capacity = mmap_max_current_size(self.status.len);
+
+        if new_len > current_capacity {
+            self.reopen_mmap(new_len)?;
+        }
+
+        if new_len < self.status.len {
+            return Err(OperationError::service_error(format!(
+                "Cannot shrink the mmap flags from {} to {}",
+                self.status.len, new_len
+            )));
+        }
+
+        self.status.len = new_len;
+        write_to_mmap(&mut self.status_mmap, 0, self.status.len);
+        return Ok(());
+    }
+
+    pub fn get<TKey>(&self, key: TKey) -> bool
+    where
+        TKey: num_traits::cast::AsPrimitive<usize>,
+    {
+        let key: usize = key.as_();
+        self.flags.as_ref().map(|flags| flags[key]).unwrap_or(false)
+    }
+
+    /// Set the `true` value of the flag at the given index.
+    /// Ignore the call if the index is out of bounds.
+    ///
+    /// Returns previous value of the flag.
+    pub fn set_true<TKey>(&mut self, key: TKey) -> bool
+    where
+        TKey: num_traits::cast::AsPrimitive<usize>,
+    {
+        let key: usize = key.as_();
+        debug_assert!(key < self.status.len);
+        if key >= self.status.len {
+            return false;
+        }
+
+        if let Some(flags) = self.flags.as_mut() {
+            return flags.replace(key, true);
+        }
+
+        false
+    }
+
+    pub fn flush(&self) -> OperationResult<()> {
+        self.status_mmap.flush()?;
+        if let Some(flags_mmap) = &self._flags_mmap {
+            flags_mmap.flush()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::prelude::StdRng;
+    use rand::{Rng, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+
+    #[test]
+    fn test_bitflags_saving() {
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let num_flags = 5000;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let random_flags: Vec<bool> = (0..num_flags).map(|_| rng.gen_bool(0.5)).collect();
+
+        {
+            let mut dynamic_flags = DynamicMmapFlags::open(dir.path()).unwrap();
+            dynamic_flags.set_len(num_flags).unwrap();
+            for (i, flag) in random_flags.iter().enumerate() {
+                if *flag {
+                    assert!(!dynamic_flags.set_true(i));
+                }
+            }
+
+            dynamic_flags.set_len(num_flags * 2).unwrap();
+            for (i, flag) in random_flags.iter().enumerate() {
+                if !*flag {
+                    assert!(!dynamic_flags.set_true(num_flags + i));
+                }
+            }
+
+            dynamic_flags.flush().unwrap();
+        }
+
+        {
+            let dynamic_flags = DynamicMmapFlags::open(dir.path()).unwrap();
+            assert_eq!(dynamic_flags.status.len, num_flags * 2);
+            for (i, flag) in random_flags.iter().enumerate() {
+                assert_eq!(dynamic_flags.get(i), *flag);
+                assert_eq!(dynamic_flags.get(num_flags + i), !*flag);
+            }
+        }
+    }
+
+    #[test]
+    fn test_capacity() {
+        assert_eq!(mmap_capacity_bytes(0), 1024);
+        assert_eq!(mmap_capacity_bytes(1), 1024);
+        assert_eq!(mmap_capacity_bytes(1023), 1024);
+        assert_eq!(mmap_capacity_bytes(1024), 1024);
+        assert_eq!(mmap_capacity_bytes(1025), 1024);
+        assert_eq!(mmap_capacity_bytes(10000), 2048);
+    }
+}

--- a/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
@@ -18,7 +18,7 @@ use crate::vector_storage::mmap_vectors::mmap_to_bitslice;
 const MINIMAL_MMAP_SIZE: usize = 1024; // 1Kb
 
 #[cfg(not(test))]
-const MINIMAL_MMAP_SIZE: usize = 1 * 1024 * 1024; // 1Mb
+const MINIMAL_MMAP_SIZE: usize = 1024 * 1024; // 1Mb
 
 const FLAGS_FILE: &str = "flags.dat";
 
@@ -109,7 +109,7 @@ impl DynamicMmapFlags {
 
         self.status.len = new_len;
         write_to_mmap(&mut self.status_mmap, 0, self.status.len);
-        return Ok(());
+        Ok(())
     }
 
     pub fn get<TKey>(&self, key: TKey) -> bool

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -97,7 +97,7 @@ impl VectorStorage for MemmapVectorStorage {
         for id in other_ids {
             check_process_stopped(stopped)?;
             let vector = other.get_vector(id);
-            let raw_bites = mmap_ops::transmute_to_u8_array(vector);
+            let raw_bites = mmap_ops::transmute_to_u8_slice(vector);
             vectors_file.write_all(raw_bites)?;
             end_index += 1;
 
@@ -199,7 +199,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use crate::common::mmap_ops::transmute_to_u8_array;
+    use crate::common::mmap_ops::transmute_to_u8_slice;
     use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::IdTracker;
@@ -540,7 +540,7 @@ mod tests {
     fn test_casts() {
         let data: Vec<VectorElementType> = vec![0.42, 0.069, 333.1, 100500.];
 
-        let raw_data = transmute_to_u8_array(&data);
+        let raw_data = transmute_to_u8_slice(&data);
 
         eprintln!("raw_data.len() = {:#?}", raw_data.len());
 

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -1,6 +1,5 @@
 use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::{self, Write};
-use std::mem;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -11,7 +10,7 @@ use bitvec::prelude::BitSlice;
 
 use super::quantized::quantized_vectors_base::QuantizedVectorsStorage;
 use super::VectorStorageEnum;
-use crate::common::Flusher;
+use crate::common::{mmap_ops, Flusher};
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::{check_process_stopped, OperationResult};
 use crate::types::{Distance, PointOffsetType, QuantizationConfig};
@@ -98,7 +97,7 @@ impl VectorStorage for MemmapVectorStorage {
         for id in other_ids {
             check_process_stopped(stopped)?;
             let vector = other.get_vector(id);
-            let raw_bites = vf_to_u8(vector);
+            let raw_bites = mmap_ops::transmute_to_u8_array(vector);
             vectors_file.write_all(raw_bites)?;
             end_index += 1;
 
@@ -193,10 +192,6 @@ fn open_append<P: AsRef<Path>>(path: P) -> io::Result<File> {
         .open(path)
 }
 
-fn vf_to_u8<T>(v: &[T]) -> &[u8] {
-    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, mem::size_of_val(v)) }
-}
-
 #[cfg(test)]
 mod tests {
     use std::mem::transmute;
@@ -204,6 +199,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
+    use crate::common::mmap_ops::transmute_to_u8_array;
     use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::IdTracker;
@@ -544,7 +540,7 @@ mod tests {
     fn test_casts() {
         let data: Vec<VectorElementType> = vec![0.42, 0.069, 333.1, 100500.];
 
-        let raw_data = vf_to_u8(&data);
+        let raw_data = transmute_to_u8_array(&data);
 
         eprintln!("raw_data.len() = {:#?}", raw_data.len());
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -62,10 +62,10 @@ impl MmapVectors {
         let mut deleted_mmap =
             mmap_ops::open_write_mmap(deleted_path).describe("Open mmap deleted for writing")?;
 
-        // Advice kernel that we'll need this page soon so the kernel can prepare
+        // Advise kernel that we'll need this page soon so the kernel can prepare
         #[cfg(unix)]
         if let Err(err) = deleted_mmap.advise(memmap2::Advice::WillNeed) {
-            log::error!("Failed to advice MADV_WILLNEED for deleted flags: {}", err,);
+            log::error!("Failed to advise MADV_WILLNEED for deleted flags: {}", err,);
         }
 
         // Create convenient BitSlice view over it

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod chunked_mmap_vectors;
 pub mod chunked_vectors;
 pub mod memmap_vector_storage;
 mod mmap_vectors;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,13 +1,13 @@
-pub mod dynamic_mmap_flags;
 pub mod chunked_mmap_vectors;
+mod chunked_utils;
 pub mod chunked_vectors;
+pub mod dynamic_mmap_flags;
 pub mod memmap_vector_storage;
 mod mmap_vectors;
 pub mod quantized;
 pub mod raw_scorer;
 pub mod simple_vector_storage;
 mod vector_storage_base;
-mod chunked_utils;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod dynamic_mmap_flags;
 pub mod chunked_mmap_vectors;
 pub mod chunked_vectors;
 pub mod memmap_vector_storage;
@@ -6,6 +7,7 @@ pub mod quantized;
 pub mod raw_scorer;
 pub mod simple_vector_storage;
 mod vector_storage_base;
+mod chunked_utils;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;


### PR DESCRIPTION
https://github.com/qdrant/qdrant/issues/1818

We need to upload faster than optimizer can convert into mmap. So why not write to mmap right away?

Also we need mmaped deleted flags, but we can't do chunks because it is incompatible with `scorer` and we don't want to change the interface cause it is very performance-sensitive. So instead we can re-allocate bitslice, it should be ok since it is small 