### PR TITLE
Update Cargo.toml, specify license and other things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",
 ]
+readme = "README.md"
+homepage = "https://qdrant.tech/"
+repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2021"
 default-run = "qdrant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ license = "Apache-2.0"
 edition = "2021"
 default-run = "qdrant"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["web", "parking_lot"]
 web = ["actix-web"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qdrant"
 version = "0.11.1"
 authors = ["Andrey Vasnetsov <andrey@vasnetsov.com>"]
+license = "Apache-2.0"
 edition = "2021"
 default-run = "qdrant"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "qdrant"
 version = "0.11.1"
-authors = ["Andrey Vasnetsov <andrey@vasnetsov.com>"]
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 default-run = "qdrant"

--- a/benches/search-points/Cargo.toml
+++ b/benches/search-points/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "search-points"
 version = "0.0.0"
+license = "Apache-2.0"
 edition = "2021"
 publish = false
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "api"
 version = "0.11.1"
+license = "Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "api"
 version = "0.11.1"
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.11.1"
 license = "Apache-2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 log = "0.4"
 env_logger = "0.10.0"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Qdrant Team <info@qdrant.tech>"]
 license = "Apache-2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
 tempfile = "3.5.0"
 criterion = "0.4"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "collection"
 version = "0.4.2"
-authors = ["Qdrant Team <info@qdrant.tech>"]
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -2,6 +2,7 @@
 name = "collection"
 version = "0.4.2"
 authors = ["Qdrant Team <info@qdrant.tech>"]
+license = "Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
 tempfile = "3.5.0"
 criterion = "0.4"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "segment"
 version = "0.6.0"
-authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -2,6 +2,7 @@
 name = "segment"
 version = "0.6.0"
 authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
+license = "Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "storage"
 version = "0.2.0"
-authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
+authors = [
+    "Andrey Vasnetsov <vasnetsov93@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "storage"
 version = "0.2.0"
 authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
+license = "Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Andrey Vasnetsov <vasnetsov93@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 tempfile = "3.5.0"
 proptest = "1.1.0"


### PR DESCRIPTION
This updates the `Cargo.toml` definitions to specify the usage of Apache 2.0 in SPDX format.

This was recommended by: https://github.com/qdrant/wal/issues/49#issuecomment-1557650475

Along with it this also:
- updates the authors list
- adds README, homepage and repository links

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?