### PR TITLE
Derive/implement `fmt::Debug` for major types in Qdrant

### DIFF
--- a/lib/api/src/grpc/dynamic_channel_pool.rs
+++ b/lib/api/src/grpc/dynamic_channel_pool.rs
@@ -21,6 +21,7 @@ pub async fn make_grpc_channel(
     endpoint.connect().await
 }
 
+#[derive(Debug)]
 pub struct DynamicChannelPool {
     pool: Mutex<DynamicPool<Channel>>,
     init_at: Instant,

--- a/lib/api/src/grpc/dynamic_pool.rs
+++ b/lib/api/src/grpc/dynamic_pool.rs
@@ -22,6 +22,7 @@ impl<T: Clone> ItemWithStats<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct DynamicPool<T: Clone> {
     items: HashMap<u64, Arc<ItemWithStats<T>>>,
     /// How many times one item can be used

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -67,6 +67,7 @@ enum RequestFailure {
 /// Holds a pool of channels established for a set of URIs.
 /// Channel are shared by cloning them.
 /// Make the `pool_size` larger to increase throughput.
+#[derive(Debug)]
 pub struct TransportChannelPool {
     uri_to_pool: tokio::sync::RwLock<HashMap<Uri, DynamicChannelPool>>,
     pool_size: NonZeroUsize,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::future::Future;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -99,6 +100,27 @@ pub struct Collection {
     search_runtime: Handle,
     // Update runtime handle.
     update_runtime: Handle,
+}
+
+impl fmt::Debug for Collection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Collection")
+            .field("id", &self.id)
+            .field("shards_holder", &self.shards_holder)
+            .field("collection_config", &self.collection_config)
+            .field("shared_storage_config", &self.shared_storage_config)
+            .field("this_peer_id", &self.this_peer_id)
+            .field("path", &self.path)
+            .field("snapshots_path", &self.snapshots_path)
+            .field("channel_service", &self.channel_service)
+            .field("transfer_tasks", &self.transfer_tasks)
+            .field("init_time", &self.init_time)
+            .field("is_initialized", &self.is_initialized)
+            .field("updates_lock", &self.updates_lock)
+            .field("search_runtime", &self.search_runtime)
+            .field("update_runtime", &self.update_runtime)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Collection {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -24,6 +24,7 @@ type LockedFieldsMap = Arc<RwLock<HashMap<PayloadKeyType, PayloadFieldSchema>>>;
 /// This object is a wrapper around read-only segment.
 /// It could be used to provide all read and write operations while wrapped segment is being optimized (i.e. not available for writing)
 /// It writes all changed records into a temporary `write_segment` and keeps track on changed points
+#[derive(Debug)]
 pub struct ProxySegment {
     pub write_segment: LockedSegment,
     pub wrapped_segment: LockedSegment,

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -23,6 +23,7 @@ const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 /// Object, which unifies the access to different types of segments, but still allows to
 /// access the original type of the segment if it is required for more efficient operations.
+#[derive(Debug)]
 pub enum LockedSegment {
     Original(Arc<RwLock<Segment>>),
     Proxy(Arc<RwLock<ProxySegment>>),
@@ -107,7 +108,7 @@ impl From<ProxySegment> for LockedSegment {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SegmentHolder {
     segments: HashMap<SegmentId, LockedSegment>,
     /// Seq number of the first un-recovered operation.

--- a/lib/collection/src/common/is_ready.rs
+++ b/lib/collection/src/common/is_ready.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use parking_lot::{Condvar, Mutex};
 
+#[derive(Debug)]
 pub struct IsReady {
     condvar: Condvar,
     value: Mutex<bool>,

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Weak};
 
 use tokio::task::JoinHandle;
 
+#[derive(Debug)]
 pub struct StoppableTaskHandle<T> {
     pub join_handle: JoinHandle<T>,
     finished: Arc<AtomicBool>,

--- a/lib/collection/src/common/stoppable_task_async.rs
+++ b/lib/collection/src/common/stoppable_task_async.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Weak};
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
+#[derive(Debug)]
 pub struct StoppableAsyncTaskHandle<T: Clone> {
     pub join_handle: JoinHandle<T>,
     result_holder: Arc<Mutex<Option<T>>>,

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::hash::Hash;
 
 pub enum HashRing<T: Hash + Copy> {
@@ -6,6 +7,18 @@ pub enum HashRing<T: Hash + Copy> {
         ring: hashring::HashRing<(T, u32)>,
         scale: u32,
     },
+}
+
+impl<T: Hash + Copy> fmt::Debug for HashRing<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Raw(_) => f.debug_tuple("Raw").finish(),
+            Self::Fair { scale, .. } => f
+                .debug_struct("Fair")
+                .field("scale", &scale)
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 impl<T: Hash + Copy> HashRing<T> {

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -6,7 +6,7 @@ use tonic::transport::Uri;
 
 use crate::shards::shard::PeerId;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ChannelService {
     // Shared with consensus_state
     pub id_to_address: Arc<parking_lot::RwLock<HashMap<PeerId, Uri>>>,

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -26,6 +26,7 @@ use crate::shards::telemetry::LocalShardTelemetry;
 ///
 /// It can be used to provide all read and write operations while the wrapped shard is being transferred to another node.
 /// Proxy forwards all operations to remote shards.
+#[derive(Debug)]
 pub struct ForwardProxyShard {
     pub(crate) wrapped_shard: LocalShard,
     pub(crate) remote_shard: RemoteShard,

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -4,7 +4,7 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread;
+use std::{fmt, thread};
 
 use arc_swap::ArcSwap;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -60,6 +60,20 @@ pub struct LocalShard {
     pub(super) path: PathBuf,
     pub(super) optimizers: Arc<Vec<Arc<Optimizer>>>,
     update_runtime: Handle,
+}
+
+impl fmt::Debug for LocalShard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalShard")
+            .field("segments", &self.segments)
+            .field("collection_config", &self.collection_config)
+            .field("shred_storage_config", &self.shred_storage_config)
+            .field("wal", &self.wal)
+            .field("update_handler", &self.update_handler)
+            .field("update_sender", &self.update_sender)
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Shard holds information about segments and WAL.

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -34,6 +34,7 @@ type ChangedPointsSet = Arc<RwLock<HashSet<PointIdType>>>;
 ///
 /// It can be used to provide all read and write operations while the wrapped shard is being transferred to another node.
 /// It keeps track of changed points during the shard transfer to assure consistency.
+#[derive(Debug)]
 pub struct ProxyShard {
     wrapped_shard: LocalShard,
     changed_points: ChangedPointsSet,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -48,6 +48,7 @@ use crate::shards::CollectionId;
 /// RemoteShard
 ///
 /// Remote Shard is a representation of a shard that is located on a remote peer.
+#[derive(Debug)]
 pub struct RemoteShard {
     pub(crate) id: ShardId,
     pub(crate) collection_id: CollectionId,

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
@@ -7,6 +6,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use std::{cmp, fmt};
 
 use futures::future::{join, join_all};
 use futures::stream::FuturesUnordered;
@@ -171,6 +171,26 @@ pub struct ShardReplicaSet {
     update_runtime: Handle,
     /// Lock to serialized write operations on the replicaset when a write ordering is used.
     write_ordering_lock: Mutex<()>,
+}
+
+impl fmt::Debug for ShardReplicaSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShardReplicaSet")
+            .field("local", &self.local)
+            .field("remotes", &self.remotes)
+            .field("replica_state", &self.replica_state)
+            .field("locally_disabled_peers", &self.locally_disabled_peers)
+            .field("shard_path", &self.shard_path)
+            .field("shard_id", &self.shard_id)
+            .field("read_remote_replicas", &self.read_remote_replicas)
+            .field("channel_service", &self.channel_service)
+            .field("collection_id", &self.collection_id)
+            .field("collection_config", &self.collection_config)
+            .field("shared_storage_config", &self.shared_storage_config)
+            .field("update_runtime", &self.update_runtime)
+            .field("write_ordering_lock", &self.write_ordering_lock)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ShardReplicaSet {

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -18,6 +18,7 @@ pub type PeerId = u64;
 /// Contains a part of the collection's points
 ///
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub enum Shard {
     Local(LocalShard),
     Proxy(ProxyShard),

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -22,12 +22,14 @@ use crate::shards::CollectionId;
 
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
 
+#[derive(Debug)]
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
     ring: HashRing<ShardId>,
 }
 
+#[derive(Debug)]
 pub struct LockedShardHolder(pub RwLock<ShardHolder>);
 
 impl ShardHolder {

--- a/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
+++ b/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
@@ -4,6 +4,7 @@ use crate::common::stoppable_task_async::StoppableAsyncTaskHandle;
 use crate::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::CollectionId;
 
+#[derive(Debug)]
 pub struct TransferTasksPool {
     collection_id: CollectionId,
     tasks: HashMap<ShardTransferKey, StoppableAsyncTaskHandle<bool>>,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,5 +1,6 @@
 use std::cmp::min;
 use std::collections::HashSet;
+use std::fmt;
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -82,6 +83,24 @@ pub struct UpdateHandler {
     wal: LockedWal,
     optimization_handles: Arc<TokioMutex<Vec<StoppableTaskHandle<bool>>>>,
     max_optimization_threads: usize,
+}
+
+impl fmt::Debug for UpdateHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpdateHandler")
+            .field("shared_storage_config", &self.shared_storage_config)
+            .field("flush_interval_sec", &self.flush_interval_sec)
+            .field("segments", &self.segments)
+            .field("update_worker", &self.update_worker)
+            .field("optimizer_worker", &self.optimizer_worker)
+            .field("flush_worker", &self.flush_worker)
+            .field("flush_stop", &self.flush_stop)
+            .field("runtime_handle", &self.runtime_handle)
+            .field("wal", &self.wal)
+            .field("optimization_handles", &self.optimization_handles)
+            .field("max_optimization_threads", &self.max_optimization_threads)
+            .finish_non_exhaustive()
+    }
 }
 
 impl UpdateHandler {

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -62,6 +62,7 @@ impl WalState {
 /// Each stored record is enumerated with sequential number.
 /// Sequential number can be used to read stored records starting from some IDs,
 /// for removing old, no longer required, records.
+#[derive(Debug)]
 pub struct SerdeWal<R> {
     record: PhantomData<R>,
     wal: Wal,

--- a/lib/segment/src/common/mmap_type.rs
+++ b/lib/segment/src/common/mmap_type.rs
@@ -43,6 +43,7 @@ type Result<T> = std::result::Result<T, Error>;
 /// This directly maps (transmutes) the type onto the memory mapped data. This is dangerous and
 /// very error prone and must be used with utmost care. Types holding references are not supported
 /// for example. Malformed data in the mmap will break type `T` and will cause undefined behavior.
+#[derive(Debug)]
 pub struct MmapType<T>
 where
     T: ?Sized + 'static,
@@ -213,6 +214,7 @@ where
 /// Functions as if it is `&[T]` because this implements [`Deref`] and [`DerefMut`].
 ///
 /// A helper because [`MmapType`] doesn't support slices directly.
+#[derive(Debug)]
 pub struct MmapSlice<T>
 where
     T: Sized + 'static,
@@ -281,6 +283,7 @@ impl<T> DerefMut for MmapSlice<T> {
 /// [`BitSlice`] on a memory mapped file
 ///
 /// Functions as if it is a [`BitSlice`] because this implements [`Deref`] and [`DerefMut`].
+#[derive(Debug)]
 pub struct MmapBitSlice {
     mmap: MmapType<BitSlice>,
 }

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -36,6 +36,7 @@ pub struct OperationDurationStatistics {
     pub last_responded: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug)]
 pub struct OperationDurationsAggregator {
     ok_count: usize,
     fail_count: usize,

--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -18,7 +18,7 @@ pub const DB_PAYLOAD_CF: &str = "payload";
 pub const DB_MAPPING_CF: &str = "mapping";
 pub const DB_VERSIONS_CF: &str = "version";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DatabaseColumnWrapper {
     pub database: Arc<RwLock<DB>>,
     pub column_name: String,

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -114,6 +114,7 @@ pub trait ValueIndexer<T> {
 /// Enables polymorphism on field indexes
 /// TODO: Rename with major release
 #[allow(clippy::enum_variant_names)]
+#[derive(Debug)]
 pub enum FieldIndex {
     IntIndex(NumericIndex<IntPayloadType>),
     IntMapIndex(MapIndex<IntPayloadType>),

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -55,7 +55,7 @@ impl ParsedQuery {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct InvertedIndex {
     postings: Vec<Option<PostingList>>,
     pub vocab: HashMap<String, TokenId>,

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -20,6 +20,7 @@ use crate::index::field_index::{
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, PayloadKeyType, PointOffsetType};
 
+#[derive(Debug)]
 pub struct FullTextIndex {
     inverted_index: InvertedIndex,
     db_wrapper: DatabaseColumnWrapper,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -28,6 +28,7 @@ use crate::types::{
 // TODO discuss value, should it be dynamically computed?
 const GEO_QUERY_MAX_REGION: usize = 12;
 
+#[derive(Debug)]
 pub struct GeoMapIndex {
     /**
     {

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -26,6 +26,7 @@ use crate::types::{
 use crate::vector_storage::div_ceil;
 
 /// HashMap-based type of index
+#[derive(Debug)]
 pub struct MapIndex<N: Hash + Eq + Clone + Display> {
     map: HashMap<N, BTreeSet<PointOffsetType>>,
     point_to_values: Vec<Vec<N>>,

--- a/lib/segment/src/index/field_index/numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index.rs
@@ -51,6 +51,7 @@ impl Encodable for FloatPayloadType {
     }
 }
 
+#[derive(Debug)]
 pub struct NumericIndex<T: Encodable + Numericable> {
     map: BTreeMap<Vec<u8>, u32>,
     db_wrapper: DatabaseColumnWrapper,

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -46,7 +46,7 @@ for lvl > 0:
 links offset = level_offsets[level] + offsets[reindex[point_id]]
 */
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct GraphLinksFileHeader {
     pub point_count: u64,
     pub levels_count: u64,
@@ -380,7 +380,7 @@ pub trait GraphLinks: Default {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GraphLinksRam {
     // all flattened links of all levels
     links: Vec<PointOffsetType>,
@@ -481,7 +481,7 @@ impl GraphLinks for GraphLinksRam {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GraphLinksMmap {
     mmap: Option<Arc<Mmap>>,
     header: GraphLinksFileHeader,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -52,6 +53,20 @@ pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     searches_telemetry: SearchesTelemetry,
 }
 
+impl<T: GraphLinks + fmt::Debug> fmt::Debug for HNSWIndex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HNSWIndex")
+            .field("vector_storage", &self.vector_storage)
+            .field("payload_index", &self.payload_index)
+            .field("config", &self.config)
+            .field("path", &self.path)
+            .field("graph", &self.graph)
+            .field("searches_telemetry", &self.searches_telemetry)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 struct SearchesTelemetry {
     unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_hnsw: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -202,6 +203,23 @@ pub struct PlainIndex {
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+impl fmt::Debug for PlainIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlainIndex")
+            .field("vector_storage", &self.vector_storage)
+            .field("payload_index", &self.payload_index)
+            .field(
+                "filtered_searches_telemetry",
+                &self.filtered_searches_telemetry,
+            )
+            .field(
+                "unfiltered_searches_telemetry",
+                &self.unfiltered_searches_telemetry,
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 impl PlainIndex {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs::create_dir_all;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -51,6 +52,19 @@ pub struct StructPayloadIndex {
     /// Used to select unique point ids
     visited_pool: VisitedPool,
     db: Arc<RwLock<DB>>,
+}
+
+impl fmt::Debug for StructPayloadIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StructPayloadIndex")
+            .field("payload", &self.payload)
+            .field("field_indexes", &self.field_indexes)
+            .field("config", &self.config)
+            .field("path", &self.path)
+            .field("visited_pool", &self.visited_pool)
+            .field("db", &self.db)
+            .finish_non_exhaustive()
+    }
 }
 
 impl StructPayloadIndex {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -35,6 +35,7 @@ pub trait VectorIndex {
     fn is_appendable(&self) -> bool;
 }
 
+#[derive(Debug)]
 pub enum VectorIndexEnum {
     Plain(PlainIndex),
     HnswRam(HNSWIndex<GraphLinksRam>),

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -5,7 +5,7 @@ use crate::types::{Payload, PointOffsetType};
 
 /// Same as `SimplePayloadStorage` but without persistence
 /// Warn: for tests only
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct InMemoryPayloadStorage {
     pub(crate) payload: HashMap<PointOffsetType, Payload>,
 }

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -12,6 +12,7 @@ use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 
 /// On-disk implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, does not keep payload in memory
+#[derive(Debug)]
 pub struct OnDiskPayloadStorage {
     db_wrapper: DatabaseColumnWrapper,
 }

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -8,6 +8,7 @@ use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
 use crate::payload_storage::PayloadStorage;
 use crate::types::{Payload, PayloadKeyTypeRef, PointOffsetType};
 
+#[derive(Debug)]
 pub enum PayloadStorageEnum {
     InMemoryPayloadStorage(InMemoryPayloadStorage),
     SimplePayloadStorage(SimplePayloadStorage),

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -10,6 +10,7 @@ use crate::types::{Payload, PointOffsetType};
 
 /// In-memory implementation of `PayloadStorage`.
 /// Persists all changes to disk using `store`, but only uses this storage during the initial load
+#[derive(Debug)]
 pub struct SimplePayloadStorage {
     pub(crate) payload: HashMap<PointOffsetType, Payload>,
     pub(crate) db_wrapper: DatabaseColumnWrapper,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -84,6 +85,25 @@ pub struct Segment {
     pub flush_thread: Mutex<Option<JoinHandle<OperationResult<SeqNumberType>>>>,
 }
 
+impl fmt::Debug for Segment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Segment")
+            .field("version", &self.version)
+            .field("persisted_version", &self.persisted_version)
+            .field("current_path", &self.current_path)
+            .field("vector_data", &self.vector_data)
+            .field("payload_index", &self.payload_index)
+            .field("appendable_flag", &self.appendable_flag)
+            .field("segment_type", &self.segment_type)
+            .field("segment_config", &self.segment_config)
+            .field("error_status", &self.error_status)
+            .field("database", &self.database)
+            .field("flush_thread", &self.flush_thread)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 pub struct VectorData {
     pub vector_index: Arc<AtomicRefCell<VectorIndexEnum>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,

--- a/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
@@ -19,6 +19,7 @@ use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 const VECTORS_DIR_PATH: &str = "vectors";
 const DELETED_DIR_PATH: &str = "deleted";
 
+#[derive(Debug)]
 pub struct AppendableMmapVectorStorage {
     vectors: ChunkedMmapVectors,
     deleted: DynamicMmapFlags,

--- a/lib/segment/src/vector_storage/async_io.rs
+++ b/lib/segment/src/vector_storage/async_io.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::fs::File;
 use std::os::fd::AsRawFd;
 
@@ -10,6 +11,7 @@ use crate::types::PointOffsetType;
 
 const DISK_PARALLELISM: usize = 16; // TODO: benchmark it better, or make it configurable
 
+#[derive(Debug)]
 struct BufferMeta {
     /// Sequential index of the processing point
     pub index: usize,
@@ -17,6 +19,7 @@ struct BufferMeta {
     pub point_id: PointOffsetType,
 }
 
+#[derive(Debug)]
 struct Buffer {
     /// Stores the buffer for the point vectors
     pub buffer: Vec<u8>,
@@ -24,6 +27,7 @@ struct Buffer {
     pub meta: Option<BufferMeta>,
 }
 
+#[derive(Debug)]
 struct BufferStore {
     /// Stores the buffer for the point vectors
     pub buffers: Vec<Buffer>,
@@ -53,6 +57,17 @@ pub struct UringReader {
     io_uring: Option<IoUring>,
     raw_size: usize,
     header_size: usize,
+}
+
+impl fmt::Debug for UringReader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UringReader")
+            .field("file", &self.file)
+            .field("buffers", &self.buffers)
+            .field("raw_size", &self.raw_size)
+            .field("header_size", &self.header_size)
+            .finish_non_exhaustive()
+    }
 }
 
 impl UringReader {

--- a/lib/segment/src/vector_storage/async_io_mock.rs
+++ b/lib/segment/src/vector_storage/async_io_mock.rs
@@ -4,6 +4,7 @@ use crate::entry::entry_point::OperationResult;
 
 // This is a mock implementation of the async_io module for those platforms that don't support io_uring.
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct UringReader;
 
 #[allow(dead_code)]

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -22,18 +22,20 @@ const DEFAULT_CHUNK_SIZE: usize = 32 * 1024 * 1024; // 32Mb
 const CONFIG_FILE_NAME: &str = "config.json";
 const STATUS_FILE_NAME: &str = "status.dat";
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct Status {
     pub len: usize,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct ChunkedMmapConfig {
     chunk_size_bytes: usize,
     chunk_size_vectors: usize,
     dim: usize,
 }
 
+#[derive(Debug)]
 pub struct ChunkedMmapVectors {
     config: ChunkedMmapConfig,
     status: MmapType<Status>,

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -14,6 +14,7 @@ const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 // if dimension is too high, use this capacity
 const MIN_CHUNK_CAPACITY: usize = 16;
 
+#[derive(Debug)]
 pub struct ChunkedVectors<T> {
     dim: usize,
     len: usize,            // amount of stored vectors

--- a/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fmt, fs};
 
 use bitvec::prelude::BitSlice;
 use memmap2::MmapMut;
@@ -58,6 +58,7 @@ impl FileId {
     }
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct DynamicMmapStatus {
     pub len: usize,
@@ -83,6 +84,16 @@ pub struct DynamicMmapFlags {
     flags_flusher: Arc<Mutex<Option<Flusher>>>,
     status: MmapType<DynamicMmapStatus>,
     directory: PathBuf,
+}
+
+impl fmt::Debug for DynamicMmapFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamicMmapFlags")
+            .field("flags", &self.flags)
+            .field("status", &self.status)
+            .field("directory", &self.directory)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Based on the number of flags determines the size of the mmap file.

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -26,6 +26,7 @@ const DELETED_PATH: &str = "deleted.dat";
 /// but possible to mark some vectors as removed
 ///
 /// Mem-mapped storage can only be constructed from another storage
+#[derive(Debug)]
 pub struct MemmapVectorStorage {
     vectors_path: PathBuf,
     deleted_path: PathBuf,

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -27,6 +27,7 @@ const VECTORS_HEADER: &[u8; HEADER_SIZE] = b"data";
 const DELETED_HEADER: &[u8; HEADER_SIZE] = b"drop";
 
 /// Mem-mapped file
+#[derive(Debug)]
 pub struct MmapVectors {
     pub dim: usize,
     pub num_vectors: usize,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -22,12 +23,23 @@ pub const QUANTIZED_CONFIG_PATH: &str = "quantized.config.json";
 pub const QUANTIZED_DATA_PATH: &str = "quantized.data";
 pub const QUANTIZED_META_PATH: &str = "quantized.meta.json";
 
+// TODO: Derive/implement `fmt::Debug` for types in `quantization` crate!
 #[derive(Deserialize, Serialize, Clone)]
 pub struct QuantizedVectorsConfig {
     pub quantization_config: QuantizationConfig,
     pub vector_parameters: quantization::VectorParameters,
 }
 
+// TODO: Derive/implement `fmt::Debug` for types in `quantization` crate!
+impl fmt::Debug for QuantizedVectorsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuantizedVectorsConfig")
+            .field("quantization_config", &self.quantization_config)
+            .finish_non_exhaustive()
+    }
+}
+
+// TODO: Derive/implement `fmt::Debug` for types in `quantization` crate!
 pub enum QuantizedVectorStorage {
     ScalarRam(EncodedVectorsU8<ChunkedVectors<u8>>),
     ScalarMmap(EncodedVectorsU8<QuantizedMmapStorage>),
@@ -35,6 +47,19 @@ pub enum QuantizedVectorStorage {
     PQMmap(EncodedVectorsPQ<QuantizedMmapStorage>),
 }
 
+// TODO: Derive/implement `fmt::Debug` for types in `quantization` crate!
+impl fmt::Debug for QuantizedVectorStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ScalarRam(_) => f.debug_tuple("ScalarRam").finish(),
+            Self::ScalarMmap(_) => f.debug_tuple("ScalarMmap").finish(),
+            Self::PQRam(_) => f.debug_tuple("PQRam").finish(),
+            Self::PQMmap(_) => f.debug_tuple("PQMmap").finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct QuantizedVectors {
     storage_impl: QuantizedVectorStorage,
     config: QuantizedVectorsConfig,

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -22,6 +22,7 @@ use crate::types::{Distance, PointOffsetType, QuantizationConfig};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
 /// In-memory vector storage with on-update persistence using `store`
+#[derive(Debug)]
 pub struct SimpleVectorStorage {
     dim: usize,
     distance: Distance,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -128,6 +128,7 @@ pub trait VectorStorage {
     fn is_appendable(&self) -> bool;
 }
 
+#[derive(Debug)]
 pub enum VectorStorageEnum {
     Simple(SimpleVectorStorage),
     Memmap(Box<MemmapVectorStorage>),

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -12,6 +12,7 @@ use crate::{ConsensusOperations, StorageError};
 
 const COLLECTIONS_META_WAL_DIR: &str = "collections_meta_wal";
 
+#[derive(Debug)]
 pub struct ConsensusOpWal(Wal);
 
 impl ConsensusOpWal {

--- a/lib/storage/src/content_manager/consensus/operation_sender.rs
+++ b/lib/storage/src/content_manager/consensus/operation_sender.rs
@@ -5,6 +5,7 @@ use parking_lot::Mutex;
 use crate::{ConsensusOperations, StorageError};
 
 /// Structure used to notify consensus about operation
+#[derive(Debug)]
 pub struct OperationSender(Mutex<Sender<ConsensusOperations>>);
 
 impl OperationSender {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -64,6 +64,7 @@ impl TryFrom<&[u8]> for SnapshotData {
     }
 }
 
+#[derive(Debug)]
 pub struct ConsensusManager<C: CollectionContainer> {
     pub persistent: RwLock<Persistent>,
     /// Notifies if the current node knows who the leader and is not in the process of election
@@ -746,7 +747,7 @@ impl<C: CollectionContainer> Storage for ConsensusManager<C> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConsensusStateRef(pub Arc<prelude::ConsensusState>);
 
 impl Deref for ConsensusStateRef {

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -68,6 +68,7 @@ pub const DEFAULT_WRITE_LOCK_ERROR_MESSAGE: &str = "Write operations are forbidd
 /// The main object of the service. It holds all objects, required for proper functioning.
 /// In most cases only one `TableOfContent` is enough for service. It is created only once during
 /// the launch of the service.
+#[derive(Debug)]
 pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: Arc<StorageConfig>,

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -8,6 +8,7 @@ use crate::{
     TableOfContent,
 };
 
+#[derive(Debug)]
 pub struct Dispatcher {
     toc: Arc<TableOfContent>,
     consensus_state: Option<ConsensusStateRef>,

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -17,6 +17,7 @@ use super::validate;
 use crate::common::collections::*;
 use crate::tonic::api::collections_common::get;
 
+#[derive(Debug)]
 pub struct CollectionsService {
     dispatcher: Arc<Dispatcher>,
 }


### PR DESCRIPTION
Pretty much PR title. It's just annoying to not be able to dump the content of a structure when you need it during debug.

__TODO:__
- [ ] ensure there are no recursive references between the types
  - e.g., with either `Arc`s or references lifetime-erased with `unsafe`
- [ ] validate that `fmt::Debug` derives/implementations for unsafe-ish types are safe/correct/sound
  - e.g., `MmapType`, `MmapSlice`, etc

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
