### PR TITLE
add recovery mode flag to telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6718,6 +6718,7 @@
         "type": "object",
         "required": [
           "debug",
+          "recovery_mode",
           "service_debug_feature",
           "web_feature"
         ],
@@ -6729,6 +6730,9 @@
             "type": "boolean"
           },
           "service_debug_feature": {
+            "type": "boolean"
+          },
+          "recovery_mode": {
             "type": "boolean"
           }
         }

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -74,7 +74,7 @@ impl TelemetryCollector {
         TelemetryData {
             id: self.process_id.to_string(),
             collections: CollectionsTelemetry::collect(level, self.dispatcher.toc()).await,
-            app: AppBuildTelemetry::collect(level, &self.app_telemetry_collector),
+            app: AppBuildTelemetry::collect(level, &self.app_telemetry_collector, &self.settings),
             cluster: ClusterTelemetry::collect(level, &self.dispatcher, &self.settings),
             requests: RequestsTelemetry::collect(
                 &self.actix_telemetry_collector.lock(),

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -5,6 +5,8 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
 
+use crate::settings::Settings;
+
 pub struct AppBuildTelemetryCollector {
     pub startup: DateTime<Utc>,
 }
@@ -22,6 +24,7 @@ pub struct AppFeaturesTelemetry {
     debug: bool,
     web_feature: bool,
     service_debug_feature: bool,
+    recovery_mode: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -49,7 +52,11 @@ pub struct AppBuildTelemetry {
 }
 
 impl AppBuildTelemetry {
-    pub fn collect(level: usize, collector: &AppBuildTelemetryCollector) -> Self {
+    pub fn collect(
+        level: usize,
+        collector: &AppBuildTelemetryCollector,
+        settings: &Settings,
+    ) -> Self {
         AppBuildTelemetry {
             name: env!("CARGO_PKG_NAME").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -58,6 +65,7 @@ impl AppBuildTelemetry {
                     debug: cfg!(debug_assertions),
                     web_feature: cfg!(feature = "web"),
                     service_debug_feature: cfg!(feature = "service_debug"),
+                    recovery_mode: settings.storage.recovery_mode.is_some(),
                 })
             } else {
                 None
@@ -125,6 +133,7 @@ impl Anonymize for AppFeaturesTelemetry {
             debug: self.debug,
             web_feature: self.web_feature,
             service_debug_feature: self.service_debug_feature,
+            recovery_mode: self.recovery_mode,
         }
     }
 }


### PR DESCRIPTION
Add flag to telemetry endpoint, so cluster manager could alert is cluster is in recovery.


http://localhost:6333/telemetry?details_level=1

![image](https://github.com/qdrant/qdrant/assets/1935623/10b0ec95-1a3a-4042-91b5-744b04297808)
