### PR TITLE
Cluster operation coalescing channel requires only one message

### DIFF
--- a/tests/consensus_tests/test_cluster_operation_coalescing.py
+++ b/tests/consensus_tests/test_cluster_operation_coalescing.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import pathlib
 
-from .fixtures import upsert_random_points, create_collection, drop_collection
+from .fixtures import create_collection, drop_collection
 from .utils import *
 
 N_PEERS = 3
@@ -11,7 +11,7 @@ N_REPLICA = 3
 
 def delete_collection_in_loop(peer_url, collection_name):
     while True:
-        # fails if the the response is NOT successful
+        # fails if the response is NOT successful
         drop_collection(peer_url, collection_name)
 
 


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/2003

The broadcast channel does not require to be bounded with a magic number as we know that only a single ACK message per operation is generated.