### PR TITLE
Update collection: HNSW config

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -849,7 +849,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | collection_name | [string](#string) |  | Name of the collection |
-| optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete |
+| optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | New configuration parameters for the collection. This operation is blocking, it will only proceed once all current optimizations are complete |
 | timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied |
 | params | [CollectionParamsDiff](#qdrant-CollectionParamsDiff) | optional | New configuration parameters for the collection |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | New HNSW parameters for the collection index |

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -852,6 +852,7 @@ Note: 1kB = 1 vector of size 256. |
 | optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | New configuration parameters for the collection |
 | timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds, if not specified - default value will be supplied |
 | params | [CollectionParamsDiff](#qdrant-CollectionParamsDiff) | optional | New configuration parameters for the collection |
+| hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | New HNSW parameters for the collection index |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -849,8 +849,8 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | collection_name | [string](#string) |  | Name of the collection |
-| optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | New configuration parameters for the collection |
-| timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds, if not specified - default value will be supplied |
+| optimizers_config | [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff) | optional | New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete |
+| timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied |
 | params | [CollectionParamsDiff](#qdrant-CollectionParamsDiff) | optional | New configuration parameters for the collection |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | New HNSW parameters for the collection index |
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5869,7 +5869,7 @@
         "type": "object",
         "properties": {
           "optimizers_config": {
-            "description": "Custom params for Optimizers.  If none - it is left unchanged. This operation is blocking, it will only proceed ones all current optimizations are complete",
+            "description": "Custom params for Optimizers.  If none - it is left unchanged. This operation is blocking, it will only proceed once all current optimizations are complete",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OptimizersConfigDiff"

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5889,6 +5889,17 @@
                 "nullable": true
               }
             ]
+          },
+          "hnsw_config": {
+            "description": "New HNSW parameters for the collection index. If none - values from service configuration file are used.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HnswConfigDiff"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5869,7 +5869,7 @@
         "type": "object",
         "properties": {
           "optimizers_config": {
-            "description": "Custom params for Optimizers.  If none - values from service configuration file are used. This operation is blocking, it will only proceed ones all current optimizations are complete",
+            "description": "Custom params for Optimizers.  If none - it is left unchanged. This operation is blocking, it will only proceed ones all current optimizations are complete",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OptimizersConfigDiff"
@@ -5880,7 +5880,7 @@
             ]
           },
           "params": {
-            "description": "Collection base params.  If none - values from service configuration file are used.",
+            "description": "Collection base params. If none - it is left unchanged.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/CollectionParamsDiff"
@@ -5891,7 +5891,7 @@
             ]
           },
           "hnsw_config": {
-            "description": "New HNSW parameters for the collection index. If none - values from service configuration file are used.",
+            "description": "HNSW parameters to update for the collection index. If none - it is left unchanged.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/HnswConfigDiff"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -90,6 +90,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdateCollection.optimizers_config", ""),
             ("UpdateCollection.params", ""),
             ("UpdateCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
+            ("UpdateCollection.hnsw_config", ""),
             ("DeleteCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("CollectionConfig.params", ""),

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -220,6 +220,7 @@ message UpdateCollection {
   optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection
   optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
   optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
+  optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index
 }
 
 message DeleteCollection {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -217,8 +217,8 @@ message CreateCollection {
 
 message UpdateCollection {
   string collection_name = 1; // Name of the collection
-  optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection
-  optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+  optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete
+  optional uint64 timeout = 3; // Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied
   optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
   optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -217,7 +217,7 @@ message CreateCollection {
 
 message UpdateCollection {
   string collection_name = 1; // Name of the collection
-  optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete
+  optional OptimizersConfigDiff optimizers_config = 2; // New configuration parameters for the collection. This operation is blocking, it will only proceed once all current optimizations are complete
   optional uint64 timeout = 3; // Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied
   optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
   optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -322,6 +322,7 @@ pub struct UpdateCollection {
     pub params: ::core::option::Option<CollectionParamsDiff>,
     /// New HNSW parameters for the collection index
     #[prost(message, optional, tag = "5")]
+    #[validate]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
 }
 #[derive(validator::Validate)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -320,6 +320,9 @@ pub struct UpdateCollection {
     #[prost(message, optional, tag = "4")]
     #[validate]
     pub params: ::core::option::Option<CollectionParamsDiff>,
+    /// New HNSW parameters for the collection index
+    #[prost(message, optional, tag = "5")]
+    pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -308,11 +308,11 @@ pub struct UpdateCollection {
     #[prost(string, tag = "1")]
     #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
-    /// New configuration parameters for the collection
+    /// New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete
     #[prost(message, optional, tag = "2")]
     #[validate]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,
-    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    /// Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "3")]
     #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub timeout: ::core::option::Option<u64>,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -308,7 +308,7 @@ pub struct UpdateCollection {
     #[prost(string, tag = "1")]
     #[validate(length(min = 1, max = 255))]
     pub collection_name: ::prost::alloc::string::String,
-    /// New configuration parameters for the collection. This operation is blocking, it will only proceed ones all current optimizations are complete
+    /// New configuration parameters for the collection. This operation is blocking, it will only proceed once all current optimizations are complete
     #[prost(message, optional, tag = "2")]
     #[validate]
     pub optimizers_config: ::core::option::Option<OptimizersConfigDiff>,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -25,7 +25,7 @@ use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
-use crate::operations::config_diff::{CollectionParamsDiff, DiffConfig, OptimizersConfigDiff};
+use crate::operations::config_diff::{CollectionParamsDiff, DiffConfig, OptimizersConfigDiff, HnswConfigDiff};
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shared_storage_config::SharedStorageConfig;
@@ -1101,6 +1101,18 @@ impl Collection {
         {
             let mut config = self.collection_config.write().await;
             config.params = params_diff.update(&config.params)?;
+        }
+        self.collection_config.read().await.save(&self.path)?;
+        Ok(())
+    }
+
+    pub async fn update_hnsw_config_from_diff(
+        &self,
+        hnsw_config_diff: HnswConfigDiff,
+    ) -> CollectionResult<()> {
+        {
+            let mut config = self.collection_config.write().await;
+            config.hnsw_config = hnsw_config_diff.update(&config.hnsw_config)?;
         }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1114,12 +1114,7 @@ impl Collection {
             let mut config = self.collection_config.write().await;
             config.hnsw_config = hnsw_config_diff.update(&config.hnsw_config)?;
         }
-        {
-            let shard_holder = self.shards_holder.read().await;
-            for replica_set in shard_holder.all_shards() {
-                replica_set.on_optimizer_config_update().await?;
-            }
-        }
+        self.trigger_optimizers().await?;
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
     }
@@ -1188,12 +1183,7 @@ impl Collection {
             config.optimizer_config =
                 DiffConfig::update(optimizer_config_diff, &config.optimizer_config)?;
         }
-        {
-            let shard_holder = self.shards_holder.read().await;
-            for replica_set in shard_holder.all_shards() {
-                replica_set.on_optimizer_config_update().await?;
-            }
-        }
+        self.trigger_optimizers().await?;
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
     }
@@ -1210,13 +1200,17 @@ impl Collection {
             let mut config = self.collection_config.write().await;
             config.optimizer_config = optimizer_config;
         }
-        {
-            let shard_holder = self.shards_holder.read().await;
-            for replica_set in shard_holder.all_shards() {
-                replica_set.on_optimizer_config_update().await?;
-            }
-        }
+        self.trigger_optimizers().await?;
         self.collection_config.read().await.save(&self.path)?;
+        Ok(())
+    }
+
+    /// Trigger the optimizers on all shards for this collection
+    async fn trigger_optimizers(&self) -> CollectionResult<()> {
+        let shard_holder = self.shards_holder.read().await;
+        for replica_set in shard_holder.all_shards() {
+            replica_set.on_optimizer_config_update().await?;
+        }
         Ok(())
     }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -25,7 +25,9 @@ use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
-use crate::operations::config_diff::{CollectionParamsDiff, DiffConfig, OptimizersConfigDiff, HnswConfigDiff};
+use crate::operations::config_diff::{
+    CollectionParamsDiff, DiffConfig, HnswConfigDiff, OptimizersConfigDiff,
+};
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shared_storage_config::SharedStorageConfig;

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1225,7 +1225,9 @@ impl Collection {
     /// not blocking.
     pub async fn recreate_optimizers_blocking(&self) -> CollectionResult<()> {
         let shard_holder = self.shards_holder.read().await;
-        let updates = shard_holder.all_shards().map(|replica_set| replica_set.on_optimizer_config_update());
+        let updates = shard_holder
+            .all_shards()
+            .map(|replica_set| replica_set.on_optimizer_config_update());
         try_join_all(updates).await?;
         Ok(())
     }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1114,6 +1114,12 @@ impl Collection {
             let mut config = self.collection_config.write().await;
             config.hnsw_config = hnsw_config_diff.update(&config.hnsw_config)?;
         }
+        {
+            let shard_holder = self.shards_holder.read().await;
+            for replica_set in shard_holder.all_shards() {
+                replica_set.on_optimizer_config_update().await?;
+            }
+        }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
     }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -1,0 +1,158 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use segment::common::operation_time_statistics::{
+    OperationDurationStatistics, OperationDurationsAggregator,
+};
+use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE};
+
+use crate::collection_manager::holders::segment_holder::{LockedSegmentHolder, SegmentId};
+use crate::collection_manager::optimizers::segment_optimizer::{
+    OptimizerThresholds, SegmentOptimizer,
+};
+use crate::config::CollectionParams;
+
+/// Looks for segments having a mismatch between configured and actual parameters
+///
+/// For example, a user may change the HNSW parameters for a collection. A segment that was already
+/// indexed with different parameters now has a mismatch. This segment should be optimized (and
+/// indexed) again in order to update the effective configuration.
+pub struct ConfigMismatchOptimizer {
+    thresholds_config: OptimizerThresholds,
+    segments_path: PathBuf,
+    collection_temp_dir: PathBuf,
+    collection_params: CollectionParams,
+    hnsw_config: HnswConfig,
+    quantization_config: Option<QuantizationConfig>,
+    telemetry_durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+impl ConfigMismatchOptimizer {
+    pub fn new(
+        thresholds_config: OptimizerThresholds,
+        segments_path: PathBuf,
+        collection_temp_dir: PathBuf,
+        collection_params: CollectionParams,
+        hnsw_config: HnswConfig,
+        quantization_config: Option<QuantizationConfig>,
+    ) -> Self {
+        ConfigMismatchOptimizer {
+            thresholds_config,
+            segments_path,
+            collection_temp_dir,
+            collection_params,
+            hnsw_config,
+            quantization_config,
+            telemetry_durations_aggregator: OperationDurationsAggregator::new(),
+        }
+    }
+
+    fn worst_segment(
+        &self,
+        segments: LockedSegmentHolder,
+        excluded_ids: &HashSet<SegmentId>,
+    ) -> Vec<SegmentId> {
+        let segments_read_guard = segments.read();
+        let candidates: Vec<_> = segments_read_guard
+            .iter()
+            // Excluded externally, might already be scheduled for optimization
+            .filter(|(idx, _)| !excluded_ids.contains(idx))
+            .filter_map(|(idx, segment)| {
+                let segment_entry = segment.get();
+                let read_segment = segment_entry.read();
+                let point_count = read_segment.available_point_count();
+                let vector_size = point_count
+                    * read_segment
+                        .vector_dims()
+                        .values()
+                        .max()
+                        .copied()
+                        .unwrap_or(0)
+                    * VECTOR_ELEMENT_SIZE;
+
+                let segment_config = read_segment.config();
+
+                if read_segment.segment_type() == SegmentType::Special {
+                    return None; // Never optimize already optimized segment
+                }
+
+                // Determine whether segment has mismatch
+                let has_mismatch =
+                    segment_config
+                        .vector_data
+                        .iter()
+                        .any(|(_vector_name, vector_data)| {
+                            // Check HNSW mismatch
+                            match &vector_data.index {
+                                Indexes::Plain {} => {}
+                                Indexes::Hnsw(effective_hnsw) => {
+                                    let target_hnsw = &self.hnsw_config;
+
+                                    let is_mismatch =
+                                        target_hnsw.mismatch_requires_rebuild(effective_hnsw);
+                                    if is_mismatch {
+                                        return true;
+                                    }
+                                }
+                            }
+
+                            false
+                        });
+
+                has_mismatch.then_some((*idx, vector_size))
+            })
+            .collect();
+
+        // Select the largest unindexed segment
+        candidates
+            .into_iter()
+            .max_by_key(|(_, vector_size)| *vector_size)
+            .map(|(segment_id, _)| segment_id)
+            .into_iter()
+            .collect()
+    }
+}
+
+impl SegmentOptimizer for ConfigMismatchOptimizer {
+    fn collection_path(&self) -> &Path {
+        self.segments_path.as_path()
+    }
+
+    fn temp_path(&self) -> &Path {
+        self.collection_temp_dir.as_path()
+    }
+
+    fn collection_params(&self) -> CollectionParams {
+        self.collection_params.clone()
+    }
+
+    fn hnsw_config(&self) -> &HnswConfig {
+        &self.hnsw_config
+    }
+
+    fn quantization_config(&self) -> Option<QuantizationConfig> {
+        self.quantization_config.clone()
+    }
+
+    fn threshold_config(&self) -> &OptimizerThresholds {
+        &self.thresholds_config
+    }
+
+    fn check_condition(
+        &self,
+        segments: LockedSegmentHolder,
+        excluded_ids: &HashSet<SegmentId>,
+    ) -> Vec<SegmentId> {
+        self.worst_segment(segments, excluded_ids)
+    }
+
+    fn get_telemetry_data(&self) -> OperationDurationStatistics {
+        self.get_telemetry_counter().lock().get_statistics()
+    }
+
+    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {
+        self.telemetry_durations_aggregator.clone()
+    }
+}

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -116,17 +116,13 @@ impl ConfigMismatchOptimizer {
                         .any(|(vector_name, vector_data)| {
                             // Check HNSW mismatch
                             match &vector_data.index {
-                                Indexes::Plain {} => {}
+                                Indexes::Plain {} => false,
                                 Indexes::Hnsw(effective_hnsw) => {
                                     // Select segment if we have an HNSW mismatch that requires rebuild
                                     let target_hnsw = self.get_required_hnsw_config(vector_name);
-                                    if effective_hnsw.mismatch_requires_rebuild(&target_hnsw) {
-                                        return true;
-                                    }
+                                    effective_hnsw.mismatch_requires_rebuild(&target_hnsw)
                                 }
                             }
-
-                            false
                         });
 
                 has_mismatch.then_some((*idx, vector_size))

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -59,12 +59,9 @@ impl IndexingOptimizer {
     ) -> Option<(SegmentId, usize)> {
         segments
             .iter()
+            // Excluded externally, might already be scheduled for optimization
+            .filter(|(idx, _)| !excluded_ids.contains(idx))
             .filter_map(|(idx, segment)| {
-                if excluded_ids.contains(idx) {
-                    // This segment is excluded externally. It might already be scheduled for optimization
-                    return None;
-                }
-
                 let segment_entry = segment.get();
                 let read_segment = segment_entry.read();
                 let point_count = read_segment.available_point_count();
@@ -103,12 +100,9 @@ impl IndexingOptimizer {
         let segments_read_guard = segments.read();
         let candidates: Vec<_> = segments_read_guard
             .iter()
+            // Excluded externally, might already be scheduled for optimization
+            .filter(|(idx, _)| !excluded_ids.contains(idx))
             .filter_map(|(idx, segment)| {
-                if excluded_ids.contains(idx) {
-                    // This segment is excluded externally. It might already be scheduled for optimization
-                    return None;
-                }
-
                 let segment_entry = segment.get();
                 let read_segment = segment_entry.read();
                 let point_count = read_segment.available_point_count();

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -1,3 +1,4 @@
+pub mod config_mismatch_optimizer;
 pub mod indexing_optimizer;
 pub mod merge_optimizer;
 pub mod segment_optimizer;

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -71,6 +71,7 @@ impl VacuumOptimizer {
         let segments_read_guard = segments.read();
         segments_read_guard
             .iter()
+            // Excluded externally, might already be scheduled for optimization
             .filter(|(idx, _segment)| !excluded_ids.contains(idx))
             .flat_map(|(idx, segment)| {
                 // Calculate littered ratio for segment and named vectors

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -76,10 +76,12 @@ impl State {
             .update_optimizer_params(new_config.optimizer_config)
             .await?;
 
-        // updating replication factor
-        let mut config = collection.collection_config.write().await;
-        config.params.replication_factor = new_config.params.replication_factor;
-        config.params.write_consistency_factor = new_config.params.write_consistency_factor;
+        // Update replication factor
+        {
+            let mut config = collection.collection_config.write().await;
+            config.params.replication_factor = new_config.params.replication_factor;
+            config.params.write_consistency_factor = new_config.params.write_consistency_factor;
+        }
 
         collection.recreate_optimizers_blocking().await?;
 

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -81,7 +81,7 @@ impl State {
         config.params.replication_factor = new_config.params.replication_factor;
         config.params.write_consistency_factor = new_config.params.write_consistency_factor;
 
-        self.recreate_optimizers_blocking().await?;
+        collection.recreate_optimizers_blocking().await?;
 
         Ok(())
     }

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -75,10 +75,14 @@ impl State {
         collection
             .update_optimizer_params(new_config.optimizer_config)
             .await?;
+
         // updating replication factor
         let mut config = collection.collection_config.write().await;
         config.params.replication_factor = new_config.params.replication_factor;
         config.params.write_consistency_factor = new_config.params.write_consistency_factor;
+
+        self.recreate_optimizers_blocking().await?;
+
         Ok(())
     }
 

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -32,7 +32,18 @@ pub trait DiffConfig<T: DeserializeOwned + Serialize> {
 }
 
 #[derive(
-    Debug, Deserialize, Serialize, JsonSchema, Validate, Copy, Clone, PartialEq, Eq, Merge, Hash,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    Validate,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Merge,
+    Hash,
 )]
 #[serde(rename_all = "snake_case")]
 pub struct HnswConfigDiff {

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -7,6 +7,7 @@ use segment::types::{HnswConfig, QuantizationConfig};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+use crate::collection_manager::optimizers::config_mismatch_optimizer::ConfigMismatchOptimizer;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 use crate::collection_manager::optimizers::merge_optimizer::MergeOptimizer;
 use crate::collection_manager::optimizers::segment_optimizer::OptimizerThresholds;
@@ -156,6 +157,14 @@ pub fn build_optimizers(
         Arc::new(VacuumOptimizer::new(
             optimizers_config.deleted_threshold,
             optimizers_config.vacuum_min_vector_number,
+            threshold_config.clone(),
+            segments_path.clone(),
+            temp_segments_path.clone(),
+            collection_params.clone(),
+            hnsw_config.clone(),
+            quantization_config.clone(),
+        )),
+        Arc::new(ConfigMismatchOptimizer::new(
             threshold_config,
             segments_path,
             temp_segments_path,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -361,6 +361,23 @@ pub struct HnswConfig {
     pub payload_m: Option<usize>,
 }
 
+impl HnswConfig {
+    /// Detect configuration mismatch against `other` that requires rebuilding
+    ///
+    /// Returns true only if both conditions are met:
+    /// - this configuration does not match `other`
+    /// - to effectively change the configuration, a HNSW rebuild is required
+    ///
+    /// For example, a change in `max_indexing_threads` will not require rebuilding because it
+    /// doesn't affect the final index, and thus this would return false.
+    pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
+        self.m != other.m
+            || self.ef_construct != other.ef_construct
+            || self.on_disk != other.on_disk
+            || self.payload_m != other.payload_m
+    }
+}
+
 const fn default_max_indexing_threads() -> usize {
     0
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -374,6 +374,10 @@ impl HnswConfig {
         self.m != other.m
             || self.ef_construct != other.ef_construct
             || self.payload_m != other.payload_m
+            // Data on disk is the same, we have a unit test for that. We can eventually optimize
+            // this to just reload the collection rather than optimizing it again as a whole just
+            // to flip this flag
+            || self.on_disk != other.on_disk
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -373,7 +373,6 @@ impl HnswConfig {
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self.m != other.m
             || self.ef_construct != other.ef_construct
-            || self.on_disk != other.on_disk
             || self.payload_m != other.payload_m
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -373,6 +373,7 @@ impl HnswConfig {
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self.m != other.m
             || self.ef_construct != other.ef_construct
+            || self.full_scan_threshold != other.full_scan_threshold
             || self.payload_m != other.payload_m
             // Data on disk is the same, we have a unit test for that. We can eventually optimize
             // this to just reload the collection rather than optimizing it again as a whole just

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -179,13 +179,13 @@ impl CreateCollectionOperation {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateCollection {
-    /// Custom params for Optimizers.  If none - values from service configuration file are used.
+    /// Custom params for Optimizers.  If none - it is left unchanged.
     /// This operation is blocking, it will only proceed ones all current optimizations are complete
     #[serde(alias = "optimizer_config")]
-    pub optimizers_config: Option<OptimizersConfigDiff>, // ToDo: Allow updates for other configuration params as well
-    /// Collection base params.  If none - values from service configuration file are used.
+    pub optimizers_config: Option<OptimizersConfigDiff>, // TODO: Allow updates for other configuration params as well
+    /// Collection base params. If none - it is left unchanged.
     pub params: Option<CollectionParamsDiff>,
-    /// New HNSW parameters for the collection index. If none - values from service configuration file are used.
+    /// HNSW parameters to update for the collection index. If none - it is left unchanged.
     #[validate]
     pub hnsw_config: Option<HnswConfigDiff>,
 }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -185,6 +185,9 @@ pub struct UpdateCollection {
     pub optimizers_config: Option<OptimizersConfigDiff>, // ToDo: Allow updates for other configuration params as well
     /// Collection base params.  If none - values from service configuration file are used.
     pub params: Option<CollectionParamsDiff>,
+    /// New HNSW parameters for the collection index. If none - values from service configuration file are used.
+    #[validate]
+    pub hnsw_config: Option<HnswConfigDiff>,
 }
 
 /// Operation for updating parameters of the existing collection
@@ -203,6 +206,7 @@ impl UpdateCollectionOperation {
             update_collection: UpdateCollection {
                 optimizers_config: None,
                 params: None,
+                hnsw_config: None,
             },
             shard_replica_changes: None,
         }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -180,7 +180,7 @@ impl CreateCollectionOperation {
 #[serde(rename_all = "snake_case")]
 pub struct UpdateCollection {
     /// Custom params for Optimizers.  If none - it is left unchanged.
-    /// This operation is blocking, it will only proceed ones all current optimizations are complete
+    /// This operation is blocking, it will only proceed once all current optimizations are complete
     #[serde(alias = "optimizer_config")]
     pub optimizers_config: Option<OptimizersConfigDiff>, // TODO: Allow updates for other configuration params as well
     /// Collection base params. If none - it is left unchanged.

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -80,6 +80,8 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
             UpdateCollection {
                 optimizers_config: value.optimizers_config.map(Into::into),
                 params: value.params.map(TryInto::try_into).transpose()?,
+                // TODO: implement conversion once field is added in gRPC
+                hnsw_config: None,
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -80,8 +80,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
             UpdateCollection {
                 optimizers_config: value.optimizers_config.map(Into::into),
                 params: value.params.map(TryInto::try_into).transpose()?,
-                // TODO: implement conversion once field is added in gRPC
-                hnsw_config: None,
+                hnsw_config: value.hnsw_config.map(Into::into),
             },
         )))
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -105,6 +105,7 @@ pub mod consensus_ops {
                 UpdateCollection {
                     optimizers_config: None,
                     params: None,
+                    hnsw_config: None,
                 },
             );
             operation

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -775,6 +775,7 @@ impl TableOfContent {
         let UpdateCollection {
             optimizers_config,
             params,
+            hnsw_config,
         } = operation.update_collection;
         let collection = self.get_collection(&operation.collection_name).await?;
         if let Some(diff) = optimizers_config {
@@ -782,6 +783,9 @@ impl TableOfContent {
         }
         if let Some(diff) = params {
             collection.update_params_from_diff(diff).await?;
+        }
+        if let Some(diff) = hnsw_config {
+            collection.update_hnsw_config_from_diff(diff).await?;
         }
         if let Some(changes) = replica_changes {
             collection.handle_replica_changes(changes).await?;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -778,17 +778,27 @@ impl TableOfContent {
             hnsw_config,
         } = operation.update_collection;
         let collection = self.get_collection(&operation.collection_name).await?;
+        let mut recreate_optimizers = false;
+
         if let Some(diff) = optimizers_config {
-            collection.update_optimizer_params_from_diff(diff).await?
+            collection.update_optimizer_params_from_diff(diff).await?;
+            recreate_optimizers = true;
         }
         if let Some(diff) = params {
             collection.update_params_from_diff(diff).await?;
+            recreate_optimizers = true;
         }
         if let Some(diff) = hnsw_config {
             collection.update_hnsw_config_from_diff(diff).await?;
+            recreate_optimizers = true;
         }
         if let Some(changes) = replica_changes {
             collection.handle_replica_changes(changes).await?;
+        }
+
+        // Recreate optimizers
+        if recreate_optimizers {
+            collection.recreate_optimizers_blocking().await?;
         }
         Ok(true)
     }

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -21,8 +21,12 @@ def test_collection_update():
         body={
             "optimizers_config": {
                 "default_segment_number": 6,
-                "indexing_threshold": 10_000,
-            }
+                "indexing_threshold": 10000,
+            },
+            "hnsw": {
+                "m": 42,
+                "ef_construct": 123,
+            },
         }
     )
     assert response.ok


### PR DESCRIPTION
Tracking issue: <https://github.com/qdrant/qdrant/issues/2088>

Adds support for changing the HNSW configuration of an existing collection.

This now allows the update HNSW parameters through the [collection update](https://qdrant.tech/documentation/concepts/collections/#update-collection-parameters) endpoint. To update segments that already have an HNSW with the old parameters, a new configuration mismatch optimizer is added. The optimizer will pick these segments up and optimize them again with the new parameters.

Example API call:

```
PATCH /collections/{collection_name}
{
    "hnsw_config": {
        "m": 8,
        "ef_construct": 50
    }
}
```

This change can be very useful for users to experiment with different HNSW configurations, because it can now be changed at any time without recreating the whole collection.

### Tasks

- [x] Add HNSW field to collection update endpoint
- [x] Update HNSW configuration in collection
- [x] Add configuration mismatch optimizer to detect HNSW changes
- [x] Add tests  

### Future tasks

The following tasks will be worked on in follow up PRs for the sake of keeping this PR as small as possible: <https://github.com/qdrant/qdrant/issues/2088>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?