### PR TITLE
Add `prefault_mmap_pages` method to the `GraphLinksMmap` (#1791)

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use super::graph_links::GraphLinks;
+use super::graph_links::{GraphLinks, GraphLinksMmap};
 use crate::common::file_operations::{atomic_save_bin, read_bin, FileStorageError};
+use crate::common::mmap_ops;
 use crate::common::utils::rev_range;
 use crate::entry::entry_point::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
@@ -279,6 +280,12 @@ where
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
         Ok(atomic_save_bin(path, self)?)
+    }
+}
+
+impl GraphLayers<GraphLinksMmap> {
+    pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
+        self.links.prefault_mmap_pages(path)
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -11,7 +11,8 @@ use rand::thread_rng;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 
-use super::graph_links::GraphLinks;
+use super::graph_links::{GraphLinks, GraphLinksMmap};
+use crate::common::mmap_ops;
 use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
@@ -352,6 +353,12 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 })
                 .collect()
         }
+    }
+}
+
+impl HNSWIndex<GraphLinksMmap> {
+    pub fn prefault_mmap_pages(&self) -> Option<mmap_ops::PrefaultMmapPages> {
+        self.graph.as_ref()?.prefault_mmap_pages(&self.path)
     }
 }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -681,7 +681,12 @@ impl Segment {
             .flat_map(|data| data.prefault_mmap_pages())
             .collect();
 
-        let _ = thread::spawn(move || tasks.iter().for_each(mmap_ops::PrefaultMmapPages::exec));
+        let _ = thread::Builder::new()
+            .name(format!(
+                "segment-{:?}-prefault-mmap-pages",
+                self.current_path,
+            ))
+            .spawn(move || tasks.iter().for_each(mmap_ops::PrefaultMmapPages::exec));
     }
 }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -12,9 +12,8 @@ use tar::Builder;
 use uuid::Uuid;
 
 use crate::common::file_operations::{atomic_save_json, read_json};
-use crate::common::mmap_ops::PrefaultMmapPages;
 use crate::common::version::{StorageVersion, VERSION_FILE};
-use crate::common::{check_vector_name, check_vectors_set};
+use crate::common::{check_vector_name, check_vectors_set, mmap_ops};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationError::TypeInferenceError;
@@ -93,6 +92,20 @@ impl VectorData {
     /// This requires an index and storage type that both support appending.
     pub fn is_appendable(&self) -> bool {
         self.vector_index.borrow().is_appendable() && self.vector_storage.borrow().is_appendable()
+    }
+
+    pub fn prefault_mmap_pages(&self) -> impl Iterator<Item = mmap_ops::PrefaultMmapPages> {
+        let index_task = match &*self.vector_index.borrow() {
+            VectorIndexEnum::HnswMmap(index) => index.prefault_mmap_pages(),
+            _ => None,
+        };
+
+        let storage_task = match &*self.vector_storage.borrow() {
+            VectorStorageEnum::Memmap(storage) => storage.prefault_mmap_pages(),
+            _ => None,
+        };
+
+        index_task.into_iter().chain(storage_task)
     }
 }
 
@@ -665,13 +678,10 @@ impl Segment {
         let tasks: Vec<_> = self
             .vector_data
             .values()
-            .filter_map(|storage| match &*storage.vector_storage.borrow() {
-                VectorStorageEnum::Memmap(storage) => storage.prefault_mmap_pages(),
-                _ => None,
-            })
+            .flat_map(|data| data.prefault_mmap_pages())
             .collect();
 
-        let _ = thread::spawn(move || tasks.iter().for_each(PrefaultMmapPages::exec));
+        let _ = thread::spawn(move || tasks.iter().for_each(mmap_ops::PrefaultMmapPages::exec));
     }
 }
 


### PR DESCRIPTION
Added `prefault_mmap_pages` method to the `GraphLinksMmap` type (and propagated it all the way up to `Segment` type).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
