### PR TITLE
new simpler dockerfile, incremental still uses caching for local iter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN mkdir -p ${APP}
 
 COPY --from=builder /qdrant/qdrant ${APP}/qdrant
 COPY --from=builder /qdrant/config ${APP}/config
+COPY --from=builder /qdrant/tools/entrypoint.sh ${APP}/entrypoint.sh
 
 WORKDIR ${APP}
 
-CMD ["./qdrant"]
+CMD ["./entrypoint.sh"]

--- a/IncrementalDockerfile
+++ b/IncrementalDockerfile
@@ -1,4 +1,14 @@
-FROM rust:latest as builder
+# Leveraging the pre-built Docker images with
+# cargo-chef and the Rust toolchain
+# https://www.lpalmieri.com/posts/fast-rust-docker-builds/
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.68.2 AS chef
+WORKDIR /qdrant
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef as builder
 
 # based on https://github.com/docker/buildx/issues/510
 ARG TARGETARCH
@@ -9,14 +19,21 @@ WORKDIR /qdrant
 COPY ./tools/target_arch.sh ./target_arch.sh
 RUN echo "Building for $TARGETARCH, arch: $(bash target_arch.sh)"
 
+COPY --from=planner /qdrant/recipe.json recipe.json
+
 RUN apt-get update \
     && ( apt-get install -y gcc-multilib || echo "Warning: not installing gcc-multilib" ) \
     && apt-get install -y clang cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler \
     && rustup component add rustfmt
 
+
 RUN rustup target add $(bash target_arch.sh)
 
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --target $(bash target_arch.sh) --recipe-path recipe.json
+
 COPY . .
+
 
 # Build actual target here
 RUN cargo build --release --target $(bash target_arch.sh) --bin qdrant

--- a/IncrementalDockerfile
+++ b/IncrementalDockerfile
@@ -1,7 +1,7 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.68.2 AS chef
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.69.0 AS chef
 WORKDIR /qdrant
 
 FROM chef AS planner
@@ -57,7 +57,8 @@ RUN mkdir -p ${APP}
 
 COPY --from=builder /qdrant/qdrant ${APP}/qdrant
 COPY --from=builder /qdrant/config ${APP}/config
+COPY --from=builder /qdrant/tools/entrypoint.sh ${APP}/entrypoint.sh
 
 WORKDIR ${APP}
 
-CMD ["./qdrant"]
+CMD ["./entrypoint.sh"]


### PR DESCRIPTION
Attempting #1812 (won't claim until I see the required improvements, previous pr was with a fork that only had master)

That idea is that the chef images are not readily available in github actions, and excess time is spent with docker setting it up. Simplify it for CI builds with an image most likely cached within github actions, while keep a Dockerfile for local building when the environment is consistent.

Another change could be building outside of docker to not pay containerization overhead, then just copy bits it into the container. You'd still keep around the IncrementalDockerFile shown here for local building to avoid "works on my machine". (This approach is what I do for my own rust backend into a container in ~10 mins for --release)

(I do subscribe to the idea that any crate should work out-the-box `git clone <repo> && cd <repo> && cargo b`)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?