### PR TITLE
Add script to list commits that have yet to be picked into master

### DIFF
--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# List all commits that have not been cherry-picked from dev into master yet
+#
+# Example usage:
+# ./missed_cherry_picks.sh
+
+set -euo pipefail
+
+# Ignore all commits upto and including this commit hash on dev
+IGNORE_UPTO=071d1948b0467fb292c9fc72bc76f2b1218489d9
+
+# Fetch latest branch info from remote
+git fetch -q origin master
+git fetch -q origin dev
+
+# Get remote/local commit hash of dev, user must have up-to-date branch
+REMOTE_SHA=$(git log -n 1 --pretty=format:"%H" origin/dev)
+LOCAL_SHA=$(git log -n 1 --pretty=format:"%H" dev)
+if [[ "$REMOTE_SHA" != "$LOCAL_SHA" ]]; then
+    echo Error: your local dev branch must match the current remote
+    echo To pull latest dev, use: git checkout dev \&\& git pull --ff-only origin dev
+    exit 1
+fi
+
+# List all commits yet-to-be-cherry-picked
+git cherry -v origin/master origin/dev $IGNORE_UPTO \
+| grep --color=never '^+ ' \
+| cut -d' ' -f2-

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=071d1948b0467fb292c9fc72bc76f2b1218489d9
+IGNORE_UPTO=1d035501a4de27065e6fefe7bcff7cfa4d754713
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
This allows us to easily detect cherry-picks we missed from `dev` to `master` on our release branch.

For example:
```
$ ./tools/missed_cherry_picks.sh
286ca9f5e4230bed1a1c726cbc2d93b7b8aa0f25 0.11.0 cherry picks (#1174)
93a4499859b31cea94dbad0ee4df8b7aeea407a8 Update: unmaintained crate memmap -> memmap2 (#559) (#1160)
a0b6fa81b75c1695766c056650e3e8d8b6ab97c5 Consensus q n a (#1169)
017df525289fad13e129a58137fad028cc34ded4 Use less ram for id tracker (#1176)
383100ebb6e60328f7bf1aa93b80ecd6c82d4de1 remove suggesting changes in replications on replication factor change (#1177)
# -- snip --
7916f01fa4abe5a03fe0ce011b1d788395f3bc3b Migrate from OpenSSL to Rustls (#1865)
8342288e1f2bc9b65d96d74c5946eb94a53acc6b Fix documentation links (#2000)
d67bf1ce3742e9b5d61dda2c4c3274686dfce5a7 Update memmap2 to remove Windows specific edge case (#1964)
d40ef296801ae75db0e42d1aaeb3b857423fea98 Update Cargo.toml, specify license and other things (#1943)
967d387a3761191e96d3d33f0697868882c6ec1a Web UI integration (#2009)
114a8dcc8730e7dee4dcbe9438dbc80072233f7d Bump memmap2 from 0.6.2 to 0.7.0 (#2049)
1d035501a4de27065e6fefe7bcff7cfa4d754713 Bump constant_time_eq from 0.2.6 to 0.3.0 (#2106)
```

On the current branches we are not missing anything, so that is fantastic:
```
$ ./tools/missed_cherry_picks.sh
```

We can update the `IGNORE_UPTO` constant to a new value to ignore all commits before it. That way we remove noise of commits that were merged (but changed). I've manually checked all commits that were listed before and have updated this hash accordingly.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?