### PR TITLE
Remove unused Serialize derive in `build.rs`

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -166,8 +166,6 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendPointGroups.params", ""),
             ("CountPoints.collection_name", "length(min = 1, max = 255)"),
         ], &[])
-        .type_attribute("NamedVectors", "#[derive(serde::Serialize)]")
-        .type_attribute("Vector", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[
             ("UpsertPointsInternal.upsert_points", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2492,7 +2492,6 @@ pub mod point_id {
         Uuid(::prost::alloc::string::String),
     }
 }
-#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
@@ -2742,7 +2741,6 @@ pub mod with_payload_selector {
         Exclude(super::PayloadExcludeSelector),
     }
 }
-#[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedVectors {


### PR DESCRIPTION
Removes unused Serialize derives which _I think_ were used for validating before, but are not needed anymore
