### PR TITLE
Prevent deadlock in Consensus Manager

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -696,12 +696,13 @@ impl<C: CollectionContainer> Storage for ConsensusManager<C> {
     }
 
     fn term(&self, idx: u64) -> raft::Result<u64> {
+        let wal_guard = self.wal.lock();
         let persistent = self.persistent.read();
         let snapshot_meta = persistent.latest_snapshot_meta();
         if idx == snapshot_meta.index {
             return Ok(snapshot_meta.term);
         }
-        Ok(self.wal.lock().entry(idx)?.term)
+        Ok(wal_guard.entry(idx)?.term)
     }
 
     fn first_index(&self) -> raft::Result<u64> {


### PR DESCRIPTION
Playing with `lockbud` (again) I got the following warning regarding a possible deadlock in the consensus manager.

```json
[
  {
    "ConflictLock": {
      "bug_kind": "ConflictLock",
      "possibility": "Possibly",
      "diagnosis": [
        {
          "first_lock_type": "ParkingLotRead(content_manager::consensus::persistent::Persistent)",
          "first_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:699:13: 699:23 (#0)",
          "second_lock_type": "ParkingLotMutex(content_manager::consensus::consensus_wal::ConsensusOpWal)",
          "second_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:704:12: 704:27 (#0)",
          "callchains": []
        },
        {
          "first_lock_type": "ParkingLotMutex(content_manager::consensus::consensus_wal::ConsensusOpWal)",
          "first_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:716:27: 716:42 (#0)",
          "second_lock_type": "ParkingLotRead(content_manager::consensus::persistent::Persistent)",
          "second_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:718:21: 718:43 (#0)",
          "callchains": []
        }
      ],
      "explanation": "Locks mutually wait for each other to form a cycle"
    }
  },
  {
    "ConflictLock": {
      "bug_kind": "ConflictLock",
      "possibility": "Possibly",
      "diagnosis": [
        {
          "first_lock_type": "ParkingLotRead(content_manager::consensus::persistent::Persistent)",
          "first_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:699:13: 699:23 (#0)",
          "second_lock_type": "ParkingLotMutex(content_manager::consensus::consensus_wal::ConsensusOpWal)",
          "second_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:704:12: 704:27 (#0)",
          "callchains": []
        },
        {
          "first_lock_type": "ParkingLotMutex(content_manager::consensus::consensus_wal::ConsensusOpWal)",
          "first_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:708:27: 708:42 (#0)",
          "second_lock_type": "ParkingLotRead(content_manager::consensus::persistent::Persistent)",
          "second_lock_span": "lib/storage/src/content_manager/consensus_manager.rs:710:21: 710:43 (#0)",
          "callchains": []
        }
      ],
      "explanation": "Locks mutually wait for each other to form a cycle"
    }
  }
]
```

The functions `first_index` and `last_index` acquire first the WAL lock and then the persistence state lock.
Whereas the function `term` acquire those in the opposite order.

This PR changes `term` to acquire first the WAL lock to remove any chance for a deadlock.