### PR TITLE
Build: `cargo run --bin qdrant` -> `cargo run`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "qdrant"
 version = "0.11.1"
 authors = ["Andrey Vasnetsov <andrey@vasnetsov.com>"]
 edition = "2021"
+default-run = "qdrant"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## What's this?
Sets the `qdrant` binary by default when using `cargo run` to avoid writing the more verbose `cargo run --bin qdrant`

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?
