### PR TITLE
TableOfContent now accepts Handle, not Runtime

### DIFF
--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -68,9 +68,9 @@ fn test_alias_operation() {
 
     let toc = Arc::new(TableOfContent::new(
         &config,
-        search_runtime,
-        update_runtime,
-        general_runtime,
+        search_runtime.handle().clone(),
+        update_runtime.handle().clone(),
+        general_runtime.handle().clone(),
         Default::default(),
         0,
         Some(propose_operation_sender),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -107,7 +107,6 @@ impl Consensus {
                     } else {
                         log::info!("Consensus stopped");
                         state_ref_clone.on_consensus_stopped();
-                        state_ref_clone.on_consensus_stopped();
                     }
                     Ok(())
                 })?;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -52,6 +53,7 @@ pub struct Consensus {
     /// ToDo: Make if many
     config: ConsensusConfig,
     broker: RaftMessageBroker,
+    shutdown_requested: Arc<AtomicBool>,
 }
 
 impl Consensus {
@@ -68,7 +70,10 @@ impl Consensus {
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
         runtime: Handle,
-    ) -> anyhow::Result<JoinHandle<std::io::Result<()>>> {
+    ) -> anyhow::Result<(
+        JoinHandle<std::io::Result<()>>,
+        JoinHandle<std::io::Result<()>>,
+    )> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
         let p2p_host = settings.service.host;
@@ -86,20 +91,23 @@ impl Consensus {
             channel_service,
             runtime.clone(),
         )?;
+        let shutdown_requested = consensus.shutdown_requested.clone();
 
         let state_ref_clone = state_ref.clone();
-        thread::Builder::new()
-            .name("consensus".to_string())
-            .spawn(move || {
-                if let Err(err) = consensus.start() {
-                    log::error!("Consensus stopped with error: {err}");
-                    state_ref_clone.on_consensus_thread_err(err);
-                } else {
-                    log::info!("Consensus stopped");
-                    state_ref_clone.on_consensus_stopped();
-                    state_ref_clone.on_consensus_stopped();
-                }
-            })?;
+        let consensus_handle =
+            thread::Builder::new()
+                .name("consensus".to_string())
+                .spawn(move || {
+                    if let Err(err) = consensus.start() {
+                        log::error!("Consensus stopped with error: {err}");
+                        state_ref_clone.on_consensus_thread_err(err);
+                    } else {
+                        log::info!("Consensus stopped");
+                        state_ref_clone.on_consensus_stopped();
+                        state_ref_clone.on_consensus_stopped();
+                    }
+                    Ok(())
+                })?;
 
         let message_sender_moved = message_sender.clone();
         thread::Builder::new()
@@ -126,7 +134,7 @@ impl Consensus {
             None
         };
 
-        let handle = thread::Builder::new()
+        let grpc_handle = thread::Builder::new()
             .name("grpc_internal".to_string())
             .spawn(move || {
                 init_internal(
@@ -138,11 +146,12 @@ impl Consensus {
                     server_tls,
                     message_sender,
                     runtime,
+                    shutdown_requested,
                 )
             })
             .unwrap();
 
-        Ok(handle)
+        Ok((grpc_handle, consensus_handle))
     }
 
     /// If `bootstrap_peer` peer is supplied, then either `uri` or `p2p_port` should be also supplied
@@ -228,12 +237,15 @@ impl Consensus {
             channel_service.channel_pool,
         );
 
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+
         let consensus = Self {
             node,
             receiver,
             runtime,
             config,
             broker,
+            shutdown_requested,
         };
 
         Ok((consensus, sender))
@@ -427,6 +439,9 @@ impl Consensus {
         let mut timeout = Duration::from_millis(self.config.tick_period_ms);
 
         loop {
+            if self.shutdown_requested.load(Ordering::Acquire) {
+                return Ok(());
+            }
             if !self
                 .try_promote_learner()
                 .map_err(|err| anyhow!("Failed to promote learner: {}", err))?

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -58,7 +58,7 @@ pub struct Consensus {
 
 impl Consensus {
     /// Create and run consensus node
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn run(
         logger: &slog::Logger,
         state_ref: ConsensusStateRef,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -32,6 +32,12 @@ use crate::tonic::init_internal;
 
 type Node = RawNode<ConsensusStateRef>;
 
+/// gRPC and consensus thread handles.
+type ConsensusHandles = (
+    JoinHandle<std::io::Result<()>>,
+    JoinHandle<std::io::Result<()>>,
+);
+
 const RECOVERY_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 const RECOVERY_MAX_RETRY_COUNT: usize = 3;
 
@@ -58,7 +64,7 @@ pub struct Consensus {
 
 impl Consensus {
     /// Create and run consensus node
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
     pub fn run(
         logger: &slog::Logger,
         state_ref: ConsensusStateRef,
@@ -70,10 +76,7 @@ impl Consensus {
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
         runtime: Handle,
-    ) -> anyhow::Result<(
-        JoinHandle<std::io::Result<()>>,
-        JoinHandle<std::io::Result<()>>,
-    )> {
+    ) -> anyhow::Result<ConsensusHandles> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
         let p2p_host = settings.service.host;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1045,9 +1045,9 @@ mod tests {
         let operation_sender = OperationSender::new(propose_sender);
         let toc = TableOfContent::new(
             &settings.storage,
-            search_runtime,
-            update_runtime,
-            general_runtime,
+            search_runtime.handle().clone(),
+            update_runtime.handle().clone(),
+            general_runtime.handle().clone(),
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,29 +444,24 @@ fn main() -> anyhow::Result<()> {
     drop(update_runtime);
     drop(general_runtime);
     drop(settings);
-    drop(wait_unwrap(toc_arc));
+    if let Ok(toc) = wait_unwrap(toc_arc, Duration::from_secs(30)) {
+        drop(toc);
+    }
     Ok(())
 }
 
-/// Wait for the current thread to become a single referent of an [`Arc`] and returns it.
+/// Blocks current thread for up to specified amount of time to become the single referent
+/// of an [`Arc`] and returns it.
 ///
 /// This methods move a value out from an [`Arc`] when there is only one reference left
-/// and it is safe to do so.
-///
-/// **CAUTION**: this method may create live lock if parallel threads are not going to finish
-/// and decrement [`Arc`] counter. Caller should initiate shutdown of all the threads holding the
-/// [`Arc`] before calling this method.
-fn wait_unwrap<T>(mut input: Arc<T>) -> T {
+/// and it is safe to do so. `Err()` is returned if an [`Arc`] still has more than 1 reference
+/// after given duration is passed.
+fn wait_unwrap<T>(mut input: Arc<T>, duration: Duration) -> Result<T, ()> {
     let start_time = Instant::now();
-    let mut notified = false;
-    loop {
-        if !notified && start_time.elapsed() > Duration::from_secs(10) {
-            log::warn!("Waiting for Arc to be dropped...");
-            notified = true;
-        }
+    while start_time.elapsed() < duration {
         match Arc::try_unwrap(input) {
             Ok(input) => {
-                return input;
+                return Ok(input);
             }
             Err(new_input) => {
                 input = new_input;
@@ -474,4 +469,5 @@ fn wait_unwrap<T>(mut input: Arc<T>) -> T {
             }
         }
     }
+    Err(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn main() -> anyhow::Result<()> {
 
         // Runs raft consensus in a separate thread.
         // Create a pipe `message_sender` to communicate with the consensus
-        let handle = Consensus::run(
+        let (grpc_handle, consensus_handle) = Consensus::run(
             &slog_logger,
             consensus_state.clone(),
             args.bootstrap,
@@ -276,7 +276,8 @@ fn main() -> anyhow::Result<()> {
         )
         .expect("Can't initialize consensus");
 
-        handles.push(handle);
+        handles.push(grpc_handle);
+        handles.push(consensus_handle);
 
         let toc_arc_clone = toc_arc.clone();
         let consensus_state_clone = consensus_state.clone();


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] ~~Have you written new tests for your core changes, as applicable?~~ (not applicable)
* [x] Have you successfully ran tests with your changes locally?

As discussed in #1316 there is a segmentation fault when the application is exited. It happens because RocksDB relies on global static variables which are removed when `main()` is returned. Therefore, the application should ensure no ongoing RocksDB operations are in flight when exiting. This PR proposes one simple change that fixes the issue (to the best of my ability to test this non-deterministic issue).

Qdrant already does a lot to gather all background thread handles and join them at the end of `main()`. Unfortunately, `TableOfContent` which holds the `Runtime` cannot be easily dropped from the `main()` because it is behind `Arc`. `main()` drops `Arc`, but it just decrements the counter not doing anything to the `ToC` itself.

This PR moves ownership of all the `Runtime` back to `main()` and drops them at the end. This effectively initiates the shutdown of `Runtime` and stops all async tasks. A simple spin loop in `main()` is used to wait to move the `ToC` out of `Arc` and drop it. This effectively cleanup all RocksDB background activity.

The only side effect of this change is that now on exit sometimes consensus loop is now firing an error:

```console
[2023-06-16T08:49:17.843Z ERROR qdrant::startup] Panic backtrace:
      [...]
      13: tokio::time::sleep::Sleep::poll_elapsed
      14: <tokio::time::sleep::Sleep as core::future::future::Future>::poll
      15: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll::{{closure}}
      16: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll
      17: qdrant::consensus::Consensus::propose_updates::{{closure}}
```

Right now consensus loops is just dying silently on exit, which is effectively the same from correctness point of view. But I'm looking forward to investigate how can consensus loop be stopped gracefully.