### PR TITLE
Log better TLS and REST/gRPC start errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /snapshots
 /consensus_test_logs
 /config/local
+/tls
 *.log
 .qdrant-initialized

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -191,9 +191,7 @@ pub fn validate_named_vectors_not_empty(
 mod tests {
     use validator::Validate;
 
-    use crate::grpc::qdrant::{
-        CreateCollection, CreateFieldIndexCollection, SearchPoints, UpdateCollection,
-    };
+    use crate::grpc::qdrant::{CreateCollection, CreateFieldIndexCollection, SearchPoints};
 
     #[test]
     fn test_good_request() {

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -191,7 +191,9 @@ pub fn validate_named_vectors_not_empty(
 mod tests {
     use validator::Validate;
 
-    use crate::grpc::qdrant::{CreateCollection, CreateFieldIndexCollection, SearchPoints};
+    use crate::grpc::qdrant::{
+        CreateCollection, CreateFieldIndexCollection, SearchPoints, UpdateCollection,
+    };
 
     #[test]
     fn test_good_request() {

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -11,6 +11,8 @@ use rustls_pemfile::Item;
 
 use crate::settings::{Settings, TlsConfig};
 
+type Result<T> = std::result::Result<T, Error>;
+
 /// A TTL based rotating server certificate resolver
 struct RotatingCertificateResolver {
     /// TLS configuration used for loading/refreshing certified key
@@ -24,7 +26,7 @@ struct RotatingCertificateResolver {
 }
 
 impl RotatingCertificateResolver {
-    pub fn new(tls_config: TlsConfig, ttl: Option<Duration>) -> io::Result<Self> {
+    pub fn new(tls_config: TlsConfig, ttl: Option<Duration>) -> Result<Self> {
         let certified_key = load_certified_key(&tls_config)?;
 
         Ok(Self {
@@ -84,7 +86,7 @@ impl CertifiedKeyWithAge {
         }
     }
 
-    pub fn refresh(&mut self, tls_config: &TlsConfig) -> io::Result<()> {
+    pub fn refresh(&mut self, tls_config: &TlsConfig) -> Result<()> {
         *self = Self::from(load_certified_key(tls_config)?);
         Ok(())
     }
@@ -99,7 +101,7 @@ impl CertifiedKeyWithAge {
 }
 
 /// Load TLS configuration and construct certified key.
-fn load_certified_key(tls_config: &TlsConfig) -> io::Result<Arc<CertifiedKey>> {
+fn load_certified_key(tls_config: &TlsConfig) -> Result<Arc<CertifiedKey>> {
     // Load certificates
     let certs: Vec<Certificate> = with_buf_read(&tls_config.cert, rustls_pemfile::read_all)?
         .into_iter()
@@ -109,21 +111,17 @@ fn load_certified_key(tls_config: &TlsConfig) -> io::Result<Arc<CertifiedKey>> {
         })
         .collect();
     if certs.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            "No server certificate found",
-        ));
+        return Err(Error::NoServerCert);
     }
 
     // Load private key
-    let private_key_item = with_buf_read(&tls_config.key, rustls_pemfile::read_one)?
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "No private key found"))?;
+    let private_key_item =
+        with_buf_read(&tls_config.key, rustls_pemfile::read_one)?.ok_or(Error::NoPrivateKey)?;
     let (Item::RSAKey(pkey) | Item::PKCS8Key(pkey) | Item::ECKey(pkey)) = private_key_item else {
-        return Err(io::Error::new(io::ErrorKind::Other, "No private key found"))
+        return Err(Error::NoPrivateKey);
     };
     let private_key = rustls::PrivateKey(pkey);
-    let signing_key = rustls::sign::any_supported_type(&private_key)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+    let signing_key = rustls::sign::any_supported_type(&private_key).map_err(Error::Sign)?;
 
     // Construct certified key
     let certified_key = CertifiedKey::new(certs, signing_key);
@@ -133,12 +131,13 @@ fn load_certified_key(tls_config: &TlsConfig) -> io::Result<Arc<CertifiedKey>> {
 /// Generate an actix server configuration with TLS
 ///
 /// Uses TLS settings as configured in configuration by user.
-pub fn actix_tls_server_config(settings: &Settings) -> io::Result<ServerConfig> {
+pub fn actix_tls_server_config(settings: &Settings) -> Result<ServerConfig> {
     let config = ServerConfig::builder().with_safe_defaults();
     let tls_config = settings
         .tls
         .clone()
-        .ok_or_else(Settings::tls_config_is_undefined_error)?;
+        .ok_or_else(Settings::tls_config_is_undefined_error)
+        .map_err(Error::Io)?;
 
     // Verify client CA or not
     let config = if settings.service.verify_https_client_certificate {
@@ -161,12 +160,26 @@ pub fn actix_tls_server_config(settings: &Settings) -> io::Result<ServerConfig> 
     Ok(config)
 }
 
-fn with_buf_read<T>(
-    path: &str,
-    f: impl FnOnce(&mut dyn BufRead) -> io::Result<T>,
-) -> io::Result<T> {
-    let file = File::open(path)?;
+fn with_buf_read<T>(path: &str, f: impl FnOnce(&mut dyn BufRead) -> io::Result<T>) -> Result<T> {
+    let file = File::open(path).map_err(|err| Error::OpenFile(err, path.into()))?;
     let mut reader = BufReader::new(file);
     let dyn_reader: &mut dyn BufRead = &mut reader;
-    f(dyn_reader)
+    f(dyn_reader).map_err(|err| Error::ReadFile(err, path.into()))
+}
+
+/// Actix TLS errors.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("TLS file could not be opened: {1}")]
+    OpenFile(#[source] io::Error, String),
+    #[error("TLS file could not be read: {1}")]
+    ReadFile(#[source] io::Error, String),
+    #[error("TLS IO error")]
+    Io(#[source] io::Error),
+    #[error("no server certificate found")]
+    NoServerCert,
+    #[error("no private key found")]
+    NoPrivateKey,
+    #[error("TLS IO error")]
+    Sign(#[source] rustls::sign::SignError),
 }

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -118,7 +118,7 @@ fn load_certified_key(tls_config: &TlsConfig) -> Result<Arc<CertifiedKey>> {
     let private_key_item =
         with_buf_read(&tls_config.key, rustls_pemfile::read_one)?.ok_or(Error::NoPrivateKey)?;
     let (Item::RSAKey(pkey) | Item::PKCS8Key(pkey) | Item::ECKey(pkey)) = private_key_item else {
-        return Err(Error::NoPrivateKey);
+        return Err(Error::InvalidPrivateKey);
     };
     let private_key = rustls::PrivateKey(pkey);
     let signing_key = rustls::sign::any_supported_type(&private_key).map_err(Error::Sign)?;
@@ -180,6 +180,8 @@ pub enum Error {
     NoServerCert,
     #[error("no private key found")]
     NoPrivateKey,
+    #[error("invalid private key")]
+    InvalidPrivateKey,
     #[error("TLS signing error")]
     Sign(#[source] rustls::sign::SignError),
 }

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -174,12 +174,12 @@ pub enum Error {
     OpenFile(#[source] io::Error, String),
     #[error("TLS file could not be read: {1}")]
     ReadFile(#[source] io::Error, String),
-    #[error("TLS IO error")]
+    #[error("general TLS IO error")]
     Io(#[source] io::Error),
     #[error("no server certificate found")]
     NoServerCert,
     #[error("no private key found")]
     NoPrivateKey,
-    #[error("TLS IO error")]
+    #[error("TLS signing error")]
     Sign(#[source] rustls::sign::SignError),
 }

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -115,10 +115,8 @@ pub fn init(
                     .unwrap_or_else(|| "none".into()),
             );
 
-            let config = certificate_helpers::actix_tls_server_config(&settings).map_err(|err| io::Error::new(
-                io::ErrorKind::Other,
-                err,
-            ))?;
+            let config = certificate_helpers::actix_tls_server_config(&settings)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
             server.bind_rustls(bind_addr, config)?
         } else {
             log::info!("TLS disabled for REST API");

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -115,7 +115,10 @@ pub fn init(
                     .unwrap_or_else(|| "none".into()),
             );
 
-            let config = certificate_helpers::actix_tls_server_config(&settings)?;
+            let config = certificate_helpers::actix_tls_server_config(&settings).map_err(|err| io::Error::new(
+                io::ErrorKind::Other,
+                err,
+            ))?;
             server.bind_rustls(bind_addr, config)?
         } else {
             log::info!("TLS disabled for REST API");

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Helper to better log start errors
-    let log_err = |server_name, result| match result {
+    let log_err_if_any = |server_name, result| match result {
         Err(err) => {
             log::error!("Error while starting {} server: {}", server_name, err);
             Err(err)
@@ -357,7 +357,7 @@ fn main() -> anyhow::Result<()> {
         let handle = thread::Builder::new()
             .name("web".to_string())
             .spawn(move || {
-                log_err(
+                log_err_if_any(
                     "REST",
                     actix::init(dispatcher_arc.clone(), telemetry_collector, settings),
                 )
@@ -375,7 +375,7 @@ fn main() -> anyhow::Result<()> {
         let handle = thread::Builder::new()
             .name("grpc".to_string())
             .spawn(move || {
-                log_err(
+                log_err_if_any(
                     "gRPC",
                     tonic::init(
                         dispatcher_arc,


### PR DESCRIPTION
This improves error logging for TLS loading errors and errors that occur while starting REST and gRPC servers.

For example, if the REST server can't start because the TLS certificate file is missing, this is now shown:

```
[2023-05-31T15:13:03.093Z ERROR qdrant] Error while starting REST server: TLS file could not be opened: ./tls/localhost.pem
```

Before it simply `eprintln`ed a raw `io::Error` with no context it was relating to starting the REST or gRPC server.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?