### PR TITLE
CI: use nextest for running rust tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+[profile.ci]
+# Retry tests before failing them.
+retries = { backoff = "exponential", count = 5, delay = "2s" }
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+
+[[profile.ci.overrides]]
+# This test is flaky when run in parallel, so this makes sure to run it on its own.
+filter = "test(segment_builder_test::test_building_cancellation)"
+threads-required = "num-test-threads"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,13 +1,8 @@
 [profile.ci]
 # Retry tests before failing them.
-retries = { backoff = "exponential", count = 5, delay = "2s" }
+retries = { backoff = "exponential", count = 3, delay = "2s" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).
 failure-output = "immediate-final"
-
-[[profile.ci.overrides]]
-# This test is flaky when run in parallel, so this makes sure to run it on its own.
-filter = "test(segment_builder_test::test_building_cancellation)"
-threads-required = "num-test-threads"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,7 @@ fail-fast = false
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).
 failure-output = "immediate-final"
+
+# save junit report
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,21 @@
+---
+title: Flaky test `{{ env.TEST_NAME }}`
+---
+
+## Last report
+
+### System error
+
+```text
+{{ env.SYSTEM_ERROR }}
+```
+
+### Context
+
+[Flaky failure run](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }})
+
+[Commit](https://github.com/{{ env.REPOSITORY }}/tree/{{ env.SHA }})
+
+OS: {{ env.OS }}
+
+Branch: {{ env.BRANCH }}

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Install miniml nightly (only for fmt)
       uses: dtolnay/rust-toolchain@nightly
       with:
-        profile: minimal
         components: rustfmt
     - name: Install minimal stable
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Rust tests
 
 on:
   push:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,12 @@ jobs:
           echo "content<<$delimiter" >> $GITHUB_OUTPUT
           echo "$(jq '[.flakyFailure] | flatten | .[0]["system-err"]' flaky_tests.json -r)" >> $GITHUB_OUTPUT
           echo $delimiter >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - name: pull issue template
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE/flaky_test.md
+          sparse-checkout-cone-mode: false
         if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
       - name: Create issue for flaky tests
         if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   test:
-    name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install cargo nextest
       uses: taiki-e/install-action@nextest
     - name: Build and archive tests
-      run: cargo nextest archive --archive-file nextest-archive.tar.zst
+      run: cargo nextest archive --archive-file nextest-archive-${{ matrix.os }}.tar.zst --workspace
     - name: Upload archive to workflow
       uses: actions/upload-artifact@v3
       with:
@@ -45,8 +45,6 @@ jobs:
         partition: [ 1, 2 ]
 
     steps:
-    - name: Run tests
-      run: cargo nextest run --workspace --profile ci --partition hash:${{ matrix.partition }}/2
     # nextest does not require cargo to run the tests, instead, create ~/.cargo/bin required by install action.
     - run: mkdir -p ~/.cargo/bin
     - name: Install nextest
@@ -58,5 +56,5 @@ jobs:
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: |
-        ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-archive${{ matrix.os }}.tar.zst \
-          --partition hash:${{ matrix.partition }}/2
+        ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.os }}.tar.zst \
+          --partition hash:${{ matrix.partition }}/2 --profile ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        partition: [ 1, 2 ]
 
     steps:
     - name: Install minimal stable
@@ -29,4 +30,5 @@ jobs:
     - name: Install cargo nextest
       uses: taiki-e/install-action@nextest
     - name: Run tests
-      run: cargo nextest run --all --profile ci # Profile "ci" is configured in .config/nextest.toml
+      # Profile "ci" is configured in .config/nextest.toml
+      run: cargo nextest run --workspace --profile ci --partition hash:${{ matrix.partition }}/2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-
-  build: 
+  test:
+    name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,35 +26,8 @@ jobs:
       uses: arduino/setup-protoc@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install cargo nextest
-      uses: taiki-e/install-action@nextest
-    - name: Build and archive tests
-      run: cargo nextest archive --archive-file nextest-archive-${{ matrix.os }}.tar.zst --workspace
-    - name: Upload archive to workflow
-      uses: actions/upload-artifact@v3
-      with:
-        name: nextest-archive-${{ matrix.os }}
-        path: nextest-archive-${{ matrix.os }}.tar.zst
-    
-  test:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-        partition: [ 1, 2 ]
-
-    steps:
-    # nextest does not require cargo to run the tests, instead, create ~/.cargo/bin required by install action.
-    - run: mkdir -p ~/.cargo/bin
     - name: Install nextest
       uses: taiki-e/install-action@nextest
-    - name: Download archive
-      uses: actions/download-artifact@v3
-      with:
-        name: nextest-archive-${{ matrix.os }}
-    - name: Run tests
+    - name: Build and run tests
       # Profile "ci" is configured in .config/nextest.toml
-      run: |
-        ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.os }}.tar.zst \
-          --partition hash:${{ matrix.partition }}/2 --profile ci
+      run: cargo nextest run --workspace --profile ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
 
+  build: 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        partition: [ 1, 2 ]
 
     steps:
     - name: Install minimal stable
@@ -29,6 +28,35 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo nextest
       uses: taiki-e/install-action@nextest
+    - name: Build and archive tests
+      run: cargo nextest archive --archive-file nextest-archive.tar.zst
+    - name: Upload archive to workflow
+      uses: actions/upload-artifact@v3
+      with:
+        name: nextest-archive-${{ matrix.os }}
+        path: nextest-archive-${{ matrix.os }}.tar.zst
+    
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        partition: [ 1, 2 ]
+
+    steps:
+    - name: Run tests
+      run: cargo nextest run --workspace --profile ci --partition hash:${{ matrix.partition }}/2
+    # nextest does not require cargo to run the tests, instead, create ~/.cargo/bin required by install action.
+    - run: mkdir -p ~/.cargo/bin
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+    - name: Download archive
+      uses: actions/download-artifact@v3
+      with:
+        name: nextest-archive-${{ matrix.os }}
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
-      run: cargo nextest run --workspace --profile ci --partition hash:${{ matrix.partition }}/2
+      run: |
+        ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-archive${{ matrix.os }}.tar.zst \
+          --partition hash:${{ matrix.partition }}/2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,3 +31,58 @@ jobs:
     - name: Build and run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci
+    - name: Upload test report
+      uses: actions/upload-artifact@v2
+      with:
+        name: junit-${{ matrix.os }}.xml
+        path: target/nextest/ci/junit.xml
+    
+  process-results:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      issues: write 
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    steps:
+      - name: Download test report
+        uses: actions/download-artifact@v2
+        with:
+          name: junit-${{ matrix.os }}.xml
+      - name: Process test report
+        id: process-test-report
+        run: |
+          pip install yq
+          xq '.testsuites.testsuite.testcase[] | select(. | has("flakyFailure"))' junit.xml > flaky_tests.json
+          echo has_flaky_tests=$(jq '. | has("flakyFailure")' flaky_tests.json) >> $GITHUB_OUTPUT
+      - name: Get flaky test details
+        id: get-flaky-tests
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        run: |
+          echo "Flaky tests found"
+          echo test=$(jq '.["@name"]' flaky_tests.json -r ) >> $GITHUB_OUTPUT
+          delimiter="###r###" 
+          echo "content<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$(jq '[.flakyFailure] | flatten | .[0]["system-err"]' flaky_tests.json -r)" >> $GITHUB_OUTPUT
+          echo $delimiter >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+      - name: Create issue for flaky tests
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_NAME: ${{ steps.get-flaky-tests.outputs.test }}
+          SYSTEM_ERROR: ${{ steps.get-flaky-tests.outputs.content }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          WORKFLOW: ${{ github.workflow }}
+          JOB: ${{ github.job }}
+          BRANCH: ${{ github.ref }}
+          OS: ${{ matrix.os }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/flaky_test.md
+          update_existing: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,12 +26,7 @@ jobs:
       uses: arduino/setup-protoc@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install cargo nextest
+      uses: taiki-e/install-action@nextest
     - name: Run tests
-      run: cargo test --all
-
-#   build:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v4
-#     - name: Build
-#       run: docker build . --tag=qdrant
+      run: cargo nextest run --all --profile ci # Profile "ci" is configured in .config/nextest.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci
     - name: Upload test report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: junit-${{ matrix.os }}.xml
         path: target/nextest/ci/junit.xml
@@ -44,17 +44,17 @@ jobs:
       issues: write 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest  ]
     steps:
       - name: Download test report
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: junit-${{ matrix.os }}.xml
       - name: Process test report
         id: process-test-report
         run: |
           pip install yq
-          xq '.testsuites.testsuite.testcase[] | select(. | has("flakyFailure"))' junit.xml > flaky_tests.json
+          xq '.. | select(type == "object") | select(has("flakyFailure"))' junit.xml > flaky_tests.json
           echo has_flaky_tests=$(jq '. | has("flakyFailure")' flaky_tests.json) >> $GITHUB_OUTPUT
       - name: Get flaky test details
         id: get-flaky-tests


### PR DESCRIPTION
## Motivation

Our current CI test scheme uses the integrated `cargo test` tool for running tests, but sometimes tests begin to flake out, which makes us retry the workflow run to make sure it wasn't our fault. Arguably this makes us pay more attention to flaky tests, but it becomes a distraction when doing unrelated work.

Recently I found out about [`nextest`](https://nexte.st/book), and while we don't need a lot of its features, it does have a couple of them that may benefit us. For instance, it allows retries with backoff, test timeouts, and test reporting (using junit format). 

## Changes

- adds `nextest` as the test runner on GH Actions (for Rust only, obviously).
- enable retries with exponential backoff
- automate creating issues for flaky tests.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->