### PR TITLE
Fix panic in `chunked_vectors`

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -168,10 +168,17 @@ impl Segment {
         debug_assert!(self.is_appendable());
         check_vectors_set(&vectors, &self.segment_config)?;
         for (vector_name, new_vector) in vectors {
-            self.vector_data[vector_name.as_ref()]
-                .vector_storage
-                .borrow_mut()
-                .insert_vector(internal_id, new_vector.as_ref())?;
+            let vector_data = &self.vector_data[vector_name.as_ref()];
+            let mut vector_storage = vector_data.vector_storage.borrow_mut();
+            let vector_dim = vector_storage.vector_dim();
+            if vector_dim != new_vector.len() {
+                return Err(OperationError::WrongVector {
+                    expected_dim: vector_dim,
+                    received_dim: new_vector.len(),
+                });
+            }
+
+            vector_storage.insert_vector(internal_id, new_vector.as_ref())?;
         }
         Ok(())
     }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2121>.

When inserting points, vector dimensions were checked. When updating vectors, dimensions were not checked.

This is now implemented in the same way as for points: https://github.com/qdrant/qdrant/blob/6b1452b8edcb90e7ff1cf9502c543403d901a0a3/lib/segment/src/segment.rs#L790-L795

Merging this will also fix the panic on startup issue for one of our customers.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?