### PR TITLE
Remove unused `keep_alive_while_idle`

### DIFF
--- a/lib/api/src/grpc/dynamic_channel_pool.rs
+++ b/lib/api/src/grpc/dynamic_channel_pool.rs
@@ -13,8 +13,7 @@ pub async fn make_grpc_channel(
 ) -> Result<Channel, TonicError> {
     let mut endpoint = Channel::builder(uri)
         .timeout(timeout)
-        .connect_timeout(connection_timeout)
-        .keep_alive_while_idle(true);
+        .connect_timeout(connection_timeout);
     if let Some(config) = tls_config {
         endpoint = endpoint.tls_config(config)?;
     }


### PR DESCRIPTION
Related to <https://github.com/qdrant/qdrant/issues/1907>.

This removes the `keep_alive_while_idle` setting from our internal gRPC client. It has no effect (because it requires additional settings to enable) and is therefore confusing.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?