### PR TITLE
Assume points with no mapping/delete flag are deleted

### DIFF
--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -105,16 +105,18 @@ where
         point < self.points_count
             // Deleted points propagate to vectors; check vector deletion for possible early return
             && !self
-            .vec_deleted
-            .get(point as usize)
-            .map(|x| *x)
-            .unwrap_or(false)
+                .vec_deleted
+                .get(point as usize)
+                .map(|x| *x)
+                // Default to not deleted if our deleted flags failed grow
+                .unwrap_or(false)
             // Additionally check point deletion for integrity if delete propagation to vector failed
             && !self
-            .point_deleted
-            .get(point as usize)
-            .map(|x| *x)
-            .unwrap_or(false)
+                .point_deleted
+                .get(point as usize)
+                .map(|x| *x)
+                // Default to deleted if the point mapping was removed from the ID tracker
+                .unwrap_or(true)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_raw_scorer.rs
@@ -60,6 +60,7 @@ where
             .get(point as usize)
             .as_deref()
             .copied()
+            // Default to not deleted if our deleted flags failed grow
             .unwrap_or(false)
         // Additionally check point deletion for integrity if delete propagation to vector failed
         && !self
@@ -67,7 +68,8 @@ where
             .get(point as usize)
             .as_deref()
             .copied()
-            .unwrap_or(false)
+            // Default to deleted if the point mapping was removed from the ID tracker
+            .unwrap_or(true)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -183,13 +183,15 @@ where
                 .vec_deleted
                 .get(point as usize)
                 .map(|x| *x)
+                // Default to not deleted if our deleted flags failed grow
                 .unwrap_or(false)
             // Additionally check point deletion for integrity if delete propagation to vector failed
             && !self
                 .point_deleted
                 .get(point as usize)
                 .map(|x| *x)
-                .unwrap_or(false)
+                // Default to deleted if the point mapping was removed from the ID tracker
+                .unwrap_or(true)
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {


### PR DESCRIPTION
This PR changes the default state of deletion for points. Before, a point having no delete flag was considered available. This changes it to consider it as deleted.

Note that this doesn't change the default deletion state for vectors, just for points.

This improves a problematic situation that could occur when the ID tracker is flushed while storage is not. In that case we could have points in storage that don't have a corresponding point ID mapped. These leaked vectors caused issues.

More specifically, this fixes a bug where leaked vectors would reach the final stage in a segment producing the warnings below, while the scorers shouldn't consider the vectors at all.


```
...
[2023-06-12T14:20:03.582Z WARN  segment::segment] Point with internal ID 71851 not found in id tracker, skipping
[2023-06-12T14:20:03.583Z WARN  segment::segment] Point with internal ID 71910 not found in id tracker, skipping
[2023-06-12T14:20:03.584Z WARN  segment::segment] Point with internal ID 68342 not found in id tracker, skipping
[2023-06-12T14:20:03.584Z WARN  segment::segment] Point with internal ID 72480 not found in id tracker, skipping
[2023-06-12T14:20:03.585Z WARN  segment::segment] Point with internal ID 71234 not found in id tracker, skipping
[2023-06-12T14:20:03.585Z WARN  segment::segment] Point with internal ID 68029 not found in id tracker, skipping
[2023-06-12T14:20:03.587Z WARN  segment::segment] Point with internal ID 71922 not found in id tracker, skipping
[2023-06-12T14:20:03.587Z WARN  segment::segment] Point with internal ID 68178 not found in id tracker, skipping
[2023-06-12T14:20:03.588Z WARN  segment::segment] Point with internal ID 71425 not found in id tracker, skipping
...
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?