### PR TITLE
Remove mlock from mmap

### DIFF
--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -22,8 +22,6 @@
 //! utmost care. Security is critical here as this is an easy place to introduce undefined
 //! behavior. Problems caused by this are very hard to debug.
 
-#[cfg(unix)]
-use std::io;
 use std::ops::{Deref, DerefMut};
 #[cfg(windows)]
 use std::ptr::NonNull;
@@ -172,14 +170,6 @@ impl<T> MmapType<T>
 where
     T: ?Sized + 'static,
 {
-    /// Lock memory mapped pages in memory
-    ///
-    /// See [`MmapMut::lock`] for details.
-    #[cfg(unix)]
-    pub fn mlock(&self) -> io::Result<()> {
-        self.mmap.lock()
-    }
-
     /// Get flusher to explicitly flush mmap at a later time
     pub fn flusher(&self) -> Flusher {
         // TODO: if we explicitly flush when dropping this type, we can switch to a weak reference
@@ -270,14 +260,6 @@ impl<T> MmapSlice<T> {
         MmapType::try_slice_from(mmap_with_slice).map(|mmap| Self { mmap })
     }
 
-    /// Lock memory mapped pages in memory
-    ///
-    /// See [`MmapMut::lock`] for details.
-    #[cfg(unix)]
-    pub fn mlock(&self) -> io::Result<()> {
-        self.mmap.mlock()
-    }
-
     /// Get flusher to explicitly flush mmap at a later time
     pub fn flusher(&self) -> Flusher {
         self.mmap.flusher()
@@ -342,14 +324,6 @@ impl MmapBitSlice {
                 mmap,
             },
         })
-    }
-
-    /// Lock memory mapped pages in memory
-    ///
-    /// See [`MmapMut::lock`] for details.
-    #[cfg(unix)]
-    pub fn mlock(&self) -> io::Result<()> {
-        self.mmap.mlock()
     }
 
     /// Get flusher to explicitly flush mmap at a later time

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -173,24 +173,6 @@ impl MmapVectors {
     pub fn deleted_vector_bitslice(&self) -> &BitSlice {
         &self.deleted
     }
-
-    /// Lock memory map of deleted flags into RAM for optimal access performance
-    ///
-    /// Because the deleted flags are backed by a memory mapped file, its pages may be swapped out
-    /// to disk. This will hurt performance in case of quantization because the access times may be
-    /// huge. Calling this will lock the deleted flags in memory to prevent this.
-    ///
-    /// This is only supported on Unix.
-    #[allow(unused)]
-    fn lock_deleted_flags(&self) {
-        #[cfg(unix)]
-        if let Err(err) = self.deleted.mlock() {
-            log::error!(
-                "Failed to lock deleted flags for quantized mmap segment in memory: {}",
-                err,
-            );
-        }
-    }
 }
 
 /// Ensure the given mmap file exists and is the given size

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -82,14 +82,12 @@ impl MmapVectors {
         max_threads: usize,
         stopped: &AtomicBool,
     ) -> OperationResult<()> {
-        // In theory, we can lock deleted flags here, as we assume that it is the hottest data.
-        // Uncomment the following code if you want to do that:
-        //
-        // self.lock_deleted_flags();
-        //
-        // But it seems, that mlock functionality is not working properly if qdrant is running
-        // inside docker container with limited memory.
-        // Additionally, the speedup is not measured explicitly.
+        // In theory, we can lock deleted flags here, as we assume that it is the hottest data. We
+        // can use mlock to achieve that. Docker (and some other systems) has a very low default
+        // limit for lockable memory however, which is causing lock errors. Since this is the
+        // default configuration it is hard to make practical use of this. Additionally, the
+        // speedup is not measured explicitly.
+        // See <https://github.com/qdrant/qdrant/pull/1885#issuecomment-1547408116>
 
         let vector_data_iterator = (0..self.num_vectors as u32).map(|i| {
             let offset = self.data_offset(i as PointOffsetType).unwrap_or_default();
@@ -115,14 +113,13 @@ impl MmapVectors {
         distance: Distance,
     ) -> OperationResult<()> {
         if QuantizedVectors::config_exists(data_path) {
-            // In theory, we can lock deleted flags here, as we assume that it is the hottest data.
-            // Uncomment the following code if you want to do that:
-            //
-            // self.lock_deleted_flags();
-            //
-            // But it seems, that mlock functionality is not working properly if qdrant is running
-            // inside docker container with limited memory.
-            // Additionally, the speedup is not measured explicitly.
+            // In theory, we can lock deleted flags here, as we assume that it is the hottest data. We
+            // can use mlock to achieve that. Docker (and some other systems) has a very low default
+            // limit for lockable memory however, which is causing lock errors. Since this is the
+            // default configuration it is hard to make practical use of this. Additionally, the
+            // speedup is not measured explicitly.
+            // See <https://github.com/qdrant/qdrant/pull/1885#issuecomment-1547408116>
+
             self.quantized_vectors = Some(QuantizedVectors::load(data_path, true, distance)?);
         }
         Ok(())


### PR DESCRIPTION
Continuation of <https://github.com/qdrant/qdrant/pull/1885>.

This removes `mlock` for mmap all together to simplifying the interface a bit. If we'd ever need it again we can simply revert or re-implement.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
