### PR TITLE
Do not error if config file does not exist with RUN_MODE specified

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -205,16 +205,6 @@ impl Settings {
         let config_path = config_path.unwrap_or_else(|| "config/config".into());
         let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
 
-        if env::var("RUN_MODE").is_ok()
-            && Config::builder()
-                .add_source(File::with_name(&config_path))
-                .add_source(File::with_name(&format!("config/{env}")))
-                .build()
-                .is_err()
-        {
-            return Err(ConfigError::Message("`RUN_MODE` environment variable is set, but couldn't find matching configuration files".to_string()));
-        }
-
         let mut s = Config::builder()
             // Start with the default configuration file contents at compile time
             .add_source(File::from_str(DEFAULT_CONFIG, FileFormat::Yaml));


### PR DESCRIPTION
_<https://github.com/qdrant/qdrant/pull/1972> includes this change and improves other things as well. We might want to merge that instead._

---

Before this PR we had the following:

- if `RUN_MODE` is set
- check if both `config/config.yml` and `config/RUN_MODE.yml` exist
- if they don't, throw an error

This hard error is unnecessary, and causes problems in deployments. The validator will show a warning if no configuration file is found at all.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?