### PR TITLE
Configurable location of temporary snapshot files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 /static
 *.log
 .qdrant-initialized
-/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /static
 *.log
 .qdrant-initialized
+/tmp

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,8 +9,8 @@ storage:
   snapshots_path: ./snapshots
 
   # Where to store temporary files
-  # If null, temporary snapshot are stored in: storage/snapshots_tmp/
-  tmp_path: null
+  # If null, temporary snapshot are stored in: storage/snapshots_temp/
+  temp_path: null
 
   # If true - point's payload will not be stored in memory.
   # It will be read from the disk every time it is requested.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,10 @@ storage:
   # Where to store snapshots
   snapshots_path: ./snapshots
 
+  # Where to store tmp files
+  tmp_path: ./tmp
+
+
   # If true - point's payload will not be stored in memory.
   # It will be read from the disk every time it is requested.
   # This setting saves RAM by (slightly) increasing the response time.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,6 +9,7 @@ storage:
   snapshots_path: ./snapshots
 
   # Where to store temporary files
+  # If null, temporary snapshot are stored in: storage/snapshots_tmp/
   tmp_path: null
 
   # If true - point's payload will not be stored in memory.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,9 +8,8 @@ storage:
   # Where to store snapshots
   snapshots_path: ./snapshots
 
-  # Where to store tmp files
-  tmp_path: ./tmp
-
+  # Where to store temporary files
+  tmp_path: null
 
   # If true - point's payload will not be stored in memory.
   # It will be read from the disk every time it is requested.

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1411,7 +1411,7 @@ impl Collection {
                 // If node is listener, we can save whatever currently is in the storage
                 let save_wal = self.shared_storage_config.node_type != NodeType::Listener;
                 replica_set
-                    .create_snapshot(&shard_snapshot_path, save_wal)
+                    .create_snapshot(temp_dir, &shard_snapshot_path, save_wal)
                     .await?;
             }
         }

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -721,7 +721,11 @@ impl SegmentEntry for ProxySegment {
         self.write_segment.get().read().vector_dims()
     }
 
-    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<PathBuf> {
+    fn take_snapshot(
+        &self,
+        temp_path: &Path,
+        snapshot_dir_path: &Path,
+    ) -> OperationResult<PathBuf> {
         log::info!(
             "Taking a snapshot of a proxy segment into {:?}",
             snapshot_dir_path
@@ -732,7 +736,7 @@ impl SegmentEntry for ProxySegment {
             let wrapped_segment_guard = wrapped_segment_arc.read();
 
             // snapshot wrapped segment data into the temporary dir
-            wrapped_segment_guard.take_snapshot(snapshot_dir_path)?
+            wrapped_segment_guard.take_snapshot(temp_path, snapshot_dir_path)?
         };
 
         // snapshot write_segment
@@ -740,7 +744,7 @@ impl SegmentEntry for ProxySegment {
         let write_segment_guard = write_segment_rw.read();
 
         // Write segment is not unique to the proxy segment, therefore it might overwrite an existing snapshot.
-        write_segment_guard.take_snapshot(snapshot_dir_path)?;
+        write_segment_guard.take_snapshot(temp_path, snapshot_dir_path)?;
 
         Ok(archive_path)
     }
@@ -1192,8 +1196,15 @@ mod tests {
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
         eprintln!("Snapshot into {:?}", snapshot_dir.path());
 
-        proxy_segment.take_snapshot(snapshot_dir.path()).unwrap();
-        proxy_segment2.take_snapshot(snapshot_dir.path()).unwrap();
+        let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+        let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
+
+        proxy_segment
+            .take_snapshot(temp_dir.path(), snapshot_dir.path())
+            .unwrap();
+        proxy_segment2
+            .take_snapshot(temp_dir2.path(), snapshot_dir.path())
+            .unwrap();
 
         // validate that 3 archives were created:
         // wrapped_segment1, wrapped_segment2 & shared write_segment

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -27,7 +27,12 @@ impl DummyShard {
         }
     }
 
-    pub async fn create_snapshot(&self, _: &Path, _: bool) -> CollectionResult<()> {
+    pub async fn create_snapshot(
+        &self,
+        _temp_path: &Path,
+        _: &Path,
+        _: bool,
+    ) -> CollectionResult<()> {
         self.dummy()
     }
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -30,8 +30,8 @@ impl DummyShard {
     pub async fn create_snapshot(
         &self,
         _temp_path: &Path,
-        _: &Path,
-        _: bool,
+        _target_path: &Path,
+        _save_wal: bool,
     ) -> CollectionResult<()> {
         self.dummy()
     }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -122,11 +122,12 @@ impl ForwardProxyShard {
     /// Forward `create_snapshot` to `wrapped_shard`
     pub async fn create_snapshot(
         &self,
+        temp_path: &Path,
         target_path: &Path,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(target_path, save_wal)
+            .create_snapshot(temp_path, target_path, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -559,7 +559,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let temp_path = temp_path.join(format!("{}.snapshot", Uuid::new_v4()));
+        let temp_path = temp_path.join(format!("snapshot-{}", Uuid::new_v4()));
         create_dir_all(&temp_path).await?;
 
         tokio::task::spawn_blocking(move || {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -24,6 +24,7 @@ use tokio::fs::{copy, create_dir_all, remove_dir_all};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock as TokioRwLock};
+use uuid::Uuid;
 use wal::{Wal, WalOptions};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
@@ -531,9 +532,10 @@ impl LocalShard {
         Ok(())
     }
 
-    /// create snapshot for local shard into `target_path`
+    /// Create snapshot for local shard into `target_path`
     pub async fn create_snapshot(
         &self,
+        temp_path: &Path,
         target_path: &Path,
         save_wal: bool,
     ) -> CollectionResult<()> {
@@ -557,11 +559,14 @@ impl LocalShard {
             rx.await?;
         }
 
+        let temp_path = temp_path.join(format!("{}.snapshot", Uuid::new_v4()));
+        create_dir_all(&temp_path).await?;
+
         tokio::task::spawn_blocking(move || {
             let segments_read = segments.read();
 
             // Do not change segments while snapshotting
-            segments_read.snapshot_all_segments(&snapshot_segments_shard_path)?;
+            segments_read.snapshot_all_segments(&temp_path, &snapshot_segments_shard_path)?;
 
             if save_wal {
                 // snapshot all shard's WAL

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -64,11 +64,12 @@ impl ProxyShard {
     /// Forward `create_snapshot` to `wrapped_shard`
     pub async fn create_snapshot(
         &self,
+        temp_path: &Path,
         target_path: &Path,
         save_wal: bool,
     ) -> CollectionResult<()> {
         self.wrapped_shard
-            .create_snapshot(target_path, save_wal)
+            .create_snapshot(temp_path, target_path, save_wal)
             .await
     }
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1047,13 +1047,16 @@ impl ShardReplicaSet {
 
     pub async fn create_snapshot(
         &self,
+        temp_path: &Path,
         target_path: &Path,
         save_wal: bool,
     ) -> CollectionResult<()> {
         let local_read = self.local.read().await;
 
         if let Some(local) = &*local_read {
-            local.create_snapshot(target_path, save_wal).await?
+            local
+                .create_snapshot(temp_path, target_path, save_wal)
+                .await?
         }
 
         self.replica_state

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -66,16 +66,31 @@ impl Shard {
 
     pub async fn create_snapshot(
         &self,
+        temp_path: &Path,
         target_path: &Path,
         save_wal: bool,
     ) -> CollectionResult<()> {
         match self {
-            Shard::Local(local_shard) => local_shard.create_snapshot(target_path, save_wal).await,
-            Shard::Proxy(proxy_shard) => proxy_shard.create_snapshot(target_path, save_wal).await,
-            Shard::ForwardProxy(proxy_shard) => {
-                proxy_shard.create_snapshot(target_path, save_wal).await
+            Shard::Local(local_shard) => {
+                local_shard
+                    .create_snapshot(temp_path, target_path, save_wal)
+                    .await
             }
-            Shard::Dummy(dummy_shard) => dummy_shard.create_snapshot(target_path, save_wal).await,
+            Shard::Proxy(proxy_shard) => {
+                proxy_shard
+                    .create_snapshot(temp_path, target_path, save_wal)
+                    .await
+            }
+            Shard::ForwardProxy(proxy_shard) => {
+                proxy_shard
+                    .create_snapshot(temp_path, target_path, save_wal)
+                    .await
+            }
+            Shard::Dummy(dummy_shard) => {
+                dummy_shard
+                    .create_snapshot(temp_path, target_path, save_wal)
+                    .await
+            }
         }
     }
 

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -98,7 +98,6 @@ async fn _test_snapshot_collection(node_type: NodeType) {
     .unwrap();
 
     let snapshots_temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
-    std::fs::create_dir_all(&snapshots_temp_dir).unwrap();
     let snapshot_description = collection
         .create_snapshot(snapshots_temp_dir.path(), 0)
         .await

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -97,10 +97,10 @@ async fn _test_snapshot_collection(node_type: NodeType) {
     .await
     .unwrap();
 
-    let snapshots_tmp_dir = collection_dir.path().join("snapshots_tmp");
+    let snapshots_tmp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
     let snapshot_description = collection
-        .create_snapshot(&snapshots_tmp_dir, 0)
+        .create_snapshot(snapshots_tmp_dir.path(), 0)
         .await
         .unwrap();
 

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -97,10 +97,10 @@ async fn _test_snapshot_collection(node_type: NodeType) {
     .await
     .unwrap();
 
-    let snapshots_tmp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
-    std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
+    let snapshots_temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    std::fs::create_dir_all(&snapshots_temp_dir).unwrap();
     let snapshot_description = collection
-        .create_snapshot(snapshots_tmp_dir.path(), 0)
+        .create_snapshot(snapshots_temp_dir.path(), 0)
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -111,7 +111,6 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
 
     // Take a snapshot
     let snapshots_temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
-    std::fs::create_dir_all(&snapshots_temp_dir).unwrap();
     let snapshot_description = collection
         .create_snapshot(snapshots_temp_dir.path(), 0)
         .await

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -110,10 +110,10 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         .unwrap();
 
     // Take a snapshot
-    let snapshots_tmp_dir = collection_dir.path().join("snapshots_tmp");
+    let snapshots_tmp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
     let snapshot_description = collection
-        .create_snapshot(&snapshots_tmp_dir, 0)
+        .create_snapshot(snapshots_tmp_dir.path(), 0)
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -110,10 +110,10 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         .unwrap();
 
     // Take a snapshot
-    let snapshots_tmp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
-    std::fs::create_dir_all(&snapshots_tmp_dir).unwrap();
+    let snapshots_temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    std::fs::create_dir_all(&snapshots_temp_dir).unwrap();
     let snapshot_description = collection
-        .create_snapshot(snapshots_tmp_dir.path(), 0)
+        .create_snapshot(snapshots_temp_dir.path(), 0)
         .await
         .unwrap();
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -369,7 +369,9 @@ pub trait SegmentEntry {
     /// Take a snapshot of the segment.
     ///
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
-    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<PathBuf>;
+    /// Uses `temp_path` to prepare files to archive.
+    fn take_snapshot(&self, temp_path: &Path, snapshot_dir_path: &Path)
+        -> OperationResult<PathBuf>;
 
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self) -> SegmentTelemetry;

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -151,7 +151,7 @@ fn get_texts() -> Vec<String> {
 
 #[test]
 fn test_prefix_search() {
-    let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config = TextIndexParams {
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::Prefix,
@@ -160,7 +160,7 @@ fn test_prefix_search() {
         lowercase: None,
     };
 
-    let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+    let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
     let mut index = FullTextIndex::new(db, config, "text");
     index.recreate().unwrap();
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -271,7 +271,7 @@ mod tests {
             serde_json::json!("Yet now, for a day, perhaps for a week, even Multivac might celebrate the great time, and rest."),
         ];
 
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         let config = TextIndexParams {
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
@@ -281,7 +281,7 @@ mod tests {
         };
 
         {
-            let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
             let mut index = FullTextIndex::new(db, config.clone(), "text");
 
@@ -332,7 +332,7 @@ mod tests {
         }
 
         {
-            let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
             let mut index = FullTextIndex::new(db, config, "text");
             let loaded = index.load().unwrap();
             assert!(loaded);

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -639,8 +639,8 @@ mod tests {
     }
 
     fn build_random_index(num_points: usize, num_geo_values: usize) -> GeoMapIndex {
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
         let mut rnd = StdRng::seed_from_u64(42);
         let mut index = GeoMapIndex::new(db, FIELD_NAME);
@@ -747,8 +747,8 @@ mod tests {
 
     #[test]
     fn match_cardinality_point_with_multi_far_geo_payload() {
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
         let mut index = GeoMapIndex::new(db, FIELD_NAME);
 
@@ -808,8 +808,8 @@ mod tests {
 
     #[test]
     fn match_cardinality_point_with_multi_close_geo_payload() {
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
-        let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
         let mut index = GeoMapIndex::new(db, FIELD_NAME);
 
@@ -843,9 +843,9 @@ mod tests {
 
     #[test]
     fn load_from_disk() {
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         {
-            let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
 
             let mut index = GeoMapIndex::new(db, FIELD_NAME);
 
@@ -867,7 +867,7 @@ mod tests {
             drop(index);
         }
 
-        let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+        let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
         let mut new_index = GeoMapIndex::new(db, FIELD_NAME);
         new_index.load().unwrap();
 
@@ -883,9 +883,9 @@ mod tests {
 
     #[test]
     fn same_geo_index_between_points_test() {
-        let tmp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
         {
-            let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+            let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
             let mut index = GeoMapIndex::new(db, FIELD_NAME);
             index.recreate().unwrap();
 
@@ -910,7 +910,7 @@ mod tests {
             drop(index);
         }
 
-        let db = open_db_with_existing_cf(&tmp_dir.path().join("test_db")).unwrap();
+        let db = open_db_with_existing_cf(&temp_dir.path().join("test_db")).unwrap();
         let mut new_index = GeoMapIndex::new(db, FIELD_NAME);
         new_index.load().unwrap();
         assert_eq!(new_index.points_count, 1);

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -584,9 +584,9 @@ mod tests {
             vec![25],
         ];
 
-        let tmp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
-        save_map_index(&data, tmp_dir.path());
-        load_map_index(&data, tmp_dir.path());
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+        save_map_index(&data, temp_dir.path());
+        load_map_index(&data, temp_dir.path());
     }
 
     #[test]
@@ -615,8 +615,8 @@ mod tests {
             vec![String::from("PPGG")],
         ];
 
-        let tmp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
-        save_map_index(&data, tmp_dir.path());
-        load_map_index(&data, tmp_dir.path());
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+        save_map_index(&data, temp_dir.path());
+        load_map_index(&data, temp_dir.path());
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -511,19 +511,19 @@ mod tests {
     const COLUMN_NAME: &str = "test";
 
     fn get_index() -> (TempDir, NumericIndex<f64>) {
-        let tmp_dir = Builder::new()
+        let temp_dir = Builder::new()
             .prefix("test_numeric_index")
             .tempdir()
             .unwrap();
-        let db = open_db_with_existing_cf(tmp_dir.path()).unwrap();
+        let db = open_db_with_existing_cf(temp_dir.path()).unwrap();
         let index: NumericIndex<_> = NumericIndex::new(db, COLUMN_NAME);
         index.recreate().unwrap();
-        (tmp_dir, index)
+        (temp_dir, index)
     }
 
     fn random_index(num_points: usize, values_per_point: usize) -> (TempDir, NumericIndex<f64>) {
         let mut rng = StdRng::seed_from_u64(42);
-        let (tmp_dir, mut index) = get_index();
+        let (temp_dir, mut index) = get_index();
 
         for i in 0..num_points {
             let values = (0..values_per_point).map(|_| rng.gen_range(0.0..100.0));
@@ -532,7 +532,7 @@ mod tests {
                 .unwrap();
         }
 
-        (tmp_dir, index)
+        (temp_dir, index)
     }
 
     fn cardinality_request(index: &NumericIndex<f64>, query: Range) -> CardinalityEstimation {
@@ -553,7 +553,7 @@ mod tests {
 
     #[test]
     fn test_cardinality_exp() {
-        let (_tmp_dir, index) = random_index(1000, 1);
+        let (_temp_dir, index) = random_index(1000, 1);
 
         cardinality_request(
             &index,
@@ -574,7 +574,7 @@ mod tests {
             },
         );
 
-        let (_tmp_dir, index) = random_index(1000, 2);
+        let (_temp_dir, index) = random_index(1000, 2);
         cardinality_request(
             &index,
             Range {
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_payload_blocks() {
-        let (_tmp_dir, index) = random_index(1000, 2);
+        let (_temp_dir, index) = random_index(1000, 2);
         let threshold = 100;
         let blocks = index
             .payload_blocks(threshold, "test".to_owned())
@@ -649,7 +649,7 @@ mod tests {
 
     #[test]
     fn test_payload_blocks_small() {
-        let (_tmp_dir, mut index) = get_index();
+        let (_temp_dir, mut index) = get_index();
         let threshold = 4;
         let values = vec![
             vec![1.0],
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn test_numeric_index_load_from_disk() {
-        let (_tmp_dir, mut index) = get_index();
+        let (_temp_dir, mut index) = get_index();
 
         let values = vec![
             vec![1.0],
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_numeric_index() {
-        let (_tmp_dir, mut index) = get_index();
+        let (_temp_dir, mut index) = get_index();
 
         let values = vec![
             vec![1.0],

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -267,13 +267,13 @@ impl GraphLinksConverter {
 
     pub fn save_as(&mut self, path: &Path) -> OperationResult<()> {
         self.path = Some(path.to_path_buf());
-        let tmp_path = path.with_extension("tmp");
+        let temp_path = path.with_extension("tmp");
         {
             let file = OpenOptions::new()
                 .read(true)
                 .write(true)
                 .create(true)
-                .open(tmp_path.as_path())?;
+                .open(temp_path.as_path())?;
 
             file.set_len(self.data_size())?;
             let m = unsafe { MmapMut::map_mut(&file) };
@@ -283,7 +283,7 @@ impl GraphLinksConverter {
 
             mmap.flush()?;
         }
-        std::fs::rename(tmp_path, path)?;
+        std::fs::rename(temp_path, path)?;
 
         Ok(())
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1352,11 +1352,15 @@ impl SegmentEntry for Segment {
             .collect()
     }
 
-    fn take_snapshot(&self, snapshot_dir_path: &Path) -> OperationResult<PathBuf> {
+    fn take_snapshot(
+        &self,
+        temp_path: &Path,
+        snapshot_dir_path: &Path,
+    ) -> OperationResult<PathBuf> {
         log::debug!(
             "Taking snapshot of segment {:?} into {:?}",
             self.current_path,
-            snapshot_dir_path
+            snapshot_dir_path,
         );
 
         if !snapshot_dir_path.exists() {
@@ -1374,10 +1378,9 @@ impl SegmentEntry for Segment {
         // flush segment to capture latest state
         self.flush(true)?;
 
-        let tmp_path = self.current_path.join(format!("tmp-{}", Uuid::new_v4()));
-
-        let db_backup_path = tmp_path.join(DB_BACKUP_PATH);
-        let payload_index_db_backup_path = tmp_path.join(PAYLOAD_DB_BACKUP_PATH);
+        let temp_path = temp_path.join(format!("snapshot-{}", Uuid::new_v4()));
+        let db_backup_path = temp_path.join(DB_BACKUP_PATH);
+        let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
 
         {
             let db = self.database.read();
@@ -1406,8 +1409,8 @@ impl SegmentEntry for Segment {
         let mut builder = Builder::new(file);
 
         builder
-            .append_dir_all(SNAPSHOT_PATH, &tmp_path)
-            .map_err(|err| utils::tar::failed_to_append_error(&tmp_path, err))?;
+            .append_dir_all(SNAPSHOT_PATH, &temp_path)
+            .map_err(|err| utils::tar::failed_to_append_error(&temp_path, err))?;
 
         let files = Path::new(SNAPSHOT_PATH).join(SNAPSHOT_FILES_PATH);
 
@@ -1456,11 +1459,11 @@ impl SegmentEntry for Segment {
 
         // remove tmp directory in background
         let _ = std::thread::spawn(move || {
-            let res = std::fs::remove_dir_all(&tmp_path);
+            let res = std::fs::remove_dir_all(&temp_path);
             if let Err(err) = res {
                 log::error!(
                     "Failed to remove tmp directory at {}: {:?}",
-                    tmp_path.display(),
+                    temp_path.display(),
                     err
                 );
             }
@@ -1727,9 +1730,12 @@ mod tests {
             .unwrap();
 
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
 
         // snapshotting!
-        let archive = segment.take_snapshot(snapshot_dir.path()).unwrap();
+        let archive = segment
+            .take_snapshot(temp_dir.path(), snapshot_dir.path())
+            .unwrap();
         let archive_extension = archive.extension().unwrap();
         let archive_name = archive.file_name().unwrap().to_str().unwrap().to_string();
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,7 +91,7 @@ async fn _do_recover_from_snapshot(
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 
-    let tmp_collection_dir = Path::new(toc.tmp_path().unwrap_or_else(|| toc.storage_path())
+    let tmp_collection_dir = Path::new(toc.tmp_path().unwrap_or_else(|| toc.storage_path()))
         .join("tmp_collections")
         .join(collection_name);
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,7 +91,7 @@ async fn _do_recover_from_snapshot(
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 
-    let tmp_collection_dir = Path::new(toc.tmp_path().unwrap_or_else(|| toc.storage_path()))
+    let tmp_collection_dir = Path::new(toc.temp_path().unwrap_or_else(|| toc.storage_path()))
         .join("tmp_collections")
         .join(collection_name);
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,7 +91,7 @@ async fn _do_recover_from_snapshot(
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 
-    let tmp_collection_dir = Path::new(toc.tmp_path())
+    let tmp_collection_dir = Path::new(toc.tmp_path().unwrap_or_else(|| toc.storage_path())
         .join("tmp_collections")
         .join(collection_name);
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use collection::collection::Collection;
 use collection::config::CollectionConfig;
 use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,7 +91,8 @@ async fn _do_recover_from_snapshot(
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 
-    let tmp_collection_dir = Path::new(toc.temp_path().unwrap_or_else(|| toc.storage_path()))
+    let tmp_collection_dir = toc
+        .temp_storage_path()
         .join("tmp_collections")
         .join(collection_name);
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -91,7 +91,7 @@ async fn _do_recover_from_snapshot(
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 
-    let tmp_collection_dir = Path::new(toc.storage_path())
+    let tmp_collection_dir = Path::new(toc.tmp_path())
         .join("tmp_collections")
         .join(collection_name);
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1464,7 +1464,7 @@ impl TableOfContent {
         let collection = self.get_collection(collection_name).await?;
         // We want to use tmp dir inside the tmp_path (storage if not specified), because it is possible, that
         // snapshot directory is mounted as network share and multiple writes to it could be slow
-        let tmp_dir = Path::new(self.tmp_path().unwrap_or_else(|| &self.storage_path()))
+        let tmp_dir = Path::new(self.tmp_path().unwrap_or_else(|| self.storage_path()))
             .join(SNAPSHOTS_TMP_DIR);
         tokio::fs::create_dir_all(&tmp_dir).await?;
         Ok(collection

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -104,9 +104,8 @@ impl TableOfContent {
         create_dir_all(&snapshots_path).expect("Can't create Snapshots directory");
         let collections_path = Path::new(&storage_config.storage_path).join(COLLECTIONS_DIR);
         create_dir_all(&collections_path).expect("Can't create Collections directory");
-        if storage_config.storage_path != storage_config.tmp_path {
-            let tmp_path = Path::new(&storage_config.tmp_path.clone()).to_owned();
-            create_dir_all(tmp_path).expect("Can't create temporary files directory");
+        if let Some(path) = storage_config.tmp_path {
+            create_dir_all(path).expect("Can't create temporary files directory");
         }
         let collection_paths =
             read_dir(&collections_path).expect("Can't read Collections directory");

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -220,6 +220,14 @@ impl TableOfContent {
         self.storage_config.temp_path.as_deref()
     }
 
+    /// Get path for temporary storage files.
+    ///
+    /// Defaults to `storage_path()`.
+    /// A user may specify `storage.temp_path` to override this.
+    pub fn temp_storage_path(&self) -> &Path {
+        Path::new(self.temp_path().unwrap_or_else(|| self.storage_path()))
+    }
+
     fn collection_snapshots_path(snapshots_path: &Path, collection_name: &str) -> PathBuf {
         snapshots_path.join(collection_name)
     }
@@ -1464,8 +1472,7 @@ impl TableOfContent {
         let collection = self.get_collection(collection_name).await?;
         // We want to use temp dir inside the temp_path (storage if not specified), because it is possible, that
         // snapshot directory is mounted as network share and multiple writes to it could be slow
-        let temp_dir = Path::new(self.temp_path().unwrap_or_else(|| self.storage_path()))
-            .join(SNAPSHOTS_TEMP_DIR);
+        let temp_dir = self.temp_storage_path().join(SNAPSHOTS_TEMP_DIR);
         tokio::fs::create_dir_all(&temp_dir).await?;
         Ok(collection
             .create_snapshot(&temp_dir, self.this_peer_id)

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -61,7 +61,7 @@ use crate::ConsensusOperations;
 
 pub const ALIASES_PATH: &str = "aliases";
 pub const COLLECTIONS_DIR: &str = "collections";
-pub const SNAPSHOTS_TMP_DIR: &str = "snapshots_tmp";
+pub const SNAPSHOTS_TEMP_DIR: &str = "snapshots_temp";
 pub const FULL_SNAPSHOT_FILE_NAME: &str = "full-snapshot";
 pub const DEFAULT_WRITE_LOCK_ERROR_MESSAGE: &str = "Write operations are forbidden";
 
@@ -104,9 +104,9 @@ impl TableOfContent {
         create_dir_all(&snapshots_path).expect("Can't create Snapshots directory");
         let collections_path = Path::new(&storage_config.storage_path).join(COLLECTIONS_DIR);
         create_dir_all(&collections_path).expect("Can't create Collections directory");
-        if let Some(path) = storage_config.tmp_path.as_deref() {
-            let tmp_path = Path::new(path);
-            create_dir_all(tmp_path).expect("Can't create temporary files directory");
+        if let Some(path) = storage_config.temp_path.as_deref() {
+            let temp_path = Path::new(path);
+            create_dir_all(temp_path).expect("Can't create temporary files directory");
         }
         let collection_paths =
             read_dir(&collections_path).expect("Can't read Collections directory");
@@ -216,8 +216,8 @@ impl TableOfContent {
         &self.storage_config.snapshots_path
     }
 
-    pub fn tmp_path(&self) -> Option<&str> {
-        self.storage_config.tmp_path.as_deref()
+    pub fn temp_path(&self) -> Option<&str> {
+        self.storage_config.temp_path.as_deref()
     }
 
     fn collection_snapshots_path(snapshots_path: &Path, collection_name: &str) -> PathBuf {
@@ -1462,13 +1462,13 @@ impl TableOfContent {
         collection_name: &str,
     ) -> Result<SnapshotDescription, StorageError> {
         let collection = self.get_collection(collection_name).await?;
-        // We want to use tmp dir inside the tmp_path (storage if not specified), because it is possible, that
+        // We want to use temp dir inside the temp_path (storage if not specified), because it is possible, that
         // snapshot directory is mounted as network share and multiple writes to it could be slow
-        let tmp_dir = Path::new(self.tmp_path().unwrap_or_else(|| self.storage_path()))
-            .join(SNAPSHOTS_TMP_DIR);
-        tokio::fs::create_dir_all(&tmp_dir).await?;
+        let temp_dir = Path::new(self.temp_path().unwrap_or_else(|| self.storage_path()))
+            .join(SNAPSHOTS_TEMP_DIR);
+        tokio::fs::create_dir_all(&temp_dir).await?;
         Ok(collection
-            .create_snapshot(&tmp_dir, self.this_peer_id)
+            .create_snapshot(&temp_dir, self.this_peer_id)
             .await?)
     }
 

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -38,8 +38,8 @@ pub struct StorageConfig {
     #[validate(length(min = 1))]
     pub snapshots_path: String,
     #[validate(length(min = 1))]
-    #[serde(default = "default_tmp_path")]
-    pub tmp_path: String,
+    #[serde(default)]
+    pub tmp_path: Option<String>,
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
     #[validate]

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -37,6 +37,9 @@ pub struct StorageConfig {
     #[serde(default = "default_snapshots_path")]
     #[validate(length(min = 1))]
     pub snapshots_path: String,
+    #[validate(length(min = 1))]
+    #[serde(default = "default_tmp_path")]
+    pub tmp_path: String,
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
     #[validate]

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -39,7 +39,7 @@ pub struct StorageConfig {
     pub snapshots_path: String,
     #[validate(length(min = 1))]
     #[serde(default)]
-    pub tmp_path: Option<String>,
+    pub temp_path: Option<String>,
     #[serde(default = "default_on_disk_payload")]
     pub on_disk_payload: bool,
     #[validate]

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -28,7 +28,7 @@ fn test_alias_operation() {
             .to_str()
             .unwrap()
             .to_string(),
-        tmp_path: storage_dir.path().to_str().unwrap().to_string(),
+        tmp_path: None,
         on_disk_payload: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -28,6 +28,7 @@ fn test_alias_operation() {
             .to_str()
             .unwrap()
             .to_string(),
+        tmp_path: storage_dir.path().to_str().unwrap().to_string(),
         on_disk_payload: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -28,7 +28,7 @@ fn test_alias_operation() {
             .to_str()
             .unwrap()
             .to_string(),
-        tmp_path: None,
+        temp_path: None,
         on_disk_payload: false,
         optimizers: OptimizersConfig {
             deleted_threshold: 0.5,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

This PR is a proposal to solve issue 1905. It allows to use a tmp_path configuration to be used instead of the current storage. If not specified, it will use storage as default.

/claim #1905 
