### PR TITLE
Align the fmt command with `.rusty-hook.toml`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@
 ### New Feature Submissions:
 
 1. [ ] Does your submission pass tests?
-2. [ ] Have you formatted your code locally using `cargo fmt` command prior to submission?
-3. [ ] Have you checked your code using `cargo clippy` command?
+2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
+3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?
 
 ### Changes to Core Features:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 ## Use a Consistent Coding Style
 
 If you are modifying Rust code, make sure it has no warnings from Cargo and follow [Rust code style](https://doc.rust-lang.org/1.0.0/style/).
-The project uses [rustfmt](https://github.com/rust-lang/rustfmt) formatter. Please ensure to run it using the 
-```cargo fmt``` command. The project also use [clippy](https://github.com/rust-lang/rust-clippy) lint collection, 
-so please ensure running ``cargo clippy`` before submitting the PR.
+The project uses [rustfmt](https://github.com/rust-lang/rustfmt) formatter. Please ensure to run it using the
+```cargo +nightly fmt --all``` command. The project also use [clippy](https://github.com/rust-lang/rust-clippy) lint collection,
+so please ensure running ``cargo clippy --all --all-features`` before submitting the PR.
 
 ## License
 By contributing, you agree that your contributions will be licensed under its Apache License 2.0.

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -256,7 +256,7 @@ fn delete_array_path(
                         return MultiValue::one(array.remove(array_index as usize));
                     }
                 } else {
-                    return MultiValue::one(Value::Array(array.drain(..).collect()));
+                    return MultiValue::one(Value::Array(std::mem::take(array)));
                 }
             }
             Some(rest_path) => {

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -237,7 +237,7 @@ impl<T: Numericable> Histogram<T> {
         let estimation = left_border
             .into_iter()
             .chain(self.borders.range((from_, to_)))
-            .chain(right_border.into_iter())
+            .chain(right_border)
             .tuple_windows()
             .map(
                 |((a, a_count), (b, _b_count)): ((&Point<T>, &Counts), (&Point<T>, _))| {


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

In Contributing document we suggest contributors use `cargo fmt` but we use `cargo +nightly fmt --all` in our `.rusty-hook.toml`. So better to align them.

Also fixed some clippy issues. But not all of them. Because one of the issues requires a deep look and I will fix it later.