### PR TITLE
SegmentSearcher retrieve is not async

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -132,8 +132,8 @@ mod tests {
                                     // points 11 and 12 are not updated as they are same as before
     }
 
-    #[tokio::test]
-    async fn test_point_ops() {
+    #[test]
+    fn test_point_ops() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
         let segments = build_test_holder(dir.path());
@@ -159,7 +159,6 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
         )
-        .await
         .unwrap();
 
         assert_eq!(records.len(), 3);
@@ -190,7 +189,6 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
         )
-        .await
         .unwrap();
 
         for record in records {
@@ -199,8 +197,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_payload_ops() {
+    #[test]
+    fn test_payload_ops() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segments = build_test_holder(dir.path());
 
@@ -221,7 +219,6 @@ mod tests {
 
         let res =
             SegmentsSearcher::retrieve(&segments, &points, &WithPayload::from(true), &false.into())
-                .await
                 .unwrap();
 
         assert_eq!(res.len(), 3);
@@ -254,7 +251,6 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .await
         .unwrap();
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));
@@ -267,7 +263,6 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .await
         .unwrap();
         assert_eq!(res.len(), 1);
         assert!(res[0].payload.as_ref().unwrap().contains_key("color"));
@@ -286,7 +281,6 @@ mod tests {
             &WithPayload::from(true),
             &false.into(),
         )
-        .await
         .unwrap();
         assert_eq!(res.len(), 1);
         assert!(!res[0].payload.as_ref().unwrap().contains_key("color"));

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -252,7 +252,7 @@ impl SegmentsSearcher {
         Ok(top_scores)
     }
 
-    pub async fn retrieve(
+    pub fn retrieve(
         segments: &RwLock<SegmentHolder>,
         points: &[PointIdType],
         with_payload: &WithPayload,
@@ -595,8 +595,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_retrieve() {
+    #[test]
+    fn test_retrieve() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let segment_holder = build_test_holder(dir.path());
 
@@ -606,7 +606,6 @@ mod tests {
             &WithPayload::from(true),
             &true.into(),
         )
-        .await
         .unwrap();
         assert_eq!(records.len(), 3);
     }

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -89,7 +89,7 @@ impl ShardOperation for LocalShard {
 
         let with_payload = WithPayload::from(with_payload_interface);
         let mut points =
-            SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector).await?;
+            SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector)?;
         points.sort_by_key(|point| point.id);
 
         Ok(points)
@@ -161,6 +161,6 @@ impl ShardOperation for LocalShard {
         with_payload: &WithPayload,
         with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>> {
-        SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector).await
+        SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector)
     }
 }


### PR DESCRIPTION
This PR removes the `async` modifier to `SegmentSearcher::retrieve` because it is not an async. function.

This makes it explicit that the `LocalShard` implementation for `ShardOperation` is a place where we run potentially blocking operations on the caller's Tokio runtime.