### PR TITLE
Fix unused io_uring warning on non-Linux platforms

### DIFF
--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -35,6 +35,7 @@ pub struct MmapVectors {
     /// Has an exact size to fit a header and `num_vectors` of vectors.
     mmap: Arc<Mmap>,
     /// Context for io_uring-base async IO
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     uring_reader: Mutex<UringReader>,
     /// Memory mapped deletion flags
     deleted: MmapBitSlice,


### PR DESCRIPTION
Fixes the following warning on non-Linux platforms:

```
warning: field `uring_reader` is never read
  --> lib\segment\src\vector_storage\mmap_vectors.rs:38:5
   |
30 | pub struct MmapVectors {
   |            ----------- field in this struct
...
38 |     uring_reader: Mutex<UringReader>,
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?