### PR TITLE
Cancel sooner consensus test and upload logs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,9 +49,10 @@ jobs:
         shell: bash
       - name: Run integration tests - multiple peers - pytest
         run: pytest ./tests/consensus_tests
+        timeout-minutes: 60
       - name: upload logs in case of failure
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: consensus-test-logs
           retention-days: 90 # default max value


### PR DESCRIPTION
Change Github action setup to debug the following test https://github.com/qdrant/qdrant/actions/runs/5292158522/jobs/9578689729?pr=2083

This PR does two important things:
- set explicit shorter cancellation timeout
- enable pushing logs on cancellation