### PR TITLE
Coalesce cluster operation to fix dropped callback

### DIFF
--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -161,7 +161,16 @@ impl<T> From<std::sync::mpsc::SendError<T>> for StorageError {
 impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
     fn from(err: tokio::sync::oneshot::error::RecvError) -> Self {
         StorageError::ServiceError {
-            description: format!("Channel sender dropped: {err}"),
+            description: format!("Oneshot channel sender dropped: {err}"),
+            backtrace: Some(Backtrace::force_capture().to_string()),
+        }
+    }
+}
+
+impl From<tokio::sync::broadcast::error::RecvError> for StorageError {
+    fn from(err: tokio::sync::broadcast::error::RecvError) -> Self {
+        StorageError::ServiceError {
+            description: format!("Broadcast channel sender dropped: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -44,9 +44,9 @@ def create_collection(peer_url, collection="test_collection", shard_number=1, re
 
 def drop_collection(peer_url, collection="test_collection", timeout=10):
     # Delete collection in peer_url
-    r_batch = requests.delete(
+    r_delete = requests.delete(
         f"{peer_url}/collections/{collection}?timeout={timeout}")
-    assert_http_ok(r_batch)
+    assert_http_ok(r_delete)
 
 
 def search(peer_url, vector, city, collection="test_collection"):

--- a/tests/consensus_tests/test_cluster_operation_coalescing.py
+++ b/tests/consensus_tests/test_cluster_operation_coalescing.py
@@ -1,0 +1,47 @@
+import multiprocessing
+import pathlib
+
+from .fixtures import upsert_random_points, create_collection, drop_collection
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICA = 3
+
+
+def delete_collection_in_loop(peer_url, collection_name):
+    while True:
+        # fails if the the response is NOT successful
+        drop_collection(peer_url, collection_name)
+
+
+# Triggers repeatedly at most 2 concurrent collection deletions
+def run_delete_collection_in_background(peer_url, collection_name):
+    p1 = multiprocessing.Process(target=delete_collection_in_loop, args=(peer_url, collection_name))
+    p2 = multiprocessing.Process(target=delete_collection_in_loop, args=(peer_url, collection_name))
+    p1.start()
+    p2.start()
+    return [p1, p2]
+
+
+def test_cluster_operation_coalescing(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name="test_collection",
+        peer_api_uris=peer_api_uris
+    )
+
+    [delete_p1, delete_p2] = run_delete_collection_in_background(peer_api_uris[1], "test_collection")
+
+    time.sleep(3)
+
+    # check that the delete processes did not fail
+    if not delete_p1.is_alive() or not delete_p2.is_alive():
+        raise Exception("Parallel delete processes failed")
+
+    delete_p1.kill()
+    delete_p2.kill()


### PR DESCRIPTION
This PR contains a fix and an optimization regarding dropped callback for cluster operation.

## Problem

Sending concurrent collection delete requests currently generates an internal error.

```
"Service internal error: Channel sender dropped: channel closed"
```

There are two issues here:

1. internal errors are not good
2. the error message is quite cryptic

The root cause of the problem is due to the way we are tracking callbacks for consensus operations.

That is, the way we notify a user that an operation was applied via consensus.

Given a cluster operations we:

1. generate a one shot channel to materialize the callback
2. send the operation to the consensus
3. save in the callbacks map the association between `operation` -> `channel sender`
4. wait for the `channel receiver` to receive a message for a given duration

In the consensus thread, when applying an incoming operation, we check if there exists a callback to notify which will unblock 4.

The problem is that we rely on the hashing of the operation struct for assigning callbacks.
This means two identical **concurrent**  operations will fight for the same callback spot and the last writer will win.

```rust
 // insert new sender AND drop existing binding
 on_apply_lock.insert(operation, sender);
```

The first operation gets its callback dropped, causing the `Channel sender dropped: channel closed` error on 4.

## Fix

This PR first makes the error much clearer with

```
"Service internal error: Error occurred while waiting for consensus operation. Channel sender dropped (channel closed)"
```

Then for the actual fix, this PR proposes to track multiple callbacks per operation to avoid dropping potential existing callbacks.

To do so, callbacks are tracked with a `broadcast` channel so that new operation can subscribe to an existing callback.

Broadcast channels must be bounded so I used a magic number that can be discussed.

## Optimization

If two identical operations are submitted concurrently to consensus, do we have to execute both?

This PR proposes to not submit the operation to consensus if there is already an identical operation in-flight.

The new operation simply subscribes to existing channel for a faster feedback.

## Test

The newly added integration test fails without the fix