### PR TITLE
TableOfContent now accepts Handle, not Runtime (2nd attempt)

### DIFF
--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -36,7 +36,7 @@ use collection::shards::{replica_set, CollectionId};
 use collection::telemetry::CollectionTelemetry;
 use segment::common::cpu::get_num_cpus;
 use segment::types::ScoredPoint;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
 use uuid::Uuid;
 
@@ -71,9 +71,9 @@ pub const DEFAULT_WRITE_LOCK_ERROR_MESSAGE: &str = "Write operations are forbidd
 pub struct TableOfContent {
     collections: Arc<RwLock<Collections>>,
     storage_config: Arc<StorageConfig>,
-    search_runtime: Runtime,
-    update_runtime: Runtime,
-    general_runtime: Runtime,
+    search_runtime: Handle,
+    update_runtime: Handle,
+    general_runtime: Handle,
     alias_persistence: RwLock<AliasPersistence>,
     pub this_peer_id: PeerId,
     channel_service: ChannelService,
@@ -96,9 +96,9 @@ impl TableOfContent {
     /// PeerId does not change during execution so it is ok to copy it here.
     pub fn new(
         storage_config: &StorageConfig,
-        search_runtime: Runtime,
-        update_runtime: Runtime,
-        general_runtime: Runtime,
+        search_runtime: Handle,
+        update_runtime: Handle,
+        general_runtime: Handle,
         channel_service: ChannelService,
         this_peer_id: PeerId,
         consensus_proposal_sender: Option<OperationSender>,
@@ -156,8 +156,8 @@ impl TableOfContent {
                     consensus_proposal_sender.clone(),
                     collection_name.clone(),
                 ),
-                Some(search_runtime.handle().clone()),
-                Some(update_runtime.handle().clone()),
+                Some(search_runtime.clone()),
+                Some(update_runtime.clone()),
             ));
 
             collections.insert(collection_name, collection);
@@ -456,8 +456,8 @@ impl TableOfContent {
                 self.consensus_proposal_sender.clone(),
                 collection_name.to_string(),
             ),
-            Some(self.search_runtime.handle().clone()),
-            Some(self.update_runtime.handle().clone()),
+            Some(self.search_runtime.clone()),
+            Some(self.update_runtime.clone()),
         )
         .await?;
 
@@ -1444,8 +1444,8 @@ impl TableOfContent {
                             self.consensus_proposal_sender.clone(),
                             id.to_string(),
                         ),
-                        Some(self.search_runtime.handle().clone()),
-                        Some(self.update_runtime.handle().clone()),
+                        Some(self.search_runtime.clone()),
+                        Some(self.update_runtime.clone()),
                     )
                     .await?;
                     collections.validate_collection_not_exists(id).await?;

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -69,9 +69,9 @@ fn test_alias_operation() {
 
     let toc = Arc::new(TableOfContent::new(
         &config,
-        search_runtime,
-        update_runtime,
-        general_runtime,
+        search_runtime.handle().clone(),
+        update_runtime.handle().clone(),
+        general_runtime.handle().clone(),
         Default::default(),
         0,
         Some(propose_operation_sender),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -58,7 +58,7 @@ pub struct Consensus {
 
 impl Consensus {
     /// Create and run consensus node
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn run(
         logger: &slog::Logger,
         state_ref: ConsensusStateRef,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1044,9 +1044,9 @@ mod tests {
         let operation_sender = OperationSender::new(propose_sender);
         let toc = TableOfContent::new(
             &settings.storage,
-            search_runtime,
-            update_runtime,
-            general_runtime,
+            search_runtime.handle().clone(),
+            update_runtime.handle().clone(),
+            general_runtime.handle().clone(),
             ChannelService::default(),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -32,6 +32,12 @@ use crate::tonic::init_internal;
 
 type Node = RawNode<ConsensusStateRef>;
 
+/// gRPC and consensus thread handles.
+type ConsensusHandles = (
+    JoinHandle<std::io::Result<()>>,
+    JoinHandle<std::io::Result<()>>,
+);
+
 const RECOVERY_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 const RECOVERY_MAX_RETRY_COUNT: usize = 3;
 
@@ -58,7 +64,7 @@ pub struct Consensus {
 
 impl Consensus {
     /// Create and run consensus node
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
     pub fn run(
         logger: &slog::Logger,
         state_ref: ConsensusStateRef,
@@ -70,10 +76,7 @@ impl Consensus {
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
         runtime: Handle,
-    ) -> anyhow::Result<(
-        JoinHandle<std::io::Result<()>>,
-        JoinHandle<std::io::Result<()>>,
-    )> {
+    ) -> anyhow::Result<ConsensusHandles> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
         let p2p_host = settings.service.host;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -52,6 +53,7 @@ pub struct Consensus {
     /// ToDo: Make if many
     config: ConsensusConfig,
     broker: RaftMessageBroker,
+    shutdown_requested: Arc<AtomicBool>,
 }
 
 impl Consensus {
@@ -68,7 +70,10 @@ impl Consensus {
         telemetry_collector: Arc<parking_lot::Mutex<TonicTelemetryCollector>>,
         toc: Arc<TableOfContent>,
         runtime: Handle,
-    ) -> anyhow::Result<JoinHandle<std::io::Result<()>>> {
+    ) -> anyhow::Result<(
+        JoinHandle<std::io::Result<()>>,
+        JoinHandle<std::io::Result<()>>,
+    )> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
         let p2p_host = settings.service.host;
@@ -86,19 +91,23 @@ impl Consensus {
             channel_service,
             runtime.clone(),
         )?;
+        let shutdown_requested = consensus.shutdown_requested.clone();
 
         let state_ref_clone = state_ref.clone();
-        thread::Builder::new()
-            .name("consensus".to_string())
-            .spawn(move || {
-                if let Err(err) = consensus.start() {
-                    log::error!("Consensus stopped with error: {err}");
-                    state_ref_clone.on_consensus_thread_err(err);
-                } else {
-                    log::info!("Consensus stopped");
-                    state_ref_clone.on_consensus_stopped();
-                }
-            })?;
+
+        let consensus_handle =
+            thread::Builder::new()
+                .name("consensus".to_string())
+                .spawn(move || {
+                    if let Err(err) = consensus.start() {
+                        log::error!("Consensus stopped with error: {err}");
+                        state_ref_clone.on_consensus_thread_err(err);
+                    } else {
+                        log::info!("Consensus stopped");
+                        state_ref_clone.on_consensus_stopped();
+                    }
+                    Ok(())
+                })?;
 
         let message_sender_moved = message_sender.clone();
         thread::Builder::new()
@@ -125,7 +134,7 @@ impl Consensus {
             None
         };
 
-        let handle = thread::Builder::new()
+        let grpc_handle = thread::Builder::new()
             .name("grpc_internal".to_string())
             .spawn(move || {
                 init_internal(
@@ -137,11 +146,12 @@ impl Consensus {
                     server_tls,
                     message_sender,
                     runtime,
+                    shutdown_requested,
                 )
             })
             .unwrap();
 
-        Ok(handle)
+        Ok((grpc_handle, consensus_handle))
     }
 
     /// If `bootstrap_peer` peer is supplied, then either `uri` or `p2p_port` should be also supplied
@@ -227,12 +237,15 @@ impl Consensus {
             channel_service.channel_pool,
         );
 
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+
         let consensus = Self {
             node,
             receiver,
             runtime,
             config,
             broker,
+            shutdown_requested,
         };
 
         Ok((consensus, sender))
@@ -426,6 +439,9 @@ impl Consensus {
         let mut timeout = Duration::from_millis(self.config.tick_period_ms);
 
         loop {
+            if self.shutdown_requested.load(Ordering::Acquire) {
+                return Ok(());
+            }
             if !self
                 .try_promote_learner()
                 .map_err(|err| anyhow!("Failed to promote learner: {}", err))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,7 +266,7 @@ fn main() -> anyhow::Result<()> {
 
         // Runs raft consensus in a separate thread.
         // Create a pipe `message_sender` to communicate with the consensus
-        let handle = Consensus::run(
+        let (grpc_handle, consensus_handle) = Consensus::run(
             &slog_logger,
             consensus_state.clone(),
             args.bootstrap,
@@ -280,7 +280,8 @@ fn main() -> anyhow::Result<()> {
         )
         .expect("Can't initialize consensus");
 
-        handles.push(handle);
+        handles.push(grpc_handle);
+        handles.push(consensus_handle);
 
         let toc_arc_clone = toc_arc.clone();
         let consensus_state_clone = consensus_state.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,9 +474,9 @@ fn main() -> anyhow::Result<()> {
 /// This methods move a value out from an [`Arc`] when there is only one reference left
 /// and it is safe to do so. `Err()` is returned if an [`Arc`] still has more than 1 reference
 /// after given duration is passed.
-fn wait_unwrap<T>(mut input: Arc<T>, duration: Duration) -> Result<T, ()> {
+fn wait_unwrap<T>(mut input: Arc<T>, timeout: Duration) -> Result<T, ()> {
     let start_time = Instant::now();
-    while start_time.elapsed() < duration {
+    while start_time.elapsed() < timeout {
         match Arc::try_unwrap(input) {
             Ok(input) => {
                 return Ok(input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::io::Error;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
@@ -216,9 +216,9 @@ fn main() -> anyhow::Result<()> {
     // It is a main entry point for the storage.
     let toc = TableOfContent::new(
         &settings.storage,
-        search_runtime,
-        update_runtime,
-        general_runtime,
+        search_runtime.handle().clone(),
+        update_runtime.handle().clone(),
+        general_runtime.handle().clone(),
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
@@ -443,7 +443,38 @@ fn main() -> anyhow::Result<()> {
         );
         handle.join().expect("thread is not panicking")?;
     }
-    drop(toc_arc);
+    drop(search_runtime);
+    drop(update_runtime);
+    drop(general_runtime);
     drop(settings);
+    drop(wait_unwrap(toc_arc));
     Ok(())
+}
+
+/// Wait for the current thread to become a single referent of an [`Arc`] and returns it.
+///
+/// This methods move a value out from an [`Arc`] when there is only one reference left
+/// and it is safe to do so.
+///
+/// **CAUTION**: this method may create live lock if parallel threads are not going to finish
+/// and decrement [`Arc`] counter. Caller should initiate shutdown of all the threads holding the
+/// [`Arc`] before calling this method.
+fn wait_unwrap<T>(mut input: Arc<T>) -> T {
+    let start_time = Instant::now();
+    let mut notified = false;
+    loop {
+        if !notified && start_time.elapsed() > Duration::from_secs(10) {
+            log::warn!("Waiting for Arc to be dropped...");
+            notified = true;
+        }
+        match Arc::try_unwrap(input) {
+            Ok(input) => {
+                return input;
+            }
+            Err(new_input) => {
+                input = new_input;
+                thread::sleep_ms(100);
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,10 +444,6 @@ fn main() -> anyhow::Result<()> {
         );
         handle.join().expect("thread is not panicking")?;
     }
-    drop(search_runtime);
-    drop(update_runtime);
-    drop(general_runtime);
-    drop(settings);
     if let Ok(toc) = wait_unwrap(toc_arc, Duration::from_secs(30)) {
         drop(toc);
     }


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

This is a second attempt to solve #1316. After #2096 was merged there were integration problems described in #2191. The source of the problem was basically the incorrect `drop()` order in the `main()`. All the runtimes was dropped before the `TableOfContent`, which is incorrect, because ToC uses runtimes and should be dropped first.

Changes (wrt. to #2096)

- removed explicit `drop()` calls from the `main()`. I also removed the explicit `drop()` of `Settings` which is useless IMO.
- moved `wait_stop_signal()` to the main module and orchestrate the shutdown of all the system components using `tokio::sync::watch` channel.
- telemetry loop can now be stopped by SIGTERM/SIGINT.

Tested with both telemetry disabled and enabled. The following messages are not happening anymore.

```
[2023-07-06T04:23:39.756Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-06T04:23:39.756Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-06T04:23:39.892Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 994 was cancelled
[2023-07-06T04:23:39.933Z WARN  collection::shards::local_shard] Error sending stop signal to update handler: channel closed
[2023-07-06T04:23:39.933Z WARN  collection::update_handler] Failed to stop flush worker as it is already stopped.
[2023-07-06T04:23:39.933Z WARN  collection::shards::local_shard] Update workers failed with: Service internal error: task 1001 was cancelled
```