### PR TITLE
Fixes for group-by

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1657,6 +1657,8 @@ The JSON representation for `Value` is a JSON value.
 | text | [string](#string) |  | Match text |
 | keywords | [RepeatedStrings](#qdrant-RepeatedStrings) |  | Match multiple keywords |
 | integers | [RepeatedIntegers](#qdrant-RepeatedIntegers) |  | Match multiple integers |
+| except_integers | [RepeatedIntegers](#qdrant-RepeatedIntegers) |  | Match any other value except those integers |
+| except_keywords | [RepeatedStrings](#qdrant-RepeatedStrings) |  | Match any other value except those keywords |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5023,6 +5023,9 @@
           },
           {
             "$ref": "#/components/schemas/MatchAny"
+          },
+          {
+            "$ref": "#/components/schemas/MatchExcept"
           }
         ]
       },
@@ -5092,6 +5095,18 @@
             }
           }
         ]
+      },
+      "MatchExcept": {
+        "description": "Should have at least one value not matching the any given values",
+        "type": "object",
+        "required": [
+          "except"
+        ],
+        "properties": {
+          "except": {
+            "$ref": "#/components/schemas/AnyVariants"
+          }
+        }
       },
       "Range": {
         "description": "Range filter request",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -959,6 +959,12 @@ impl TryFrom<Match> for segment::types::Match {
                 MatchValue::Text(text) => segment::types::Match::Text(text.into()),
                 MatchValue::Keywords(kwds) => kwds.strings.into(),
                 MatchValue::Integers(ints) => ints.integers.into(),
+                MatchValue::ExceptIntegers(kwds) => {
+                    segment::types::Match::Except(kwds.integers.into())
+                }
+                MatchValue::ExceptKeywords(ints) => {
+                    segment::types::Match::Except(ints.strings.into())
+                }
             }),
             _ => Err(Status::invalid_argument("Malformed Match condition")),
         }
@@ -984,6 +990,14 @@ impl From<segment::types::Match> for Match {
                     MatchValue::Integers(RepeatedIntegers { integers })
                 }
             },
+            segment::types::Match::Except(except) => match except.except {
+                segment::types::AnyVariants::Keywords(strings) => {
+                    MatchValue::ExceptKeywords(RepeatedStrings { strings })
+                }
+                segment::types::AnyVariants::Integers(integers) => {
+                    MatchValue::ExceptIntegers(RepeatedIntegers { integers })
+                }
+            }
         };
         Self {
             match_value: Some(match_value),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -997,7 +997,7 @@ impl From<segment::types::Match> for Match {
                 segment::types::AnyVariants::Integers(integers) => {
                     MatchValue::ExceptIntegers(RepeatedIntegers { integers })
                 }
-            }
+            },
         };
         Self {
             match_value: Some(match_value),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -471,6 +471,8 @@ message Match {
     string text = 4; // Match text
     RepeatedStrings keywords = 5; // Match multiple keywords
     RepeatedIntegers integers = 6; // Match multiple integers
+    RepeatedIntegers except_integers = 7; // Match any other value except those integers
+    RepeatedStrings except_keywords = 8; // Match any other value except those keywords
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3352,7 +3352,7 @@ pub struct FieldCondition {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Match {
-    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "r#match::MatchValue", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
     pub match_value: ::core::option::Option<r#match::MatchValue>,
 }
 /// Nested message and enum types in `Match`.
@@ -3378,6 +3378,12 @@ pub mod r#match {
         /// Match multiple integers
         #[prost(message, tag = "6")]
         Integers(super::RepeatedIntegers),
+        /// Match any other value except those integers
+        #[prost(message, tag = "7")]
+        ExceptIntegers(super::RepeatedIntegers),
+        /// Match any other value except those keywords
+        #[prost(message, tag = "8")]
+        ExceptKeywords(super::RepeatedStrings),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -114,8 +114,8 @@ impl GroupRequest {
             |field| {
                 // Hack 2: `with_payload` doesn't work with `[]` at the end of the field name.
                 // Remove the ending `[]`.
-                let field = if field.ends_with("[]") {
-                    &field[..field.len() - 2]
+                let field = if let Some(stripped_field) = field.strip_suffix("[]") {
+                    stripped_field
                 } else {
                     field
                 };

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -107,7 +107,7 @@ impl GroupRequest {
         group_by.split('.').next().map_or_else(
             || {
                 Err(CollectionError::bad_request(format!(
-                    "Malformed group_by parameter: {}",
+                    "Malformed group_by parameter which uses unsupported nested path: {}",
                     group_by
                 )))
             },

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -114,13 +114,7 @@ impl GroupRequest {
             |field| {
                 // Hack 2: `with_payload` doesn't work with `[]` at the end of the field name.
                 // Remove the ending `[]`.
-                let field = if let Some(stripped_field) = field.strip_suffix("[]") {
-                    stripped_field
-                } else {
-                    field
-                };
-
-                Ok(field.to_owned())
+                Ok(field.strip_suffix("[]").unwrap_or(field).to_owned())
             },
         )
     }

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -414,7 +414,7 @@ fn except_on(path: &str, values: Vec<Value>) -> Vec<Condition> {
 fn match_on(path: &str, values: Vec<Value>) -> Vec<Condition> {
     values_to_any_variants(values)
         .into_iter()
-        .map(move |any_variants| {
+        .map(|any_variants| {
             Condition::Field(FieldCondition::new_match(
                 path,
                 Match::new_any(any_variants),

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -298,4 +298,15 @@ impl FieldIndex {
             FieldIndex::FullTextIndex(index) => index.get_telemetry_data(),
         }
     }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        match self {
+            FieldIndex::IntIndex(index) => index.values_count(point_id),
+            FieldIndex::IntMapIndex(index) => index.values_count(point_id),
+            FieldIndex::KeywordIndex(index) => index.values_count(point_id),
+            FieldIndex::FloatIndex(index) => index.values_count(point_id),
+            FieldIndex::GeoIndex(index) => index.values_count(point_id),
+            FieldIndex::FullTextIndex(index) => index.values_count(point_id),
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -29,10 +29,10 @@ pub trait PayloadFieldIndex {
 
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
-    fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>>;
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
@@ -222,10 +222,10 @@ impl FieldIndex {
         self.get_payload_field_index().flusher()
     }
 
-    pub fn filter(
-        &self,
-        condition: &FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+    pub fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         self.get_payload_field_index().filter(condition)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -20,6 +20,10 @@ impl Document {
         Self { tokens }
     }
 
+    pub fn len(&self) -> usize {
+        self.tokens.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.tokens.is_empty()
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -117,6 +117,11 @@ impl FullTextIndex {
         let parsed_query = self.parse_query(query);
         self.inverted_index.filter(&parsed_query)
     }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        // Maybe we want number of documents in the future?
+        self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
+    }
 }
 
 impl ValueIndexer<String> for FullTextIndex {

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -465,6 +465,10 @@ impl GeoMapIndex {
 
         Box::new(edge_region.into_iter())
     }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
+    }
 }
 
 impl ValueIndexer<GeoPoint> for GeoMapIndex {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -299,8 +299,8 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         let iter = self
             .map
             .keys()
-            .filter(move |key| !excluded.contains(*key))
-            .flat_map(move |key| self.get_iterator(key))
+            .filter(|key| !excluded.contains(*key))
+            .flat_map(|key| self.get_iterator(key))
             .unique();
         Box::new(iter)
     }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -427,7 +427,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             })) => Some(Box::new(
                 integers
                     .iter()
-                    .flat_map(move |integer| self.get_iterator(integer))
+                    .flat_map(|integer| self.get_iterator(integer))
                     .unique(),
             )),
             Some(Match::Except(MatchExcept {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -194,7 +194,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     /// * `CardinalityEstimation` - estimation of cardinality
     fn except_cardinality(&self, excluded: &[N]) -> CardinalityEstimation {
         // Minimal case: we exclude as many points as possible.
-        // In this case, excluded points does not have any other values except excluded ones.
+        // In this case, excluded points do not have any other values except excluded ones.
         // So the first step - we estimate how many other points is needed to fit unused values.
 
         // Example:

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -12,15 +12,17 @@ use serde_json::Value;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
 };
 use crate::index::query_estimator::combine_should_estimations;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
-    AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchValue, PayloadKeyType,
-    PointOffsetType, ValueVariants,
+    AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
+    PayloadKeyType, PointOffsetType, ValueVariants,
 };
+use crate::vector_storage::div_ceil;
 
 /// HashMap-based type of index
 pub struct MapIndex<N: Hash + Eq + Clone + Display> {
@@ -175,6 +177,117 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
 
         Ok(())
     }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
+    }
+
+    /// Estimates cardinality for `except` clause
+    ///
+    /// # Arguments
+    ///     * `excluded` - values, which are not considered as matching
+    ///
+    /// # Returns
+    ///    * `CardinalityEstimation` - estimation of cardinality
+    fn except_cardinality(&self, excluded: &[N]) -> CardinalityEstimation {
+        // Minimal case: we exclude as many points as possible.
+        // In this case, excluded points does not have any other values except excluded ones.
+        // So the first step - we estimate how many other points is needed to fit unused values.
+
+        // Example:
+        // Values: 20, 20
+        // Unique values: 5
+        // Total points: 100
+        // Total values: 110
+        // total_excluded_value_count = 40
+        // non_excluded_values_count = 110 - 40 = 70
+        // max_values_per_point = 5 - 2 = 3
+        // min_not_excluded_by_values = 70 / 3 = 24
+        // min = max(24, 100 - 40) = 60
+        // exp = ...
+        // max = min(20, 70) = 20
+
+        // Values, 60, 60
+        // Unique values: 5
+        // Total points: 100
+        // Total values: 200
+        // total_excluded_value_count = 120
+        // non_excluded_values_count = 200 - 120 = 80
+        // max_values_per_point = 5 - 2 = 3
+        // min_not_excluded_by_values = 80 / 3 = 27
+        // min = max(27, 100 - 120) = 27
+        // exp = ...
+        // max = min(60, 80) = 60
+
+        // Values, 60, 60, 60
+        // Unique values: 5
+        // Total points: 100
+        // Total values: 200
+        // total_excluded_value_count = 180
+        // non_excluded_values_count = 200 - 180 = 20
+        // max_values_per_point = 5 - 3 = 2
+        // min_not_excluded_by_values = 20 / 2 = 10
+        // min = max(10, 100 - 180) = 10
+        // exp = ...
+        // max = min(60, 20) = 20
+
+        let excluded_value_counts: Vec<_> = excluded
+            .iter()
+            .map(|val| self.map.get(val).map(|points| points.len()).unwrap_or(0))
+            .collect();
+        let total_excluded_value_count: usize = excluded_value_counts.iter().sum();
+
+        debug_assert!(total_excluded_value_count <= self.values_count);
+
+        let non_excluded_values_count =
+            self.values_count.saturating_sub(total_excluded_value_count);
+        let max_values_per_point = self.map.len().saturating_sub(excluded.len());
+
+        if max_values_per_point == 0 {
+            // All points are excluded, so we can't select any point
+            debug_assert_eq!(non_excluded_values_count, 0);
+            return CardinalityEstimation {
+                primary_clauses: vec![],
+                min: 0,
+                exp: 0,
+                max: 0,
+            };
+        }
+
+        // Minimal amount of points, required to fit all unused values.
+        // Cardinality can't be less than this value.
+        let min_not_excluded_by_values = div_ceil(non_excluded_values_count, max_values_per_point);
+
+        let min = min_not_excluded_by_values.max(
+            self.indexed_points
+                .saturating_sub(total_excluded_value_count),
+        );
+
+        // Maximum scenario: selected points overlap as much as possible.
+        // From one side, all excluded values should be assigned to the same point
+        // => we can take the value with the maximum amount of points.
+        // From another side, all other values should be enough to fill all other points.
+
+        let max_excluded_value_count = excluded_value_counts.iter().max().copied().unwrap_or(0);
+
+        let max = self
+            .indexed_points
+            .saturating_sub(max_excluded_value_count)
+            .min(non_excluded_values_count);
+
+        // Expected case: we assume that all points are filled equally.
+        // So we can estimate the probability of the point to have non-excluded value.
+        let exp = number_of_selected_points(self.indexed_points, non_excluded_values_count)
+            .max(min)
+            .min(max);
+
+        CardinalityEstimation {
+            primary_clauses: vec![],
+            min,
+            exp,
+            max,
+        }
+    }
 }
 
 impl PayloadFieldIndex for MapIndex<String> {
@@ -229,6 +342,9 @@ impl PayloadFieldIndex for MapIndex<String> {
                     self.indexed_points,
                 ))
             }
+            Some(Match::Except(MatchExcept {
+                except: AnyVariants::Keywords(keywords),
+            })) => Some(self.except_cardinality(keywords)),
             _ => None,
         }
     }
@@ -306,6 +422,9 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                     self.indexed_points,
                 ))
             }
+            Some(Match::Except(MatchExcept {
+                except: AnyVariants::Integers(integers),
+            })) => Some(self.except_cardinality(integers)),
             _ => None,
         }
     }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -336,7 +336,7 @@ impl PayloadFieldIndex for MapIndex<String> {
             })) => Some(Box::new(
                 keywords
                     .iter()
-                    .flat_map(move |keyword| self.get_iterator(keyword))
+                    .flat_map(|keyword| self.get_iterator(keyword))
                     .unique(),
             )),
             Some(Match::Except(MatchExcept {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -222,7 +222,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         // exp = ...
         // max = min(60, 80) = 60
 
-        // Values, 60, 60, 60
+        // Values: 60, 60, 60
         // Unique values: 5
         // Total points: 100
         // Total values: 200
@@ -234,11 +234,10 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         // exp = ...
         // max = min(60, 20) = 20
 
-        let excluded_value_counts: Vec<_> = excluded
+        let total_excluded_value_count: usize = excluded
             .iter()
             .map(|val| self.map.get(val).map(|points| points.len()).unwrap_or(0))
-            .collect();
-        let total_excluded_value_count: usize = excluded_value_counts.iter().sum();
+            .sum();
 
         debug_assert!(total_excluded_value_count <= self.values_count);
 

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -210,7 +210,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         // exp = ...
         // max = min(20, 70) = 20
 
-        // Values, 60, 60
+        // Values: 60, 60
         // Unique values: 5
         // Total points: 100
         // Total values: 200

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -186,10 +186,12 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     /// Estimates cardinality for `except` clause
     ///
     /// # Arguments
-    ///     * `excluded` - values, which are not considered as matching
+    ///
+    /// * 'excluded' - values, which are not considered as matching
     ///
     /// # Returns
-    ///    * `CardinalityEstimation` - estimation of cardinality
+    ///
+    /// * `CardinalityEstimation` - estimation of cardinality
     fn except_cardinality(&self, excluded: &[N]) -> CardinalityEstimation {
         // Minimal case: we exclude as many points as possible.
         // In this case, excluded points does not have any other values except excluded ones.

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -249,12 +249,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         if max_values_per_point == 0 {
             // All points are excluded, so we can't select any point
             debug_assert_eq!(non_excluded_values_count, 0);
-            return CardinalityEstimation {
-                primary_clauses: vec![],
-                min: 0,
-                exp: 0,
-                max: 0,
-            };
+            return CardinalityEstimation::exact(0);
         }
 
         // Minimal amount of points, required to fit all unused values.

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -234,10 +234,11 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         // exp = ...
         // max = min(60, 20) = 20
 
-        let total_excluded_value_count: usize = excluded
+        let excluded_value_counts: Vec<_> = excluded
             .iter()
             .map(|val| self.map.get(val).map(|points| points.len()).unwrap_or(0))
-            .sum();
+            .collect();
+        let total_excluded_value_count: usize = excluded_value_counts.iter().sum();
 
         debug_assert!(total_excluded_value_count <= self.values_count);
 

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -293,6 +293,10 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
             histogram_bucket_size: Some(self.histogram.current_bucket_size()),
         }
     }
+
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
+    }
 }
 
 impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {

--- a/lib/segment/src/index/field_index/stat_tools.rs
+++ b/lib/segment/src/index/field_index/stat_tools.rs
@@ -70,6 +70,14 @@ fn prob_not_select(total: usize, avg: f64, selected: usize) -> f64 {
     .exp()
 }
 
+/// Calculate number of selected points, based on the amount of matched values.
+/// Assuming that values are randomly distributed among points and each point can have multiple values.
+/// Math is based on: https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives
+pub fn number_of_selected_points(points: usize, values: usize) -> usize {
+    let prob_of_selection = 1. - (-(values as f64 / points as f64)).exp();
+    (prob_of_selection * points as f64).round() as usize
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -79,6 +87,17 @@ mod tests {
     use rand::SeedableRng;
 
     use super::*;
+
+    #[test]
+    fn test_selected_points_est() {
+        let res = number_of_selected_points(100, 1000);
+        assert!(res > 95);
+        assert!(res <= 100);
+
+        let res = number_of_selected_points(1000, 10);
+        assert!(res > 5);
+        assert!(res <= 10);
+    }
 
     fn simulate(uniq: usize, avg: usize, selected: usize) -> usize {
         let mut data: Vec<_> = vec![];

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -277,7 +277,7 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
                     }
                 }))
             }
-            (_, index) => Some(Box::new(move |point_id: PointOffsetType| {
+            (_, index) => Some(Box::new(|point_id: PointOffsetType| {
                 // If there is any other value of any other index, then it's a match
                 index.values_count(point_id) > 0
             })),

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -270,10 +270,9 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             }
             (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    match index.get_values(point_id) {
-                        None => false,
-                        Some(values) => values.iter().any(|i| !list.contains(i)),
-                    }
+                    index
+                        .get_values(point_id)
+                        .map_or(false, |values| values.iter().any(|i| !list.contains(i)))
                 }))
             }
             (_, index) => Some(Box::new(|point_id: PointOffsetType| {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -263,10 +263,9 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
         Match::Except(MatchExcept { except }) => match (except, index) {
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    match index.get_values(point_id) {
-                        None => false,
-                        Some(values) => values.iter().any(|k| !list.contains(k)),
-                    }
+                    index
+                        .get_values(point_id)
+                        .map_or(false, |values| values.iter().any(|k| !list.contains(k)))
                 }))
             }
             (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -77,10 +77,10 @@ impl StructPayloadIndex {
         })
     }
 
-    fn query_field(
-        &self,
-        field_condition: &FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
+    fn query_field<'a>(
+        &'a self,
+        field_condition: &'a FieldCondition,
+    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         let indexes = self
             .field_indexes
             .get(&field_condition.key)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -975,6 +975,13 @@ pub struct MatchAny {
     pub any: AnyVariants,
 }
 
+/// Should have at least one value not matching the any given values
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct MatchExcept {
+    pub except: AnyVariants,
+}
+
 /// Match filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -983,6 +990,7 @@ pub enum MatchInterface {
     Value(MatchValue),
     Text(MatchText),
     Any(MatchAny),
+    Except(MatchExcept),
 }
 
 /// Match filter request
@@ -993,6 +1001,7 @@ pub enum Match {
     Value(MatchValue),
     Text(MatchText),
     Any(MatchAny),
+    Except(MatchExcept),
 }
 
 impl Match {
@@ -1023,6 +1032,9 @@ impl From<MatchInterface> for Match {
             MatchInterface::Value(value) => Self::Value(MatchValue { value: value.value }),
             MatchInterface::Text(text) => Self::Text(MatchText { text: text.text }),
             MatchInterface::Any(any) => Self::Any(MatchAny { any: any.any }),
+            MatchInterface::Except(except) => Self::Except(MatchExcept {
+                except: except.except,
+            }),
         }
     }
 }
@@ -1059,11 +1071,27 @@ impl From<Vec<String>> for Match {
     }
 }
 
+impl From<Vec<String>> for MatchExcept {
+    fn from(keywords: Vec<String>) -> Self {
+        MatchExcept {
+            except: AnyVariants::Keywords(keywords),
+        }
+    }
+}
+
 impl From<Vec<IntPayloadType>> for Match {
     fn from(integers: Vec<IntPayloadType>) -> Self {
         Self::Any(MatchAny {
             any: AnyVariants::Integers(integers),
         })
+    }
+}
+
+impl From<Vec<IntPayloadType>> for MatchExcept {
+    fn from(integers: Vec<IntPayloadType>) -> Self {
+        MatchExcept {
+            except: AnyVariants::Integers(integers),
+        }
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1296,6 +1296,14 @@ impl From<String> for IsNullCondition {
     }
 }
 
+impl From<String> for IsEmptyCondition {
+    fn from(key: String) -> Self {
+        IsEmptyCondition {
+            is_empty: PayloadField { key },
+        }
+    }
+}
+
 /// ID-based filtering condition
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct HasIdCondition {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1018,6 +1018,10 @@ impl Match {
     pub fn new_any(any: AnyVariants) -> Self {
         Self::Any(MatchAny { any })
     }
+
+    pub fn new_except(except: AnyVariants) -> Self {
+        Self::Except(MatchExcept { except })
+    }
 }
 
 impl From<AnyVariants> for Match {

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -30,6 +30,6 @@ pub use vector_storage_base::*;
 // - <https://github.com/rust-lang/rust/issues/88581>
 // - <https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil>
 #[inline]
-const fn div_ceil(a: usize, b: usize) -> usize {
+pub const fn div_ceil(a: usize, b: usize) -> usize {
     (a + b - 1) / b
 }

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -30,6 +30,6 @@ pub use vector_storage_base::*;
 // - <https://github.com/rust-lang/rust/issues/88581>
 // - <https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil>
 #[inline]
-pub const fn div_ceil(a: usize, b: usize) -> usize {
+pub(crate) const fn div_ceil(a: usize, b: usize) -> usize {
     (a + b - 1) / b
 }

--- a/openapi/tests/openapi_integration/test_group.py
+++ b/openapi/tests/openapi_integration/test_group.py
@@ -100,7 +100,7 @@ def setup():
     upsert_with_heterogenous_fields(collection_name=collection_name)
     upsert_multi_value_payload(collection_name=collection_name)
     yield
-    # drop_collection(collection_name=collection_name)
+    drop_collection(collection_name=collection_name)
 
 
 def test_search_with_multiple_groups():

--- a/openapi/tests/openapi_integration/test_group.py
+++ b/openapi/tests/openapi_integration/test_group.py
@@ -100,7 +100,7 @@ def setup():
     upsert_with_heterogenous_fields(collection_name=collection_name)
     upsert_multi_value_payload(collection_name=collection_name)
     yield
-    drop_collection(collection_name=collection_name)
+    # drop_collection(collection_name=collection_name)
 
 
 def test_search_with_multiple_groups():


### PR DESCRIPTION
- Fix for the payload selector: 
  - search request doesn't support nested payload selectors, but `group_by` should
  - New logic only pre-selects top-level key, which might be a subject for possible further improvements

- additional `must-not` condition for re-search requests doesn't work with multiple payload values per field. It excludes too much
  - had to introduce a new `except` match condition, which fixes the problem.
  - as a bonus: `except` condition also available outside the groups
  - test for reproducing the problem also included

