### PR TITLE
Bump requests from 2.28.1 to 2.31.0 in /openapi/tests

### DIFF
--- a/openapi/tests/requirements-freeze.txt
+++ b/openapi/tests/requirements-freeze.txt
@@ -27,7 +27,7 @@ pytest==7.2.2
 pytest-subtests==0.7.0
 pytest-timeout==2.1.0
 PyYAML==6.0
-requests==2.28.1
+requests==2.31.0
 schemathesis==3.19.0
 six==1.16.0
 sniffio==1.3.0

--- a/openapi/tests/requirements-freeze.txt
+++ b/openapi/tests/requirements-freeze.txt
@@ -28,7 +28,7 @@ pytest-subtests==0.7.0
 pytest-timeout==2.1.0
 PyYAML==6.0
 requests==2.31.0
-schemathesis==3.19.0
+schemathesis==3.19.5
 six==1.16.0
 sniffio==1.3.0
 sortedcontainers==2.4.0

--- a/openapi/tests/requirements.txt
+++ b/openapi/tests/requirements.txt
@@ -1,4 +1,4 @@
-schemathesis~=3.19.0
+schemathesis~=3.19.5
 requests
 pytest==7.2.2
 pytest-timeout==2.1.0

--- a/tests/openapi_integration_test.sh
+++ b/tests/openapi_integration_test.sh
@@ -11,4 +11,4 @@ docker run --rm \
             --network=host \
             -e OPENAPI_FILE='openapi.json' \
             -v "${PWD}"/openapi/tests:/code \
-            "$(docker build --load -q ./openapi/tests)" sh -c /code/run_docker.sh
+            "$(docker buildx build --load -q ./openapi/tests)" sh -c /code/run_docker.sh

--- a/tests/openapi_integration_test.sh
+++ b/tests/openapi_integration_test.sh
@@ -11,4 +11,4 @@ docker run --rm \
             --network=host \
             -e OPENAPI_FILE='openapi.json' \
             -v "${PWD}"/openapi/tests:/code \
-            "$(docker buildx build --load -q ./openapi/tests)" sh -c /code/run_docker.sh
+            "$(docker build --load -q ./openapi/tests)" sh -c /code/run_docker.sh


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/pull/1942.

Update the `requests` dependency to `v2.31.0`. This mitigates a [vulnerability](https://github.com/qdrant/qdrant/security/dependabot/42).

Originally suggested by dependabot [here](https://github.com/qdrant/qdrant/pull/1942), but ported to `dev` because this is not a high priority issue in our codebase. It is not used in production/release code.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?