### PR TITLE
remove unused "no_bracket_syntax" error code

### DIFF
--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -86,10 +86,6 @@ fn describe_error(
             Some(value) => format!("value {value} invalid, must not be empty"),
             None => err.to_string(),
         },
-        "no_bracket_syntax" => match params.get("value") {
-            Some(value) => format!("key {value} is invalid, bracket syntax is not supported here"),
-            None => err.to_string(),
-        },
         // Undescribed error codes
         _ => err.to_string(),
     }


### PR DESCRIPTION
This was introduced when developing the grouping feature, but is no longer necessary
