### PR TITLE
Update memmap2 to remove Windows specific edge case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aa1b505aeecb0adb017db2b6a79a17a38e64f882a201f05e9de8a982cd6096"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
 dependencies = [
  "libc",
 ]
@@ -3727,7 +3727,7 @@ dependencies = [
  "geohash",
  "itertools",
  "log",
- "memmap2 0.6.1",
+ "memmap2 0.6.2",
  "num-derive",
  "num-traits",
  "num_cpus",
@@ -4659,7 +4659,7 @@ dependencies = [
  "env_logger",
  "fs4",
  "log",
- "memmap2 0.6.1",
+ "memmap2 0.6.2",
  "rand 0.8.5",
  "rand_distr",
  "rustix 0.37.4",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -34,7 +34,7 @@ ordered-float = "3.7"
 thiserror = "1.0"
 atomic_refcell = "0.1.10"
 atomicwrites = "0.4.1"
-memmap2 = "0.6.1"
+memmap2 = "0.6.2"
 schemars = { version = "0.8.12", features = ["uuid1", "preserve_order", "chrono"] }
 log = "0.4"
 geo = "0.25.0"


### PR DESCRIPTION
We had a problem with mmap on Windows, where an empty file would give us an unaligned pointer. We [added](https://github.com/qdrant/qdrant/blob/137def66508b2b3ae36821b6890d8af2a0d70ba1/lib/segment/src/common/mmap_type.rs#L452-L457) a Windows specific edge case to resolve this.

I've upstreamed this logic into the `memmap2` crate in this PR: https://github.com/RazrFalcon/memmap2-rs/pull/79

This PR updates the crate and removes our edge case handling, since it is now done externally. :tada: 

Related: https://github.com/qdrant/qdrant/pull/1873

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?