### PR TITLE
Fix mmap on Windows

### DIFF
--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -526,7 +526,7 @@ mod tests {
         check_open_zero_slice::<f32>(1, 0.0);
         check_open_zero_slice::<f32>(123, 0.0);
 
-        // Test empty mmap, not supported on Windows
+        // Empty mmap is not supported on Windows
         #[cfg(not(windows))]
         {
             check_open_zero_slice::<u8>(0, 0);
@@ -564,7 +564,7 @@ mod tests {
         check_reopen_random::<f32, _>(1, || rng.gen());
         check_reopen_random::<f32, _>(123, || rng.gen());
 
-        // Test empty mmap, not supported on Windows
+        // Empty mmap is not supported on Windows
         #[cfg(not(windows))]
         {
             check_reopen_random::<u8, _>(0, || rng.gen());
@@ -601,9 +601,14 @@ mod tests {
 
     #[test]
     fn test_bitslice() {
+        check_bitslice_with_header(0, 128);
         check_bitslice_with_header(512, 0);
         check_bitslice_with_header(512, 256);
         check_bitslice_with_header(11721 * 8, 256);
+
+        // Empty mmap is not supported on Windows
+        #[cfg(not(windows))]
+        check_bitslice_with_header(0, 0);
     }
 
     fn check_bitslice_with_header(bits: usize, header_size: usize) {

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -378,7 +378,7 @@ pub enum Error {
     #[error("Mmap length must be multiple of {0} to match the size of type, but it is {1}")]
     SizeMultiple(usize, usize),
     #[cfg(windows)]
-    #[error("Mmap is empty, this is not supported on Windows")]
+    #[error("Mmap is empty, not supported on Windows")]
     Empty,
 }
 
@@ -400,7 +400,7 @@ unsafe fn mmap_to_type_unbounded<'unbnd, T>(mmap: &mut MmapMut) -> Result<&'unbn
 where
     T: Sized,
 {
-    // On Windows, mmap cannot be empty
+    // Empty mmap is not supported on Windows
     #[cfg(windows)]
     if mmap.is_empty() {
         return Err(Error::Empty);
@@ -448,7 +448,7 @@ unsafe fn mmap_to_slice_unbounded<'unbnd, T>(
 where
     T: Sized,
 {
-    // On Windows, mmap cannot be empty
+    // Empty mmap is not supported on Windows
     #[cfg(windows)]
     if mmap.is_empty() {
         return Err(Error::Empty);
@@ -638,11 +638,14 @@ mod tests {
         let mmap = mmap_ops::open_write_mmap(tempfile.path()).unwrap();
         let result = unsafe { MmapType::<()>::try_from(mmap) };
 
+        // Empty mmap is supported on non-Windows
         #[cfg(not(windows))]
         assert!(
             result.is_ok(),
             "using empty mmap on non-Windows should be okay",
         );
+
+        // Empty mmap is not supported on Windows
         #[cfg(windows)]
         assert!(result.is_err(), "using empty mmap on Windows must error",);
     }

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -22,9 +22,11 @@
 //! utmost care. Security is critical here as this is an easy place to introduce undefined
 //! behavior. Problems caused by this are very hard to debug.
 
+#[cfg(unix)]
+use std::io;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::{io, mem, slice};
+use std::{mem, slice};
 
 use bitvec::slice::BitSlice;
 use memmap2::MmapMut;

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -505,12 +505,14 @@ mod tests {
     use crate::common::mmap_ops;
 
     fn create_temp_mmap_file(len: usize) -> NamedTempFile {
+        assert!(len > 0, "should not create empty file");
         let tempfile = Builder::new()
             .prefix("test.")
             .suffix(".mmap")
             .tempfile()
             .unwrap();
         tempfile.as_file().set_len(len as u64).unwrap();
+        tempfile.as_file().sync_all().unwrap();
         tempfile
     }
 


### PR DESCRIPTION
This fixes mmap alignment issues on Windows we had on <https://github.com/qdrant/qdrant/pull/1860> and <https://github.com/qdrant/qdrant/pull/1838>.

A round of applause for @Jesse-Bakker for taking the time to [figure](https://github.com/qdrant/qdrant/pull/1860#discussion_r1189037474) this out!

On Windows you _cannot_ open a mmap for an empty file. Then, instead of the API returning a null pointer (0x00000000), it returns the very next address (0x00000001). That explains why we were seeing off-by-one alignment errors.

This PR:
- adds an error case on Windows platforms to prevent this from happening; using an empty mmap
- enables alignment assertion again on all platforms
- extended tests to test this specific case

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?