### PR TITLE
handle inconsistent vector storage in sync operation

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -579,6 +579,10 @@ impl From<OperationError> for CollectionError {
             OperationError::OutOfMemory { description, free } => {
                 Self::OutOfMemory { description, free }
             }
+            OperationError::InconsistentStorage { .. } => Self::ServiceError {
+                error: format!("{err}"),
+                backtrace: None,
+            },
         }
     }
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -50,6 +50,8 @@ pub enum OperationError {
         description: String,
         backtrace: Option<String>,
     },
+    #[error("Inconsistent storage: {description}")]
+    InconsistentStorage { description: String },
     #[error("Out of memory, free: {free}, {description}")]
     OutOfMemory { description: String, free: u64 },
     #[error("Operation cancelled: {description}")]


### PR DESCRIPTION
Fixes: https://github.com/qdrant/qdrant/issues/2184

Introduces special type of internal error, which prevents panic and handled properly by sync API.