### PR TITLE
Add missed vector preprocess

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -77,7 +77,7 @@ pub fn random_multi_vec_segment(
         let random_keyword = format!("keyword_{}", rnd.gen_range(1..10));
         let payload: Payload =
             json!({ payload_key: vec![payload_value], keyword_key: random_keyword}).into();
-        segment.upsert_point(opnum, point_id, &vectors).unwrap();
+        segment.upsert_point(opnum, point_id, vectors).unwrap();
         segment.set_payload(opnum, point_id, &payload).unwrap();
     }
     segment
@@ -94,7 +94,7 @@ pub fn random_segment(path: &Path, opnum: SeqNumberType, num_vectors: u64, dim: 
         let payload_value = rnd.gen_range(1..1_000);
         let payload: Payload = json!({ payload_key: vec![payload_value] }).into();
         segment
-            .upsert_point(opnum, point_id, &only_default_vector(&random_vector))
+            .upsert_point(opnum, point_id, only_default_vector(&random_vector))
             .unwrap();
         segment.set_payload(opnum, point_id, &payload).unwrap();
     }
@@ -111,19 +111,19 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
     segment1
-        .upsert_point(1, 1.into(), &only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1))
         .unwrap();
     segment1
-        .upsert_point(2, 2.into(), &only_default_vector(&vec2))
+        .upsert_point(2, 2.into(), only_default_vector(&vec2))
         .unwrap();
     segment1
-        .upsert_point(3, 3.into(), &only_default_vector(&vec3))
+        .upsert_point(3, 3.into(), only_default_vector(&vec3))
         .unwrap();
     segment1
-        .upsert_point(4, 4.into(), &only_default_vector(&vec4))
+        .upsert_point(4, 4.into(), only_default_vector(&vec4))
         .unwrap();
     segment1
-        .upsert_point(5, 5.into(), &only_default_vector(&vec5))
+        .upsert_point(5, 5.into(), only_default_vector(&vec5))
         .unwrap();
 
     let payload_key = "color";
@@ -155,26 +155,26 @@ pub fn build_segment_2(path: &Path) -> Segment {
     let vec15 = vec![1.0, 1.0, 0.0, 0.0];
 
     segment2
-        .upsert_point(7, 4.into(), &only_default_vector(&vec4))
+        .upsert_point(7, 4.into(), only_default_vector(&vec4))
         .unwrap();
     segment2
-        .upsert_point(8, 5.into(), &only_default_vector(&vec5))
+        .upsert_point(8, 5.into(), only_default_vector(&vec5))
         .unwrap();
 
     segment2
-        .upsert_point(11, 11.into(), &only_default_vector(&vec11))
+        .upsert_point(11, 11.into(), only_default_vector(&vec11))
         .unwrap();
     segment2
-        .upsert_point(12, 12.into(), &only_default_vector(&vec12))
+        .upsert_point(12, 12.into(), only_default_vector(&vec12))
         .unwrap();
     segment2
-        .upsert_point(13, 13.into(), &only_default_vector(&vec13))
+        .upsert_point(13, 13.into(), only_default_vector(&vec13))
         .unwrap();
     segment2
-        .upsert_point(14, 14.into(), &only_default_vector(&vec14))
+        .upsert_point(14, 14.into(), only_default_vector(&vec14))
         .unwrap();
     segment2
-        .upsert_point(15, 15.into(), &only_default_vector(&vec15))
+        .upsert_point(15, 15.into(), only_default_vector(&vec15))
         .unwrap();
 
     segment2

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -118,7 +118,7 @@ impl ProxySegment {
         let segment_arc = self.write_segment.get();
         let mut write_segment = segment_arc.write();
 
-        write_segment.upsert_point(op_num, point_id, &all_vectors)?;
+        write_segment.upsert_point(op_num, point_id, all_vectors)?;
         write_segment.set_full_payload(op_num, point_id, &payload)?;
 
         Ok(true)
@@ -287,7 +287,7 @@ impl SegmentEntry for ProxySegment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vectors: &NamedVectors,
+        vectors: NamedVectors,
     ) -> OperationResult<bool> {
         self.move_if_exists(op_num, point_id)?;
         self.write_segment
@@ -790,11 +790,11 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4))
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), &only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6))
             .unwrap();
         proxy_segment.delete_point(102, 1.into()).unwrap();
 
@@ -857,11 +857,11 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4))
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), &only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6))
             .unwrap();
         proxy_segment.delete_point(102, 1.into()).unwrap();
 
@@ -1181,16 +1181,16 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         proxy_segment
-            .upsert_point(100, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4))
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         proxy_segment
-            .upsert_point(101, 6.into(), &only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6))
             .unwrap();
         proxy_segment.delete_point(102, 1.into()).unwrap();
 
         proxy_segment2
-            .upsert_point(201, 11.into(), &only_default_vector(&vec6))
+            .upsert_point(201, 11.into(), only_default_vector(&vec6))
             .unwrap();
 
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
@@ -1305,14 +1305,14 @@ mod tests {
             .upsert_point(
                 100,
                 4.into(),
-                &NamedVectors::from([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
+                NamedVectors::from([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
             )
             .unwrap();
         original_segment
             .upsert_point(
                 101,
                 6.into(),
-                &NamedVectors::from([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
+                NamedVectors::from([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
             )
             .unwrap();
 
@@ -1340,17 +1340,13 @@ mod tests {
 
         // Insert point ID 8 and 10 partially, assert counts
         proxy_segment
-            .upsert_point(
-                102,
-                8.into(),
-                &NamedVectors::from([("a".into(), vec![0.0])]),
-            )
+            .upsert_point(102, 8.into(), NamedVectors::from([("a".into(), vec![0.0])]))
             .unwrap();
         proxy_segment
             .upsert_point(
                 103,
                 10.into(),
-                &NamedVectors::from([("b".into(), vec![1.0])]),
+                NamedVectors::from([("b".into(), vec![1.0])]),
             )
             .unwrap();
         let segment_info = proxy_segment.info();
@@ -1383,11 +1379,7 @@ mod tests {
 
         // Replace vector 'a' for point 8, counts should remain the same
         proxy_segment
-            .upsert_point(
-                108,
-                8.into(),
-                &NamedVectors::from([("a".into(), vec![0.0])]),
-            )
+            .upsert_point(108, 8.into(), NamedVectors::from([("a".into(), vec![0.0])]))
             .unwrap();
         let segment_info = proxy_segment.info();
         assert_eq!(segment_info.num_points, 3);
@@ -1398,7 +1390,7 @@ mod tests {
             .upsert_point(
                 109,
                 8.into(),
-                &NamedVectors::from([("a".into(), vec![0.0]), ("b".into(), vec![0.0])]),
+                NamedVectors::from([("a".into(), vec![0.0]), ("b".into(), vec![0.0])]),
             )
             .unwrap();
         let segment_info = proxy_segment.info();

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -360,7 +360,7 @@ impl<'s> SegmentHolder {
                         let all_vectors = write_segment.all_vectors(point_id)?;
                         let payload = write_segment.payload(point_id)?;
 
-                        appendable_write_segment.upsert_point(op_num, point_id, &all_vectors)?;
+                        appendable_write_segment.upsert_point(op_num, point_id, all_vectors)?;
                         appendable_write_segment.set_full_payload(op_num, point_id, &payload)?;
 
                         write_segment.delete_point(op_num, point_id)?;

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -247,7 +247,7 @@ fn upsert_with_payload(
     segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
     op_num: SeqNumberType,
     point_id: PointIdType,
-    vectors: &NamedVectors,
+    vectors: NamedVectors,
     payload: Option<&Payload>,
 ) -> OperationResult<bool> {
     let mut res = segment.upsert_point(op_num, point_id, vectors)?;
@@ -360,7 +360,7 @@ where
                 write_segment,
                 op_num,
                 id,
-                &point.get_vectors(),
+                point.get_vectors(),
                 point.payload.as_ref(),
             )
         })?;
@@ -385,7 +385,7 @@ where
                 &mut write_segment,
                 op_num,
                 point_id,
-                &point.get_vectors(),
+                point.get_vectors(),
                 point.payload.as_ref(),
             )? as usize;
         }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use super::tiny_map;
 use super::vectors::{VectorElementType, DEFAULT_VECTOR_NAME};
+use crate::types::Distance;
 
 type CowKey<'a> = Cow<'a, str>;
 type CowValue<'a> = Cow<'a, [VectorElementType]>;
@@ -92,6 +93,18 @@ impl<'a> NamedVectors<'a> {
 
     pub fn get(&self, key: &str) -> Option<&[VectorElementType]> {
         self.map.get(key).map(|v| v.as_ref())
+    }
+
+    pub fn preprocess<F>(&mut self, distance_map: F)
+    where
+        F: Fn(&str) -> Distance,
+    {
+        for (name, vector) in self.map.iter_mut() {
+            let distance = distance_map(name);
+            if let Some(preprocessed_vector) = distance.preprocess_vector(vector) {
+                *vector = CowValue::Owned(preprocessed_vector);
+            }
+        }
     }
 }
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -225,7 +225,7 @@ pub trait SegmentEntry {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vectors: &NamedVectors,
+        vectors: NamedVectors,
     ) -> OperationResult<bool>;
 
     fn delete_point(

--- a/lib/segment/src/fixtures/segment_fixtures.rs
+++ b/lib/segment/src/fixtures/segment_fixtures.rs
@@ -25,7 +25,7 @@ pub fn random_segment(path: &Path, num_points: usize) -> Segment {
             .upsert_point(
                 100,
                 (point_id as u64).into(),
-                &NamedVectors::from_ref(DEFAULT_VECTOR_NAME, &vector),
+                NamedVectors::from_ref(DEFAULT_VECTOR_NAME, &vector),
             )
             .unwrap();
         segment

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -712,6 +712,15 @@ impl Segment {
             ))
             .spawn(move || tasks.iter().for_each(mmap_ops::PrefaultMmapPages::exec));
     }
+
+    fn preprocess_named_vectors<'a>(
+        &self,
+        mut vectors: NamedVectors<'a>,
+    ) -> OperationResult<NamedVectors<'a>> {
+        check_named_vectors(&vectors, &self.segment_config)?;
+        vectors.preprocess(|name| self.segment_config.vector_data[name].distance);
+        Ok(vectors)
+    }
 }
 
 /// This is a basic implementation of `SegmentEntry`,
@@ -780,31 +789,17 @@ impl SegmentEntry for Segment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vectors: &NamedVectors,
+        vectors: NamedVectors,
     ) -> OperationResult<bool> {
         debug_assert!(self.is_appendable());
-        check_named_vectors(vectors, &self.segment_config)?;
+        let vectors = self.preprocess_named_vectors(vectors)?;
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
         self.handle_version_and_failure(op_num, stored_internal_point, |segment| {
-            let mut processed_vectors = NamedVectors::default();
-            for (vector_name, vector) in vectors.iter() {
-                let vector_name: &str = vector_name;
-                let processed_vector_opt = segment.segment_config.vector_data[vector_name]
-                    .distance
-                    .preprocess_vector(vector);
-                match processed_vector_opt {
-                    None => processed_vectors.insert_ref(vector_name, vector),
-                    Some(preprocess_vector) => {
-                        processed_vectors.insert(vector_name.to_string(), preprocess_vector)
-                    }
-                }
-            }
-
             if let Some(existing_internal_id) = stored_internal_point {
-                segment.replace_all_vectors(existing_internal_id, processed_vectors)?;
+                segment.replace_all_vectors(existing_internal_id, vectors)?;
                 Ok((true, Some(existing_internal_id)))
             } else {
-                let new_index = segment.insert_new_vectors(point_id, processed_vectors)?;
+                let new_index = segment.insert_new_vectors(point_id, vectors)?;
                 Ok((false, Some(new_index)))
             }
         })
@@ -843,7 +838,7 @@ impl SegmentEntry for Segment {
         point_id: PointIdType,
         vectors: NamedVectors,
     ) -> OperationResult<bool> {
-        check_named_vectors(&vectors, &self.segment_config)?;
+        let vectors = self.preprocess_named_vectors(vectors)?;
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
             None => Err(OperationError::PointIdError {
@@ -1561,11 +1556,11 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         segment
-            .upsert_point(100, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4))
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         segment
-            .upsert_point(101, 6.into(), &only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6))
             .unwrap();
         segment.delete_point(102, 1.into()).unwrap();
 
@@ -1630,7 +1625,7 @@ mod tests {
 
         let mut segment = build_segment(dir.path(), &config, true).unwrap();
         segment
-            .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
+            .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
             .unwrap();
 
         let payload: Payload = serde_json::from_str(data).unwrap();
@@ -1720,7 +1715,7 @@ mod tests {
         let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
 
         segment
-            .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
+            .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
             .unwrap();
 
         segment
@@ -1810,7 +1805,7 @@ mod tests {
 
         let mut segment = build_segment(segment_base_dir.path(), &config, true).unwrap();
         segment
-            .upsert_point(0, 0.into(), &only_default_vector(&[1.0, 1.0]))
+            .upsert_point(0, 0.into(), only_default_vector(&[1.0, 1.0]))
             .unwrap();
 
         let payload: Payload = serde_json::from_str(data).unwrap();
@@ -1842,11 +1837,11 @@ mod tests {
 
         let vec4 = vec![1.1, 1.0, 0.0, 1.0];
         segment
-            .upsert_point(100, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(100, 4.into(), only_default_vector(&vec4))
             .unwrap();
         let vec6 = vec![1.0, 1.0, 0.5, 1.0];
         segment
-            .upsert_point(101, 6.into(), &only_default_vector(&vec6))
+            .upsert_point(101, 6.into(), only_default_vector(&vec6))
             .unwrap();
 
         // first pass on consistent data
@@ -1937,10 +1932,10 @@ mod tests {
 
         // Insert point ID 4 and 6, assert counts
         segment
-            .upsert_point(100, 4.into(), &only_default_vector(&[0.4]))
+            .upsert_point(100, 4.into(), only_default_vector(&[0.4]))
             .unwrap();
         segment
-            .upsert_point(101, 6.into(), &only_default_vector(&[0.6]))
+            .upsert_point(101, 6.into(), only_default_vector(&[0.6]))
             .unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 2);
@@ -2003,28 +1998,24 @@ mod tests {
             .upsert_point(
                 100,
                 4.into(),
-                &NamedVectors::from([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
+                NamedVectors::from([("a".into(), vec![0.4]), ("b".into(), vec![0.5])]),
             )
             .unwrap();
         segment
             .upsert_point(
                 101,
                 6.into(),
-                &NamedVectors::from([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
+                NamedVectors::from([("a".into(), vec![0.6]), ("b".into(), vec![0.7])]),
             )
             .unwrap();
         segment
-            .upsert_point(
-                102,
-                8.into(),
-                &NamedVectors::from([("a".into(), vec![0.0])]),
-            )
+            .upsert_point(102, 8.into(), NamedVectors::from([("a".into(), vec![0.0])]))
             .unwrap();
         segment
             .upsert_point(
                 103,
                 10.into(),
-                &NamedVectors::from([("b".into(), vec![1.0])]),
+                NamedVectors::from([("b".into(), vec![1.0])]),
             )
             .unwrap();
         let segment_info = segment.info();
@@ -2113,7 +2104,7 @@ mod tests {
             .upsert_point(
                 100,
                 point_id,
-                &NamedVectors::from([
+                NamedVectors::from([
                     ("a".into(), vec![0.1, 0.2, 0.3, 0.4]),
                     ("b".into(), vec![1.0, 0.9]),
                 ]),
@@ -2200,7 +2191,10 @@ mod tests {
 
         for vectors in wrong_vectors_multi {
             check_named_vectors(&vectors, &config).err().unwrap();
-            segment.upsert_point(101, point_id, &vectors).err().unwrap();
+            segment
+                .upsert_point(101, point_id, vectors.clone())
+                .err()
+                .unwrap();
             segment
                 .update_vectors(internal_id, vectors.clone())
                 .err()

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -104,26 +104,26 @@ mod tests {
         let vec4 = vec![1.0, 1.0, 0.0, 1.0];
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
-        match segment.upsert_point(1, 120.into(), &only_default_vector(&wrong_vec)) {
+        match segment.upsert_point(1, 120.into(), only_default_vector(&wrong_vec)) {
             Err(OperationError::WrongVector { .. }) => (),
             Err(_) => panic!("Wrong error"),
             Ok(_) => panic!("Operation with wrong vector should fail"),
         };
 
         segment
-            .upsert_point(2, 1.into(), &only_default_vector(&vec1))
+            .upsert_point(2, 1.into(), only_default_vector(&vec1))
             .unwrap();
         segment
-            .upsert_point(2, 2.into(), &only_default_vector(&vec2))
+            .upsert_point(2, 2.into(), only_default_vector(&vec2))
             .unwrap();
         segment
-            .upsert_point(2, 3.into(), &only_default_vector(&vec3))
+            .upsert_point(2, 3.into(), only_default_vector(&vec3))
             .unwrap();
         segment
-            .upsert_point(2, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(2, 4.into(), only_default_vector(&vec4))
             .unwrap();
         segment
-            .upsert_point(2, 5.into(), &only_default_vector(&vec5))
+            .upsert_point(2, 5.into(), only_default_vector(&vec5))
             .unwrap();
 
         segment
@@ -160,25 +160,25 @@ mod tests {
 
         // Replace vectors
         segment
-            .upsert_point(4, 1.into(), &only_default_vector(&vec1))
+            .upsert_point(4, 1.into(), only_default_vector(&vec1))
             .unwrap();
         segment
-            .upsert_point(5, 2.into(), &only_default_vector(&vec2))
+            .upsert_point(5, 2.into(), only_default_vector(&vec2))
             .unwrap();
         segment
-            .upsert_point(6, 3.into(), &only_default_vector(&vec3))
+            .upsert_point(6, 3.into(), only_default_vector(&vec3))
             .unwrap();
         segment
-            .upsert_point(7, 4.into(), &only_default_vector(&vec4))
+            .upsert_point(7, 4.into(), only_default_vector(&vec4))
             .unwrap();
         segment
-            .upsert_point(8, 5.into(), &only_default_vector(&vec5))
+            .upsert_point(8, 5.into(), only_default_vector(&vec5))
             .unwrap();
 
         assert_eq!(segment.version(), 8);
 
         let declined = segment
-            .upsert_point(3, 5.into(), &only_default_vector(&vec5))
+            .upsert_point(3, 5.into(), only_default_vector(&vec5))
             .unwrap();
 
         // Should not be processed due to operation number

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -59,7 +59,7 @@ fn test_batch_and_single_request_equivalency() {
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, &only_default_vector(&vector))
+            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
             .unwrap();
         segment
             .set_full_payload(n as SeqNumberType, idx, &payload)

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -27,7 +27,7 @@ fn test_rebuild_with_removed_vectors() {
             .upsert_point(
                 1,
                 i.into(),
-                &NamedVectors::from([
+                NamedVectors::from([
                     ("vector1".to_string(), vec![i as f32, 0., 0., 0.]),
                     ("vector2".to_string(), vec![0., i as f32, 0., 0., 0., 0.]),
                 ]),
@@ -46,7 +46,7 @@ fn test_rebuild_with_removed_vectors() {
         };
 
         segment2
-            .upsert_point(1, (NUM_VECTORS_1 + i).into(), &vectors)
+            .upsert_point(1, (NUM_VECTORS_1 + i).into(), vectors)
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -62,7 +62,7 @@ fn exact_search_test() {
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, &only_default_vector(&vector))
+            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
             .unwrap();
         segment
             .set_full_payload(n as SeqNumberType, idx, &payload)

--- a/lib/segment/tests/integration/fail_recovery_test.rs
+++ b/lib/segment/tests/integration/fail_recovery_test.rs
@@ -14,10 +14,10 @@ fn test_insert_fail_recovery() {
     let mut segment = empty_segment(dir.path());
 
     segment
-        .upsert_point(1, 1.into(), &only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1))
         .unwrap();
     segment
-        .upsert_point(1, 2.into(), &only_default_vector(&vec1))
+        .upsert_point(1, 2.into(), only_default_vector(&vec1))
         .unwrap();
 
     segment.error_status = Some(SegmentFailedState {

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -63,7 +63,7 @@ fn test_filterable_hnsw() {
         let payload: Payload = json!({int_key:int_payload,}).into();
 
         segment
-            .upsert_point(n as SeqNumberType, idx, &only_default_vector(&vector))
+            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
             .unwrap();
         segment
             .set_full_payload(n as SeqNumberType, idx, &payload)

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -25,19 +25,19 @@ pub fn build_segment_1(path: &Path) -> Segment {
     let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
     segment1
-        .upsert_point(1, 1.into(), &only_default_vector(&vec1))
+        .upsert_point(1, 1.into(), only_default_vector(&vec1))
         .unwrap();
     segment1
-        .upsert_point(2, 2.into(), &only_default_vector(&vec2))
+        .upsert_point(2, 2.into(), only_default_vector(&vec2))
         .unwrap();
     segment1
-        .upsert_point(3, 3.into(), &only_default_vector(&vec3))
+        .upsert_point(3, 3.into(), only_default_vector(&vec3))
         .unwrap();
     segment1
-        .upsert_point(4, 4.into(), &only_default_vector(&vec4))
+        .upsert_point(4, 4.into(), only_default_vector(&vec4))
         .unwrap();
     segment1
-        .upsert_point(5, 5.into(), &only_default_vector(&vec5))
+        .upsert_point(5, 5.into(), only_default_vector(&vec5))
         .unwrap();
 
     let payload_key = "color";
@@ -66,19 +66,19 @@ pub fn build_segment_2(path: &Path) -> Segment {
     let vec5 = vec![-1.0, 0.0, 0.0, 0.0];
 
     segment2
-        .upsert_point(11, 11.into(), &only_default_vector(&vec1))
+        .upsert_point(11, 11.into(), only_default_vector(&vec1))
         .unwrap();
     segment2
-        .upsert_point(12, 12.into(), &only_default_vector(&vec2))
+        .upsert_point(12, 12.into(), only_default_vector(&vec2))
         .unwrap();
     segment2
-        .upsert_point(13, 13.into(), &only_default_vector(&vec3))
+        .upsert_point(13, 13.into(), only_default_vector(&vec3))
         .unwrap();
     segment2
-        .upsert_point(14, 14.into(), &only_default_vector(&vec4))
+        .upsert_point(14, 14.into(), only_default_vector(&vec4))
         .unwrap();
     segment2
-        .upsert_point(15, 15.into(), &only_default_vector(&vec5))
+        .upsert_point(15, 15.into(), only_default_vector(&vec5))
         .unwrap();
 
     let payload_key = "color";
@@ -184,19 +184,19 @@ pub fn build_segment_3(path: &Path) -> Segment {
     ];
 
     segment3
-        .upsert_point(1, 1.into(), &collect_points_data(&vec1))
+        .upsert_point(1, 1.into(), collect_points_data(&vec1))
         .unwrap();
     segment3
-        .upsert_point(2, 2.into(), &collect_points_data(&vec2))
+        .upsert_point(2, 2.into(), collect_points_data(&vec2))
         .unwrap();
     segment3
-        .upsert_point(3, 3.into(), &collect_points_data(&vec3))
+        .upsert_point(3, 3.into(), collect_points_data(&vec3))
         .unwrap();
     segment3
-        .upsert_point(4, 4.into(), &collect_points_data(&vec4))
+        .upsert_point(4, 4.into(), collect_points_data(&vec4))
         .unwrap();
     segment3
-        .upsert_point(5, 5.into(), &collect_points_data(&vec5))
+        .upsert_point(5, 5.into(), collect_points_data(&vec5))
         .unwrap();
 
     let payload_key = "color";

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -63,7 +63,7 @@ fn hnsw_quantized_search_test(
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);
         segment
-            .upsert_point(n as SeqNumberType, idx, &only_default_vector(&vector))
+            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
             .unwrap();
     }
     segment.vector_data.values_mut().for_each(|vector_storage| {

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -61,10 +61,10 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
         let payload: Payload = generate_diverse_payload(&mut rnd);
 
         plain_segment
-            .upsert_point(opnum, idx, &only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector))
             .unwrap();
         struct_segment
-            .upsert_point(opnum, idx, &only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector))
             .unwrap();
         plain_segment
             .set_full_payload(opnum, idx, &payload)
@@ -198,10 +198,10 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
         let payload: Payload = generate_diverse_nested_payload(&mut rnd);
 
         plain_segment
-            .upsert_point(opnum, idx, &only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector))
             .unwrap();
         struct_segment
-            .upsert_point(opnum, idx, &only_default_vector(&vector))
+            .upsert_point(opnum, idx, only_default_vector(&vector))
             .unwrap();
         plain_segment
             .set_full_payload(opnum, idx, &payload)

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -31,7 +31,7 @@ fn test_building_new_segment() {
 
     // Include overlapping with segment1 to check the
     segment2
-        .upsert_point(100, 3.into(), &only_default_vector(&[0., 0., 0., 0.]))
+        .upsert_point(100, 3.into(), only_default_vector(&[0., 0., 0., 0.]))
         .unwrap();
 
     builder.update_from(&segment1, &stopped).unwrap();
@@ -133,7 +133,7 @@ fn test_building_cancellation() {
 
     for idx in 0..1000 {
         segment
-            .upsert_point(1, idx.into(), &only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
     }
 

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -1,11 +1,14 @@
 use std::collections::HashSet;
 use std::iter::FromIterator;
 
+use itertools::Itertools;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use segment::data_types::vectors::{only_default_vector, VectorStruct, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::{OperationError, SegmentEntry};
+use segment::fixtures::index_fixtures::random_vector;
 use segment::segment_constructor::load_segment;
-use segment::types::{Condition, Filter, WithPayload};
+use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+use segment::types::{Condition, Distance, Filter, SearchParams, WithPayload};
 use tempfile::Builder;
 
 use crate::fixtures::segment::{build_segment_1, build_segment_3};
@@ -204,4 +207,95 @@ fn ordered_deletion_test() {
         .unwrap();
     let best_match = res.get(0).expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
+}
+
+#[test]
+fn test_update_named_vector() {
+    let num_points = 25;
+    let dim = 4;
+    let mut rng = rand::thread_rng();
+    let distance = Distance::Cosine;
+    let vectors = (0..num_points)
+        .map(|_| random_vector(&mut rng, dim))
+        .collect_vec();
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
+
+    for (i, vec) in vectors.iter().enumerate() {
+        let i = i as u64;
+        segment
+            .upsert_point(i, i.into(), &only_default_vector(&vec))
+            .unwrap();
+    }
+
+    let query_vector = random_vector(&mut rng, dim);
+
+    // do exact search
+    let search_params = SearchParams {
+        hnsw_ef: None,
+        exact: true,
+        quantization: None,
+    };
+    let nearest_upsert = segment
+        .search(
+            DEFAULT_VECTOR_NAME,
+            &query_vector,
+            &false.into(),
+            &true.into(),
+            None,
+            1,
+            Some(&search_params),
+        )
+        .unwrap();
+    let nearest_upsert = nearest_upsert.get(0).unwrap();
+
+    let sqrt_distance = |v: &[f32]| -> f32 { v.iter().map(|x| x * x).sum::<f32>().sqrt() };
+
+    // check if nearest_upsert is normalized
+    match &nearest_upsert.vector {
+        Some(VectorStruct::Single(v)) => {
+            assert!((sqrt_distance(&v) - 1.).abs() < 1e-5);
+        }
+        Some(VectorStruct::Multi(v)) => {
+            assert!((sqrt_distance(&v[DEFAULT_VECTOR_NAME]) - 1.).abs() < 1e-5);
+        }
+        _ => panic!("unexpected vector type"),
+    }
+
+    // update vector using the same values
+    for (i, vec) in vectors.iter().enumerate() {
+        let i = i as u64;
+        segment
+            .update_vectors(i + num_points as u64, i.into(), only_default_vector(&vec))
+            .unwrap();
+    }
+
+    // do search after update
+    let nearest_update = segment
+        .search(
+            DEFAULT_VECTOR_NAME,
+            &query_vector,
+            &false.into(),
+            &true.into(),
+            None,
+            1,
+            Some(&search_params),
+        )
+        .unwrap();
+    let nearest_update = nearest_update.get(0).unwrap();
+
+    // check that nearest_upsert is normalized
+    match &nearest_update.vector {
+        Some(VectorStruct::Single(v)) => {
+            assert!((sqrt_distance(&v) - 1.).abs() < 1e-5);
+        }
+        Some(VectorStruct::Multi(v)) => {
+            assert!((sqrt_distance(&v[DEFAULT_VECTOR_NAME]) - 1.).abs() < 1e-5);
+        }
+        _ => panic!("unexpected vector type"),
+    }
+
+    // check that nearests are the same
+    assert_eq!(nearest_upsert.id, nearest_update.id);
 }

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -225,7 +225,7 @@ fn test_update_named_vector() {
     for (i, vec) in vectors.iter().enumerate() {
         let i = i as u64;
         segment
-            .upsert_point(i, i.into(), only_default_vector(&vec))
+            .upsert_point(i, i.into(), only_default_vector(vec))
             .unwrap();
     }
 
@@ -255,7 +255,7 @@ fn test_update_named_vector() {
     // check if nearest_upsert is normalized
     match &nearest_upsert.vector {
         Some(VectorStruct::Single(v)) => {
-            assert!((sqrt_distance(&v) - 1.).abs() < 1e-5);
+            assert!((sqrt_distance(v) - 1.).abs() < 1e-5);
         }
         Some(VectorStruct::Multi(v)) => {
             assert!((sqrt_distance(&v[DEFAULT_VECTOR_NAME]) - 1.).abs() < 1e-5);
@@ -267,7 +267,7 @@ fn test_update_named_vector() {
     for (i, vec) in vectors.iter().enumerate() {
         let i = i as u64;
         segment
-            .update_vectors(i + num_points as u64, i.into(), only_default_vector(&vec))
+            .update_vectors(i + num_points as u64, i.into(), only_default_vector(vec))
             .unwrap();
     }
 
@@ -288,7 +288,7 @@ fn test_update_named_vector() {
     // check that nearest_upsert is normalized
     match &nearest_update.vector {
         Some(VectorStruct::Single(v)) => {
-            assert!((sqrt_distance(&v) - 1.).abs() < 1e-5);
+            assert!((sqrt_distance(v) - 1.).abs() < 1e-5);
         }
         Some(VectorStruct::Multi(v)) => {
             assert!((sqrt_distance(&v[DEFAULT_VECTOR_NAME]) - 1.).abs() < 1e-5);

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -136,7 +136,7 @@ fn test_missed_vector_name() {
         .upsert_point(
             7,
             1.into(),
-            &NamedVectors::from([
+            NamedVectors::from([
                 ("vector2".to_owned(), vec![10.]),
                 ("vector3".to_owned(), vec![5., 6., 7., 8.]),
             ]),
@@ -148,7 +148,7 @@ fn test_missed_vector_name() {
         .upsert_point(
             8,
             6.into(),
-            &NamedVectors::from([
+            NamedVectors::from([
                 ("vector2".to_owned(), vec![10.]),
                 ("vector3".to_owned(), vec![5., 6., 7., 8.]),
             ]),
@@ -165,7 +165,7 @@ fn test_vector_name_not_exists() {
     let result = segment.upsert_point(
         6,
         6.into(),
-        &NamedVectors::from([
+        NamedVectors::from([
             ("vector1".to_owned(), vec![5., 6., 7., 8.]),
             ("vector2".to_owned(), vec![10.]),
             ("vector3".to_owned(), vec![5., 6., 7., 8.]),
@@ -225,7 +225,7 @@ fn test_update_named_vector() {
     for (i, vec) in vectors.iter().enumerate() {
         let i = i as u64;
         segment
-            .upsert_point(i, i.into(), &only_default_vector(&vec))
+            .upsert_point(i, i.into(), only_default_vector(&vec))
             .unwrap();
     }
 

--- a/openapi/tests/openapi_integration/test_optional_vectors.py
+++ b/openapi/tests/openapi_integration/test_optional_vectors.py
@@ -13,6 +13,15 @@ def setup():
     drop_collection(collection_name=collection_name)
 
 
+def compare_vectors(v1, v2):
+    if len(v1) != len(v2):
+        return False
+    for i in range(len(v1)):
+        if abs(v1[i] - v2[i]) > 1e-5:
+            return False
+    return True
+
+
 def test_delete_and_search():
     response = request_with_validation(
         api='/collections/{collection_name}/points/vectors/delete',
@@ -187,7 +196,12 @@ def update_vectors():
     result = response.json()["result"]
     assert result["vector"].get("text") is None
 
-    text_vector = [0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98]
+    text_vector = [
+        0.34035879, 0.344099,
+        0.3478392, 0.35157941,
+        0.35531961, 0.35905982,
+        0.36280003, 0.36654023
+    ]
     response = request_with_validation(
         api='/collections/{collection_name}/points/vectors',
         method="PUT",
@@ -213,10 +227,15 @@ def update_vectors():
     )
     assert response.ok
     result = response.json()["result"]
-    assert result["vector"]["text"] == text_vector
+    assert compare_vectors(result["vector"]["text"], text_vector)
     assert result["payload"]["city"] == "Berlin"
 
-    text_vector = [0.12, 0.34, 0.56, 0.78, 0.90, 0.12, 0.34, 0.56]
+    text_vector = [
+        0.07902951, 0.22391693,
+        0.36880436, 0.51369179,
+        0.59272129, 0.07902951,
+        0.22391693, 0.36880436
+    ]
     image_vector = [0.19, 0.28, 0.37, 0.46]
     response = request_with_validation(
         api='/collections/{collection_name}/points/vectors',
@@ -244,8 +263,8 @@ def update_vectors():
     )
     assert response.ok
     result = response.json()["result"]
-    assert result["vector"]["image"] == image_vector
-    assert result["vector"]["text"] == text_vector
+    assert compare_vectors(result["vector"]["image"], image_vector)
+    assert compare_vectors(result["vector"]["text"], text_vector)
 
     image_vector = [0.00, 0.01, 0.00, 0.01]
     response = request_with_validation(
@@ -273,8 +292,8 @@ def update_vectors():
     )
     assert response.ok
     result = response.json()["result"]
-    assert result["vector"]["image"] == image_vector
-    assert result["vector"]["text"] == text_vector
+    assert compare_vectors(result["vector"]["image"], image_vector)
+    assert compare_vectors(result["vector"]["text"], text_vector)
 
 
 def test_update_vectors():
@@ -308,7 +327,12 @@ def update_empty_vectors():
     assert "text" not in result["vector"]
     assert "image" not in result["vector"]
 
-    text_vector = [0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98]
+    text_vector = [
+        0.34035879, 0.344099,
+        0.3478392, 0.35157941,
+        0.35531961, 0.35905982,
+        0.36280003, 0.36654023
+    ]
     response = request_with_validation(
         api='/collections/{collection_name}/points/vectors',
         method="PUT",
@@ -334,7 +358,7 @@ def update_empty_vectors():
     )
     assert response.ok
     result = response.json()["result"]
-    assert result["vector"]["text"] == text_vector
+    assert compare_vectors(result["vector"]["text"], text_vector)
     assert "image" not in result["vector"]
 
     image_vector = [0.19, 0.28, 0.37, 0.46]
@@ -363,8 +387,8 @@ def update_empty_vectors():
     )
     assert response.ok
     result = response.json()["result"]
-    assert result["vector"]["image"] == image_vector
-    assert result["vector"]["text"] == text_vector
+    assert compare_vectors(result["vector"]["image"], image_vector)
+    assert compare_vectors(result["vector"]["text"], text_vector)
 
 
 def test_update_empty_vectors():


### PR DESCRIPTION
This PR is related to issue https://github.com/qdrant/qdrant/issues/2202.

This PR adds missed `distance.preprocess` to `segment.update_vector`. Also, this PR optimizes preprocessing and avoids named vector map recreation.

It's not a full solution. Because users may have broke non-normalized vectors, it's important to add storage migration to next release. I propose to do it in custom codebooks feature with also requires storage migration.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
