### PR TITLE
Add debug message when segment storage has point and vector count mismatch

### DIFF
--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -16,6 +16,7 @@ use crate::common::version::StorageVersion;
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::id_tracker::simple_id_tracker::SimpleIdTracker;
+use crate::id_tracker::IdTracker;
 use crate::index::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use crate::index::hnsw_index::hnsw::HNSWIndex;
 use crate::index::plain_payload_index::PlainIndex;
@@ -117,6 +118,16 @@ fn create_segment(
                 vector_config.distance,
             )?,
         };
+
+        // Warn when number of points between ID tracker and storage differs
+        let point_count = id_tracker.borrow().total_point_count();
+        let vector_count = vector_storage.borrow().total_vector_count();
+        if vector_count != point_count {
+            log::debug!(
+                "Mismatch of point and vector counts ({point_count} != {vector_count}, storage: {})",
+                vector_storage_path.display(),
+            );
+        }
 
         if config.quantization_config(vector_name).is_some() {
             let quantized_data_path = vector_storage_path;


### PR DESCRIPTION
Extension to https://github.com/qdrant/qdrant/pull/2061.

Log a debug message when a segment has an ID tracker and storage having a different number of points.

For example:

```
[2023-06-13T12:47:54.814Z DEBUG segment::segment_constructor::segment_constructor_base] Mismatch of point and vector counts (66001 != 73773, storage: ./storage/collections/snapshot/0/segments/712278e6-15cc-4295-b0a4-2cbf28f950e9/vector_storage)
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?