### PR TITLE
Add TLS config validation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -181,10 +181,10 @@ telemetry_disabled: false
 # Required if either service.enable_tls or cluster.p2p.enable_tls is true.
 tls:
   # Server certificate chain file
-  cert: ./tls/cert.pem
+  cert: null # E.g.: ./tls/cert.pem
 
   # Server private key file
-  key: ./tls/key.pem
+  key: null # E.g.: ./tls/key.pem
 
   # Certificate authority certificate file.
   # This certificate will be used to validate the certificates
@@ -194,7 +194,7 @@ tls:
   # HTTPS client certificate
   #
   # Required if cluster.p2p.enable_tls is true.
-  ca_cert: ./tls/cacert.pem
+  ca_cert: null # E.g.: ./tls/cacert.pem
 
   # TTL in seconds to reload certificate from disk, useful for certificate rotations.
   # Only works for HTTPS endpoints. Does not support gRPC (and intra-cluster communication).

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use actix_web_validator::error::flatten_errors;
 use validator::{ValidationError, ValidationErrors};
 
@@ -86,9 +88,23 @@ fn describe_error(
             Some(value) => format!("key {value} is invalid, bracket syntax is not supported here"),
             None => err.to_string(),
         },
+        "no_file" => format!(
+            "file '{}' does not exist",
+            params.get("value").and_then(|v| v.as_str()).unwrap_or("?"),
+        ),
         // Undescribed error codes
         _ => err.to_string(),
     }
+}
+
+/// Validate that the file exists
+pub fn validate_file_exists<P: AsRef<Path>>(path: P) -> Result<(), ValidationError> {
+    let path = path.as_ref();
+    if path.is_file() {
+        return Ok(());
+    }
+
+    Err(ValidationError::new("no_file"))
 }
 
 #[cfg(test)]

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -107,13 +107,22 @@ pub fn load_tls_internal_server_config(tls_config: &TlsConfig) -> io::Result<Ser
 }
 
 fn load_identity(tls_config: &TlsConfig) -> io::Result<Identity> {
-    let cert = fs::read_to_string(&tls_config.cert)?;
-    let key = fs::read_to_string(&tls_config.key)?;
+    let cert = fs::read_to_string(tls_config.cert.as_ref().ok_or(io::Error::new(
+        io::ErrorKind::Other,
+        "No server TLS certificate specified (tls.cert)",
+    ))?)?;
+    let key = fs::read_to_string(tls_config.key.as_ref().ok_or(io::Error::new(
+        io::ErrorKind::Other,
+        "No server TLS private key specified (tls.key)",
+    ))?)?;
     Ok(Identity::from_pem(cert, key))
 }
 
 fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
-    let pem = fs::read_to_string(&tls_config.ca_cert)?;
+    let pem = fs::read_to_string(tls_config.ca_cert.as_ref().ok_or(io::Error::new(
+        io::ErrorKind::Other,
+        "No server CA certificate specified (tls.ca_cert)",
+    ))?)?;
     Ok(Certificate::from_pem(pem))
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -95,9 +95,12 @@ impl Default for ConsensusConfig {
 
 #[derive(Debug, Deserialize, Clone, Validate)]
 pub struct TlsConfig {
-    pub cert: String,
-    pub key: String,
-    pub ca_cert: String,
+    #[validate(custom = "validation::validate_file_exists")]
+    pub cert: Option<String>,
+    #[validate(custom = "validation::validate_file_exists")]
+    pub key: Option<String>,
+    #[validate(custom = "validation::validate_file_exists")]
+    pub ca_cert: Option<String>,
     #[serde(default = "default_tls_cert_ttl")]
     #[validate(range(min = 1))]
     pub cert_ttl: Option<u64>,


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/1865>.

This adds basic validation to the TLS configuration.

More specifically, this tests whether the specified certificate files exists on disk. If files don't exist, a validation warning is shown on startup. It also sets the default certificate files to `null`, to prevent validation warnings with the default values we had before.

Potential problems:
- This makes certificate paths nullable
- This always checks certificate paths, even if TLS is disabled (validation limitation)
- Users with default settings in their configuration from previous versions will start seeing './tls/cert.pem does not exist' warnings

Based on the above problems, I'm not 100% we want to merge this in its current state. What do others think?

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/1865>
- [x] Rebase on `dev`
- [x] Point to `dev`
- [x] Undraft

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?