### PR TITLE
add create-collection lock + remove shard versioning function

### DIFF
--- a/lib/collection/src/shards/shard_versioning.rs
+++ b/lib/collection/src/shards/shard_versioning.rs
@@ -68,23 +68,6 @@ pub fn versioned_shard_path(
     }
 }
 
-pub async fn suggest_next_version_path(
-    collection_path: &Path,
-    shard_id: ShardId,
-) -> CollectionResult<PathBuf> {
-    // Assume `all_versions` is sorted by version in descending order.
-    let all_versions = shards_versions(collection_path, shard_id).await?;
-    if all_versions.is_empty() {
-        return Ok(versioned_shard_path(collection_path, shard_id, 0));
-    }
-    let (last_version, _) = all_versions.first().unwrap();
-    Ok(versioned_shard_path(
-        collection_path,
-        shard_id,
-        last_version + 1,
-    ))
-}
-
 pub async fn latest_shard_paths(
     collection_path: &Path,
     shard_id: ShardId,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -306,7 +306,7 @@ impl TableOfContent {
         // Collection operations require multiple file operations,
         // before collection can actually be registered in the service.
         // To prevent parallel writing of the files, we use this lock.
-        let _lock = self.collection_create_lock.lock().await;
+        let collection_create_guard = self.collection_create_lock.lock().await;
 
         let CreateCollection {
             vectors,
@@ -437,6 +437,8 @@ impl TableOfContent {
                 .await?;
             write_collections.insert(collection_name.to_string(), collection);
         }
+
+        drop(collection_create_guard);
 
         // Notify the collection is created and ready to use
         for shard_id in local_shards {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -37,7 +37,7 @@ use collection::telemetry::CollectionTelemetry;
 use segment::common::cpu::get_num_cpus;
 use segment::types::ScoredPoint;
 use tokio::runtime::Runtime;
-use tokio::sync::{RwLock, RwLockReadGuard, Semaphore};
+use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
 use uuid::Uuid;
 
 use super::collection_meta_ops::{
@@ -87,6 +87,9 @@ pub struct TableOfContent {
     ///
     /// If not defined - no rate limiting is applied.
     update_rate_limiter: Option<Semaphore>,
+    /// A lock to prevent concurrent collection creation.
+    /// Effectively, this lock ensures that `create_collection` is called sequentially.
+    collection_create_lock: Mutex<()>,
 }
 
 impl TableOfContent {
@@ -194,6 +197,7 @@ impl TableOfContent {
             is_write_locked: AtomicBool::new(false),
             lock_error_message: parking_lot::Mutex::new(None),
             update_rate_limiter: rate_limiter,
+            collection_create_lock: Default::default(),
         }
     }
 
@@ -299,6 +303,11 @@ impl TableOfContent {
         operation: CreateCollection,
         collection_shard_distribution: CollectionShardDistribution,
     ) -> Result<bool, StorageError> {
+        // Collection operations require multiple file operations,
+        // before collection can actually be registered in the service.
+        // To prevent parallel writing of the files, we use this lock.
+        let _lock = self.collection_create_lock.lock().await;
+
         let CreateCollection {
             vectors,
             shard_number,


### PR DESCRIPTION
related issue: https://github.com/qdrant/qdrant/issues/2158

What happened:

If there are multiple parallel requests to create the same collection - it might create problem of parallel writing to the same directory:

- collections HashMap only updated with ready-made collection
- It is required to write files to disk in order to create collection
- We can't move already created collection, as there are in-memory state which assumes correct path

As a result, multiple parallel requests triggered (deprecated) shards versioning logic.


Solution:

- Force create_collection API to be sequential with tokio Mutex
- Remove deprecated logic of shard versioning 


Possible alternatieves solutions:

- Associate mutex with collection names, so that we can create multiple collections in parallel
Decided to go with the simpler mutex, as in distributed mode all consensus operations are sequential anyway.

- File-based resolving of the existence of the collection
Alternatively, we can check if collection already exists by checking the files on disk.
But this approach is potentially error-prone as the collection might be partially created and not loaded into memory.
In this case the create API will report that collection exists, while list API will show no collection.

Please feel free to suggest better alternatieves



 

