### PR TITLE
Create snapshot dir. during upload if it does not exist

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -216,11 +216,18 @@ impl TableOfContent {
         snapshots_path.join(collection_name)
     }
 
-    async fn create_snapshots_path(&self, collection_name: &str) -> Result<PathBuf, StorageError> {
-        let snapshots_path = Self::collection_snapshots_path(
+    pub fn snapshots_path_for_collection(&self, collection_name: &str) -> PathBuf {
+        Self::collection_snapshots_path(
             Path::new(&self.storage_config.snapshots_path),
             collection_name,
-        );
+        )
+    }
+
+    pub async fn create_snapshots_path(
+        &self,
+        collection_name: &str,
+    ) -> Result<PathBuf, StorageError> {
+        let snapshots_path = self.snapshots_path_for_collection(collection_name);
         tokio::fs::create_dir_all(&snapshots_path)
             .await
             .map_err(|err| {


### PR DESCRIPTION
This PR fixes a bug happening during the upload of a snapshot.

```
curl -X POST 'http://localhost:6343/collections/bfb_stress/snapshots/upload'
 -H 'Content-Type:multipart/form-data' 
 -F 'snapshot=@bfb_stress-7064541537839969-2023-06-12-14-34-49.snapshot'
{"status":{"error":"Service internal error: Persist error: failed to persist temporary file: No such file or directory (os error 2)"},"time":0.019918391}
```

Persisting the snapshot locally fails if the the node is not aware of this collection because the snapshot directory for the collection does not exist. 

This folder is either created either when the collection is created or when applying a collection snapshot.