### PR TITLE
Add support for providing API key in query parameter

### DIFF
--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -56,8 +56,18 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        let key: Option<&[u8]> = req.headers().get("api-key").map(|key| key.as_bytes());
+        // Grab API key from request
+        let key: Option<&[u8]> =
+            // Request header
+            req.headers().get("api-key").map(|key| key.as_bytes())
+            // Fall back to query parameter
+            .or_else(|| req.query_string()
+                .split('&')
+                .filter_map(|option| option.split_once('='))
+                .find(|(key, _)| key == &"api-key")
+                .map(|(_, value)| value.as_bytes()));
 
+        // If we have an API key, compare in constant time
         if let Some(key) = key {
             if constant_time_eq(self.api_key.as_bytes(), key) {
                 return Box::pin(self.service.call(req));

--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -56,11 +56,11 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        if let Some(key) = req.headers().get("api-key") {
-            if let Ok(key) = key.to_str() {
-                if constant_time_eq(self.api_key.as_bytes(), key.as_bytes()) {
-                    return Box::pin(self.service.call(req));
-                }
+        let key: Option<&[u8]> = req.headers().get("api-key").map(|key| key.as_bytes());
+
+        if let Some(key) = key {
+            if constant_time_eq(self.api_key.as_bytes(), key) {
+                return Box::pin(self.service.call(req));
             }
         }
 

--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -65,7 +65,8 @@ where
                 .split('&')
                 .filter_map(|option| option.split_once('='))
                 .find(|(key, _)| key.eq_ignore_ascii_case("api-key"))
-                .map(|(_, value)| value.as_bytes()));
+                .map(|(_, value)| value.as_bytes())
+            );
 
         // If we have an API key, compare in constant time
         if let Some(key) = key {

--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -57,14 +57,14 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         // Grab API key from request
-        let key: Option<&[u8]> =
+        let key =
             // Request header
             req.headers().get("api-key").map(|key| key.as_bytes())
             // Fall back to query parameter
             .or_else(|| req.query_string()
                 .split('&')
                 .filter_map(|option| option.split_once('='))
-                .find(|(key, _)| key == &"api-key")
+                .find(|(key, _)| key.eq_ignore_ascii_case("api-key"))
                 .map(|(_, value)| value.as_bytes()));
 
         // If we have an API key, compare in constant time

--- a/src/tonic/api_key.rs
+++ b/src/tonic/api_key.rs
@@ -40,16 +40,16 @@ where
         &mut self,
         request: tonic::codegen::http::Request<tonic::transport::Body>,
     ) -> Self::Future {
-        if let Some(key) = request.headers().get("api-key") {
-            if let Ok(key) = key.to_str() {
-                if constant_time_eq(self.api_key.as_bytes(), key.as_bytes()) {
-                    let future = self.service.call(request);
+        let key = request.headers().get("api-key").map(|key| key.as_bytes());
 
-                    return Box::pin(async move {
-                        let response = future.await?;
-                        Ok(response)
-                    });
-                }
+        if let Some(key) = key {
+            if constant_time_eq(self.api_key.as_bytes(), key) {
+                let future = self.service.call(request);
+
+                return Box::pin(async move {
+                    let response = future.await?;
+                    Ok(response)
+                });
             }
         }
 


### PR DESCRIPTION
Works on <https://github.com/qdrant/qdrant/issues/1980>.

In some cases it is not possible to specify custom headers. This adds support for falling back to an API key in a query parameter. This works for REST and gRPC.

For example, this would allow: `https://localhost:6333/metrics?api-key=secret`

Documentation will be updated separately, recommending to not use this unless absolutely necessary.

I'll look into adding tests for this (and testing HTTP headers) in a separate PR.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?