### PR TITLE
Increase HTTP2 reset stream limit for internal gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,9 +1955,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4421,8 +4421,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+source = "git+https://github.com/timvisee/tonic?branch=http2-max-pending-reset-streams#c496843b032193fb83b3b12b0be413e1361d5b1d"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.9.2"
-source = "git+https://github.com/timvisee/tonic?branch=http2-max-pending-reset-streams#c496843b032193fb83b3b12b0be413e1361d5b1d"
+source = "git+https://github.com/qdrant/tonic?branch=v0.9.2-patched#060ab88c87955adc59d46a44b4e3b72cb4cc1522"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,7 @@ lto = false
 inherits = "release"
 lto = false
 opt-level = 3
+
+[patch.crates-io]
+# Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is implemented
+tonic = { git = 'https://github.com/timvisee/tonic', branch = "http2-max-pending-reset-streams" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,5 +133,5 @@ lto = false
 opt-level = 3
 
 [patch.crates-io]
-# Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is implemented
-tonic = { git = 'https://github.com/timvisee/tonic', branch = "http2-max-pending-reset-streams" }
+# Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
+tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -17,7 +17,11 @@ pub const DEFAULT_GRPC_TIMEOUT: Duration = Duration::from_secs(60);
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 pub const DEFAULT_POOL_SIZE: usize = 2;
 
-const MAX_CONNECTIONS_PER_CHANNEL: usize = usize::MAX; // Unlimited
+/// Allow a large number of connections per channel, that is close to the limit of
+/// `http2_max_pending_accept_reset_streams` that we configure to minimize the chance of
+/// GOAWAY/ENHANCE_YOUR_CALM errors from occurring.
+/// More info: <https://github.com/qdrant/qdrant/issues/1907>
+const MAX_CONNECTIONS_PER_CHANNEL: usize = 1024;
 const DEFAULT_RETRIES: usize = 2;
 const DEFAULT_BACKOFF: Duration = Duration::from_millis(100);
 


### PR DESCRIPTION
Works on <https://github.com/qdrant/qdrant/issues/1907>.

![image](https://github.com/qdrant/qdrant/assets/856222/e7a0ef9d-0bf8-4092-b150-edccfa4b2dde)

This PR increases the limit for HTTP2 reset streams in our internal gRPC communication.

This is one of the steps we have to make in an attempt to minimize GOAWAY/ENHANCE_YOUR_CALM errors in internal cluster communication breaking cluster consensus. This likely doesn't solve it completely, but significantly minimizes the chance of it happening.

Future PRs will add to this fix, further minimizing the chance of this happening. See the future list of tasks below.

More info here: https://github.com/qdrant/qdrant/issues/1907#issuecomment-1564234664

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/1926
- [ ] ~Merge https://github.com/hyperium/tonic/pull/1401~
- [x] Fork tonic with required changes: https://github.com/qdrant/tonic/tree/v0.9.2-patched

### Future PR tasks
- Add [`reset_stream_duration`](https://docs.rs/h2/latest/h2/server/struct.Builder.html#method.reset_stream_duration) property
- Decrease stream reset duration from 30 seconds to 5 (?)
- Remove patched `tonic` crate
- Properly document the problem and how it is fixed
- Document what effect (CPU/memory) tweaking these values has
- Make our gRPC connection pool aware of pending reset streams (if possible)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
