### PR TITLE
Revert "TableOfContent now accepts Handle, not Runtime (#2096)"

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -36,7 +36,7 @@ use collection::shards::{replica_set, CollectionId};
 use collection::telemetry::CollectionTelemetry;
 use segment::common::cpu::get_num_cpus;
 use segment::types::ScoredPoint;
-use tokio::runtime::Handle;
+use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
 use uuid::Uuid;
 
@@ -71,9 +71,9 @@ pub const DEFAULT_WRITE_LOCK_ERROR_MESSAGE: &str = "Write operations are forbidd
 pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: Arc<StorageConfig>,
-    search_runtime: Handle,
-    update_runtime: Handle,
-    general_runtime: Handle,
+    search_runtime: Runtime,
+    update_runtime: Runtime,
+    general_runtime: Runtime,
     alias_persistence: RwLock<AliasPersistence>,
     pub this_peer_id: PeerId,
     channel_service: ChannelService,
@@ -96,9 +96,9 @@ impl TableOfContent {
     /// PeerId does not change during execution so it is ok to copy it here.
     pub fn new(
         storage_config: &StorageConfig,
-        search_runtime: Handle,
-        update_runtime: Handle,
-        general_runtime: Handle,
+        search_runtime: Runtime,
+        update_runtime: Runtime,
+        general_runtime: Runtime,
         channel_service: ChannelService,
         this_peer_id: PeerId,
         consensus_proposal_sender: Option<OperationSender>,
@@ -156,8 +156,8 @@ impl TableOfContent {
                     consensus_proposal_sender.clone(),
                     collection_name.clone(),
                 ),
-                Some(search_runtime.clone()),
-                Some(update_runtime.clone()),
+                Some(search_runtime.handle().clone()),
+                Some(update_runtime.handle().clone()),
             ));
 
             collections.insert(collection_name, collection);
@@ -456,8 +456,8 @@ impl TableOfContent {
                 self.consensus_proposal_sender.clone(),
                 collection_name.to_string(),
             ),
-            Some(self.search_runtime.clone()),
-            Some(self.update_runtime.clone()),
+            Some(self.search_runtime.handle().clone()),
+            Some(self.update_runtime.handle().clone()),
         )
         .await?;
 
@@ -1430,8 +1430,8 @@ impl TableOfContent {
                             self.consensus_proposal_sender.clone(),
                             id.to_string(),
                         ),
-                        Some(self.search_runtime.clone()),
-                        Some(self.update_runtime.clone()),
+                        Some(self.search_runtime.handle().clone()),
+                        Some(self.update_runtime.handle().clone()),
                     )
                     .await?;
                     collections.validate_collection_not_exists(id).await?;

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -68,9 +68,9 @@ fn test_alias_operation() {
 
     let toc = Arc::new(TableOfContent::new(
         &config,
-        search_runtime.handle().clone(),
-        update_runtime.handle().clone(),
-        general_runtime.handle().clone(),
+        search_runtime,
+        update_runtime,
+        general_runtime,
         Default::default(),
         0,
         Some(propose_operation_sender),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -32,12 +31,6 @@ use crate::tonic::init_internal;
 
 type Node = RawNode<ConsensusStateRef>;
 
-/// gRPC and consensus thread handles.
-type ConsensusHandles = (
-    JoinHandle<std::io::Result<()>>,
-    JoinHandle<std::io::Result<()>>,
-);
-
 const RECOVERY_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 const RECOVERY_MAX_RETRY_COUNT: usize = 3;
 
@@ -59,7 +52,6 @@ pub struct Consensus {
     /// ToDo: Make if many
     config: ConsensusConfig,
     broker: RaftMessageBroker,
-    shutdown_requested: Arc<AtomicBool>,
 }
 
 impl Consensus {
@@ -76,7 +68,7 @@ impl Consensus {
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
         runtime: Handle,
-    ) -> anyhow::Result<ConsensusHandles> {
+    ) -> anyhow::Result<JoinHandle<std::io::Result<()>>> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
         let p2p_host = settings.service.host;
@@ -94,22 +86,20 @@ impl Consensus {
             channel_service,
             runtime.clone(),
         )?;
-        let shutdown_requested = consensus.shutdown_requested.clone();
 
         let state_ref_clone = state_ref.clone();
-        let consensus_handle =
-            thread::Builder::new()
-                .name("consensus".to_string())
-                .spawn(move || {
-                    if let Err(err) = consensus.start() {
-                        log::error!("Consensus stopped with error: {err}");
-                        state_ref_clone.on_consensus_thread_err(err);
-                    } else {
-                        log::info!("Consensus stopped");
-                        state_ref_clone.on_consensus_stopped();
-                    }
-                    Ok(())
-                })?;
+        thread::Builder::new()
+            .name("consensus".to_string())
+            .spawn(move || {
+                if let Err(err) = consensus.start() {
+                    log::error!("Consensus stopped with error: {err}");
+                    state_ref_clone.on_consensus_thread_err(err);
+                } else {
+                    log::info!("Consensus stopped");
+                    state_ref_clone.on_consensus_stopped();
+                    state_ref_clone.on_consensus_stopped();
+                }
+            })?;
 
         let message_sender_moved = message_sender.clone();
         thread::Builder::new()
@@ -136,7 +126,7 @@ impl Consensus {
             None
         };
 
-        let grpc_handle = thread::Builder::new()
+        let handle = thread::Builder::new()
             .name("grpc_internal".to_string())
             .spawn(move || {
                 init_internal(
@@ -148,12 +138,11 @@ impl Consensus {
                     server_tls,
                     message_sender,
                     runtime,
-                    shutdown_requested,
                 )
             })
             .unwrap();
 
-        Ok((grpc_handle, consensus_handle))
+        Ok(handle)
     }
 
     /// If `bootstrap_peer` peer is supplied, then either `uri` or `p2p_port` should be also supplied
@@ -239,15 +228,12 @@ impl Consensus {
             channel_service.channel_pool,
         );
 
-        let shutdown_requested = Arc::new(AtomicBool::new(false));
-
         let consensus = Self {
             node,
             receiver,
             runtime,
             config,
             broker,
-            shutdown_requested,
         };
 
         Ok((consensus, sender))
@@ -441,9 +427,6 @@ impl Consensus {
         let mut timeout = Duration::from_millis(self.config.tick_period_ms);
 
         loop {
-            if self.shutdown_requested.load(Ordering::Acquire) {
-                return Ok(());
-            }
             if !self
                 .try_promote_learner()
                 .map_err(|err| anyhow!("Failed to promote learner: {}", err))?
@@ -1062,9 +1045,9 @@ mod tests {
         let operation_sender = OperationSender::new(propose_sender);
         let toc = TableOfContent::new(
             &settings.storage,
-            search_runtime.handle().clone(),
-            update_runtime.handle().clone(),
-            general_runtime.handle().clone(),
+            search_runtime,
+            update_runtime,
+            general_runtime,
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::io::Error;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
@@ -212,9 +212,9 @@ fn main() -> anyhow::Result<()> {
     // It is a main entry point for the storage.
     let toc = TableOfContent::new(
         &settings.storage,
-        search_runtime.handle().clone(),
-        update_runtime.handle().clone(),
-        general_runtime.handle().clone(),
+        search_runtime,
+        update_runtime,
+        general_runtime,
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
@@ -262,7 +262,7 @@ fn main() -> anyhow::Result<()> {
 
         // Runs raft consensus in a separate thread.
         // Create a pipe `message_sender` to communicate with the consensus
-        let (grpc_handle, consensus_handle) = Consensus::run(
+        let handle = Consensus::run(
             &slog_logger,
             consensus_state.clone(),
             args.bootstrap,
@@ -276,8 +276,7 @@ fn main() -> anyhow::Result<()> {
         )
         .expect("Can't initialize consensus");
 
-        handles.push(grpc_handle);
-        handles.push(consensus_handle);
+        handles.push(handle);
 
         let toc_arc_clone = toc_arc.clone();
         let consensus_state_clone = consensus_state.clone();
@@ -440,34 +439,7 @@ fn main() -> anyhow::Result<()> {
         );
         handle.join().expect("thread is not panicking")?;
     }
-    drop(search_runtime);
-    drop(update_runtime);
-    drop(general_runtime);
+    drop(toc_arc);
     drop(settings);
-    if let Ok(toc) = wait_unwrap(toc_arc, Duration::from_secs(30)) {
-        drop(toc);
-    }
     Ok(())
-}
-
-/// Blocks current thread for up to specified amount of time to become the single referent
-/// of an [`Arc`] and returns it.
-///
-/// This methods move a value out from an [`Arc`] when there is only one reference left
-/// and it is safe to do so. `Err()` is returned if an [`Arc`] still has more than 1 reference
-/// after given duration is passed.
-fn wait_unwrap<T>(mut input: Arc<T>, duration: Duration) -> Result<T, ()> {
-    let start_time = Instant::now();
-    while start_time.elapsed() < duration {
-        match Arc::try_unwrap(input) {
-            Ok(input) => {
-                return Ok(input);
-            }
-            Err(new_input) => {
-                input = new_input;
-                thread::sleep_ms(100);
-            }
-        }
-    }
-    Err(())
 }

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -5,7 +5,6 @@ mod tonic_telemetry;
 
 use std::io;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use ::api::grpc::models::VersionInfo;
@@ -156,7 +155,6 @@ pub fn init_internal(
     tls_config: Option<ServerTlsConfig>,
     to_consensus: tokio::sync::mpsc::Sender<crate::consensus::Message>,
     runtime: Handle,
-    shutdown_requested: Arc<AtomicBool>,
 ) -> std::io::Result<()> {
     use ::api::grpc::qdrant::raft_server::RaftServer;
 
@@ -227,7 +225,6 @@ pub fn init_internal(
                 )
                 .serve_with_shutdown(socket, async {
                     wait_stop_signal("internal gRPC").await;
-                    shutdown_requested.store(true, Ordering::Relaxed);
                 })
                 .await
         })


### PR DESCRIPTION
This PR unfortunately reverts the great work done in https://github.com/qdrant/qdrant/pull/2096

This is necessary because shutting down an instance with collections currently yields the following logs:

```
[2023-07-03T09:44:12.144Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 395 was cancelled
[2023-07-03T09:44:12.148Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.149Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.149Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.149Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 123 was cancelled
[2023-07-03T09:44:12.152Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.153Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.153Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.153Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 127 was cancelled
[2023-07-03T09:44:12.157Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.159Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.159Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.159Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 231 was cancelled
[2023-07-03T09:44:12.162Z INFO  wal] segment creator shutting down
[2023-07-03T09:44:12.163Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-03T09:44:12.163Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-03T09:44:12.163Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 203 was cancelled
[2023-07-03T09:44:12.168Z INFO  wal] segment creator shutting down
```

The system cannot shutdown properly because a Tokio runtime is not available when dropping collections.

This happens because the refactoring of the Tokio handles was merged **after** the concurrent PR https://github.com/qdrant/qdrant/pull/2144 which requires to have access to a runtime when dropping a collection.

I thought an easy fix was to simply shutdown the `toc` before the runtimes but unfortunately it brings a different set of issues as discovered in https://github.com/qdrant/qdrant/pull/2190

The bottom line is that more work is required in order to have a clean shutdown without noisy logs in the presence of telemetry and/or consensus.

Given that we need to cut a release very soon, the most sensible approach is to revert and research how to re-integrate the change afterwards without pressure.

I apologize for the bad turn of events @bazhenov as you are not responsible for this integration issue :bow: 




