### PR TITLE
Remove duplicate on_consensus_stopped call

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -97,7 +97,6 @@ impl Consensus {
                 } else {
                     log::info!("Consensus stopped");
                     state_ref_clone.on_consensus_stopped();
-                    state_ref_clone.on_consensus_stopped();
                 }
             })?;
 


### PR DESCRIPTION
Fixes duplicate invocation missed in <https://github.com/qdrant/qdrant/pull/2191>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?