### PR TITLE
Add optional ID tracker to check_payload, remove boxed closure

### DIFF
--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -92,7 +92,7 @@ pub fn condition_converter<'a>(
                             let get_payload = || OwnedPayloadRef::from(object);
                             if check_payload(
                                 Box::new(get_payload),
-                                Box::new(|_| None),
+                                None,
                                 &nested.nested.filter,
                                 point_id,
                                 &nested_indexes,

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -64,7 +64,6 @@ mod tests {
     use super::*;
     use crate::common::utils::IndexesMap;
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
-    use crate::id_tracker::IdTracker;
     use crate::payload_storage::query_checker::check_payload;
     use crate::types::{Condition, FieldCondition, Filter, OwnedPayloadRef};
 
@@ -111,7 +110,7 @@ mod tests {
                 }
                 payload.borrow().as_ref().cloned().unwrap()
             }),
-            Box::new(|offset| id_tracker.external_id(offset)),
+            Some(&id_tracker),
             &query,
             0,
             &IndexesMap::new(),

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -254,10 +254,8 @@ impl ConditionChecker for SimpleConditionChecker {
                         }
                     };
 
-                    payload_ref_cell.replace(Some(match payload_ptr {
-                        None => (&self.empty_payload).into(),
-                        Some(x) => x,
-                    }));
+                    payload_ref_cell
+                        .replace(payload_ptr.or_else(|| Some((&self.empty_payload).into())));
                 }
                 payload_ref_cell.borrow().as_ref().cloned().unwrap()
             }),

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -14,7 +14,7 @@ use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::ConditionChecker;
 use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, OwnedPayloadRef, Payload,
-    PayloadContainer, PayloadKeyType, PointIdType, PointOffsetType,
+    PayloadContainer, PayloadKeyType, PointOffsetType,
 };
 
 fn check_condition<F>(checker: &F, condition: &Condition) -> bool
@@ -94,7 +94,7 @@ where
 
 pub fn check_payload<'a, R>(
     get_payload: Box<dyn Fn() -> OwnedPayloadRef<'a> + 'a>,
-    get_external_id: Box<dyn Fn(PointOffsetType) -> Option<PointIdType> + 'a>,
+    id_tracker: Option<&IdTrackerSS>,
     query: &Filter,
     point_id: PointOffsetType,
     field_indexes: &HashMap<PayloadKeyType, R>,
@@ -108,13 +108,9 @@ where
         }
         Condition::IsEmpty(is_empty) => check_is_empty_condition(is_empty, get_payload().deref()),
         Condition::IsNull(is_null) => check_is_null_condition(is_null, get_payload().deref()),
-        Condition::HasId(has_id) => {
-            let external_id = match get_external_id(point_id) {
-                None => return false,
-                Some(id) => id,
-            };
-            has_id.has_id.contains(&external_id)
-        }
+        Condition::HasId(has_id) => id_tracker
+            .and_then(|id_tracker| id_tracker.external_id(point_id))
+            .map_or(false, |id| has_id.has_id.contains(&id)),
         Condition::Nested(nested) => {
             let nested_path = nested.array_key();
             let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
@@ -125,7 +121,7 @@ where
                     let get_payload = || OwnedPayloadRef::from(object);
                     if check_payload(
                         Box::new(get_payload),
-                        Box::new(|_| None),
+                        None,
                         &nested.nested.filter,
                         point_id,
                         &nested_indexes,
@@ -265,7 +261,7 @@ impl ConditionChecker for SimpleConditionChecker {
                 }
                 payload_ref_cell.borrow().as_ref().cloned().unwrap()
             }),
-            Box::new(|offset| id_tracker.external_id(offset)),
+            Some(id_tracker.deref()),
             query,
             point_id,
             &IndexesMap::new(),


### PR DESCRIPTION
Extends <https://github.com/qdrant/qdrant/pull/1935>.

This replaces

```rust
    get_external_id: Box<dyn Fn(PointOffsetType) -> Option<PointIdType> + 'a>,
```

with

```rust
    id_tracker: Option<&IdTrackerSS>,
```

to remove the boxed closure. Instead we pass a reference to ID tracker.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->