### PR TITLE
Fix warnings pointed out by `cargo doc`

### DIFF
--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -237,11 +237,11 @@ pub fn rectangle_hashes(rectangle: &GeoBoundingBox, max_regions: usize) -> Vec<G
 }
 
 /// A globally-average value is usually considered to be 6,371 kilometres (3,959 mi) with a 0.3% variability (±10 km).
-/// https://en.wikipedia.org/wiki/Earth_radius.
+/// <https://en.wikipedia.org/wiki/Earth_radius>.
 const EARTH_RADIUS_METERS: f64 = 6371.0 * 1000.;
 
 /// Returns the GeoBoundingBox that defines the MBR
-/// http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates#Longitude
+/// <http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates#Longitude>
 fn minimum_bounding_rectangle_for_circle(circle: &GeoRadius) -> GeoBoundingBox {
     // circle.radius is in meter
     let angular_radius: f64 = circle.radius / EARTH_RADIUS_METERS;

--- a/lib/segment/src/index/field_index/stat_tools.rs
+++ b/lib/segment/src/index/field_index/stat_tools.rs
@@ -72,7 +72,7 @@ fn prob_not_select(total: usize, avg: f64, selected: usize) -> f64 {
 
 /// Calculate number of selected points, based on the amount of matched values.
 /// Assuming that values are randomly distributed among points and each point can have multiple values.
-/// Math is based on: https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives
+/// Math is based on: <https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives>
 pub fn number_of_selected_points(points: usize, values: usize) -> usize {
     let prob_of_selection = 1. - (-(values as f64 / points as f64)).exp();
     (prob_of_selection * points as f64).round() as usize

--- a/lib/segment/src/index/key_encoding.rs
+++ b/lib/segment/src/index/key_encoding.rs
@@ -18,7 +18,7 @@ const I64_KEY_LEN: usize = 12;
 /// A single-byte prefix tag is appended to the front of the encoding slice to ensures that
 /// NaNs are always sorted first.
 ///
-/// This approach was inspired by https://github.com/cockroachdb/cockroach/blob/master/pkg/util/encoding/float.go
+/// This approach was inspired by <https://github.com/cockroachdb/cockroach/blob/master/pkg/util/encoding/float.go>
 ///
 ///
 /// #f64 encoding format

--- a/lib/segment/src/madvise.rs
+++ b/lib/segment/src/madvise.rs
@@ -6,24 +6,24 @@ use std::io;
 use serde::Deserialize;
 
 /// Global [`Advice`] value, to trivially set [`Advice`] value
-/// used by all memmaps created by the [`segment`] crate.
+/// used by all memmaps created by the `segment` crate.
 ///
-/// See [`store_global`] and [`load_global`].
+/// See [`set_global`] and [`get_global`].
 static ADVICE: parking_lot::RwLock<Advice> = parking_lot::RwLock::new(Advice::Random);
 
 /// Set global [`Advice`] value.
 ///
-/// When [`segment`] crate creates [`memmap2::Mmap`] or [`memmap2::MmapMut`]
-/// _for a memmapeped, on-disk HNSW index or vector storage access_
-/// it will "advise" created memmap with the current global [`Advice`] value
-/// (obtained with [`load_global`]).
+/// When the `segment` crate creates [`memmap2::Mmap`] or [`memmap2::MmapMut`]
+/// _for a memory-mapped, on-disk HNSW index or vector storage access_
+/// it will "advise" the created memmap with the current global [`Advice`] value
+/// (obtained with [`get_global`]).
 ///
 /// It is recommended to set the desired [`Advice`] value before calling any other function
-/// from the [`segment`] crate and not to change it afterwards.
+/// from the `segment` crate and not to change it afterwards.
 ///
-/// The [`segment`] crate itself does not modify global [`Advice`] value.
+/// The `segment` crate itself does not modify the global [`Advice`] value.
 ///
-/// Default global [`Advice`] value is [`Advice::Random`].
+/// The default global [`Advice`] value is [`Advice::Random`].
 pub fn set_global(advice: Advice) {
     *ADVICE.write() = advice;
 }
@@ -34,9 +34,9 @@ pub fn get_global() -> Advice {
 }
 
 /// Platform-independent version of [`memmap2::Advice`].
-/// See [`memmap2::Advice`] and [madvise()] man page.
+/// See [`memmap2::Advice`] and [`madvise(2)`] man page.
 ///
-/// [madvice()]: https://man7.org/linux/man-pages/man2/madvise.2.html
+/// [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Advice {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -104,7 +104,7 @@ impl Segment {
     /// - existing named vectors are replaced
     /// - existing named vectors not specified are deleted
     ///
-    /// This differs with [`update_vectors`], because this deletes unspecified vectors.
+    /// This differs with [`Segment::update_vectors`], because this deletes unspecified vectors.
     ///
     /// # Warning
     ///
@@ -141,7 +141,7 @@ impl Segment {
     /// - existing named vectors are replaced
     /// - existing named vectors not specified are untouched and kept as-is
     ///
-    /// This differs with [`replace_all_vectors`], because this keeps unspecified vectors as-is.
+    /// This differs with [`Segment::replace_all_vectors`], because this keeps unspecified vectors as-is.
     ///
     /// # Warning
     ///

--- a/lib/segment/src/utils/tar.rs
+++ b/lib/segment/src/utils/tar.rs
@@ -33,7 +33,7 @@ pub fn append_file(
         .map_err(|err| failed_to_append_error(file, err))
 }
 
-/// Create "failed to append <path> to the archive" error.
+/// Create "failed to append `<path>` to the archive" error.
 pub fn failed_to_append_error(path: &Path, err: impl fmt::Display) -> OperationError {
     OperationError::service_error(format!(
         "failed to append {path:?} path to the archive: {err}"

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -50,11 +50,11 @@ pub trait VectorStorage {
 
     /// Get the number of available vectors, considering deleted points and vectors
     ///
-    /// This uses [`total_vector_count`] and [`deleted_vector_count`] internally.
+    /// This uses [`VectorStorage::total_vector_count`] and [`VectorStorage::deleted_vector_count`] internally.
     ///
     /// # Warning
     ///
-    /// This number may not always be accurate. See warning in [`deleted_vector_count`] documentation.
+    /// This number may not always be accurate. See warning in [`VectorStorage::deleted_vector_count`] documentation.
     fn available_vector_count(&self) -> usize {
         self.total_vector_count()
             .saturating_sub(self.deleted_vector_count())

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -19,7 +19,7 @@ use crate::{StorageError, TableOfContent};
 pub struct SnapshotConfig {
     /// Map collection name to snapshot file name
     pub collections_mapping: HashMap<String, String>,
-    /// Aliases for collections <alias>:<collection_name>
+    /// Aliases for collections `<alias>:<collection_name>`
     #[serde(default)]
     pub collections_aliases: HashMap<String, String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ struct Args {
 
     /// Disable telemetry sending to developers
     /// If provided - telemetry collection will be disabled.
-    /// Read more: https://qdrant.tech/documentation/guides/telemetry
+    /// Read more: <https://qdrant.tech/documentation/guides/telemetry>
     #[arg(long, action, default_value_t = false)]
     disable_telemetry: bool,
 }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -12,7 +12,7 @@ use storage::content_manager::toc::{ALIASES_PATH, COLLECTIONS_DIR};
 ///
 /// # Arguments
 ///
-/// * `mapping` - [ "<path>:<collection_name>" ]
+/// * `mapping` - `[ <path>:<collection_name> ]`
 /// * `force` - if true, allow to overwrite collections from snapshots
 ///
 /// # Returns


### PR DESCRIPTION
Fixes warnings pointed out by `cargo doc` as well as some typos. The adjusted links were not clickable prior to this change. The `madvise(2)` change removes an ambiguity between the manual reference and the module name: prior to this change, it would link to the `madvise` module rather than to the manpage.

There are some more warnings which concern mentioning private items in docstrings of public items but I think they can be safely ignored as the libraries are not public.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
