### PR TITLE
Better error reporting for missing static folder

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -63,7 +63,25 @@ pub fn init(
             .unwrap_or(DEFAULT_STATIC_DIR.to_string());
 
         let web_ui_enabled = settings.service.enable_static_content.unwrap_or(true);
-        let skip_api_key_prefixes = if web_ui_enabled {
+        // validate that the static folder exists IF the web UI is enabled
+        let web_ui_available = if web_ui_enabled {
+            let static_folder = Path::new(&static_folder);
+            if !static_folder.exists() || !static_folder.is_dir() {
+                // enabled BUT folder does not exist
+                log::error!(
+                    "Static content folder for Web UI '{}' does not exist",
+                    static_folder.display()
+                );
+                false
+            } else {
+                // enabled AND folder exists
+                true
+            }
+        } else {
+            // not enabled
+            false
+        };
+        let skip_api_key_prefixes = if web_ui_available {
             vec![WEB_UI_PATH.to_string()]
         } else {
             vec![]
@@ -119,19 +137,10 @@ pub fn init(
                 .service(scroll_points)
                 .service(count_points);
 
-            if web_ui_enabled {
-                let static_folder = Path::new(&static_folder);
-                if !static_folder.exists() || !static_folder.is_dir() {
-                    log::error!(
-                        "Static content folder for Web UI '{}' does not exist",
-                        static_folder.display()
-                    );
-                } else {
-                    app = app.service(
-                        actix_files::Files::new(WEB_UI_PATH, static_folder)
-                            .index_file("index.html"),
-                    )
-                }
+            if web_ui_available {
+                app = app.service(
+                    actix_files::Files::new(WEB_UI_PATH, &static_folder).index_file("index.html"),
+                )
             }
             app
         })

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -7,6 +7,7 @@ mod certificate_helpers;
 pub mod helpers;
 
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
 
 use ::api::grpc::models::{ApiResponse, ApiStatus, VersionInfo};
@@ -119,9 +120,18 @@ pub fn init(
                 .service(count_points);
 
             if web_ui_enabled {
-                app = app.service(
-                    actix_files::Files::new(WEB_UI_PATH, &static_folder).index_file("index.html"),
-                )
+                let static_folder = Path::new(&static_folder);
+                if !static_folder.exists() || !static_folder.is_dir() {
+                    log::error!(
+                        "Static content folder for Web UI '{}' does not exist",
+                        static_folder.display()
+                    );
+                } else {
+                    app = app.service(
+                        actix_files::Files::new(WEB_UI_PATH, static_folder)
+                            .index_file("index.html"),
+                    )
+                }
             }
             app
         })


### PR DESCRIPTION
This PR improves the error reporting for user missing the static directory serving the web UI.

1. only one error is displayed instead of one per actix runtime
2. the static file serving is not enabled if the static folder does not exist

e.g.

Before this PR

```
[2023-06-08T09:00:43.777Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.793Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.809Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.827Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.845Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.862Z ERROR actix_files::files] Specified path is not a directory: "./static"
[2023-06-08T09:00:43.879Z ERROR actix_files::files] Specified path is not a directory: "./static"
```

After this PR

```
[2023-06-08T09:43:37.266Z ERROR qdrant::actix] Static content folder for Web UI './static' does not exist
```