### PR TITLE
Lookup: expose feature to REST and gRPC interfaces

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -143,7 +143,6 @@
     - [Vectors](#qdrant-Vectors)
     - [VectorsSelector](#qdrant-VectorsSelector)
     - [WithLookup](#qdrant-WithLookup)
-    - [WithLookupInterface](#qdrant-WithLookupInterface)
     - [WithPayloadSelector](#qdrant-WithPayloadSelector)
     - [WithVectorsSelector](#qdrant-WithVectorsSelector)
     - [WriteOrdering](#qdrant-WriteOrdering)
@@ -1994,7 +1993,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
-| with_lookup | [WithLookupInterface](#qdrant-WithLookupInterface) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2266,7 +2265,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
-| with_lookup | [WithLookupInterface](#qdrant-WithLookupInterface) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2474,25 +2473,8 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | collection | [string](#string) |  | Name of the collection to use for points lookup |
-| with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include (or not) |
-| with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) |  | Options for specifying which vectors to include (or not) |
-
-
-
-
-
-
-<a name="qdrant-WithLookupInterface"></a>
-
-### WithLookupInterface
-Interface for specifying lookup collection, intended for groups API only.
-This allows specifying the collection name only, or the collection name and payload/vectors options.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| with_lookup | [WithLookup](#qdrant-WithLookup) |  |  |
-| collection | [string](#string) |  |  |
+| with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) | optional | Options for specifying which payload to include (or not) |
+| with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) | optional | Options for specifying which vectors to include (or not) |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -89,6 +89,7 @@
     - [GeoRadius](#qdrant-GeoRadius)
     - [GetPoints](#qdrant-GetPoints)
     - [GetResponse](#qdrant-GetResponse)
+    - [GroupId](#qdrant-GroupId)
     - [GroupsResult](#qdrant-GroupsResult)
     - [HasIdCondition](#qdrant-HasIdCondition)
     - [IsEmptyCondition](#qdrant-IsEmptyCondition)
@@ -101,7 +102,6 @@
     - [PayloadExcludeSelector](#qdrant-PayloadExcludeSelector)
     - [PayloadIncludeSelector](#qdrant-PayloadIncludeSelector)
     - [PointGroup](#qdrant-PointGroup)
-    - [PointGroup.GroupId](#qdrant-PointGroup-GroupId)
     - [PointId](#qdrant-PointId)
     - [PointStruct](#qdrant-PointStruct)
     - [PointStruct.PayloadEntry](#qdrant-PointStruct-PayloadEntry)
@@ -1552,6 +1552,23 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-GroupId"></a>
+
+### GroupId
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unsigned_value | [uint64](#uint64) |  | Represents a double value. |
+| integer_value | [int64](#int64) |  | Represents an integer value |
+| string_value | [string](#string) |  | Represents a string value. |
+
+
+
+
+
+
 <a name="qdrant-GroupsResult"></a>
 
 ### GroupsResult
@@ -1735,26 +1752,9 @@ The JSON representation for `Value` is a JSON value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [PointGroup.GroupId](#qdrant-PointGroup-GroupId) |  | Group id |
+| id | [GroupId](#qdrant-GroupId) |  | Group id |
 | hits | [ScoredPoint](#qdrant-ScoredPoint) | repeated | Points in the group |
 | lookups | [RetrievedPoint](#qdrant-RetrievedPoint) | repeated | Point(s) from the lookup collection that matches the group id |
-
-
-
-
-
-
-<a name="qdrant-PointGroup-GroupId"></a>
-
-### PointGroup.GroupId
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unsigned_value | [uint64](#uint64) |  | Represents a double value. |
-| integer_value | [int64](#int64) |  | Represents an integer value |
-| string_value | [string](#string) |  | Represents a string value. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -89,7 +89,6 @@
     - [GeoRadius](#qdrant-GeoRadius)
     - [GetPoints](#qdrant-GetPoints)
     - [GetResponse](#qdrant-GetResponse)
-    - [GroupId](#qdrant-GroupId)
     - [GroupsResult](#qdrant-GroupsResult)
     - [HasIdCondition](#qdrant-HasIdCondition)
     - [IsEmptyCondition](#qdrant-IsEmptyCondition)
@@ -102,6 +101,7 @@
     - [PayloadExcludeSelector](#qdrant-PayloadExcludeSelector)
     - [PayloadIncludeSelector](#qdrant-PayloadIncludeSelector)
     - [PointGroup](#qdrant-PointGroup)
+    - [PointGroup.GroupId](#qdrant-PointGroup-GroupId)
     - [PointId](#qdrant-PointId)
     - [PointStruct](#qdrant-PointStruct)
     - [PointStruct.PayloadEntry](#qdrant-PointStruct-PayloadEntry)
@@ -120,6 +120,7 @@
     - [RecommendResponse](#qdrant-RecommendResponse)
     - [RepeatedIntegers](#qdrant-RepeatedIntegers)
     - [RepeatedStrings](#qdrant-RepeatedStrings)
+    - [RetrievedLookup](#qdrant-RetrievedLookup)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
     - [ScoredPoint](#qdrant-ScoredPoint)
@@ -142,6 +143,7 @@
     - [Vector](#qdrant-Vector)
     - [Vectors](#qdrant-Vectors)
     - [VectorsSelector](#qdrant-VectorsSelector)
+    - [WithLookup](#qdrant-WithLookup)
     - [WithPayloadSelector](#qdrant-WithPayloadSelector)
     - [WithVectorsSelector](#qdrant-WithVectorsSelector)
     - [WriteOrdering](#qdrant-WriteOrdering)
@@ -1550,23 +1552,6 @@ The JSON representation for `Value` is a JSON value.
 
 
 
-<a name="qdrant-GroupId"></a>
-
-### GroupId
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unsigned_value | [uint64](#uint64) |  | Represents a double value. |
-| integer_value | [int64](#int64) |  | Represents an integer value |
-| string_value | [string](#string) |  | Represents a string value. |
-
-
-
-
-
-
 <a name="qdrant-GroupsResult"></a>
 
 ### GroupsResult
@@ -1750,8 +1735,26 @@ The JSON representation for `Value` is a JSON value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [GroupId](#qdrant-GroupId) |  | Group id |
+| id | [PointGroup.GroupId](#qdrant-PointGroup-GroupId) |  | Group id |
 | hits | [ScoredPoint](#qdrant-ScoredPoint) | repeated | Points in the group |
+| lookup | [RetrievedLookup](#qdrant-RetrievedLookup) | optional | Point from the lookup collection that matches the group id |
+
+
+
+
+
+
+<a name="qdrant-PointGroup-GroupId"></a>
+
+### PointGroup.GroupId
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unsigned_value | [uint64](#uint64) |  | Represents a double value. |
+| integer_value | [int64](#int64) |  | Represents an integer value |
+| string_value | [string](#string) |  | Represents a string value. |
 
 
 
@@ -1991,6 +1994,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2064,6 +2068,21 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | strings | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-RetrievedLookup"></a>
+
+### RetrievedLookup
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| single_point | [RetrievedPoint](#qdrant-RetrievedPoint) |  | Point from the lookup collection that matches the group id |
 
 
 
@@ -2262,6 +2281,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
+| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2454,6 +2474,23 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | names | [string](#string) | repeated | List of vectors to include into result |
+
+
+
+
+
+
+<a name="qdrant-WithLookup"></a>
+
+### WithLookup
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| collection | [string](#string) |  | Name of the collection to use for points lookup |
+| with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include (or not) |
+| with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) |  | Options for specifying which vectors to include (or not) |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -144,6 +144,7 @@
     - [Vectors](#qdrant-Vectors)
     - [VectorsSelector](#qdrant-VectorsSelector)
     - [WithLookup](#qdrant-WithLookup)
+    - [WithLookupInterface](#qdrant-WithLookupInterface)
     - [WithPayloadSelector](#qdrant-WithPayloadSelector)
     - [WithVectorsSelector](#qdrant-WithVectorsSelector)
     - [WriteOrdering](#qdrant-WriteOrdering)
@@ -1994,7 +1995,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
-| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| with_lookup | [WithLookupInterface](#qdrant-WithLookupInterface) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2281,7 +2282,7 @@ The JSON representation for `Value` is a JSON value.
 | group_by | [string](#string) |  | Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups. |
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
-| with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| with_lookup | [WithLookupInterface](#qdrant-WithLookupInterface) | optional | Options for specifying how to use the group id to lookup points in another collection |
 
 
 
@@ -2491,6 +2492,23 @@ The JSON representation for `Value` is a JSON value.
 | collection | [string](#string) |  | Name of the collection to use for points lookup |
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include (or not) |
 | with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) |  | Options for specifying which vectors to include (or not) |
+
+
+
+
+
+
+<a name="qdrant-WithLookupInterface"></a>
+
+### WithLookupInterface
+Interface for specifying lookup collection, intended for groups API only.
+This allows specifying the collection name only, or the collection name and payload/vectors options.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| with_lookup | [WithLookup](#qdrant-WithLookup) |  |  |
+| collection | [string](#string) |  |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1753,7 +1753,7 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | id | [GroupId](#qdrant-GroupId) |  | Group id |
 | hits | [ScoredPoint](#qdrant-ScoredPoint) | repeated | Points in the group |
-| lookups | [RetrievedPoint](#qdrant-RetrievedPoint) | repeated | Point(s) from the lookup collection that matches the group id |
+| lookup | [RetrievedPoint](#qdrant-RetrievedPoint) |  | Point(s) from the lookup collection that matches the group id |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -120,7 +120,6 @@
     - [RecommendResponse](#qdrant-RecommendResponse)
     - [RepeatedIntegers](#qdrant-RepeatedIntegers)
     - [RepeatedStrings](#qdrant-RepeatedStrings)
-    - [RetrievedLookup](#qdrant-RetrievedLookup)
     - [RetrievedPoint](#qdrant-RetrievedPoint)
     - [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry)
     - [ScoredPoint](#qdrant-ScoredPoint)
@@ -1738,7 +1737,7 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | id | [PointGroup.GroupId](#qdrant-PointGroup-GroupId) |  | Group id |
 | hits | [ScoredPoint](#qdrant-ScoredPoint) | repeated | Points in the group |
-| lookup | [RetrievedLookup](#qdrant-RetrievedLookup) | optional | Point from the lookup collection that matches the group id |
+| lookups | [RetrievedPoint](#qdrant-RetrievedPoint) | repeated | Point(s) from the lookup collection that matches the group id |
 
 
 
@@ -2069,21 +2068,6 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | strings | [string](#string) | repeated |  |
-
-
-
-
-
-
-<a name="qdrant-RetrievedLookup"></a>
-
-### RetrievedLookup
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| single_point | [RetrievedPoint](#qdrant-RetrievedPoint) |  | Point from the lookup collection that matches the group id |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7981,7 +7981,7 @@
           },
           "with_vectors": {
             "description": "Options for specifying which vectors to include (or not)",
-            "default": true,
+            "default": null,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/WithVector"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7938,7 +7938,7 @@
             "description": "Look for points in another collection using the group ids",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/WithLookup"
+                "$ref": "#/components/schemas/WithLookupInterface"
               },
               {
                 "nullable": true
@@ -7946,6 +7946,16 @@
             ]
           }
         }
+      },
+      "WithLookupInterface": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/WithLookup"
+          }
+        ]
       },
       "WithLookup": {
         "type": "object",
@@ -8101,7 +8111,7 @@
             "description": "Look for points in another collection using the group ids",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/WithLookup"
+                "$ref": "#/components/schemas/WithLookupInterface"
               },
               {
                 "nullable": true

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7933,6 +7933,51 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 1
+          },
+          "with_lookup": {
+            "description": "Look for points in another collection using the group ids",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WithLookup"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "WithLookup": {
+        "type": "object",
+        "required": [
+          "collection"
+        ],
+        "properties": {
+          "collection": {
+            "description": "Name of the collection to use for points lookup",
+            "type": "string"
+          },
+          "with_payload": {
+            "description": "Options for specifying which payload to include (or not)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WithPayloadInterface"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "with_vectors": {
+            "description": "Options for specifying which vectors to include (or not)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WithVector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -8051,6 +8096,17 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 1
+          },
+          "with_lookup": {
+            "description": "Look for points in another collection using the group ids",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WithLookup"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7969,6 +7969,7 @@
           },
           "with_payload": {
             "description": "Options for specifying which payload to include (or not)",
+            "default": true,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/WithPayloadInterface"
@@ -7980,6 +7981,7 @@
           },
           "with_vectors": {
             "description": "Options for specifying which vectors to include (or not)",
+            "default": true,
             "anyOf": [
               {
                 "$ref": "#/components/schemas/WithVector"

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -8,8 +8,7 @@ use segment::types::{default_quantization_ignore_value, default_quantization_res
 use tonic::Status;
 use uuid::Uuid;
 
-use super::qdrant::point_group::GroupId;
-use super::qdrant::CompressionRatio;
+use super::qdrant::{CompressionRatio, GroupId};
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
 use crate::grpc::qdrant::payload_index_params::IndexParams;
@@ -428,13 +427,13 @@ impl From<segment::data_types::groups::GroupId> for GroupId {
     fn from(key: segment::data_types::groups::GroupId) -> Self {
         match key {
             segment::data_types::groups::GroupId::String(str) => Self {
-                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::StringValue(str)),
+                kind: Some(crate::grpc::qdrant::group_id::Kind::StringValue(str)),
             },
             segment::data_types::groups::GroupId::NumberU64(n) => Self {
-                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::UnsignedValue(n)),
+                kind: Some(crate::grpc::qdrant::group_id::Kind::UnsignedValue(n)),
             },
             segment::data_types::groups::GroupId::NumberI64(n) => Self {
-                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::IntegerValue(n)),
+                kind: Some(crate::grpc::qdrant::group_id::Kind::IntegerValue(n)),
             },
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -8,6 +8,7 @@ use segment::types::{default_quantization_ignore_value, default_quantization_res
 use tonic::Status;
 use uuid::Uuid;
 
+use super::qdrant::point_group::GroupId;
 use super::qdrant::CompressionRatio;
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
@@ -19,13 +20,13 @@ use crate::grpc::qdrant::vectors::VectorsOptions;
 use crate::grpc::qdrant::with_payload_selector::SelectorOptions;
 use crate::grpc::qdrant::{
     with_vectors_selector, CollectionDescription, CollectionOperationResponse, Condition, Distance,
-    FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoRadius, GroupId, HasIdCondition,
-    HealthCheckReply, HnswConfigDiff, IsEmptyCondition, IsNullCondition, ListCollectionsResponse,
-    ListValue, Match, NamedVectors, NestedCondition, PayloadExcludeSelector,
-    PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo, PayloadSchemaType, PointId,
-    QuantizationConfig, QuantizationSearchParams, Range, RepeatedIntegers, RepeatedStrings,
-    ScalarQuantization, ScoredPoint, SearchParams, Struct, TextIndexParams, TokenizerType, Value,
-    ValuesCount, Vector, Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
+    FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoRadius, HasIdCondition, HealthCheckReply,
+    HnswConfigDiff, IsEmptyCondition, IsNullCondition, ListCollectionsResponse, ListValue, Match,
+    NamedVectors, NestedCondition, PayloadExcludeSelector, PayloadIncludeSelector,
+    PayloadIndexParams, PayloadSchemaInfo, PayloadSchemaType, PointId, QuantizationConfig,
+    QuantizationSearchParams, Range, RepeatedIntegers, RepeatedStrings, ScalarQuantization,
+    ScoredPoint, SearchParams, Struct, TextIndexParams, TokenizerType, Value, ValuesCount, Vector,
+    Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
 };
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {
@@ -427,13 +428,13 @@ impl From<segment::data_types::groups::GroupId> for GroupId {
     fn from(key: segment::data_types::groups::GroupId) -> Self {
         match key {
             segment::data_types::groups::GroupId::String(str) => Self {
-                kind: Some(crate::grpc::qdrant::group_id::Kind::StringValue(str)),
+                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::StringValue(str)),
             },
             segment::data_types::groups::GroupId::NumberU64(n) => Self {
-                kind: Some(crate::grpc::qdrant::group_id::Kind::UnsignedValue(n)),
+                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::UnsignedValue(n)),
             },
             segment::data_types::groups::GroupId::NumberI64(n) => Self {
-                kind: Some(crate::grpc::qdrant::group_id::Kind::IntegerValue(n)),
+                kind: Some(crate::grpc::qdrant::point_group::group_id::Kind::IntegerValue(n)),
             },
         }
     }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -229,6 +229,12 @@ message SearchBatchPoints {
   optional ReadConsistency read_consistency = 3; // Options for specifying read consistency guarantees
 }
 
+message WithLookup {
+  string collection = 1; // Name of the collection to use for points lookup
+  WithPayloadSelector with_payload = 2; // Options for specifying which payload to include (or not)
+  WithVectorsSelector with_vectors = 3; // Options for specifying which vectors to include (or not)
+}
+
 message SearchPointGroups {
   string collection_name = 1; // Name of the collection
   repeated float vector = 2; // Vector to compare against
@@ -242,6 +248,7 @@ message SearchPointGroups {
   string group_by = 10; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 11; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
+  optional WithLookup with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message ScrollPoints {
@@ -298,6 +305,7 @@ message RecommendPointGroups {
   string group_by = 12; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 13; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
+  optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message CountPoints {
@@ -335,20 +343,28 @@ message ScoredPoint {
   optional Vectors vectors = 6; // Vectors to search
 }
 
-message GroupId {
+message RetrievedLookup {
   oneof kind {
-    // Represents a double value.
-    uint64 unsigned_value = 1;
-    // Represents an integer value
-    int64 integer_value = 2;
-    // Represents a string value.
-    string string_value = 3;
+    RetrievedPoint single_point = 1; // Point from the lookup collection that matches the group id
+    // we might want to return multiple points in the future
   }
 }
 
 message PointGroup {
+  message GroupId {
+    oneof kind {
+      // Represents a double value.
+      uint64 unsigned_value = 1;
+      // Represents an integer value
+      int64 integer_value = 2;
+      // Represents a string value.
+      string string_value = 3;
+    }
+  }
+
   GroupId id = 1; // Group id
-  repeated ScoredPoint hits = 2; // Points in the group
+  repeated ScoredPoint hits = 2; // Points in the group 
+  optional RetrievedLookup lookup = 3; // Point from the lookup collection that matches the group id
 }
 
 message GroupsResult {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -231,18 +231,10 @@ message SearchBatchPoints {
 
 message WithLookup {
   string collection = 1; // Name of the collection to use for points lookup
-  WithPayloadSelector with_payload = 2; // Options for specifying which payload to include (or not)
-  WithVectorsSelector with_vectors = 3; // Options for specifying which vectors to include (or not)
+  optional WithPayloadSelector with_payload = 2; // Options for specifying which payload to include (or not)
+  optional WithVectorsSelector with_vectors = 3; // Options for specifying which vectors to include (or not)
 }
 
-// Interface for specifying lookup collection, intended for groups API only.
-// This allows specifying the collection name only, or the collection name and payload/vectors options.
-message WithLookupInterface {
-  oneof with_lookup_interface {
-    WithLookup with_lookup = 1;
-    string collection = 2;
-  }
-}
 
 message SearchPointGroups {
   string collection_name = 1; // Name of the collection
@@ -257,7 +249,7 @@ message SearchPointGroups {
   string group_by = 10; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 11; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
-  optional WithLookupInterface with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
+  optional WithLookup with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message ScrollPoints {
@@ -314,7 +306,7 @@ message RecommendPointGroups {
   string group_by = 12; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 13; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
-  optional WithLookupInterface with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
+  optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message CountPoints {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -352,13 +352,6 @@ message ScoredPoint {
   optional Vectors vectors = 6; // Vectors to search
 }
 
-message RetrievedLookup {
-  oneof kind {
-    RetrievedPoint single_point = 1; // Point from the lookup collection that matches the group id
-    // we might want to return multiple points in the future
-  }
-}
-
 message PointGroup {
   message GroupId {
     oneof kind {
@@ -373,7 +366,7 @@ message PointGroup {
 
   GroupId id = 1; // Group id
   repeated ScoredPoint hits = 2; // Points in the group 
-  optional RetrievedLookup lookup = 3; // Point from the lookup collection that matches the group id
+  repeated RetrievedPoint lookups = 3; // Point(s) from the lookup collection that matches the group id
 }
 
 message GroupsResult {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -352,18 +352,18 @@ message ScoredPoint {
   optional Vectors vectors = 6; // Vectors to search
 }
 
-message PointGroup {
-  message GroupId {
-    oneof kind {
-      // Represents a double value.
-      uint64 unsigned_value = 1;
-      // Represents an integer value
-      int64 integer_value = 2;
-      // Represents a string value.
-      string string_value = 3;
-    }
+message GroupId {
+  oneof kind {
+    // Represents a double value.
+    uint64 unsigned_value = 1;
+    // Represents an integer value
+    int64 integer_value = 2;
+    // Represents a string value.
+    string string_value = 3;
   }
+}
 
+message PointGroup {
   GroupId id = 1; // Group id
   repeated ScoredPoint hits = 2; // Points in the group 
   repeated RetrievedPoint lookups = 3; // Point(s) from the lookup collection that matches the group id

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -235,6 +235,15 @@ message WithLookup {
   WithVectorsSelector with_vectors = 3; // Options for specifying which vectors to include (or not)
 }
 
+// Interface for specifying lookup collection, intended for groups API only.
+// This allows specifying the collection name only, or the collection name and payload/vectors options.
+message WithLookupInterface {
+  oneof with_lookup_interface {
+    WithLookup with_lookup = 1;
+    string collection = 2;
+  }
+}
+
 message SearchPointGroups {
   string collection_name = 1; // Name of the collection
   repeated float vector = 2; // Vector to compare against
@@ -248,7 +257,7 @@ message SearchPointGroups {
   string group_by = 10; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 11; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
-  optional WithLookup with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
+  optional WithLookupInterface with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message ScrollPoints {
@@ -305,7 +314,7 @@ message RecommendPointGroups {
   string group_by = 12; // Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
   uint32 group_size = 13; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
-  optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
+  optional WithLookupInterface with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
 }
 
 message CountPoints {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -358,7 +358,7 @@ message GroupId {
 message PointGroup {
   GroupId id = 1; // Group id
   repeated ScoredPoint hits = 2; // Points in the group 
-  repeated RetrievedPoint lookups = 3; // Point(s) from the lookup collection that matches the group id
+  RetrievedPoint lookup = 3; // Point(s) from the lookup collection that matches the group id
 }
 
 message GroupsResult {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2887,27 +2887,6 @@ pub struct WithLookup {
     #[prost(message, optional, tag = "3")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
-/// Interface for specifying lookup collection, intended for groups API only.
-/// This allows specifying the collection name only, or the collection name and payload/vectors options.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WithLookupInterface {
-    #[prost(oneof = "with_lookup_interface::WithLookupInterface", tags = "1, 2")]
-    pub with_lookup_interface: ::core::option::Option<
-        with_lookup_interface::WithLookupInterface,
-    >,
-}
-/// Nested message and enum types in `WithLookupInterface`.
-pub mod with_lookup_interface {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum WithLookupInterface {
-        #[prost(message, tag = "1")]
-        WithLookup(super::WithLookup),
-        #[prost(string, tag = "2")]
-        Collection(::prost::alloc::string::String),
-    }
-}
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2955,7 +2934,7 @@ pub struct SearchPointGroups {
     pub read_consistency: ::core::option::Option<ReadConsistency>,
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "13")]
-    pub with_lookup: ::core::option::Option<WithLookupInterface>,
+    pub with_lookup: ::core::option::Option<WithLookup>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3105,7 +3084,7 @@ pub struct RecommendPointGroups {
     pub read_consistency: ::core::option::Option<ReadConsistency>,
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "15")]
-    pub with_lookup: ::core::option::Option<WithLookupInterface>,
+    pub with_lookup: ::core::option::Option<WithLookup>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3162,41 +3162,38 @@ pub struct ScoredPoint {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GroupId {
+    #[prost(oneof = "group_id::Kind", tags = "1, 2, 3")]
+    pub kind: ::core::option::Option<group_id::Kind>,
+}
+/// Nested message and enum types in `GroupId`.
+pub mod group_id {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        /// Represents a double value.
+        #[prost(uint64, tag = "1")]
+        UnsignedValue(u64),
+        /// Represents an integer value
+        #[prost(int64, tag = "2")]
+        IntegerValue(i64),
+        /// Represents a string value.
+        #[prost(string, tag = "3")]
+        StringValue(::prost::alloc::string::String),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointGroup {
     /// Group id
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<point_group::GroupId>,
+    pub id: ::core::option::Option<GroupId>,
     /// Points in the group
     #[prost(message, repeated, tag = "2")]
     pub hits: ::prost::alloc::vec::Vec<ScoredPoint>,
     /// Point(s) from the lookup collection that matches the group id
     #[prost(message, repeated, tag = "3")]
     pub lookups: ::prost::alloc::vec::Vec<RetrievedPoint>,
-}
-/// Nested message and enum types in `PointGroup`.
-pub mod point_group {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct GroupId {
-        #[prost(oneof = "group_id::Kind", tags = "1, 2, 3")]
-        pub kind: ::core::option::Option<group_id::Kind>,
-    }
-    /// Nested message and enum types in `GroupId`.
-    pub mod group_id {
-        #[allow(clippy::derive_partial_eq_without_eq)]
-        #[derive(Clone, PartialEq, ::prost::Oneof)]
-        pub enum Kind {
-            /// Represents a double value.
-            #[prost(uint64, tag = "1")]
-            UnsignedValue(u64),
-            /// Represents an integer value
-            #[prost(int64, tag = "2")]
-            IntegerValue(i64),
-            /// Represents a string value.
-            #[prost(string, tag = "3")]
-            StringValue(::prost::alloc::string::String),
-        }
-    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3171,8 +3171,8 @@ pub struct PointGroup {
     #[prost(message, repeated, tag = "2")]
     pub hits: ::prost::alloc::vec::Vec<ScoredPoint>,
     /// Point(s) from the lookup collection that matches the group id
-    #[prost(message, repeated, tag = "3")]
-    pub lookups: ::prost::alloc::vec::Vec<RetrievedPoint>,
+    #[prost(message, optional, tag = "3")]
+    pub lookup: ::core::option::Option<RetrievedPoint>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3162,22 +3162,6 @@ pub struct ScoredPoint {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RetrievedLookup {
-    #[prost(oneof = "retrieved_lookup::Kind", tags = "1")]
-    pub kind: ::core::option::Option<retrieved_lookup::Kind>,
-}
-/// Nested message and enum types in `RetrievedLookup`.
-pub mod retrieved_lookup {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Kind {
-        /// Point from the lookup collection that matches the group id
-        #[prost(message, tag = "1")]
-        SinglePoint(super::RetrievedPoint),
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointGroup {
     /// Group id
     #[prost(message, optional, tag = "1")]
@@ -3185,9 +3169,9 @@ pub struct PointGroup {
     /// Points in the group
     #[prost(message, repeated, tag = "2")]
     pub hits: ::prost::alloc::vec::Vec<ScoredPoint>,
-    /// Point from the lookup collection that matches the group id
-    #[prost(message, optional, tag = "3")]
-    pub lookup: ::core::option::Option<RetrievedLookup>,
+    /// Point(s) from the lookup collection that matches the group id
+    #[prost(message, repeated, tag = "3")]
+    pub lookups: ::prost::alloc::vec::Vec<RetrievedPoint>,
 }
 /// Nested message and enum types in `PointGroup`.
 pub mod point_group {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2874,6 +2874,19 @@ pub struct SearchBatchPoints {
     #[prost(message, optional, tag = "3")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WithLookup {
+    /// Name of the collection to use for points lookup
+    #[prost(string, tag = "1")]
+    pub collection: ::prost::alloc::string::String,
+    /// Options for specifying which payload to include (or not)
+    #[prost(message, optional, tag = "2")]
+    pub with_payload: ::core::option::Option<WithPayloadSelector>,
+    /// Options for specifying which vectors to include (or not)
+    #[prost(message, optional, tag = "3")]
+    pub with_vectors: ::core::option::Option<WithVectorsSelector>,
+}
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2919,6 +2932,9 @@ pub struct SearchPointGroups {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "12")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[prost(message, optional, tag = "13")]
+    pub with_lookup: ::core::option::Option<WithLookup>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3066,6 +3082,9 @@ pub struct RecommendPointGroups {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "14")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[prost(message, optional, tag = "15")]
+    pub with_lookup: ::core::option::Option<WithLookup>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3122,24 +3141,18 @@ pub struct ScoredPoint {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GroupId {
-    #[prost(oneof = "group_id::Kind", tags = "1, 2, 3")]
-    pub kind: ::core::option::Option<group_id::Kind>,
+pub struct RetrievedLookup {
+    #[prost(oneof = "retrieved_lookup::Kind", tags = "1")]
+    pub kind: ::core::option::Option<retrieved_lookup::Kind>,
 }
-/// Nested message and enum types in `GroupId`.
-pub mod group_id {
+/// Nested message and enum types in `RetrievedLookup`.
+pub mod retrieved_lookup {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
-        /// Represents a double value.
-        #[prost(uint64, tag = "1")]
-        UnsignedValue(u64),
-        /// Represents an integer value
-        #[prost(int64, tag = "2")]
-        IntegerValue(i64),
-        /// Represents a string value.
-        #[prost(string, tag = "3")]
-        StringValue(::prost::alloc::string::String),
+        /// Point from the lookup collection that matches the group id
+        #[prost(message, tag = "1")]
+        SinglePoint(super::RetrievedPoint),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3147,10 +3160,38 @@ pub mod group_id {
 pub struct PointGroup {
     /// Group id
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<GroupId>,
+    pub id: ::core::option::Option<point_group::GroupId>,
     /// Points in the group
     #[prost(message, repeated, tag = "2")]
     pub hits: ::prost::alloc::vec::Vec<ScoredPoint>,
+    /// Point from the lookup collection that matches the group id
+    #[prost(message, optional, tag = "3")]
+    pub lookup: ::core::option::Option<RetrievedLookup>,
+}
+/// Nested message and enum types in `PointGroup`.
+pub mod point_group {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct GroupId {
+        #[prost(oneof = "group_id::Kind", tags = "1, 2, 3")]
+        pub kind: ::core::option::Option<group_id::Kind>,
+    }
+    /// Nested message and enum types in `GroupId`.
+    pub mod group_id {
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Kind {
+            /// Represents a double value.
+            #[prost(uint64, tag = "1")]
+            UnsignedValue(u64),
+            /// Represents an integer value
+            #[prost(int64, tag = "2")]
+            IntegerValue(i64),
+            /// Represents a string value.
+            #[prost(string, tag = "3")]
+            StringValue(::prost::alloc::string::String),
+        }
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2887,6 +2887,27 @@ pub struct WithLookup {
     #[prost(message, optional, tag = "3")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
+/// Interface for specifying lookup collection, intended for groups API only.
+/// This allows specifying the collection name only, or the collection name and payload/vectors options.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WithLookupInterface {
+    #[prost(oneof = "with_lookup_interface::WithLookupInterface", tags = "1, 2")]
+    pub with_lookup_interface: ::core::option::Option<
+        with_lookup_interface::WithLookupInterface,
+    >,
+}
+/// Nested message and enum types in `WithLookupInterface`.
+pub mod with_lookup_interface {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum WithLookupInterface {
+        #[prost(message, tag = "1")]
+        WithLookup(super::WithLookup),
+        #[prost(string, tag = "2")]
+        Collection(::prost::alloc::string::String),
+    }
+}
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2934,7 +2955,7 @@ pub struct SearchPointGroups {
     pub read_consistency: ::core::option::Option<ReadConsistency>,
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "13")]
-    pub with_lookup: ::core::option::Option<WithLookup>,
+    pub with_lookup: ::core::option::Option<WithLookupInterface>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3084,7 +3105,7 @@ pub struct RecommendPointGroups {
     pub read_consistency: ::core::option::Option<ReadConsistency>,
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "15")]
-    pub with_lookup: ::core::option::Option<WithLookup>,
+    pub with_lookup: ::core::option::Option<WithLookupInterface>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -935,6 +935,21 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
+
+        // short-circuit if not needed
+        if let (&Some(WithPayloadInterface::Bool(false)), &WithVector::Bool(false)) =
+            (&with_payload, &with_vector)
+        {
+            return Ok(search_result
+                .into_iter()
+                .map(|point| ScoredPoint {
+                    payload: None,
+                    vector: None,
+                    ..point
+                })
+                .collect());
+        };
+
         let retrieve_request = PointRequest {
             ids: search_result.iter().map(|x| x.id).collect(),
             with_payload,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -935,7 +935,6 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<ScoredPoint>> {
-
         // short-circuit if not needed
         if let (&Some(WithPayloadInterface::Bool(false)), &WithVector::Bool(false)) =
             (&with_payload, &with_vector)

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO: remove
-
 use futures::Future;
 use itertools::Itertools;
 use tokio::sync::RwLockReadGuard;

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -186,7 +186,7 @@ impl From<SearchGroupsRequest> for GroupRequest {
                     group_by,
                     group_size,
                     limit,
-                    with_lookup,
+                    with_lookup: with_lookup_interface,
                 },
         } = request;
 
@@ -206,7 +206,7 @@ impl From<SearchGroupsRequest> for GroupRequest {
             group_by,
             group_size: group_size as usize,
             limit: limit as usize,
-            with_lookup,
+            with_lookup: with_lookup_interface.map(Into::into),
         }
     }
 }
@@ -228,7 +228,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
                     group_by,
                     group_size,
                     limit,
-                    with_lookup,
+                    with_lookup: with_lookup_interface,
                 },
         } = request;
 
@@ -251,7 +251,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
             group_by,
             group_size: group_size as usize,
             limit: limit as usize,
-            with_lookup,
+            with_lookup: with_lookup_interface.map(Into::into),
         }
     }
 }

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -186,6 +186,7 @@ impl From<SearchGroupsRequest> for GroupRequest {
                     group_by,
                     group_size,
                     limit,
+                    with_lookup,
                 },
         } = request;
 
@@ -205,7 +206,7 @@ impl From<SearchGroupsRequest> for GroupRequest {
             group_by,
             group_size: group_size as usize,
             limit: limit as usize,
-            with_lookup: None, // TODO: update when ui is updated
+            with_lookup,
         }
     }
 }
@@ -227,6 +228,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
                     group_by,
                     group_size,
                     limit,
+                    with_lookup,
                 },
         } = request;
 
@@ -249,7 +251,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
             group_by,
             group_size: group_size as usize,
             limit: limit as usize,
-            with_lookup: None, // TODO: update when ui is updated
+            with_lookup,
         }
     }
 }

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -27,12 +27,8 @@ pub struct WithLookup {
 
     /// Options for specifying which vectors to include (or not)
     #[serde(alias = "with_vector")]
-    #[serde(default = "default_with_vectors")]
+    #[serde(default)]
     pub with_vectors: Option<WithVector>,
-}
-
-const fn default_with_vectors() -> Option<WithVector> {
-    Some(WithVector::Bool(true))
 }
 
 const fn default_with_payload() -> Option<WithPayloadInterface> {

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -22,10 +22,21 @@ pub struct WithLookup {
     pub collection_name: String,
 
     /// Options for specifying which payload to include (or not)
+    #[serde(default = "default_with_payload")]
     pub with_payload: Option<WithPayloadInterface>,
 
     /// Options for specifying which vectors to include (or not)
+    #[serde(alias = "with_vector")]
+    #[serde(default = "default_with_vectors")]
     pub with_vectors: Option<WithVector>,
+}
+
+const fn default_with_vectors() -> Option<WithVector> {
+    Some(WithVector::Bool(true))
+}
+
+const fn default_with_payload() -> Option<WithPayloadInterface> {
+    Some(WithPayloadInterface::Bool(true))
 }
 
 pub async fn lookup_ids<'a, F, Fut>(

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -21,7 +21,7 @@ impl From<WithLookupInterface> for WithLookup {
             WithLookupInterface::Collection(collection_name) => Self {
                 collection_name,
                 with_payload: Some(true.into()),
-                with_vectors: Some(true.into()),
+                with_vectors: Some(false.into()),
             },
             WithLookupInterface::WithLookup(with_lookup) => with_lookup,
         }

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -1,8 +1,32 @@
 use std::fmt::Display;
 
+use schemars::JsonSchema;
 use segment::data_types::groups::GroupId;
 use segment::types::PointIdType;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use super::WithLookup;
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(untagged)]
+pub enum WithLookupInterface {
+    Collection(String),
+    WithLookup(WithLookup),
+}
+
+impl From<WithLookupInterface> for WithLookup {
+    fn from(with_lookup: WithLookupInterface) -> Self {
+        match with_lookup {
+            WithLookupInterface::Collection(collection_name) => Self {
+                collection_name,
+                with_payload: None,
+                with_vectors: None,
+            },
+            WithLookupInterface::WithLookup(with_lookup) => with_lookup,
+        }
+    }
+}
 
 /// A value that can be used as a temporary ID
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -20,8 +20,8 @@ impl From<WithLookupInterface> for WithLookup {
         match with_lookup {
             WithLookupInterface::Collection(collection_name) => Self {
                 collection_name,
-                with_payload: None,
-                with_vectors: None,
+                with_payload: Some(true.into()),
+                with_vectors: Some(true.into()),
             },
             WithLookupInterface::WithLookup(with_lookup) => with_lookup,
         }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -699,29 +699,25 @@ impl TryFrom<api::grpc::qdrant::WithLookup> for WithLookup {
     type Error = Status;
 
     fn try_from(value: api::grpc::qdrant::WithLookup) -> Result<Self, Self::Error> {
+        let with_default_payload = || Some(segment::types::WithPayloadInterface::Bool(true));
+
         Ok(Self {
             collection_name: value.collection,
-            with_payload: value.with_payload.map(|wp| wp.try_into()).transpose()?,
+            with_payload: value
+                .with_payload
+                .map(|wp| wp.try_into())
+                .transpose()?
+                .or_else(with_default_payload),
             with_vectors: value.with_vectors.map(|wv| wv.into()),
         })
     }
 }
 
-impl TryFrom<api::grpc::qdrant::WithLookupInterface> for WithLookupInterface {
+impl TryFrom<api::grpc::qdrant::WithLookup> for WithLookupInterface {
     type Error = Status;
 
-    fn try_from(value: api::grpc::qdrant::WithLookupInterface) -> Result<Self, Self::Error> {
-        match value.with_lookup_interface {
-            Some(api::grpc::qdrant::with_lookup_interface::WithLookupInterface::Collection(
-                name,
-            )) => Ok(Self::Collection(name)),
-            Some(api::grpc::qdrant::with_lookup_interface::WithLookupInterface::WithLookup(
-                with_lookup,
-            )) => Ok(Self::WithLookup(with_lookup.try_into()?)),
-            None => Err(Status::invalid_argument(
-                "Malformed WithLookupInterface type",
-            )),
-        }
+    fn try_from(value: api::grpc::qdrant::WithLookup) -> Result<Self, Self::Error> {
+        Ok(Self::WithLookup(value.try_into()?))
     }
 }
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -20,7 +20,7 @@ use crate::config::{
     CollectionParams, WalConfig,
 };
 use crate::lookup::types::WithLookupInterface;
-use crate::lookup::{RetrievedLookup, WithLookup};
+use crate::lookup::WithLookup;
 use crate::operations::cluster_ops::{
     AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShard, MoveShardOperation,
     Replica, ReplicateShardOperation,
@@ -800,25 +800,12 @@ impl TryFrom<api::grpc::qdrant::SearchPointGroups> for SearchGroupsRequest {
     }
 }
 
-impl From<RetrievedLookup> for api::grpc::qdrant::RetrievedLookup {
-    fn from(value: RetrievedLookup) -> Self {
-        match value {
-            RetrievedLookup::Single(record) => Self {
-                kind: Some(api::grpc::qdrant::retrieved_lookup::Kind::SinglePoint(
-                    record.into(),
-                )),
-            },
-            RetrievedLookup::None => Self { kind: None },
-        }
-    }
-}
-
 impl From<PointGroup> for api::grpc::qdrant::PointGroup {
     fn from(group: PointGroup) -> Self {
         Self {
             hits: group.hits.into_iter().map_into().collect(),
             id: Some(group.id.into()),
-            lookup: group.lookup.map(Into::into),
+            lookups: group.lookup.into_iter().map_into().collect(),
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -801,7 +801,7 @@ impl From<PointGroup> for api::grpc::qdrant::PointGroup {
         Self {
             hits: group.hits.into_iter().map_into().collect(),
             id: Some(group.id.into()),
-            lookups: group.lookup.into_iter().map_into().collect(),
+            lookup: group.lookup.map(|record| record.into()),
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -277,6 +277,9 @@ pub struct SearchGroupsRequest {
     #[serde(flatten)]
     #[validate]
     pub group_request: BaseGroupRequest,
+
+    /// Look for points in another collection using the group ids
+    pub lookup: Option<LookupRequest>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -31,6 +31,7 @@ use tonic::codegen::http::uri::InvalidUri;
 use validator::{Validate, ValidationErrors};
 
 use crate::config::CollectionConfig;
+use crate::lookup::types::WithLookupInterface;
 use crate::lookup::WithLookup;
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::save_on_disk;
@@ -899,5 +900,5 @@ pub struct BaseGroupRequest {
     pub limit: u32,
 
     /// Look for points in another collection using the group ids
-    pub with_lookup: Option<WithLookup>,
+    pub with_lookup: Option<WithLookupInterface>,
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -31,6 +31,7 @@ use tonic::codegen::http::uri::InvalidUri;
 use validator::{Validate, ValidationErrors};
 
 use crate::config::CollectionConfig;
+use crate::lookup::WithLookup;
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;
@@ -277,9 +278,6 @@ pub struct SearchGroupsRequest {
     #[serde(flatten)]
     #[validate]
     pub group_request: BaseGroupRequest,
-
-    /// Look for points in another collection using the group ids
-    pub lookup: Option<LookupRequest>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
@@ -899,4 +897,7 @@ pub struct BaseGroupRequest {
     /// Maximum amount of groups to return
     #[validate(range(min = 1))]
     pub limit: u32,
+
+    /// Look for points in another collection using the group ids
+    pub with_lookup: Option<WithLookup>,
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -32,7 +32,6 @@ use validator::{Validate, ValidationErrors};
 
 use crate::config::CollectionConfig;
 use crate::lookup::types::WithLookupInterface;
-use crate::lookup::WithLookup;
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -29,8 +29,8 @@ struct Resources {
 async fn setup() -> Resources {
     let request = WithLookup {
         collection_name: "test".to_string(),
-        with_payload: Some(false.into()),
-        with_vectors: Some(false.into()),
+        with_payload: None,
+        with_vectors: None,
     };
 
     let collection_dir = Builder::new().prefix("storage").tempdir().unwrap();

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -12,7 +12,8 @@ use collection::config::{
     default_replication_factor, default_write_consistency_factor, CollectionConfig,
     CollectionParams,
 };
-use collection::grouping::group_by::{group_by, GroupRequest};
+use collection::grouping::group_by::GroupRequest;
+use collection::grouping::GroupBy;
 use collection::operations::config_diff::DiffConfig;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::point_ops::WriteOrdering;
@@ -1190,16 +1191,21 @@ impl TableOfContent {
 
         let collection_by_name = |name| self.get_collection_opt(name);
 
-        group_by(
-            request,
-            &collection,
-            collection_by_name,
-            read_consistency,
-            shard_selection,
-        )
-        .await
-        .map(|groups| GroupsResult { groups })
-        .map_err(|err| err.into())
+        let mut group_by = GroupBy::new(request, &collection, collection_by_name);
+
+        if let Some(read_consistency) = read_consistency {
+            group_by = group_by.with_read_consistency(read_consistency);
+        }
+
+        if let Some(shard_selection) = shard_selection {
+            group_by = group_by.with_shard_selection(shard_selection);
+        }
+
+        group_by
+            .execute()
+            .await
+            .map(|groups| GroupsResult { groups })
+            .map_err(|err| err.into())
     }
 
     /// List of all collections

--- a/openapi/tests/openapi_integration/test_group.py
+++ b/openapi/tests/openapi_integration/test_group.py
@@ -318,7 +318,7 @@ lookup_params = [
         {
             "collection": lookup_collection_name,
             "with_payload": True,
-            "with_vectors": True,
+            "with_vectors": False,
         },
         id="explicit with_payload and with_vectors",
     )
@@ -334,7 +334,7 @@ def assert_group_with_full_lookup(group):
 
     lookup = group["lookup"]
     assert lookup["payload"]
-    assert lookup["vector"]
+    assert not lookup["vector"]
 
 
 @pytest.mark.parametrize("with_lookup", lookup_params)

--- a/openapi/tests/openapi_integration/test_group.py
+++ b/openapi/tests/openapi_integration/test_group.py
@@ -5,24 +5,29 @@ import pytest
 from .helpers.helpers import request_with_validation
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 
-collection_name = 'test_collection_groups'
+collection_name = "test_collection_groups"
+lookup_collection_name = "test_collection_groups_lookup"
+
+POINTS_API = "/collections/{collection_name}/points"
+SEARCH_GROUPS_API = "/collections/{collection_name}/points/search/groups"
+RECO_GROUPS_API = "/collections/{collection_name}/points/recommend/groups"
 
 
 def upsert_chunked_docs(collection_name, docs=50, chunks=5):
     points = []
     for doc in range(docs):
         for chunk in range(chunks):
-            doc_id = f"doc_{doc}"
+            doc_id = doc
             i = doc * chunks + chunk
             p = {"id": i, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {"docId": doc_id}}
             points.append(p)
 
     response = request_with_validation(
-        api='/collections/{collection_name}/points',
+        api=POINTS_API,
         method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={"points": points}
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": points},
     )
 
     assert response.ok
@@ -34,15 +39,19 @@ def upsert_points_with_array_fields(collection_name, docs=3, chunks=5, id_offset
         for chunk in range(chunks):
             doc_ids = [f"valid_{doc}", f"valid_too_{doc}"]
             i = doc * chunks + chunk + id_offset
-            p = {"id": i, "vector": [0.0, 1.0, 0.0, 0.0], "payload": {"multiId": doc_ids}}
+            p = {
+                "id": i,
+                "vector": [0.0, 1.0, 0.0, 0.0],
+                "payload": {"multiId": doc_ids},
+            }
             points.append(p)
 
     response = request_with_validation(
-        api='/collections/{collection_name}/points',
+        api="/collections/{collection_name}/points",
         method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={"points": points}
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": points},
     )
 
     assert response.ok
@@ -62,11 +71,11 @@ def upsert_with_heterogenous_fields(collection_name):
     ]
 
     response = request_with_validation(
-        api='/collections/{collection_name}/points',
+        api="/collections/{collection_name}/points",
         method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={"points": points}
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": points},
     )
 
     assert response.ok
@@ -82,11 +91,28 @@ def upsert_multi_value_payload(collection_name):
     ]
 
     response = request_with_validation(
-        api='/collections/{collection_name}/points',
+        api="/collections/{collection_name}/points",
         method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={"points": points}
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": points},
+    )
+
+    assert response.ok
+    
+
+def upsert_doc_points(collection_name, docs=50):
+    points = [
+        {"id": i, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {"body": f"doc body {i}"}}
+        for i in range(100)
+    ]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={"points": points},
     )
 
     assert response.ok
@@ -99,22 +125,25 @@ def setup():
     upsert_points_with_array_fields(collection_name=collection_name)
     upsert_with_heterogenous_fields(collection_name=collection_name)
     upsert_multi_value_payload(collection_name=collection_name)
+    basic_collection_setup(collection_name=lookup_collection_name)
+    upsert_doc_points(collection_name=lookup_collection_name)
     yield
     drop_collection(collection_name=collection_name)
+    drop_collection(collection_name=lookup_collection_name)
 
 
 def test_search_with_multiple_groups():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api="/collections/{collection_name}/points/search/groups",
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [0.0, 0.0, 1.0, 1.0],
             "limit": 2,
             "with_payload": True,
             "group_by": "mkey",
             "group_size": 2,
-        }
+        },
     )
     assert response.ok
     groups = response.json()["result"]["groups"]
@@ -126,16 +155,16 @@ def test_search_with_multiple_groups():
 
 def test_search():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api=SEARCH_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [1.0, 0.0, 0.0, 0.0],
             "limit": 10,
             "with_payload": True,
             "group_by": "docId",
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -150,9 +179,9 @@ def test_search():
 
 def test_recommend():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/recommend/groups',
+        api=RECO_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "positive": [5, 10, 15],
             "negative": [6, 11, 16],
@@ -160,7 +189,7 @@ def test_recommend():
             "with_payload": True,
             "group_by": "docId",
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -175,9 +204,9 @@ def test_recommend():
 
 def test_with_vectors():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api=SEARCH_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [1.0, 0.0, 0.0, 0.0],
             "limit": 5,
@@ -185,7 +214,7 @@ def test_with_vectors():
             "with_vector": True,
             "group_by": "docId",
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -201,9 +230,9 @@ def test_with_vectors():
 
 def test_inexistent_group_by():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api=SEARCH_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [1.0, 0.0, 0.0, 0.0],
             "limit": 10,
@@ -211,7 +240,7 @@ def test_inexistent_group_by():
             "with_vector": True,
             "group_by": "inexistentDocId",
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -222,16 +251,16 @@ def test_inexistent_group_by():
 
 def search_array_group_by(group_by: str):
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api=SEARCH_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [0.0, 1.0, 0.0, 0.0],
             "limit": 6,
             "with_payload": True,
             "group_by": group_by,
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -252,16 +281,16 @@ def test_multi_value_group_by():
 
 def test_groups_by_heterogenous_fields():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search/groups',
+        api=SEARCH_GROUPS_API,
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [0.0, 0.0, 1.0, 0.0],
             "limit": 10,
             "with_payload": True,
             "group_by": "heterogenousId",
             "group_size": 3,
-        }
+        },
     )
     assert response.ok
 
@@ -280,3 +309,157 @@ def test_groups_by_heterogenous_fields():
     assert "string" in group_ids
     assert "b" in group_ids
     assert "a" in group_ids
+
+
+lookup_params = [
+    pytest.param(lookup_collection_name, id="string name"),
+    pytest.param({"collection": lookup_collection_name}, id="only collection name"),
+    pytest.param(
+        {
+            "collection": lookup_collection_name,
+            "with_payload": True,
+            "with_vectors": True,
+        },
+        id="explicit with_payload and with_vectors",
+    )
+]
+
+
+def assert_group_with_full_lookup(group):
+    assert group["hits"]
+    assert len(group["hits"]) == 3
+
+    assert group["lookup"]
+    assert group["id"] == group["lookup"]["id"]
+
+    lookup = group["lookup"]
+    assert lookup["payload"]
+    assert lookup["vector"]
+
+
+@pytest.mark.parametrize("with_lookup", lookup_params)
+def test_search_groups_with_lookup(with_lookup):
+    response = request_with_validation(
+        api=SEARCH_GROUPS_API,
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+            "with_lookup": with_lookup,
+        },
+    )
+
+    assert response.ok
+
+    groups = response.json()["result"]["groups"]
+
+    assert len(groups) == 10
+    for group in groups:
+        assert_group_with_full_lookup(group)
+
+
+@pytest.mark.parametrize("with_lookup", lookup_params)
+def test_recommend_groups_with_lookup(with_lookup):
+    response = request_with_validation(
+        api=RECO_GROUPS_API,
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [5, 10, 15],
+            "negative": [6, 11, 16],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+            "with_lookup": with_lookup,
+        },
+    )
+
+    assert response.ok
+
+    groups = response.json()["result"]["groups"]
+
+    assert len(groups) == 10
+    for group in groups:
+        assert_group_with_full_lookup(group)
+
+@pytest.mark.parametrize("with_lookup", [
+    pytest.param(
+        {
+            "collection": lookup_collection_name,
+            "with_payload": False,
+            "with_vectors": False,
+        },
+        id="with_payload and with_vectors",
+    ),
+    pytest.param(
+        {
+            "collection": lookup_collection_name,
+            "with_payload": False,
+            "with_vector": False,
+        },
+        id="with_vector is alias of with_vectors",
+    ),
+])
+def test_search_groups_with_lookup_without_payload_nor_vectors(with_lookup):
+    response = request_with_validation(
+        api=SEARCH_GROUPS_API,
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+            "with_lookup": with_lookup,
+        },
+    )
+
+    assert response.ok
+
+    groups = response.json()["result"]["groups"]
+
+    assert len(groups) == 10
+    for group in groups:
+        assert group["hits"]
+        assert len(group["hits"]) == 3
+
+        assert group["lookup"]
+        assert group["id"] == group["lookup"]["id"]
+
+        lookup = group["lookup"]
+        assert not lookup["payload"]
+        assert not lookup["vector"]
+
+
+def test_search_groups_lookup_with_non_existing_collection():
+    non_existing_collection = "non_existing_collection"
+    response = request_with_validation(
+        api=SEARCH_GROUPS_API,
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "with_payload": True,
+            "group_by": "docId",
+            "group_size": 3,
+            "with_lookup": {
+                "collection": non_existing_collection,
+                "with_payload": True,
+                "with_vector": True,
+            },
+        },
+    )
+
+    assert response.status_code == 404
+
+    assert (
+        f"Collection {non_existing_collection} not found"
+        in response.json()["status"]["error"]
+    )


### PR DESCRIPTION
Exposes the lookup feature in the Groups API, in both REST and gRPC interfaces

## Dependencies
Builds on top of #1996 

## TO DOs:
- [x] Expose feature
- [x] Write integration tests

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
