### PR TITLE
Add .qdrant-initialized to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /snapshots
 /consensus_test_logs
 *.log
+.qdrant-initialized


### PR DESCRIPTION
Qdrant now creates a `.qdrant-initialized` file after initialization. We don't want to commit it.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?