### PR TITLE
Add integration tests for REST update/delete optional named vectors

### DIFF
--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -15,6 +15,7 @@ use crate::shards::shard::ShardId;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 pub struct UpdateVectors {
     /// Points with named vectors
+    #[validate]
     #[validate(length(min = 1, message = "must specify points to update"))]
     pub points: Vec<PointVectors>,
 }

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -377,7 +377,7 @@ def delete_unknown_vectors():
         query_params={'wait': 'true'},
         body={
             "point_selector": {"points": [1, 2]},
-            "vector": ["a", "b", "c"]
+            "vector": ["a"]
         }
     )
 

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -1,0 +1,367 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection, multivec_collection_setup
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_collection'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    multivec_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def upsert_partial_vectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 101,
+                    "vector": {
+                        "text": [0.05, 0.61, 0.76, 0.74, 0.05, 0.61, 0.76, 0.74],
+                    },
+                    "payload": {"city": "Berlin"}
+                },
+                {
+                    "id": 102,
+                    "vector": {
+                        "image": [0.19, 0.81, 0.75, 0.11],
+                    },
+                    "payload": {"city": ["Berlin", "London"]}
+                },
+                {
+                    "id": 103,
+                    "vector": {},
+                    "payload": {"city": ["Berlin", "Moscow"]}
+                },
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 101},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["id"] == 101
+    assert "image" not in result["vector"]
+    assert "text" in result["vector"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 102},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["id"] == 102
+    assert "image" in result["vector"]
+    assert "text" not in result["vector"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 103},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["id"] == 103
+    assert "image" not in result["vector"]
+    assert "text" not in result["vector"]
+
+
+def test_upsert_partial_vectors():
+    upsert_partial_vectors()
+
+
+def update_vectors():
+    text_vector = [0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98]
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {
+                "text": text_vector,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["vector"]["text"] == text_vector
+
+    text_vector = [0.12, 0.34, 0.56, 0.78, 0.90, 0.12, 0.34, 0.56]
+    image_vector = [0.19, 0.28, 0.37, 0.46]
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {
+                "text": text_vector,
+                "image": image_vector,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["vector"]["image"] == image_vector
+    assert result["vector"]["text"] == text_vector
+
+    image_vector = [0.00, 0.01, 0.00, 0.01]
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {
+                "image": image_vector,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["vector"]["image"] == image_vector
+    assert result["vector"]["text"] == text_vector
+
+
+def test_update_vectors():
+    update_vectors()
+
+
+def update_empty_vectors():
+    """
+    Remove all named vectors for a point. Then add named vectors and test
+    against it.
+    """
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "point_selector": {"points": [1]},
+            "vector": ["image", "text"]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert "text" not in result["vector"]
+    assert "image" not in result["vector"]
+
+    text_vector = [0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98]
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {
+                "text": text_vector,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["vector"]["text"] == text_vector
+    assert "image" not in result["vector"]
+
+    image_vector = [0.19, 0.28, 0.37, 0.46]
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {
+                "image": image_vector,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert result["vector"]["image"] == image_vector
+    assert result["vector"]["text"] == text_vector
+
+
+def test_update_empty_vectors():
+    update_empty_vectors()
+
+
+def update_no_vectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "id": 1,
+            "vector": {},
+        }
+    )
+    assert not response.ok
+    assert response.status_code == 422
+    error = response.json()["status"]["error"]
+    assert error.__contains__("Validation error in JSON body: [vector: must specify vectors to update]")
+
+
+def test_update_no_vectors():
+    update_no_vectors()
+
+
+def delete_vectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "point_selector": {"points": [1, 2]},
+            "vector": ["image"]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "point_selector": {"points": [2, 3]},
+            "vector": ["text"]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert "image" not in result["vector"]
+    assert "text" in result["vector"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert "image" not in result["vector"]
+    assert "text" not in result["vector"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 3},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    assert "image" in result["vector"]
+    assert "text" not in result["vector"]
+
+
+def test_delete_vectors():
+    delete_vectors()
+    # Deleting a second time should work fine
+    delete_vectors()
+
+
+def delete_all_vectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "point_selector": {"filter": {}},
+            "vector": ["image", "text"]
+        }
+    )
+    assert response.ok
+
+
+def test_delete_all_vectors():
+    delete_all_vectors()
+
+
+def delete_unknown_vectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "point_selector": {"points": [1, 2]},
+            "vector": ["a", "b", "c"]
+        }
+    )
+
+    assert not response.ok
+    assert response.status_code == 400
+    error = response.json()["status"]["error"]
+    assert error.__contains__("Wrong input: Not existing vector name error: a")
+
+
+def test_delete_unknown_vectors():
+    delete_unknown_vectors()

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -267,7 +267,7 @@ def test_update_empty_vectors():
     update_empty_vectors()
 
 
-def update_no_vectors():
+def no_vectors():
     response = request_with_validation(
         api='/collections/{collection_name}/points/vectors',
         method="PUT",
@@ -285,11 +285,11 @@ def update_no_vectors():
     assert not response.ok
     assert response.status_code == 422
     error = response.json()["status"]["error"]
-    assert error.__contains__("Validation error in JSON body: [vector: must specify vectors to update]")
+    assert error.__contains__("Validation error in JSON body: [points[0].vector: must specify vectors to update for point]")
 
 
-def test_update_no_vectors():
-    update_no_vectors()
+def test_no_vectors():
+    no_vectors()
 
 
 def delete_vectors():

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -91,10 +91,14 @@ def update_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {
-                "text": text_vector,
-            },
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": text_vector,
+                    }
+                }
+            ]
         }
     )
     assert response.ok
@@ -116,11 +120,15 @@ def update_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {
-                "text": text_vector,
-                "image": image_vector,
-            },
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": text_vector,
+                        "image": image_vector,
+                    }
+                }
+            ]
         }
     )
     assert response.ok
@@ -142,10 +150,14 @@ def update_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {
-                "image": image_vector,
-            },
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "image": image_vector,
+                    }
+                }
+            ]
         }
     )
     assert response.ok
@@ -199,10 +211,14 @@ def update_empty_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {
-                "text": text_vector,
-            },
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "text": text_vector,
+                    }
+                }
+            ]
         }
     )
     assert response.ok
@@ -224,10 +240,14 @@ def update_empty_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {
-                "image": image_vector,
-            },
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "image": image_vector,
+                    }
+                }
+            ]
         }
     )
     assert response.ok
@@ -254,8 +274,12 @@ def update_no_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "id": 1,
-            "vector": {},
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {},
+                }
+            ]
         }
     )
     assert not response.ok


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/1836>. Continuation of <https://github.com/qdrant/qdrant/pull/1836>. Part of <https://github.com/qdrant/qdrant/issues/1045>.

This adds some integration tests for the REST endpoints covering updating and deleting optional named vectors.

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/1836
- [x] Rebase on `dev`
- [x] Target `dev` branch
- [x] Undraft PR

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?