### PR TITLE
Extend `SerdeWal` to better track the last truncated-to WAL index (#1815)

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -23,11 +23,10 @@ pub(crate) fn check_unprocessed_points(
 ) -> CollectionResult<usize> {
     let first_missed_point = points.iter().copied().find(|p| !processed.contains(p));
 
-    if let Some(missed_point_id) = first_missed_point {
-        log::warn!("{}", CollectionError::PointNotFound { missed_point_id });
+    match first_missed_point {
+        None => Ok(processed.len()),
+        Some(missed_point_id) => Err(CollectionError::PointNotFound { missed_point_id }),
     }
-
-    Ok(processed.len())
 }
 
 /// Tries to delete points from all segments, returns number of actually deleted points

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use itertools::Itertools;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::{OperationResult, SegmentEntry};
@@ -22,21 +21,13 @@ pub(crate) fn check_unprocessed_points(
     points: &[PointIdType],
     processed: &HashSet<PointIdType>,
 ) -> CollectionResult<usize> {
-    let unprocessed_points = points
-        .iter()
-        .cloned()
-        .filter(|p| !processed.contains(p))
-        .collect_vec();
-    let missed_point = unprocessed_points.iter().cloned().next();
+    let first_missed_point = points.iter().copied().find(|p| !processed.contains(p));
 
-    // ToDo: check pre-existing points
-
-    match missed_point {
-        None => Ok(processed.len()),
-        Some(missed_point) => Err(CollectionError::PointNotFound {
-            missed_point_id: missed_point,
-        }),
+    if let Some(missed_point_id) = first_missed_point {
+        log::warn!("{}", CollectionError::PointNotFound { missed_point_id });
     }
+
+    Ok(processed.len())
 }
 
 /// Tries to delete points from all segments, returns number of actually deleted points

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -392,7 +392,20 @@ impl LocalShard {
 
         bar.set_message(format!("Recovering collection {collection_id}"));
         let segments = self.segments();
-        // ToDo: Start from minimal applied version
+
+        // When `Segment`s are flushed, WAL is truncated up to the index of the last operation
+        // that has been applied and flushed.
+        //
+        // `SerdeWal` wrapper persists/keeps track of this index (in addition to any handling
+        // in the `wal` crate itself).
+        //
+        // `SerdeWal::read_all` starts reading WAL from the first "un-truncated" index,
+        // so no additional handling required to "skip" any potentially applied entries.
+        //
+        // Note, that it's not guaranted that some operation won't be re-applied to the storage.
+        // (`SerdeWal::read_all` may even start reading WAL from some already truncated
+        // index *occasionally*), but the storage can handle operations being re-applied.
+
         for (op_num, update) in wal.read_all() {
             // Propagate `CollectionError::ServiceError`, but skip other error types.
             match &CollectionUpdater::update(segments, op_num, update) {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -407,16 +407,30 @@ impl LocalShard {
 
         let segments = self.segments();
 
-        let minimal_persisted_version = segments
+        let min_persisted_version = segments
             .read()
             .iter()
             .map(|(_, segment)| segment.get().read().version())
-            .min();
+            .min()
+            .unwrap_or(0);
 
-        for (op_num, update) in wal
-            .read_all()
-            .skip_while(|&(op_num, _)| Some(op_num) <= minimal_persisted_version)
-        {
+        // `0` is a valid version.
+        //
+        // `Segment::version` declared as `Option<SeqNumberType>`.
+        //
+        // However, `<Segment as SegmentEntry>::version` returns `self.version.unwrap_or(0)`,
+        // which means we can't precisely distinguish an empty `Segment` (i.e., no operations applied)
+        // from a `Segment` with version `0` (i.e., exactly one operation with version `0` applied).
+        //
+        // To work around this corner case, we explicitly check that `min_persisted_version > 0`,
+        // so that if `min_persisted_version == 0` we won't skip operation `0` and will always
+        // (re)apply it.
+
+        let ops = wal.read_all().skip_while(|&(op_num, _)| {
+            op_num <= min_persisted_version && min_persisted_version > 0
+        });
+
+        for (op_num, update) in ops {
             // Propagate `CollectionError::ServiceError`, but skip other error types.
             match &CollectionUpdater::update(segments, op_num, update) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -404,7 +404,7 @@ impl LocalShard {
         //
         // Note, that it's not guaranted that some operation won't be re-applied to the storage.
         // (`SerdeWal::read_all` may even start reading WAL from some already truncated
-        // index *occasionally*), but the storage can handle operations being re-applied.
+        // index *occasionally*), but the storage can handle it.
 
         for (op_num, update) in wal.read_all() {
             // Propagate `CollectionError::ServiceError`, but skip other error types.

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -429,6 +429,7 @@ impl LocalShard {
                     log::error!("{err}");
                     return Err(err.clone());
                 }
+                Err(err @ CollectionError::NotFound { .. }) => log::warn!("{err}"),
                 Err(err) => log::error!("{err}"),
                 Ok(_) => (),
             }

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -158,10 +158,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
             .map_err(|err| WalError::TruncateWalError(format!("{err:?}")))?;
 
         // Update current `first_index`
-        self.first_index = self
-            .first_index
-            .unwrap_or(until_index.clamp(self.wal.first_index(), self.wal.last_index()))
-            .into();
+        self.first_index = Some(until_index.clamp(self.wal.first_index(), self.wal.last_index()));
 
         // Persist current `first_index` value on disk
         // TODO: Should we log this error and continue instead of failing?

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -304,17 +304,17 @@ impl Segment {
             }
         }
 
-        let res = operation(self);
+        let (applied, point_id) = operation(self)?;
 
-        if res.is_ok() {
-            self.version = Some(max(op_num, self.version.unwrap_or(0)));
-            if let Ok((_, Some(point_id))) = res {
-                self.id_tracker
-                    .borrow_mut()
-                    .set_internal_version(point_id, op_num)?;
-            }
+        self.version = Some(max(op_num, self.version.unwrap_or(0)));
+
+        if let Some(point_id) = point_id {
+            self.id_tracker
+                .borrow_mut()
+                .set_internal_version(point_id, op_num)?;
         }
-        res.map(|(res, _)| res)
+
+        Ok(applied)
     }
 
     fn lookup_internal_id(&self, point_id: PointIdType) -> OperationResult<PointOffsetType> {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -285,7 +285,8 @@ impl Segment {
     {
         match op_point_offset {
             None => {
-                // Not a point operation, use global version to check if already applied
+                // Not a point operation *or* point does not exist.
+                // Use global version to check if operation has been already applied.
                 if self.version.unwrap_or(0) > op_num {
                     return Ok(false); // Skip without execution
                 }


### PR DESCRIPTION
WAL operates in _segments_. When `Wal::prefix_truncate` is called (during `SerdeWal::ack`), WAL is not truncated _precisely_ up to the `until_index`, but up to the nearest segment with `last_index` that is less-or-equal than `until_index`.

Consider the pseudo-graphic illustration of the WAL that was truncated up to index 35:

```
| -------- | -------- | ===='++++ | ++++++++ | ++++++++ | ++++++++ |
10         20         30    35    40         50         60         70
```

- `'` marks the index 35 that has been truncated-to
- `---` marks segments 10-30 that has been physically deleted
- `+++` marks segments 35-70 that are still valid
- and `===` marks part of segment 30-34, that is still physically present on disk, but that is "logically" deleted

This PR extends `SerdeWal` type to track the last truncated-to index and transparently hide the "logically deleted" parts of WAL from the user of the `SerdeWal` type.