### PR TITLE
Add message to unimplemented!

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -452,7 +452,7 @@ impl SegmentEntry for ProxySegment {
     fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_> {
         // iter_points is not available for Proxy implementation
         // Due to internal locks it is almost impossible to return iterator with proper owning, lifetimes, e.t.c.
-        unimplemented!()
+        unimplemented!("call to iter_points is not implemented for Proxy segment")
     }
 
     fn read_filtered<'a>(

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -38,7 +38,9 @@ impl From<StoredPointId> for ExtendedPointId {
         match point_id {
             StoredPointId::NumId(idx) => ExtendedPointId::NumId(idx),
             StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(uuid),
-            StoredPointId::String(_str) => unimplemented!(),
+            StoredPointId::String(_str) => {
+                unimplemented!("cannot convert internal string id to external id")
+            }
         }
     }
 }

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -38,8 +38,8 @@ impl From<StoredPointId> for ExtendedPointId {
         match point_id {
             StoredPointId::NumId(idx) => ExtendedPointId::NumId(idx),
             StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(uuid),
-            StoredPointId::String(_str) => {
-                unimplemented!("cannot convert internal string id to external id")
+            StoredPointId::String(str) => {
+                unimplemented!("cannot convert internal string id '{}' to external id", str)
             }
         }
     }

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -39,7 +39,7 @@ impl From<StoredPointId> for ExtendedPointId {
             StoredPointId::NumId(idx) => ExtendedPointId::NumId(idx),
             StoredPointId::Uuid(uuid) => ExtendedPointId::Uuid(uuid),
             StoredPointId::String(str) => {
-                unimplemented!("cannot convert internal string id '{}' to external id", str)
+                unimplemented!("cannot convert internal string id '{str}' to external id")
             }
         }
     }


### PR DESCRIPTION
While looking for an `unimplemented` error I found two call sites without messages.

This PR adds messages to make those explicit if they ever were to happen.