### PR TITLE
Add WAL inspector binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,7 @@ dependencies = [
  "tower-layer",
  "uuid",
  "validator",
+ "wal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ clap = { version = "4.2.7", features = ["derive"] }
 serde_cbor = { version = "0.11.2"}
 uuid = { version = "1.3", features = ["v4", "serde"] }
 sys-info = "0.9.1"
+wal = { git = "https://github.com/qdrant/wal.git", rev = "660ccf17b117e7a0667a17177e96fdaeb166851b" }
 
 config = "~0.13.3"
 
@@ -80,6 +81,12 @@ tikv-jemallocator = "0.5"
 [[bin]]
 name = "schema_generator"
 path = "src/schema_generator.rs"
+test = false
+bench = false
+
+[[bin]]
+name = "wal_inspector"
+path = "src/wal_inspector.rs"
 test = false
 bench = false
 

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -1,0 +1,27 @@
+use std::env;
+use std::path::Path;
+
+use collection::operations::CollectionUpdateOperations;
+use collection::wal::SerdeWal;
+use wal::WalOptions;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let wal_path = Path::new(&args[1]);
+    let wal: Result<SerdeWal<CollectionUpdateOperations>, _> =
+        SerdeWal::new(wal_path.to_str().unwrap(), WalOptions::default());
+
+    match wal {
+        Err(error) => {
+            eprintln!("Unable to open write ahead log in directory {wal_path:?}: {error}.");
+        }
+        Ok(wal) => {
+            // print all entries
+            wal.read_all().for_each(|(idx, op)| {
+                println!("==========================");
+                println!("Entry {}", idx);
+                println!("{:?}", op);
+            });
+        }
+    }
+}

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -17,11 +17,16 @@ fn main() {
         }
         Ok(wal) => {
             // print all entries
-            wal.read_all().for_each(|(idx, op)| {
+            let mut count = 0;
+            for (idx, op) in wal.read_all() {
                 println!("==========================");
                 println!("Entry {}", idx);
                 println!("{:?}", op);
-            });
+                count += 1;
+            }
+            println!("==========================");
+            println!("End of WAL.");
+            println!("Found {} entries.", count);
         }
     }
 }

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -5,6 +5,8 @@ use collection::operations::CollectionUpdateOperations;
 use collection::wal::SerdeWal;
 use wal::WalOptions;
 
+/// Executable to inspect the content of a write ahead log folder.
+/// e.g `cargo run --bin wal_inspector storage/collections/test-collection/0/wal/`
 fn main() {
     let args: Vec<String> = env::args().collect();
     let wal_path = Path::new(&args[1]);


### PR DESCRIPTION
This PR adds a new minimal binary that decodes and displays the content of a WAL folder.
It can be useful during investigation.

Usage:

`cargo run --bin wal_inspector storage/collections/test-collection/0/wal/ `

~~Opening as a Draft because it might be considered a bit hacky for the time being.~~