### PR TITLE
Add `prefault_mmap_pages` method to the `ChunkedMmapVectors` (#1791)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,6 +3785,7 @@ dependencies = [
  "uuid",
  "validator",
  "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,7 +3785,7 @@ dependencies = [
  "uuid",
  "validator",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -62,7 +62,7 @@ cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false }
 io-uring = "0.6.0"
 
-[target.'cfg(windows)'.dependencies.windows-sys]
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.48"
 features = [
     "Win32_Foundation",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -62,6 +62,15 @@ cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false }
 io-uring = "0.6.0"
 
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.48"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+]
+
 [[bench]]
 name = "vector_search"
 harness = false

--- a/lib/segment/src/common/mmap_ops.rs
+++ b/lib/segment/src/common/mmap_ops.rs
@@ -106,12 +106,12 @@ impl PrefaultableMmap {
     }
 
     fn prefault_with_madv_populate_read(&self, sep: &str, path: &Path) -> bool {
-        // Prefaulting memmapped pages with `MADV_POPULATE_READ` is only supported on Linux
+        // Prefaulting memmapped pages with `MADV_POPULATE_READ` is only supported on Linux and Windows
         //
         // The `cfg!(...)` runtime check could have been expressed as `#[cfg(...)]` conditional
         // compilation directive, but ergonomics of `cfg!(...)` check is better. 🤷‍♀️
 
-        if !cfg!(target_os = "linux") {
+        if !cfg!(any(target_os = "linux", windows)) {
             return false;
         }
 
@@ -166,14 +166,14 @@ impl TryFrom<Arc<MmapMut>> for PrefaultableMmap {
     type Error = Unsupported;
 
     fn try_from(mmap: Arc<MmapMut>) -> Result<Self, Self::Error> {
-        // Prefaulting `MmapMut` pages is only supported on Linux:
-        // - because prefaulting with `MADV_POPULATE_READ` is only supported on Linux
+        // Prefaulting `MmapMut` pages is only supported on Linux and Windows:
+        // - because prefaulting with `MADV_POPULATE_READ` is only supported on Linux and Windows
         // - and prefaulting with explicit read is not supported for `MmapMut`
         //
         // The `cfg!(...)` runtime check could have been expressed as `#[cfg(...)]` conditional
         // compilation directive, but ergonomics of `cfg!(...)` check is better. 🤷‍♀️
 
-        if cfg!(target_os = "linux") {
+        if cfg!(any(target_os = "linux", windows)) {
             Ok(Self::MmapMut(mmap))
         } else {
             Err(Unsupported)
@@ -182,7 +182,7 @@ impl TryFrom<Arc<MmapMut>> for PrefaultableMmap {
 }
 
 #[derive(Copy, Clone, Debug, thiserror::Error)]
-#[error("prefaulting MmapMut pages is only supported on Linux")]
+#[error("prefaulting MmapMut pages is only supported on Linux and Windows")]
 pub struct Unsupported;
 
 pub fn transmute_to_u8<T>(v: &T) -> &[u8] {

--- a/lib/segment/src/common/mmap_ops.rs
+++ b/lib/segment/src/common/mmap_ops.rs
@@ -111,7 +111,7 @@ impl PrefaultableMmap {
         // The `cfg!(...)` runtime check could have been expressed as `#[cfg(...)]` conditional
         // compilation directive, but ergonomics of `cfg!(...)` check is better. 🤷‍♀️
 
-        if cfg!(target_os = "linux") {
+        if !cfg!(target_os = "linux") {
             return false;
         }
 

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -23,12 +23,14 @@
 //! behavior. Problems caused by this are very hard to debug.
 
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{mem, slice};
 
 use bitvec::slice::BitSlice;
 use memmap2::MmapMut;
 
+use super::mmap_ops;
 use crate::common::Flusher;
 
 /// Result for mmap errors.
@@ -180,6 +182,13 @@ where
             }
         })
     }
+
+    pub fn prefault_mmap_pages(
+        &self,
+        path: impl Into<PathBuf>,
+    ) -> Option<mmap_ops::PrefaultMmapPages> {
+        mmap_ops::PrefaultMmapPages::from_mmap_mut(self.mmap.clone(), Some(path))
+    }
 }
 
 impl<T> Deref for MmapType<T>
@@ -261,6 +270,13 @@ impl<T> MmapSlice<T> {
     /// Get flusher to explicitly flush mmap at a later time
     pub fn flusher(&self) -> Flusher {
         self.mmap.flusher()
+    }
+
+    pub fn prefault_mmap_pages(
+        &self,
+        path: impl Into<PathBuf>,
+    ) -> Option<mmap_ops::PrefaultMmapPages> {
+        self.mmap.prefault_mmap_pages(path)
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -514,7 +514,7 @@ impl GraphLinksMmap {
     }
 
     pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
-        mmap_ops::PrefaultMmapPages::new(self.mmap.clone()?, Some(path)).into()
+        mmap_ops::PrefaultMmapPages::from_mmap(self.mmap.clone()?, Some(path)).into()
     }
 }
 

--- a/lib/segment/src/madvise.rs
+++ b/lib/segment/src/madvise.rs
@@ -37,7 +37,7 @@ pub fn get_global() -> Advice {
 /// See [`memmap2::Advice`] and [`madvise(2)`] man page.
 ///
 /// [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Advice {
     /// See [`memmap2::Advice::Normal`].
@@ -103,6 +103,12 @@ impl Madviseable for memmap2::Mmap {
     fn madvise(&self, advice: Advice) -> io::Result<()> {
         #[cfg(unix)]
         self.advise(advice.try_into()?)?;
+
+        #[cfg(windows)]
+        if advice == Advice::PopulateRead {
+            win::prefetch_virtual_memory(self)?;
+        }
+
         Ok(())
     }
 }
@@ -111,6 +117,138 @@ impl Madviseable for memmap2::MmapMut {
     fn madvise(&self, advice: Advice) -> io::Result<()> {
         #[cfg(unix)]
         self.advise(advice.try_into()?)?;
+
+        #[cfg(windows)]
+        if advice == Advice::PopulateRead {
+            win::prefetch_virtual_memory(self)?;
+        }
+
         Ok(())
+    }
+}
+
+#[cfg(windows)]
+mod win {
+    use std::{ops, ptr, slice};
+
+    use windows_sys::Win32::Foundation::GetLastError;
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        FormatMessageW, FORMAT_MESSAGE_ALLOCATE_BUFFER, FORMAT_MESSAGE_FROM_SYSTEM,
+    };
+    use windows_sys::Win32::System::Memory::{
+        GetProcessHeap, HeapFree, PrefetchVirtualMemory, WIN32_MEMORY_RANGE_ENTRY,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    use super::*;
+
+    pub fn prefetch_virtual_memory(mmap: &impl ops::Deref<Target = [u8]>) -> io::Result<()> {
+        let ptr = mmap.deref().as_ptr().cast_mut().cast();
+        let len = mmap.deref().len();
+
+        if len == 0 {
+            return Ok(());
+        }
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/ns-memoryapi-win32_memory_range_entry
+        let memory_range_entry = WIN32_MEMORY_RANGE_ENTRY {
+            VirtualAddress: ptr,
+            NumberOfBytes: len,
+        };
+
+        let result = unsafe {
+            // - https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-prefetchvirtualmemory
+            // - https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess
+            PrefetchVirtualMemory(GetCurrentProcess(), 1, &memory_range_entry, 0)
+        };
+
+        if result != 0 {
+            return Ok(());
+        }
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+        let error_code = unsafe { GetLastError() };
+
+        let error_message = match error_message(error_code) {
+            Ok(error_message) => format!(
+                "PrefetchVirtualMemory failed with {error_code} error code: \
+                 {error_message}"
+            ),
+
+            Err(format_message_error_code) => format!(
+                "PrefetchVirtualMemory failed with {error_code} error code \
+                 (FormatMessageW failed to format error message with {format_message_error_code} error code)"
+            ),
+        };
+
+        Err(io::Error::new(io::ErrorKind::Other, error_message))
+    }
+
+    // - https://learn.microsoft.com/en-us/windows/win32/debug/retrieving-the-last-error-code
+    // - `windows_core::hresult::Hresult::message` implementation
+    //   - https://github.com/microsoft/windows-rs/blob/311b080/crates/libs/core/src/hresult.rs#L83-L92
+    fn error_message(error_code: u32) -> Result<String, u32> {
+        let mut error_message_buf_ptr = ptr::null_mut();
+
+        let error_message_buf_len = unsafe {
+            // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew
+            FormatMessageW(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+                ptr::null(),
+                error_code,
+                // Equivalent of `MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)` in C/C++
+                //
+                // - https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-makelangid
+                // - https://github.com/microsoft/windows-rs/issues/829#issuecomment-851553538
+                0x0000_0400,
+                // This is super confusing, but correct, as far as I can tell:
+                // - `error_message_ptr` is a NULL-pointer of `*mut u16` type
+                // - we take pointer to `error_message_ptr`
+                //   - which is of `*mut *mut u16` type
+                // - and pass it as `lpbuffer` argument of `FormatMessageW`
+                //   - `which is of `*mut u16` type
+                //   - so we cast pointer to `error_message_ptr` from `*mut *mut u16` to `*mut u16`
+                // - because we pass `FORMAT_MESSAGE_ALLOCATE_BUFFER` flag to `FormatMessageW`,
+                //   it would cast `lpbuffer` back to `*mut *mut u16` and write an address
+                //   of a UTF-16 message buffer (i.e., `*mut u16` value) to `error_message_ptr`
+                //
+                // - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew#parameters
+                //   - `lpBuffer` parameter
+                // - https://learn.microsoft.com/en-us/windows/win32/debug/retrieving-the-last-error-code
+                // - `windows_core::hresult::Hresult::message` implementation
+                //   - https://github.com/microsoft/windows-rs/blob/311b080/crates/libs/core/src/hresult.rs#L83-L92
+                &mut error_message_buf_ptr as *mut _ as *mut _,
+                0,
+                ptr::null_mut(),
+            )
+        };
+
+        if error_message_buf_len == 0 {
+            // https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+            return Err(unsafe { GetLastError() });
+        }
+
+        let error_message_buf = unsafe {
+            slice::from_raw_parts(
+                error_message_buf_ptr as *const _,
+                error_message_buf_len as _,
+            )
+        };
+
+        let error_message = String::from_utf16_lossy(error_message_buf);
+
+        unsafe {
+            // - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-localfree
+            //   - note at the top regarding "heap functions"
+            // - https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapfree
+            // - https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap
+            // - `windows_core::strings::hstrng::HSTRING` drop implementation:
+            //   - https://github.com/microsoft/windows-rs/blob/311b080/crates/libs/core/src/strings/hstring.rs#L119-L136
+            // - `windows_core::imp::heap::heap_free` implementation:
+            //   - https://github.com/microsoft/windows-rs/blob/311b080/crates/libs/core/src/imp/heap.rs#L26-L35
+            HeapFree(GetProcessHeap(), 0, error_message_buf_ptr);
+        }
+
+        Ok(error_message)
     }
 }

--- a/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use bitvec::prelude::BitSlice;
 
-use crate::common::Flusher;
+use crate::common::{mmap_ops, Flusher};
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::{check_process_stopped, OperationResult};
 use crate::types::{Distance, PointOffsetType, QuantizationConfig};
@@ -82,6 +82,10 @@ impl AppendableMmapVectorStorage {
             self.deleted_count -= 1;
         }
         Ok(previous)
+    }
+
+    pub fn prefault_mmap_pages(&self) -> impl Iterator<Item = mmap_ops::PrefaultMmapPages> + '_ {
+        self.vectors.prefault_mmap_pages()
     }
 }
 

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -189,7 +189,7 @@ impl MmapVectors {
     }
 
     pub fn prefault_mmap_pages(&self, path: &Path) -> mmap_ops::PrefaultMmapPages {
-        mmap_ops::PrefaultMmapPages::new(self.mmap.clone(), Some(path))
+        mmap_ops::PrefaultMmapPages::from_mmap(self.mmap.clone(), Some(path))
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Refactored `PrefaultMmapPages` type to support `MmapMut` pages prefault (on Linux and Windows) and added `prefault_mmap_pages` to the `ChunkedMmapVectors` type (and propagated all the way up to `Segment` type).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
