### PR TITLE
Enable `Segment::prefault_mmap_pages` after load and optimization (#1791)

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -529,6 +529,8 @@ pub trait SegmentOptimizer {
                 )?;
             }
 
+            optimized_segment.prefault_mmap_pages();
+
             let (_, proxies) = write_segments_guard.swap(optimized_segment, &proxy_ids);
 
             let has_appendable_segments =

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -236,6 +236,12 @@ impl LocalShard {
 
         collection.load_from_wal(collection_id)?;
 
+        for (_, segment) in collection.segments.read().iter() {
+            if let LockedSegment::Original(segment) = segment {
+                segment.read().prefault_mmap_pages();
+            }
+        }
+
         Ok(collection)
     }
 

--- a/lib/segment/src/common/mmap_ops.rs
+++ b/lib/segment/src/common/mmap_ops.rs
@@ -1,4 +1,5 @@
 use std::fs::OpenOptions;
+use std::hint::black_box;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -83,6 +84,8 @@ where
     for chunk in mmap.chunks(dst.len()) {
         dst[..chunk.len()].copy_from_slice(chunk);
     }
+
+    black_box(dst);
 
     log::trace!(
         "Reading mmap{separator}{path:?} to populate cache took {:?}",


### PR DESCRIPTION
This PR adds a few calls to `Segment::prefault_mmap_pages`:

- on `Segment` load
- and after `Segment` optimization