### PR TITLE
Fix batch request with duplicated filter

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -303,7 +303,7 @@ impl SegmentsSearcher {
     }
 }
 
-#[derive(PartialEq, Default)]
+#[derive(PartialEq, Default, Debug)]
 struct BatchSearchParams<'a> {
     pub vector_name: &'a str,
     pub filter: Option<&'a Filter>,

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -31,7 +31,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter).len();
             query_count += 1;
         })
     });
@@ -47,7 +47,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     group.bench_function("conditional-search-query-points-large", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 1);
-            result_size += plain_index.query_points(&filter).count();
+            result_size += plain_index.query_points(&filter).len();
             query_count += 1;
         })
     });
@@ -107,7 +107,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
     group.bench_function("struct-conditional-search-query-points", |b| {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
-            result_size += struct_index.query_points(&filter).count();
+            result_size += struct_index.query_points(&filter).len();
             query_count += 1;
         })
     });

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -42,10 +42,7 @@ pub trait PayloadIndex {
     /// Return list of all point ids, which satisfy filtering criteria
     ///
     /// A best estimation of the number of available points should be given.
-    fn query_points<'a>(
-        &'a self,
-        query: &'a Filter,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>;
+    fn query_points(&self, query: &Filter) -> Vec<PointOffsetType>;
 
     /// Return number of points, indexed by this field
     fn indexed_points(&self, field: PayloadKeyTypeRef) -> usize;

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -64,14 +64,30 @@ pub fn adjust_to_available_vectors(
     // It is possible, all deleted vectors are selected in worst case
     let min = estimation.min.saturating_sub(number_of_deleted_vectors);
     // Another extreme case - all deleted vectors are not selected
-    let max = estimation.max.min(available_vectors);
+    let max = estimation.max.min(available_vectors).min(available_points);
 
-    let availability_prob = available_vectors as f64 / available_points as f64;
+    let availability_prob = (available_vectors as f64 / available_points as f64).min(1.0);
 
     let exp = (estimation.exp as f64 * availability_prob).round() as usize;
 
-    debug_assert!(min <= exp);
-    debug_assert!(exp <= max);
+    debug_assert!(
+        min <= exp,
+        "estimation: {:?}, available_vectors: {}, available_points: {}, min: {}, exp: {}",
+        estimation,
+        available_vectors,
+        available_points,
+        min,
+        exp
+    );
+    debug_assert!(
+        exp <= max,
+        "estimation: {:?}, available_vectors: {}, available_points: {}, exp: {}, max: {}",
+        estimation,
+        available_vectors,
+        available_points,
+        exp,
+        max
+    );
 
     CardinalityEstimation {
         primary_clauses: estimation.primary_clauses,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -585,6 +585,7 @@ impl Segment {
 
         let ids_iterator = payload_index
             .query_points(condition)
+            .into_iter()
             .filter_map(|internal_id| {
                 let external_id = id_tracker.external_id(internal_id);
                 match external_id {

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+
+use rand::prelude::StdRng;
+use rand::SeedableRng;
+use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
+use segment::entry::entry_point::SegmentEntry;
+use segment::fixtures::index_fixtures::random_vector;
+use segment::fixtures::payload_fixtures::random_int_payload;
+use segment::index::hnsw_index::graph_links::GraphLinksRam;
+use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::VectorIndex;
+use segment::segment_constructor::build_segment;
+use segment::types::{
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
+    SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType, WithPayload,
+};
+use serde_json::json;
+use tempfile::Builder;
+
+#[test]
+fn test_batch_and_single_request_equivalency() {
+    let num_vectors: u64 = 1_000;
+    let distance = Distance::Cosine;
+    let num_payload_values = 2;
+    let dim = 8;
+
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance,
+                storage_type: VectorStorageType::Memory,
+                index: Indexes::Plain {},
+                quantization_config: None,
+            },
+        )]),
+        payload_storage_type: Default::default(),
+    };
+
+    let int_key = "int";
+
+    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+
+    segment
+        .create_field_index(0, int_key, Some(&PayloadSchemaType::Integer.into()))
+        .unwrap();
+
+    for n in 0..num_vectors {
+        let idx = n.into();
+        let vector = random_vector(&mut rnd, dim);
+
+        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let payload: Payload = json!({int_key:int_payload,}).into();
+
+        segment
+            .upsert_point(n as SeqNumberType, idx, &only_default_vector(&vector))
+            .unwrap();
+        segment
+            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .unwrap();
+    }
+
+    for _ in 0..10 {
+        let query_vector_1 = random_vector(&mut rnd, dim);
+        let query_vector_2 = random_vector(&mut rnd, dim);
+
+        let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
+
+        let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+            int_key,
+            payload_value.into(),
+        )));
+
+        let search_res_1 = segment
+            .search(
+                DEFAULT_VECTOR_NAME,
+                &query_vector_1,
+                &WithPayload::default(),
+                &false.into(),
+                Some(&filter),
+                10,
+                None,
+            )
+            .unwrap();
+
+        let search_res_2 = segment
+            .search(
+                DEFAULT_VECTOR_NAME,
+                &query_vector_2,
+                &WithPayload::default(),
+                &false.into(),
+                Some(&filter),
+                10,
+                None,
+            )
+            .unwrap();
+
+        let batch_res = segment
+            .search_batch(
+                DEFAULT_VECTOR_NAME,
+                &[&query_vector_1, &query_vector_2],
+                &WithPayload::default(),
+                &false.into(),
+                Some(&filter),
+                10,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(search_res_1, batch_res[0]);
+        assert_eq!(search_res_2, batch_res[1]);
+    }
+
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+
+    let payload_index_ptr = segment.payload_index.clone();
+
+    let m = 8;
+    let ef_construct = 100;
+    let full_scan_threshold = 10000;
+
+    let hnsw_config = HnswConfig {
+        m,
+        ef_construct,
+        full_scan_threshold,
+        max_indexing_threads: 2,
+        on_disk: Some(false),
+        payload_m: None,
+    };
+
+    let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
+    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+        hnsw_dir.path(),
+        segment.id_tracker.clone(),
+        vector_storage.clone(),
+        payload_index_ptr,
+        hnsw_config,
+    )
+    .unwrap();
+
+    hnsw_index.build_index(&stopped).unwrap();
+
+    for _ in 0..10 {
+        let query_vector_1 = random_vector(&mut rnd, dim);
+        let query_vector_2 = random_vector(&mut rnd, dim);
+
+        let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
+
+        let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+            int_key,
+            payload_value.into(),
+        )));
+
+        let search_res_1 = hnsw_index.search(&[&query_vector_1], Some(&filter), 10, None);
+
+        let search_res_2 = hnsw_index.search(&[&query_vector_2], Some(&filter), 10, None);
+
+        let batch_res =
+            hnsw_index.search(&[&query_vector_1, &query_vector_2], Some(&filter), 10, None);
+
+        assert_eq!(search_res_1[0], batch_res[0]);
+        assert_eq!(search_res_2[0], batch_res[1]);
+    }
+}

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+pub mod batch_search_test;
+#[cfg(test)]
 pub mod disbalanced_vectors_test;
 #[cfg(test)]
 pub mod exact_search_test;

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -114,7 +114,7 @@ fn test_filtering_context_consistency() {
         );
 
         let nested_filter_0 = Filter::new_must(nested_condition_0);
-        let res0: Vec<_> = index.query_points(&nested_filter_0).collect();
+        let res0 = index.query_points(&nested_filter_0);
 
         let filter_context = index.filter_context(&nested_filter_0);
 
@@ -151,7 +151,7 @@ fn test_filtering_context_consistency() {
 
         let nested_filter_1 = Filter::new_must(nested_condition_1);
 
-        let res1: Vec<_> = index.query_points(&nested_filter_1).collect();
+        let res1 = index.query_points(&nested_filter_1);
 
         let filter_context = index.filter_context(&nested_filter_1);
 
@@ -185,7 +185,7 @@ fn test_filtering_context_consistency() {
 
         let nested_filter_2 = Filter::new_must(nested_condition_2);
 
-        let res2: Vec<_> = index.query_points(&nested_filter_2).collect();
+        let res2 = index.query_points(&nested_filter_2);
 
         let filter_context = index.filter_context(&nested_filter_2);
 
@@ -236,7 +236,7 @@ fn test_filtering_context_consistency() {
             must_not: None,
         };
 
-        let res3: Vec<_> = index.query_points(&nested_filter_3).collect();
+        let res3 = index.query_points(&nested_filter_3);
 
         let filter_context = index.filter_context(&nested_filter_3);
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -274,7 +274,7 @@ fn test_is_empty_conditions() {
         .payload_index
         .borrow()
         .query_points(&filter)
-        .count();
+        .len();
 
     eprintln!("estimation_plain = {estimation_plain:#?}");
     eprintln!("estimation_struct = {estimation_struct:#?}");


### PR DESCRIPTION
Current behavior:

If there is a batch request with multiple identical filtering conditions, executor tried to re-use filtering results.
The problem is, that filtering result is the iterator, so when the first results are prepared, the second request is left with empty iterator. Which results in empty search result for all sub-requests except for the first one.

This PR:

Replaces iterator with owned vector. Which is fine, because:

- it fixes the double usage of iterator
- In previous implementation "iterator" was, in fact, just collected vector in most cases anyway. And in other case potential collect of the vector is not the critical part of the execution.