### PR TITLE
Add REST interface to update/delete optional named vectors

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2612,10 +2612,10 @@
           "points"
         ],
         "summary": "Update vectors",
-        "description": "Update specified named vectors of a point, keep other vectors intact.",
+        "description": "Update specified named vectors on points, keep unspecified vectors intact.",
         "operationId": "update_vectors",
         "requestBody": {
-          "description": "Update named vectors on point",
+          "description": "Update named vectors on points",
           "content": {
             "application/json": {
               "schema": {
@@ -7507,6 +7507,22 @@
         ]
       },
       "UpdateVectors": {
+        "type": "object",
+        "required": [
+          "points"
+        ],
+        "properties": {
+          "points": {
+            "description": "Points with named vectors",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PointVectors"
+            },
+            "minItems": 1
+          }
+        }
+      },
+      "PointVectors": {
         "type": "object",
         "required": [
           "id",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -2606,6 +2606,200 @@
         }
       }
     },
+    "/collections/{collection_name}/points/vectors": {
+      "put": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Update vectors",
+        "description": "Update specified named vectors of a point, keep other vectors intact.",
+        "operationId": "update_vectors",
+        "requestBody": {
+          "description": "Update named vectors on point",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVectors"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to update from",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "define ordering guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WriteOrdering"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/UpdateResult"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{collection_name}/points/vectors/delete": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Delete vectors",
+        "description": "Delete named vectors from the given points.",
+        "operationId": "delete_vectors",
+        "requestBody": {
+          "description": "Delete named vectors from points",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteVectors"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "collection_name",
+            "in": "path",
+            "description": "Name of the collection to delete from",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for changes to actually happen",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "define ordering guarantees for the operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WriteOrdering"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/UpdateResult"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collection_name}/points/payload": {
       "post": {
         "tags": [
@@ -7311,6 +7505,42 @@
           "quorum",
           "all"
         ]
+      },
+      "UpdateVectors": {
+        "type": "object",
+        "required": [
+          "id",
+          "vector"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ExtendedPointId"
+          },
+          "vector": {
+            "$ref": "#/components/schemas/VectorStruct"
+          }
+        }
+      },
+      "DeleteVectors": {
+        "type": "object",
+        "required": [
+          "point_selector",
+          "vector"
+        ],
+        "properties": {
+          "point_selector": {
+            "$ref": "#/components/schemas/PointsSelector"
+          },
+          "vector": {
+            "description": "Vector names",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          }
+        }
       }
     }
   }

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -113,11 +113,9 @@ impl SplitByShard for VectorOperations {
 }
 
 /// Validate the vector struct is not empty.
-pub fn validate_vector_struct_not_empty(value: &VectorStruct) -> Result<(), ValidationError> {
-    // If any vector is specified we're good
-    match value {
-        VectorStruct::Multi(vectors) if vectors.is_empty() => {}
-        VectorStruct::Single(_) | VectorStruct::Multi(_) => return Ok(()),
+fn validate_vector_struct_not_empty(value: &VectorStruct) -> Result<(), ValidationError> {
+    if !value.is_empty() {
+        return Ok(());
     }
 
     let mut err = ValidationError::new("length");

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -30,6 +30,16 @@ pub enum VectorStruct {
     Multi(HashMap<String, VectorType>),
 }
 
+impl VectorStruct {
+    /// Check if this vector struct is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            VectorStruct::Single(vector) => vector.is_empty(),
+            VectorStruct::Multi(vectors) => vectors.values().all(|v| v.is_empty()),
+        }
+    }
+}
+
 impl From<VectorType> for VectorStruct {
     fn from(v: VectorType) -> Self {
         VectorStruct::Single(v)

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -127,6 +127,76 @@ paths:
             $ref: "#/components/schemas/WriteOrdering"
       responses: #@ response(reference("UpdateResult"))
 
+  /collections/{collection_name}/points/vectors:
+    put:
+      tags:
+        - points
+      summary: Update vectors
+      description: Update specified named vectors of a point, keep other vectors intact.
+      operationId: update_vectors
+      requestBody:
+        description: Update named vectors on point
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateVectors"
+
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to update from
+          required: true
+          schema:
+            type: string
+        - name: wait
+          in: query
+          description: "If true, wait for changes to actually happen"
+          required: false
+          schema:
+            type: boolean
+        - name: ordering
+          in: query
+          description: "define ordering guarantees for the operation"
+          required: false
+          schema:
+            $ref: "#/components/schemas/WriteOrdering"
+      responses: #@ response(reference("UpdateResult"))
+
+  /collections/{collection_name}/points/vectors/delete:
+    post:
+      tags:
+        - points
+      summary: Delete vectors
+      description: Delete named vectors from the given points.
+      operationId: delete_vectors
+      requestBody:
+        description: Delete named vectors from points
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteVectors"
+
+      parameters:
+        - name: collection_name
+          in: path
+          description: Name of the collection to delete from
+          required: true
+          schema:
+            type: string
+        - name: wait
+          in: query
+          description: "If true, wait for changes to actually happen"
+          required: false
+          schema:
+            type: boolean
+        - name: ordering
+          in: query
+          description: "define ordering guarantees for the operation"
+          required: false
+          schema:
+            $ref: "#/components/schemas/WriteOrdering"
+      responses: #@ response(reference("UpdateResult"))
+
   /collections/{collection_name}/points/payload:
     post:
       tags:

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -132,10 +132,10 @@ paths:
       tags:
         - points
       summary: Update vectors
-      description: Update specified named vectors of a point, keep other vectors intact.
+      description: Update specified named vectors on points, keep unspecified vectors intact.
       operationId: update_vectors
       requestBody:
-        description: Update named vectors on point
+        description: Update named vectors on points
         content:
           application/json:
             schema:

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -9,6 +9,7 @@ use collection::operations::types::{
     CountRequest, CountResult, PointRequest, RecommendRequest, RecommendRequestBatch, Record,
     ScrollRequest, ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult,
 };
+use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::gen::SchemaSettings;
 use schemars::JsonSchema;
 use segment::types::ScoredPoint;
@@ -63,6 +64,8 @@ struct AllDefinitions {
     ay: AliasDescription,
     az: WriteOrdering,
     b1: ReadConsistency,
+    b2: UpdateVectors,
+    b3: DeleteVectors,
 }
 
 fn save_schema<T: JsonSchema>() {


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/1816>. Continuation of <https://github.com/qdrant/qdrant/pull/1816>. Part of <https://github.com/qdrant/qdrant/issues/1045>.

This adds the REST interface endpoints for updating and deleting optional named vectors.

Tests will be added in a separate PR.

I did some basic testing for this against the REST interface locally.

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/1816
- [x] Rebase on `dev`
- [x] Target `dev` branch
- [x] Undraft PR

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?