### PR TITLE
update collection: on_disk parameters

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -959,6 +959,7 @@ Note: 1kB = 1 vector of size 256. |
 | ----- | ---- | ----- | ----------- |
 | hnsw_config | [HnswConfigDiff](#qdrant-HnswConfigDiff) | optional | Update params for HNSW index. If empty object - it will be unset |
 | quantization_config | [QuantizationConfigDiff](#qdrant-QuantizationConfigDiff) | optional | Update quantization params. If none - it is left unchanged. |
+| on_disk | [bool](#bool) | optional | If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -393,6 +393,7 @@
 | ----- | ---- | ----- | ----------- |
 | replication_factor | [uint32](#uint32) | optional | Number of replicas of each shard that network tries to maintain |
 | write_consistency_factor | [uint32](#uint32) | optional | How many replicas should apply the operation for us to consider it successful |
+| on_disk_payload | [bool](#bool) | optional | If true - point&#39;s payload will not be stored in memory |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5931,6 +5931,11 @@
                 "nullable": true
               }
             ]
+          },
+          "on_disk": {
+            "description": "If true, vectors are served from disk, improving RAM usage at the cost of latency",
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5969,6 +5969,12 @@
             "format": "uint32",
             "minimum": 1,
             "nullable": true
+          },
+          "on_disk_payload": {
+            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
+            "default": null,
+            "type": "boolean",
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -12,6 +12,7 @@ message VectorParams {
 message VectorParamsDiff {
   optional HnswConfigDiff hnsw_config = 1; // Update params for HNSW index. If empty object - it will be unset
   optional QuantizationConfigDiff quantization_config = 2; // Update quantization params. If none - it is left unchanged.
+  optional bool on_disk = 3; // If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
 }
 
 message VectorParamsMap {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -276,6 +276,7 @@ message CollectionParams {
 message CollectionParamsDiff {
   optional uint32 replication_factor = 1; // Number of replicas of each shard that network tries to maintain
   optional uint32 write_consistency_factor = 2; // How many replicas should apply the operation for us to consider it successful
+  optional bool on_disk_payload = 3; // If true - point's payload will not be stored in memory
 }
 
 message CollectionConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -33,6 +33,9 @@ pub struct VectorParamsDiff {
     #[prost(message, optional, tag = "2")]
     #[validate]
     pub quantization_config: ::core::option::Option<QuantizationConfigDiff>,
+    /// If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
+    #[prost(bool, optional, tag = "3")]
+    pub on_disk: ::core::option::Option<bool>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -455,6 +455,9 @@ pub struct CollectionParamsDiff {
     /// How many replicas should apply the operation for us to consider it successful
     #[prost(uint32, optional, tag = "2")]
     pub write_consistency_factor: ::core::option::Option<u32>,
+    /// If true - point's payload will not be stored in memory
+    #[prost(bool, optional, tag = "3")]
+    pub on_disk_payload: ::core::option::Option<bool>,
 }
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -7,9 +7,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator,
 };
-use segment::types::{
-    HnswConfig, Indexes, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE,
-};
+use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE};
 
 use crate::collection_manager::holders::segment_holder::{LockedSegmentHolder, SegmentId};
 use crate::collection_manager::optimizers::segment_optimizer::{

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -8,8 +8,7 @@ use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator,
 };
 use segment::types::{
-    HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SegmentType,
-    VECTOR_ELEMENT_SIZE,
+    HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE,
 };
 
 use crate::collection_manager::holders::segment_holder::{LockedSegmentHolder, SegmentId};

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -80,9 +80,9 @@ impl IndexingOptimizer {
 
                 let segment_config = read_segment.config();
                 let is_any_vector_indexed = segment_config.is_any_vector_indexed();
-                let is_any_mmap = segment_config.is_any_mmap();
+                let is_any_on_disk = segment_config.is_any_on_disk();
 
-                if !(is_any_vector_indexed || is_any_mmap) {
+                if !(is_any_vector_indexed || is_any_on_disk) {
                     return None;
                 }
 
@@ -123,7 +123,7 @@ impl IndexingOptimizer {
 
                 // Apply indexing to plain segments which have grown too big
                 let are_all_vectors_indexed = segment_config.are_all_vectors_indexed();
-                let is_any_mmap = segment_config.is_any_mmap();
+                let is_any_on_disk = segment_config.is_any_on_disk();
 
                 let big_for_mmap = vector_size
                     >= self
@@ -137,7 +137,7 @@ impl IndexingOptimizer {
                         .saturating_mul(BYTES_IN_KB);
 
                 let require_indexing =
-                    (big_for_mmap && !is_any_mmap) || (big_for_index && !are_all_vectors_indexed);
+                    (big_for_mmap && !is_any_on_disk) || (big_for_index && !are_all_vectors_indexed);
 
                 require_indexing.then_some((*idx, vector_size))
             })
@@ -520,9 +520,9 @@ mod tests {
             "Testing that 2 segments are actually indexed"
         );
 
-        let mmap_count = configs.iter().filter(|config| config.is_any_mmap()).count();
+        let on_disk_count = configs.iter().filter(|config| config.is_any_on_disk()).count();
         assert_eq!(
-            mmap_count, 1,
+            on_disk_count, 1,
             "Testing that only largest segment is not Mmap"
         );
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -136,8 +136,8 @@ impl IndexingOptimizer {
                         .indexing_threshold
                         .saturating_mul(BYTES_IN_KB);
 
-                let require_indexing =
-                    (big_for_mmap && !is_any_on_disk) || (big_for_index && !are_all_vectors_indexed);
+                let require_indexing = (big_for_mmap && !is_any_on_disk)
+                    || (big_for_index && !are_all_vectors_indexed);
 
                 require_indexing.then_some((*idx, vector_size))
             })
@@ -520,7 +520,10 @@ mod tests {
             "Testing that 2 segments are actually indexed"
         );
 
-        let on_disk_count = configs.iter().filter(|config| config.is_any_on_disk()).count();
+        let on_disk_count = configs
+            .iter()
+            .filter(|config| config.is_any_on_disk())
+            .count();
         assert_eq!(
             on_disk_count, 1,
             "Testing that only largest segment is not Mmap"

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -190,6 +190,7 @@ impl CollectionParams {
             let VectorParamsDiff {
                 hnsw_config,
                 quantization_config,
+                on_disk,
             } = update_params.clone();
 
             if let Some(hnsw_diff) = hnsw_config {
@@ -210,6 +211,10 @@ impl CollectionParams {
                     }
                     QuantizationConfigDiff::Disabled(_) => None,
                 }
+            }
+
+            if let Some(on_disk) = on_disk {
+                vector_params.on_disk = Some(on_disk);
             }
         }
         Ok(())

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -99,6 +99,12 @@ pub struct CollectionParamsDiff {
     pub replication_factor: Option<NonZeroU32>,
     /// Minimal number successful responses from replicas to consider operation successful
     pub write_consistency_factor: Option<NonZeroU32>,
+    /// If true - point's payload will not be stored in memory.
+    /// It will be read from the disk every time it is requested.
+    /// This setting saves RAM by (slightly) increasing the response time.
+    /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    #[serde(default)]
+    pub on_disk_payload: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, Merge)]
@@ -340,12 +346,14 @@ mod tests {
         let diff = CollectionParamsDiff {
             replication_factor: None,
             write_consistency_factor: Some(NonZeroU32::new(2).unwrap()),
+            on_disk_payload: None,
         };
 
         let new_params = diff.update(&params).unwrap();
 
         assert_eq!(new_params.replication_factor.get(), 1);
         assert_eq!(new_params.write_consistency_factor.get(), 2);
+        assert!(!new_params.on_disk_payload);
     }
 
     #[test]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -421,6 +421,7 @@ impl TryFrom<api::grpc::qdrant::VectorParamsDiff> for VectorParamsDiff {
                 .quantization_config
                 .map(TryInto::try_into)
                 .transpose()?,
+            on_disk: vector_params.on_disk,
         })
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -157,6 +157,7 @@ impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
                     })
                 })
                 .transpose()?,
+            on_disk_payload: value.on_disk_payload,
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1001,6 +1001,9 @@ pub struct VectorParamsDiff {
     )]
     #[validate]
     pub quantization_config: Option<QuantizationConfigDiff>,
+    /// If true, vectors are served from disk, improving RAM usage at the cost of latency
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_disk: Option<bool>,
 }
 
 /// Vector update params for multiple vectors

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -561,6 +561,12 @@ pub enum PayloadStorageType {
     OnDisk,
 }
 
+impl PayloadStorageType {
+    pub fn is_on_disk(&self) -> bool {
+        matches!(self, PayloadStorageType::OnDisk)
+    }
+}
+
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentConfig {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -593,14 +593,11 @@ impl SegmentConfig {
             .all(|config| config.index.is_indexed())
     }
 
-    /// Check if any vector storage is mmap'ed
-    ///
-    /// This assumes that when the storage for a named vector requests to be stored on disk; it is
-    /// mmap'ed.
-    pub fn is_any_mmap(&self) -> bool {
+    /// Check if any vector storage is on-disk
+    pub fn is_any_on_disk(&self) -> bool {
         self.vector_data
             .values()
-            .any(|config| config.storage_type.is_mmap())
+            .any(|config| config.storage_type.is_on_disk())
     }
 }
 
@@ -624,7 +621,7 @@ pub enum VectorStorageType {
 
 impl VectorStorageType {
     /// Whether this storage type is a mmap on disk
-    fn is_mmap(&self) -> bool {
+    pub fn is_on_disk(&self) -> bool {
         match self {
             Self::Memory => false,
             Self::Mmap | Self::ChunkedMmap => true,

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -104,8 +104,8 @@ def test_edit_collection_params():
                             "quantile": 0.8
                         }
                     },
+                    "on_disk": True,
                 },
-                "on_disk": True,
             },
             "hnsw_config": {
                 "ef_construct": 123,
@@ -161,8 +161,8 @@ def test_edit_collection_params():
                             "always_ram": True
                         }
                     },
+                    "on_disk": False,
                 },
-                "on_disk": False,
             },
             "params": {
                 "on_disk_payload": False,

--- a/openapi/tests/openapi_integration/test_collection_update_multivec.py
+++ b/openapi/tests/openapi_integration/test_collection_update_multivec.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from .helpers.helpers import request_with_validation
@@ -68,7 +69,10 @@ def test_collection_update_multivec():
     assert response.ok
 
 
-def test_hnsw_update():
+def test_edit_collection_params():
+    # If Qdrant is tested with vectors on disk mode
+    on_disk_vectors = bool(int(os.getenv('QDRANT__ON_DISK_VECTORS', 0)))
+
     response = request_with_validation(
         api='/collections/{collection_name}',
         method="GET",
@@ -79,6 +83,8 @@ def test_hnsw_update():
     config = result["config"]
     assert "hnsw_config" not in config["params"]["vectors"]
     assert "quantization_config" not in config["params"]["vectors"]
+    assert config["params"]["vectors"]["text"]["on_disk"] == on_disk_vectors
+    assert not config["params"]["on_disk_payload"]
     assert config["hnsw_config"]["m"] == 16
     assert config["hnsw_config"]["ef_construct"] == 100
     assert config["quantization_config"] is None
@@ -99,6 +105,7 @@ def test_hnsw_update():
                             "quantile": 0.8
                         }
                     },
+                    "on_disk": True,
                 }
             },
             "hnsw_config": {
@@ -110,6 +117,9 @@ def test_hnsw_update():
                     "quantile": 0.99,
                     "always_ram": True
                 }
+            },
+            "params": {
+                "on_disk_payload": True,
             },
         }
     )
@@ -127,6 +137,8 @@ def test_hnsw_update():
     assert config["params"]["vectors"]["text"]["quantization_config"]["scalar"]["type"] == "int8"
     assert config["params"]["vectors"]["text"]["quantization_config"]["scalar"]["quantile"] == 0.8
     assert "always_ram" not in config["params"]["vectors"]["text"]["quantization_config"]["scalar"]
+    assert config["params"]["vectors"]["text"]["on_disk"]
+    assert config["params"]["on_disk_payload"]
     assert config["hnsw_config"]["m"] == 16
     assert config["hnsw_config"]["ef_construct"] == 123
     assert config["quantization_config"]["scalar"]["type"] == "int8"
@@ -150,7 +162,11 @@ def test_hnsw_update():
                             "always_ram": True
                         }
                     },
+                    "on_disk": False,
                 },
+            },
+            "params": {
+                "on_disk_payload": False,
             },
         }
     )
@@ -168,6 +184,8 @@ def test_hnsw_update():
     assert config["params"]["vectors"]["text"]["hnsw_config"]["ef_construct"] == 100
     assert config["params"]["vectors"]["text"]["quantization_config"]["product"]["compression"] == "x32"
     assert config["params"]["vectors"]["text"]["quantization_config"]["product"]["always_ram"]
+    assert not config["params"]["vectors"]["text"]["on_disk"]
+    assert not config["params"]["on_disk_payload"]
     assert config["quantization_config"]["scalar"]["type"] == "int8"
     assert config["quantization_config"]["scalar"]["quantile"] == 0.99
     assert config["quantization_config"]["scalar"]["always_ram"]


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/2090>. Tracking issue: <https://github.com/qdrant/qdrant/issues/2088>

Adds support for changing the `on_disk` and `on_disk_payload` flags of an existing collection.

Example API call to enable `on_disk` for `myvector`:

```
PATCH /collections/{collection_name}
{
    "vectors": {
        "myvector": {
            "on_disk": true,
        }
    }
}
```


### Tasks

- [x] Add option to change `on_disk` for payload and vectors
- [x] Merge <https://github.com/qdrant/qdrant/pull/2090>
- [x] Rebase on `dev`
- [x] Point PR to `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?