### PR TITLE
Rework settings/configuration loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /storage
 /snapshots
 /consensus_test_logs
+/config/local
 *.log
 .qdrant-initialized

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -202,6 +202,15 @@ const fn default_tls_cert_ttl() -> u64 {
 impl Settings {
     #[allow(dead_code)]
     pub fn new(config_path: Option<String>) -> Result<Self, ConfigError> {
+        // If config path is explicitly set, make sure it exists
+        if let Some(ref config_path) = config_path {
+            if let Err(err) = File::with_name(config_path).collect() {
+                log::error!(
+                    "Configuration specified with --config-path could not be loaded: {err}"
+                );
+            }
+        }
+
         let config_path = config_path.unwrap_or_else(|| "config/config".into());
         let env = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
         let config_path_env = format!("config/{env}");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -287,6 +287,7 @@ pub fn max_web_workers(settings: &Settings) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::io::Write;
 
     use sealed_test::prelude::*;
@@ -348,13 +349,8 @@ mod tests {
 
         // Create custom config file
         {
-            std::fs::create_dir("config").unwrap();
-            let mut custom = std::fs::File::options()
-                .read(true)
-                .write(true)
-                .create_new(true)
-                .open(path)
-                .unwrap();
+            fs::create_dir("config").unwrap();
+            let mut custom = fs::File::create(path).unwrap();
             write!(&mut custom, "service:\n    http_port: 9999").unwrap();
             custom.flush().unwrap();
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -311,15 +311,14 @@ mod tests {
 
     #[sealed_test(files = ["config/config.yaml", "config/development.yaml"])]
     fn test_runtime_development_config() {
+        env::set_var("RUN_MODE", "development");
+
         // `sealed_test` copies files into the same directory as the test runs in.
         // We need them in a subdirectory.
         std::fs::create_dir("config").expect("failed to create `config` subdirectory.");
         std::fs::copy("config.yaml", "config/config.yaml").expect("failed to copy `config.yaml`.");
         std::fs::copy("development.yaml", "config/development.yaml")
             .expect("failed to copy `development.yaml`.");
-
-        let key = "RUN_MODE";
-        env::set_var(key, "development");
 
         // Read config
         let config = Settings::new(None).expect("failed to load development config at runtime");
@@ -334,7 +333,6 @@ mod tests {
     #[sealed_test]
     fn test_no_config_files() {
         let non_existing_config_path = "config/non_existing_config".to_string();
-        env::remove_var("RUN_MODE");
 
         // Read config
         let config = Settings::new(Some(non_existing_config_path))


### PR DESCRIPTION
Includes <https://github.com/qdrant/qdrant/pull/1971>.

This reworks loading and merging of configuration files.
I've discussed this extensively with @agourlay in a call.

We figured there were a few problems with the previous implementation, mainly:
- there were unnecessary hard errors (if config files didn't exist)
- the load/merge order of configuration was wrong, a user specified configuration would be overwritten by `production.yaml`.

With this change, the configuration is now loaded and merged in the following manner:

1. Embedded base config (always complete)
2. File `config/config.yaml`
3. File `config/{env}.yaml`
4. File `config/local.yaml`
5. Config provided with `--config-path` (if set)
6. Environment variables

All files (2-5) are optional. Any properties in later configs, override previous properties.

For example, if a user would provide `--config-path` with a new port number. It would override the port number in all previous configuration files (1-4). Assuming that it is not overwritten by an environment variable (6), the user specified port will be the effective one.

This also:
- if a user provides `--config-path` and it doens't exist, an error is rendered
- if `config/config.yaml` or `config/{env}.yaml` doesn't exist, a warning is rendered

There is one potential compatibility problem:
if a user specified `--config-path` before, but dependned on an effective value from `production.yaml` which was different, then it may cause problems. Now `--config-path` is more important than `production.yaml`, while before it was the other way around. I think the new approach is logical, and don't think users will run into this situation.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?