### PR TITLE
Use const fn where possible for serde defaults

### DIFF
--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -99,7 +99,7 @@ pub fn default_write_consistency_factor() -> NonZeroU32 {
     NonZeroU32::new(1).unwrap()
 }
 
-fn default_on_disk_payload() -> bool {
+const fn default_on_disk_payload() -> bool {
     false
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -425,7 +425,7 @@ pub struct CountRequest {
     pub exact: bool,
 }
 
-pub fn default_exact_count() -> bool {
+pub const fn default_exact_count() -> bool {
     true
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -354,7 +354,7 @@ pub struct HnswConfig {
     pub payload_m: Option<usize>,
 }
 
-fn default_max_indexing_threads() -> usize {
+const fn default_max_indexing_threads() -> usize {
     0
 }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -25,7 +25,7 @@ pub struct PerformanceConfig {
     pub update_rate_limit: Option<usize>,
 }
 
-fn default_max_optimization_threads() -> usize {
+const fn default_max_optimization_threads() -> usize {
     1
 }
 
@@ -78,11 +78,11 @@ fn default_snapshots_path() -> String {
     "./snapshots".to_string()
 }
 
-fn default_on_disk_payload() -> bool {
+const fn default_on_disk_payload() -> bool {
     false
 }
 
-fn default_mmap_advice() -> madvise::Advice {
+const fn default_mmap_advice() -> madvise::Advice {
     madvise::Advice::Random
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -149,15 +149,15 @@ impl Settings {
     }
 }
 
-fn default_telemetry_disabled() -> bool {
+const fn default_telemetry_disabled() -> bool {
     false
 }
 
-fn default_cors() -> bool {
+const fn default_cors() -> bool {
     true
 }
 
-fn default_debug() -> bool {
+const fn default_debug() -> bool {
     false
 }
 
@@ -165,32 +165,32 @@ fn default_log_level() -> String {
     "INFO".to_string()
 }
 
-fn default_timeout_ms() -> u64 {
+const fn default_timeout_ms() -> u64 {
     DEFAULT_GRPC_TIMEOUT.as_millis() as u64
 }
 
-fn default_connection_timeout_ms() -> u64 {
+const fn default_connection_timeout_ms() -> u64 {
     DEFAULT_CONNECT_TIMEOUT.as_millis() as u64
 }
 
-fn default_tick_period_ms() -> u64 {
+const fn default_tick_period_ms() -> u64 {
     100
 }
 
 // Should not be less than `DEFAULT_META_OP_WAIT` as bootstrapping perform sync. consensus meta operations.
-fn default_bootstrap_timeout_sec() -> u64 {
+const fn default_bootstrap_timeout_sec() -> u64 {
     15
 }
 
-fn default_max_message_queue_size() -> usize {
+const fn default_max_message_queue_size() -> usize {
     100
 }
 
-fn default_connection_pool_size() -> usize {
+const fn default_connection_pool_size() -> usize {
     DEFAULT_POOL_SIZE
 }
 
-fn default_message_timeout_tics() -> u64 {
+const fn default_message_timeout_tics() -> u64 {
     10
 }
 


### PR DESCRIPTION
Use `const fn` for serde defaults where possible to allow compile time evaluation.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?