### PR TITLE
Cargo.toml: Emit debuginfos in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ exclude = ["benches/search-points"]
 
 [profile.release]
 lto = "fat"
+# Emit only the line info tables, not full debug info, in release builds. This
+# tends to be the right trade-off between debuggability and size.
+debug = 1
 
 # Inherit from release, because we are not rebuilding often,
 # and we don't want the huge binary sizes from debug builds.


### PR DESCRIPTION
I was going to open an issue before opening this PR, but since it's just a one-line change, I thought we can also have the discussion here.

This change is required for profilers to be able to translate program counter addresses to human-readable function names. Without this change, profilers can already correctly capture stacks but we would only see memory addresses in stack traces. This information can also be communicated to profilers through other means (eg. [split-debuginfo](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo)) but having it in the production binary is easiest and makes everything work out of the box.

Let me know what you think!