### PR TITLE
Non blocking Scroll and parallel segments runs

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1021,6 +1021,7 @@ impl Collection {
                     &with_vector,
                     request.filter.as_ref(),
                     read_consistency,
+                    &self.search_runtime,
                 )
             });
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -75,6 +75,7 @@ impl ShardOperation for DummyShard {
         _: &WithPayloadInterface,
         _: &WithVector,
         _: Option<&Filter>,
+        _: &Handle,
     ) -> CollectionResult<Vec<Record>> {
         self.dummy()
     }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -68,6 +68,7 @@ impl ForwardProxyShard {
         &self,
         offset: Option<PointIdType>,
         batch_size: usize,
+        runtime_handle: &Handle,
     ) -> CollectionResult<Option<PointIdType>> {
         debug_assert!(batch_size > 0);
         let limit = batch_size + 1;
@@ -80,6 +81,7 @@ impl ForwardProxyShard {
                 &WithPayloadInterface::Bool(true),
                 &true.into(),
                 None,
+                runtime_handle,
             )
             .await?;
         let next_page_offset = if batch.len() < limit {
@@ -168,10 +170,18 @@ impl ShardOperation for ForwardProxyShard {
         with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
+        search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Record>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .scroll_by(offset, limit, with_payload_interface, with_vector, filter)
+            .scroll_by(
+                offset,
+                limit,
+                with_payload_interface,
+                with_vector,
+                filter,
+                search_runtime_handle,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -175,10 +175,18 @@ impl ShardOperation for ProxyShard {
         with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
+        search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Record>> {
         let local_shard = &self.wrapped_shard;
         local_shard
-            .scroll_by(offset, limit, with_payload_interface, with_vector, filter)
+            .scroll_by(
+                offset,
+                limit,
+                with_payload_interface,
+                with_vector,
+                filter,
+                search_runtime_handle,
+            )
             .await
     }
 

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -427,6 +427,7 @@ impl ShardOperation for RemoteShard {
         with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
+        search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Record>> {
         let scroll_points = ScrollPoints {
             collection_name: self.collection_id.clone(),

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -28,6 +28,7 @@ pub trait ShardOperation {
         with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
+        search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Record>>;
 
     async fn info(&self) -> CollectionResult<CollectionInfo>;

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -40,6 +40,7 @@ pub fn create_search_runtime(max_search_threads: usize) -> io::Result<Runtime> {
 
     runtime::Builder::new_multi_thread()
         .worker_threads(search_threads)
+        .max_blocking_threads(search_threads)
         .enable_all()
         .thread_name_fn(|| {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
The current implementation of `scroll_by` at the collection level is performing potential heavy blocking I/O operation on the caller's Tokio runtime one segment at a time.

Scrolling can use a filter which can in turn require a full scan or an index traversal.

The caller's runtime is generally the actix runtime or the gRPC runtime which is not ideal because in a cooperative scheduling, tasks are supposed to yield often to play nicely with others.

This PR does two thing:
- run `read_filtered` on the search runtime
- execute segment read in parallel

## Benchmarks

I have added support for scrolling in BFB https://github.com/qdrant/bfb/pull/10

Using my local system with the following data setup

```bash
cargo run -r -- --segments 4 --num-vectors 1000000 --keywords 10000 --on-disk-payload --on-disk-vectors true
````

I cannot see a significant difference between the current and new scroll implementation for the following benchmark.

```bash
cargo run -r -- --skip-create --skip-upload --skip-wait-index --scroll --scroll-limit 100 --keywords 10000
``` 

I think my local disk is just too fast to make the new implementation shine.