### PR TITLE
WIP: Async uring vector storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1e1a01cfb924fd8c5c43b6827965db394f5a3a16c599ce03452266e1cf984c"
+checksum = "8b7b36074613a723279637061b40db993208908a94f10ccb14436ce735bc0f57"
 dependencies = [
  "bitflags",
  "libc",
@@ -3744,6 +3744,7 @@ dependencies = [
  "futures",
  "geo",
  "geohash",
+ "io-uring",
  "itertools",
  "log",
  "memmap2 0.6.2",
@@ -3772,7 +3773,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tinyvec",
- "tokio-uring",
  "uuid",
  "validator",
  "walkdir",
@@ -4383,20 +4383,6 @@ checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-uring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
-dependencies = [
- "io-uring",
- "libc",
- "scoped-tls",
- "slab",
- "socket2",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1e1a01cfb924fd8c5c43b6827965db394f5a3a16c599ce03452266e1cf984c"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,6 +3741,7 @@ dependencies = [
  "chrono",
  "criterion",
  "fs_extra",
+ "futures",
  "geo",
  "geohash",
  "itertools",
@@ -3761,6 +3772,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tinyvec",
+ "tokio-uring",
  "uuid",
  "validator",
  "walkdir",
@@ -4371,6 +4383,20 @@ checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-uring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
+dependencies = [
+ "io-uring",
+ "libc",
+ "scoped-tls",
+ "slab",
+ "socket2",
  "tokio",
 ]
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -60,7 +60,7 @@ futures = "0.3.28"
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false }
-tokio-uring = "0.4.0"
+io-uring = "0.6.0"
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -55,6 +55,8 @@ validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 
 sysinfo = "0.29"
+tokio-uring = "0.4.0"
+futures = "0.3.28"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -55,12 +55,12 @@ validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 
 sysinfo = "0.29"
-tokio-uring = "0.4.0"
 futures = "0.3.28"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false }
+tokio-uring = "0.4.0"
 
 [[bench]]
 name = "vector_search"

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -278,10 +278,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     &vector_storage,
                     id_tracker.deleted_point_bitslice(),
                 );
-                search_result.iter_mut().for_each(|scored_point| {
-                    scored_point.score = raw_scorer.score_point(scored_point.idx);
-                });
-                search_result
+                let mut ids_iterator = search_result.iter_mut().map(|x| x.idx);
+                let mut re_scored = raw_scorer.score_points_unfiltered(&mut ids_iterator);
+                re_scored.sort_unstable();
+                re_scored
             } else {
                 search_result
             }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -267,7 +267,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let points_scorer = FilteredScorer::new(raw_scorer.as_ref(), filter_context.as_deref());
 
         if let Some(graph) = &self.graph {
-            let mut search_result = graph.search(top, ef, points_scorer);
+            let search_result = graph.search(top, ef, points_scorer);
             let if_rescore = params
                 .and_then(|p| p.quantization)
                 .map(|q| q.rescore)
@@ -278,7 +278,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     &vector_storage,
                     id_tracker.deleted_point_bitslice(),
                 );
-                let mut ids_iterator = search_result.iter_mut().map(|x| x.idx);
+                let mut ids_iterator = search_result.iter().map(|x| x.idx);
                 let mut re_scored = raw_scorer.score_points_unfiltered(&mut ids_iterator);
                 re_scored.sort_unstable();
                 re_scored

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -72,11 +72,13 @@ impl UringReader {
     fn submit_and_read(
         &mut self,
         mut callback: impl FnMut(usize, PointOffsetType, &[VectorElementType]),
-        unseen_buffer_ids: &mut Vec<usize>,
+        unused_buffer_ids: &mut Vec<usize>,
     ) -> OperationResult<()> {
         let buffers_count = self.buffers.buffers.len();
+        let used_buffers_count = buffers_count - unused_buffer_ids.len();
+
         // Wait for at least one buffer to become available
-        self.io_uring.submit_and_wait(buffers_count)?;
+        self.io_uring.submit_and_wait(used_buffers_count)?;
 
         let cqe = self.io_uring.completion();
         for entry in cqe {
@@ -98,7 +100,7 @@ impl UringReader {
             let buffer = &self.buffers.buffers[buffer_id].buffer;
             let vector = transmute_from_u8_to_slice(buffer);
             callback(meta.index, meta.point_id, vector);
-            unseen_buffer_ids.push(buffer_id);
+            unused_buffer_ids.push(buffer_id);
         }
 
         Ok(())
@@ -112,16 +114,16 @@ impl UringReader {
     ) -> OperationResult<()> {
         let buffers_count = self.buffers.buffers.len();
 
-        let mut unseen_buffer_ids = (0..buffers_count).collect::<Vec<_>>();
+        let mut unused_buffer_ids = (0..buffers_count).collect::<Vec<_>>();
 
         for item in points.into_iter().enumerate() {
             let (idx, point): (usize, PointOffsetType) = item;
 
-            if unseen_buffer_ids.is_empty() {
-                self.submit_and_read(&mut callback, &mut unseen_buffer_ids)?;
+            if unused_buffer_ids.is_empty() {
+                self.submit_and_read(&mut callback, &mut unused_buffer_ids)?;
             }
             // Assume there is at least one buffer available at this point
-            let buffer_id = unseen_buffer_ids.pop().unwrap();
+            let buffer_id = unused_buffer_ids.pop().unwrap();
 
             self.buffers.buffers[buffer_id].meta = Some(BufferMeta {
                 index: idx,
@@ -150,11 +152,11 @@ impl UringReader {
             }
         }
 
-        let mut operations_to_wait_for = self.buffers.buffers.len() - unseen_buffer_ids.len();
+        let mut operations_to_wait_for = self.buffers.buffers.len() - unused_buffer_ids.len();
 
         while operations_to_wait_for > 0 {
-            self.submit_and_read(&mut callback, &mut unseen_buffer_ids)?;
-            operations_to_wait_for = self.buffers.buffers.len() - unseen_buffer_ids.len();
+            self.submit_and_read(&mut callback, &mut unused_buffer_ids)?;
+            operations_to_wait_for = self.buffers.buffers.len() - unused_buffer_ids.len();
         }
         Ok(())
     }

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -34,7 +34,7 @@ impl BufferStore {
     }
 }
 
-pub struct UringBufferedReader {
+pub struct UringReader {
     file: File,
     buffers: BufferStore,
     io_uring: IoUring,
@@ -42,7 +42,7 @@ pub struct UringBufferedReader {
     header_size: usize,
 }
 
-impl UringBufferedReader {
+impl UringReader {
     pub fn new(file: File, raw_size: usize, header_size: usize) -> OperationResult<Self> {
         let buffers = BufferStore::new(DISK_PARALLELISM, raw_size);
         let io_uring = IoUring::new(DISK_PARALLELISM as _)?;

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -1,0 +1,144 @@
+use std::fs::File;
+use std::os::fd::AsRawFd;
+
+use io_uring::{opcode, types, IoUring};
+
+use crate::common::mmap_ops::transmute_from_u8_to_slice;
+use crate::data_types::vectors::VectorElementType;
+use crate::entry::entry_point::{OperationError, OperationResult};
+use crate::types::PointOffsetType;
+
+const DISK_PARALLELISM: usize = 16; // TODO: benchmark it better, or make it configurable
+
+struct BufferStore {
+    /// Stores the buffer for the point vectors
+    pub buffers: Vec<Vec<u8>>,
+    /// Stores the point ids that are currently being processed in each buffer.
+    pub processing_ids: Vec<PointOffsetType>,
+}
+
+impl BufferStore {
+    pub fn new(num_buffers: usize, buffer_raw_size: usize) -> Self {
+        Self {
+            buffers: (0..num_buffers).map(|_| vec![0; buffer_raw_size]).collect(),
+            processing_ids: vec![0; num_buffers],
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_empty() -> Self {
+        Self {
+            buffers: vec![],
+            processing_ids: vec![],
+        }
+    }
+}
+
+pub struct UringBufferedReader {
+    file: File,
+    buffers: BufferStore,
+    io_uring: IoUring,
+    raw_size: usize,
+    header_size: usize,
+}
+
+impl UringBufferedReader {
+    pub fn new(file: File, raw_size: usize, header_size: usize) -> OperationResult<Self> {
+        let buffers = BufferStore::new(DISK_PARALLELISM, raw_size);
+        let io_uring = IoUring::new(DISK_PARALLELISM as _)?;
+
+        Ok(Self {
+            file,
+            buffers,
+            io_uring,
+            raw_size,
+            header_size,
+        })
+    }
+
+    fn encode_user_data(buffer_id: usize, entry_num: usize) -> u64 {
+        ((buffer_id as u64) << 32) | (entry_num as u64)
+    }
+
+    fn decode_user_data(user_data: u64) -> (usize, usize) {
+        (
+            (user_data >> 32) as usize,
+            (user_data & 0xFFFFFFFF) as usize,
+        )
+    }
+
+    /// Takes in iterator of point offsets, reads it, and yields a callback with the read data.
+    pub fn read_stream(
+        &mut self,
+        points: impl IntoIterator<Item = PointOffsetType>,
+        mut callback: impl FnMut(usize, PointOffsetType, &[VectorElementType]),
+    ) -> OperationResult<()> {
+        let buffers_count = self.buffers.buffers.len();
+
+        let mut unused_buffer_ids = (0..buffers_count).collect::<Vec<_>>();
+
+        for item in points.into_iter().enumerate() {
+            let (idx, point): (usize, PointOffsetType) = item;
+
+            if unused_buffer_ids.is_empty() {
+                // Wait for at least one buffer to become available
+                self.io_uring.submit_and_wait(buffers_count)?;
+
+                let mut cqe = self.io_uring.completion();
+                cqe.sync();
+
+                for entry in cqe {
+                    let (buffer_id, idx) = Self::decode_user_data(entry.user_data());
+                    let point_id = self.buffers.processing_ids[buffer_id];
+                    let buffer = &self.buffers.buffers[buffer_id];
+                    let vector = transmute_from_u8_to_slice(buffer);
+                    callback(idx, point_id, vector);
+                    unused_buffer_ids.push(buffer_id);
+                }
+            }
+            // Assume there is at least one buffer available at this point
+            let buffer_id = unused_buffer_ids.pop().unwrap();
+
+            self.buffers.processing_ids[buffer_id] = point;
+            let buffer = &mut self.buffers.buffers[buffer_id];
+            let offset = self.header_size + self.raw_size * point as usize;
+
+            let user_data = Self::encode_user_data(buffer_id, idx);
+
+            let read_e = opcode::Read::new(
+                types::Fd(self.file.as_raw_fd()),
+                buffer.as_mut_ptr(),
+                buffer.len() as _,
+            )
+            .offset(offset as _)
+            .build()
+            .user_data(user_data);
+
+            unsafe {
+                // self.io_uring.submission().push(&read_e).unwrap();
+                self.io_uring.submission().push(&read_e).map_err(|err| {
+                    OperationError::service_error(format!("Failed using io-uring: {}", err))
+                })?;
+            }
+        }
+
+        let mut operations_to_wait_for = self.buffers.buffers.len() - unused_buffer_ids.len();
+
+        while operations_to_wait_for > 0 {
+            self.io_uring.submit_and_wait(operations_to_wait_for)?;
+            let mut cqe = self.io_uring.completion();
+            cqe.sync();
+            for entry in cqe {
+                let (buffer_id, idx) = Self::decode_user_data(entry.user_data());
+                let point = self.buffers.processing_ids[buffer_id];
+                let buffer = &self.buffers.buffers[buffer_id];
+                let vector = transmute_from_u8_to_slice(buffer);
+                callback(idx, point, vector);
+                unused_buffer_ids.push(buffer_id);
+            }
+
+            operations_to_wait_for = self.buffers.buffers.len() - unused_buffer_ids.len();
+        }
+        Ok(())
+    }
+}

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -84,9 +84,7 @@ impl UringBufferedReader {
                 // Wait for at least one buffer to become available
                 self.io_uring.submit_and_wait(buffers_count)?;
 
-                let mut cqe = self.io_uring.completion();
-                cqe.sync();
-
+                let cqe = self.io_uring.completion();
                 for entry in cqe {
                     let (buffer_id, idx) = Self::decode_user_data(entry.user_data());
                     let point_id = self.buffers.processing_ids[buffer_id];
@@ -126,8 +124,7 @@ impl UringBufferedReader {
 
         while operations_to_wait_for > 0 {
             self.io_uring.submit_and_wait(operations_to_wait_for)?;
-            let mut cqe = self.io_uring.completion();
-            cqe.sync();
+            let cqe = self.io_uring.completion();
             for entry in cqe {
                 let (buffer_id, idx) = Self::decode_user_data(entry.user_data());
                 let point = self.buffers.processing_ids[buffer_id];

--- a/lib/segment/src/vector_storage/async_io_mock.rs
+++ b/lib/segment/src/vector_storage/async_io_mock.rs
@@ -4,10 +4,10 @@ use crate::entry::entry_point::OperationResult;
 
 // This is a mock implementation of the async_io module for those platforms that don't support io_uring.
 #[allow(dead_code)]
-pub struct UringBufferedReader;
+pub struct UringReader;
 
 #[allow(dead_code)]
-impl UringBufferedReader {
+impl UringReader {
     pub fn new(_file: File, _raw_size: usize, _header_size: usize) -> OperationResult<Self> {
         Ok(Self {})
     }

--- a/lib/segment/src/vector_storage/async_io_mock.rs
+++ b/lib/segment/src/vector_storage/async_io_mock.rs
@@ -1,0 +1,14 @@
+use std::fs::File;
+
+use crate::entry::entry_point::OperationResult;
+
+// This is a mock implementation of the async_io module for those platforms that don't support io_uring.
+#[allow(dead_code)]
+pub struct UringBufferedReader;
+
+#[allow(dead_code)]
+impl UringBufferedReader {
+    pub fn new(_file: File, _raw_size: usize, _header_size: usize) -> OperationResult<Self> {
+        Ok(Self {})
+    }
+}

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -63,7 +63,7 @@ where
 
         let mut processed = 0;
         self.storage
-            .process_points(points_stream, |idx, point_id, other_vector| {
+            .read_vectors_async(points_stream, |idx, point_id, other_vector| {
                 scores[idx] = ScoredPointOffset {
                     idx: point_id,
                     score: TMetric::similarity(&self.query, other_vector),
@@ -119,7 +119,7 @@ where
         let points_stream = points.filter(|point_id| self.check_vector(*point_id));
 
         self.storage
-            .process_points(points_stream, |_, point_id, other_vector| {
+            .read_vectors_async(points_stream, |_, point_id, other_vector| {
                 let scored_point_offset = ScoredPointOffset {
                     idx: point_id,
                     score: TMetric::similarity(&self.query, other_vector),
@@ -144,7 +144,7 @@ where
 
         let mut pq = FixedLengthPriorityQueue::new(top);
         self.storage
-            .process_points(points_stream, |_, point_id, other_vector| {
+            .read_vectors_async(points_stream, |_, point_id, other_vector| {
                 let scored_point_offset = ScoredPointOffset {
                     idx: point_id,
                     score: TMetric::similarity(&self.query, other_vector),

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -1,0 +1,213 @@
+use std::marker::PhantomData;
+
+use bitvec::prelude::BitSlice;
+use futures::StreamExt;
+use tokio_uring::fs::File as UringFile;
+
+use crate::common::mmap_ops::transmute_from_u8_to_slice;
+use crate::data_types::vectors::VectorElementType;
+use crate::entry::entry_point::OperationResult;
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
+use crate::spaces::tools::FixedLengthPriorityQueue;
+use crate::types::{Distance, PointOffsetType, ScoreType};
+use crate::vector_storage::mmap_vectors::MmapVectors;
+use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage, VectorStorageEnum};
+
+const DISK_PARALLELISM: usize = 16; // TODO: benchmark it better, or make it configurable
+
+pub struct AsyncRawScorerImpl<'a, TMetric: Metric> {
+    points_count: PointOffsetType,
+    query: Vec<VectorElementType>,
+    point_deleted: &'a BitSlice,
+    vec_deleted: &'a BitSlice,
+    metric: PhantomData<TMetric>,
+    uring_file: UringFile,
+    storage: &'a MmapVectors,
+}
+
+impl<'a, TMetric> AsyncRawScorerImpl<'a, TMetric>
+where
+    TMetric: Metric,
+{
+    pub fn new_raw_scorer(
+        vector: Vec<VectorElementType>,
+        vector_storage: &'a VectorStorageEnum,
+        point_deleted: &'a BitSlice,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        let points_count = vector_storage.total_vector_count() as PointOffsetType;
+        let vec_deleted = vector_storage.deleted_vector_bitslice();
+
+        match vector_storage {
+            VectorStorageEnum::Simple(_vs) => {
+                unreachable!("Simple vector storage is not supported for async raw scorer")
+            }
+            VectorStorageEnum::AppendableMemmap(_vs) => unreachable!(
+                "Appendable memmap vector storage is not supported for async raw scorer"
+            ),
+            VectorStorageEnum::Memmap(vs) => {
+                let uring_file =
+                    tokio_uring::start(async { UringFile::open(vs.vector_path()).await })?;
+
+                let storage = vs.get_mmap_vectors();
+
+                match vs.distance() {
+                    Distance::Cosine => Ok(Box::new(AsyncRawScorerImpl::<'a, CosineMetric> {
+                        points_count,
+                        query: CosineMetric::preprocess(&vector).unwrap_or(vector),
+                        point_deleted,
+                        vec_deleted,
+                        metric: PhantomData,
+                        uring_file,
+                        storage,
+                    })),
+                    Distance::Euclid => Ok(Box::new(AsyncRawScorerImpl::<'a, EuclidMetric> {
+                        points_count,
+                        query: EuclidMetric::preprocess(&vector).unwrap_or(vector),
+                        point_deleted,
+                        vec_deleted,
+                        metric: PhantomData,
+                        uring_file,
+                        storage,
+                    })),
+                    Distance::Dot => Ok(Box::new(AsyncRawScorerImpl::<'a, DotProductMetric> {
+                        points_count,
+                        query: DotProductMetric::preprocess(&vector).unwrap_or(vector),
+                        point_deleted,
+                        vec_deleted,
+                        metric: PhantomData,
+                        uring_file,
+                        storage,
+                    })),
+                }
+            }
+        }
+    }
+
+    async fn score_point(&self, point_id: PointOffsetType) -> ScoredPointOffset {
+        let offset = self.storage.data_offset(point_id).unwrap(); // this is fine
+        let raw_size = self.storage.raw_size();
+
+        let buff = vec![0u8; raw_size];
+
+        let (res, buff) = self.uring_file.read_at(buff, offset as u64).await;
+
+        match res {
+            Ok(sz) => {
+                debug_assert_eq!(sz, raw_size);
+                // Convert bytes vector into VectorElementType vector
+                let other_vector = transmute_from_u8_to_slice(&buff);
+                ScoredPointOffset {
+                    idx: point_id,
+                    score: TMetric::similarity(&self.query, other_vector),
+                }
+            }
+            Err(err) => {
+                debug_assert!(false, "Failed to read with uring: {:?}", err);
+                // Fall back to mmap, if for some reason we can't read with uring
+                // It might happen if we allowed to use uring on the old kernels
+                let other_vector = self.storage.get_vector(point_id);
+                ScoredPointOffset {
+                    idx: point_id,
+                    score: TMetric::similarity(&self.query, other_vector),
+                }
+            }
+        }
+    }
+}
+
+impl<'a, TMetric> RawScorer for AsyncRawScorerImpl<'a, TMetric>
+where
+    TMetric: Metric,
+{
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
+        tokio_uring::start(async {
+            let points_stream = points
+                .iter()
+                .copied()
+                .filter(|point_id| self.check_vector(*point_id))
+                .map(|point_id| self.score_point(point_id));
+
+            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
+            let mut n: usize = 0;
+            while let Some(result) = scored_stream.next().await {
+                scores[n] = result;
+                n += 1;
+            }
+            n
+        })
+    }
+
+    fn check_vector(&self, point: PointOffsetType) -> bool {
+        point < self.points_count
+            // Deleted points propagate to vectors; check vector deletion for possible early return
+            && !self
+            .vec_deleted
+            .get(point as usize)
+            .map(|x| *x)
+            .unwrap_or(false)
+            // Additionally check point deletion for integrity if delete propagation to vector failed
+            && !self
+            .point_deleted
+            .get(point as usize)
+            .map(|x| *x)
+            .unwrap_or(false)
+    }
+
+    fn score_point(&self, point: PointOffsetType) -> ScoreType {
+        let other_vector = self.storage.get_vector(point);
+        TMetric::similarity(&self.query, other_vector)
+    }
+
+    fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
+        let vector_a = self.storage.get_vector(point_a);
+        let vector_b = self.storage.get_vector(point_b);
+        TMetric::similarity(vector_a, vector_b)
+    }
+
+    fn peek_top_iter(
+        &self,
+        points: &mut dyn Iterator<Item = PointOffsetType>,
+        top: usize,
+    ) -> Vec<ScoredPointOffset> {
+        if top == 0 {
+            return vec![];
+        }
+
+        tokio_uring::start(async {
+            let points_stream = points
+                .filter(|point_id| self.check_vector(*point_id))
+                .map(|point_id| self.score_point(point_id));
+
+            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
+
+            // Implement peek_top_iter, but with async streams
+            let mut pq = FixedLengthPriorityQueue::new(top);
+            while let Some(scored_point_offset) = scored_stream.next().await {
+                pq.push(scored_point_offset);
+            }
+            pq.into_vec()
+        })
+    }
+
+    fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
+        if top == 0 {
+            return vec![];
+        }
+
+        tokio_uring::start(async {
+            let points_stream = (0..self.points_count)
+                .filter(|point_id| self.check_vector(*point_id))
+                .map(|point_id| self.score_point(point_id));
+
+            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
+
+            // Implement peek_top_iter, but with async streams
+            let mut pq = FixedLengthPriorityQueue::new(top);
+            while let Some(scored_point_offset) = scored_stream.next().await {
+                pq.push(scored_point_offset);
+            }
+            pq.into_vec()
+        })
+    }
+}

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -1,10 +1,7 @@
 use std::marker::PhantomData;
 
 use bitvec::prelude::BitSlice;
-use futures::StreamExt;
-use tokio_uring::fs::File as UringFile;
 
-use crate::common::mmap_ops::transmute_from_u8_to_slice;
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
 use crate::spaces::metric::Metric;
@@ -14,8 +11,6 @@ use crate::types::{Distance, PointOffsetType, ScoreType};
 use crate::vector_storage::memmap_vector_storage::MemmapVectorStorage;
 use crate::vector_storage::mmap_vectors::MmapVectors;
 use crate::vector_storage::{RawScorer, ScoredPointOffset, VectorStorage as _};
-
-const DISK_PARALLELISM: usize = 16; // TODO: benchmark it better, or make it configurable
 
 pub fn new<'a>(
     vector: Vec<VectorElementType>,
@@ -31,7 +26,6 @@ pub struct AsyncRawScorerImpl<'a, TMetric: Metric> {
     storage: &'a MmapVectors,
     point_deleted: &'a BitSlice,
     vec_deleted: &'a BitSlice,
-    uring_file: UringFile,
     metric: PhantomData<TMetric>,
 }
 
@@ -45,7 +39,6 @@ where
         storage: &'a MmapVectors,
         point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
-        uring_file: UringFile,
     ) -> Self {
         Self {
             points_count,
@@ -53,39 +46,7 @@ where
             storage,
             point_deleted,
             vec_deleted,
-            uring_file,
             metric: PhantomData,
-        }
-    }
-
-    async fn score_point(&self, point_id: PointOffsetType) -> ScoredPointOffset {
-        let offset = self.storage.data_offset(point_id).unwrap(); // this is fine
-        let raw_size = self.storage.raw_size();
-
-        let buff = vec![0u8; raw_size];
-
-        let (res, buff) = self.uring_file.read_at(buff, offset as u64).await;
-
-        match res {
-            Ok(sz) => {
-                debug_assert_eq!(sz, raw_size);
-                // Convert bytes vector into VectorElementType vector
-                let other_vector = transmute_from_u8_to_slice(&buff);
-                ScoredPointOffset {
-                    idx: point_id,
-                    score: TMetric::similarity(&self.query, other_vector),
-                }
-            }
-            Err(err) => {
-                debug_assert!(false, "Failed to read with uring: {:?}", err);
-                // Fall back to mmap, if for some reason we can't read with uring
-                // It might happen if we allowed to use uring on the old kernels
-                let other_vector = self.storage.get_vector(point_id);
-                ScoredPointOffset {
-                    idx: point_id,
-                    score: TMetric::similarity(&self.query, other_vector),
-                }
-            }
         }
     }
 }
@@ -95,21 +56,29 @@ where
     TMetric: Metric,
 {
     fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
-        tokio_uring::start(async {
-            let points_stream = points
-                .iter()
-                .copied()
-                .filter(|point_id| self.check_vector(*point_id))
-                .map(|point_id| self.score_point(point_id));
+        let points_stream = points
+            .iter()
+            .copied()
+            .filter(|point_id| self.check_vector(*point_id));
 
-            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
-            let mut n: usize = 0;
-            while let Some(result) = scored_stream.next().await {
-                scores[n] = result;
-                n += 1;
-            }
-            n
-        })
+        let mut processed = 0;
+        let process_result =
+            self.storage
+                .process_points(points_stream, |idx, point_id, other_vector| {
+                    scores[idx] = ScoredPointOffset {
+                        idx: point_id,
+                        score: TMetric::similarity(&self.query, other_vector),
+                    };
+                    processed += 1;
+                });
+
+        if process_result.is_ok() {
+            return processed;
+        }
+
+        log::warn!("{:?}", process_result);
+
+        todo!("Fallback to mmap read")
     }
 
     fn check_vector(&self, point: PointOffsetType) -> bool {
@@ -148,20 +117,25 @@ where
             return vec![];
         }
 
-        tokio_uring::start(async {
-            let points_stream = points
-                .filter(|point_id| self.check_vector(*point_id))
-                .map(|point_id| self.score_point(point_id));
+        let mut pq = FixedLengthPriorityQueue::new(top);
+        let points_stream = points.filter(|point_id| self.check_vector(*point_id));
 
-            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
+        let process_result =
+            self.storage
+                .process_points(points_stream, |_, point_id, other_vector| {
+                    let scored_point_offset = ScoredPointOffset {
+                        idx: point_id,
+                        score: TMetric::similarity(&self.query, other_vector),
+                    };
+                    pq.push(scored_point_offset);
+                });
 
-            // Implement peek_top_iter, but with async streams
-            let mut pq = FixedLengthPriorityQueue::new(top);
-            while let Some(scored_point_offset) = scored_stream.next().await {
-                pq.push(scored_point_offset);
-            }
-            pq.into_vec()
-        })
+        if process_result.is_ok() {
+            return pq.into_vec();
+        }
+
+        log::warn!("{:?}", process_result);
+        todo!("Fallback to mmap read")
     }
 
     fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
@@ -169,20 +143,25 @@ where
             return vec![];
         }
 
-        tokio_uring::start(async {
-            let points_stream = (0..self.points_count)
-                .filter(|point_id| self.check_vector(*point_id))
-                .map(|point_id| self.score_point(point_id));
+        let points_stream = (0..self.points_count).filter(|point_id| self.check_vector(*point_id));
 
-            let mut scored_stream = futures::stream::iter(points_stream).buffered(DISK_PARALLELISM);
+        let mut pq = FixedLengthPriorityQueue::new(top);
+        let process_result =
+            self.storage
+                .process_points(points_stream, |_, point_id, other_vector| {
+                    let scored_point_offset = ScoredPointOffset {
+                        idx: point_id,
+                        score: TMetric::similarity(&self.query, other_vector),
+                    };
+                    pq.push(scored_point_offset);
+                });
 
-            // Implement peek_top_iter, but with async streams
-            let mut pq = FixedLengthPriorityQueue::new(top);
-            while let Some(scored_point_offset) = scored_stream.next().await {
-                pq.push(scored_point_offset);
-            }
-            pq.into_vec()
-        })
+        if process_result.is_ok() {
+            return pq.into_vec();
+        }
+
+        log::warn!("{:?}", process_result);
+        todo!("Fallback to mmap read")
     }
 }
 
@@ -192,7 +171,6 @@ struct AsyncRawScorerBuilder<'a> {
     storage: &'a MmapVectors,
     point_deleted: &'a BitSlice,
     vec_deleted: &'a BitSlice,
-    uring_file: UringFile,
     distance: Distance,
 }
 
@@ -202,9 +180,6 @@ impl<'a> AsyncRawScorerBuilder<'a> {
         storage: &'a MemmapVectorStorage,
         point_deleted: &'a BitSlice,
     ) -> OperationResult<Self> {
-        let uring_file =
-            tokio_uring::start(async { UringFile::open(storage.vector_path()).await })?;
-
         let points_count = storage.total_vector_count() as _;
         let vec_deleted = storage.deleted_vector_bitslice();
 
@@ -217,7 +192,6 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             point_deleted,
             vec_deleted,
             storage,
-            uring_file,
             distance,
         };
 
@@ -239,7 +213,6 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             self.storage,
             self.point_deleted,
             self.vec_deleted,
-            self.uring_file,
         )
     }
 }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -62,6 +62,14 @@ impl MemmapVectorStorage {
                 .prefault_mmap_pages(&self.vectors_path),
         )
     }
+
+    pub fn vector_path(&self) -> &Path {
+        &self.vectors_path
+    }
+
+    pub fn get_mmap_vectors(&self) -> &MmapVectors {
+        self.mmap_store.as_ref().unwrap()
+    }
 }
 
 impl VectorStorage for MemmapVectorStorage {

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -19,7 +19,7 @@ use crate::types::{Distance, PointOffsetType, QuantizationConfig};
 #[cfg(target_os = "linux")]
 use crate::vector_storage::async_io::UringReader;
 #[cfg(not(target_os = "linux"))]
-use crate::vector_storage::async_io_mock::UringBufferedReader;
+use crate::vector_storage::async_io_mock::UringReader;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
 const HEADER_SIZE: usize = 4;

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -145,7 +145,7 @@ impl MmapVectors {
         &arr[0..self.dim]
     }
 
-    /// Creates returns owned vector (copy of internal vector)
+    /// Returns reference to vector data by key
     pub fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
         let offset = self.data_offset(key).unwrap();
         self.raw_vector_offset(offset)

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -17,7 +17,7 @@ use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
 use crate::types::{Distance, PointOffsetType, QuantizationConfig};
 #[cfg(target_os = "linux")]
-use crate::vector_storage::async_io::UringBufferedReader;
+use crate::vector_storage::async_io::UringReader;
 #[cfg(not(target_os = "linux"))]
 use crate::vector_storage::async_io_mock::UringBufferedReader;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -35,7 +35,7 @@ pub struct MmapVectors {
     /// Has an exact size to fit a header and `num_vectors` of vectors.
     mmap: Arc<Mmap>,
     /// Context for io_uring-base async IO
-    uring_reader: Mutex<UringBufferedReader>,
+    uring_reader: Mutex<UringReader>,
     /// Memory mapped deletion flags
     deleted: MmapBitSlice,
     /// Current number of deleted vectors.
@@ -71,7 +71,7 @@ impl MmapVectors {
         // Keep file handle open for async IO
         let vectors_file = File::open(vectors_path)?;
         let raw_size = dim * size_of::<VectorElementType>();
-        let uring_reader = UringBufferedReader::new(vectors_file, raw_size, HEADER_SIZE)?;
+        let uring_reader = UringReader::new(vectors_file, raw_size, HEADER_SIZE)?;
 
         Ok(MmapVectors {
             dim,

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod appendable_mmap_vector_storage;
+pub mod async_raw_scorer;
 mod chunked_mmap_vectors;
 mod chunked_utils;
 pub mod chunked_vectors;
@@ -7,7 +8,6 @@ pub mod memmap_vector_storage;
 mod mmap_vectors;
 pub mod quantized;
 pub mod raw_scorer;
-pub mod async_raw_scorer;
 pub mod simple_vector_storage;
 mod vector_storage_base;
 

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -7,6 +7,7 @@ pub mod memmap_vector_storage;
 mod mmap_vectors;
 pub mod quantized;
 pub mod raw_scorer;
+pub mod async_raw_scorer;
 pub mod simple_vector_storage;
 mod vector_storage_base;
 

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod appendable_mmap_vector_storage;
+#[cfg(target_os = "linux")]
 pub mod async_raw_scorer;
 mod chunked_mmap_vectors;
 mod chunked_utils;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -15,6 +15,10 @@ mod vector_storage_base;
 #[cfg(test)]
 mod tests;
 
+#[cfg(target_os = "linux")]
+mod async_io;
+mod async_io_mock;
+
 pub use raw_scorer::*;
 pub use vector_storage_base::*;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_raw_scorer.rs
@@ -39,6 +39,20 @@ where
         size
     }
 
+    fn score_points_unfiltered(
+        &self,
+        points: &mut dyn Iterator<Item = PointOffsetType>,
+    ) -> Vec<ScoredPointOffset> {
+        let mut scores = vec![];
+        for point in points {
+            scores.push(ScoredPointOffset {
+                idx: point,
+                score: self.quantized_data.score_point(&self.query, point),
+            });
+        }
+        scores
+    }
+
     fn check_vector(&self, point: PointOffsetType) -> bool {
         // Deleted points propagate to vectors; check vector deletion for possible early return
         !self

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+use std::{error, result};
+
+use atomic_refcell::AtomicRefCell;
+
+use crate::common::rocksdb_wrapper;
+use crate::fixtures::payload_context_fixture::FixtureIdTracker;
+use crate::id_tracker::IdTracker as _;
+use crate::types::{Distance, PointOffsetType};
+use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
+use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::vector_storage_base::VectorStorage as _;
+use crate::vector_storage::{
+    async_raw_scorer, new_raw_scorer, ScoredPointOffset, VectorStorageEnum,
+};
+
+type Result<T, E = Error> = result::Result<T, E>;
+type Error = Box<dyn error::Error>;
+
+#[test]
+fn async_raw_scorer_dot() -> Result<()> {
+    async_raw_scorer(Distance::Dot)
+}
+
+fn async_raw_scorer(distance: Distance) -> Result<()> {
+    let dir = tempfile::Builder::new()
+        .prefix("immutable-storage")
+        .tempdir()?;
+
+    let points = vec![
+        vec![1.0, 0.0, 1.0, 1.0],
+        vec![1.0, 0.0, 1.0, 0.0],
+        vec![1.0, 1.0, 1.0, 1.0],
+        vec![1.0, 1.0, 0.0, 1.0],
+        vec![1.0, 0.0, 0.0, 0.0],
+    ];
+
+    let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
+    let storage = open_memmap_vector_storage(dir.path(), 4, distance)?;
+
+    let id_tracker = id_tracker.borrow_mut();
+    let mut storage = storage.borrow_mut();
+
+    {
+        let dir = tempfile::Builder::new()
+            .prefix("mutable-storage")
+            .tempdir()?;
+        let db = rocksdb_wrapper::open_db(dir.path(), &[rocksdb_wrapper::DB_VECTOR_CF])?;
+        let mutable_storage =
+            open_simple_vector_storage(db, rocksdb_wrapper::DB_VECTOR_CF, 4, distance)?;
+        let mut mutable_storage = mutable_storage.borrow_mut();
+
+        for (index, vector) in points.iter().enumerate() {
+            mutable_storage.insert_vector(index as PointOffsetType, vector)?;
+        }
+
+        storage.update_from(
+            &mutable_storage,
+            &mut (0..points.len() as _),
+            &Default::default(),
+        )?;
+    }
+
+    let query = vec![-1.0, -1.0, -1.0, -1.0];
+    let query_points: Vec<PointOffsetType> = vec![0, 2, 4];
+
+    let raw_scorer = new_raw_scorer(query.clone(), &storage, id_tracker.deleted_point_bitslice());
+
+    let async_raw_scorer = if let VectorStorageEnum::Memmap(storage) = &*storage {
+        async_raw_scorer::new(query, storage, id_tracker.deleted_point_bitslice())?
+    } else {
+        unreachable!();
+    };
+
+    let mut res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
+    let res_count = raw_scorer.score_points(&query_points, &mut res);
+    res.resize(res_count, ScoredPointOffset { idx: 0, score: 0. });
+
+    assert_eq!(res.len(), 3);
+    assert_eq!(res[0].idx, 0);
+    assert_eq!(res[1].idx, 2);
+    assert_eq!(res[2].idx, 4);
+
+    assert_eq!(res[2].score, -1.0);
+
+    let mut async_res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
+    let res_count = async_raw_scorer.score_points(&query_points, &mut async_res);
+    async_res.resize(res_count, ScoredPointOffset { idx: 0, score: 0. });
+
+    assert_eq!(res, async_res);
+
+    Ok(())
+}

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -1,93 +1,157 @@
-use std::sync::Arc;
 use std::{error, result};
 
-use atomic_refcell::AtomicRefCell;
+use bitvec::slice::BitSlice;
+use rand::seq::IteratorRandom as _;
+use rand::SeedableRng as _;
 
 use crate::common::rocksdb_wrapper;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
-use crate::id_tracker::IdTracker as _;
+use crate::id_tracker::IdTracker;
 use crate::types::{Distance, PointOffsetType};
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
-use crate::vector_storage::vector_storage_base::VectorStorage as _;
+use crate::vector_storage::vector_storage_base::VectorStorage;
 use crate::vector_storage::{
-    async_raw_scorer, new_raw_scorer, ScoredPointOffset, VectorStorageEnum,
+    async_raw_scorer, new_raw_scorer, RawScorer, ScoredPointOffset, VectorStorageEnum,
 };
 
-type Result<T, E = Error> = result::Result<T, E>;
-type Error = Box<dyn error::Error>;
+#[test]
+fn async_raw_scorer_cosine() -> Result<()> {
+    test_async_raw_scorer_defaults(Distance::Cosine)
+}
+
+#[test]
+fn async_raw_scorer_euclid() -> Result<()> {
+    test_async_raw_scorer_defaults(Distance::Euclid)
+}
 
 #[test]
 fn async_raw_scorer_dot() -> Result<()> {
-    async_raw_scorer(Distance::Dot)
+    test_async_raw_scorer_defaults(Distance::Dot)
 }
 
-fn async_raw_scorer(distance: Distance) -> Result<()> {
+fn test_async_raw_scorer_defaults(distance: Distance) -> Result<()> {
+    test_async_raw_scorer(6942, 128, distance, 1024, 128, 256)
+}
+
+fn test_async_raw_scorer(
+    seed: u64,
+    dim: usize,
+    distance: Distance,
+    points: usize,
+    delete: usize,
+    score: usize,
+) -> Result<()> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
     let dir = tempfile::Builder::new()
         .prefix("immutable-storage")
         .tempdir()?;
 
-    let points = vec![
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![1.0, 0.0, 0.0, 0.0],
-    ];
-
-    let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
-    let storage = open_memmap_vector_storage(dir.path(), 4, distance)?;
-
-    let id_tracker = id_tracker.borrow_mut();
+    let storage = open_memmap_vector_storage(dir.path(), dim, distance)?;
     let mut storage = storage.borrow_mut();
+
+    let mut id_tracker = FixtureIdTracker::new(points);
 
     {
         let dir = tempfile::Builder::new()
             .prefix("mutable-storage")
             .tempdir()?;
+
         let db = rocksdb_wrapper::open_db(dir.path(), &[rocksdb_wrapper::DB_VECTOR_CF])?;
+
         let mutable_storage =
             open_simple_vector_storage(db, rocksdb_wrapper::DB_VECTOR_CF, 4, distance)?;
+
         let mut mutable_storage = mutable_storage.borrow_mut();
 
-        for (index, vector) in points.iter().enumerate() {
-            mutable_storage.insert_vector(index as PointOffsetType, vector)?;
-        }
+        insert_random_vectors(&mut rng, &mut *mutable_storage, points)?;
+        delete_random_vectors(&mut rng, &mut *mutable_storage, &mut id_tracker, delete)?;
 
-        storage.update_from(
-            &mutable_storage,
-            &mut (0..points.len() as _),
-            &Default::default(),
-        )?;
+        storage.update_from(&mutable_storage, &mut (0..points as _), &Default::default())?;
     }
 
-    let query = vec![-1.0, -1.0, -1.0, -1.0];
-    let query_points: Vec<PointOffsetType> = vec![0, 2, 4];
+    for _ in 0..score {
+        test_random_score(&mut rng, &storage, id_tracker.deleted_point_bitslice())?;
+    }
 
-    let raw_scorer = new_raw_scorer(query.clone(), &storage, id_tracker.deleted_point_bitslice());
+    Ok(())
+}
 
-    let async_raw_scorer = if let VectorStorageEnum::Memmap(storage) = &*storage {
-        async_raw_scorer::new(query, storage, id_tracker.deleted_point_bitslice())?
+fn insert_random_vectors(
+    rng: &mut impl rand::Rng,
+    storage: &mut impl VectorStorage,
+    vectors: usize,
+) -> Result<()> {
+    let start = storage.total_vector_count() as u32;
+    let end = start + vectors as u32;
+
+    let mut vector = vec![0.; storage.vector_dim()];
+    let mut sampler = sampler(rng);
+
+    for offset in start..end {
+        for (item, value) in vector.iter_mut().zip(&mut sampler) {
+            *item = value;
+        }
+
+        storage.insert_vector(offset, &vector)?;
+    }
+
+    Ok(())
+}
+
+fn delete_random_vectors(
+    rng: &mut impl rand::Rng,
+    storage: &mut impl VectorStorage,
+    id_tracker: &mut impl IdTracker,
+    vectors: usize,
+) -> Result<()> {
+    let offsets = (0..storage.total_vector_count() as _).choose_multiple(rng, vectors);
+
+    for offset in offsets {
+        storage.delete_vector(offset)?;
+        id_tracker.drop(crate::types::ExtendedPointId::NumId(offset.into()))?;
+    }
+
+    Ok(())
+}
+
+fn test_random_score(
+    mut rng: impl rand::Rng,
+    storage: &VectorStorageEnum,
+    deleted_points: &BitSlice,
+) -> Result<()> {
+    let query: Vec<_> = sampler(&mut rng).take(storage.vector_dim()).collect();
+
+    let raw_scorer = new_raw_scorer(query.clone(), storage, deleted_points);
+
+    let async_raw_scorer = if let VectorStorageEnum::Memmap(storage) = storage {
+        async_raw_scorer::new(query, storage, deleted_points)?
     } else {
         unreachable!();
     };
 
-    let mut res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
-    let res_count = raw_scorer.score_points(&query_points, &mut res);
-    res.resize(res_count, ScoredPointOffset { idx: 0, score: 0. });
+    let points = rng.gen_range(1..storage.total_vector_count());
+    let points = (0..storage.total_vector_count() as _).choose_multiple(&mut rng, points);
 
-    assert_eq!(res.len(), 3);
-    assert_eq!(res[0].idx, 0);
-    assert_eq!(res[1].idx, 2);
-    assert_eq!(res[2].idx, 4);
-
-    assert_eq!(res[2].score, -1.0);
-
-    let mut async_res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
-    let res_count = async_raw_scorer.score_points(&query_points, &mut async_res);
-    async_res.resize(res_count, ScoredPointOffset { idx: 0, score: 0. });
+    let res = score(&*raw_scorer, &points);
+    let async_res = score(&*async_raw_scorer, &points);
 
     assert_eq!(res, async_res);
 
     Ok(())
 }
+
+fn score(scorer: &dyn RawScorer, points: &[PointOffsetType]) -> Vec<ScoredPointOffset> {
+    let mut scores = vec![Default::default(); points.len()];
+    let scored = scorer.score_points(points, &mut scores);
+    scores.resize_with(scored, Default::default);
+    scores
+}
+
+fn sampler(rng: impl rand::Rng) -> impl Iterator<Item = f32> {
+    rng.sample_iter(rand::distributions::Uniform::new_inclusive(-1., 1.))
+}
+
+type Result<T, E = Error> = result::Result<T, E>;
+type Error = Box<dyn error::Error>;

--- a/lib/segment/src/vector_storage/tests/mod.rs
+++ b/lib/segment/src/vector_storage/tests/mod.rs
@@ -1,1 +1,3 @@
+#[cfg(target_os = "linux")]
+mod async_raw_scorer;
 mod test_appendable_vector_storage;

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -56,6 +56,8 @@ pub struct StorageConfig {
     pub update_queue_size: Option<usize>,
     #[serde(default)]
     pub handle_collection_load_errors: bool,
+    #[serde(default)]
+    pub async_scorer: bool,
     /// If provided - qdrant will start in recovery mode, which means that it will not accept any new data.
     /// Only collection metadata will be available, and it will only process collection delete requests.
     /// Provided value will be used error message for unavailable requests.

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -52,6 +52,7 @@ fn test_alias_operation() {
         update_queue_size: Default::default(),
         handle_collection_load_errors: false,
         recovery_mode: None,
+        async_scorer: false,
     };
 
     let search_runtime = Runtime::new().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn main() -> anyhow::Result<()> {
     setup_panic_hook(reporting_enabled, reporting_id.to_string());
 
     segment::madvise::set_global(settings.storage.mmap_advice);
+    segment::vector_storage::raw_scorer::set_async_scorer(settings.storage.async_scorer);
 
     welcome(&settings);
 


### PR DESCRIPTION
Based on @ffuugoo's overview and @timvisee's experiments:

![image](https://github.com/qdrant/qdrant/assets/1935623/5d6a3a17-f6f6-4442-992c-82cf19414779)

It looks like io_uring is very promising for speeding-up the slow-disk deployments.

tokio implementation mounts on the current thread, so creating a uring runtime should be cheap enough, in case of network-mounted disk.

This PR introduces an AsyncRawScorer, which utilizes the uring for scoring points.

Pros:

- Uses same file layout as the MmapVectors, can be switched dynamically
- Can fallback to mmap if uring is not available
- Disk cache is shared between mmap and using

Limitations:

- Due to `RC` in tokio-uring File, we need to open vector files on each request. Hopefully, it is cheap
- Parallel reads only achieved for given list of points, e.g. on re-scroing of filtered selection, scoring nodes in HNSW, oversampling, e.t.c. 
- Only works with immutable files. Doesn't work with deleted flags, as it is not clear how changes are propagated between mmap and disk reads - needs more experiments.
- Disk parallelism is hard-coded, there should be a sweat-spot, but it is not trivial to detect

ToDo:

- Exclude from compilation for windows
- Create a config option to allow scoring with async scorer
- Actually use async scorer, if we have appropriate storage + it is enables
- Tests
- Benchmarks
