### PR TITLE
Make branching strategy more explicit in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 ### All Submissions:
 
+* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
 * [ ] Have you followed the guidelines in our Contributing document?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 


### PR DESCRIPTION
Make the branching strategy more explicit in PR template to avoid friction during reviews.