### PR TITLE
Initial implementation of Jaccard similarity for vectors

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1016,6 +1016,7 @@ Note: 1kB = 1 vector of size 256. |
 | Cosine | 1 |  |
 | Euclid | 2 |  |
 | Dot | 3 |  |
+| Jaccard | 4 |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4233,7 +4233,8 @@
         "enum": [
           "Cosine",
           "Euclid",
-          "Dot"
+          "Dot",
+          "Jaccard"
         ]
       },
       "HnswConfigDiff": {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1030,6 +1030,7 @@ impl TryFrom<Distance> for segment::types::Distance {
             Distance::Cosine => segment::types::Distance::Cosine,
             Distance::Euclid => segment::types::Distance::Euclid,
             Distance::Dot => segment::types::Distance::Dot,
+            Distance::Jaccard => segment::types::Distance::Jaccard,
         })
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -46,6 +46,7 @@ enum Distance {
   Cosine = 1;
   Euclid = 2;
   Dot = 3;
+  Jaccard = 4;
 }
 
 enum CollectionStatus {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -697,6 +697,7 @@ pub enum Distance {
     Cosine = 1,
     Euclid = 2,
     Dot = 3,
+    Jaccard = 4,
 }
 impl Distance {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -709,6 +710,7 @@ impl Distance {
             Distance::Cosine => "Cosine",
             Distance::Euclid => "Euclid",
             Distance::Dot => "Dot",
+            Distance::Jaccard => "Jaccard",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -718,6 +720,7 @@ impl Distance {
             "Cosine" => Some(Self::Cosine),
             "Euclid" => Some(Self::Euclid),
             "Dot" => Some(Self::Dot),
+            "Jaccard" => Some(Self::Jaccard),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -918,6 +918,7 @@ impl From<VectorParams> for api::grpc::qdrant::VectorParams {
                 Distance::Cosine => api::grpc::qdrant::Distance::Cosine,
                 Distance::Euclid => api::grpc::qdrant::Distance::Euclid,
                 Distance::Dot => api::grpc::qdrant::Distance::Dot,
+                Distance::Jaccard => api::grpc::qdrant::Distance::Jaccard,
             }
             .into(),
             hnsw_config: value.hnsw_config.map(Into::into),

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -189,7 +189,29 @@ impl Metric for JaccardMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        // TODO(pabloem): Add SIMD implementations for this function.
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
+            {
+                return unsafe { jaccard_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { jaccard_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { jaccard_similarity_neon(v1, v2) };
+            }
+        }
         jaccard_similarity(v1, v2)
     }
 

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -2,6 +2,7 @@
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+use std::cmp::{max_by, min_by, Ordering};
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::ScoreType;
@@ -147,6 +148,45 @@ pub(crate) unsafe fn dot_similarity_sse(
     result
 }
 
+#[target_feature(enable = "sse")]
+pub(crate) unsafe fn jaccard_similarity_sse(
+    v1: &[VectorElementType],
+    v2: &[VectorElementType],
+) -> ScoreType {
+    let n = v1.len();
+    let m = n - (n % 4);
+    let mut ptr1: *const f32 = v1.as_ptr();
+    let mut ptr2: *const f32 = v2.as_ptr();
+
+    let mut total_intersection: f32 = 0.;
+    let mut total_union: f32 = 0.;
+
+    let mut i: usize = 0;
+    while i < m {
+        total_union += hsum128_ps_sse(_mm_max_ps(_mm_loadu_ps(ptr1), _mm_loadu_ps(ptr2)));
+        total_intersection += hsum128_ps_sse(_mm_min_ps(_mm_loadu_ps(ptr1), _mm_loadu_ps(ptr2)));
+
+        ptr1 = ptr1.add(4);
+        ptr2 = ptr2.add(4);
+        i += 4;
+    }
+
+    for i in 0..n - m {
+        total_intersection += min_by(*ptr1.add(i), *ptr2.add(i), |a, b| {
+            a.partial_cmp(b).unwrap_or(Ordering::Equal)
+        });
+        total_union += max_by(*ptr1.add(i), *ptr2.add(i), |a, b| {
+            a.partial_cmp(b).unwrap_or(Ordering::Equal)
+        });
+    }
+
+    if total_union < f32::EPSILON {
+        0.0
+    } else {
+        total_intersection / total_union
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -175,6 +215,10 @@ mod tests {
             let dot_simd = unsafe { dot_similarity_sse(&v1, &v2) };
             let dot = dot_similarity(&v1, &v2);
             assert_eq!(dot_simd, dot);
+
+            let jaccard_simd = unsafe { jaccard_similarity_sse(&v1, &v2) };
+            let jaccard = jaccard_similarity(&v1, &v2);
+            assert_eq!(jaccard_simd, jaccard);
 
             let cosine_simd = unsafe { cosine_preprocess_sse(&v1) };
             let cosine = cosine_preprocess(&v1);

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -22,7 +22,7 @@ use crate::common::utils::MultiValue;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{VectorElementType, VectorStruct};
 use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, JaccardMetric};
 
 /// Type of point index inside a segment
 pub type PointOffsetType = u32;
@@ -120,6 +120,8 @@ pub enum Distance {
     Euclid,
     // <https://en.wikipedia.org/wiki/Dot_product>
     Dot,
+    // <https://en.wikipedia.org/wiki/Jaccard_index>
+    Jaccard,
 }
 
 impl Distance {
@@ -131,6 +133,7 @@ impl Distance {
             Distance::Cosine => CosineMetric::preprocess(vector),
             Distance::Euclid => EuclidMetric::preprocess(vector),
             Distance::Dot => DotProductMetric::preprocess(vector),
+            Distance::Jaccard => JaccardMetric::preprocess(vector),
         }
     }
 
@@ -139,6 +142,7 @@ impl Distance {
             Distance::Cosine => CosineMetric::postprocess(score),
             Distance::Euclid => EuclidMetric::postprocess(score),
             Distance::Dot => DotProductMetric::postprocess(score),
+            Distance::Jaccard => JaccardMetric::postprocess(score),
         }
     }
 
@@ -146,6 +150,7 @@ impl Distance {
         match self {
             Distance::Cosine | Distance::Dot => Order::LargeBetter,
             Distance::Euclid => Order::SmallBetter,
+            Distance::Jaccard => Order::LargeBetter, // TODO(pabloem): Verify LargeBetter is correct for Jaccard
         }
     }
 

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::BitSlice;
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
 use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, JaccardMetric};
 use crate::spaces::tools::FixedLengthPriorityQueue;
 use crate::types::{Distance, PointOffsetType, ScoreType};
 use crate::vector_storage::memmap_vector_storage::MemmapVectorStorage;
@@ -223,6 +223,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
             Distance::Cosine => Box::new(self.with_metric::<CosineMetric>()),
             Distance::Euclid => Box::new(self.with_metric::<EuclidMetric>()),
             Distance::Dot => Box::new(self.with_metric::<DotProductMetric>()),
+            Distance::Jaccard => Box::new(self.with_metric::<JaccardMetric>()),
         }
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -328,6 +328,8 @@ impl QuantizedVectors {
                 Distance::Cosine => quantization::DistanceType::Dot,
                 Distance::Euclid => quantization::DistanceType::L2,
                 Distance::Dot => quantization::DistanceType::Dot,
+                // TODO(pabloem): Figure out what sort of quantized distance to use for Jaccard.
+                Distance::Jaccard => quantization::DistanceType::Dot,
             },
             invert: distance == Distance::Euclid,
         }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -6,7 +6,7 @@ use bitvec::prelude::BitSlice;
 use super::{ScoredPointOffset, VectorStorage, VectorStorageEnum};
 use crate::data_types::vectors::VectorElementType;
 use crate::spaces::metric::Metric;
-use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, JaccardMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
 use crate::types::{Distance, PointOffsetType, ScoreType};
 
@@ -128,6 +128,14 @@ pub fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
         Distance::Dot => Box::new(RawScorerImpl::<'a, DotProductMetric, TVectorStorage> {
             points_count,
             query: DotProductMetric::preprocess(&vector).unwrap_or(vector),
+            vector_storage,
+            point_deleted,
+            vec_deleted,
+            metric: PhantomData,
+        }),
+        Distance::Jaccard => Box::new(RawScorerImpl::<'a, JaccardMetric, TVectorStorage> {
+            points_count,
+            query: JaccardMetric::preprocess(&vector).unwrap_or(vector),
             vector_storage,
             point_deleted,
             vec_deleted,

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -142,6 +142,16 @@ pub fn build_segment_3(path: &Path) -> Segment {
                         quantization_config: None,
                     },
                 ),
+                (
+                    "vector4".to_owned(),
+                    VectorDataConfig {
+                        size: 4,
+                        distance: Distance::Jaccard,
+                        storage_type: VectorStorageType::Memory,
+                        index: Indexes::Plain {},
+                        quantization_config: None,
+                    },
+                ),
             ]),
             payload_storage_type: Default::default(),
         },

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -169,12 +169,12 @@ fn test_vector_name_not_exists() {
             ("vector1".to_owned(), vec![5., 6., 7., 8.]),
             ("vector2".to_owned(), vec![10.]),
             ("vector3".to_owned(), vec![5., 6., 7., 8.]),
-            ("vector4".to_owned(), vec![5., 6., 7., 8.]),
+            ("vector5".to_owned(), vec![5., 6., 7., 8.]),
         ]),
     );
 
     if let Err(OperationError::VectorNameNotExists { received_name }) = result {
-        assert!(received_name == "vector4");
+        assert!(received_name == "vector5");
     } else {
         panic!("wrong upsert result")
     }


### PR DESCRIPTION
Implementation of Jaccard vector similarity for positive, floating-point-valued vectors.

**Not implemented**
- Quantization

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
