### PR TITLE
refactor: move common `FieldIndex` methods into traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3754,7 @@ dependencies = [
  "cgroups-rs",
  "chrono",
  "criterion",
+ "enum_dispatch",
  "fs_extra",
  "futures",
  "geo",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -54,6 +54,7 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 quantization = { git = "https://github.com/qdrant/quantization.git" }
 validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.26", features = ["serde"] }
+enum_dispatch = "0.3.11"
 
 sysinfo = "0.29"
 futures = "0.3.28"

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -6,7 +6,7 @@ use rocksdb::DB;
 use self::memory::{BinaryItem, BinaryMemory};
 use super::private::DbWrapper;
 use super::{
-    CardinalityEstimation, FieldTypeIndex, IndexingStrategy, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadFieldIndex, PayloadFieldIndexExt, PrimaryCondition, ValueIndexer,
 };
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::OperationResult;
@@ -190,7 +190,7 @@ impl DbWrapper for BinaryIndex {
     }
 }
 
-impl IndexingStrategy for BinaryIndex {
+impl PayloadFieldIndex for BinaryIndex {
     fn load(&mut self) -> OperationResult<bool> {
         if !self.db_wrapper.has_column_family()? {
             return Ok(false);
@@ -230,7 +230,7 @@ impl IndexingStrategy for BinaryIndex {
     }
 }
 
-impl FieldTypeIndex for BinaryIndex {
+impl PayloadFieldIndexExt for BinaryIndex {
     fn filter<'a>(
         &'a self,
         condition: &'a crate::types::FieldCondition,
@@ -346,7 +346,7 @@ mod tests {
     use super::BinaryIndex;
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
     use crate::common::utils::MultiValue;
-    use crate::index::field_index::{FieldTypeIndex, IndexingStrategy, ValueIndexer};
+    use crate::index::field_index::{PayloadFieldIndex, PayloadFieldIndexExt, ValueIndexer};
 
     const FIELD_NAME: &str = "bool_field";
     const DB_NAME: &str = "test_db";

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -17,7 +17,7 @@ use crate::types::{
 };
 
 #[enum_dispatch]
-pub trait PayloadFieldIndex {
+pub trait BasePayloadFieldIndex {
     /// Return number of points with at least one value indexed in here
     fn count_indexed_points(&self) -> usize;
 
@@ -40,24 +40,19 @@ pub trait PayloadFieldIndex {
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool;
 }
 
+/// Main trait for all specific payload indexes, allowing polymorphic access to them
 #[enum_dispatch]
-pub trait Filterable {
+pub trait PayloadFieldIndex: BasePayloadFieldIndex {
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
-}
 
-#[enum_dispatch]
-pub trait EstimateCardinality {
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
-}
 
-#[enum_dispatch]
-pub trait PayloadBlocks {
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
     fn payload_blocks(
@@ -132,7 +127,7 @@ pub trait ValueIndexer<T> {
 /// Common interface for all possible types of field indexes
 /// Enables polymorphism on field indexes
 /// TODO: Rename with major release
-#[enum_dispatch(PayloadFieldIndex, Filterable, EstimateCardinality, PayloadBlocks)]
+#[enum_dispatch(BasePayloadFieldIndex, PayloadFieldIndex)]
 #[allow(clippy::enum_variant_names)]
 pub enum FieldIndex {
     IntIndex(NumericIndex<IntPayloadType>),

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -31,7 +31,7 @@ pub(super) mod private {
 
 /// Base trait for all field indexes, meant to be implemented only once per indexing approach
 #[enum_dispatch]
-pub trait IndexingStrategy: private::DbWrapper {
+pub trait PayloadFieldIndex: private::DbWrapper {
     /// Return number of points with at least one value indexed in here
     fn count_indexed_points(&self) -> usize;
 
@@ -62,7 +62,7 @@ pub trait IndexingStrategy: private::DbWrapper {
 /// Main trait for all concrete field indexes, allowing polymorphic implementations for them.
 /// Depending on the specific field type they act on.
 #[enum_dispatch]
-pub trait FieldTypeIndex: IndexingStrategy {
+pub trait PayloadFieldIndexExt: PayloadFieldIndex {
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
     fn filter<'a>(
@@ -151,7 +151,7 @@ pub trait ValueIndexer {
 /// Common interface for all possible types of field indexes
 /// Enables polymorphism on field indexes
 /// TODO: Rename with major release
-#[enum_dispatch(IndexingStrategy, FieldTypeIndex, DbWrapper)]
+#[enum_dispatch(PayloadFieldIndex, PayloadFieldIndexExt, DbWrapper)]
 #[allow(clippy::enum_variant_names)]
 pub enum FieldIndex {
     IntIndex(NumericIndex<IntPayloadType>),

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -1,3 +1,4 @@
+use enum_dispatch::enum_dispatch;
 use serde_json::Value;
 
 use crate::common::utils::MultiValue;
@@ -15,6 +16,7 @@ use crate::types::{
     PointOffsetType,
 };
 
+#[enum_dispatch]
 pub trait PayloadFieldIndex {
     /// Return number of points with at least one value indexed in here
     fn count_indexed_points(&self) -> usize;
@@ -28,16 +30,34 @@ pub trait PayloadFieldIndex {
     /// Return function that flushes all pending updates to disk.
     fn flusher(&self) -> Flusher;
 
+    // TODO: add get_db_wrapper() to this trait, make recreate() pre-implemented
+    fn recreate(&self) -> OperationResult<()>;
+
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+
+    fn values_count(&self, point_id: PointOffsetType) -> usize;
+
+    fn values_is_empty(&self, point_id: PointOffsetType) -> bool;
+}
+
+#[enum_dispatch]
+pub trait Filterable {
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
     ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
+}
 
+#[enum_dispatch]
+pub trait EstimateCardinality {
     /// Return estimation of points amount which satisfy given condition
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation>;
+}
 
+#[enum_dispatch]
+pub trait PayloadBlocks {
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
     fn payload_blocks(
@@ -47,6 +67,7 @@ pub trait PayloadFieldIndex {
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 }
 
+// enum_dispatch won't work nicely with generics, so we implement the sugar manually
 pub trait ValueIndexer<T> {
     /// Add multiple values associated with a single point
     /// This function should be called only once for each point
@@ -111,6 +132,7 @@ pub trait ValueIndexer<T> {
 /// Common interface for all possible types of field indexes
 /// Enables polymorphism on field indexes
 /// TODO: Rename with major release
+#[enum_dispatch(PayloadFieldIndex, Filterable, EstimateCardinality, PayloadBlocks)]
 #[allow(clippy::enum_variant_names)]
 pub enum FieldIndex {
     IntIndex(NumericIndex<IntPayloadType>),
@@ -158,99 +180,6 @@ impl FieldIndex {
         }
     }
 
-    fn get_payload_field_index(&self) -> &dyn PayloadFieldIndex {
-        match self {
-            FieldIndex::IntIndex(payload_field_index) => payload_field_index,
-            FieldIndex::IntMapIndex(payload_field_index) => payload_field_index,
-            FieldIndex::KeywordIndex(payload_field_index) => payload_field_index,
-            FieldIndex::FloatIndex(payload_field_index) => payload_field_index,
-            FieldIndex::GeoIndex(payload_field_index) => payload_field_index,
-            FieldIndex::BinaryIndex(payload_field_index) => payload_field_index,
-            FieldIndex::FullTextIndex(payload_field_index) => payload_field_index,
-        }
-    }
-
-    #[allow(dead_code)]
-    fn get_payload_field_index_mut(&mut self) -> &mut dyn PayloadFieldIndex {
-        match self {
-            FieldIndex::IntIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::IntMapIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::KeywordIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::FloatIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::GeoIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::BinaryIndex(ref mut payload_field_index) => payload_field_index,
-            FieldIndex::FullTextIndex(ref mut payload_field_index) => payload_field_index,
-        }
-    }
-
-    pub fn load(&mut self) -> OperationResult<bool> {
-        match self {
-            FieldIndex::IntIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::IntMapIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::KeywordIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::FloatIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::GeoIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::BinaryIndex(ref mut payload_field_index) => payload_field_index.load(),
-            FieldIndex::FullTextIndex(ref mut payload_field_index) => payload_field_index.load(),
-        }
-    }
-
-    pub fn clear(self) -> OperationResult<()> {
-        match self {
-            FieldIndex::IntIndex(index) => index.clear(),
-            FieldIndex::IntMapIndex(index) => index.clear(),
-            FieldIndex::KeywordIndex(index) => index.clear(),
-            FieldIndex::FloatIndex(index) => index.clear(),
-            FieldIndex::GeoIndex(index) => index.clear(),
-            FieldIndex::BinaryIndex(index) => index.clear(),
-            FieldIndex::FullTextIndex(index) => index.clear(),
-        }
-    }
-
-    pub fn recreate(&self) -> OperationResult<()> {
-        match self {
-            FieldIndex::IntIndex(index) => index.recreate(),
-            FieldIndex::IntMapIndex(index) => index.recreate(),
-            FieldIndex::KeywordIndex(index) => index.recreate(),
-            FieldIndex::FloatIndex(index) => index.recreate(),
-            FieldIndex::GeoIndex(index) => index.recreate(),
-            FieldIndex::BinaryIndex(index) => index.recreate(),
-            FieldIndex::FullTextIndex(index) => index.recreate(),
-        }
-    }
-
-    pub fn count_indexed_points(&self) -> usize {
-        self.get_payload_field_index().count_indexed_points()
-    }
-
-    pub fn flusher(&self) -> Flusher {
-        self.get_payload_field_index().flusher()
-    }
-
-    pub fn filter<'a>(
-        &'a self,
-        condition: &'a FieldCondition,
-    ) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
-        self.get_payload_field_index().filter(condition)
-    }
-
-    pub fn estimate_cardinality(
-        &self,
-        condition: &FieldCondition,
-    ) -> Option<CardinalityEstimation> {
-        self.get_payload_field_index()
-            .estimate_cardinality(condition)
-    }
-
-    pub fn payload_blocks(
-        &self,
-        threshold: usize,
-        key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
-        self.get_payload_field_index()
-            .payload_blocks(threshold, key)
-    }
-
     pub fn add_point(
         &mut self,
         id: PointOffsetType,
@@ -290,42 +219,6 @@ impl FieldIndex {
             FieldIndex::GeoIndex(index) => index.remove_point(point_id),
             FieldIndex::BinaryIndex(index) => index.remove_point(point_id),
             FieldIndex::FullTextIndex(index) => index.remove_point(point_id),
-        }
-    }
-
-    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
-        match self {
-            FieldIndex::IntIndex(index) => index.get_telemetry_data(),
-            FieldIndex::IntMapIndex(index) => index.get_telemetry_data(),
-            FieldIndex::KeywordIndex(index) => index.get_telemetry_data(),
-            FieldIndex::FloatIndex(index) => index.get_telemetry_data(),
-            FieldIndex::GeoIndex(index) => index.get_telemetry_data(),
-            FieldIndex::BinaryIndex(index) => index.get_telemetry_data(),
-            FieldIndex::FullTextIndex(index) => index.get_telemetry_data(),
-        }
-    }
-
-    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
-        match self {
-            FieldIndex::IntIndex(index) => index.values_count(point_id),
-            FieldIndex::IntMapIndex(index) => index.values_count(point_id),
-            FieldIndex::KeywordIndex(index) => index.values_count(point_id),
-            FieldIndex::FloatIndex(index) => index.values_count(point_id),
-            FieldIndex::GeoIndex(index) => index.values_count(point_id),
-            FieldIndex::BinaryIndex(index) => index.values_count(point_id),
-            FieldIndex::FullTextIndex(index) => index.values_count(point_id),
-        }
-    }
-
-    pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        match self {
-            FieldIndex::IntIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::IntMapIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::KeywordIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::FloatIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::GeoIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::BinaryIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::FullTextIndex(index) => index.values_is_empty(point_id),
         }
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -62,17 +62,19 @@ pub trait PayloadFieldIndex: BasePayloadFieldIndex {
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 }
 
-// enum_dispatch won't work nicely with generics, so we implement the sugar manually
-pub trait ValueIndexer<T> {
+// enum_dispatch won't work nicely with associated types (nor generics), so we implement the sugar manually
+pub trait ValueIndexer {
+    type ValueType;
+
     /// Add multiple values associated with a single point
     /// This function should be called only once for each point
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<T>) -> OperationResult<()>;
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()>;
 
     /// Extract index-able value from payload `Value`
-    fn get_value(&self, value: &Value) -> Option<T>;
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType>;
 
     /// Try to extract index-able values from payload `Value`, even if it is an array
-    fn get_values(&self, value: &Value) -> Vec<T> {
+    fn get_values(&self, value: &Value) -> Vec<Self::ValueType> {
         match value {
             Value::Array(values) => values.iter().flat_map(|x| self.get_value(x)).collect(),
             _ => self.get_value(value).map(|x| vec![x]).unwrap_or_default(),

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -29,7 +29,6 @@ pub(super) mod private {
     }
 }
 
-
 /// Base trait for all payload indexes, intended to be implemented only once per index
 #[enum_dispatch]
 pub trait BasePayloadFieldIndex: private::DbWrapper {
@@ -82,25 +81,21 @@ pub trait PayloadFieldIndex: BasePayloadFieldIndex {
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_>;
 }
 
-// enum_dispatch won't work with associated types (nor generics), because it would be 
-// impossible to implement it as a trait with a specific associated type. 
+// enum_dispatch won't work with associated types (nor generics), because it would be
+// impossible to implement it as a trait with a specific associated type.
 // Instead, we add these methods as part of the target enum implementation.
 pub trait ValueIndexer {
-    type ValueType;
+    type Value;
 
     /// Add multiple values associated with a single point
     /// This function should be called only once for each point
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()>;
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()>;
 
     /// Extract index-able value from payload `Value`
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType>;
+    fn get_value(&self, value: &Value) -> Option<Self::Value>;
 
     /// Try to extract index-able values from payload `Value`, even if it is an array
-    fn get_values(&self, value: &Value) -> Vec<Self::ValueType> {
+    fn get_values(&self, value: &Value) -> Vec<Self::Value> {
         match value {
             Value::Array(values) => values.iter().flat_map(|x| self.get_value(x)).collect(),
             _ => self.get_value(value).map(|x| vec![x]).unwrap_or_default(),

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -1,6 +1,7 @@
 use enum_dispatch::enum_dispatch;
 use serde_json::Value;
 
+use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::utils::MultiValue;
 use crate::common::Flusher;
 use crate::entry::entry_point::OperationResult;
@@ -25,13 +26,20 @@ pub trait BasePayloadFieldIndex {
     fn load(&mut self) -> OperationResult<bool>;
 
     /// Remove db content of the current payload index
-    fn clear(self) -> OperationResult<()>;
+    fn clear(&self) -> OperationResult<()> {
+        Self::db_wrapper(self).remove_column_family()
+    }
 
     /// Return function that flushes all pending updates to disk.
-    fn flusher(&self) -> Flusher;
+    fn flusher(&self) -> Flusher {
+        self.db_wrapper().flusher()
+    }
 
-    // TODO: add get_db_wrapper() to this trait, make recreate() pre-implemented
-    fn recreate(&self) -> OperationResult<()>;
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper;
+
+    fn recreate(&self) -> OperationResult<()> {
+        self.db_wrapper().recreate_column_family()
+    }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -3,7 +3,7 @@ use tempfile::Builder;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::text_index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
-use crate::index::field_index::{BasePayloadFieldIndex, ValueIndexer};
+use crate::index::field_index::{IndexingStrategy, ValueIndexer};
 use crate::types::PointOffsetType;
 
 fn get_texts() -> Vec<String> {

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -3,7 +3,7 @@ use tempfile::Builder;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::text_index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
-use crate::index::field_index::{IndexingStrategy, ValueIndexer};
+use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
 use crate::types::PointOffsetType;
 
 fn get_texts() -> Vec<String> {

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -3,7 +3,7 @@ use tempfile::Builder;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::text_index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
-use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
+use crate::index::field_index::{BasePayloadFieldIndex, ValueIndexer};
 use crate::types::PointOffsetType;
 
 fn get_texts() -> Vec<String> {

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -3,7 +3,7 @@ use tempfile::Builder;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::data_types::text_index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
-use crate::index::field_index::ValueIndexer;
+use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
 use crate::types::PointOffsetType;
 
 fn get_texts() -> Vec<String> {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -13,9 +13,10 @@ use crate::index::field_index::full_text_index::inverted_index::{
     Document, InvertedIndex, ParsedQuery,
 };
 use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
+use crate::index::field_index::private::DbWrapper;
 use crate::index::field_index::{
-    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition,
-    PayloadFieldIndex, ValueIndexer,
+    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex,
+    ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType, PointOffsetType};
@@ -109,7 +110,11 @@ impl FullTextIndex {
 impl ValueIndexer for FullTextIndex {
     type ValueType = String;
 
-    fn add_many(&mut self, idx: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
+    fn add_many(
+        &mut self,
+        idx: PointOffsetType,
+        values: Vec<Self::ValueType>,
+    ) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());
         }
@@ -154,6 +159,12 @@ impl ValueIndexer for FullTextIndex {
     }
 }
 
+impl DbWrapper for FullTextIndex {
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
+    }
+}
+
 impl BasePayloadFieldIndex for FullTextIndex {
     fn count_indexed_points(&self) -> usize {
         self.inverted_index.points_count
@@ -170,10 +181,6 @@ impl BasePayloadFieldIndex for FullTextIndex {
             self.inverted_index.index_document(idx, document);
         }
         Ok(true)
-    }
-
-    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
-        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -15,8 +15,7 @@ use crate::index::field_index::full_text_index::inverted_index::{
 use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
 use crate::index::field_index::private::DbWrapper;
 use crate::index::field_index::{
-    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex,
-    ValueIndexer,
+    CardinalityEstimation, FieldTypeIndex, IndexingStrategy, PayloadBlockCondition, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType, PointOffsetType};
@@ -161,7 +160,7 @@ impl DbWrapper for FullTextIndex {
     }
 }
 
-impl BasePayloadFieldIndex for FullTextIndex {
+impl IndexingStrategy for FullTextIndex {
     fn count_indexed_points(&self) -> usize {
         self.inverted_index.points_count
     }
@@ -198,7 +197,7 @@ impl BasePayloadFieldIndex for FullTextIndex {
     }
 }
 
-impl PayloadFieldIndex for FullTextIndex {
+impl FieldTypeIndex for FullTextIndex {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -15,7 +15,7 @@ use crate::index::field_index::full_text_index::inverted_index::{
 };
 use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
 use crate::index::field_index::{
-    CardinalityEstimation, EstimateCardinality, Filterable, PayloadBlockCondition, PayloadBlocks,
+    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition,
     PayloadFieldIndex, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
@@ -153,7 +153,7 @@ impl ValueIndexer<String> for FullTextIndex {
     }
 }
 
-impl PayloadFieldIndex for FullTextIndex {
+impl BasePayloadFieldIndex for FullTextIndex {
     fn count_indexed_points(&self) -> usize {
         self.inverted_index.points_count
     }
@@ -202,7 +202,7 @@ impl PayloadFieldIndex for FullTextIndex {
     }
 }
 
-impl Filterable for FullTextIndex {
+impl PayloadFieldIndex for FullTextIndex {
     fn filter(
         &self,
         condition: &FieldCondition,
@@ -213,9 +213,7 @@ impl Filterable for FullTextIndex {
         }
         None
     }
-}
 
-impl EstimateCardinality for FullTextIndex {
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         if let Some(Match::Text(text_match)) = &condition.r#match {
             let parsed_query = self.parse_query(&text_match.text);
@@ -226,9 +224,7 @@ impl EstimateCardinality for FullTextIndex {
         }
         None
     }
-}
 
-impl PayloadBlocks for FullTextIndex {
     fn payload_blocks(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -108,13 +108,9 @@ impl FullTextIndex {
 }
 
 impl ValueIndexer for FullTextIndex {
-    type ValueType = String;
+    type Value = String;
 
-    fn add_many(
-        &mut self,
-        idx: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, idx: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());
         }
@@ -138,7 +134,7 @@ impl ValueIndexer for FullTextIndex {
         Ok(())
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -107,8 +107,10 @@ impl FullTextIndex {
     }
 }
 
-impl ValueIndexer<String> for FullTextIndex {
-    fn add_many(&mut self, idx: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
+impl ValueIndexer for FullTextIndex {
+    type ValueType = String;
+
+    fn add_many(&mut self, idx: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
         if values.is_empty() {
             return Ok(());
         }
@@ -132,7 +134,7 @@ impl ValueIndexer<String> for FullTextIndex {
         Ok(())
     }
 
-    fn get_value(&self, value: &Value) -> Option<String> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
-use crate::common::Flusher;
 use crate::data_types::text_index::TextIndexParams;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::full_text_index::inverted_index::{
@@ -173,16 +172,8 @@ impl BasePayloadFieldIndex for FullTextIndex {
         Ok(true)
     }
 
-    fn clear(self) -> OperationResult<()> {
-        self.db_wrapper.remove_column_family()
-    }
-
-    fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
-    }
-
-    fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -15,7 +15,8 @@ use crate::index::field_index::full_text_index::inverted_index::{
 use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
 use crate::index::field_index::private::DbWrapper;
 use crate::index::field_index::{
-    CardinalityEstimation, FieldTypeIndex, IndexingStrategy, PayloadBlockCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexExt,
+    ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType, PointOffsetType};
@@ -160,7 +161,7 @@ impl DbWrapper for FullTextIndex {
     }
 }
 
-impl IndexingStrategy for FullTextIndex {
+impl PayloadFieldIndex for FullTextIndex {
     fn count_indexed_points(&self) -> usize {
         self.inverted_index.points_count
     }
@@ -197,7 +198,7 @@ impl IndexingStrategy for FullTextIndex {
     }
 }
 
-impl FieldTypeIndex for FullTextIndex {
+impl PayloadFieldIndexExt for FullTextIndex {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -456,12 +456,14 @@ impl GeoMapIndex {
     }
 }
 
-impl ValueIndexer<GeoPoint> for GeoMapIndex {
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<GeoPoint>) -> OperationResult<()> {
+impl ValueIndexer for GeoMapIndex {
+    type ValueType = GeoPoint;
+
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
         self.add_many_geo_points(id, &values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<GeoPoint> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         match value {
             Value::Object(obj) => {
                 let lon_op = obj.get("lon").and_then(|x| x.as_f64());

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 
 use super::{ PayloadFieldIndex};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
-use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
     circle_hashes, common_hash_prefix, encode_max_precision, geo_hash_to_box, rectangle_hashes,
@@ -246,10 +245,6 @@ impl GeoMapIndex {
         result[0..8].clone_from_slice(&value.lat.to_be_bytes());
         result[8..16].clone_from_slice(&value.lon.to_be_bytes());
         result
-    }
-
-    pub fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<&Vec<GeoPoint>> {
@@ -491,17 +486,9 @@ impl BasePayloadFieldIndex for GeoMapIndex {
     fn load(&mut self) -> OperationResult<bool> {
         GeoMapIndex::load(self)
     }
-
-    fn clear(self) -> OperationResult<()> {
-        self.db_wrapper.remove_column_family()
-    }
-
-    fn flusher(&self) -> Flusher {
-        GeoMapIndex::flusher(self)
-    }
-
-    fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
+    
+    fn db_wrapper(&self) ->  &DatabaseColumnWrapper {
+        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -9,7 +9,7 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::PayloadFieldIndex;
+use super::FieldTypeIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
@@ -18,8 +18,7 @@ use crate::index::field_index::geo_hash::{
 };
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PrimaryCondition,
-    ValueIndexer,
+    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -485,7 +484,7 @@ impl DbWrapper for GeoMapIndex {
     }
 }
 
-impl BasePayloadFieldIndex for GeoMapIndex {
+impl IndexingStrategy for GeoMapIndex {
     fn count_indexed_points(&self) -> usize {
         self.points_count
     }
@@ -514,7 +513,7 @@ impl BasePayloadFieldIndex for GeoMapIndex {
     }
 }
 
-impl PayloadFieldIndex for GeoMapIndex {
+impl FieldTypeIndex for GeoMapIndex {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -453,17 +453,13 @@ impl GeoMapIndex {
 }
 
 impl ValueIndexer for GeoMapIndex {
-    type ValueType = GeoPoint;
+    type Value = GeoPoint;
 
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         self.add_many_geo_points(id, &values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         match value {
             Value::Object(obj) => {
                 let lon_op = obj.get("lon").and_then(|x| x.as_f64());

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -8,7 +8,8 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
 
-use super::{ PayloadFieldIndex};
+use super::private::DbWrapper;
+use super::PayloadFieldIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
@@ -454,7 +455,11 @@ impl GeoMapIndex {
 impl ValueIndexer for GeoMapIndex {
     type ValueType = GeoPoint;
 
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
+    fn add_many(
+        &mut self,
+        id: PointOffsetType,
+        values: Vec<Self::ValueType>,
+    ) -> OperationResult<()> {
         self.add_many_geo_points(id, &values)
     }
 
@@ -478,6 +483,12 @@ impl ValueIndexer for GeoMapIndex {
     }
 }
 
+impl DbWrapper for GeoMapIndex {
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
+    }
+}
+
 impl BasePayloadFieldIndex for GeoMapIndex {
     fn count_indexed_points(&self) -> usize {
         self.points_count
@@ -485,10 +496,6 @@ impl BasePayloadFieldIndex for GeoMapIndex {
 
     fn load(&mut self) -> OperationResult<bool> {
         GeoMapIndex::load(self)
-    }
-    
-    fn db_wrapper(&self) ->  &DatabaseColumnWrapper {
-        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -8,7 +8,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
 
-use super::{EstimateCardinality, Filterable, PayloadBlocks};
+use super::{ PayloadFieldIndex};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
@@ -18,7 +18,8 @@ use crate::index::field_index::geo_hash::{
 };
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
+    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PrimaryCondition,
+    ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -480,7 +481,7 @@ impl ValueIndexer<GeoPoint> for GeoMapIndex {
     }
 }
 
-impl PayloadFieldIndex for GeoMapIndex {
+impl BasePayloadFieldIndex for GeoMapIndex {
     fn count_indexed_points(&self) -> usize {
         self.points_count
     }
@@ -521,7 +522,7 @@ impl PayloadFieldIndex for GeoMapIndex {
     }
 }
 
-impl Filterable for GeoMapIndex {
+impl PayloadFieldIndex for GeoMapIndex {
     fn filter(
         &self,
         condition: &FieldCondition,
@@ -556,9 +557,7 @@ impl Filterable for GeoMapIndex {
 
         None
     }
-}
 
-impl EstimateCardinality for GeoMapIndex {
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         if let Some(geo_bounding_box) = &condition.geo_bounding_box {
             let geo_hashes = rectangle_hashes(geo_bounding_box, GEO_QUERY_MAX_REGION);
@@ -580,9 +579,7 @@ impl EstimateCardinality for GeoMapIndex {
 
         None
     }
-}
 
-impl PayloadBlocks for GeoMapIndex {
     fn payload_blocks(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -9,7 +9,7 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::FieldTypeIndex;
+use super::PayloadFieldIndexExt;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
@@ -18,7 +18,7 @@ use crate::index::field_index::geo_hash::{
 };
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -484,7 +484,7 @@ impl DbWrapper for GeoMapIndex {
     }
 }
 
-impl IndexingStrategy for GeoMapIndex {
+impl PayloadFieldIndex for GeoMapIndex {
     fn count_indexed_points(&self) -> usize {
         self.points_count
     }
@@ -513,7 +513,7 @@ impl IndexingStrategy for GeoMapIndex {
     }
 }
 
-impl FieldTypeIndex for GeoMapIndex {
+impl PayloadFieldIndexExt for GeoMapIndex {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -11,13 +11,12 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::PayloadFieldIndex;
+use super::FieldTypeIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
-    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PrimaryCondition,
-    ValueIndexer,
+    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
 };
 use crate::index::query_estimator::combine_should_estimations;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -283,7 +282,7 @@ impl<N: Hash + Eq + Clone + Display> DbWrapper for MapIndex<N> {
     }
 }
 
-impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapIndex<N> {
+impl<N: Hash + Eq + Clone + Display + FromStr> IndexingStrategy for MapIndex<N> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points
     }
@@ -316,7 +315,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapInde
     }
 }
 
-impl PayloadFieldIndex for MapIndex<String> {
+impl FieldTypeIndex for MapIndex<String> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
@@ -387,7 +386,7 @@ impl PayloadFieldIndex for MapIndex<String> {
     }
 }
 
-impl PayloadFieldIndex for MapIndex<IntPayloadType> {
+impl FieldTypeIndex for MapIndex<IntPayloadType> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -459,17 +459,13 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
 }
 
 impl ValueIndexer for MapIndex<String> {
-    type ValueType = String;
+    type Value = String;
 
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         self.add_many_to_map(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }
@@ -482,17 +478,13 @@ impl ValueIndexer for MapIndex<String> {
 }
 
 impl ValueIndexer for MapIndex<IntPayloadType> {
-    type ValueType = IntPayloadType;
+    type Value = IntPayloadType;
 
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         self.add_many_to_map(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         if let Value::Number(num) = value {
             return num.as_i64();
         }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -12,7 +12,6 @@ use serde_json::Value;
 
 use super::{ PayloadFieldIndex};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
-use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
@@ -75,10 +74,6 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
             self.map.entry(value).or_default().insert(idx);
         }
         Ok(true)
-    }
-
-    pub fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
     }
 
     pub fn match_cardinality(&self, value: &N) -> CardinalityEstimation {
@@ -290,16 +285,12 @@ impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapInde
         MapIndex::load(self)
     }
 
-    fn clear(self) -> OperationResult<()> {
+    fn clear(&self) -> OperationResult<()> {
         self.db_wrapper.recreate_column_family()
     }
 
-    fn flusher(&self) -> Flusher {
-        MapIndex::flusher(self)
-    }
-
-    fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
+    fn db_wrapper(&self) ->  &DatabaseColumnWrapper {
+        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -464,12 +464,14 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
     }
 }
 
-impl ValueIndexer<String> for MapIndex<String> {
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<String>) -> OperationResult<()> {
+impl ValueIndexer for MapIndex<String> {
+    type ValueType = String;
+
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
         self.add_many_to_map(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<String> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         if let Value::String(keyword) = value {
             return Some(keyword.to_owned());
         }
@@ -481,16 +483,18 @@ impl ValueIndexer<String> for MapIndex<String> {
     }
 }
 
-impl ValueIndexer<IntPayloadType> for MapIndex<IntPayloadType> {
+impl ValueIndexer for MapIndex<IntPayloadType> {
+    type ValueType = IntPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,
-        values: Vec<IntPayloadType>,
+        values: Vec<Self::ValueType>,
     ) -> OperationResult<()> {
         self.add_many_to_map(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<IntPayloadType> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         if let Value::Number(num) = value {
             return num.as_i64();
         }

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -10,7 +10,8 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
 
-use super::{ PayloadFieldIndex};
+use super::private::DbWrapper;
+use super::PayloadFieldIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::stat_tools::number_of_selected_points;
@@ -276,6 +277,12 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 }
 
+impl<N: Hash + Eq + Clone + Display> DbWrapper for MapIndex<N> {
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
+    }
+}
+
 impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapIndex<N> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points
@@ -287,10 +294,6 @@ impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapInde
 
     fn clear(&self) -> OperationResult<()> {
         self.db_wrapper.recreate_column_family()
-    }
-
-    fn db_wrapper(&self) ->  &DatabaseColumnWrapper {
-        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -458,7 +461,11 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
 impl ValueIndexer for MapIndex<String> {
     type ValueType = String;
 
-    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::ValueType>) -> OperationResult<()> {
+    fn add_many(
+        &mut self,
+        id: PointOffsetType,
+        values: Vec<Self::ValueType>,
+    ) -> OperationResult<()> {
         self.add_many_to_map(id, values)
     }
 

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -11,12 +11,12 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::FieldTypeIndex;
+use super::PayloadFieldIndexExt;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
-    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
 };
 use crate::index::query_estimator::combine_should_estimations;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -282,7 +282,7 @@ impl<N: Hash + Eq + Clone + Display> DbWrapper for MapIndex<N> {
     }
 }
 
-impl<N: Hash + Eq + Clone + Display + FromStr> IndexingStrategy for MapIndex<N> {
+impl<N: Hash + Eq + Clone + Display + FromStr> PayloadFieldIndex for MapIndex<N> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points
     }
@@ -315,7 +315,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> IndexingStrategy for MapIndex<N> 
     }
 }
 
-impl FieldTypeIndex for MapIndex<String> {
+impl PayloadFieldIndexExt for MapIndex<String> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
@@ -386,7 +386,7 @@ impl FieldTypeIndex for MapIndex<String> {
     }
 }
 
-impl FieldTypeIndex for MapIndex<IntPayloadType> {
+impl PayloadFieldIndexExt for MapIndex<IntPayloadType> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -10,13 +10,14 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
 
-use super::{EstimateCardinality, Filterable, PayloadBlocks};
+use super::{ PayloadFieldIndex};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
+    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PrimaryCondition,
+    ValueIndexer,
 };
 use crate::index::query_estimator::combine_should_estimations;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -280,7 +281,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
     }
 }
 
-impl<N: Hash + Eq + Clone + Display + FromStr> PayloadFieldIndex for MapIndex<N> {
+impl<N: Hash + Eq + Clone + Display + FromStr> BasePayloadFieldIndex for MapIndex<N> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points
     }
@@ -321,7 +322,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> PayloadFieldIndex for MapIndex<N>
     }
 }
 
-impl Filterable for MapIndex<String> {
+impl PayloadFieldIndex for MapIndex<String> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
@@ -344,9 +345,7 @@ impl Filterable for MapIndex<String> {
             _ => None,
         }
     }
-}
 
-impl EstimateCardinality for MapIndex<String> {
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
@@ -376,9 +375,7 @@ impl EstimateCardinality for MapIndex<String> {
             _ => None,
         }
     }
-}
 
-impl PayloadBlocks for MapIndex<String> {
     fn payload_blocks(
         &self,
         threshold: usize,
@@ -396,7 +393,7 @@ impl PayloadBlocks for MapIndex<String> {
     }
 }
 
-impl Filterable for MapIndex<IntPayloadType> {
+impl PayloadFieldIndex for MapIndex<IntPayloadType> {
     fn filter<'a>(
         &'a self,
         condition: &'a FieldCondition,
@@ -419,9 +416,7 @@ impl Filterable for MapIndex<IntPayloadType> {
             _ => None,
         }
     }
-}
 
-impl EstimateCardinality for MapIndex<IntPayloadType> {
     fn estimate_cardinality(&self, condition: &FieldCondition) -> Option<CardinalityEstimation> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
@@ -451,9 +446,7 @@ impl EstimateCardinality for MapIndex<IntPayloadType> {
             _ => None,
         }
     }
-}
 
-impl PayloadBlocks for MapIndex<IntPayloadType> {
     fn payload_blocks(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -8,7 +8,8 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use serde_json::Value;
 
-use super::{ PayloadFieldIndex};
+use super::private::DbWrapper;
+use super::PayloadFieldIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
@@ -279,6 +280,12 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
     }
 }
 
+impl<T: Encodable + Numericable> DbWrapper for NumericIndex<T> {
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
+    }
+}
+
 impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
     fn count_indexed_points(&self) -> usize {
         self.points_count
@@ -290,10 +297,6 @@ impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
 
     fn clear(&self) -> OperationResult<()> {
         self.db_wrapper.recreate_column_family()
-    }
-
-    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
-        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -9,13 +9,13 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::FieldTypeIndex;
+use super::PayloadFieldIndexExt;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
 };
 use crate::index::key_encoding::{
     decode_f64_key_ascending, decode_i64_key_ascending, encode_f64_key_ascending,
@@ -285,7 +285,7 @@ impl<T: Encodable + Numericable> DbWrapper for NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable> IndexingStrategy for NumericIndex<T> {
+impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
     fn count_indexed_points(&self) -> usize {
         self.points_count
     }
@@ -318,7 +318,7 @@ impl<T: Encodable + Numericable> IndexingStrategy for NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable> FieldTypeIndex for NumericIndex<T> {
+impl<T: Encodable + Numericable> PayloadFieldIndexExt for NumericIndex<T> {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 
 use super::{ PayloadFieldIndex};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
-use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -135,10 +134,6 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
             }
         }
         Ok(true)
-    }
-
-    pub fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
@@ -293,12 +288,12 @@ impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
         NumericIndex::load(self)
     }
 
-    fn clear(self) -> OperationResult<()> {
+    fn clear(&self) -> OperationResult<()> {
         self.db_wrapper.recreate_column_family()
     }
 
-    fn flusher(&self) -> Flusher {
-        NumericIndex::flusher(self)
+    fn db_wrapper(&self) -> &DatabaseColumnWrapper {
+        &self.db_wrapper
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -318,10 +313,6 @@ impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
         self.get_values(point_id)
             .map(|x| x.is_empty())
             .unwrap_or(true)
-    }
-
-    fn recreate(&self) -> OperationResult<()> {
-        self.db_wrapper.recreate_column_family()
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -451,17 +451,13 @@ impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
 }
 
 impl ValueIndexer for NumericIndex<IntPayloadType> {
-    type ValueType = IntPayloadType;
+    type Value = IntPayloadType;
 
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         self.add_many_to_list(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         if let Value::Number(num) = value {
             return num.as_i64();
         }
@@ -474,17 +470,13 @@ impl ValueIndexer for NumericIndex<IntPayloadType> {
 }
 
 impl ValueIndexer for NumericIndex<FloatPayloadType> {
-    type ValueType = FloatPayloadType;
+    type Value = FloatPayloadType;
 
-    fn add_many(
-        &mut self,
-        id: PointOffsetType,
-        values: Vec<Self::ValueType>,
-    ) -> OperationResult<()> {
+    fn add_many(&mut self, id: PointOffsetType, values: Vec<Self::Value>) -> OperationResult<()> {
         self.add_many_to_list(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
+    fn get_value(&self, value: &Value) -> Option<Self::Value> {
         if let Value::Number(num) = value {
             return num.as_f64();
         }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -456,16 +456,18 @@ impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
     }
 }
 
-impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
+impl ValueIndexer for NumericIndex<IntPayloadType> {
+    type ValueType = IntPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,
-        values: Vec<IntPayloadType>,
+        values: Vec<Self::ValueType>,
     ) -> OperationResult<()> {
         self.add_many_to_list(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<IntPayloadType> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         if let Value::Number(num) = value {
             return num.as_i64();
         }
@@ -477,16 +479,18 @@ impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
     }
 }
 
-impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
+impl ValueIndexer for NumericIndex<FloatPayloadType> {
+    type ValueType = FloatPayloadType;
+
     fn add_many(
         &mut self,
         id: PointOffsetType,
-        values: Vec<FloatPayloadType>,
+        values: Vec<Self::ValueType>,
     ) -> OperationResult<()> {
         self.add_many_to_list(id, values)
     }
 
-    fn get_value(&self, value: &Value) -> Option<FloatPayloadType> {
+    fn get_value(&self, value: &Value) -> Option<Self::ValueType> {
         if let Value::Number(num) = value {
             return num.as_f64();
         }

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -9,14 +9,13 @@ use rocksdb::DB;
 use serde_json::Value;
 
 use super::private::DbWrapper;
-use super::PayloadFieldIndex;
+use super::FieldTypeIndex;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    BasePayloadFieldIndex, CardinalityEstimation, PayloadBlockCondition, PrimaryCondition,
-    ValueIndexer,
+    CardinalityEstimation, IndexingStrategy, PayloadBlockCondition, PrimaryCondition, ValueIndexer,
 };
 use crate::index::key_encoding::{
     decode_f64_key_ascending, decode_i64_key_ascending, encode_f64_key_ascending,
@@ -286,7 +285,7 @@ impl<T: Encodable + Numericable> DbWrapper for NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
+impl<T: Encodable + Numericable> IndexingStrategy for NumericIndex<T> {
     fn count_indexed_points(&self) -> usize {
         self.points_count
     }
@@ -319,7 +318,7 @@ impl<T: Encodable + Numericable> BasePayloadFieldIndex for NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
+impl<T: Encodable + Numericable> FieldTypeIndex for NumericIndex<T> {
     fn filter(
         &self,
         condition: &FieldCondition,

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::IdTrackerSS;
-use crate::index::field_index::FieldIndex;
+use crate::index::field_index::{FieldIndex, PayloadFieldIndex};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::payload_storage::query_checker::{

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::IdTrackerSS;
-use crate::index::field_index::{FieldIndex, PayloadFieldIndex};
+use crate::index::field_index::{BasePayloadFieldIndex, FieldIndex};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::payload_storage::query_checker::{

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::IdTrackerSS;
-use crate::index::field_index::{BasePayloadFieldIndex, FieldIndex};
+use crate::index::field_index::{FieldIndex, IndexingStrategy};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::payload_storage::query_checker::{

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::IdTrackerSS;
-use crate::index::field_index::{FieldIndex, IndexingStrategy};
+use crate::index::field_index::{FieldIndex, PayloadFieldIndex};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::payload_storage::query_checker::{

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
-use super::field_index::{FieldTypeIndex, IndexingStrategy};
+use super::field_index::{PayloadFieldIndex, PayloadFieldIndexExt};
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -10,9 +10,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
-use super::field_index::{
-    BasePayloadFieldIndex, PayloadFieldIndex,
-};
+use super::field_index::{BasePayloadFieldIndex, PayloadFieldIndex};
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -10,6 +10,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
+use super::field_index::{EstimateCardinality, Filterable, PayloadBlocks, PayloadFieldIndex};
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};
@@ -121,7 +122,7 @@ impl StructPayloadIndex {
         let mut indexes = index_selector(field, &payload_schema, self.db.clone());
 
         let mut is_loaded = true;
-        for ref mut index in indexes.iter_mut() {
+        for index in indexes.iter_mut() {
             if !index.load()? {
                 is_loaded = false;
                 break;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
-use super::field_index::{BasePayloadFieldIndex, PayloadFieldIndex};
+use super::field_index::{FieldTypeIndex, IndexingStrategy};
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -10,7 +10,9 @@ use parking_lot::RwLock;
 use rocksdb::DB;
 use schemars::_serde_json::Value;
 
-use super::field_index::{EstimateCardinality, Filterable, PayloadBlocks, PayloadFieldIndex};
+use super::field_index::{
+    BasePayloadFieldIndex, PayloadFieldIndex,
+};
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -11,7 +11,7 @@ use segment::fixtures::payload_fixtures::{
     random_vector, FLICKING_KEY, GEO_KEY, INT_KEY, INT_KEY_2, LAT_RANGE, LON_RANGE, STR_KEY,
     STR_PROJ_KEY, STR_ROOT_PROJ_KEY, TEXT_KEY,
 };
-use segment::index::field_index::PrimaryCondition;
+use segment::index::field_index::{PayloadFieldIndex, PrimaryCondition};
 use segment::index::PayloadIndex;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -11,7 +11,7 @@ use segment::fixtures::payload_fixtures::{
     random_vector, FLICKING_KEY, GEO_KEY, INT_KEY, INT_KEY_2, LAT_RANGE, LON_RANGE, STR_KEY,
     STR_PROJ_KEY, STR_ROOT_PROJ_KEY, TEXT_KEY,
 };
-use segment::index::field_index::{IndexingStrategy, PrimaryCondition};
+use segment::index::field_index::{PayloadFieldIndex, PrimaryCondition};
 use segment::index::PayloadIndex;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -11,7 +11,7 @@ use segment::fixtures::payload_fixtures::{
     random_vector, FLICKING_KEY, GEO_KEY, INT_KEY, INT_KEY_2, LAT_RANGE, LON_RANGE, STR_KEY,
     STR_PROJ_KEY, STR_ROOT_PROJ_KEY, TEXT_KEY,
 };
-use segment::index::field_index::{PayloadFieldIndex, PrimaryCondition};
+use segment::index::field_index::{BasePayloadFieldIndex, PrimaryCondition};
 use segment::index::PayloadIndex;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -11,7 +11,7 @@ use segment::fixtures::payload_fixtures::{
     random_vector, FLICKING_KEY, GEO_KEY, INT_KEY, INT_KEY_2, LAT_RANGE, LON_RANGE, STR_KEY,
     STR_PROJ_KEY, STR_ROOT_PROJ_KEY, TEXT_KEY,
 };
-use segment::index::field_index::{BasePayloadFieldIndex, PrimaryCondition};
+use segment::index::field_index::{IndexingStrategy, PrimaryCondition};
 use segment::index::PayloadIndex;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;


### PR DESCRIPTION
Consolidates the payload indexing logic into using common traits, instead of implementing some parts with a trait and some parts without. AFAIK, initially we started using traits and trait objects, but then we switched to enums. So currently there are some methods that need to be implemented for all indexes that are included in the `FieldIndex` enum, but are not part of any trait. 

This PR tries to consolidate them, while using [`enum_dispatch`](https://crates.io/crates/enum_dispatch) crate to reduce the boilerplate needed on the main `FieldIndex` for implementing (dispatching) all necessary traits.

Summary:
- Sealed (private) `DbWrapper` trait for exposing the inner `db_wrapper` field to the other traits and being able to preimplement `clear()`, `flusher()`, and `recreate()`
- Base `PayloadFieldIndex` to implement once per indexing approach.
- Specific `PayloadFieldIndexExt` to allow polymorphism on the indexing approaches.
- `ValueIndexer` changed from being a generic trait to trait with generic associated type. Which was more fitting because it should be only implemented once per `PayloadFieldIndexExt`.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
