### PR TITLE
Update memmap2 to remove mutex from typed mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9ff02d2efdc645fca1ee55f45545b996e7da776b5b60c4e170334457551693"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,7 +3754,7 @@ dependencies = [
  "geohash",
  "itertools",
  "log",
- "memmap2",
+ "memmap2 0.6.0",
  "num-derive",
  "num-traits",
  "num_cpus",
@@ -4059,7 +4068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid",
 ]
@@ -4694,7 +4703,7 @@ dependencies = [
  "env_logger",
  "fs4",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "rand 0.8.5",
  "rand_distr",
  "rustix 0.37.4",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -34,7 +34,7 @@ ordered-float = "3.7"
 thiserror = "1.0"
 atomic_refcell = "0.1.10"
 atomicwrites = "0.4.1"
-memmap2 = "0.5.10"
+memmap2 = "0.6.0"
 schemars = { version = "0.8.12", features = ["uuid1", "preserve_order", "chrono"] }
 log = "0.4"
 geo = "0.24.1"

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -175,7 +175,7 @@ where
     /// See [`MmapMut::lock`] for details.
     #[cfg(unix)]
     pub fn mlock(&mut self) -> io::Result<()> {
-        let mut mmap_guard = self.mmap.lock().unwrap();
+        let mmap_guard = self.mmap.lock().unwrap();
         mmap_guard.lock()
     }
 

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -23,7 +23,7 @@
 //! behavior. Problems caused by this are very hard to debug.
 
 use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{io, mem, slice};
 
 use bitvec::slice::BitSlice;
@@ -69,9 +69,7 @@ where
     /// This should never be accessed directly, because it shares a mutable reference with
     /// `r#type`. That must be used instead. The sole purpose of this is to keep ownership of the
     /// mmap, and to allow properly cleaning up when this struct is dropped.
-    ///
-    /// Uses a mutex because mutable access is needed for locking pages in memory.
-    mmap: Arc<Mutex<MmapMut>>,
+    mmap: Arc<MmapMut>,
 }
 
 impl<T> MmapType<T>
@@ -109,7 +107,7 @@ where
     /// - See: [`mmap_to_type_unbounded`]
     pub unsafe fn try_from(mut mmap_with_type: MmapMut) -> Result<Self> {
         let r#type = mmap_to_type_unbounded(&mut mmap_with_type)?;
-        let mmap = Arc::new(Mutex::new(mmap_with_type));
+        let mmap = Arc::new(mmap_with_type);
         Ok(Self { r#type, mmap })
     }
 }
@@ -161,7 +159,7 @@ where
     /// - See: [`mmap_to_slice_unbounded`]
     pub unsafe fn try_slice_from(mut mmap_with_slice: MmapMut) -> Result<Self> {
         let r#type = mmap_to_slice_unbounded(&mut mmap_with_slice, 0)?;
-        let mmap = Arc::new(Mutex::new(mmap_with_slice));
+        let mmap = Arc::new(mmap_with_slice);
         Ok(Self { r#type, mmap })
     }
 }
@@ -174,9 +172,8 @@ where
     ///
     /// See [`MmapMut::lock`] for details.
     #[cfg(unix)]
-    pub fn mlock(&mut self) -> io::Result<()> {
-        let mmap_guard = self.mmap.lock().unwrap();
-        mmap_guard.lock()
+    pub fn mlock(&self) -> io::Result<()> {
+        self.mmap.lock()
     }
 
     /// Get flusher to explicitly flush mmap at a later time
@@ -186,7 +183,7 @@ where
         Box::new({
             let mmap = self.mmap.clone();
             move || {
-                mmap.lock().unwrap().flush()?;
+                mmap.flush()?;
                 Ok(())
             }
         })
@@ -268,6 +265,19 @@ impl<T> MmapSlice<T> {
     pub unsafe fn try_from(mmap_with_slice: MmapMut) -> Result<Self> {
         MmapType::try_slice_from(mmap_with_slice).map(|mmap| Self { mmap })
     }
+
+    /// Lock memory mapped pages in memory
+    ///
+    /// See [`MmapMut::lock`] for details.
+    #[cfg(unix)]
+    pub fn mlock(&self) -> io::Result<()> {
+        self.mmap.mlock()
+    }
+
+    /// Get flusher to explicitly flush mmap at a later time
+    pub fn flusher(&self) -> Flusher {
+        self.mmap.flusher()
+    }
 }
 
 impl<T> Deref for MmapSlice<T> {
@@ -320,7 +330,7 @@ impl MmapBitSlice {
     pub fn try_from(mut mmap: MmapMut, header_size: usize) -> Result<Self> {
         let data = unsafe { mmap_to_slice_unbounded(&mut mmap, header_size)? };
         let bitslice = BitSlice::from_slice_mut(data);
-        let mmap = Arc::new(Mutex::new(mmap));
+        let mmap = Arc::new(mmap);
 
         Ok(Self {
             mmap: MmapType {
@@ -334,7 +344,7 @@ impl MmapBitSlice {
     ///
     /// See [`MmapMut::lock`] for details.
     #[cfg(unix)]
-    pub fn mlock(&mut self) -> io::Result<()> {
+    pub fn mlock(&self) -> io::Result<()> {
         self.mmap.mlock()
     }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -165,7 +165,7 @@ impl MmapVectors {
     /// huge. Calling this will lock the deleted flags in memory to prevent this.
     ///
     /// This is only supported on Unix.
-    fn lock_deleted_flags(&mut self) {
+    fn lock_deleted_flags(&self) {
         #[cfg(unix)]
         if let Err(err) = self.deleted.mlock() {
             log::error!(


### PR DESCRIPTION
This updates `memmap2` to `v0.6.0` to remove a mutex from the typed mmap, simplifying the mmap types.

The PR required for this has now been merged: <https://github.com/RazrFalcon/memmap2-rs/issues/74>

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?