### PR TITLE
Fix deleted.dat missing in mmap storage snapshot

### DIFF
--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -181,7 +181,7 @@ impl VectorStorage for MemmapVectorStorage {
     }
 
     fn files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.vectors_path.clone()];
+        let mut files = vec![self.vectors_path.clone(), self.deleted_path.clone()];
         if let Some(Some(quantized_vectors)) =
             &self.mmap_store.as_ref().map(|x| &x.quantized_vectors)
         {

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -252,6 +252,15 @@ mod tests {
         let mut borrowed_id_tracker = id_tracker.borrow_mut();
         let mut borrowed_storage = storage.borrow_mut();
 
+        // Assert this storage lists both the vector and deleted file
+        let files = borrowed_storage.files();
+        for file_name in [VECTORS_PATH, DELETED_PATH] {
+            files
+                .iter()
+                .find(|p| p.file_name().unwrap() == file_name)
+                .expect("storage is missing required file");
+        }
+
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -63,10 +63,6 @@ impl MemmapVectorStorage {
         )
     }
 
-    pub fn vector_path(&self) -> &Path {
-        &self.vectors_path
-    }
-
     pub fn get_mmap_vectors(&self) -> &MmapVectors {
         self.mmap_store.as_ref().unwrap()
     }


### PR DESCRIPTION
The `deleted.dat` is currently missing in memmap storage snapshots. This is problematic.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?