### PR TITLE
Feature: Implement inverted index on disk with rocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,6 +3806,7 @@ dependencies = [
  "rocksdb",
  "schemars",
  "seahash",
+ "self_cell",
  "semver",
  "serde",
  "serde-value",
@@ -3820,6 +3821,12 @@ dependencies = [
  "validator",
  "walkdir",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "semver"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "actix-codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +353,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "alloc-no-stdlib"
@@ -2662,6 +2674,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,6 +3794,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "ordered-float 3.7.0",
+ "ouroboros",
  "parking_lot",
  "pprof",
  "procfs",

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -522,7 +522,10 @@ impl SegmentEntry for ProxySegment {
         self.write_segment.get().read().deleted_point_count()
     }
 
-    fn estimate_point_count<'a>(&'a self, filter: Option<&'a Filter>) -> OperationResult<CardinalityEstimation> {
+    fn estimate_point_count<'a>(
+        &'a self,
+        filter: Option<&'a Filter>,
+    ) -> OperationResult<CardinalityEstimation> {
         let deleted_point_count = self.deleted_points.read().len();
 
         let (wrapped_segment_est, total_wrapped_size) = {
@@ -534,7 +537,11 @@ impl SegmentEntry for ProxySegment {
             )
         };
 
-        let write_segment_est = self.write_segment.get().read().estimate_point_count(filter)?;
+        let write_segment_est = self
+            .write_segment
+            .get()
+            .read()
+            .estimate_point_count(filter)?;
 
         let expected_deleted_count = if total_wrapped_size > 0 {
             (wrapped_segment_est.exp as f64
@@ -551,13 +558,13 @@ impl SegmentEntry for ProxySegment {
             };
 
         Ok(CardinalityEstimation {
-                    primary_clauses,
-                    min: wrapped_segment_est.min.saturating_sub(deleted_point_count)
-                        + write_segment_est.min,
-                    exp: (wrapped_segment_est.exp + write_segment_est.exp)
-                        .saturating_sub(expected_deleted_count),
-                    max: wrapped_segment_est.max + write_segment_est.max,
-                })
+            primary_clauses,
+            min: wrapped_segment_est.min.saturating_sub(deleted_point_count)
+                + write_segment_est.min,
+            exp: (wrapped_segment_est.exp + write_segment_est.exp)
+                .saturating_sub(expected_deleted_count),
+            max: wrapped_segment_est.max + write_segment_est.max,
+        })
     }
 
     fn segment_type(&self) -> SegmentType {
@@ -1038,20 +1045,23 @@ mod tests {
         let original_points = original_segment
             .get()
             .read()
-            .read_filtered(None, Some(100), None).unwrap();
+            .read_filtered(None, Some(100), None)
+            .unwrap();
 
-        let original_points_filtered =
-            original_segment
-                .get()
-                .read()
-                .read_filtered(None, Some(100), Some(&filter)).unwrap();
+        let original_points_filtered = original_segment
+            .get()
+            .read()
+            .read_filtered(None, Some(100), Some(&filter))
+            .unwrap();
 
         let mut proxy_segment = wrap_proxy(&dir, original_segment);
 
         proxy_segment.delete_point(100, 2.into()).unwrap();
 
         let proxy_res = proxy_segment.read_filtered(None, Some(100), None).unwrap();
-        let proxy_res_filtered = proxy_segment.read_filtered(None, Some(100), Some(&filter)).unwrap();
+        let proxy_res_filtered = proxy_segment
+            .read_filtered(None, Some(100), Some(&filter))
+            .unwrap();
 
         assert_eq!(original_points_filtered.len() - 1, proxy_res_filtered.len());
         assert_eq!(original_points.len() - 1, proxy_res.len());

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -148,7 +148,7 @@ fn points_by_filter(
 ) -> CollectionResult<Vec<PointIdType>> {
     let mut affected_points: Vec<PointIdType> = Vec::new();
     segments.for_each_segment(|s| {
-        let points = s.read_filtered(None, None, Some(filter));
+        let points = s.read_filtered(None, None, Some(filter))?;
         affected_points.extend_from_slice(points.as_slice());
         Ok(true)
     })?;

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -84,7 +84,13 @@ fn test_update_proxy_segments() {
     let all_ids = segments
         .read()
         .iter()
-        .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, Some(100), None).unwrap())
+        .flat_map(|(_id, segment)| {
+            segment
+                .get()
+                .read()
+                .read_filtered(None, Some(100), None)
+                .unwrap()
+        })
         .sorted()
         .collect_vec();
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -84,7 +84,7 @@ fn test_update_proxy_segments() {
     let all_ids = segments
         .read()
         .iter()
-        .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, Some(100), None))
+        .flat_map(|(_id, segment)| segment.get().read().read_filtered(None, Some(100), None).unwrap())
         .sorted()
         .collect_vec();
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -604,11 +604,11 @@ impl LocalShard {
             let x = segment.get().read().estimate_point_count(filter)?;
 
             cardinality = CardinalityEstimation {
-                    primary_clauses: vec![],
-                    min: cardinality.min + x.min,
-                    exp: cardinality.exp + x.exp,
-                    max: cardinality.max + x.max,
-                }
+                primary_clauses: vec![],
+                min: cardinality.min + x.min,
+                exp: cardinality.exp + x.exp,
+                max: cardinality.max + x.max,
+            }
         }
         Ok(cardinality)
     }
@@ -625,8 +625,8 @@ impl LocalShard {
         }
         let mut all_points = BTreeSet::new();
         for (_id, segment) in segments.iter() {
-           let vals = segment.get().read().read_filtered(None, None, filter)?;
-           all_points.extend(vals); 
+            let vals = segment.get().read().read_filtered(None, None, filter)?;
+            all_points.extend(vals);
         }
         Ok(all_points)
     }

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use itertools::Itertools;
 use segment::entry::entry_point::OperationResult;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector, PointIdType,
+    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -84,18 +84,15 @@ impl ShardOperation for LocalShard {
                     .read_filtered(offset, Some(limit), filter)
             })
             .flatten_ok()
-            .sorted_by(|res1, res2| {
-                match (res1, res2) {
-                        (Ok(val1), Ok(val2)) => Ord::cmp(val1, val2),
-                        (Ok(_), Err(_)) => std::cmp::Ordering::Greater,
-                        (Err(_), Ok(_)) => std::cmp::Ordering::Less,
-                        (Err(_), Err(_)) => std::cmp::Ordering::Equal,
-                }
+            .sorted_by(|res1, res2| match (res1, res2) {
+                (Ok(val1), Ok(val2)) => Ord::cmp(val1, val2),
+                (Ok(_), Err(_)) => std::cmp::Ordering::Greater,
+                (Err(_), Ok(_)) => std::cmp::Ordering::Less,
+                (Err(_), Err(_)) => std::cmp::Ordering::Equal,
             })
             .collect::<OperationResult<Vec<ExtendedPointId>>>()?;
         point_ids.dedup();
-        point_ids = point_ids.into_iter()
-            .take(limit).collect_vec();
+        point_ids = point_ids.into_iter().take(limit).collect_vec();
 
         let with_payload = WithPayload::from(with_payload_interface);
         let mut points =

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -54,6 +54,7 @@ chrono = { version = "0.4.24", features = ["serde"] }
 
 sysinfo = "0.29"
 ouroboros = "0.15.6"
+self_cell = "0.10.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -53,6 +53,7 @@ validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.24", features = ["serde"] }
 
 sysinfo = "0.29"
+ouroboros = "0.15.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -31,7 +31,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter).unwrap().count();
             query_count += 1;
         })
     });
@@ -47,7 +47,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points-large", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 1);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter).unwrap().count();
             query_count += 1;
         })
     });
@@ -65,7 +65,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
             let sample = (0..CHECK_SAMPLE_SIZE)
                 .map(|_| rng.gen_range(0..NUM_POINTS) as PointOffsetType)
                 .collect_vec();
-            let context = plain_index.filter_context(&filter);
+            let context = plain_index.filter_context(&filter).unwrap();
 
             let filtered_sample = sample
                 .into_iter()
@@ -107,7 +107,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     group.bench_function("struct-conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += struct_index.query_points(&filter).count();
+            result_size += struct_index.query_points(&filter).unwrap().count();
             query_count += 1;
         })
     });
@@ -125,7 +125,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
             let sample = (0..CHECK_SAMPLE_SIZE)
                 .map(|_| rng.gen_range(0..NUM_POINTS) as PointOffsetType)
                 .collect_vec();
-            let context = struct_index.filter_context(&filter);
+            let context = struct_index.filter_context(&filter).unwrap();
 
             let filtered_sample = sample
                 .into_iter()

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -1,18 +1,11 @@
-use std::borrow::BorrowMut;
-use std::marker::{PhantomData, PhantomPinned};
 use std::ops::Deref;
 use std::path::Path;
-use std::pin::Pin;
-use std::ptr::{addr_of, addr_of_mut, NonNull};
+
 use std::sync::Arc;
 
-use ouroboros::self_referencing;
-use parking_lot::{RwLock, RwLockReadGuard};
+use parking_lot::RwLock;
 //use atomic_refcell::{AtomicRef, AtomicRefCell};
-use rocksdb::{
-    ColumnFamily, DBIteratorWithThreadMode, DBRawIteratorWithThreadMode, LogLevel, Options,
-    WriteOptions, DB,
-};
+use rocksdb::{ColumnFamily, LogLevel, Options, WriteOptions, DB};
 
 use crate::common::Flusher;
 //use crate::common::arc_rwlock_iterator::ArcRwLockIterator;
@@ -161,7 +154,7 @@ impl DatabaseColumnWrapper {
         Ok(())
     }
 
-    pub fn lock_db<'a>(&'a self) -> LockedDatabaseColumnWrapper<'a> {
+    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper<'_> {
         LockedDatabaseColumnWrapper {
             guard: self.database.read(),
             column_name: &self.column_name,

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 use std::path::Path;
-
 use std::sync::Arc;
 
 use parking_lot::RwLock;

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -228,9 +228,6 @@ impl DatabaseColumnWrapper {
             ))
         })
     }
-    // pub fn iter<'a: 'b, 'b>(&'a self) -> OperationResult<LockedDatabaseColumnIterator<'a, 'b>> {
-    //     LockedDatabaseColumnIterator::from_guard_and_column(self.database, &self.column_name)
-    // }
 }
 
 impl<'a> LockedDatabaseColumnWrapper<'a> {
@@ -254,58 +251,6 @@ impl<'a> DatabaseColumnIterator<'a> {
         })
     }
 }
-
-pub struct LockedDatabaseColumnIterator<T: Deref<Target = DB>> {
-    db: T,
-}
-
-// impl<'a: 'b, 'b> LockedDatabaseColumnIterator<'a, 'b> {
-//     pub fn from_guard_and_column(
-//         db: Arc<RwLock<DB>>,
-//         column_name: &str,
-//     ) -> OperationResult<LockedDatabaseColumnIterator<'a, 'b>> {
-//         let handle = db.read().cf_handle(column_name).ok_or_else(|| {
-//             OperationError::service_error(format!(
-//                 "RocksDB cf_handle error: Cannot find column family {column_name}"
-//             ))
-//         })?;
-//         let mut iter = db.read().iterator_cf(handle);
-//         iter.seek_to_first();
-//         Ok(Self {
-//                     iter,
-//                     just_seeked: true,
-//                     _marker: &Default::default(),
-//                 })
-//     }
-// }
-
-// impl<'a: 'b, 'b> Iterator for LockedDatabaseColumnIterator<'a, 'b> {
-//     type Item = (Box<[u8]>, Box<[u8]>);
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         if !self.iter.valid() {
-//             return None;
-//         }
-
-//         // Initial call to next() after seeking should not move the iterator
-//         // or the first item will not be returned
-//         if self.just_seeked {
-//             self.just_seeked = false;
-//         } else {
-//             self.iter.next();
-//         }
-
-//         if self.iter.valid() {
-//             // .key() and .value() only ever return None if valid == false, which we've just checked
-//             Some((
-//                 Box::from(self.iter.key().unwrap()),
-//                 Box::from(self.iter.value().unwrap()),
-//             ))
-//         } else {
-//             None
-//         }
-//     }
-// }
 
 impl<'a> Iterator for DatabaseColumnIterator<'a> {
     type Item = (Box<[u8]>, Box<[u8]>);

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -153,7 +153,7 @@ impl DatabaseColumnWrapper {
         Ok(())
     }
 
-    pub fn lock_db(&self) -> LockedDatabaseColumnWrapper {
+    pub fn lock_db<'a>(&'a self) -> LockedDatabaseColumnWrapper<'a> {
         LockedDatabaseColumnWrapper {
             guard: self.database.read(),
             column_name: &self.column_name,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -291,7 +291,7 @@ pub trait SegmentEntry {
         offset: Option<PointIdType>,
         limit: Option<usize>,
         filter: Option<&'a Filter>,
-    ) -> Vec<PointIdType>;
+    ) -> OperationResult<Vec<PointIdType>>;
 
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType>;
@@ -300,7 +300,10 @@ pub trait SegmentEntry {
     fn has_point(&self, point_id: PointIdType) -> bool;
 
     /// Estimate available point count in this segment for given filter.
-    fn estimate_point_count<'a>(&'a self, filter: Option<&'a Filter>) -> CardinalityEstimation;
+    fn estimate_point_count<'a>(
+        &'a self,
+        filter: Option<&'a Filter>,
+    ) -> OperationResult<CardinalityEstimation>;
 
     fn vector_dim(&self, vector_name: &str) -> OperationResult<usize>;
 

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -23,8 +23,8 @@ pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<Vecto
 pub struct FakeFilterContext {}
 
 impl FilterContext for FakeFilterContext {
-    fn check(&self, _point_id: PointOffsetType) -> bool {
-        true
+    fn check(&self, _point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(true)
     }
 }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -138,27 +138,27 @@ impl FieldIndex {
         &self,
         condition: &FieldCondition,
         payload_value: &Value,
-    ) -> Option<bool> {
-        match self {
-            FieldIndex::IntIndex(_) => None,
-            FieldIndex::IntMapIndex(_) => None,
-            FieldIndex::KeywordIndex(_) => None,
-            FieldIndex::FloatIndex(_) => None,
-            FieldIndex::GeoIndex(_) => None,
-            FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
-                Some(Match::Text(MatchText { text })) => {
-                    let query = full_text_index.parse_query(text);
-                    for value in full_text_index.get_values(payload_value) {
-                        let document = full_text_index.parse_document(&value);
-                        if query.check_match(&document) {
-                            return Some(true);
+    ) -> OperationResult<Option<bool>> {
+        Ok(match self {
+                    FieldIndex::IntIndex(_) => None,
+                    FieldIndex::IntMapIndex(_) => None,
+                    FieldIndex::KeywordIndex(_) => None,
+                    FieldIndex::FloatIndex(_) => None,
+                    FieldIndex::GeoIndex(_) => None,
+                    FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
+                        Some(Match::Text(MatchText { text })) => {
+                            let query = full_text_index.parse_query(text)?;
+                            for value in full_text_index.get_values(payload_value) {
+                                let document = full_text_index.parse_document(&value);
+                                if query.check_match(&document) {
+                                    return Ok(Some(true));
+                                }
+                            }
+                            Some(false)
                         }
-                    }
-                    Some(false)
-                }
-                _ => None,
-            },
-        }
+                        _ => None,
+                    },
+                })
     }
 
     fn get_payload_field_index(&self) -> &dyn PayloadFieldIndex {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -140,25 +140,25 @@ impl FieldIndex {
         payload_value: &Value,
     ) -> OperationResult<Option<bool>> {
         Ok(match self {
-                    FieldIndex::IntIndex(_) => None,
-                    FieldIndex::IntMapIndex(_) => None,
-                    FieldIndex::KeywordIndex(_) => None,
-                    FieldIndex::FloatIndex(_) => None,
-                    FieldIndex::GeoIndex(_) => None,
-                    FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
-                        Some(Match::Text(MatchText { text })) => {
-                            let query = full_text_index.parse_query(text)?;
-                            for value in full_text_index.get_values(payload_value) {
-                                let document = full_text_index.parse_document(&value);
-                                if query.check_match(&document) {
-                                    return Ok(Some(true));
-                                }
-                            }
-                            Some(false)
+            FieldIndex::IntIndex(_) => None,
+            FieldIndex::IntMapIndex(_) => None,
+            FieldIndex::KeywordIndex(_) => None,
+            FieldIndex::FloatIndex(_) => None,
+            FieldIndex::GeoIndex(_) => None,
+            FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
+                Some(Match::Text(MatchText { text })) => {
+                    let query = full_text_index.parse_query(text)?;
+                    for value in full_text_index.get_values(payload_value) {
+                        let document = full_text_index.parse_document(&value);
+                        if query.check_match(&document) {
+                            return Ok(Some(true));
                         }
-                        _ => None,
-                    },
-                })
+                    }
+                    Some(false)
+                }
+                _ => None,
+            },
+        })
     }
 
     fn get_payload_field_index(&self) -> &dyn PayloadFieldIndex {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -29,10 +29,10 @@ pub trait PayloadFieldIndex {
 
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
-    fn filter<'a>(
-        &'a self,
-        condition: &'a FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
+    fn filter(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>>;
 
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
@@ -222,10 +222,10 @@ impl FieldIndex {
         self.get_payload_field_index().flusher()
     }
 
-    pub fn filter<'a>(
-        &'a self,
-        condition: &'a FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+    pub fn filter(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
         self.get_payload_field_index().filter(condition)
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -35,7 +35,10 @@ pub trait PayloadFieldIndex {
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
 
     /// Return estimation of points amount which satisfy given condition
-    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<CardinalityEstimation>>;
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
@@ -232,7 +235,7 @@ impl FieldIndex {
     pub fn estimate_cardinality(
         &self,
         condition: &FieldCondition,
-    ) -> Option<CardinalityEstimation> {
+    ) -> OperationResult<Option<CardinalityEstimation>> {
         self.get_payload_field_index()
             .estimate_cardinality(condition)
     }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -29,10 +29,10 @@ pub trait PayloadFieldIndex {
 
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
-    fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>>;
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
 
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
@@ -222,10 +222,10 @@ impl FieldIndex {
         self.get_payload_field_index().flusher()
     }
 
-    pub fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+    pub fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         self.get_payload_field_index().filter(condition)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -264,7 +264,7 @@ impl InvertedIndex for InvertedIndexInMemory {
             })
         };
     }
-    
+
     fn payload_blocks(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 
+use super::inverted_index_on_disk::InvertedIndexOnDisk;
 use super::posting_list::PostingList;
 use super::postings_iterator::intersect_postings_iterator;
 use crate::entry::entry_point::OperationResult;
@@ -81,6 +82,11 @@ pub(crate) trait InvertedIndex {
         threshold: usize,
         key: PayloadKeyType,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + 'a>;
+}
+
+pub enum InvertedIndexType {
+    InMemory(InvertedIndexInMemory),
+    OnDisk(InvertedIndexOnDisk),
 }
 
 #[derive(Default)]

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -1,0 +1,260 @@
+use std::collections::{BTreeSet, HashMap};
+use std::ops::Index;
+
+use bitvec::view::AsBits;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+use super::inverted_index::{Document, TokenId, ParsedQuery};
+use super::posting_list::PostingList;
+use super::postings_iterator::intersect_postings_iterator;
+use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
+use crate::types::{FieldCondition, Match, MatchText, PayloadKeyType, PointOffsetType};
+
+
+pub fn db_encode_tokens(data: &[u32]) -> Vec<u8> {
+    let mut res = Vec::with_capacity(data.len() * 4);
+    for i in 0..data.len() {
+        res[4*i..][..4].copy_from_slice(&data[i].to_be_bytes());
+    }
+    res
+}
+
+pub fn db_decode_tokens(data: &[u8]) -> Vec<u32> {
+    if data.len() == 0 {
+        return vec![];
+    }
+    let token_count = data.len() / 4 + 1;
+    let mut res = Vec::<u32>::with_capacity(token_count);
+    for (chunk, i) in data.windows(4).step_by(4).zip(0..token_count) {
+        res[i] = u32::from_be_bytes(chunk.try_into().unwrap());
+    }
+    res
+}
+
+pub struct InvertedIndex {
+    postings: DatabaseColumnWrapper,
+    pub vocab: DatabaseColumnWrapper,
+    pub point_to_docs: DatabaseColumnWrapper,
+    pub points_count: usize,
+}
+
+impl InvertedIndex {
+    fn store_key(id: &PointOffsetType) -> Vec<u8> {
+        bincode::serialize(&id).unwrap()
+    }
+
+    fn restore_key(data: &[u8]) -> PointOffsetType {
+        bincode::deserialize(data).unwrap()
+    }
+
+    fn serialize_document_tokens(&self, tokens: BTreeSet<String>) -> OperationResult<Vec<u8>> {
+        #[derive(Serialize)]
+        struct StoredDocument {
+            tokens: BTreeSet<String>,
+        }
+        let doc = StoredDocument { tokens };
+        serde_cbor::to_vec(&doc).map_err(|e| {
+            OperationError::service_error(format!("Failed to serialize document: {e}"))
+        })
+    }
+
+    fn deserialize_document(&self, data: &[u8]) -> OperationResult<Document> {
+        #[derive(Deserialize)]
+        struct StoredDocument {
+            tokens: BTreeSet<String>,
+        }
+        match serde_cbor::from_slice::<StoredDocument>(data)
+        {
+            Ok(doc) => self.document_from_tokens(&doc.tokens),
+            Err(e) => Err(OperationError::service_error(format!("Failed to deserialize document: {e}")))
+        } 
+    }
+
+    pub fn document_from_tokens(&self, tokens: &BTreeSet<String>) -> Result<Document, OperationError> {
+        let mut document_tokens = vec![];
+        for token in tokens {
+            // check if in vocab
+            let vocab_idx = match self.vocab.get_pinned(token.as_bytes(), |raw| serde_cbor::from_slice(raw))? {
+                    Some(cbor_result) => cbor_result?,
+                    None => {
+                        let next_token_id = self.vocab.lock_db().iter()?.count() as TokenId;
+                        self.vocab.put(token.as_bytes(), next_token_id.to_be_bytes());
+                        next_token_id
+                    }
+            };
+            document_tokens.push(vocab_idx);
+        }
+
+        Ok(Document::new(document_tokens))
+    }
+
+    pub fn index_document(&mut self, idx: PointOffsetType, document: Document) -> Result<(), OperationError> {
+        self.points_count += 1;
+
+        for token_idx in document.tokens() {
+            let mut posting = self
+                .postings
+                .get_pinned(&Self::store_key(&token_idx), |raw| db_decode_tokens(raw))
+                .expect("posting must exist even if with None");
+            let new_posting = match posting {
+                None => vec![idx],
+                Some(vec) => {
+                    vec.push(idx);
+                    vec
+                },
+            };
+            self.postings.put(Self::store_key(&token_idx), db_encode_tokens(&new_posting));
+        }
+        let db_document = db_encode_tokens(document.tokens());
+        self.point_to_docs.put(Self::store_key(&idx), db_document);
+        Ok(())
+    }
+
+    pub fn remove_document(&mut self, idx: PointOffsetType) -> OperationResult<Option<()>> {
+        if self.point_to_docs.lock_db().iter()?.count() <= idx as usize {
+            return Ok(None); // Already removed or never actually existed
+        }
+        let db_idx = Self::store_key(&idx);
+        let tokens = self.point_to_docs.get_pinned(&db_idx, |raw| db_decode_tokens(raw))?.ok_or(OperationError::service_error(format!("Document to be deleted is empty {idx}")))?;
+        self.point_to_docs.put(&db_idx, vec![])?;
+
+        self.points_count -= 1;
+
+        for removed_token in tokens {
+            // unwrap safety: posting list exists and contains the document id
+            let db_key = Self::store_key(&removed_token);
+            let posting = self.postings.get_pinned(&db_key, |raw| db_decode_tokens(raw))?;
+            if let Some(vec) = posting {
+                if let Ok(removal_idx) = vec.binary_search(&idx) {
+                    vec.remove(removal_idx);
+                    self.postings.put(&db_key, db_encode_tokens(&vec))?;
+                }
+            }
+        }
+        Ok(Some(()))
+    }
+
+    pub fn filter(&self, query: &ParsedQuery) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+        let postings_opt: Option<Vec<_>> = query
+            .tokens
+            .iter()
+            .map(|&vocab_idx| match vocab_idx {
+                None => None,
+                // if a ParsedQuery token was given an index, then it must exist in the vocabulary
+                // dictionary. Posting list entry can be None but it exists.
+                Some(idx) => Some(PostingList::from(self.postings.get_pinned(&Self::store_key(&idx), |raw| db_decode_tokens(raw)))),
+            })
+            
+            .collect();
+        if postings_opt.is_none() {
+            // There are unseen tokens -> no matches
+            return Box::new(vec![].into_iter());
+        }
+        let postings = postings_opt.unwrap();
+        if postings.is_empty() {
+            // Empty request -> no matches
+            return Box::new(vec![].into_iter());
+        }
+        let postings = postings.iter().collect_vec();
+        intersect_postings_iterator(postings)
+    }
+
+    // pub fn estimate_cardinality(
+    //     &self,
+    //     query: &ParsedQuery,
+    //     condition: &FieldCondition,
+    // ) -> CardinalityEstimation {
+    //     let postings_opt: Option<Vec<_>> = query
+    //         .tokens
+    //         .iter()
+    //         .map(|&vocab_idx| match vocab_idx {
+    //             None => None,
+    //             // unwrap safety: same as in filter()
+    //             Some(idx) => self.postings.get(idx as usize).unwrap().as_ref(),
+    //         })
+    //         .collect();
+    //     if postings_opt.is_none() {
+    //         // There are unseen tokens -> no matches
+    //         return CardinalityEstimation {
+    //             primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+    //             min: 0,
+    //             exp: 0,
+    //             max: 0,
+    //         };
+    //     }
+    //     let postings = postings_opt.unwrap();
+    //     if postings.is_empty() {
+    //         // Empty request -> no matches
+    //         return CardinalityEstimation {
+    //             primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+    //             min: 0,
+    //             exp: 0,
+    //             max: 0,
+    //         };
+    //     }
+    //     // Smallest posting is the largest possible cardinality
+    //     let smallest_posting = postings.iter().map(|posting| posting.len()).min().unwrap();
+
+    //     return if postings.len() == 1 {
+    //         CardinalityEstimation {
+    //             primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+    //             min: smallest_posting,
+    //             exp: smallest_posting,
+    //             max: smallest_posting,
+    //         }
+    //     } else {
+    //         let expected_frac: f64 = postings
+    //             .iter()
+    //             .map(|posting| posting.len() as f64 / self.points_count as f64)
+    //             .product();
+    //         let exp = (expected_frac * self.points_count as f64) as usize;
+    //         CardinalityEstimation {
+    //             primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
+    //             min: 0, // ToDo: make better estimation
+    //             exp,
+    //             max: smallest_posting,
+    //         }
+    //     };
+    // }
+
+    // pub fn payload_blocks(
+    //     &self,
+    //     threshold: usize,
+    //     key: PayloadKeyType,
+    // ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
+    //     // It might be very hard to predict possible combinations of conditions,
+    //     // so we only build it for individual tokens
+    //     Box::new(
+    //         self.vocab
+    //             .lock_db().iter().unwrap()
+    //             .filter(|(_token, &posting_idx)| self.postings[posting_idx as usize].is_some())
+    //             .filter(move |(_token, &posting_idx)| {
+    //                 // unwrap crash safety: all tokens that passes the first filter should have postings
+    //                 self.postings[posting_idx as usize].as_ref().unwrap().len() >= threshold
+    //             })
+    //             .map(|(token, &posting_idx)| {
+    //                 (
+    //                     token,
+    //                     // same as the above case
+    //                     self.postings[posting_idx as usize].as_ref().unwrap(),
+    //                 )
+    //             })
+    //             .map(move |(token, posting)| PayloadBlockCondition {
+    //                 condition: FieldCondition {
+    //                     key: key.clone(),
+    //                     r#match: Some(Match::Text(MatchText {
+    //                         text: token.clone(),
+    //                     })),
+    //                     range: None,
+    //                     geo_bounding_box: None,
+    //                     geo_radius: None,
+    //                     values_count: None,
+    //                 },
+    //                 cardinality: posting.len(),
+    //             }),
+    //     )
+    // }
+}

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -172,10 +172,7 @@ impl<'a> Iterator for PayloadBlocksIterator<'a> {
 
 impl InvertedIndex for InvertedIndexOnDisk {
     type Document<'a> = Document;
-    fn document_from_tokens(
-        &mut self,
-        tokens: &BTreeSet<String>,
-    ) -> OperationResult<Document> {
+    fn document_from_tokens(&mut self, tokens: &BTreeSet<String>) -> OperationResult<Document> {
         let mut document_tokens = vec![];
         for token in tokens {
             // check if in vocab

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -175,7 +175,7 @@ impl InvertedIndex for InvertedIndexOnDisk {
     fn document_from_tokens(
         &mut self,
         tokens: &BTreeSet<String>,
-    ) -> Result<Document, OperationError> {
+    ) -> OperationResult<Document> {
         let mut document_tokens = vec![];
         for token in tokens {
             // check if in vocab

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-
 use std::sync::Arc;
 
 use parking_lot::RwLock;

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -141,11 +141,11 @@ impl InvertedIndexOnDisk {
     //     };
     // }
 
-    pub fn payload_blocks(
-        &self,
+    pub fn payload_blocks<'a>(
+        &'a self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> OperationResult<Box<dyn Iterator<Item = PayloadBlockCondition> + '_>> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PayloadBlockCondition> + 'a>> {
         // It might be very hard to predict possible combinations of conditions,
         // so we only build it for individual tokens
         Ok(Box::new(self.vocab.lock_db().iter()?.filter_map(
@@ -156,7 +156,7 @@ impl InvertedIndexOnDisk {
                         condition: FieldCondition {
                             key: key.clone(),
                             r#match: Some(Match::Text(MatchText {
-                                text: _token_idx,
+                                text: String::from_utf8(_token_idx.into()).expect("Token slice read from rocksDB is not valid utf8. This should never happen."),
                             })),
                             range: None,
                             geo_bounding_box: None,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -82,6 +82,7 @@ impl InvertedIndexOnDisk {
             point_to_docs_flusher()
         })
     }
+
     pub fn payload_blocks<'a>(
         &'a self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index_on_disk.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::iter::empty;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -11,7 +12,7 @@ use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::PayloadBlockCondition;
-use crate::types::{PayloadKeyType, PointOffsetType};
+use crate::types::{PayloadKeyType, PointOffsetType, Match, FieldCondition, MatchText};
 
 pub fn db_encode_tokens(data: &[u32]) -> Vec<u8> {
     if data.is_empty() {
@@ -144,40 +145,27 @@ impl InvertedIndexOnDisk {
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PayloadBlockCondition> + '_>> {
         // It might be very hard to predict possible combinations of conditions,
         // so we only build it for individual tokens
-        Box::new(
-            self.vocab
-                .lock_db()
-                .iter()
-                .unwrap()
-                .filter(|(_token, posting_idx)| self.postings[posting_idx as usize].is_some())
-                .filter(move |(_token, posting_idx)| {
-                    // unwrap crash safety: all tokens that passes the first filter should have postings
-                    self.postings[posting_idx as usize].as_ref().unwrap().len() >= threshold
-                })
-                .map(|(token, posting_idx)| {
-                    (
-                        token,
-                        // same as the above case
-                        self.postings[posting_idx as usize].as_ref().unwrap(),
-                    )
-                })
-                .map(move |(token, posting)| PayloadBlockCondition {
-                    condition: FieldCondition {
-                        key: key.clone(),
-                        r#match: Some(Match::Text(MatchText {
-                            text: token.clone(),
-                        })),
-                        range: None,
-                        geo_bounding_box: None,
-                        geo_radius: None,
-                        values_count: None,
-                    },
-                    cardinality: posting.len(),
-                }),
-        )
+        Ok(Box::new(self.vocab.lock_db().iter()?.filter_map(
+                                            |(_token_idx, posting_idx)| match self.vocab.get_pinned(&posting_idx, db_decode_tokens) { 
+                                                Ok(Some(val)) if !val.is_empty() && val.len() >= threshold => Some(PayloadBlockCondition {
+                                            condition: FieldCondition {
+                                                key: key.clone(),
+                                                r#match: Some(Match::Text(MatchText {
+                                                    text: String::from_utf8(_token_idx.into()).unwrap(),
+                                                })),
+                                                range: None,
+                                                geo_bounding_box: None,
+                                                geo_radius: None,
+                                                values_count: None,
+                                            },
+                                            cardinality: val.len(),
+                                        }), 
+                                                Ok(Some(_) | None) | Err(_) => None,
+                                            }
+                                        )))
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -1,4 +1,5 @@
 mod inverted_index;
+mod inverted_index_on_disk;
 mod posting_list;
 mod postings_iterator;
 pub mod text_index;

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -48,3 +48,9 @@ impl IntoIterator for PostingList {
         self.list.into_iter()
     }
 }
+
+impl From<Vec<u32>> for PostingList {
+    fn from(value: Vec<u32>) -> Self {
+        Self { list: value }
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -19,6 +19,24 @@ pub fn intersect_postings_iterator<'a>(
     Box::new(and_iter)
 }
 
+pub fn intersect_postings_iterator_owned(
+    mut postings: Vec<PostingList>,
+) -> Box<dyn Iterator<Item = PointOffsetType>> {
+    let smallest_posting_idx = postings
+        .iter()
+        .enumerate()
+        .min_by_key(|(_idx, posting)| posting.len())
+        .map(|(idx, _posting)| idx)
+        .unwrap();
+    let smallest_posting = postings.remove(smallest_posting_idx);
+
+    let and_iter = smallest_posting
+        .into_iter()
+        .filter(move |doc_id| postings.iter().all(|posting| posting.contains(doc_id)));
+
+    Box::new(and_iter)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -172,7 +172,7 @@ fn test_prefix_search() {
             .unwrap();
     }
 
-    let res: Vec<_> = index.query("ROBO").collect();
+    let res: Vec<_> = index.query("ROBO").unwrap().collect();
 
     let query = index.parse_query("ROBO");
 
@@ -183,7 +183,7 @@ fn test_prefix_search() {
 
     assert_eq!(res.len(), 3);
 
-    let res: Vec<_> = index.query("q231").collect();
+    let res: Vec<_> = index.query("q231").unwrap().collect();
 
     let query = index.parse_query("q231");
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use tempfile::Builder;
 
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
@@ -174,22 +176,22 @@ fn test_prefix_search() {
 
     let res: Vec<_> = index.query("ROBO").unwrap().collect();
 
-    let query = index.parse_query("ROBO");
+    let query = index.parse_query("ROBO").unwrap();
 
     for idx in res.iter() {
         let doc = index.get_doc(*idx).unwrap();
-        assert!(query.check_match(doc));
+        assert!(query.check_match(doc.borrow()));
     }
 
     assert_eq!(res.len(), 3);
 
     let res: Vec<_> = index.query("q231").unwrap().collect();
 
-    let query = index.parse_query("q231");
+    let query = index.parse_query("q231").unwrap();
 
     for idx in [1, 2, 3] {
         let doc = index.get_doc(idx).unwrap();
-        assert!(!query.check_match(doc));
+        assert!(!query.check_match(doc.borrow()));
     }
 
     assert_eq!(res.len(), 0);

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -75,10 +75,7 @@ impl FullTextIndex {
     }
 
     pub fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
-        match self.inverted_index.point_to_docs.get(idx as usize) {
-            Some(Some(doc)) => Some(doc),
-            _ => None,
-        }
+        self.inverted_index.get_doc(idx)
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -97,7 +94,7 @@ impl FullTextIndex {
     pub fn parse_query(&self, text: &str) -> ParsedQuery {
         let mut tokens = HashSet::new();
         Tokenizer::tokenize_query(text, &self.config, |token| {
-            tokens.insert(self.inverted_index.vocab.get(token).copied());
+            tokens.insert(self.inverted_index.get_token_id(token).unwrap());
         });
         ParsedQuery {
             tokens: tokens.into_iter().collect(),

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -218,7 +218,7 @@ impl PayloadFieldIndex for FullTextIndex {
             return self
                 .inverted_index
                 .estimate_cardinality(&parsed_query, condition)
-                .map(|r| Some(r));
+                .map(Some);
         }
         Ok(None)
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -209,15 +209,18 @@ impl PayloadFieldIndex for FullTextIndex {
         Ok(None)
     }
 
-    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
         if let Some(Match::Text(text_match)) = &condition.r#match {
             let parsed_query = self.parse_query(&text_match.text);
-            return Some(
-                self.inverted_index
-                    .estimate_cardinality(&parsed_query, condition),
-            );
+            return self
+                .inverted_index
+                .estimate_cardinality(&parsed_query, condition)
+                .map(|r| Some(r));
         }
-        None
+        Ok(None)
     }
 
     fn payload_blocks(

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -97,16 +97,22 @@ impl FullTextIndex {
         let mut error = None;
         Tokenizer::tokenize_query(text, &self.config, |token| {
             match self.inverted_index.get_token_id(token) {
-                Ok(token_id) => { tokens.insert(token_id); },
-                Err(err) => if error.is_none() { error = Some(Err(err)) },
+                Ok(token_id) => {
+                    tokens.insert(token_id);
+                }
+                Err(err) => {
+                    if error.is_none() {
+                        error = Some(Err(err))
+                    }
+                }
             };
         });
         if let Some(err) = error {
             err
         } else {
-        Ok(ParsedQuery {
-                    tokens: tokens.into_iter().collect(),
-                })
+            Ok(ParsedQuery {
+                tokens: tokens.into_iter().collect(),
+            })
         }
     }
 
@@ -131,7 +137,9 @@ impl FullTextIndex {
 
     pub fn values_count(&self, point_id: PointOffsetType) -> usize {
         // Maybe we want number of documents in the future?
-        self.get_doc(point_id).map(|x| x.borrow().len()).unwrap_or(0)
+        self.get_doc(point_id)
+            .map(|x| x.borrow().len())
+            .unwrap_or(0)
     }
 }
 

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -516,11 +516,11 @@ impl PayloadFieldIndex for GeoMapIndex {
     fn filter(
         &self,
         condition: &FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
         if let Some(geo_bounding_box) = &condition.geo_bounding_box {
             let geo_hashes = rectangle_hashes(geo_bounding_box, GEO_QUERY_MAX_REGION);
             let geo_condition_copy = geo_bounding_box.clone();
-            return Some(Box::new(self.get_iterator(geo_hashes).filter(
+            return Ok(Some(Box::new(self.get_iterator(geo_hashes).filter(
                 move |point| {
                     self.point_to_values
                         .get(*point as usize)
@@ -528,13 +528,13 @@ impl PayloadFieldIndex for GeoMapIndex {
                         .iter()
                         .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
                 },
-            )));
+            ))));
         }
 
         if let Some(geo_radius) = &condition.geo_radius {
             let geo_hashes = circle_hashes(geo_radius, GEO_QUERY_MAX_REGION);
             let geo_condition_copy = geo_radius.clone();
-            return Some(Box::new(self.get_iterator(geo_hashes).filter(
+            return Ok(Some(Box::new(self.get_iterator(geo_hashes).filter(
                 move |point| {
                     self.point_to_values
                         .get(*point as usize)
@@ -542,10 +542,10 @@ impl PayloadFieldIndex for GeoMapIndex {
                         .iter()
                         .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
                 },
-            )));
+            ))));
         }
 
-        None
+        Ok(None)
     }
 
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
@@ -708,8 +708,11 @@ mod tests {
 
         let field_condition = condition_for_geo_radius("test".to_string(), geo_radius);
 
-        let mut indexed_matched_points =
-            field_index.filter(&field_condition).unwrap().collect_vec();
+        let mut indexed_matched_points = field_index
+            .filter(&field_condition)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
 
         matched_points.sort_unstable();
         indexed_matched_points.sort_unstable();
@@ -734,7 +737,11 @@ mod tests {
             .payload_blocks(100, "test".to_string())
             .collect_vec();
         blocks.iter().for_each(|block| {
-            let block_points = field_index.filter(&block.condition).unwrap().collect_vec();
+            let block_points = field_index
+                .filter(&block.condition)
+                .unwrap()
+                .unwrap()
+                .collect_vec();
             assert_eq!(block_points.len(), block.cardinality);
         });
     }
@@ -871,7 +878,11 @@ mod tests {
         };
 
         let field_condition = condition_for_geo_radius("test".to_string(), berlin_geo_radius);
-        let point_offsets = new_index.filter(&field_condition).unwrap().collect_vec();
+        let point_offsets = new_index
+            .filter(&field_condition)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
         assert_eq!(point_offsets, vec![1]);
     }
 

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -341,7 +341,10 @@ impl PayloadFieldIndex for MapIndex<String> {
         })
     }
 
-    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Keyword(keyword),
@@ -350,7 +353,7 @@ impl PayloadFieldIndex for MapIndex<String> {
                 estimation
                     .primary_clauses
                     .push(PrimaryCondition::Condition(condition.clone()));
-                Some(estimation)
+                Ok(Some(estimation))
             }
             Some(Match::Any(MatchAny {
                 any: AnyVariants::Keywords(keywords),
@@ -359,15 +362,15 @@ impl PayloadFieldIndex for MapIndex<String> {
                     .iter()
                     .map(|keyword| self.match_cardinality(keyword))
                     .collect::<Vec<_>>();
-                Some(combine_should_estimations(
+                Ok(Some(combine_should_estimations(
                     &estimations,
                     self.indexed_points,
-                ))
+                )))
             }
             Some(Match::Except(MatchExcept {
                 except: AnyVariants::Keywords(keywords),
-            })) => Some(self.except_cardinality(keywords)),
-            _ => None,
+            })) => Ok(Some(self.except_cardinality(keywords))),
+            _ => Ok(None),
         }
     }
 
@@ -432,7 +435,10 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         })
     }
 
-    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Integer(integer),
@@ -441,7 +447,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                 estimation
                     .primary_clauses
                     .push(PrimaryCondition::Condition(condition.clone()));
-                Some(estimation)
+                Ok(Some(estimation))
             }
             Some(Match::Any(MatchAny {
                 any: AnyVariants::Integers(integers),
@@ -450,15 +456,15 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                     .iter()
                     .map(|integer| self.match_cardinality(integer))
                     .collect::<Vec<_>>();
-                Some(combine_should_estimations(
+                Ok(Some(combine_should_estimations(
                     &estimations,
                     self.indexed_points,
-                ))
+                )))
             }
             Some(Match::Except(MatchExcept {
                 except: AnyVariants::Integers(integers),
-            })) => Some(self.except_cardinality(integers)),
-            _ => None,
+            })) => Ok(Some(self.except_cardinality(integers))),
+            _ => Ok(None),
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -318,11 +318,19 @@ impl PayloadFieldIndex for MapIndex<String> {
         MapIndex::flusher(self)
     }
 
+<<<<<<< HEAD
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match &condition.r#match {
+=======
+    fn filter(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+        Ok(match &condition.r#match {
+>>>>>>> 590af504 (Extract common InvertedIndex functionality into a trait; PayloadFieldIndex.filter is now failable to accomodate InvertedIndex.filter being failable (needed for OnDisk impl as it can fail when reading from DB))
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Keyword(keyword),
             })) => Some(self.get_iterator(keyword)),
@@ -338,7 +346,7 @@ impl PayloadFieldIndex for MapIndex<String> {
                 except: AnyVariants::Keywords(keywords),
             })) => Some(self.except_iterator(keywords)),
             _ => None,
-        }
+        })
     }
 
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
@@ -409,11 +417,19 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         MapIndex::flusher(self)
     }
 
+<<<<<<< HEAD
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match &condition.r#match {
+=======
+    fn filter(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+        Ok(match &condition.r#match {
+>>>>>>> 590af504 (Extract common InvertedIndex functionality into a trait; PayloadFieldIndex.filter is now failable to accomodate InvertedIndex.filter being failable (needed for OnDisk impl as it can fail when reading from DB))
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Integer(integer),
             })) => Some(self.get_iterator(integer)),
@@ -429,7 +445,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                 except: AnyVariants::Integers(integers),
             })) => Some(self.except_iterator(integers)),
             _ => None,
-        }
+        })
     }
 
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -318,19 +318,11 @@ impl PayloadFieldIndex for MapIndex<String> {
         MapIndex::flusher(self)
     }
 
-<<<<<<< HEAD
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
-        match &condition.r#match {
-=======
-    fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         Ok(match &condition.r#match {
->>>>>>> 590af504 (Extract common InvertedIndex functionality into a trait; PayloadFieldIndex.filter is now failable to accomodate InvertedIndex.filter being failable (needed for OnDisk impl as it can fail when reading from DB))
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Keyword(keyword),
             })) => Some(self.get_iterator(keyword)),
@@ -417,19 +409,11 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         MapIndex::flusher(self)
     }
 
-<<<<<<< HEAD
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
-        match &condition.r#match {
-=======
-    fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         Ok(match &condition.r#match {
->>>>>>> 590af504 (Extract common InvertedIndex functionality into a trait; PayloadFieldIndex.filter is now failable to accomodate InvertedIndex.filter being failable (needed for OnDisk impl as it can fail when reading from DB))
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Integer(integer),
             })) => Some(self.get_iterator(integer)),

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -369,14 +369,17 @@ impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
         )))
     }
 
-    fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
-        condition.range.as_ref().map(|range| {
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        Ok(condition.range.as_ref().map(|range| {
             let mut cardinality = self.range_cardinality(range);
             cardinality
                 .primary_clauses
                 .push(PrimaryCondition::Condition(condition.clone()));
             cardinality
-        })
+        }))
     }
 
     fn payload_blocks(

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -1,3 +1,4 @@
+use crate::entry::entry_point::OperationResult;
 use crate::index::visited_pool::VisitedList;
 use crate::payload_storage::FilterContext;
 use crate::types::PointOffsetType;
@@ -8,10 +9,10 @@ pub struct BuildConditionChecker<'a> {
 }
 
 impl<'a> FilterContext for BuildConditionChecker<'a> {
-    fn check(&self, point_id: PointOffsetType) -> bool {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         if point_id == self.current_point {
-            return false; // Do not match current point while inserting it (second time)
+            return Ok(false); // Do not match current point while inserting it (second time)
         }
-        self.filter_list.check(point_id)
+        Ok(self.filter_list.check(point_id))
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -155,7 +155,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
         let points_to_index: Vec<_> = payload_index
-            .query_points(&filter)
+            .query_points(&filter)?
             .filter(|&point_id| {
                 !deleted_bitslice
                     .get(point_id as usize)
@@ -216,7 +216,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<ScoredPointOffset> {
+    ) -> OperationResult<Vec<ScoredPointOffset>> {
         let req_ef = params
             .and_then(|params| params.hnsw_ef)
             .unwrap_or(self.config.ef);
@@ -261,7 +261,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         };
         let payload_index = self.payload_index.borrow();
 
-        let filter_context = filter.map(|f| payload_index.filter_context(f));
+        let filter_context = if let Some(f) = filter {
+            Some(payload_index.filter_context(f)?)
+        } else {
+            None
+        };
 
         let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
@@ -271,7 +275,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 .and_then(|p| p.quantization)
                 .map(|q| q.rescore)
                 .unwrap_or(default_quantization_rescore_value());
-            if quantized && if_rescore {
+            Ok(if quantized && if_rescore {
                 let raw_scorer = new_raw_scorer(
                     vector.to_owned(),
                     &vector_storage,
@@ -283,9 +287,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 search_result
             } else {
                 search_result
-            }
+            })
         } else {
-            Vec::new()
+            Ok(Vec::new())
         }
     }
 
@@ -295,7 +299,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         vectors
             .iter()
             .map(|vector| self.search_with_graph(vector, filter, top, params))
@@ -308,16 +312,16 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         filter: &Filter,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let id_tracker = self.id_tracker.borrow();
         let payload_index = self.payload_index.borrow();
         let vector_storage = self.vector_storage.borrow();
-        let mut filtered_iter = payload_index.query_points(filter);
+        let mut filtered_iter = payload_index.query_points(filter)?;
         let ignore_quantization = params
             .and_then(|p| p.quantization)
             .map(|q| q.ignore)
             .unwrap_or(default_quantization_ignore_value());
-        if ignore_quantization {
+        Ok(if ignore_quantization {
             vectors
                 .iter()
                 .map(|vector| {
@@ -351,7 +355,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     }
                 })
                 .collect()
-        }
+        })
     }
 }
 
@@ -362,7 +366,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let exact = params.map(|params| params.exact).unwrap_or(false);
         match filter {
             None => {
@@ -383,7 +387,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     } else {
                         &self.searches_telemetry.exact_unfiltered
                     });
-                    vectors
+                    Ok(vectors
                         .iter()
                         .map(|vector| {
                             new_raw_scorer(
@@ -393,7 +397,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                             )
                             .peek_top_all(top)
                         })
-                        .collect()
+                        .collect())
                 } else {
                     let _timer =
                         ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_hnsw);
@@ -429,7 +433,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 let vector_storage = self.vector_storage.borrow();
                 let id_tracker = self.id_tracker.borrow();
                 let available_vector_count = vector_storage.available_vector_count();
-                let query_point_cardinality = payload_index.estimate_cardinality(query_filter);
+                let query_point_cardinality = payload_index.estimate_cardinality(query_filter)?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
@@ -450,7 +454,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     return self.search_vectors_with_graph(vectors, filter, top, params);
                 }
 
-                let filter_context = payload_index.filter_context(query_filter);
+                let filter_context = payload_index.filter_context(query_filter)?;
 
                 // Fast cardinality estimation is not enough, do sample estimation of cardinality
                 let id_tracker = self.id_tracker.borrow();

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -30,14 +30,14 @@ pub trait PayloadIndex {
     /// Estimate amount of points (min, max) which satisfies filtering condition.
     ///
     /// A best estimation of the number of available points should be given.
-    fn estimate_cardinality(&self, query: &Filter) -> CardinalityEstimation;
+    fn estimate_cardinality(&self, query: &Filter) -> OperationResult<CardinalityEstimation>;
 
     /// Estimate amount of points (min, max) which satisfies filtering of a nested condition.
     fn estimate_nested_cardinality(
         &self,
         query: &Filter,
         nested_path: &JsonPathPayload,
-    ) -> CardinalityEstimation;
+    ) -> OperationResult<CardinalityEstimation>;
 
     /// Return list of all point ids, which satisfy filtering criteria
     ///
@@ -45,12 +45,15 @@ pub trait PayloadIndex {
     fn query_points<'a>(
         &'a self,
         query: &'a Filter,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>;
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
     /// Return number of points, indexed by this field
     fn indexed_points(&self, field: PayloadKeyTypeRef) -> usize;
 
-    fn filter_context<'a>(&'a self, filter: &'a Filter) -> Box<dyn FilterContext + 'a>;
+    fn filter_context<'a>(
+        &'a self,
+        filter: &'a Filter,
+    ) -> OperationResult<Box<dyn FilterContext + 'a>>;
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -312,7 +312,7 @@ pub struct PlainFilterContext<'a> {
 }
 
 impl<'a> FilterContext for PlainFilterContext<'a> {
-    fn check(&self, point_id: PointOffsetType) -> bool {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         self.condition_checker.check(point_id, self.filter)
     }
 }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -5,8 +5,6 @@
 
 use std::cmp::{max, min};
 
-use itertools::Itertools;
-
 use crate::entry::entry_point::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::types::{Condition, Filter};

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,8 +1,10 @@
+use std::borrow::Borrow;
 use std::collections::HashSet;
 
 use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
+use crate::entry::entry_point::OperationResult;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
@@ -22,106 +24,109 @@ pub fn condition_converter<'a>(
     field_indexes: &'a IndexesMap,
     payload_provider: PayloadProvider,
     id_tracker: &IdTrackerSS,
-) -> ConditionCheckerFn<'a> {
-    match condition {
-        Condition::Field(field_condition) => field_indexes
-            .get(&field_condition.key)
-            .and_then(|indexes| {
-                indexes
-                    .iter()
-                    .find_map(|index| field_condition_index(index, field_condition))
-            })
-            .unwrap_or_else(|| {
-                Box::new(move |point_id| {
-                    payload_provider.with_payload(point_id, |payload| {
-                        check_field_condition(field_condition, &payload, field_indexes)
-                    })
-                })
-            }),
-        // ToDo: It might be possible to make this condition faster by using index to check
-        //       if there is any value. But if value if not found,
-        //       it does not mean that there are no values in payload
-        Condition::IsEmpty(is_empty) => Box::new(move |point_id| {
-            payload_provider.with_payload(point_id, |payload| {
-                check_is_empty_condition(is_empty, &payload)
-            })
-        }),
-        Condition::IsNull(is_null) => Box::new(move |point_id| {
-            payload_provider.with_payload(point_id, |payload| {
-                check_is_null_condition(is_null, &payload)
-            })
-        }),
-        // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
-        Condition::HasId(has_id) => {
-            let segment_ids: HashSet<_> = has_id
-                .has_id
-                .iter()
-                .filter_map(|external_id| id_tracker.internal_id(*external_id))
-                .collect();
-            Box::new(move |point_id| segment_ids.contains(&point_id))
-        }
-        Condition::Nested(nested) => {
-            // Select indexes for nested fields. Trim nested part from key, so
-            // that nested condition can address fields without nested part.
-
-            // Example:
-            // Index for field `nested.field` will be stored under key `nested.field`
-            // And we have a query:
-            // {
-            //   "nested": {
-            //     "path": "nested",
-            //     "filter": {
-            //         ...
-            //         "match": {"key": "field", "value": "value"}
-            //     }
-            //   }
-
-            // In this case we want to use `nested.field`, but we only have `field` in query.
-            // Therefore we need to trim `nested` part from key. So that query executor
-            // can address proper index for nested field.
-            let nested_path = nested.array_key();
-
-            let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
-
-            Box::new(move |point_id| {
-                payload_provider.with_payload(point_id, |payload| {
-                    let field_values = payload.get_value(&nested_path).values();
-
-                    for value in field_values {
-                        if let Value::Object(object) = value {
-                            let get_payload = || OwnedPayloadRef::from(object);
-                            if check_payload(
-                                Box::new(get_payload),
-                                // None because has_id in nested is not supported. So retrieving
-                                // IDs throug the tracker would always return None.
-                                None,
-                                &nested.nested.filter,
-                                point_id,
-                                &nested_indexes,
-                            ) {
-                                // If at least one nested object matches, return true
-                                return true;
+) -> OperationResult<ConditionCheckerFn<'a>> {
+    Ok(match condition {
+                Condition::Field(field_condition) => {
+                    let maybe_indexes = field_indexes
+                    .get(&field_condition.key);
+                    if let Some(indexes) = maybe_indexes {
+                        for index in indexes.iter() {
+                            if let Some(val) = field_condition_index(index, field_condition)? {
+                                return Ok(val);
                             }
                         }
                     }
-                    false
-                })
+    
+                    Box::new(move |point_id| {
+                        payload_provider.with_payload(point_id, |payload| {
+                            check_field_condition(field_condition, &payload, field_indexes)
+                        })
+                    })
+                },
+                // ToDo: It might be possible to make this condition faster by using index to check
+                //       if there is any value. But if value if not found,
+                //       it does not mean that there are no values in payload
+                Condition::IsEmpty(is_empty) => Box::new(move |point_id| {
+                    payload_provider.with_payload(point_id, |payload| {
+                        check_is_empty_condition(is_empty, &payload)
+                    })
+                }),
+                Condition::IsNull(is_null) => Box::new(move |point_id| {
+                    payload_provider.with_payload(point_id, |payload| {
+                        check_is_null_condition(is_null, &payload)
+                    })
+                }),
+                // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
+                Condition::HasId(has_id) => {
+                    let segment_ids: HashSet<_> = has_id
+                        .has_id
+                        .iter()
+                        .filter_map(|external_id| id_tracker.internal_id(*external_id))
+                        .collect();
+                    Box::new(move |point_id| segment_ids.contains(&point_id))
+                }
+                Condition::Nested(nested) => {
+                    // Select indexes for nested fields. Trim nested part from key, so
+                    // that nested condition can address fields without nested part.
+        
+                    // Example:
+                    // Index for field `nested.field` will be stored under key `nested.field`
+                    // And we have a query:
+                    // {
+                    //   "nested": {
+                    //     "path": "nested",
+                    //     "filter": {
+                    //         ...
+                    //         "match": {"key": "field", "value": "value"}
+                    //     }
+                    //   }
+        
+                    // In this case we want to use `nested.field`, but we only have `field` in query.
+                    // Therefore we need to trim `nested` part from key. So that query executor
+                    // can address proper index for nested field.
+                    let nested_path = nested.array_key();
+        
+                    let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
+        
+                    Box::new(move |point_id| {
+                        payload_provider.with_payload(point_id, |payload| {
+                            let field_values = payload.get_value(&nested_path).values();
+        
+                            for value in field_values {
+                                if let Value::Object(object) = value {
+                                    let get_payload = || OwnedPayloadRef::from(object);
+                                    if check_payload(
+                                        Box::new(get_payload),
+                                        // None because has_id in nested is not supported. So retrieving
+                                        // IDs throug the tracker would always return None.
+                                        None,
+                                        &nested.nested.filter,
+                                        point_id,
+                                        &nested_indexes,
+                                    ) {
+                                        // If at least one nested object matches, return true
+                                        return true;
+                                    }
+                                }
+                            }
+                            false
+                        })
+                    })
+                }
+                Condition::Filter(_) => unreachable!(),
             })
-        }
-        Condition::Filter(_) => unreachable!(),
-    }
 }
 
 pub fn field_condition_index<'a>(
     index: &'a FieldIndex,
     field_condition: &FieldCondition,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
     if let Some(checker) = field_condition
         .r#match
         .clone()
-        .and_then(|cond| get_match_checkers(index, cond))
+        .map(|cond| get_match_checkers(index, cond))
     {
-        return Some(checker);
+        return checker;
     }
 
     if let Some(checker) = field_condition
@@ -129,7 +134,7 @@ pub fn field_condition_index<'a>(
         .clone()
         .and_then(|cond| get_range_checkers(index, cond))
     {
-        return Some(checker);
+        return Ok(Some(checker));
     }
 
     if let Some(checker) = field_condition
@@ -137,7 +142,7 @@ pub fn field_condition_index<'a>(
         .clone()
         .and_then(|cond| get_geo_radius_checkers(index, cond))
     {
-        return Some(checker);
+        return Ok(Some(checker));
     }
 
     if let Some(checker) = field_condition
@@ -145,10 +150,10 @@ pub fn field_condition_index<'a>(
         .clone()
         .and_then(|cond| get_geo_bounding_box_checkers(index, cond))
     {
-        return Some(checker);
+        return Ok(Some(checker));
     }
 
-    None
+    Ok(None)
 }
 
 pub fn get_geo_radius_checkers(
@@ -203,74 +208,74 @@ pub fn get_range_checkers(index: &FieldIndex, range: Range) -> Option<ConditionC
     }
 }
 
-pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<ConditionCheckerFn> {
-    match cond_match {
-        Match::Value(MatchValue {
-            value: value_variant,
-        }) => match (value_variant, index) {
-            (ValueVariants::Keyword(keyword), FieldIndex::KeywordIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|k| k == &keyword))
-                }))
-            }
-            (ValueVariants::Integer(value), FieldIndex::IntMapIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|i| i == &value))
-                }))
-            }
-            _ => None,
-        },
-        Match::Text(MatchText { text }) => match index {
-            FieldIndex::FullTextIndex(full_text_index) => {
-                let parsed_query = full_text_index.parse_query(&text);
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    full_text_index
-                        .get_doc(point_id)
-                        .map_or(false, |doc| parsed_query.check_match(doc))
-                }))
-            }
-            _ => None,
-        },
-        Match::Any(MatchAny { any }) => match (any, index) {
-            (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|k| list.contains(k)))
-                }))
-            }
-            (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|i| list.contains(i)))
-                }))
-            }
-            _ => None,
-        },
-        Match::Except(MatchExcept { except }) => match (except, index) {
-            (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|k| !list.contains(k)))
-                }))
-            }
-            (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|i| !list.contains(i)))
-                }))
-            }
-            (_, index) => Some(Box::new(|point_id: PointOffsetType| {
-                // If there is any other value of any other index, then it's a match
-                index.values_count(point_id) > 0
-            })),
-        },
-    }
+pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> OperationResult<Option<ConditionCheckerFn>> {
+    Ok(match cond_match {
+            Match::Value(MatchValue {
+                value: value_variant,
+            }) => match (value_variant, index) {
+                (ValueVariants::Keyword(keyword), FieldIndex::KeywordIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|k| k == &keyword))
+                    }))
+                }
+                (ValueVariants::Integer(value), FieldIndex::IntMapIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|i| i == &value))
+                    }))
+                }
+                _ => None,
+            },
+            Match::Text(MatchText { text }) => match index {
+                FieldIndex::FullTextIndex(full_text_index) => {
+                    let parsed_query = full_text_index.parse_query(&text)?;
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        full_text_index
+                            .get_doc(point_id)
+                            .map_or(false, |doc| parsed_query.check_match(doc.borrow()))
+                    }))
+                }
+                _ => None,
+            },
+            Match::Any(MatchAny { any }) => match (any, index) {
+                (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|k| list.contains(k)))
+                    }))
+                }
+                (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|i| list.contains(i)))
+                    }))
+                }
+                _ => None,
+            },
+            Match::Except(MatchExcept { except }) => match (except, index) {
+                (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|k| !list.contains(k)))
+                    }))
+                }
+                (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
+                    Some(Box::new(move |point_id: PointOffsetType| {
+                        index
+                            .get_values(point_id)
+                            .map_or(false, |values| values.iter().any(|i| !list.contains(i)))
+                    }))
+                }
+                (_, index) => Some(Box::new(|point_id: PointOffsetType| {
+                    // If there is any other value of any other index, then it's a match
+                    index.values_count(point_id) > 0
+                })),
+            },
+        })
 }

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -90,7 +90,7 @@ where
                     conditions,
                     id_tracker,
                     field_indexes,
-                    payload_provider.clone(),
+                    payload_provider,
                     estimator,
                     total,
                 )?;

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -142,7 +142,7 @@ where
                     field_indexes,
                     payload_provider.clone(),
                     id_tracker,
-                );
+                )?;
                 Ok((OptimizedCondition::Checker(condition_checker), estimation?))
             }
         })

--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 
-use crate::{types::PointOffsetType, entry::entry_point::OperationResult};
+use crate::{entry::entry_point::OperationResult, types::PointOffsetType};
 
 const MAX_ESTIMATED_POINTS: usize = 1000;
 
@@ -98,7 +98,8 @@ mod tests {
             |idx| Ok(idx % 2 == 0),
             10_000,
             100_000,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(res)
     }

--- a/lib/segment/src/index/struct_filter_context.rs
+++ b/lib/segment/src/index/struct_filter_context.rs
@@ -1,4 +1,5 @@
 use crate::common::utils::IndexesMap;
+use crate::entry::entry_point::OperationResult;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::query_optimization::optimized_filter::{check_optimized_filter, OptimizedFilter};
@@ -19,9 +20,9 @@ impl<'a> StructFilterContext<'a> {
         field_indexes: &'a IndexesMap,
         estimator: &F,
         total: usize,
-    ) -> Self
+    ) -> OperationResult<Self>
     where
-        F: Fn(&Condition) -> CardinalityEstimation,
+        F: Fn(&Condition) -> OperationResult<CardinalityEstimation>,
     {
         let (optimized_filter, _) = optimize_filter(
             filter,
@@ -30,9 +31,9 @@ impl<'a> StructFilterContext<'a> {
             payload_provider,
             estimator,
             total,
-        );
+        )?;
 
-        Self { optimized_filter }
+        Ok(Self { optimized_filter })
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -77,10 +77,10 @@ impl StructPayloadIndex {
         })
     }
 
-    fn query_field(
-        &self,
-        field_condition: &FieldCondition,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>> {
+    fn query_field<'a>(
+        &'a self,
+        field_condition: &'a FieldCondition,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         let indexes = if let Some(indexes) = self.field_indexes.get(&field_condition.key) {
             let mut maybe_indexes = None;
             for filter_result in indexes

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -19,7 +19,7 @@ pub trait VectorIndex {
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<Vec<ScoredPointOffset>>;
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>>;
 
     /// Force internal index rebuild.
     fn build_index(&mut self, stopped: &AtomicBool) -> OperationResult<()>;
@@ -58,7 +58,7 @@ impl VectorIndex for VectorIndexEnum {
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match self {
             VectorIndexEnum::Plain(index) => index.search(vectors, filter, top, params),
             VectorIndexEnum::HnswRam(index) => index.search(vectors, filter, top, params),

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -38,12 +38,12 @@ pub trait PayloadStorage {
 
 pub trait ConditionChecker {
     /// Check if point satisfies filter condition. Return true if satisfies
-    fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool;
+    fn check(&self, point_id: PointOffsetType, query: &Filter) -> OperationResult<bool>;
 }
 
 pub trait FilterContext {
     /// Check if point satisfies filter condition. Return true if satisfies
-    fn check(&self, point_id: PointOffsetType) -> bool;
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool>;
 }
 
 pub type PayloadStorageSS = dyn PayloadStorage + Sync + Send;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -601,7 +601,7 @@ impl Segment {
     ) -> OperationResult<Vec<PointIdType>> {
         let payload_index = self.payload_index.borrow();
         let filter_context = payload_index.filter_context(condition)?;
-        
+
         // Take first 'limit' external_ids for which filter_context check holds
         let mut points = Vec::with_capacity(limit.unwrap_or(0));
         for (external_id, internal_id) in self.id_tracker.borrow().iter_from(offset) {

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -115,7 +115,7 @@ mod tests {
         for block in &blocks {
             let px = payload_index_ptr.borrow();
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter);
+            let points = px.query_points(&filter).unwrap();
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }
@@ -141,20 +141,23 @@ mod tests {
         for _i in 0..attempts {
             let query = random_vector(&mut rnd, dim);
 
-            let index_result = hnsw_index.search(
-                &[&query],
-                None,
-                top,
-                Some(&SearchParams {
-                    hnsw_ef: Some(ef),
-                    exact: true,
-                    ..Default::default()
-                }),
-            );
+            let index_result = hnsw_index
+                .search(
+                    &[&query],
+                    None,
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        exact: true,
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
             let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], None, top, None);
+                .search(&[&query], None, top, None)
+                .unwrap();
 
             assert_eq!(
                 index_result, plain_result,
@@ -176,20 +179,23 @@ mod tests {
             )));
 
             let filter_query = Some(&filter);
-            let index_result = hnsw_index.search(
-                &[&query],
-                filter_query,
-                top,
-                Some(&SearchParams {
-                    hnsw_ef: Some(ef),
-                    exact: true,
-                    ..Default::default()
-                }),
-            );
+            let index_result = hnsw_index
+                .search(
+                    &[&query],
+                    filter_query,
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        exact: true,
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
             let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], filter_query, top, None);
+                .search(&[&query], filter_query, top, None)
+                .unwrap();
 
             assert_eq!(
                 index_result, plain_result,

--- a/lib/segment/tests/filtering_context_check.rs
+++ b/lib/segment/tests/filtering_context_check.rs
@@ -26,8 +26,8 @@ mod tests {
         for _ in 0..ATTEMPTS {
             let filter = random_filter(&mut rng, 3);
 
-            let plain_filter_context = plain_index.filter_context(&filter);
-            let struct_filter_context = struct_index.filter_context(&filter);
+            let plain_filter_context = plain_index.filter_context(&filter).unwrap();
+            let struct_filter_context = struct_index.filter_context(&filter).unwrap();
 
             let plain_result = (0..NUM_POINTS)
                 .filter(|point_id| plain_filter_context.check(*point_id as PointOffsetType))

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -115,7 +115,7 @@ mod tests {
         let px = payload_index_ptr.borrow();
         for block in &blocks {
             let filter = Filter::new_must(Condition::Field(block.condition.clone()));
-            let points = px.query_points(&filter);
+            let points = px.query_points(&filter).unwrap();
             for point in points {
                 coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
             }
@@ -159,20 +159,23 @@ mod tests {
             let filter_query = Some(&filter);
             // let filter_query = None;
 
-            let index_result = hnsw_index.search_with_graph(
-                &query,
-                filter_query,
-                top,
-                Some(&SearchParams {
-                    hnsw_ef: Some(ef),
-                    ..Default::default()
-                }),
-            );
+            let index_result = hnsw_index
+                .search_with_graph(
+                    &query,
+                    filter_query,
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
 
             let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], filter_query, top, None);
+                .search(&[&query], filter_query, top, None)
+                .unwrap();
 
             if plain_result.get(0).unwrap() == &index_result {
                 hits += 1;

--- a/lib/segment/tests/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/hnsw_quantized_search_test.rs
@@ -104,19 +104,22 @@ mod tests {
         for _i in 0..attempts {
             let query = random_vector(&mut rnd, dim);
 
-            let index_result = hnsw_index.search(
-                &[&query],
-                None,
-                top,
-                Some(&SearchParams {
-                    hnsw_ef: Some(ef),
-                    ..Default::default()
-                }),
-            );
+            let index_result = hnsw_index
+                .search(
+                    &[&query],
+                    None,
+                    top,
+                    Some(&SearchParams {
+                        hnsw_ef: Some(ef),
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
             let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], None, top, None);
+                .search(&[&query], None, top, None)
+                .unwrap();
             sames += sames_count(&index_result, &plain_result);
         }
         let acc = 100.0 * sames as f64 / (attempts * top) as f64;

--- a/lib/segment/tests/nested_filtering_test.rs
+++ b/lib/segment/tests/nested_filtering_test.rs
@@ -117,9 +117,9 @@ mod tests {
             );
 
             let nested_filter_0 = Filter::new_must(nested_condition_0);
-            let res0: Vec<_> = index.query_points(&nested_filter_0).collect();
+            let res0: Vec<_> = index.query_points(&nested_filter_0).unwrap().collect();
 
-            let filter_context = index.filter_context(&nested_filter_0);
+            let filter_context = index.filter_context(&nested_filter_0).unwrap();
 
             let check_res0: Vec<_> = (0..NUM_POINTS as PointOffsetType)
                 .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
@@ -154,9 +154,9 @@ mod tests {
 
             let nested_filter_1 = Filter::new_must(nested_condition_1);
 
-            let res1: Vec<_> = index.query_points(&nested_filter_1).collect();
+            let res1: Vec<_> = index.query_points(&nested_filter_1).unwrap().collect();
 
-            let filter_context = index.filter_context(&nested_filter_1);
+            let filter_context = index.filter_context(&nested_filter_1).unwrap();
 
             let check_res1: Vec<_> = (0..NUM_POINTS as PointOffsetType)
                 .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
@@ -188,9 +188,9 @@ mod tests {
 
             let nested_filter_2 = Filter::new_must(nested_condition_2);
 
-            let res2: Vec<_> = index.query_points(&nested_filter_2).collect();
+            let res2: Vec<_> = index.query_points(&nested_filter_2).unwrap().collect();
 
-            let filter_context = index.filter_context(&nested_filter_2);
+            let filter_context = index.filter_context(&nested_filter_2).unwrap();
 
             let check_res2: Vec<_> = (0..NUM_POINTS as PointOffsetType)
                 .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
@@ -239,9 +239,9 @@ mod tests {
                 must_not: None,
             };
 
-            let res3: Vec<_> = index.query_points(&nested_filter_3).collect();
+            let res3: Vec<_> = index.query_points(&nested_filter_3).unwrap().collect();
 
-            let filter_context = index.filter_context(&nested_filter_3);
+            let filter_context = index.filter_context(&nested_filter_3).unwrap();
 
             let check_res3: Vec<_> = (0..NUM_POINTS as PointOffsetType)
                 .filter(|point_id| filter_context.check(*point_id as PointOffsetType))

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -271,17 +271,20 @@ mod tests {
         let estimation_struct = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter)
+            .unwrap();
 
         let estimation_plain = plain_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter)
+            .unwrap();
 
         let real_number = plain_segment
             .payload_index
             .borrow()
             .query_points(&filter)
+            .unwrap()
             .count();
 
         eprintln!("estimation_plain = {estimation_plain:#?}");
@@ -320,10 +323,11 @@ mod tests {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter)
+            .unwrap();
 
         let payload_index = struct_segment.payload_index.borrow();
-        let filter_context = payload_index.filter_context(&filter);
+        let filter_context = payload_index.filter_context(&filter).unwrap();
         let exact = struct_segment
             .id_tracker
             .borrow()
@@ -358,7 +362,8 @@ mod tests {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter)
+            .unwrap();
 
         // not empty primary clauses
         assert_eq!(estimation.primary_clauses.len(), 1);
@@ -378,7 +383,7 @@ mod tests {
         }
 
         let payload_index = struct_segment.payload_index.borrow();
-        let filter_context = payload_index.filter_context(&filter);
+        let filter_context = payload_index.filter_context(&filter).unwrap();
         let exact = struct_segment
             .id_tracker
             .borrow()
@@ -416,7 +421,8 @@ mod tests {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&filter);
+            .estimate_cardinality(&filter)
+            .unwrap();
 
         // not empty primary clauses
         assert_eq!(estimation.primary_clauses.len(), 1);
@@ -436,7 +442,7 @@ mod tests {
         }
 
         let payload_index = struct_segment.payload_index.borrow();
-        let filter_context = payload_index.filter_context(&filter);
+        let filter_context = payload_index.filter_context(&filter).unwrap();
         let exact = struct_segment
             .id_tracker
             .borrow()
@@ -495,7 +501,8 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter)
+                .unwrap();
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -574,7 +581,8 @@ mod tests {
             let estimation = plain_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter)
+                .unwrap();
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -598,7 +606,8 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter)
+                .unwrap();
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");
@@ -666,7 +675,8 @@ mod tests {
             let estimation = struct_segment
                 .payload_index
                 .borrow()
-                .estimate_cardinality(&query_filter);
+                .estimate_cardinality(&query_filter)
+                .unwrap();
 
             assert!(estimation.min <= estimation.exp, "{estimation:#?}");
             assert!(estimation.exp <= estimation.max, "{estimation:#?}");

--- a/lib/segment/tests/scroll_filtering_test.rs
+++ b/lib/segment/tests/scroll_filtering_test.rs
@@ -23,10 +23,12 @@ mod tests {
 
             let random_offset = rng.gen_range(0..10);
 
-            let read_by_index_res =
-                segment.filtered_read_by_index(Some(random_offset.into()), Some(10), &filter);
-            let read_by_stream_res =
-                segment.filtered_read_by_id_stream(Some(random_offset.into()), Some(10), &filter);
+            let read_by_index_res = segment
+                .filtered_read_by_index(Some(random_offset.into()), Some(10), &filter)
+                .unwrap();
+            let read_by_stream_res = segment
+                .filtered_read_by_id_stream(Some(random_offset.into()), Some(10), &filter)
+                .unwrap();
 
             assert_eq!(read_by_index_res, read_by_stream_res, "filter: {filter:#?}");
         }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

This PR will allow full text index to be stored on disk. This will allow using them in environments with constrained RAM.

It uses RocksDB as it seems the most well maintained persistent key-value storage and the project already depends on it. Other options I considered were WickDB (no updates in the last year), plain LevelDB (no updates in the last years), sled (still considered to be beta by maintainers, they recommend RocksDB in their README), SQLite (seems too complex for this usecase), Couchbase (no Rust libraries).

Because of the C++ FFI basic calls to the key-value store, such as put and get will always be failible. This is because librocksdb may be miscompiled or misloaded, and the underlying call to rocksdb_readopts_create() may produce a null pointer to ReadOptions (or WriteOptions in the case of put). This forces the InvertedIndex implementation to have its methods return Result<> types so we can bubble up this miscompilation error and communicate it to the Qdrant user. We could alternatively unwrap at this point and crash the entire app, which does not sound great either.

Because of this low level failablility several high level APIs need to be failable now, such as filter(), as well as intermediate users of InvertedIndex, such as Tokenizers and the tokenizer callbacks we pass into those. 

In theory if we used a key-value store that was written in pure Rust it might become possible to get rid of this failability altogether, provided that this hypothetical library exposes get/put methods that are not failable or that can be handled in an obvious way (e.x. read_or_create a value).

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

