### PR TITLE
Remove max message decoding limit on internal gRPC client

### DIFF
--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -99,7 +99,9 @@ impl RemoteShard {
         self.channel_service
             .channel_pool
             .with_channel(&current_address, |channel| {
-                f(PointsInternalClient::new(channel))
+                let client = PointsInternalClient::new(channel);
+                let client = client.max_decoding_message_size(usize::MAX);
+                f(client)
             })
             .await
             .map_err(|err| err.into())
@@ -113,7 +115,9 @@ impl RemoteShard {
         self.channel_service
             .channel_pool
             .with_channel(&current_address, |channel| {
-                f(CollectionsInternalClient::new(channel))
+                let client = CollectionsInternalClient::new(channel);
+                let client = client.max_decoding_message_size(usize::MAX);
+                f(client)
             })
             .await
             .map_err(|err| err.into())


### PR DESCRIPTION
This PR removes the "new" decoding limits on the internal gRPC clients.

This is the client side follow up on https://github.com/qdrant/qdrant/pull/1659

The fix was tested locally with `coach`.

I have applied a similar fix to our Rust client a few weeks ago https://github.com/qdrant/rust-client/pull/40