### PR TITLE
Simplify/flatten point selection in delete vectors REST endpoint

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7618,14 +7618,18 @@
       },
       "DeleteVectors": {
         "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PointIdsList"
+          },
+          {
+            "$ref": "#/components/schemas/FilterSelector"
+          }
+        ],
         "required": [
-          "point_selector",
           "vector"
         ],
         "properties": {
-          "point_selector": {
-            "$ref": "#/components/schemas/PointsSelector"
-          },
           "vector": {
             "description": "Vector names",
             "type": "array",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7618,18 +7618,29 @@
       },
       "DeleteVectors": {
         "type": "object",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PointIdsList"
-          },
-          {
-            "$ref": "#/components/schemas/FilterSelector"
-          }
-        ],
         "required": [
           "vector"
         ],
         "properties": {
+          "points": {
+            "description": "Deletes values from each point in this list",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtendedPointId"
+            },
+            "nullable": true
+          },
+          "filter": {
+            "description": "Deletes values from points that satisfy this filter condition",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "vector": {
             "description": "Vector names",
             "type": "array",

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -35,6 +35,7 @@ pub struct PointVectors {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct DeleteVectors {
     /// Point selector
+    #[serde(flatten)]
     pub point_selector: PointsSelector,
     /// Vector names
     #[serde(alias = "vectors")]

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -7,7 +7,7 @@ use segment::types::{Filter, PointIdType};
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
-use super::point_ops::{PointIdsList, PointsSelector};
+use super::point_ops::PointIdsList;
 use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
 use crate::hash_ring::HashRing;
 use crate::shards::shard::ShardId;
@@ -34,9 +34,10 @@ pub struct PointVectors {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct DeleteVectors {
-    /// Point selector
-    #[serde(flatten)]
-    pub point_selector: PointsSelector,
+    /// Deletes values from each point in this list
+    pub points: Option<Vec<PointIdType>>,
+    /// Deletes values from points that satisfy this filter condition
+    pub filter: Option<Filter>,
     /// Vector names
     #[serde(alias = "vectors")]
     #[validate(length(min = 1, message = "must specify vector names to delete"))]

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -188,7 +188,7 @@ def update_empty_vectors():
         method="POST",
         path_params={'collection_name': collection_name},
         body={
-            "point_selector": {"points": [1]},
+            "points": [1],
             "vector": ["image", "text"]
         }
     )
@@ -298,7 +298,7 @@ def delete_vectors():
         method="POST",
         path_params={'collection_name': collection_name},
         body={
-            "point_selector": {"points": [1, 2]},
+            "points": [1, 2],
             "vector": ["image"]
         }
     )
@@ -309,7 +309,7 @@ def delete_vectors():
         method="POST",
         path_params={'collection_name': collection_name},
         body={
-            "point_selector": {"points": [2, 3]},
+            "points": [2, 3],
             "vector": ["text"]
         }
     )
@@ -358,7 +358,7 @@ def delete_all_vectors():
         method="POST",
         path_params={'collection_name': collection_name},
         body={
-            "point_selector": {"filter": {}},
+            "filter": {},
             "vector": ["image", "text"]
         }
     )
@@ -376,7 +376,7 @@ def delete_unknown_vectors():
         path_params={'collection_name': collection_name},
         query_params={'wait': 'true'},
         body={
-            "point_selector": {"points": [1, 2]},
+            "points": [1, 2],
             "vector": ["a"]
         }
     )

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -99,24 +99,42 @@ pub async fn do_delete_vectors(
     wait: bool,
     ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
-    let vector_names = operation.vector.into_iter().collect();
-    let vectors_operation = match operation.point_selector {
-        PointsSelector::PointIdsSelector(points) => {
-            VectorOperations::DeleteVectors(points, vector_names)
-        }
-        PointsSelector::FilterSelector(filter) => {
-            VectorOperations::DeleteVectorsByFilter(filter.filter, vector_names)
-        }
-    };
-    let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
-    toc.update(
-        collection_name,
-        collection_operation,
-        shard_selection,
-        wait,
-        ordering,
-    )
-    .await
+    let vector_names: Vec<_> = operation.vector.into_iter().collect();
+
+    let mut result = None;
+
+    if let Some(filter) = operation.filter {
+        let vectors_operation =
+            VectorOperations::DeleteVectorsByFilter(filter, vector_names.clone());
+        let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
+        result = Some(
+            toc.update(
+                collection_name,
+                collection_operation,
+                shard_selection,
+                wait,
+                ordering,
+            )
+            .await?,
+        );
+    }
+
+    if let Some(points) = operation.points {
+        let vectors_operation = VectorOperations::DeleteVectors(points.into(), vector_names);
+        let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
+        result = Some(
+            toc.update(
+                collection_name,
+                collection_operation,
+                shard_selection,
+                wait,
+                ordering,
+            )
+            .await?,
+        );
+    }
+
+    result.ok_or_else(|| StorageError::bad_request("No filter or points provided"))
 }
 
 pub async fn do_set_payload(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -222,17 +222,24 @@ pub async fn delete_vectors(
         ordering,
     } = delete_point_vectors;
 
-    let point_selector = match points_selector {
-        Some(points_selector) => points_selector.try_into()?,
-        None => return Err(Status::invalid_argument("points_selector is expected")),
+    let (points, filter) = if let Some(points_selector) = points_selector {
+        let points_selector: PointsSelector = points_selector.try_into()?;
+        match points_selector {
+            PointsSelector::PointIdsSelector(points) => (Some(points.points), None),
+            PointsSelector::FilterSelector(filter) => (None, Some(filter.filter)),
+        }
+    } else {
+        return Err(Status::invalid_argument("points_selector is expected"));
     };
+
     let vector_names = match vectors {
         Some(vectors) => vectors.names,
         None => return Err(Status::invalid_argument("vectors is expected")),
     };
 
     let operation = DeleteVectors {
-        point_selector,
+        points,
+        filter,
         vector: vector_names.into_iter().collect(),
     };
 


### PR DESCRIPTION
This flattens the point selector field for the delete vectors REST endpoint. This makes point selection [consistent](https://qdrant.tech/documentation/points/#set-payload) with other endpoints.

Before:

```json
{
  "point_selector": { "points": [1, 2] },
  "vectors": ["image"]
}
```

After:

```json
{
  "points": [1, 2],
  "vectors": ["image"]
}
```

Or using a filter:

```json
{
  "filter": {},
  "vectors": ["image"]
}
```

We can still change this interface because we haven't released a version with it yet.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
