### PR TITLE
Fix WalConfigDiff not being validated

### DIFF
--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -71,6 +71,7 @@ pub struct HnswConfigDiff {
 )]
 pub struct WalConfigDiff {
     /// Size of a single WAL segment in MB
+    #[validate(range(min = 1))]
     pub wal_capacity_mb: Option<usize>,
     /// Number of WAL segments to create ahead of actually used ones
     pub wal_segments_ahead: Option<usize>,


### PR DESCRIPTION
Fixes HTTP 500 in <https://github.com/qdrant/qdrant/issues/1880>.

This adds validation to `WalConfigDiff.wal_capacity_mb` to match `WalConfig.wal_capacity_mb`.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?