### PR TITLE
Fix wal clamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=f3029ad0e1632d5e375db55695e33121df54aa5c#f3029ad0e1632d5e375db55695e33121df54aa5c"
+source = "git+https://github.com/qdrant/wal.git?rev=e034a1814ee15941134d442198dc1fd87d767594#e034a1814ee15941134d442198dc1fd87d767594"
 dependencies = [
  "byteorder",
  "crc",
@@ -4745,7 +4745,7 @@ dependencies = [
  "memmap2 0.6.2",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.37.4",
+ "rustix 0.35.13",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ clap = { version = "4.3.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2"}
 uuid = { version = "1.3", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "f3029ad0e1632d5e375db55695e33121df54aa5c" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "e034a1814ee15941134d442198dc1fd87d767594" }
 
 config = "~0.13.3"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "f3029ad0e1632d5e375db55695e33121df54aa5c"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "e034a1814ee15941134d442198dc1fd87d767594"}
 ordered-float = "3.7"
 hashring = "0.3.0"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -85,7 +85,8 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
             let first_index = wal_state
                 .ack_index
-                .clamp(wal.first_index(), wal.last_index());
+                .max(wal.first_index())
+                .min(wal.last_index());
             Some(first_index)
         } else {
             None

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -170,7 +170,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
         // Acknowledge index should not decrease
         let minimal_first_index = self.first_index.unwrap_or(self.wal.first_index());
-        let new_first_index = Some(until_index.clamp(minimal_first_index, self.wal.last_index()));
+        let new_first_index = Some(until_index.max(minimal_first_index).min(self.wal.last_index()));
         // Update current `first_index`
         if self.first_index != new_first_index {
             self.first_index = new_first_index;

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -170,7 +170,11 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
         // Acknowledge index should not decrease
         let minimal_first_index = self.first_index.unwrap_or(self.wal.first_index());
-        let new_first_index = Some(until_index.max(minimal_first_index).min(self.wal.last_index()));
+        let new_first_index = Some(
+            until_index
+                .max(minimal_first_index)
+                .min(self.wal.last_index()),
+        );
         // Update current `first_index`
         if self.first_index != new_first_index {
             self.first_index = new_first_index;

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.10.0"
 num_cpus = "1.15"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "f3029ad0e1632d5e375db55695e33121df54aa5c" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "e034a1814ee15941134d442198dc1fd87d767594" }
 tokio = { version = "~1.28", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
There is a strange case, when we create snapshot, it produces empty WAL.

It seems that empty WAL computes `last_index` incorrectly (it assumes that WAL with offset is never empty).

This incorrect API should be fixed in WAL crate, as it is the original cause of the problem.
Still, it might be beneficial to use min/max in qdrant side, just to avoid unnecessary panic.
