### PR TITLE
Refactor consensus thread to send raft messages sequentially

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -828,8 +828,9 @@ impl RaftMessageBroker {
                     }
                 }
 
+                // This should *never* happen...
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(message)) => {
-                    panic!(
+                    unreachable!(
                         "Failed to forward message {message:?} to message sender task {peer_id}: \
                          message sender task queue is closed"
                     );

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -818,7 +818,7 @@ impl RaftMessageBroker {
                     if log::max_level() >= log::Level::Debug {
                         log::error!(
                             "Failed to forward message {message:?} to message sender task {peer_id}: \
-                             message sender taks queue is full"
+                             message sender task queue is full"
                         );
                     } else {
                         log::error!(


### PR DESCRIPTION
This PR refactor consensus thread a bit, so that consensus thread:
- spawns an async worker for each peer, that sends messages to the peer sequentially, one-by-one
- and then forwards each message to the respective worker
  - instead of spawning individual message-sending-tasks onto the runtime directly, without any synchronization/serialization between separate tasks/messages

__TODO:__
- [x] fix remaining `TODO`s in the code (these are mostly regarding error handling/messages/logs)
- ~~[ ] optimize `RaftMessageSender` to skip "outdated" heartbeat messages~~
  - instead of sending every message one-by-one, we should do `try_recv` until we either get a non-heartbeat message (and then send it immediately and continue), or until we pulled all messages from the channel (and then we could only send the last heartbeat message pulled from the channel)
  - ~~can~~ __have to__ be done in a separate PR
    - I've tried to quickly draft this optimization, and it's convoluted enough to deserve it's own PR
    - see #2131 😎

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
