### PR TITLE
Lookup internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "pprof",
  "rand 0.8.5",
  "rmp-serde",
+ "rstest",
  "schemars",
  "segment",
  "semver",
@@ -1616,6 +1617,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -2939,16 +2946,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -3106,12 +3112,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3440,6 +3440,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.107",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,7 +3582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -3568,7 +3594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce85af4dfa2fb0c0143121ab5e424c71ea693867357c9159b8777b59984c218"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7827,7 +7827,7 @@
         }
       },
       "GroupId": {
-        "description": "Value of the group_by field shared across all the hits in the group",
+        "description": "Value of the group_by key, shared across all the hits in the group",
         "anyOf": [
           {
             "type": "string"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7827,6 +7827,7 @@
         }
       },
       "GroupId": {
+        "description": "Value of the group_by field shared across all the hits in the group",
         "anyOf": [
           {
             "type": "string"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dev-dependencies]
 tempfile = "3.5.0"
 criterion = "0.5"
+rstest = "0.17.0"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.11", features = ["flamegraph", "prost-codec"] }

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -5,6 +5,7 @@ pub mod common;
 pub mod config;
 pub mod grouping;
 pub mod hash_ring;
+pub mod lookup;
 pub mod operations;
 pub mod optimizers_builder;
 pub mod recommendations;

--- a/lib/collection/src/lookup.rs
+++ b/lib/collection/src/lookup.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use futures::Future;
+use itertools::Itertools;
+use segment::data_types::groups::PseudoId;
+use segment::types::{PointIdType, WithPayloadInterface, WithVector};
+use tokio::sync::RwLockReadGuard;
+
+use crate::collection::Collection;
+use crate::operations::consistency_params::ReadConsistency;
+use crate::operations::types::{CollectionError, CollectionResult, PointRequest, Record};
+use crate::shards::shard::ShardId;
+
+#[derive(Debug, Clone)]
+pub struct LookupRequest {
+    pub collection_name: String,
+    pub values: Vec<PseudoId>,
+    pub with_payload: WithPayloadInterface,
+    pub with_vectors: WithVector,
+}
+
+pub async fn lookup_ids<'a, F, Fut>(
+    request: LookupRequest,
+    collection_by_name: F,
+    read_consistency: Option<ReadConsistency>,
+    shard_selection: Option<ShardId>,
+) -> CollectionResult<HashMap<PseudoId, Record>>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Option<RwLockReadGuard<'a, Collection>>>,
+{
+    let collection = collection_by_name(request.collection_name.clone())
+        .await
+        .ok_or(CollectionError::NotFound {
+            what: format!("Collection {}", request.collection_name),
+        })?;
+
+    let ids = request
+        .values
+        .into_iter()
+        .filter_map(|v| PointIdType::try_from(v).ok())
+        .collect_vec();
+
+    let ids_len = ids.len();
+
+    if ids_len == 0 {
+        return Ok(HashMap::new());
+    }
+
+    let point_request = PointRequest {
+        ids,
+        with_payload: Some(request.with_payload),
+        with_vector: request.with_vectors,
+    };
+
+    let result = collection
+        .retrieve(point_request, read_consistency, shard_selection)
+        .await?
+        .into_iter()
+        .map(|point| (PseudoId::from(point.id), point))
+        .collect();
+
+    Ok(result)
+}

--- a/lib/collection/src/lookup.rs
+++ b/lib/collection/src/lookup.rs
@@ -14,13 +14,13 @@ use crate::shards::shard::ShardId;
 #[derive(Debug, Clone)]
 pub struct LookupRequest {
     pub collection_name: String,
-    pub values: Vec<PseudoId>,
     pub with_payload: WithPayloadInterface,
     pub with_vectors: WithVector,
 }
 
 pub async fn lookup_ids<'a, F, Fut>(
     request: LookupRequest,
+    values: Vec<PseudoId>,
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
     shard_selection: Option<ShardId>,
@@ -35,15 +35,12 @@ where
             what: format!("Collection {}", request.collection_name),
         })?;
 
-    let ids = request
-        .values
+    let ids = values
         .into_iter()
         .filter_map(|v| PointIdType::try_from(v).ok())
         .collect_vec();
 
-    let ids_len = ids.len();
-
-    if ids_len == 0 {
+    if ids.is_empty() {
         return Ok(HashMap::new());
     }
 

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -1,12 +1,14 @@
+pub mod types;
+
 use std::collections::HashMap;
 
 use futures::Future;
 use itertools::Itertools;
 use schemars::JsonSchema;
-use segment::data_types::groups::PseudoId;
 use segment::types::{PointIdType, WithPayloadInterface, WithVector};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLockReadGuard;
+use types::PseudoId;
 
 use crate::collection::Collection;
 use crate::operations::consistency_params::ReadConsistency;
@@ -18,6 +20,7 @@ use crate::shards::shard::ShardId;
 pub enum Lookup {
     None,
     Single(Record),
+    // We may want to implement multi-record lookup in the future
 }
 
 impl From<Record> for Lookup {
@@ -28,6 +31,7 @@ impl From<Record> for Lookup {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct LookupRequest {
+    #[serde(rename = "collection")]
     pub collection_name: String,
     pub with_payload: WithPayloadInterface,
     pub with_vectors: WithVector,

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -1,0 +1,98 @@
+use std::fmt::Display;
+
+use segment::data_types::groups::GroupId;
+use segment::types::PointIdType;
+use uuid::Uuid;
+
+/// A value that can be used as a temporary ID
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub enum PseudoId {
+    String(String),
+    NumberU64(u64),
+    NumberI64(i64),
+}
+
+impl Display for PseudoId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PseudoId::String(s) => write!(f, "{}", s),
+            PseudoId::NumberU64(n) => write!(f, "{}", n),
+            PseudoId::NumberI64(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl From<GroupId> for PseudoId {
+    fn from(id: GroupId) -> Self {
+        match id {
+            GroupId::String(s) => Self::String(s),
+            GroupId::NumberU64(n) => Self::NumberU64(n),
+            GroupId::NumberI64(n) => Self::NumberI64(n),
+        }
+    }
+}
+
+impl From<PseudoId> for GroupId {
+    fn from(id: PseudoId) -> Self {
+        match id {
+            PseudoId::String(s) => Self::String(s),
+            PseudoId::NumberU64(n) => Self::NumberU64(n),
+            PseudoId::NumberI64(n) => Self::NumberI64(n),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConversionError {
+    IntError(core::num::TryFromIntError),
+    ParseError(uuid::Error),
+}
+
+impl TryFrom<PseudoId> for PointIdType {
+    type Error = ConversionError;
+
+    fn try_from(value: PseudoId) -> Result<Self, Self::Error> {
+        match value {
+            PseudoId::String(s) => Ok(PointIdType::Uuid(
+                Uuid::try_parse(&s).map_err(ConversionError::ParseError)?,
+            )),
+            PseudoId::NumberU64(n) => Ok(PointIdType::NumId(n)),
+            PseudoId::NumberI64(n) => Ok(PointIdType::NumId(
+                u64::try_from(n).map_err(ConversionError::IntError)?,
+            )),
+        }
+    }
+}
+
+impl From<PointIdType> for PseudoId {
+    fn from(id: PointIdType) -> Self {
+        match id {
+            PointIdType::NumId(n) => PseudoId::NumberU64(n),
+            PointIdType::Uuid(u) => PseudoId::String(u.to_string()),
+        }
+    }
+}
+
+impl From<u64> for PseudoId {
+    fn from(id: u64) -> Self {
+        PseudoId::NumberU64(id)
+    }
+}
+
+impl From<i64> for PseudoId {
+    fn from(id: i64) -> Self {
+        PseudoId::NumberI64(id)
+    }
+}
+
+impl From<String> for PseudoId {
+    fn from(id: String) -> Self {
+        PseudoId::String(id)
+    }
+}
+
+impl From<&str> for PseudoId {
+    fn from(id: &str) -> Self {
+        PseudoId::String(id.to_string())
+    }
+}

--- a/lib/collection/tests/lookup_test.rs
+++ b/lib/collection/tests/lookup_test.rs
@@ -1,0 +1,230 @@
+use collection::collection::Collection;
+use collection::lookup::{lookup_ids, LookupRequest};
+use collection::operations::consistency_params::ReadConsistency;
+use collection::operations::point_ops::{Batch, WriteOrdering};
+use collection::shards::shard::ShardId;
+use common::simple_collection_fixture;
+use itertools::Itertools;
+use rand::rngs::SmallRng;
+use rand::{self, Rng, SeedableRng};
+use rstest::*;
+use segment::data_types::groups::PseudoId;
+use segment::data_types::vectors::VectorStruct;
+use segment::types::{Payload, PointIdType};
+use serde_json::json;
+use tempfile::Builder;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+mod common;
+
+const SEED: u64 = 42;
+
+struct Resources {
+    request: LookupRequest,
+    collection: RwLock<Collection>,
+    read_consistency: Option<ReadConsistency>,
+    shard_selection: Option<ShardId>,
+}
+
+async fn setup() -> Resources {
+    let request = LookupRequest {
+        collection_name: "test".to_string(),
+        values: vec![],
+        with_payload: false.into(),
+        with_vectors: false.into(),
+    };
+
+    let collection_dir = Builder::new().prefix("storage").tempdir().unwrap();
+
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let int_ids = (0..1000).map(PointIdType::from);
+
+    let mut rng = SmallRng::seed_from_u64(SEED);
+    let uuids = (0..1000).map(|_| PointIdType::Uuid(Uuid::from_u128(rng.gen())));
+
+    let ids = int_ids.chain(uuids).collect_vec();
+
+    let mut rng = SmallRng::seed_from_u64(SEED);
+    let vectors = (0..2000)
+        .map(|_| rng.gen::<[f32; 4]>().to_vec())
+        .collect_vec();
+
+    let payloads = ids
+        .iter()
+        .map(|i| Some(Payload::from(json!({ "foo": format!("bar {}", i) }))))
+        .collect_vec();
+
+    let upsert_points = collection::operations::CollectionUpdateOperations::PointOperation(
+        Batch {
+            ids,
+            vectors: vectors.into(),
+            payloads: Some(payloads),
+        }
+        .into(),
+    );
+
+    collection
+        .update_from_client(upsert_points, true, WriteOrdering::default())
+        .await
+        .unwrap();
+
+    let read_consistency = None;
+
+    let shard_selection = None;
+
+    Resources {
+        request,
+        collection: RwLock::new(collection),
+        read_consistency,
+        shard_selection,
+    }
+}
+
+#[tokio::test]
+async fn happy_lookup_ids() {
+    let Resources {
+        mut request,
+        collection,
+        read_consistency,
+        shard_selection,
+    } = setup().await;
+
+    let collection = collection.read().await;
+
+    let collection_by_name = |_: String| async { Some(collection) };
+
+    let n = 100u64;
+    let ints = (0..n).map_into();
+
+    let mut rng = SmallRng::seed_from_u64(SEED);
+    let uuids = (0..n)
+        .map(|_| Uuid::from_u128(rng.gen()).to_string())
+        .map_into();
+
+    request.values.extend(ints.chain(uuids));
+    request.with_payload = true.into();
+    request.with_vectors = true.into();
+
+    let result = lookup_ids(
+        request.clone(),
+        collection_by_name,
+        read_consistency,
+        shard_selection,
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+
+    assert_eq!(result.len(), (n * 2) as usize);
+
+    let mut rng = SmallRng::seed_from_u64(SEED);
+
+    // use points 0..n and 1000..1000+n as expected vectors
+    let expected_vectors = (0..1000 + n)
+        .map(|i| (i, rng.gen::<[f32; 4]>().to_vec()))
+        .filter(|(i, _)| !(&n..&1000).contains(&i))
+        .map(|(_, v)| v)
+        .map(VectorStruct::from);
+
+    for (id_value, vector) in request.values.into_iter().zip(expected_vectors) {
+        assert_eq!(
+            result.get(&id_value).unwrap().id,
+            PointIdType::try_from(id_value.clone()).unwrap()
+        );
+        assert_eq!(
+            result.get(&id_value).unwrap().payload,
+            Some(Payload::from(json!({ "foo": format!("bar {}", id_value) })))
+        );
+        assert_eq!(result.get(&id_value).unwrap().vector, Some(vector));
+    }
+}
+
+fn first_uuid() -> String {
+    let mut rng = SmallRng::seed_from_u64(SEED);
+    Uuid::from_u128(rng.gen()).to_string()
+}
+
+#[rstest]
+#[case::existing_uuid(first_uuid())]
+#[case::zero_int(0i64)]
+#[case::positive_int(1i64)]
+#[case::existing_uint(999u64)]
+fn parsable_pseudo_id_to_point_id(#[case] value: impl Into<PseudoId>) {
+    let value = value.into();
+    assert!(PointIdType::try_from(value).is_ok());
+}
+
+#[rstest]
+#[case::negative_int(-1i64)]
+#[case::non_uuid_string("not a uuid")]
+fn non_parsable_pseudo_id_to_point_id(#[case] value: impl Into<PseudoId>) {
+    let value = value.into();
+    assert!(PointIdType::try_from(value).is_err());
+}
+
+#[rstest]
+#[case::uuid(Uuid::new_v4().to_string())]
+#[case::int(1001u64)]
+#[tokio::test]
+async fn inexisting_lookup_ids_are_ignored(#[case] value: impl Into<PseudoId>) {
+    let value = value.into();
+
+    let Resources {
+        mut request,
+        collection,
+        read_consistency,
+        shard_selection,
+    } = setup().await;
+
+    let collection = collection.read().await;
+
+    let collection_by_name = |_: String| async { Some(collection) };
+
+    request.values = vec![value];
+    request.with_payload = true.into();
+    request.with_vectors = true.into();
+
+    let result = lookup_ids(
+        request.clone(),
+        collection_by_name,
+        read_consistency,
+        shard_selection,
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+
+    assert_eq!(result.len(), 0);
+}
+
+#[tokio::test]
+async fn err_when_collection_by_name_returns_none() {
+    let Resources {
+        request,
+        collection: _,
+        read_consistency,
+        shard_selection,
+    } = setup().await;
+
+    let collection_by_name = |_: String| async { None };
+
+    let result = lookup_ids(
+        request.clone(),
+        collection_by_name,
+        read_consistency,
+        shard_selection,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Collection test not found".to_string()
+    );
+}

--- a/lib/collection/tests/lookup_test.rs
+++ b/lib/collection/tests/lookup_test.rs
@@ -1,4 +1,5 @@
 use collection::collection::Collection;
+use collection::lookup::types::PseudoId;
 use collection::lookup::{lookup_ids, Lookup, LookupRequest};
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::point_ops::{Batch, WriteOrdering};
@@ -8,7 +9,6 @@ use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
 use rstest::*;
-use segment::data_types::groups::PseudoId;
 use segment::data_types::vectors::VectorStruct;
 use segment::types::{Payload, PointIdType};
 use serde_json::json;

--- a/lib/segment/src/data_types/groups.rs
+++ b/lib/segment/src/data_types/groups.rs
@@ -7,7 +7,97 @@ use uuid::Uuid;
 
 use crate::types::PointIdType;
 
-pub type GroupId = PseudoId;
+/// Value of the group_by key, shared across all the hits in the group
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone, Hash)]
+#[serde(untagged)]
+pub enum GroupId {
+    String(String),
+    NumberU64(u64),
+    NumberI64(i64),
+}
+
+impl From<PseudoId> for GroupId {
+    fn from(id: PseudoId) -> Self {
+        match id {
+            PseudoId::String(s) => Self::String(s),
+            PseudoId::NumberU64(n) => Self::NumberU64(n),
+            PseudoId::NumberI64(n) => Self::NumberI64(n),
+        }
+    }
+}
+
+impl From<u64> for GroupId {
+    fn from(id: u64) -> Self {
+        GroupId::NumberU64(id)
+    }
+}
+
+impl From<i64> for GroupId {
+    fn from(id: i64) -> Self {
+        GroupId::NumberI64(id)
+    }
+}
+
+impl From<String> for GroupId {
+    fn from(id: String) -> Self {
+        GroupId::String(id)
+    }
+}
+
+impl From<&str> for GroupId {
+    fn from(id: &str) -> Self {
+        GroupId::String(id.to_string())
+    }
+}
+
+impl From<GroupId> for serde_json::Value {
+    fn from(key: GroupId) -> Self {
+        match key {
+            GroupId::String(s) => serde_json::Value::String(s),
+            GroupId::NumberU64(n) => json!(n),
+            GroupId::NumberI64(n) => json!(n),
+        }
+    }
+}
+
+impl TryFrom<&serde_json::Value> for GroupId {
+    type Error = ();
+
+    /// Only allows Strings and Numbers to be converted into Scalar
+    fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
+        match value {
+            serde_json::Value::String(s) => Ok(Self::String(s.to_string())),
+            serde_json::Value::Number(n) => {
+                if let Some(n_i64) = n.as_i64() {
+                    Ok(Self::NumberI64(n_i64))
+                } else if let Some(n_u64) = n.as_u64() {
+                    Ok(Self::NumberU64(n_u64))
+                } else {
+                    Err(())
+                }
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+impl GroupId {
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            GroupId::NumberI64(id) => Some(*id),
+            GroupId::NumberU64(id) => i64::try_from(*id).ok(),
+            GroupId::String(_) => None,
+        }
+    }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            GroupId::NumberI64(id) => u64::try_from(*id).ok(),
+            GroupId::NumberU64(id) => Some(*id),
+            GroupId::String(_) => None,
+        }
+    }
+}
 
 /// A value that can be used as a temporary ID
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone, Hash)]
@@ -28,57 +118,12 @@ impl Display for PseudoId {
     }
 }
 
-impl From<u64> for PseudoId {
-    fn from(id: u64) -> Self {
-        PseudoId::NumberU64(id)
-    }
-}
-
-impl From<i64> for PseudoId {
-    fn from(id: i64) -> Self {
-        PseudoId::NumberI64(id)
-    }
-}
-
-impl From<String> for PseudoId {
-    fn from(id: String) -> Self {
-        PseudoId::String(id)
-    }
-}
-
-impl From<&str> for PseudoId {
-    fn from(id: &str) -> Self {
-        PseudoId::String(id.to_string())
-    }
-}
-
-impl From<PseudoId> for serde_json::Value {
-    fn from(key: PseudoId) -> Self {
-        match key {
-            PseudoId::String(s) => serde_json::Value::String(s),
-            PseudoId::NumberU64(n) => json!(n),
-            PseudoId::NumberI64(n) => json!(n),
-        }
-    }
-}
-
-impl TryFrom<&serde_json::Value> for PseudoId {
-    type Error = ();
-
-    /// Only allows Strings and Numbers to be converted into Scalar
-    fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        match value {
-            serde_json::Value::String(s) => Ok(Self::String(s.to_string())),
-            serde_json::Value::Number(n) => {
-                if let Some(n_i64) = n.as_i64() {
-                    Ok(Self::NumberI64(n_i64))
-                } else if let Some(n_u64) = n.as_u64() {
-                    Ok(Self::NumberU64(n_u64))
-                } else {
-                    Err(())
-                }
-            }
-            _ => Err(()),
+impl From<GroupId> for PseudoId {
+    fn from(id: GroupId) -> Self {
+        match id {
+            GroupId::String(s) => Self::String(s),
+            GroupId::NumberU64(n) => Self::NumberU64(n),
+            GroupId::NumberI64(n) => Self::NumberI64(n),
         }
     }
 }
@@ -104,20 +149,26 @@ impl From<PointIdType> for PseudoId {
     }
 }
 
-impl PseudoId {
-    pub fn as_i64(&self) -> Option<i64> {
-        match self {
-            PseudoId::NumberI64(id) => Some(*id),
-            PseudoId::NumberU64(id) => i64::try_from(*id).ok(),
-            PseudoId::String(_) => None,
-        }
+impl From<u64> for PseudoId {
+    fn from(id: u64) -> Self {
+        PseudoId::NumberU64(id)
     }
+}
 
-    pub fn as_u64(&self) -> Option<u64> {
-        match self {
-            PseudoId::NumberI64(id) => u64::try_from(*id).ok(),
-            PseudoId::NumberU64(id) => Some(*id),
-            PseudoId::String(_) => None,
-        }
+impl From<i64> for PseudoId {
+    fn from(id: i64) -> Self {
+        PseudoId::NumberI64(id)
+    }
+}
+
+impl From<String> for PseudoId {
+    fn from(id: String) -> Self {
+        PseudoId::String(id)
+    }
+}
+
+impl From<&str> for PseudoId {
+    fn from(id: &str) -> Self {
+        PseudoId::String(id.to_string())
     }
 }

--- a/lib/segment/src/data_types/groups.rs
+++ b/lib/segment/src/data_types/groups.rs
@@ -1,53 +1,71 @@
+use std::fmt::Display;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use uuid::Uuid;
 
+use crate::types::PointIdType;
+
+pub type GroupId = PseudoId;
+
+/// A value that can be used as a temporary ID
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone, Hash)]
 #[serde(untagged)]
-pub enum GroupId {
+pub enum PseudoId {
     String(String),
     NumberU64(u64),
     NumberI64(i64),
 }
 
-impl From<u64> for GroupId {
-    fn from(id: u64) -> Self {
-        GroupId::NumberU64(id)
-    }
-}
-
-impl From<i64> for GroupId {
-    fn from(id: i64) -> Self {
-        GroupId::NumberI64(id)
-    }
-}
-
-impl From<String> for GroupId {
-    fn from(id: String) -> Self {
-        GroupId::String(id)
-    }
-}
-
-impl From<&str> for GroupId {
-    fn from(id: &str) -> Self {
-        GroupId::String(id.to_string())
-    }
-}
-
-impl From<GroupId> for serde_json::Value {
-    fn from(key: GroupId) -> Self {
-        match key {
-            GroupId::String(s) => serde_json::Value::String(s),
-            GroupId::NumberU64(n) => json!(n),
-            GroupId::NumberI64(n) => json!(n),
+impl Display for PseudoId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PseudoId::String(s) => write!(f, "{}", s),
+            PseudoId::NumberU64(n) => write!(f, "{}", n),
+            PseudoId::NumberI64(n) => write!(f, "{}", n),
         }
     }
 }
 
-impl TryFrom<&serde_json::Value> for GroupId {
+impl From<u64> for PseudoId {
+    fn from(id: u64) -> Self {
+        PseudoId::NumberU64(id)
+    }
+}
+
+impl From<i64> for PseudoId {
+    fn from(id: i64) -> Self {
+        PseudoId::NumberI64(id)
+    }
+}
+
+impl From<String> for PseudoId {
+    fn from(id: String) -> Self {
+        PseudoId::String(id)
+    }
+}
+
+impl From<&str> for PseudoId {
+    fn from(id: &str) -> Self {
+        PseudoId::String(id.to_string())
+    }
+}
+
+impl From<PseudoId> for serde_json::Value {
+    fn from(key: PseudoId) -> Self {
+        match key {
+            PseudoId::String(s) => serde_json::Value::String(s),
+            PseudoId::NumberU64(n) => json!(n),
+            PseudoId::NumberI64(n) => json!(n),
+        }
+    }
+}
+
+impl TryFrom<&serde_json::Value> for PseudoId {
     type Error = ();
 
-    /// Only allows Strings and Numbers to be converted into GroupId
+    /// Only allows Strings and Numbers to be converted into Scalar
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
         match value {
             serde_json::Value::String(s) => Ok(Self::String(s.to_string())),
@@ -65,20 +83,41 @@ impl TryFrom<&serde_json::Value> for GroupId {
     }
 }
 
-impl GroupId {
+impl TryFrom<PseudoId> for PointIdType {
+    type Error = ();
+
+    fn try_from(value: PseudoId) -> Result<Self, Self::Error> {
+        match value {
+            PseudoId::String(s) => Ok(PointIdType::Uuid(Uuid::try_parse(&s).map_err(|_| ())?)),
+            PseudoId::NumberU64(n) => Ok(PointIdType::NumId(n)),
+            PseudoId::NumberI64(n) => Ok(PointIdType::NumId(u64::try_from(n).map_err(|_| ())?)),
+        }
+    }
+}
+
+impl From<PointIdType> for PseudoId {
+    fn from(id: PointIdType) -> Self {
+        match id {
+            PointIdType::NumId(n) => PseudoId::NumberU64(n),
+            PointIdType::Uuid(u) => PseudoId::String(u.to_string()),
+        }
+    }
+}
+
+impl PseudoId {
     pub fn as_i64(&self) -> Option<i64> {
         match self {
-            GroupId::NumberI64(id) => Some(*id),
-            GroupId::NumberU64(id) => i64::try_from(*id).ok(),
-            GroupId::String(_) => None,
+            PseudoId::NumberI64(id) => Some(*id),
+            PseudoId::NumberU64(id) => i64::try_from(*id).ok(),
+            PseudoId::String(_) => None,
         }
     }
 
     pub fn as_u64(&self) -> Option<u64> {
         match self {
-            GroupId::NumberI64(id) => u64::try_from(*id).ok(),
-            GroupId::NumberU64(id) => Some(*id),
-            GroupId::String(_) => None,
+            PseudoId::NumberI64(id) => u64::try_from(*id).ok(),
+            PseudoId::NumberU64(id) => Some(*id),
+            PseudoId::String(_) => None,
         }
     }
 }

--- a/lib/segment/src/data_types/groups.rs
+++ b/lib/segment/src/data_types/groups.rs
@@ -1,11 +1,6 @@
-use std::fmt::Display;
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use uuid::Uuid;
-
-use crate::types::PointIdType;
 
 /// Value of the group_by key, shared across all the hits in the group
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone, Hash)]
@@ -14,16 +9,6 @@ pub enum GroupId {
     String(String),
     NumberU64(u64),
     NumberI64(i64),
-}
-
-impl From<PseudoId> for GroupId {
-    fn from(id: PseudoId) -> Self {
-        match id {
-            PseudoId::String(s) => Self::String(s),
-            PseudoId::NumberU64(n) => Self::NumberU64(n),
-            PseudoId::NumberI64(n) => Self::NumberI64(n),
-        }
-    }
 }
 
 impl From<u64> for GroupId {
@@ -96,79 +81,5 @@ impl GroupId {
             GroupId::NumberU64(id) => Some(*id),
             GroupId::String(_) => None,
         }
-    }
-}
-
-/// A value that can be used as a temporary ID
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone, Hash)]
-#[serde(untagged)]
-pub enum PseudoId {
-    String(String),
-    NumberU64(u64),
-    NumberI64(i64),
-}
-
-impl Display for PseudoId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PseudoId::String(s) => write!(f, "{}", s),
-            PseudoId::NumberU64(n) => write!(f, "{}", n),
-            PseudoId::NumberI64(n) => write!(f, "{}", n),
-        }
-    }
-}
-
-impl From<GroupId> for PseudoId {
-    fn from(id: GroupId) -> Self {
-        match id {
-            GroupId::String(s) => Self::String(s),
-            GroupId::NumberU64(n) => Self::NumberU64(n),
-            GroupId::NumberI64(n) => Self::NumberI64(n),
-        }
-    }
-}
-
-impl TryFrom<PseudoId> for PointIdType {
-    type Error = ();
-
-    fn try_from(value: PseudoId) -> Result<Self, Self::Error> {
-        match value {
-            PseudoId::String(s) => Ok(PointIdType::Uuid(Uuid::try_parse(&s).map_err(|_| ())?)),
-            PseudoId::NumberU64(n) => Ok(PointIdType::NumId(n)),
-            PseudoId::NumberI64(n) => Ok(PointIdType::NumId(u64::try_from(n).map_err(|_| ())?)),
-        }
-    }
-}
-
-impl From<PointIdType> for PseudoId {
-    fn from(id: PointIdType) -> Self {
-        match id {
-            PointIdType::NumId(n) => PseudoId::NumberU64(n),
-            PointIdType::Uuid(u) => PseudoId::String(u.to_string()),
-        }
-    }
-}
-
-impl From<u64> for PseudoId {
-    fn from(id: u64) -> Self {
-        PseudoId::NumberU64(id)
-    }
-}
-
-impl From<i64> for PseudoId {
-    fn from(id: i64) -> Self {
-        PseudoId::NumberI64(id)
-    }
-}
-
-impl From<String> for PseudoId {
-    fn from(id: String) -> Self {
-        PseudoId::String(id)
-    }
-}
-
-impl From<&str> for PseudoId {
-    fn from(id: &str) -> Self {
-        PseudoId::String(id.to_string())
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -19,7 +19,7 @@ use validator::{Validate, ValidationErrors};
 
 use crate::common::utils;
 use crate::common::utils::MultiValue;
-use crate::data_types::groups::GroupId;
+use crate::data_types::groups::PseudoId;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{VectorElementType, VectorStruct};
 use crate::spaces::metric::Metric;
@@ -203,8 +203,29 @@ impl PartialEq for ScoredPoint {
 pub struct PointGroup {
     /// Scored points that have the same value of the group_by key
     pub hits: Vec<ScoredPoint>,
-    /// Value of the group_by key shared by all the hits
-    pub id: GroupId,
+    #[schemars(with = "GroupId")]
+    pub id: PseudoId,
+}
+
+/// Only used for schema generation, hack to keep the `GroupId` type name in the openapi schema
+pub struct GroupId;
+
+impl JsonSchema for GroupId {
+    fn schema_name() -> String {
+        "GroupId".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema = PseudoId::json_schema(gen).into_object();
+
+        if let Some(mut meta) = schema.metadata.as_deref_mut() {
+            meta.description = Some(
+                "Value of the group_by field shared across all the hits in the group".to_string(),
+            );
+        }
+
+        schema.into()
+    }
 }
 
 /// Type of segment

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -19,7 +19,7 @@ use validator::{Validate, ValidationErrors};
 
 use crate::common::utils;
 use crate::common::utils::MultiValue;
-use crate::data_types::groups::PseudoId;
+use crate::data_types::groups::GroupId;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{VectorElementType, VectorStruct};
 use crate::spaces::metric::Metric;
@@ -203,29 +203,8 @@ impl PartialEq for ScoredPoint {
 pub struct PointGroup {
     /// Scored points that have the same value of the group_by key
     pub hits: Vec<ScoredPoint>,
-    #[schemars(with = "GroupId")]
-    pub id: PseudoId,
-}
-
-/// Only used for schema generation, hack to keep the `GroupId` type name in the openapi schema
-pub struct GroupId;
-
-impl JsonSchema for GroupId {
-    fn schema_name() -> String {
-        "GroupId".to_string()
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let mut schema = PseudoId::json_schema(gen).into_object();
-
-        if let Some(mut meta) = schema.metadata.as_deref_mut() {
-            meta.description = Some(
-                "Value of the group_by field shared across all the hits in the group".to_string(),
-            );
-        }
-
-        schema.into()
-    }
+    /// Value of the group_by key, shared across all the hits in the group
+    pub id: GroupId,
 }
 
 /// Type of segment

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1397,6 +1397,12 @@ pub enum WithPayloadInterface {
     Selector(PayloadSelector),
 }
 
+impl From<bool> for WithPayloadInterface {
+    fn from(b: bool) -> Self {
+        WithPayloadInterface::Bool(b)
+    }
+}
+
 /// Options for specifying which vector to include
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Adds the internal mechanism for retrieving points from another collection given a list of PseudoIds

- create new PseudoId type from GroupId
- impl try_from PseudoId to PointIdType
- create lookup_ids function
- add tests

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?
