### PR TITLE
Builds on buildjet runner, then places the binary in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,7 @@
-tests/
-target/
-storage/
-snapshots/
-lib/segment/target
-lib/api/target
-lib/collection/target
-lib/storage/target
-openapi/tests/
-*.tar
+# ignore everything
+**
+
+# allow required files
+!target/x86_64-unknown-linux-gnu/release/qdrant
+!target/aarch64-unknown-linux-gnu/release/qdrant
+!./config

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,38 +8,118 @@ on:
       - '*'           # Push events to every tag not containing /
 
 jobs:
-
-  build:
-
-    runs-on: ubuntu-latest
-
+  build-amd:
+    # runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
-    - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Get current tag
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-    - name: Build the Docker image
-      env:
-        RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-      run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker buildx create --use
+      - name: Get current tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
-        docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout source
+        uses: actions/checkout@v3
 
-        DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
-        TAGS="-t ${DOCKERHUB_TAG}"
+      - name: Install packages
+        run: sudo apt-get install -y protobuf-compiler
 
-        DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
-        TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+      - name: "Install toolchain: AMD"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "x86_64-unknown-linux-gnu"
 
-        GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+      - name: Restore rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: dependencies-amd
 
-        docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push .
+      - name: Build cargo
+        run: |
+          cargo build --target "x86_64-unknown-linux-gnu" --release --bin qdrant
 
-        docker pull $DOCKERHUB_TAG
+      - name: Build the Docker image
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        run: |
+          # docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
 
-        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
-        docker tag $DOCKERHUB_TAG $GITHUB_TAG
-        docker push $GITHUB_TAG
+          DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
+          TAGS="-t ${DOCKERHUB_TAG}"
+
+          DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
+          TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+
+          # docker pull $DOCKERHUB_TAG
+
+          GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+
+          docker build --build-arg="TARGET=x86_64-unknown-linux-gnu" $TAGS .
+
+          # docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
+          # docker tag $DOCKERHUB_TAG $GITHUB_TAG
+          # docker push $GITHUB_TAG
+
+  build-arm:
+    # runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    steps:
+      - name: Get current tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install packages
+        run: sudo apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler
+
+      - name: "Install toolchain: ARM"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "aarch64-unknown-linux-gnu"
+
+      - name: Restore rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: dependencies-arm
+
+      - name: Build cargo
+        run: |
+          cargo build --target "aarch64-unknown-linux-gnu" --release --verbose --bin qdrant
+
+      - name: Build the Docker image
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        run: |
+          # docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
+
+          DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
+          TAGS="-t ${DOCKERHUB_TAG}"
+
+          DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
+          TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+
+          # docker pull $DOCKERHUB_TAG
+
+          GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
+
+          docker build --build-arg="TARGET=aarch64-unknown-linux-gnu" $TAGS .
+
+          # docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
+          # docker tag $DOCKERHUB_TAG $GITHUB_TAG
+          # docker push $GITHUB_TAG
+
+
+
+#       - name: Build the Docker image
+#         env:
+#           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+#         run: |
+#           DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
+#           TAGS="-t ${DOCKERHUB_TAG}"
+# 
+#           DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
+#           TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
+# 
+#           GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,5 @@
-# Leveraging the pre-built Docker images with
-# cargo-chef and the Rust toolchain
-# https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.68.2 AS chef
-WORKDIR /qdrant
-
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef as builder
-
-# based on https://github.com/docker/buildx/issues/510
-ARG TARGETARCH
-ENV TARGETARCH=${TARGETARCH:-amd64}
-
-WORKDIR /qdrant
-
-COPY ./tools/target_arch.sh ./target_arch.sh
-RUN echo "Building for $TARGETARCH, arch: $(bash target_arch.sh)"
-
-COPY --from=planner /qdrant/recipe.json recipe.json
-
-RUN apt-get update \
-    && ( apt-get install -y gcc-multilib || echo "Warning: not installing gcc-multilib" ) \
-    && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler \
-    && rustup component add rustfmt
-
-
-RUN rustup target add $(bash target_arch.sh)
-
-# Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --target $(bash target_arch.sh) --recipe-path recipe.json
-
-COPY . .
-
-
-# Build actual target here
-RUN cargo build --release --target $(bash target_arch.sh) --bin qdrant
-
-RUN mv target/$(bash target_arch.sh)/release/qdrant /qdrant/qdrant
-
 FROM debian:11-slim
+ARG TARGET=x86_64-unknown-linux-gnu
 ARG APP=/qdrant
 
 RUN apt-get update \
@@ -55,8 +14,8 @@ ENV TZ=Etc/UTC \
 
 RUN mkdir -p ${APP}
 
-COPY --from=builder /qdrant/qdrant ${APP}/qdrant
-COPY --from=builder /qdrant/config ${APP}/config
+COPY ./target/${TARGET}/release/qdrant ${APP}/qdrant
+COPY ./config ${APP}/config
 
 WORKDIR ${APP}
 


### PR DESCRIPTION
Builds on buildjet runner, then places the binary in the docker image

Second run with hitting the cache took: 15m 16s

/claim #1812

close #1812

Managed to get the build down to ~15 mins(second run, hitting the cache), but will need to work with you for understanding if there is anything that i might have missed, since i took the approach of being intentional with the context sent into the docker build.
And for pushing as well as I didn't have the keys, and am not sure if the PR will actually run on your repo.

You would also have to sign up to [buildjet](https://buildjet.com/for-github-actions/docs/about/pricing#arm) which gives you more for the same price as GH actions.

Hope this helps


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<img width="2025" alt="Screenshot 2023-05-05 at 23 59 04" src="https://user-images.githubusercontent.com/1785111/236481588-d85bc3af-4f36-4e84-bbe1-e263b8976cc4.png">
