### PR TITLE
Add geo_polygon filter to proto interface, complete conversion fn, and add an integration test

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -86,6 +86,7 @@
     - [Filter](#qdrant-Filter)
     - [GeoBoundingBox](#qdrant-GeoBoundingBox)
     - [GeoPoint](#qdrant-GeoPoint)
+    - [GeoPolygon](#qdrant-GeoPolygon)
     - [GeoRadius](#qdrant-GeoRadius)
     - [GetPoints](#qdrant-GetPoints)
     - [GetResponse](#qdrant-GetResponse)
@@ -1446,6 +1447,7 @@ The JSON representation for `Value` is a JSON value.
 | geo_bounding_box | [GeoBoundingBox](#qdrant-GeoBoundingBox) |  | Check if points geolocation lies in a given area |
 | geo_radius | [GeoRadius](#qdrant-GeoRadius) |  | Check if geo point is within a given radius |
 | values_count | [ValuesCount](#qdrant-ValuesCount) |  | Check number of values for a specific field |
+| geo_polygon | [GeoPolygon](#qdrant-GeoPolygon) |  | Check if geo point is within a given polygon |
 
 
 
@@ -1495,6 +1497,21 @@ The JSON representation for `Value` is a JSON value.
 | ----- | ---- | ----- | ----------- |
 | lon | [double](#double) |  |  |
 | lat | [double](#double) |  |  |
+
+
+
+
+
+
+<a name="qdrant-GeoPolygon"></a>
+
+### GeoPolygon
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| points | [GeoPoint](#qdrant-GeoPoint) | repeated | Ordered list of coordinates representing the vertices of a polygon. The minimum size is 4, and the first coordinate and the last coordinate should be the same to form a closed polygon. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5000,6 +5000,17 @@
               }
             ]
           },
+          "geo_polygon": {
+            "description": "Check if geo point is within a given polygon",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GeoPolygon"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "values_count": {
             "description": "Check number of values of the field",
             "anyOf": [
@@ -5188,6 +5199,22 @@
             "description": "Radius of the area in meters",
             "type": "number",
             "format": "double"
+          }
+        }
+      },
+      "GeoPolygon": {
+        "description": "Geo filter request\n\nMatches coordinates inside the polygon, defined by the given coordinates in order.",
+        "type": "object",
+        "required": [
+          "points"
+        ],
+        "properties": {
+          "points": {
+            "description": "Ordered list of coordinates representing the vertices of a polygon.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeoPoint"
+            }
           }
         }
       },

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -165,7 +165,9 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendPointGroups.limit", "range(min = 1)"),
             ("RecommendPointGroups.params", ""),
             ("CountPoints.collection_name", "length(min = 1, max = 255)"),
+            ("GeoPolygon.points", "custom = \"crate::grpc::validate::validate_geo_polygon\""),
         ], &[])
+        .type_attribute("GeoPoint", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[
             ("UpsertPointsInternal.upsert_points", ""),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -483,6 +483,7 @@ message FieldCondition {
   GeoBoundingBox geo_bounding_box = 4; // Check if points geolocation lies in a given area
   GeoRadius geo_radius = 5; // Check if geo point is within a given radius
   ValuesCount values_count = 6; // Check number of values for a specific field
+  GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
 }
 
 message Match {
@@ -521,6 +522,13 @@ message GeoBoundingBox {
 message GeoRadius {
   GeoPoint center = 1; // Center of the circle
   float radius = 2; // In meters
+}
+
+message GeoPolygon {
+  // Ordered list of coordinates representing the vertices of a polygon.
+  // The minimum size is 4, and the first coordinate and the last coordinate
+  // should be the same to form a closed polygon.
+  repeated GeoPoint points = 1;
 }
 
 message ValuesCount {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3392,6 +3392,9 @@ pub struct FieldCondition {
     /// Check number of values for a specific field
     #[prost(message, optional, tag = "6")]
     pub values_count: ::core::option::Option<ValuesCount>,
+    /// Check if geo point is within a given polygon
+    #[prost(message, optional, tag = "7")]
+    pub geo_polygon: ::core::option::Option<GeoPolygon>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3474,6 +3477,17 @@ pub struct GeoRadius {
     #[prost(float, tag = "2")]
     pub radius: f32,
 }
+#[derive(validator::Validate)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeoPolygon {
+    /// Ordered list of coordinates representing the vertices of a polygon.
+    /// The minimum size is 4, and the first coordinate and the last coordinate
+    /// should be the same to form a closed polygon.
+    #[prost(message, repeated, tag = "1")]
+    #[validate(custom = "crate::grpc::validate::validate_geo_polygon")]
+    pub points: ::prost::alloc::vec::Vec<GeoPoint>,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValuesCount {
@@ -3521,6 +3535,7 @@ pub struct PointStruct {
     #[prost(message, optional, tag = "4")]
     pub vectors: ::core::option::Option<Vectors>,
 }
+#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPoint {

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -86,6 +86,15 @@ fn describe_error(
             Some(value) => format!("value {value} invalid, must not be empty"),
             None => err.to_string(),
         },
+        "closed_polygon" => {
+            "the first and the last points should be same to form a closed polygon".to_string()
+        }
+        "min_polygon_length" => match (params.get("min_length"), params.get("length")) {
+            (Some(min_length), Some(length)) => {
+                format! {"size must be at least {}, got {}", min_length, length}
+            }
+            _ => err.to_string(),
+        },
         // Undescribed error codes
         _ => err.to_string(),
     }
@@ -93,6 +102,7 @@ fn describe_error(
 
 #[cfg(test)]
 mod tests {
+    use api::grpc::qdrant::{GeoPoint, GeoPolygon};
     use validator::Validate;
 
     use super::*;
@@ -139,6 +149,44 @@ mod tests {
             vec![(
                 "things[0].idx".into(),
                 "value 0 invalid, must be 1.0 or larger".into()
+            )]
+        );
+
+        let bad_polygon = GeoPolygon {
+            points: vec![
+                GeoPoint { lat: 1., lon: 1. },
+                GeoPoint { lat: 2., lon: 2. },
+                GeoPoint { lat: 1., lon: 1. },
+            ],
+        };
+
+        let errors = bad_polygon
+            .validate()
+            .expect_err("validation of bad polygon should fail");
+
+        assert_eq!(
+            describe_errors(&errors),
+            vec![("points".into(), "size must be at least 4, got 3".into())]
+        );
+
+        let bad_polygon = GeoPolygon {
+            points: vec![
+                GeoPoint { lat: 1., lon: 1. },
+                GeoPoint { lat: 2., lon: 2. },
+                GeoPoint { lat: 3., lon: 3. },
+                GeoPoint { lat: 4., lon: 4. },
+            ],
+        };
+
+        let errors = bad_polygon
+            .validate()
+            .expect_err("validation of bad polygon should fail");
+
+        assert_eq!(
+            describe_errors(&errors),
+            vec![(
+                "points".into(),
+                "the first and the last points should be same to form a closed polygon".into()
             )]
         );
     }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -148,6 +148,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
             geo_bounding_box: None,
             geo_radius: None,
             values_count: None,
+            geo_polygon: None,
         }))),
         exact: true,
     };

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -245,6 +245,7 @@ impl InvertedIndex {
                         range: None,
                         geo_bounding_box: None,
                         geo_radius: None,
+                        geo_polygon: None,
                         values_count: None,
                     },
                     cardinality: posting.len(),

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -251,6 +251,7 @@ mod tests {
             geo_bounding_box: None,
             geo_radius: None,
             values_count: None,
+            geo_polygon: None,
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -12,8 +12,8 @@ use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{
-    circle_hashes, common_hash_prefix, encode_max_precision, geo_hash_to_box, rectangle_hashes,
-    GeoHash,
+    circle_hashes, common_hash_prefix, encode_max_precision, geo_hash_to_box, polygon_hashes,
+    rectangle_hashes, GeoHash,
 };
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
@@ -540,6 +540,20 @@ impl PayloadFieldIndex for GeoMapIndex {
         if let Some(geo_radius) = &condition.geo_radius {
             let geo_hashes = circle_hashes(geo_radius, GEO_QUERY_MAX_REGION);
             let geo_condition_copy = geo_radius.clone();
+            return Some(Box::new(self.get_iterator(geo_hashes).filter(
+                move |point| {
+                    self.point_to_values
+                        .get(*point as usize)
+                        .unwrap()
+                        .iter()
+                        .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
+                },
+            )));
+        }
+
+        if let Some(geo_polygon) = &condition.geo_polygon {
+            let geo_hashes = polygon_hashes(geo_polygon, GEO_QUERY_MAX_REGION);
+            let geo_condition_copy = geo_polygon.clone();
             return Some(Box::new(self.get_iterator(geo_hashes).filter(
                 move |point| {
                     self.point_to_values

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -801,6 +801,7 @@ mod tests {
             geo_bounding_box: None,
             geo_radius: None,
             values_count: None,
+            geo_polygon: None,
         };
 
         let offsets = index.filter(&condition).unwrap().collect_vec();

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -274,6 +274,7 @@ mod tests {
             geo_bounding_box: None,
             geo_radius: None,
             values_count: None,
+            geo_polygon: None,
         })
     }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1238,6 +1238,8 @@ pub struct FieldCondition {
     pub geo_bounding_box: Option<GeoBoundingBox>,
     /// Check if geo point is within a given radius
     pub geo_radius: Option<GeoRadius>,
+    /// Check if geo point is within a given polygon
+    pub geo_polygon: Option<GeoPolygon>,
     /// Check number of values of the field
     pub values_count: Option<ValuesCount>,
 }
@@ -1250,6 +1252,7 @@ impl FieldCondition {
             range: None,
             geo_bounding_box: None,
             geo_radius: None,
+            geo_polygon: None,
             values_count: None,
         }
     }
@@ -1261,6 +1264,7 @@ impl FieldCondition {
             range: Some(range),
             geo_bounding_box: None,
             geo_radius: None,
+            geo_polygon: None,
             values_count: None,
         }
     }
@@ -1275,6 +1279,7 @@ impl FieldCondition {
             range: None,
             geo_bounding_box: Some(geo_bounding_box),
             geo_radius: None,
+            geo_polygon: None,
             values_count: None,
         }
     }
@@ -1286,6 +1291,19 @@ impl FieldCondition {
             range: None,
             geo_bounding_box: None,
             geo_radius: Some(geo_radius),
+            geo_polygon: None,
+            values_count: None,
+        }
+    }
+
+    pub fn new_geo_polygon(key: impl Into<PayloadKeyType>, geo_polygon: GeoPolygon) -> Self {
+        Self {
+            key: key.into(),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: Some(geo_polygon),
             values_count: None,
         }
     }
@@ -1297,6 +1315,7 @@ impl FieldCondition {
             range: None,
             geo_bounding_box: None,
             geo_radius: None,
+            geo_polygon: None,
             values_count: Some(values_count),
         }
     }


### PR DESCRIPTION
This is one of a series of commits for the new feature Geo Filter by Polygon(https://github.com/qdrant/qdrant/issues/795). In this commit, a new proto interface called GeoPolygon is introduced, along with validation fn and conversion functions to/from internal struct GeoPolygon. Additionally, an integration test is included as part of this commit.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
