### PR TITLE
Shutdown collections before runtimes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -440,13 +440,17 @@ fn main() -> anyhow::Result<()> {
         );
         handle.join().expect("thread is not panicking")?;
     }
+
+    // Shutdown gracefully collections if possible.
+    if let Ok(toc) = wait_unwrap(toc_arc, Duration::from_secs(30)) {
+        drop(toc);
+    }
+
+    // Stop tokio runtimes
     drop(search_runtime);
     drop(update_runtime);
     drop(general_runtime);
     drop(settings);
-    if let Ok(toc) = wait_unwrap(toc_arc, Duration::from_secs(30)) {
-        drop(toc);
-    }
     Ok(())
 }
 


### PR DESCRIPTION
This PR fixes the order of component shutdown.

Currently, ctr+c an instance with idle collections yield.

```
[2023-07-03T09:44:12.144Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 395 was cancelled
[2023-07-03T09:44:12.148Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.149Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.149Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.149Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 123 was cancelled
[2023-07-03T09:44:12.152Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.153Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.153Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.153Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 127 was cancelled
[2023-07-03T09:44:12.157Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.159Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.159Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.159Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 231 was cancelled
[2023-07-03T09:44:12.162Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.163Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.163Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.163Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 203 was cancelled
[2023-07-03T09:44:12.168Z INFO  wal] segment creator shutting down
```

We get one warning per collection.

This is due to the interaction of two concurrent PRs:
- https://github.com/qdrant/qdrant/pull/2096 which shuts down properly the Tokio runtimes 
- https://github.com/qdrant/qdrant/pull/2144 which requires to have a runtime handle when dropping a collection.

The fix is to first drop the collections to finish gracefully the ongoing tasks and then shutdown the Tokio infrastructure.

This removes the logs

```
[2023-07-03T10:21:35.770Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.773Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.774Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.777Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.778Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.784Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.785Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.788Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.789Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.792Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.793Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.796Z INFO  wal] segment creator shutting down
[2023-07-03T10:21:35.797Z DEBUG collection::update_handler] Stopping flush worker.
[2023-07-03T10:21:35.802Z INFO  wal] segment creator shutting down
```

