### PR TITLE
Hotfix: possible loss of payload index configuration

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -8,8 +8,9 @@ use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
 };
+use segment::common::version::StorageVersion;
 use segment::entry::entry_point::{check_process_stopped, SegmentEntry};
-use segment::segment::Segment;
+use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::types::{
@@ -72,7 +73,7 @@ pub trait SegmentOptimizer {
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>>;
 
     /// Build temp segment
-    fn temp_segment(&self) -> CollectionResult<LockedSegment> {
+    fn temp_segment(&self, save_version: bool) -> CollectionResult<LockedSegment> {
         let collection_params = self.collection_params();
         let config = SegmentConfig {
             vector_data: collection_params
@@ -88,6 +89,7 @@ pub trait SegmentOptimizer {
         Ok(LockedSegment::new(build_segment(
             self.collection_path(),
             &config,
+            save_version,
         )?))
     }
 
@@ -393,7 +395,7 @@ pub trait SegmentOptimizer {
 
         check_process_stopped(stopped)?;
 
-        let tmp_segment = self.temp_segment()?;
+        let tmp_segment = self.temp_segment(false)?;
 
         let proxy_deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
         let proxy_deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
@@ -413,9 +415,18 @@ pub trait SegmentOptimizer {
             );
             // Wrapped segment is fresh, so it has no operations
             // Operation with number 0 will be applied
-            let op_num = 0;
-            proxy.replicate_field_indexes(op_num)?;
+            proxy.replicate_field_indexes(0)?;
             proxies.push(proxy);
+        }
+
+        // Save segment version once all payload indices have been converted
+        // If this ends up not being saved due to a crash, the segment will not be used
+        match &tmp_segment {
+            LockedSegment::Original(segment) => {
+                let segment_path = &segment.read().current_path;
+                SegmentVersion::save(segment_path)?;
+            }
+            LockedSegment::Proxy(_) => unreachable!(),
         }
 
         let proxy_ids: Vec<_> = {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -323,7 +323,7 @@ impl LocalShard {
             };
             let segment = thread::Builder::new()
                 .name(format!("shard-build-{collection_id}-{id}"))
-                .spawn(move || build_segment(&path_clone, &segment_config))
+                .spawn(move || build_segment(&path_clone, &segment_config, true))
                 .unwrap();
             build_handlers.push(segment);
         }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1517,7 +1517,7 @@ mod tests {
             storage_type: StorageType::InMemory,
             ..Default::default()
         };
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         segment
@@ -1590,7 +1590,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
         segment
             .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
             .unwrap();
@@ -1681,7 +1681,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut segment = build_segment(segment_base_dir.path(), &config).unwrap();
+        let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
 
         segment
             .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
@@ -1771,7 +1771,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut segment = build_segment(segment_base_dir.path(), &config).unwrap();
+        let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
         segment
             .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
             .unwrap();
@@ -1804,7 +1804,7 @@ mod tests {
             payload_storage_type: Default::default(),
             quantization_config: None,
         };
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         segment

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -29,7 +29,7 @@ impl SegmentBuilder {
         temp_dir: &Path,
         segment_config: &SegmentConfig,
     ) -> OperationResult<Self> {
-        let segment = build_segment(temp_dir, segment_config)?;
+        let segment = build_segment(temp_dir, segment_config, true)?;
         let temp_path = segment.current_path.clone();
 
         let destination_path = segment_path.join(temp_path.file_name().unwrap());

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -243,9 +243,12 @@ pub fn load_segment(path: &Path) -> OperationResult<Option<Segment>> {
 ///
 /// * `path` - A path to collection. Segment folder will be created in this directory
 /// * `config` - Segment configuration
+/// * `ready` - Whether the segment is ready after building; will save segment version
 ///
-///
-pub fn build_segment(path: &Path, config: &SegmentConfig) -> OperationResult<Segment> {
+/// To load a segment, saving the segment version is required. If `ready` is false, the version
+/// will not be stored. Then the segment is skipped on restart when trying to load it again. In
+/// that case, the segment version must be stored manually to make it ready.
+pub fn build_segment(path: &Path, config: &SegmentConfig, ready: bool) -> OperationResult<Segment> {
     let segment_path = path.join(Uuid::new_v4().to_string());
 
     std::fs::create_dir_all(&segment_path)?;
@@ -255,7 +258,9 @@ pub fn build_segment(path: &Path, config: &SegmentConfig) -> OperationResult<Seg
 
     // Version is the last file to save, as it will be used to check if segment was built correctly.
     // If it is not saved, segment will be skipped.
-    SegmentVersion::save(&segment_path)?;
+    if ready {
+        SegmentVersion::save(&segment_path)?;
+    }
 
     Ok(segment)
 }

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -34,6 +34,7 @@ pub fn build_simple_segment(
             index: Indexes::Plain {},
             ..Default::default()
         },
+        true,
     )
 }
 
@@ -72,6 +73,7 @@ pub fn build_multivec_segment(
             index: Indexes::Plain {},
             ..Default::default()
         },
+        true,
     )
 }
 

--- a/lib/segment/tests/exact_search_test.rs
+++ b/lib/segment/tests/exact_search_test.rs
@@ -57,7 +57,7 @@ mod tests {
 
         let int_key = "int";
 
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
         for n in 0..num_vectors {
             let idx = n.into();
             let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/filtrable_hnsw_test.rs
@@ -58,7 +58,7 @@ mod tests {
 
         let int_key = "int";
 
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
         for n in 0..num_vectors {
             let idx = n.into();
             let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/fixtures/segment.rs
+++ b/lib/segment/tests/fixtures/segment.rs
@@ -146,6 +146,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
             index: Indexes::Plain {},
             ..Default::default()
         },
+        true,
     )
     .unwrap();
 

--- a/lib/segment/tests/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/hnsw_quantized_search_test.rs
@@ -62,7 +62,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut segment = build_segment(dir.path(), &config).unwrap();
+        let mut segment = build_segment(dir.path(), &config, true).unwrap();
         for n in 0..num_vectors {
             let idx = n.into();
             let vector = random_vector(&mut rnd, dim);

--- a/lib/segment/tests/payload_index_test.rs
+++ b/lib/segment/tests/payload_index_test.rs
@@ -48,8 +48,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut plain_segment = build_segment(path_plain, &config).unwrap();
-        let mut struct_segment = build_segment(path_struct, &config).unwrap();
+        let mut plain_segment = build_segment(path_plain, &config, true).unwrap();
+        let mut struct_segment = build_segment(path_struct, &config, true).unwrap();
 
         let num_points = 3000;
         let points_to_delete = 500;
@@ -162,8 +162,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut plain_segment = build_segment(path_plain, &config).unwrap();
-        let mut struct_segment = build_segment(path_struct, &config).unwrap();
+        let mut plain_segment = build_segment(path_plain, &config, true).unwrap();
+        let mut struct_segment = build_segment(path_struct, &config, true).unwrap();
 
         let num_points = 3000;
         let points_to_delete = 500;


### PR DESCRIPTION
Implements <https://github.com/qdrant/qdrant/issues/1890#issuecomment-1548159690>. This is a quick and dirty hotfix for <https://github.com/qdrant/qdrant/issues/1890>.

For the temp segment, this delays storing the segment version until payload indices have been converted. If this conversion somehow fails, loading the segment is skipped on restart because the segment version is missing.

Is this approach good enough or do we want something better? And does this fix the issue on your machine?

Relevant snippet: https://github.com/qdrant/qdrant/blob/13185ef47d30066619db0b44651b2906a9b23524/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs#L398-L432

If this approach is okay, it definitely needs a bit of polishing. But I'd like an opinion on this first before wasting time on it.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
