### PR TITLE
Fix `WriteOrdering::Medium` and `WriteOrdering::Strong` semantics

### DIFF
--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1311,8 +1311,8 @@ impl ShardReplicaSet {
     pub fn leader_peer_for_update(&self, ordering: WriteOrdering) -> Option<PeerId> {
         match ordering {
             WriteOrdering::Weak => Some(self.this_peer_id()), // no requirement for consistency
-            WriteOrdering::Medium => self.highest_replica_peer_id(), // consistency with highest replica
-            WriteOrdering::Strong => self.highest_alive_replica_peer_id(), // consistency with highest alive replica
+            WriteOrdering::Medium => self.highest_alive_replica_peer_id(), // consistency with highest alive replica
+            WriteOrdering::Strong => self.highest_replica_peer_id(), // consistency with highest replica
         }
     }
 

--- a/tests/consensus_tests/test_write_ordering.py
+++ b/tests/consensus_tests/test_write_ordering.py
@@ -60,15 +60,14 @@ def test_write_ordering(tmp_path: pathlib.Path):
                     "id": 1,
                     "vector": [0.05, 0.61, 0.76, 0.74],
                     "payload": {
-                        "city": "Dresden",
+                        "city": "Munich",
                         "country": "Germany",
                     }
                 }
             ]
         })
-
-    # fails as highest peer is dead
-    assert r.status_code == 500
+    # succeeds as Medium selects an Alive peer
+    assert_http_ok(r)
 
     # write ordering strong
     r = requests.put(
@@ -78,14 +77,15 @@ def test_write_ordering(tmp_path: pathlib.Path):
                     "id": 1,
                     "vector": [0.05, 0.61, 0.76, 0.74],
                     "payload": {
-                        "city": "Munich",
+                        "city": "Dresden",
                         "country": "Germany",
                     }
                 }
             ]
         })
-    # succeeds as Strong selects an Alive peer
-    assert_http_ok(r)
+
+    # fails as highest peer is dead
+    assert r.status_code == 500
 
     # Restart peer
     new_url = start_peer(peer_dirs[url_index], f"peer_{url_index}_restarted.log", bootstrap_uri)


### PR DESCRIPTION
`WriteOrdering::Medium` and `WriteOrdering::Strong` were swapped 🤡

Original intention was:
- to make `WriteOrdering::Medium` to order writes through _some_ alive node
  - which will make it always available, but may lead to some inconsistencies in some rare cases
- and `WriteOrdering::Strong` to always order through a _single_ node
  - which will make writes unavailable, if that node is down, but should prevent any possible inconcistencies

Seems like something got mixed-up or miscommunicated during implementation, but luckily no one (but me) noticed. 😎

(Btw, we can, kinda, expect failures/users complaining after the fix, when `WriteOrdering::Strong` would start failing request.... 🥲)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
