### PR TITLE
increase drop segment timeout to 1h

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -19,7 +19,7 @@ use crate::operations::types::CollectionError;
 pub type SegmentId = usize;
 
 const DROP_SPIN_TIMEOUT: Duration = Duration::from_millis(10);
-const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60);
+const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 /// Object, which unifies the access to different types of segments, but still allows to
 /// access the original type of the segment if it is required for more efficient operations.
@@ -73,7 +73,7 @@ impl LockedSegment {
                 match try_unwrap_with_timeout(proxy, DROP_SPIN_TIMEOUT, DROP_DATA_TIMEOUT) {
                     Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
                     Err(locked_segment) => Err(OperationError::service_error(format!(
-                        "Removing segment which is still in use: {:?}",
+                        "Removing proxy segment which is still in use: {:?}",
                         locked_segment.read().data_path()
                     ))),
                 }


### PR DESCRIPTION
Follow up to https://github.com/qdrant/qdrant/pull/1595

It seems the value is still too low given a user report on Discord.

This PR proposes to bump the timeout value straight to 1h to hopefully unblock the situation and give us time to investigate.