### PR TITLE
Bump starlette from 0.26.1 to 0.27.0 in /openapi/tests

### DIFF
--- a/openapi/tests/requirements-freeze.txt
+++ b/openapi/tests/requirements-freeze.txt
@@ -32,7 +32,7 @@ schemathesis==3.19.0
 six==1.16.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
-starlette==0.26.1
+starlette==0.27.0
 starlette-testclient==0.2.0
 tomli==2.0.1
 tomli_w==1.0.0


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/pull/1910.

Update the `scarlette` dependency to `v0.27.0`. This mitigates a [vulnerability](https://github.com/qdrant/qdrant/security/dependabot/41).

Originally suggested by dependabot [here](https://github.com/qdrant/qdrant/pull/1910), but ported to `dev` because this is not a high priority issue in our codebase. It is not used in production/release code.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?