### PR TITLE
Fix macOS binary release job

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-            brew update
-            brew install gcc llvm cmake protobuf-c
+            brew update-reset
+            brew install gcc cmake protobuf-c
       - uses: actions/checkout@v3
       - name: Build and publish
         uses: taiki-e/upload-rust-binary-action@v1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -3,7 +3,8 @@ permissions:
   contents: write
 on:
   release:
-    types: [created]
+    # 'published' is triggered when publishing draft release, 'created' is not
+    types: [published]
 
 jobs:
   build-linux-binaries:


### PR DESCRIPTION
The macOS binary release job failed on `v1.3.0`, this attempts to fix that.

Failed job: https://github.com/qdrant/qdrant/actions/runs/5359388215/jobs/9722912379

This also changes the release trigger from `created` to `published` to also trigger when drafted releases are published.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?