### PR TITLE
Fix flaky test: Wait for node to go down

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -19,7 +19,8 @@ impl ConsensusOpWal {
         let collections_meta_wal_path = Path::new(storage_path).join(COLLECTIONS_META_WAL_DIR);
         create_dir_all(&collections_meta_wal_path)
             .expect("Can't create Collections meta Wal directory");
-        ConsensusOpWal(Wal::open(collections_meta_wal_path).unwrap())
+        let wal = Wal::open(collections_meta_wal_path).expect("Can't open Collections meta Wal");
+        ConsensusOpWal(wal)
     }
 
     pub fn clear(&mut self) -> Result<(), StorageError> {

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -43,6 +43,10 @@ def test_triple_replication(tmp_path: pathlib.Path):
     killed_id = 0
     p = processes.pop(killed_id)
     p.kill()
+    # Make sure it is completely gone to be able to reuse the data on disk
+    if p.returncode is None:
+        print(f"Waiting for leader peer {p.pid} to go down")
+        p.wait()
     peer_api_uris.pop(killed_id)
 
     new_url = start_peer(peer_dirs[killed_id], f"peer_{killed_id}_restarted.log", bootstrap_uri)


### PR DESCRIPTION
Targets the flaky test https://github.com/qdrant/qdrant/issues/1991#issuecomment-1578263453

It seems calling `kill` on a Python `Subprocess` only means sending the termination signal.
We need to await the complete shutdown of the process.

Without this safety step, the node can be restarted before the file descriptors have been released.  