### PR TITLE
Optimize `is_empty`

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -320,15 +320,4 @@ impl FieldIndex {
             FieldIndex::FullTextIndex(index) => index.values_is_empty(point_id),
         }
     }
-
-    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
-        match self {
-            FieldIndex::IntIndex(index) => index.values_is_none(point_id),
-            FieldIndex::IntMapIndex(index) => index.values_is_none(point_id),
-            FieldIndex::KeywordIndex(index) => index.values_is_none(point_id),
-            FieldIndex::FloatIndex(index) => index.values_is_none(point_id),
-            FieldIndex::GeoIndex(index) => index.values_is_none(point_id),
-            FieldIndex::FullTextIndex(index) => index.values_is_none(point_id),
-        }
-    }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -309,4 +309,15 @@ impl FieldIndex {
             FieldIndex::FullTextIndex(index) => index.values_count(point_id),
         }
     }
+
+    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            FieldIndex::IntIndex(index) => index.values_is_none(point_id),
+            FieldIndex::IntMapIndex(index) => index.values_is_none(point_id),
+            FieldIndex::KeywordIndex(index) => index.values_is_none(point_id),
+            FieldIndex::FloatIndex(index) => index.values_is_none(point_id),
+            FieldIndex::GeoIndex(index) => index.values_is_none(point_id),
+            FieldIndex::FullTextIndex(index) => index.values_is_none(point_id),
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -310,6 +310,17 @@ impl FieldIndex {
         }
     }
 
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            FieldIndex::IntIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::IntMapIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::KeywordIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::FloatIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::GeoIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::FullTextIndex(index) => index.values_is_empty(point_id),
+        }
+    }
+
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         match self {
             FieldIndex::IntIndex(index) => index.values_is_none(point_id),

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -122,6 +122,10 @@ impl FullTextIndex {
         // Maybe we want number of documents in the future?
         self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
     }
+
+    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
+        self.get_doc(point_id).is_none()
+    }
 }
 
 impl ValueIndexer<String> for FullTextIndex {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -126,10 +126,6 @@ impl FullTextIndex {
     pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
         self.get_doc(point_id).map(|x| x.is_empty()).unwrap_or(true)
     }
-
-    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
-        self.get_doc(point_id).is_none()
-    }
 }
 
 impl ValueIndexer<String> for FullTextIndex {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -123,6 +123,10 @@ impl FullTextIndex {
         self.get_doc(point_id).map(|x| x.len()).unwrap_or(0)
     }
 
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.get_doc(point_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
+
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_doc(point_id).is_none()
     }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -469,6 +469,10 @@ impl GeoMapIndex {
     pub fn values_count(&self, point_id: PointOffsetType) -> usize {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
+
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
     
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_values(point_id).is_none()

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -469,6 +469,10 @@ impl GeoMapIndex {
     pub fn values_count(&self, point_id: PointOffsetType) -> usize {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
+    
+    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).is_none()
+    }
 }
 
 impl ValueIndexer<GeoPoint> for GeoMapIndex {

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -475,10 +475,6 @@ impl GeoMapIndex {
             .map(|x| x.is_empty())
             .unwrap_or(true)
     }
-
-    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).is_none()
-    }
 }
 
 impl ValueIndexer<GeoPoint> for GeoMapIndex {

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -471,9 +471,11 @@ impl GeoMapIndex {
     }
 
     pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+        self.get_values(point_id)
+            .map(|x| x.is_empty())
+            .unwrap_or(true)
     }
-    
+
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_values(point_id).is_none()
     }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -184,7 +184,9 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 
     pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+        self.get_values(point_id)
+            .map(|x| x.is_empty())
+            .unwrap_or(true)
     }
 
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -183,6 +183,10 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
 
+    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).is_none()
+    }
+
     /// Estimates cardinality for `except` clause
     ///
     /// # Arguments

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -189,10 +189,6 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
             .unwrap_or(true)
     }
 
-    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).is_none()
-    }
-
     /// Estimates cardinality for `except` clause
     ///
     /// # Arguments

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -183,6 +183,10 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
 
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
+
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_values(point_id).is_none()
     }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -297,6 +297,10 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
     pub fn values_count(&self, point_id: PointOffsetType) -> usize {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
+
+    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).is_none()
+    }
 }
 
 impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -303,10 +303,6 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
             .map(|x| x.is_empty())
             .unwrap_or(true)
     }
-
-    pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).is_none()
-    }
 }
 
 impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -299,13 +299,14 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
     }
 
     pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+        self.get_values(point_id)
+            .map(|x| x.is_empty())
+            .unwrap_or(true)
     }
 
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_values(point_id).is_none()
     }
-    
 }
 
 impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -298,9 +298,14 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         self.get_values(point_id).map(|x| x.len()).unwrap_or(0)
     }
 
+    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        self.get_values(point_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
+
     pub fn values_is_none(&self, point_id: PointOffsetType) -> bool {
         self.get_values(point_id).is_none()
     }
+    
 }
 
 impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -38,6 +38,8 @@ pub fn condition_converter<'a>(
                     })
                 })
             }),
+        // We can use index for `is_empty` condition effectively only when it is not empty.
+        // If the index says it is "empty", we still need to check the payload.
         Condition::IsEmpty(is_empty) => {
             let fallback = Box::new(move |point_id| {
                 payload_provider.with_payload(point_id, |payload| {
@@ -54,7 +56,7 @@ pub fn condition_converter<'a>(
                 .unwrap_or(fallback)
         }
 
-        // TODO: apply same logic as in IsEmpty
+        // Applies same logic as in IsEmpty
         Condition::IsNull(is_null) => {
             let fallback = Box::new(move |point_id| {
                 payload_provider.with_payload(point_id, |payload| {
@@ -294,11 +296,6 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
     }
 }
 
-/// Returns a checker that checks if the field is empty
-///
-/// IsEmpty has a special case because when the index does not have any value for a point,
-/// it does not mean it is actually empty, it can just mean that an index with the correct type
-/// has not been created for it. We still need to check if the field is really empty with a fallback.
 #[inline]
 fn get_is_empty_checker<'a>(
     index: &'a FieldIndex,

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -47,19 +47,24 @@ pub fn condition_converter<'a>(
             field_indexes
                 .get(&is_empty.is_empty.key)
                 .and_then(|indexes| {
-                    indexes
-                        .iter()
-                        .find_map(|index| get_is_empty_checkers(index, fallback.clone()))
+                    indexes.first().map(|index| get_is_empty_checker(index, fallback.clone()))
                 })
                 .unwrap_or(fallback)
         }
 
         // TODO: apply same logic as in IsEmpty
-        Condition::IsNull(is_null) => Box::new(move |point_id| {
-            payload_provider.with_payload(point_id, |payload| {
-                check_is_null_condition(is_null, &payload)
-            })
-        }),
+        Condition::IsNull(is_null) => {
+            let fallback = Box::new(move |point_id| {
+                payload_provider.with_payload(point_id, |payload| {
+                    check_is_null_condition(is_null, &payload)
+                })
+            });
+            field_indexes.get(&is_null.is_null.key).and_then(|indexes| {
+                indexes
+                    .first()
+                    .map(|index| get_is_null_checker(index, fallback.clone()))
+            }).unwrap_or(fallback)
+        },
         // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
         Condition::HasId(has_id) => {
             let segment_ids: HashSet<_> = has_id
@@ -289,55 +294,21 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
 /// IsEmpty has a special case because when the index does not have any value for a point,
 /// it does not mean it is actually empty, it can just mean that an index with the correct type
 /// has not been created for it. We still need to check if the field is really empty with a fallback.
-fn get_is_empty_checkers<'a>(
+#[inline]
+fn get_is_empty_checker<'a>(
     index: &'a FieldIndex,
-    fallback: Box<(dyn std::ops::Fn(u32) -> bool + 'a)>,
-) -> Option<ConditionCheckerFn<'a>> {
-    match index {
-        FieldIndex::KeywordIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            check_is_empty(index.get_values(point_id), point_id, &fallback)
-        })),
-        FieldIndex::IntMapIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            check_is_empty(index.get_values(point_id), point_id, &fallback)
-        })),
-        FieldIndex::FullTextIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            index.get_doc(point_id).map_or_else(
-                || fallback(point_id),
-                |values| {
-                    values
-                        .is_empty()
-                        .then(|| fallback(point_id))
-                        .unwrap_or(false)
-                },
-            )
-        })),
-        FieldIndex::GeoIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            check_is_empty(index.get_values(point_id), point_id, &fallback)
-        })),
-        FieldIndex::IntIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            check_is_empty(index.get_values(point_id), point_id, &fallback)
-        })),
-        FieldIndex::FloatIndex(index) => Some(Box::new(move |point_id: PointOffsetType| {
-            check_is_empty(index.get_values(point_id), point_id, &fallback)
-        })),
-    }
+    fallback: ConditionCheckerFn<'a>,
+) -> ConditionCheckerFn<'a> {
+    Box::new(move |point_id: PointOffsetType| {
+        index.values_count(point_id) == 0 && fallback(point_id)
+    })
 }
 
 #[inline]
-fn check_is_empty<T>(
-    values: Option<&Vec<T>>,
-    point_id: u32,
-    fallback: &ConditionCheckerFn,
-) -> bool {
-    values.map_or_else(
-        // if there is no value in index, use fallback
-        || fallback(point_id), 
-        |values| {
-            values
-                .is_empty()
-                // if there is an "empty" value, we still need to make sure with the fallback
-                .then(|| fallback(point_id))
-                .unwrap_or(false)
-        },
-    )
+fn get_is_null_checker<'a>( index: &'a FieldIndex,
+    fallback: Box<(dyn std::ops::Fn(u32) -> bool + 'a)>,
+) -> ConditionCheckerFn<'a> {
+    Box::new(move |point_id: PointOffsetType| {
+        index.values_is_none(point_id) && fallback(point_id)
+    })
 }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -300,7 +300,7 @@ fn get_is_empty_checker<'a>(
     fallback: ConditionCheckerFn<'a>,
 ) -> ConditionCheckerFn<'a> {
     Box::new(move |point_id: PointOffsetType| {
-        index.values_count(point_id) == 0 && fallback(point_id)
+        index.values_is_empty(point_id).then(|| fallback(point_id)).unwrap_or(false)
     })
 }
 
@@ -309,6 +309,6 @@ fn get_is_null_checker<'a>( index: &'a FieldIndex,
     fallback: Box<(dyn std::ops::Fn(u32) -> bool + 'a)>,
 ) -> ConditionCheckerFn<'a> {
     Box::new(move |point_id: PointOffsetType| {
-        index.values_is_none(point_id) && fallback(point_id)
+        index.values_is_none(point_id).then(|| fallback(point_id)).unwrap_or(false)
     })
 }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -47,7 +47,9 @@ pub fn condition_converter<'a>(
             field_indexes
                 .get(&is_empty.is_empty.key)
                 .and_then(|indexes| {
-                    indexes.first().map(|index| get_is_empty_checker(index, fallback.clone()))
+                    indexes
+                        .first()
+                        .map(|index| get_is_empty_checker(index, fallback.clone()))
                 })
                 .unwrap_or(fallback)
         }
@@ -59,12 +61,15 @@ pub fn condition_converter<'a>(
                     check_is_null_condition(is_null, &payload)
                 })
             });
-            field_indexes.get(&is_null.is_null.key).and_then(|indexes| {
-                indexes
-                    .first()
-                    .map(|index| get_is_null_checker(index, fallback.clone()))
-            }).unwrap_or(fallback)
-        },
+            field_indexes
+                .get(&is_null.is_null.key)
+                .and_then(|indexes| {
+                    indexes
+                        .first()
+                        .map(|index| get_is_null_checker(index, fallback.clone()))
+                })
+                .unwrap_or(fallback)
+        }
         // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
         Condition::HasId(has_id) => {
             let segment_ids: HashSet<_> = has_id
@@ -300,15 +305,22 @@ fn get_is_empty_checker<'a>(
     fallback: ConditionCheckerFn<'a>,
 ) -> ConditionCheckerFn<'a> {
     Box::new(move |point_id: PointOffsetType| {
-        index.values_is_empty(point_id).then(|| fallback(point_id)).unwrap_or(false)
+        index
+            .values_is_empty(point_id)
+            .then(|| fallback(point_id))
+            .unwrap_or(false)
     })
 }
 
 #[inline]
-fn get_is_null_checker<'a>( index: &'a FieldIndex,
+fn get_is_null_checker<'a>(
+    index: &'a FieldIndex,
     fallback: Box<(dyn std::ops::Fn(u32) -> bool + 'a)>,
 ) -> ConditionCheckerFn<'a> {
     Box::new(move |point_id: PointOffsetType| {
-        index.values_is_none(point_id).then(|| fallback(point_id)).unwrap_or(false)
+        index
+            .values_is_none(point_id)
+            .then(|| fallback(point_id))
+            .unwrap_or(false)
     })
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -256,7 +256,7 @@ fn test_is_empty_conditions() {
 
     let filter = Filter::new_must(Condition::IsEmpty(IsEmptyCondition {
         is_empty: PayloadField {
-            key: "flicking".to_string(),
+            key: FLICKING_KEY.to_string(),
         },
     }));
 
@@ -270,11 +270,13 @@ fn test_is_empty_conditions() {
         .borrow()
         .estimate_cardinality(&filter);
 
-    let real_number = plain_segment
-        .payload_index
-        .borrow()
-        .query_points(&filter)
-        .len();
+    let plain_result = plain_segment.payload_index.borrow().query_points(&filter);
+
+    let real_number = plain_result.len();
+
+    let struct_result = struct_segment.payload_index.borrow().query_points(&filter);
+
+    assert_eq!(plain_result, struct_result);
 
     eprintln!("estimation_plain = {estimation_plain:#?}");
     eprintln!("estimation_struct = {estimation_struct:#?}");


### PR DESCRIPTION
- Make is_empty take advantage of the index when not empty.
- ~Make is_null take advantage of the index when not null~

For both scenarios it adds an overhead of checking both the index and the payload when it is actually empty/null, so these changes improve performance only when the negated condition is true.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
