### PR TITLE
Skip outdated Raft heartbeats

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,5 +3,4 @@
 skip = .git,*.pdf,*.svg,openapi.json,key.pem,Cargo.lock
 # hel - Query token
 # generall - the boss
-# heartbeat - one of Raft message types
-ignore-words-list = crate,hel,generall,heartbeat
+ignore-words-list = crate,hel,generall

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@
 skip = .git,*.pdf,*.svg,openapi.json,key.pem,Cargo.lock
 # hel - Query token
 # generall - the boss
-ignore-words-list = crate,hel,generall
+# heartbeat - one of Raft message types
+ignore-words-list = crate,hel,generall,heartbeat

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -929,7 +929,7 @@ impl RaftMessageSender {
         // fields, but message `3` was produced more recently, and so it might contain newer values
         // of these data fields.
         //
-        // And because all messages carry the same basic data as the hearbeat message, message `4`
+        // And because all messages carry the same basic data as the heartbeat message, message `4`
         // instantly "outdates" both message `2` and `3`.
         //
         // This way, if there are more than one message queued for the `RaftMessageSender`,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -895,6 +895,7 @@ impl RaftMessageSender {
             // Check if the message is a heartbeat...
             let is_heartbeat = message.as_ref().map_or(false, |message| {
                 message.msg_type == raft::eraftpb::MessageType::MsgHeartbeat as i32
+                    || message.msg_type == raft::eraftpb::MessageType::MsgHeartbeatResponse as i32
             });
 
             // ...and if it is, replace the earlier one and try to get the next message from the queue

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -920,7 +920,7 @@ impl RaftMessageSender {
         // without any additional "payload". And all other message types in Raft also carry
         // the same basic metadata as the heartbeat message.
         //
-        // This way, message `3` instantly "outdates" message `2`: they both carrie the same data
+        // This way, message `3` instantly "outdates" message `2`: they both carry the same data
         // fields, but message `3` was produced more recently, and so it might contain newer values
         // of these data fields.
         //
@@ -962,7 +962,7 @@ impl RaftMessageSender {
         // If either `messages` queue or `heartbeat` channel is closed (e.g., `messages.recv()`
         // returns `None` or `heartbeat.changed()` returns an error), we assume that
         // `RaftMessageSenderHandle` has been dropped, and treat it as a "shutdown"/"cancellation"
-        // signal (and break from the `loop`).
+        // signal (and break from the loop).
 
         // TODO: Track last sent index (or commit?) and skip heartbeats with lower index!
 


### PR DESCRIPTION
Continuation of #2115.

Heartbeat is the most basic message type in Raft. It's the message that carries only the "common metadata" without any payload. And any other message carries the same basic info as the heartbeat message.

Considering, that any message carries the same basic info, any later message "outdates"/"overwrites" any earlier heartbeat, so it's a reasonable optimization to try to skip sending "outdated" heartbeats if multiple pending messages have been pushed into `RaftMessageSender`'s queue (which may happen if, e.g., there were some network or general slowdown and `RaftMessageSender` "lagged behind" on processing the queue).

The rules for this are simple:

- `RaftMessageSender` picks a message to be sent from the queue _without awaiting_ (e.g., using `try_recv`)
- if the message is _not_ a heartbeat message
  - send the message right away and continue to the next message in the queue
- if the message _is_ a heartbeat message
  - save it and continue to the next one
  - if the next message is _also_ a heartbeat message, then overwrite the previously saved heartbeat message and continue to the next one
  - if the next message is _not_ a heartbeat message, then send the message, drop the previously saved heartbeat and continue to the next one
  - if the queue is currently empty, then send the previously saved heartbeat and _await_ the next message

__TODO:__
- [x] also skip `MsgHeartbeatResponse` messages the same way as `MsgHeartbeat` messages? 🤔

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
