### PR TITLE
Fix flaky `test_building_cancellation`

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -20,9 +20,6 @@ fn test_building_new_segment() {
 
     let stopped = AtomicBool::new(false);
 
-    // let segment1_dir = dir.path().join("segment_1");
-    // let segment2_dir = dir.path().join("segment_2");
-
     let segment1 = build_segment_1(dir.path());
     let mut segment2 = build_segment_2(dir.path());
 
@@ -72,7 +69,7 @@ fn test_building_new_segment() {
     assert_eq!(merged_segment.point_version(3.into()), Some(100));
 }
 
-fn estimate_build_time(segment: &Segment, stop_timeout_millis: u64) -> (u64, bool) {
+fn estimate_build_time(segment: &Segment, stop_delay_millis: u64) -> (u64, bool) {
     let stopped = Arc::new(AtomicBool::new(false));
 
     let dir = Builder::new().prefix("segment_dir1").tempdir().unwrap();
@@ -103,7 +100,7 @@ fn estimate_build_time(segment: &Segment, stop_timeout_millis: u64) -> (u64, boo
     std::thread::Builder::new()
         .name("build_estimator_timeout".to_string())
         .spawn(move || {
-            std::thread::sleep(Duration::from_millis(stop_timeout_millis));
+            std::thread::sleep(Duration::from_millis(stop_delay_millis));
             stopped_t.store(true, Ordering::Release);
         })
         .unwrap();
@@ -127,27 +124,47 @@ fn estimate_build_time(segment: &Segment, stop_timeout_millis: u64) -> (u64, boo
 
 #[test]
 fn test_building_cancellation() {
+    let baseline_dir = Builder::new()
+        .prefix("segment_dir_baseline")
+        .tempdir()
+        .unwrap();
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dir_2 = Builder::new().prefix("segment_dir_2").tempdir().unwrap();
 
+    let mut baseline_segment = empty_segment(baseline_dir.path());
     let mut segment = empty_segment(dir.path());
+    let mut segment_2 = empty_segment(dir_2.path());
 
     for idx in 0..1000 {
+        baseline_segment
+            .upsert_point(1, idx.into(), &only_default_vector(&[0., 0., 0., 0.]))
+            .unwrap();
         segment
             .upsert_point(1, idx.into(), &only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
+        segment_2
+            .upsert_point(1, idx.into(), &only_default_vector(&[0., 0., 0., 0.]))
+            .unwrap();
     }
+    // Get normal build time
+    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
+    assert!(!was_cancelled_baseline);
 
-    // Checks that optimization with longed cancellation timeout will also finishes fast
-    let (time_fast, is_stopped_fast) = estimate_build_time(&segment, 20);
-    let (time_long, is_stopped_long) = estimate_build_time(&segment, 200);
+    // Checks that optimization with longer cancellation delay will also finish fast
+    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 20);
+    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 200);
 
-    assert!(is_stopped_fast);
+    assert!(was_cancelled_early);
+    assert!(time_fast < time_baseline / 4);
+
+    assert!(was_cancelled_later);
+    assert!(time_long < time_baseline / 4);
 
     assert!(
         time_fast < time_long,
-        "time_fast: {}, time_long: {}, is_stopped_long: {}",
+        "time_early: {}, time_later: {}, was_cancelled_later: {}",
         time_fast,
         time_long,
-        is_stopped_long
+        was_cancelled_later
     );
 }


### PR DESCRIPTION
running `cargo nextest run --all` consistently made this test flake out.

Reason was because the time it took for the early cancellation was often a little more than the time it took the later cancellation.

These changes create 3 different segments for this test, instead of just 1:
1. Baseline - to know how much time it normally takes to execute
2. Early cancellation - to cancel almost as soon as it's requested
3. Later cancellation - to cancel a little later

Ensures both cancellations don't take more than 1/4 of the full build time

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
