### PR TITLE
add quantization files to appendable mmap files

### DIFF
--- a/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
@@ -177,6 +177,9 @@ impl VectorStorage for AppendableMmapVectorStorage {
     fn files(&self) -> Vec<PathBuf> {
         let mut files = self.vectors.files();
         files.extend(self.deleted.files());
+        if let Some(quantized_vectors) = &self.quantized_vectors {
+            files.extend(quantized_vectors.files())
+        }
         files
     }
 


### PR DESCRIPTION
Simple and mmap vectos storages include quantization files to their files. Added same behaviour to appendable mmap