### PR TITLE
Update collection: quantization config

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -858,6 +858,7 @@ Note: 1kB = 1 vector of size 256. |
 | params | [CollectionParamsDiff](#qdrant-CollectionParamsDiff) | optional | New configuration parameters for the collection |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | New HNSW parameters for the collection index |
 | vectors_config | [VectorsConfigDiff](#qdrant-VectorsConfigDiff) | optional | New vector parameters |
+| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Quantization configuration of vector |
 
 
 
@@ -927,6 +928,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | Update params for HNSW index. If empty object - it will be unset |
+| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Update quantization params. If none - it is left unchanged.Quantization configuration of vector |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -928,7 +928,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | Update params for HNSW index. If empty object - it will be unset |
-| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Update quantization params. If none - it is left unchanged.Quantization configuration of vector |
+| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Update quantization params. If none - it is left unchanged. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -20,6 +20,7 @@
     - [CreateCollection](#qdrant-CreateCollection)
     - [DeleteAlias](#qdrant-DeleteAlias)
     - [DeleteCollection](#qdrant-DeleteCollection)
+    - [Disabled](#qdrant-Disabled)
     - [GetCollectionInfoRequest](#qdrant-GetCollectionInfoRequest)
     - [GetCollectionInfoResponse](#qdrant-GetCollectionInfoResponse)
     - [HnswConfigDiff](#qdrant-HnswConfigDiff)
@@ -36,6 +37,7 @@
     - [PayloadSchemaInfo](#qdrant-PayloadSchemaInfo)
     - [ProductQuantization](#qdrant-ProductQuantization)
     - [QuantizationConfig](#qdrant-QuantizationConfig)
+    - [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff)
     - [RemoteShardInfo](#qdrant-RemoteShardInfo)
     - [RenameAlias](#qdrant-RenameAlias)
     - [Replica](#qdrant-Replica)
@@ -470,6 +472,16 @@
 
 
 
+<a name="qdrant-Disabled"></a>
+
+### Disabled
+
+
+
+
+
+
+
 <a name="qdrant-GetCollectionInfoRequest"></a>
 
 ### GetCollectionInfoRequest
@@ -742,6 +754,23 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+<a name="qdrant-QuantizationConfigDiff"></a>
+
+### QuantizationConfigDiff
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| scalar | [ScalarQuantization](#qdrant-ScalarQuantization) |  |  |
+| product | [ProductQuantization](#qdrant-ProductQuantization) |  |  |
+| disabled | [Disabled](#qdrant-Disabled) |  |  |
+
+
+
+
+
+
 <a name="qdrant-RemoteShardInfo"></a>
 
 ### RemoteShardInfo
@@ -858,7 +887,7 @@ Note: 1kB = 1 vector of size 256. |
 | params | [CollectionParamsDiff](#qdrant-CollectionParamsDiff) | optional | New configuration parameters for the collection |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | New HNSW parameters for the collection index |
 | vectors_config | [VectorsConfigDiff](#qdrant-VectorsConfigDiff) | optional | New vector parameters |
-| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Quantization configuration of vector |
+| quantization_config | [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff) | optional | Quantization configuration of vector |
 
 
 
@@ -928,7 +957,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | Update params for HNSW index. If empty object - it will be unset |
-| quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Update quantization params. If none - it is left unchanged. |
+| quantization_config | [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff) | optional | Update quantization params. If none - it is left unchanged. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5912,6 +5912,18 @@
                 "nullable": true
               }
             ]
+          },
+          "quantization_config": {
+            "description": "Quantization parameters to update. If none - it is left unchanged.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QuantizationConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -5930,6 +5942,17 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/HnswConfigDiff"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "quantization_config": {
+            "description": "Update params for quantization. If none - it is left unchanged.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QuantizationConfig"
               },
               {
                 "nullable": true

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5918,7 +5918,7 @@
             "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/QuantizationConfig"
+                "$ref": "#/components/schemas/QuantizationConfigDiff"
               },
               {
                 "nullable": true
@@ -5952,7 +5952,7 @@
             "description": "Update params for quantization. If none - it is left unchanged.",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/QuantizationConfig"
+                "$ref": "#/components/schemas/QuantizationConfigDiff"
               },
               {
                 "nullable": true
@@ -5960,6 +5960,25 @@
             ]
           }
         }
+      },
+      "QuantizationConfigDiff": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ScalarQuantization"
+          },
+          {
+            "$ref": "#/components/schemas/ProductQuantization"
+          },
+          {
+            "$ref": "#/components/schemas/Disabled"
+          }
+        ]
+      },
+      "Disabled": {
+        "type": "string",
+        "enum": [
+          "Disabled"
+        ]
       },
       "CollectionParamsDiff": {
         "type": "object",

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -113,6 +113,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("VectorParams.quantization_config", ""),
             ("VectorParamsMap.map", ""),
             ("VectorParamsDiff.hnsw_config", ""),
+            ("VectorParamsDiff.quantization_config", ""),
             ("VectorParamsDiffMap.map", ""),
             ("QuantizationConfig.quantization", ""),
             ("ScalarQuantization.quantile", "custom = \"crate::grpc::validate::validate_f32_range_min_0_5_max_1\""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -92,6 +92,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdateCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("UpdateCollection.hnsw_config", ""),
             ("UpdateCollection.vectors_config", ""),
+            ("UpdateCollection.quantization_config", ""),
             ("DeleteCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteCollection.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("CollectionConfig.params", ""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -116,6 +116,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("VectorParamsDiff.quantization_config", ""),
             ("VectorParamsDiffMap.map", ""),
             ("QuantizationConfig.quantization", ""),
+            ("QuantizationConfigDiff.quantization", ""),
             ("ScalarQuantization.quantile", "custom = \"crate::grpc::validate::validate_f32_range_min_0_5_max_1\""),
         ], &[
             "ListCollectionsRequest",
@@ -124,6 +125,9 @@ fn configure_validation(builder: Builder) -> Builder {
             "CollectionClusterInfoRequest",
             "UpdateCollectionClusterSetupRequest",
             "ProductQuantization",
+            "Disabled",
+            "QuantizationConfigDiff",
+            "quantization_config_diff::Quantization"
         ])
         // Service: collections_internal.proto
         .validates(&[

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -23,10 +23,10 @@ use crate::grpc::qdrant::{
     HealthCheckReply, HnswConfigDiff, IsEmptyCondition, IsNullCondition, ListCollectionsResponse,
     ListValue, Match, NamedVectors, NestedCondition, PayloadExcludeSelector,
     PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo, PayloadSchemaType, PointId,
-    ProductQuantization, QuantizationConfig, QuantizationSearchParams,
-    QuantizationType, Range, RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint,
-    SearchParams, Struct, TextIndexParams, TokenizerType, Value, ValuesCount, Vector, Vectors,
-    VectorsSelector, WithPayloadSelector, WithVectorsSelector,
+    ProductQuantization, QuantizationConfig, QuantizationSearchParams, QuantizationType, Range,
+    RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint, SearchParams, Struct,
+    TextIndexParams, TokenizerType, Value, ValuesCount, Vector, Vectors, VectorsSelector,
+    WithPayloadSelector, WithVectorsSelector,
 };
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -11,6 +11,7 @@ message VectorParams {
 
 message VectorParamsDiff {
   optional HnswConfigDiff hnsw_config = 1; // Update params for HNSW index. If empty object - it will be unset
+  optional QuantizationConfig quantization_config = 2; // Update quantization params. If none - it is left unchanged.Quantization configuration of vector
 }
 
 message VectorParamsMap {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -237,6 +237,7 @@ message UpdateCollection {
   optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
   optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index
   optional VectorsConfigDiff vectors_config = 6; // New vector parameters
+  optional QuantizationConfig quantization_config = 7; // Quantization configuration of vector
 }
 
 message DeleteCollection {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -11,7 +11,7 @@ message VectorParams {
 
 message VectorParamsDiff {
   optional HnswConfigDiff hnsw_config = 1; // Update params for HNSW index. If empty object - it will be unset
-  optional QuantizationConfig quantization_config = 2; // Update quantization params. If none - it is left unchanged.
+  optional QuantizationConfigDiff quantization_config = 2; // Update quantization params. If none - it is left unchanged.
 }
 
 message VectorParamsMap {
@@ -214,6 +214,18 @@ message QuantizationConfig {
   }
 }
 
+message Disabled {
+
+}
+
+message QuantizationConfigDiff {
+  oneof quantization {
+    ScalarQuantization scalar = 1;
+    ProductQuantization product = 2;
+    Disabled disabled = 3;
+  }
+}
+
 message CreateCollection {
   string collection_name = 1; // Name of the collection
   reserved 2; // Deprecated
@@ -238,7 +250,7 @@ message UpdateCollection {
   optional CollectionParamsDiff params = 4; // New configuration parameters for the collection
   optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index
   optional VectorsConfigDiff vectors_config = 6; // New vector parameters
-  optional QuantizationConfig quantization_config = 7; // Quantization configuration of vector
+  optional QuantizationConfigDiff quantization_config = 7; // Quantization configuration of vector
 }
 
 message DeleteCollection {
@@ -404,8 +416,8 @@ message MoveShard {
 }
 
 message Replica {
-  uint32 shard_id = 1; 
-  uint64 peer_id = 2; 
+  uint32 shard_id = 1;
+  uint64 peer_id = 2;
 }
 
 message UpdateCollectionClusterSetupRequest {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -11,7 +11,7 @@ message VectorParams {
 
 message VectorParamsDiff {
   optional HnswConfigDiff hnsw_config = 1; // Update params for HNSW index. If empty object - it will be unset
-  optional QuantizationConfig quantization_config = 2; // Update quantization params. If none - it is left unchanged.Quantization configuration of vector
+  optional QuantizationConfig quantization_config = 2; // Update quantization params. If none - it is left unchanged.
 }
 
 message VectorParamsMap {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -367,6 +367,10 @@ pub struct UpdateCollection {
     #[prost(message, optional, tag = "6")]
     #[validate]
     pub vectors_config: ::core::option::Option<VectorsConfigDiff>,
+    /// Quantization configuration of vector
+    #[prost(message, optional, tag = "7")]
+    #[validate]
+    pub quantization_config: ::core::option::Option<QuantizationConfig>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -29,6 +29,10 @@ pub struct VectorParamsDiff {
     #[prost(message, optional, tag = "1")]
     #[validate]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
+    /// Update quantization params. If none - it is left unchanged.Quantization configuration of vector
+    #[prost(message, optional, tag = "2")]
+    #[validate]
+    pub quantization_config: ::core::option::Option<QuantizationConfig>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -32,7 +32,7 @@ pub struct VectorParamsDiff {
     /// Update quantization params. If none - it is left unchanged.
     #[prost(message, optional, tag = "2")]
     #[validate]
-    pub quantization_config: ::core::option::Option<QuantizationConfig>,
+    pub quantization_config: ::core::option::Option<QuantizationConfigDiff>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -296,6 +296,31 @@ pub mod quantization_config {
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Disabled {}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuantizationConfigDiff {
+    #[prost(oneof = "quantization_config_diff::Quantization", tags = "1, 2, 3")]
+    #[validate]
+    pub quantization: ::core::option::Option<quantization_config_diff::Quantization>,
+}
+/// Nested message and enum types in `QuantizationConfigDiff`.
+pub mod quantization_config_diff {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Quantization {
+        #[prost(message, tag = "1")]
+        Scalar(super::ScalarQuantization),
+        #[prost(message, tag = "2")]
+        Product(super::ProductQuantization),
+        #[prost(message, tag = "3")]
+        Disabled(super::Disabled),
+    }
+}
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateCollection {
     /// Name of the collection
     #[prost(string, tag = "1")]
@@ -374,7 +399,7 @@ pub struct UpdateCollection {
     /// Quantization configuration of vector
     #[prost(message, optional, tag = "7")]
     #[validate]
-    pub quantization_config: ::core::option::Option<QuantizationConfig>,
+    pub quantization_config: ::core::option::Option<QuantizationConfigDiff>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -29,7 +29,7 @@ pub struct VectorParamsDiff {
     #[prost(message, optional, tag = "1")]
     #[validate]
     pub hnsw_config: ::core::option::Option<HnswConfigDiff>,
-    /// Update quantization params. If none - it is left unchanged.Quantization configuration of vector
+    /// Update quantization params. If none - it is left unchanged.
     #[prost(message, optional, tag = "2")]
     #[validate]
     pub quantization_config: ::core::option::Option<QuantizationConfig>,

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -101,6 +101,18 @@ impl Validate for crate::grpc::qdrant::quantization_config::Quantization {
     }
 }
 
+impl Validate for crate::grpc::qdrant::quantization_config_diff::Quantization {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        use crate::grpc::qdrant::quantization_config_diff::Quantization;
+        match self {
+            Quantization::Scalar(scalar) => scalar.validate(),
+            Quantization::Product(product) => product.validate(),
+            Quantization::Disabled(_) => Ok(()),
+        }
+    }
+}
+
+
 /// Validate that `value` is a non-empty string or `None`.
 pub fn validate_not_empty(value: &Option<String>) -> Result<(), ValidationError> {
     match value {

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -112,7 +112,6 @@ impl Validate for crate::grpc::qdrant::quantization_config_diff::Quantization {
     }
 }
 
-
 /// Validate that `value` is a non-empty string or `None`.
 pub fn validate_not_empty(value: &Option<String>) -> Result<(), ValidationError> {
     match value {

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -12,7 +12,8 @@ use itertools::Itertools;
 use segment::common::version::StorageVersion;
 use segment::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterable};
 use segment::types::{
-    ExtendedPointId, Order, ScoredPoint, WithPayload, WithPayloadInterface, WithVector, QuantizationConfig,
+    ExtendedPointId, Order, QuantizationConfig, ScoredPoint, WithPayload, WithPayloadInterface,
+    WithVector,
 };
 use semver::Version;
 use tar::Builder as TarBuilder;

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -127,7 +127,10 @@ impl ConfigMismatchOptimizer {
                             }
 
                             // Check quantization mismatch
-                            if vector_data.quantization_config != self.quantization_config {
+                            let quantization_mismatch = vector_data.quantization_config.as_ref().zip(self.quantization_config.as_ref()).map(|(a, b)| a.mismatch_requires_rebuild(b)).unwrap_or_else(|| {
+                                vector_data.quantization_config.is_some() != self.quantization_config.is_some()
+                            });
+                            if quantization_mismatch {
                                 return true;
                             }
 

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -211,7 +211,10 @@ mod tests {
 
     use parking_lot::RwLock;
     use segment::entry::entry_point::SegmentEntry;
-    use segment::types::Distance;
+    use segment::types::{
+        CompressionRatio, Distance, ProductQuantization, ProductQuantizationConfig,
+        ScalarQuantizationConfig, ScalarType,
+    };
     use tempfile::Builder;
 
     use super::*;
@@ -506,6 +509,177 @@ mod tests {
                     segment.config().vector_data["vector2"].index,
                     Indexes::Hnsw(hnsw_config_vector2.update(&hnsw_config_collection).unwrap()),
                     "HNSW config of vector2 is not what we expect",
+                );
+            });
+    }
+
+    /// This test the config mismatch optimizer for a changed vector specific HNSW config
+    ///
+    /// Similar to `test_hnsw_config_mismatch` but for multi vector segment with a vector specific
+    /// change.
+    ///
+    /// It tests whether:
+    /// - the condition check for HNSW mismatches works for a vector specific change
+    /// - optimized segments (and vector storages) use the updated configuration
+    ///
+    /// In short, this is what happens in this test:
+    /// - create randomized multi segment as base
+    /// - use indexing optimizer to build index for our segment
+    /// - test config mismatch condition: should not trigger yet
+    /// - change HNSW config for vector2
+    /// - test config mismatch condition: should trigger due to HNSW change
+    /// - optimize segment with config mismatch optimizer
+    /// - assert segment uses changed configuration
+    #[test]
+    fn test_quantization_config_mismatch_vector_specific() {
+        // Collection configuration
+        let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
+        let thresholds_config = OptimizerThresholds {
+            max_segment_size: std::usize::MAX,
+            memmap_threshold: std::usize::MAX,
+            indexing_threshold: 10,
+        };
+        let quantization_config_vector1 =
+            QuantizationConfig::Scalar(segment::types::ScalarQuantization {
+                scalar: ScalarQuantizationConfig {
+                    r#type: ScalarType::Int8,
+                    quantile: Some(0.99),
+                    always_ram: Some(true),
+                },
+            });
+        let collection_params = CollectionParams {
+            vectors: VectorsConfig::Multi(BTreeMap::from([
+                (
+                    "vector1".into(),
+                    VectorParams {
+                        size: vector1_dim.try_into().unwrap(),
+                        distance: Distance::Dot,
+                        hnsw_config: None,
+                        quantization_config: Some(quantization_config_vector1.clone()),
+                        on_disk: None,
+                    },
+                ),
+                (
+                    "vector2".into(),
+                    VectorParams {
+                        size: vector2_dim.try_into().unwrap(),
+                        distance: Distance::Dot,
+                        hnsw_config: None,
+                        quantization_config: None,
+                        on_disk: None,
+                    },
+                ),
+            ])),
+            shard_number: 1.try_into().unwrap(),
+            on_disk_payload: false,
+            replication_factor: 1.try_into().unwrap(),
+            write_consistency_factor: 1.try_into().unwrap(),
+        };
+
+        // Base segment
+        let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let mut holder = SegmentHolder::default();
+
+        let segment = random_multi_vec_segment(
+            dir.path(),
+            100,
+            point_count,
+            vector1_dim as usize,
+            vector2_dim as usize,
+        );
+
+        let segment_id = holder.add(segment);
+        let locked_holder: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
+
+        let quantization_config_collection =
+            QuantizationConfig::Scalar(segment::types::ScalarQuantization {
+                scalar: ScalarQuantizationConfig {
+                    r#type: ScalarType::Int8,
+                    quantile: Some(0.91),
+                    always_ram: None,
+                },
+            });
+
+        // Optimizers used in test
+        let index_optimizer = IndexingOptimizer::new(
+            thresholds_config.clone(),
+            dir.path().to_owned(),
+            temp_dir.path().to_owned(),
+            collection_params.clone(),
+            Default::default(),
+            Some(quantization_config_collection.clone()),
+        );
+        let mut config_mismatch_optimizer = ConfigMismatchOptimizer::new(
+            thresholds_config,
+            dir.path().to_owned(),
+            temp_dir.path().to_owned(),
+            collection_params,
+            Default::default(),
+            Some(quantization_config_collection),
+        );
+
+        // Use indexing optimizer to build index for quantization mismatch test
+        let changed = index_optimizer
+            .optimize(locked_holder.clone(), vec![segment_id], &false.into())
+            .unwrap();
+        assert!(changed, "optimizer should have rebuilt this segment");
+        assert!(
+            locked_holder.read().get(segment_id).is_none(),
+            "optimized segment should be gone",
+        );
+        assert_eq!(locked_holder.read().len(), 2, "index must be built");
+
+        // Mismatch optimizer should not optimize yet, quantization config is not changed yet
+        let suggested_to_optimize =
+            config_mismatch_optimizer.check_condition(locked_holder.clone(), &Default::default());
+        assert_eq!(suggested_to_optimize.len(), 0);
+
+        // Create changed quantization config for vector2, update it in the optimizer
+        let quantization_config_vector2 = QuantizationConfig::Product(ProductQuantization {
+            product: ProductQuantizationConfig {
+                compression: CompressionRatio::X32,
+                always_ram: Some(true),
+            },
+        });
+        match config_mismatch_optimizer.collection_params.vectors {
+            VectorsConfig::Single(_) => unreachable!(),
+            VectorsConfig::Multi(ref mut map) => {
+                map.get_mut("vector2")
+                    .unwrap()
+                    .quantization_config
+                    .replace(quantization_config_vector2.clone());
+            }
+        }
+
+        // Run mismatch optimizer again, make sure it optimizes now
+        let suggested_to_optimize =
+            config_mismatch_optimizer.check_condition(locked_holder.clone(), &Default::default());
+        assert_eq!(suggested_to_optimize.len(), 1);
+        let changed = config_mismatch_optimizer
+            .optimize(locked_holder.clone(), suggested_to_optimize, &false.into())
+            .unwrap();
+        assert!(changed, "optimizer should have rebuilt this segment");
+
+        // Ensure new segment has changed quantization config
+        locked_holder
+            .read()
+            .iter()
+            .map(|(_, segment)| match segment {
+                LockedSegment::Original(s) => s.read(),
+                LockedSegment::Proxy(_) => unreachable!(),
+            })
+            .filter(|segment| segment.total_point_count() > 0)
+            .for_each(|segment| {
+                assert_eq!(
+                    segment.config().vector_data["vector1"].quantization_config,
+                    Some(quantization_config_vector1.clone()),
+                    "Quantization config of vector1 is not what we expect",
+                );
+                assert_eq!(
+                    segment.config().vector_data["vector2"].quantization_config,
+                    Some(quantization_config_vector2.clone()),
+                    "Quantization config of vector2 is not what we expect",
                 );
             });
     }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -116,13 +116,22 @@ impl ConfigMismatchOptimizer {
                         .any(|(vector_name, vector_data)| {
                             // Check HNSW mismatch
                             match &vector_data.index {
-                                Indexes::Plain {} => false,
+                                Indexes::Plain {} => {}
                                 Indexes::Hnsw(effective_hnsw) => {
                                     // Select segment if we have an HNSW mismatch that requires rebuild
                                     let target_hnsw = self.get_required_hnsw_config(vector_name);
-                                    effective_hnsw.mismatch_requires_rebuild(&target_hnsw)
+                                    if effective_hnsw.mismatch_requires_rebuild(&target_hnsw) {
+                                        return true;
+                                    }
                                 }
                             }
+
+                            // Check quantization mismatch
+                            if vector_data.quantization_config != self.quantization_config {
+                                return true;
+                            }
+
+                            false
                         });
 
                 has_mismatch.then_some((*idx, vector_size))

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -127,9 +127,14 @@ impl ConfigMismatchOptimizer {
                             }
 
                             // Check quantization mismatch
-                            let quantization_mismatch = vector_data.quantization_config.as_ref().zip(self.quantization_config.as_ref()).map(|(a, b)| a.mismatch_requires_rebuild(b)).unwrap_or_else(|| {
-                                vector_data.quantization_config.is_some() != self.quantization_config.is_some()
-                            });
+                            let quantization_mismatch = vector_data
+                                .quantization_config
+                                .as_ref()
+                                .zip(self.quantization_config.as_ref())
+                                // Rebuild if current parameters differ from new parameters
+                                .map(|(a, b)| a.mismatch_requires_rebuild(b))
+                                // Or rebuild if we currently have quantization but now disabled it
+                                .unwrap_or_else(|| vector_data.quantization_config.is_some() && self.quantization_config.is_none());
                             if quantization_mismatch {
                                 return true;
                             }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -149,11 +149,8 @@ impl ConfigMismatchOptimizer {
                                     vector_data.quantization_config.is_some()
                                         && target_quantization.is_none()
                                 });
-                            if quantization_mismatch {
-                                return true;
-                            }
 
-                            false
+                            quantization_mismatch
                         });
 
                 has_mismatch.then_some((*idx, vector_size))

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -129,18 +129,26 @@ impl ConfigMismatchOptimizer {
                             // Check quantization mismatch
                             let target_quantization_collection = self.quantization_config.as_ref();
                             let target_quantization_vector = self
-                                        .collection_params
-                                        .vectors
-                                        .get_params(vector_name)
-                                        .and_then(|vector_params| vector_params.quantization_config.clone());
-                            let target_quantization = target_quantization_vector.as_ref().or(target_quantization_collection);
-                            let quantization_mismatch = vector_data.quantization_config
+                                .collection_params
+                                .vectors
+                                .get_params(vector_name)
+                                .and_then(|vector_params| {
+                                    vector_params.quantization_config.clone()
+                                });
+                            let target_quantization = target_quantization_vector
+                                .as_ref()
+                                .or(target_quantization_collection);
+                            let quantization_mismatch = vector_data
+                                .quantization_config
                                 .as_ref()
                                 .zip(target_quantization)
                                 // Rebuild if current parameters differ from new parameters
                                 .map(|(a, b)| a.mismatch_requires_rebuild(b))
                                 // Or rebuild if we currently have quantization but now disabled it
-                                .unwrap_or_else(|| vector_data.quantization_config.is_some() && target_quantization.is_none());
+                                .unwrap_or_else(|| {
+                                    vector_data.quantization_config.is_some()
+                                        && target_quantization.is_none()
+                                });
                             if quantization_mismatch {
                                 return true;
                             }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -142,12 +142,13 @@ impl ConfigMismatchOptimizer {
                                 .quantization_config
                                 .as_ref()
                                 .zip(target_quantization)
-                                // Rebuild if current parameters differ from new parameters
-                                .map(|(a, b)| a.mismatch_requires_rebuild(b))
-                                // Or rebuild if we currently have quantization but now disabled it
+                                // Rebuild if current parameters differ from target parameters
+                                .map(|(current, target)| current.mismatch_requires_rebuild(target))
+                                // Or rebuild if we now change the enabled state on an indexed segment
                                 .unwrap_or_else(|| {
-                                    vector_data.quantization_config.is_some()
-                                        && target_quantization.is_none()
+                                    vector_data.index.is_indexed()
+                                        && (vector_data.quantization_config.is_some()
+                                            != target_quantization.is_some())
                                 });
 
                             quantization_mismatch

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -188,9 +188,9 @@ impl CollectionParams {
 
             if let Some(hnsw_diff) = &update_params.hnsw_config {
                 if let Some(existing_hnsw) = &vector_params.hnsw_config {
-                    vector_params.hnsw_config = Some(hnsw_diff.clone().update(existing_hnsw)?);
+                    vector_params.hnsw_config = Some((*hnsw_diff).update(existing_hnsw)?);
                 } else {
-                    vector_params.hnsw_config = Some(hnsw_diff.clone());
+                    vector_params.hnsw_config = Some(*hnsw_diff);
                 }
             }
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -386,13 +386,11 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
             })?,
             distance: from_grpc_dist(vector_params.distance)?,
             hnsw_config: vector_params.hnsw_config.map(Into::into),
-            quantization_config: match vector_params.quantization_config {
-                Some(config) => Some(
-                    grpc_to_segment_quantization_config(config)
-                        .map_err(Status::invalid_argument)?,
-                ),
-                None => None,
-            },
+            quantization_config: vector_params
+                .quantization_config
+                .map(grpc_to_segment_quantization_config)
+                .transpose()
+                .map_err(Status::invalid_argument)?,
             on_disk: vector_params.on_disk,
         })
     }
@@ -404,7 +402,11 @@ impl TryFrom<api::grpc::qdrant::VectorParamsDiff> for VectorParamsDiff {
     fn try_from(vector_params: api::grpc::qdrant::VectorParamsDiff) -> Result<Self, Self::Error> {
         Ok(Self {
             hnsw_config: vector_params.hnsw_config.map(Into::into),
-            quantization_config: None,
+            quantization_config: vector_params
+                .quantization_config
+                .map(grpc_to_segment_quantization_config)
+                .transpose()
+                .map_err(Status::invalid_argument)?,
         })
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -2,14 +2,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::num::{NonZeroU32, NonZeroU64};
 
 use api::grpc::conversions::{from_grpc_dist, payload_to_proto, proto_to_payloads};
+use api::grpc::qdrant::quantization_config_diff::Quantization;
 use api::grpc::qdrant::update_collection_cluster_setup_request::Operation as ClusterOperationsPb;
-use api::grpc::qdrant::QuantizationType;
 use itertools::Itertools;
 use segment::data_types::vectors::{NamedVector, VectorStruct, DEFAULT_VECTOR_NAME};
-use segment::types::{
-    CompressionRatio, Distance, ProductQuantization, ProductQuantizationConfig, QuantizationConfig,
-    ScalarQuantization, ScalarQuantizationConfig, ScalarType,
-};
+use segment::types::{Distance, QuantizationConfig};
 use tonic::Status;
 
 use super::types::{
@@ -27,7 +24,8 @@ use crate::operations::cluster_ops::{
     Replica, ReplicateShardOperation,
 };
 use crate::operations::config_diff::{
-    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff,
+    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
+    WalConfigDiff,
 };
 use crate::operations::point_ops::PointsSelector::PointIdsSelector;
 use crate::operations::point_ops::{
@@ -174,6 +172,23 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfigDiff {
             indexing_threshold: value.indexing_threshold.map(|v| v as usize),
             flush_interval_sec: value.flush_interval_sec,
             max_optimization_threads: value.max_optimization_threads.map(|v| v as usize),
+        }
+    }
+}
+
+impl TryFrom<api::grpc::qdrant::QuantizationConfigDiff> for QuantizationConfigDiff {
+    type Error = Status;
+
+    fn try_from(value: api::grpc::qdrant::QuantizationConfigDiff) -> Result<Self, Self::Error> {
+        match value.quantization {
+            None => Err(Status::invalid_argument(
+                "Quantization type is not specified",
+            )),
+            Some(quantization) => match quantization {
+                Quantization::Scalar(scalar) => Ok(Self::Scalar(scalar.try_into()?)),
+                Quantization::Product(product) => Ok(Self::Product(product.try_into()?)),
+                Quantization::Disabled(_) => Ok(Self::new_disabled()),
+            },
         }
     }
 }
@@ -389,8 +404,7 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
             quantization_config: vector_params
                 .quantization_config
                 .map(grpc_to_segment_quantization_config)
-                .transpose()
-                .map_err(Status::invalid_argument)?,
+                .transpose()?,
             on_disk: vector_params.on_disk,
         })
     }
@@ -404,55 +418,24 @@ impl TryFrom<api::grpc::qdrant::VectorParamsDiff> for VectorParamsDiff {
             hnsw_config: vector_params.hnsw_config.map(Into::into),
             quantization_config: vector_params
                 .quantization_config
-                .map(grpc_to_segment_quantization_config)
-                .transpose()
-                .map_err(Status::invalid_argument)?,
+                .map(TryInto::try_into)
+                .transpose()?,
         })
     }
 }
 
 fn grpc_to_segment_quantization_config(
     value: api::grpc::qdrant::QuantizationConfig,
-) -> Result<QuantizationConfig, String> {
+) -> Result<QuantizationConfig, Status> {
     let quantization = value
         .quantization
-        .ok_or_else(|| "QuantizationConfig should always have a value".to_string())?;
+        .ok_or_else(|| Status::invalid_argument("QuantizationConfig must contain quantization"))?;
     match quantization {
         api::grpc::qdrant::quantization_config::Quantization::Scalar(config) => {
-            Ok(QuantizationConfig::Scalar(ScalarQuantization {
-                scalar: ScalarQuantizationConfig {
-                    r#type: match QuantizationType::from_i32(config.r#type) {
-                        Some(QuantizationType::Int8) => ScalarType::Int8,
-                        Some(QuantizationType::UnknownQuantization) | None => {
-                            return Err(format!("Cannot convert ordering: {}", config.r#type));
-                        }
-                    },
-                    quantile: config.quantile,
-                    always_ram: config.always_ram,
-                },
-            }))
+            Ok(QuantizationConfig::Scalar(config.try_into()?))
         }
         api::grpc::qdrant::quantization_config::Quantization::Product(config) => {
-            Ok(QuantizationConfig::Product(ProductQuantization {
-                product: ProductQuantizationConfig {
-                    compression: match api::grpc::qdrant::CompressionRatio::from_i32(
-                        config.compression,
-                    ) {
-                        None => {
-                            return Err(format!(
-                                "Cannot convert compression ratio: {}",
-                                config.compression
-                            ));
-                        }
-                        Some(api::grpc::qdrant::CompressionRatio::X4) => CompressionRatio::X4,
-                        Some(api::grpc::qdrant::CompressionRatio::X8) => CompressionRatio::X8,
-                        Some(api::grpc::qdrant::CompressionRatio::X16) => CompressionRatio::X16,
-                        Some(api::grpc::qdrant::CompressionRatio::X32) => CompressionRatio::X32,
-                        Some(api::grpc::qdrant::CompressionRatio::X64) => CompressionRatio::X64,
-                    },
-                    always_ram: config.always_ram,
-                },
-            }))
+            Ok(QuantizationConfig::Product(config.try_into()?))
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -404,6 +404,7 @@ impl TryFrom<api::grpc::qdrant::VectorParamsDiff> for VectorParamsDiff {
     fn try_from(vector_params: api::grpc::qdrant::VectorParamsDiff) -> Result<Self, Self::Error> {
         Ok(Self {
             hnsw_config: vector_params.hnsw_config.map(Into::into),
+            quantization_config: None,
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -34,7 +34,7 @@ use validator::{Validate, ValidationErrors};
 use super::config_diff;
 use crate::config::{CollectionConfig, CollectionParams};
 use crate::lookup::types::WithLookupInterface;
-use crate::operations::config_diff::HnswConfigDiff;
+use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -1000,7 +1000,7 @@ pub struct VectorParamsDiff {
         skip_serializing_if = "Option::is_none"
     )]
     #[validate]
-    pub quantization_config: Option<QuantizationConfig>,
+    pub quantization_config: Option<QuantizationConfigDiff>,
 }
 
 /// Vector update params for multiple vectors

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -993,6 +993,14 @@ pub struct VectorParamsDiff {
     #[serde(default, skip_serializing_if = "is_hnsw_diff_empty")]
     #[validate]
     pub hnsw_config: Option<HnswConfigDiff>,
+    /// Update params for quantization. If none - it is left unchanged.
+    #[serde(
+        default,
+        alias = "quantization",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[validate]
+    pub quantization_config: Option<QuantizationConfig>,
 }
 
 /// Vector update params for multiple vectors

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -423,7 +423,7 @@ impl ScalarQuantizationConfig {
     ///
     /// Returns true only if both conditions are met:
     /// - this configuration does not match `other`
-    /// - to effectively change the configuration, an quantization rebuild is required
+    /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self.r#type != other.r#type || self.quantile != other.quantile
     }
@@ -457,7 +457,7 @@ impl ProductQuantizationConfig {
     ///
     /// Returns true only if both conditions are met:
     /// - this configuration does not match `other`
-    /// - to effectively change the configuration, an quantization rebuild is required
+    /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self.compression != other.compression
     }
@@ -491,7 +491,7 @@ impl QuantizationConfig {
     ///
     /// Returns true only if both conditions are met:
     /// - this configuration does not match `other`
-    /// - to effectively change the configuration, an quantization rebuild is required
+    /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Scalar(a), Self::Scalar(b)) => a.scalar.mismatch_requires_rebuild(&b.scalar),

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -418,6 +418,17 @@ pub struct ScalarQuantizationConfig {
     pub always_ram: Option<bool>,
 }
 
+impl ScalarQuantizationConfig {
+    /// Detect configuration mismatch against `other` that requires rebuilding
+    ///
+    /// Returns true only if both conditions are met:
+    /// - this configuration does not match `other`
+    /// - to effectively change the configuration, an quantization rebuild is required
+    pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
+        self.r#type != other.r#type || self.quantile != other.quantile
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
 pub struct ScalarQuantization {
     #[validate]
@@ -441,6 +452,17 @@ pub struct ProductQuantizationConfig {
     pub always_ram: Option<bool>,
 }
 
+impl ProductQuantizationConfig {
+    /// Detect configuration mismatch against `other` that requires rebuilding
+    ///
+    /// Returns true only if both conditions are met:
+    /// - this configuration does not match `other`
+    /// - to effectively change the configuration, an quantization rebuild is required
+    pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
+        self.compression != other.compression
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
 pub struct ProductQuantization {
     #[validate]
@@ -462,6 +484,22 @@ impl Eq for ScalarQuantizationConfig {}
 pub enum QuantizationConfig {
     Scalar(ScalarQuantization),
     Product(ProductQuantization),
+}
+
+impl QuantizationConfig {
+    /// Detect configuration mismatch against `other` that requires rebuilding
+    ///
+    /// Returns true only if both conditions are met:
+    /// - this configuration does not match `other`
+    /// - to effectively change the configuration, an quantization rebuild is required
+    pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Scalar(a), Self::Scalar(b)) => a.scalar.mismatch_requires_rebuild(&b.scalar),
+            (Self::Scalar(_), _) => true,
+            (Self::Product(a), Self::Product(b)) => a.product.mismatch_requires_rebuild(&b.product),
+            (Self::Product(_), _) => true,
+        }
+    }
 }
 
 impl Validate for QuantizationConfig {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -403,7 +403,7 @@ pub enum ScalarType {
     Int8,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct ScalarQuantizationConfig {
     /// Type of quantization to use
@@ -425,7 +425,7 @@ impl ScalarQuantizationConfig {
     /// - this configuration does not match `other`
     /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
-        self.r#type != other.r#type || self.quantile != other.quantile
+        self != other
     }
 }
 
@@ -433,14 +433,6 @@ impl ScalarQuantizationConfig {
 pub struct ScalarQuantization {
     #[validate]
     pub scalar: ScalarQuantizationConfig,
-}
-
-impl PartialEq for ScalarQuantizationConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.quantile == other.quantile
-            && self.always_ram == other.always_ram
-            && self.r#type == other.r#type
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
@@ -459,7 +451,7 @@ impl ProductQuantizationConfig {
     /// - this configuration does not match `other`
     /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
-        self.compression != other.compression
+        self != other
     }
 }
 
@@ -493,12 +485,7 @@ impl QuantizationConfig {
     /// - this configuration does not match `other`
     /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Scalar(a), Self::Scalar(b)) => a.scalar.mismatch_requires_rebuild(&b.scalar),
-            (Self::Scalar(_), _) => true,
-            (Self::Product(a), Self::Product(b)) => a.product.mismatch_requires_rebuild(&b.product),
-            (Self::Product(_), _) => true,
-        }
+        self != other
     }
 }
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -192,6 +192,10 @@ pub struct UpdateCollection {
     /// HNSW parameters to update for the collection index. If none - it is left unchanged.
     #[validate]
     pub hnsw_config: Option<HnswConfigDiff>,
+    /// Quantization parameters to update. If none - it is left unchanged.
+    #[serde(default, alias = "quantization")]
+    #[validate]
+    pub quantization_config: Option<QuantizationConfig>,
 }
 
 /// Operation for updating parameters of the existing collection
@@ -212,6 +216,7 @@ impl UpdateCollectionOperation {
                 hnsw_config: None,
                 params: None,
                 optimizers_config: None,
+                quantization_config: None,
             },
             shard_replica_changes: None,
         }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,7 +1,5 @@
 use collection::config::CollectionConfig;
-use collection::operations::config_diff::{
-    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, WalConfigDiff,
-};
+use collection::operations::config_diff::{CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff, WalConfigDiff};
 use collection::operations::types::{VectorsConfig, VectorsConfigDiff};
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
@@ -195,7 +193,7 @@ pub struct UpdateCollection {
     /// Quantization parameters to update. If none - it is left unchanged.
     #[serde(default, alias = "quantization")]
     #[validate]
-    pub quantization_config: Option<QuantizationConfig>,
+    pub quantization_config: Option<QuantizationConfigDiff>,
 }
 
 /// Operation for updating parameters of the existing collection

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,5 +1,8 @@
 use collection::config::CollectionConfig;
-use collection::operations::config_diff::{CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff, WalConfigDiff};
+use collection::operations::config_diff::{
+    CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
+    WalConfigDiff,
+};
 use collection::operations::types::{VectorsConfig, VectorsConfigDiff};
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -65,7 +65,10 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                 hnsw_config: value.hnsw_config.map(Into::into),
                 params: value.params.map(TryInto::try_into).transpose()?,
                 optimizers_config: value.optimizers_config.map(Into::into),
-                quantization_config: None,
+                quantization_config: value
+                    .quantization_config
+                    .map(TryInto::try_into)
+                    .transpose()?,
             },
         )))
     }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -65,6 +65,7 @@ impl TryFrom<api::grpc::qdrant::UpdateCollection> for CollectionMetaOperations {
                 hnsw_config: value.hnsw_config.map(Into::into),
                 params: value.params.map(TryInto::try_into).transpose()?,
                 optimizers_config: value.optimizers_config.map(Into::into),
+                quantization_config: None,
             },
         )))
     }

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -107,6 +107,7 @@ pub mod consensus_ops {
                     optimizers_config: None,
                     params: None,
                     hnsw_config: None,
+                    quantization_config: None,
                 },
             );
             operation

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -799,7 +799,9 @@ impl TableOfContent {
             recreate_optimizers = true;
         }
         if let Some(diff) = quantization_config {
-            collection.update_quantization_config_from_diff(diff).await?;
+            collection
+                .update_quantization_config_from_diff(diff)
+                .await?;
             recreate_optimizers = true;
         }
         if let Some(changes) = replica_changes {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -777,6 +777,7 @@ impl TableOfContent {
             hnsw_config,
             params,
             optimizers_config,
+            quantization_config,
         } = operation.update_collection;
         let collection = self.get_collection(&operation.collection_name).await?;
         let mut recreate_optimizers = false;
@@ -795,6 +796,10 @@ impl TableOfContent {
         }
         if let Some(diff) = vectors {
             collection.update_vectors_from_diff(&diff).await?;
+            recreate_optimizers = true;
+        }
+        if let Some(diff) = quantization_config {
+            collection.update_quantization_config_from_diff(diff).await?;
             recreate_optimizers = true;
         }
         if let Some(changes) = replica_changes {

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -26,12 +26,12 @@ def test_collection_update():
                         "m": 32,
                         "ef_construct": 123,
                     },
-                },
-                "quantization_config": {
-                    "scalar": {
-                        "type": "int8",
-                        "quantile": 0.8
-                    }
+                    "quantization_config": {
+                        "scalar": {
+                            "type": "int8",
+                            "quantile": 0.8
+                        }
+                    },
                 },
             },
             "optimizers_config": {
@@ -92,12 +92,12 @@ def test_hnsw_update():
                     "hnsw_config": {
                         "m": 32,
                     },
-                },
-                "quantization_config": {
-                    "scalar": {
-                        "type": "int8",
-                        "quantile": 0.8
-                    }
+                    "quantization_config": {
+                        "scalar": {
+                            "type": "int8",
+                            "quantile": 0.8
+                        }
+                    },
                 },
             },
             "hnsw_config": {
@@ -143,12 +143,12 @@ def test_hnsw_update():
                         "m": 10,
                         "ef_construct": 100,
                     },
-                },
-                "quantization_config": {
-                    "product": {
-                        "compression": "x32",
-                        "always_ram": True
-                    }
+                    "quantization_config": {
+                        "product": {
+                            "compression": "x32",
+                            "always_ram": True
+                        }
+                    },
                 },
             },
         }

--- a/openapi/tests/openapi_integration/test_collection_update_multivec.py
+++ b/openapi/tests/openapi_integration/test_collection_update_multivec.py
@@ -24,7 +24,13 @@ def test_collection_update_multivec():
                     "hnsw_config": {
                         "m": 32,
                         "ef_construct": 123,
-                    }
+                    },
+                    "quantization_config": {
+                        "scalar": {
+                            "type": "int8",
+                            "quantile": 0.8
+                        }
+                    },
                 }
             },
             "optimizers_config": {
@@ -72,8 +78,10 @@ def test_hnsw_update():
     result = response.json()["result"]
     config = result["config"]
     assert "hnsw_config" not in config["params"]["vectors"]
+    assert "quantization_config" not in config["params"]["vectors"]
     assert config["hnsw_config"]["m"] == 16
     assert config["hnsw_config"]["ef_construct"] == 100
+    assert config["quantization_config"] is None
 
     response = request_with_validation(
         api='/collections/{collection_name}',
@@ -84,11 +92,24 @@ def test_hnsw_update():
                 "text": {
                     "hnsw_config": {
                         "m": 32,
-                    }
+                    },
+                    "quantization_config": {
+                        "scalar": {
+                            "type": "int8",
+                            "quantile": 0.8
+                        }
+                    },
                 }
             },
             "hnsw_config": {
                 "ef_construct": 123,
+            },
+            "quantization_config": {
+                "scalar": {
+                    "type": "int8",
+                    "quantile": 0.99,
+                    "always_ram": True
+                }
             },
         }
     )
@@ -103,8 +124,14 @@ def test_hnsw_update():
     result = response.json()["result"]
     config = result["config"]
     assert config["params"]["vectors"]["text"]["hnsw_config"]["m"] == 32
+    assert config["params"]["vectors"]["text"]["quantization_config"]["scalar"]["type"] == "int8"
+    assert config["params"]["vectors"]["text"]["quantization_config"]["scalar"]["quantile"] == 0.8
+    assert "always_ram" not in config["params"]["vectors"]["text"]["quantization_config"]["scalar"]
     assert config["hnsw_config"]["m"] == 16
     assert config["hnsw_config"]["ef_construct"] == 123
+    assert config["quantization_config"]["scalar"]["type"] == "int8"
+    assert config["quantization_config"]["scalar"]["quantile"] == 0.99
+    assert config["quantization_config"]["scalar"]["always_ram"]
 
     response = request_with_validation(
         api='/collections/{collection_name}',
@@ -116,8 +143,14 @@ def test_hnsw_update():
                     "hnsw_config": {
                         "m": 10,
                         "ef_construct": 100,
-                    }
-                }
+                    },
+                    "quantization_config": {
+                        "product": {
+                            "compression": "x32",
+                            "always_ram": True
+                        }
+                    },
+                },
             },
         }
     )
@@ -133,6 +166,11 @@ def test_hnsw_update():
     config = result["config"]
     assert config["params"]["vectors"]["text"]["hnsw_config"]["m"] == 10
     assert config["params"]["vectors"]["text"]["hnsw_config"]["ef_construct"] == 100
+    assert config["params"]["vectors"]["text"]["quantization_config"]["product"]["compression"] == "x32"
+    assert config["params"]["vectors"]["text"]["quantization_config"]["product"]["always_ram"]
+    assert config["quantization_config"]["scalar"]["type"] == "int8"
+    assert config["quantization_config"]["scalar"]["quantile"] == 0.99
+    assert config["quantization_config"]["scalar"]["always_ram"]
 
 
 def test_invalid_vector_name():

--- a/openapi/tests/openapi_integration/test_collection_update_multivec.py
+++ b/openapi/tests/openapi_integration/test_collection_update_multivec.py
@@ -172,6 +172,30 @@ def test_hnsw_update():
     assert config["quantization_config"]["scalar"]["quantile"] == 0.99
     assert config["quantization_config"]["scalar"]["always_ram"]
 
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "text": {
+                    "quantization_config": "Disabled"
+                },
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    config = result["config"]
+    assert config["params"]["vectors"]["text"].get("quantization_config") is None
+
 
 def test_invalid_vector_name():
     response = request_with_validation(


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/2087>. Tracking issue: <https://github.com/qdrant/qdrant/issues/2088>

Adds support for changing the quantization configurations of an existing collection. This is implemented both for the collection and vector level.

Example API call to enable scalar quantization for all vectors:

```
PATCH /collections/{collection_name}
{
    "quantization_config": {
        "scalar": {
            "type": "int8",
            "quantile": 0.99,
            "always_ram": true
        }
    }
}
```

Example API call to enable product quantization for `myvector`:

```
PATCH /collections/{collection_name}
{
    "vectors": {
        "myvector": {
            "quantization_config": {
                "product": {
                    "compression": "x16",
                    "always_ram": true
                }
            }
        }
    }
}
```


### Tasks

- [x] Add option to change collection quantization config of existing collection
- [x] Add option to change vector specific quantization config of existing collection
- [x] Add tests 
- [x] Merge <https://github.com/qdrant/qdrant/pull/2087>
- [x] Rebase on `dev`
- [x] Point PR to `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?