### PR TITLE
CI: make integration tests 45% faster

### DIFF
--- a/openapi/tests/openapi_integration/test_basic_retrieve_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api.py
@@ -6,7 +6,7 @@ from .helpers.helpers import request_with_validation
 collection_name = 'test_collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_basic_retrieve_api_on_disk.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api_on_disk.py
@@ -1,14 +1,13 @@
 import pytest
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
-from .helpers.helpers import request_with_validation
 from .test_basic_retrieve_api import points_retrieve, exclude_payload, is_empty_condition, \
     recommendation, query_nested
 
 collection_name = 'test_collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name, on_disk_payload=True)
     yield

--- a/openapi/tests/openapi_integration/test_basic_retrieve_multivec_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_multivec_api.py
@@ -6,7 +6,7 @@ from .helpers.helpers import request_with_validation
 collection_name = 'test_collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     multivec_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_count.py
+++ b/openapi/tests/openapi_integration/test_count.py
@@ -6,7 +6,7 @@ from .helpers.helpers import request_with_validation
 collection_name = 'test_collection_threshold'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_euclid_dist.py
+++ b/openapi/tests/openapi_integration/test_euclid_dist.py
@@ -70,7 +70,7 @@ def basic_collection_setup(collection_name='test_collection'):
     assert response.ok
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_filter.py
+++ b/openapi/tests/openapi_integration/test_filter.py
@@ -8,7 +8,7 @@ from .helpers.collection_setup import basic_collection_setup, drop_collection
 collection_name = 'test_collection_filter'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_filter_values_count.py
+++ b/openapi/tests/openapi_integration/test_filter_values_count.py
@@ -8,7 +8,7 @@ from .helpers.collection_setup import basic_collection_setup, drop_collection
 collection_name = 'test_collection_filter_values_count'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_fts.py
+++ b/openapi/tests/openapi_integration/test_fts.py
@@ -220,7 +220,7 @@ def basic_collection_setup(collection_name='test_collection', on_disk_payload=Fa
     assert response.ok
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='module')
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_multicollection_reco.py
+++ b/openapi/tests/openapi_integration/test_multicollection_reco.py
@@ -7,7 +7,7 @@ collection_name = 'test_collection_reco'
 collection_name2 = 'test_collection_reco2'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -6,7 +6,7 @@ from .helpers.helpers import request_with_validation
 collection_name = 'test_collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     multivec_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_service.py
+++ b/openapi/tests/openapi_integration/test_service.py
@@ -6,7 +6,7 @@ from .helpers.collection_setup import basic_collection_setup, drop_collection
 
 collection_name = 'test_collection_telemetry'
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     basic_collection_setup(collection_name=collection_name)
     yield

--- a/openapi/tests/openapi_integration/test_vector_config.py
+++ b/openapi/tests/openapi_integration/test_vector_config.py
@@ -8,7 +8,7 @@ from .helpers.collection_setup import drop_collection
 collection_name = 'test_collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup():
     multivec_collection_setup(collection_name=collection_name)
     yield


### PR DESCRIPTION
Improve the performance of tests by reusing the setup for every test in the same file (where it makes sense). Also refactor to use loop and timeout where a simple `sleep` was used

Locally, the integration test suite duration went from 32.64s to 18.23s, hence the ~45% speedup

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
