### PR TITLE
Signal handling

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-push = "cargo +nightly fmt --all -- --check"
+pre-push = "rustup run nightly cargo fmt --all -- --check"
 
 [logging]
 verbose = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_urlencoded",
+ "signal-hook",
  "slog",
  "slog-stdlog",
  "storage",
@@ -3908,6 +3909,16 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rusty-hook = "^0.11.2"
 [dependencies]
 
 parking_lot = { version = "0.12.1", features=["deadlock_detection"], optional = true }
-
+signal-hook = "0.3.15"
 num_cpus = "1.15"
 thiserror = "1.0"
 log = "0.4"

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -64,6 +64,7 @@ pub fn create_update_runtime(max_optimization_threads: usize) -> io::Result<Runt
         // panics if val is not larger than 0.
         update_runtime_builder.max_blocking_threads(max_optimization_threads);
     }
+
     update_runtime_builder.build()
 }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,11 @@
+use signal_hook::{
+    consts::{SIGINT, SIGTERM},
+    flag::register,
+};
+use std::sync::{atomic::AtomicBool, Arc};
+
+pub fn register_signal_context(context: Arc<AtomicBool>) -> Result<(), std::io::Error> {
+    register(SIGTERM, context.clone())?;
+    register(SIGINT, context)?;
+    Ok(())
+}


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?

I did not run the units. I tested my functionality manually, given the tire fire that is unix signals. I didn't feel that since I changed anything fundamental other than the termination routine this was necessary, and build times were a factor.

3. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
4. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?

I did not write new tests. I feel that this may be excessively hard.

* [ ] Have you successfully ran tests with your changes locally?

This change simplifies signal handling, and also cleanly shuts down the service in the event of SIGTERM or SIGINT, resolving #2075. It does this by making a context, which is just `Arc<AtomicBool>`, and dropping the table of contents / settings prematurely if that is signaled, which I assume it will be in most cases.

To exploit more fine grained shutdown procedures, simply pass the context and monitor it for a `true` value. If it is `true`, then the system has request to shutdown. Perhaps a control socket or protocol choice could do the same thing.

I am applying for employment as a part of this patch. Please review my resume. :)
