### PR TITLE
fix clippy warning

### DIFF
--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -1,6 +1,6 @@
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::Write;
-use std::mem::size_of;
+use std::mem::size_of_val;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -19,7 +19,7 @@ use crate::vector_storage::quantized::quantized_vectors_base::QuantizedVectors;
 use crate::vector_storage::VectorStorage;
 
 fn vf_to_u8<T>(v: &[T]) -> &[u8] {
-    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, size_of_val(v)) }
 }
 
 /// Stores all vectors in mem-mapped file


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

warning: manual slice size calculation
  --> lib/segment/src/vector_storage/memmap_vector_storage.rs:22:66
   |
22 |     unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * size_of::<T>()) }
   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(v)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice_size_calculation
   = note: `#[warn(clippy::manual_slice_size_calculation)]` on by default
