### PR TITLE
Remove before_drop mechanism

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -142,12 +142,7 @@ impl Collection {
                 channel_service.clone(),
                 update_runtime.clone().unwrap_or_else(Handle::current),
             )
-            .await;
-
-            let replica_set = match replica_set {
-                Ok(replica_set) => replica_set,
-                Err(err) => return Err(err),
-            };
+            .await?;
 
             shard_holder.add_shard(shard_id, replica_set);
         }

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -79,8 +79,6 @@ pub struct Collection {
     pub(crate) shards_holder: Arc<LockedShardHolder>,
     pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
-    /// Tracks whether `before_drop` fn has been called.
-    before_drop_called: bool,
     this_peer_id: PeerId,
     path: PathBuf,
     snapshots_path: PathBuf,
@@ -148,10 +146,7 @@ impl Collection {
 
             let replica_set = match replica_set {
                 Ok(replica_set) => replica_set,
-                Err(err) => {
-                    shard_holder.before_drop().await;
-                    return Err(err);
-                }
+                Err(err) => return Err(err),
             };
 
             shard_holder.add_shard(shard_id, replica_set);
@@ -168,7 +163,6 @@ impl Collection {
             shards_holder: locked_shard_holder,
             collection_config: shared_collection_config,
             shared_storage_config,
-            before_drop_called: false,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -279,7 +273,6 @@ impl Collection {
             shards_holder: locked_shard_holder,
             collection_config: shared_collection_config,
             shared_storage_config,
-            before_drop_called: false,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -1312,11 +1305,6 @@ impl Collection {
         Ok(info)
     }
 
-    pub async fn before_drop(&mut self) {
-        self.shards_holder.write().await.before_drop().await;
-        self.before_drop_called = true
-    }
-
     pub async fn state(&self) -> State {
         let shards_holder = self.shards_holder.read().await;
         let transfers = shards_holder.shard_transfers.read().clone();
@@ -1662,19 +1650,5 @@ impl Collection {
 
     pub async fn lock_updates(&self) -> RwLockWriteGuard<()> {
         self.updates_lock.write().await
-    }
-}
-
-impl Drop for Collection {
-    fn drop(&mut self) {
-        if !self.before_drop_called {
-            // Panic is used to get fast feedback in unit and integration tests
-            // in cases where `before_drop` was not added.
-            if cfg!(test) {
-                panic!("Collection `before_drop` was not called.")
-            } else {
-                log::error!("Collection `before_drop` was not called.")
-            }
-        }
     }
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -138,11 +138,6 @@ impl ForwardProxyShard {
     pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         self.wrapped_shard.get_telemetry_data()
     }
-
-    /// Forward `before_drop` to `wrapped_shard`
-    pub async fn before_drop(&mut self) {
-        self.wrapped_shard.before_drop().await
-    }
 }
 
 #[async_trait]

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -808,11 +808,14 @@ impl LocalShard {
 impl Drop for LocalShard {
     fn drop(&mut self) {
         thread::scope(|s| {
-            s.spawn(|| {
-                // Needs dedicated thread to avoid `Cannot start a runtime from within a runtime` error.
-                self.update_runtime
-                    .block_on(async { self.stop_gracefully().await })
-            });
-        });
+            let handle = thread::Builder::new()
+                .name("drop-shard".to_string())
+                .spawn_scoped(s, || {
+                    // Needs dedicated thread to avoid `Cannot start a runtime from within a runtime` error.
+                    self.update_runtime
+                        .block_on(async { self.stop_gracefully().await })
+                });
+            handle.expect("Failed to create thread for shard drop");
+        })
     }
 }

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -58,8 +58,8 @@ pub struct LocalShard {
     pub(super) update_handler: Arc<Mutex<UpdateHandler>>,
     pub(super) update_sender: ArcSwap<Sender<UpdateSignal>>,
     pub(super) path: PathBuf,
-    before_drop_called: bool,
     pub(super) optimizers: Arc<Vec<Arc<Optimizer>>>,
+    update_runtime: Handle,
 }
 
 /// Shard holds information about segments and WAL.
@@ -136,7 +136,7 @@ impl LocalShard {
             update_handler: Arc::new(Mutex::new(update_handler)),
             update_sender: ArcSwap::from_pointee(update_sender),
             path: shard_path.to_owned(),
-            before_drop_called: false,
+            update_runtime,
             optimizers,
         }
     }
@@ -494,8 +494,8 @@ impl LocalShard {
         Ok(())
     }
 
-    pub async fn before_drop(&mut self) {
-        // Finishes update tasks right before destructor stuck to do so with runtime
+    /// Finishes ongoing update tasks
+    pub async fn stop_gracefully(&self) {
         if let Err(err) = self.update_sender.load().send(UpdateSignal::Stop).await {
             log::warn!("Error sending stop signal to update handler: {}", err);
         }
@@ -505,8 +505,6 @@ impl LocalShard {
         if let Err(err) = self.wait_update_workers_stop().await {
             log::warn!("Update workers failed with: {}", err);
         }
-
-        self.before_drop_called = true;
     }
 
     pub fn restore_snapshot(snapshot_path: &Path) -> CollectionResult<()> {
@@ -701,18 +699,6 @@ impl LocalShard {
         }
     }
 
-    fn assert_before_drop_called(&self) {
-        if !self.before_drop_called {
-            // Panic is used to get fast feedback in unit and integration tests
-            // in cases where `before_drop` was not added.
-            if cfg!(test) {
-                panic!("Collection `before_drop` was not called.")
-            } else {
-                log::error!("Collection `before_drop` was not called.")
-            }
-        }
-    }
-
     /// Returns estimated size of vector data in bytes
     async fn estimate_vector_data_size(&self) -> usize {
         let info = self.local_shard_info().await;
@@ -819,15 +805,14 @@ impl LocalShard {
     }
 }
 
-pub async fn drop_and_delete_from_disk(shard: LocalShard) -> CollectionResult<()> {
-    let path = shard.shard_path();
-    drop(shard);
-    remove_dir_all(path).await?;
-    Ok(())
-}
-
 impl Drop for LocalShard {
     fn drop(&mut self) {
-        self.assert_before_drop_called()
+        thread::scope(|s| {
+            s.spawn(|| {
+                // Needs dedicated thread to avoid `Cannot start a runtime from within a runtime` error.
+                self.update_runtime
+                    .block_on(async { self.stop_gracefully().await })
+            });
+        });
     }
 }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -116,11 +116,6 @@ impl ProxyShard {
         Ok(())
     }
 
-    /// Forward `before_drop` to `wrapped_shard`
-    pub async fn before_drop(&mut self) {
-        self.wrapped_shard.before_drop().await
-    }
-
     pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         self.wrapped_shard.get_telemetry_data()
     }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -44,15 +44,6 @@ impl Shard {
         }
     }
 
-    pub async fn before_drop(&mut self) {
-        match self {
-            Shard::Local(local_shard) => local_shard.before_drop().await,
-            Shard::Proxy(proxy_shard) => proxy_shard.before_drop().await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.before_drop().await,
-            Shard::Dummy(_) => (), // `DummyShard` don't need (and don't have) `before_drop`
-        }
-    }
-
     pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         let mut telemetry = match self {
             Shard::Local(local_shard) => local_shard.get_telemetry_data(),

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -2,8 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
 use tokio::runtime::Handle;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -170,15 +168,6 @@ impl ShardHolder {
                 Ok(shards)
             }
         }
-    }
-
-    pub async fn before_drop(&mut self) {
-        let futures: FuturesUnordered<_> = self
-            .shards
-            .iter_mut()
-            .map(|(_, shard)| shard.before_drop())
-            .collect();
-        futures.collect::<Vec<()>>().await;
     }
 
     pub fn len(&self) -> usize {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -80,7 +80,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         ..Default::default()
     };
 
-    let mut collection = Collection::new(
+    let collection = Collection::new(
         collection_name,
         1,
         collection_dir.path(),
@@ -118,11 +118,10 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         0,
         true,
     ) {
-        collection.before_drop().await;
         panic!("Failed to restore snapshot: {err}")
     }
 
-    let mut recovered_collection = Collection::load(
+    let recovered_collection = Collection::load(
         collection_name_rec,
         1,
         recover_dir.path(),
@@ -152,12 +151,9 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         assert!(replica_ser_3.is_local().await);
         assert_eq!(replica_ser_3.peers().len(), 3); // 2 remotes + 1 local
     }
-
-    collection.before_drop().await;
-    recovered_collection.before_drop().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_snapshot_collection() {
     _test_snapshot_collection(NodeType::Normal).await;
     _test_snapshot_collection(NodeType::Listener).await;

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -89,7 +89,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn searching() {
         let resources = setup(16, 8).await;
 
@@ -125,7 +125,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn recommending() {
         let resources = setup(16, 8).await;
 
@@ -178,7 +178,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn with_filter() {
         let resources = setup(16, 8).await;
 
@@ -226,7 +226,7 @@ mod group_by {
         assert_eq!(result.len(), 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn with_payload_and_vectors() {
         let resources = setup(16, 8).await;
 
@@ -267,7 +267,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn group_by_string_field() {
         let Resources {
             collection,
@@ -311,7 +311,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn zero_group_size() {
         let Resources {
             collection,
@@ -351,7 +351,7 @@ mod group_by {
         assert_eq!(result.len(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn zero_limit_groups() {
         let Resources {
             collection,
@@ -391,7 +391,7 @@ mod group_by {
         assert_eq!(result.len(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn big_limit_groups() {
         let Resources {
             collection,
@@ -435,7 +435,7 @@ mod group_by {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn big_group_size_groups() {
         let Resources {
             collection,
@@ -586,7 +586,7 @@ mod group_by_builder {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn only_group_by() {
         let Resources {
             request,
@@ -612,7 +612,7 @@ mod group_by_builder {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn group_by_with_lookup() {
         let Resources {
             mut request,

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -80,7 +80,7 @@ async fn setup() -> Resources {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn happy_lookup_ids() {
     let Resources {
         mut request,
@@ -169,7 +169,7 @@ fn non_parsable_pseudo_id_to_point_id(#[case] value: impl Into<PseudoId>) {
 #[rstest]
 #[case::uuid(Uuid::new_v4().to_string())]
 #[case::int(1001u64)]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn inexisting_lookup_ids_are_ignored(#[case] value: impl Into<PseudoId>) {
     let value = value.into();
 
@@ -204,7 +204,7 @@ async fn inexisting_lookup_ids_are_ignored(#[case] value: impl Into<PseudoId>) {
     assert_eq!(result.len(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn err_when_collection_by_name_returns_none() {
     let Resources {
         request,

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -22,7 +22,7 @@ use crate::common::{new_local_collection, N_SHARDS, TEST_OPTIMIZERS_CONFIG};
 const VEC_NAME1: &str = "vec1";
 const VEC_NAME2: &str = "vec2";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multi_vec() {
     test_multi_vec_with_shards(1).await;
     test_multi_vec_with_shards(N_SHARDS).await;
@@ -90,7 +90,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         .tempdir()
         .unwrap();
 
-    let mut collection = multi_vec_collection_fixture(collection_dir.path(), shard_number).await;
+    let collection = multi_vec_collection_fixture(collection_dir.path(), shard_number).await;
 
     // Upload 1000 random vectors to the collection
     let mut points = Vec::new();
@@ -266,6 +266,4 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
             }
         }
     }
-
-    collection.before_drop().await;
 }

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -8,7 +8,7 @@ use tempfile::Builder;
 
 use crate::common::{simple_collection_fixture, N_SHARDS};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_collection_paginated_search() {
     test_collection_paginated_search_with_shards(1).await;
     test_collection_paginated_search_with_shards(N_SHARDS).await;
@@ -20,7 +20,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         .tempdir()
         .unwrap();
 
-    let mut collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
+    let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
 
     // Upload 1000 random vectors to the collection
     let mut points = Vec::new();
@@ -59,8 +59,6 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
 
     assert_eq!(reference_result.len(), 100);
     assert_eq!(reference_result[0].id, 999.into());
-
-    collection.before_drop().await;
 
     let page_size = 10;
 

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -67,7 +67,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         this_peer_id,
     );
 
-    let mut collection = Collection::new(
+    let collection = Collection::new(
         collection_name,
         this_peer_id,
         collection_dir.path(),
@@ -122,11 +122,10 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         0,
         false,
     ) {
-        collection.before_drop().await;
         panic!("Failed to restore snapshot: {err}")
     }
 
-    let mut recovered_collection = Collection::load(
+    let recovered_collection = Collection::load(
         collection_name_rec,
         this_peer_id,
         recover_dir.path(),
@@ -170,17 +169,14 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         assert_eq!(reference.payload, recovered.payload);
         assert_eq!(reference.vector, recovered.vector);
     }
-
-    collection.before_drop().await;
-    recovered_collection.before_drop().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_snapshot_and_recover_collection_normal() {
     _test_snapshot_and_recover_collection(NodeType::Normal).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_snapshot_and_recover_collection_listener() {
     _test_snapshot_and_recover_collection(NodeType::Listener).await;
 }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -746,9 +746,7 @@ impl TableOfContent {
     }
 
     async fn delete_collection(&self, collection_name: &str) -> Result<bool, StorageError> {
-        if let Some(mut removed) = self.collections.write().await.remove(collection_name) {
-            removed.before_drop().await;
-
+        if let Some(removed) = self.collections.write().await.remove(collection_name) {
             self.alias_persistence
                 .write()
                 .await
@@ -1671,16 +1669,5 @@ impl CollectionContainer for TableOfContent {
             }
             Ok(())
         })
-    }
-}
-
-// `TableOfContent` should not be dropped from async context.
-impl Drop for TableOfContent {
-    fn drop(&mut self) {
-        self.general_runtime.block_on(async {
-            for (_, mut collection) in self.collections.write().await.drain() {
-                collection.before_drop().await;
-            }
-        });
     }
 }


### PR DESCRIPTION
This PR removes the `before_drop` mechanism.

It was introduced as a workaround to shutdown collection at the time where we had one run per collection.

The remaining complexity is due to performing a asynchronous operations within the `Drop` which is synchronous.

A few important things:

- changing to `#[tokio::test(flavor = "multi_thread")]` is required in a few test to avoid deadlocks.
- it is not possible to spawn an async. task during `drop` as the &self reference would escape 
- previously before_drop was run in parallel for each shard in a pure async. fashion, I am not sure the new implementation is as efficient