### PR TITLE
Support consensus WAL format in wal_inspector

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -124,7 +124,7 @@ impl ConsensusOpWal {
 
     /// Difference between raft index and WAL record number.
     /// Difference might be different because of consensus snapshot.
-    fn index_offset(&self) -> Result<Option<u64>, StorageError> {
+    pub fn index_offset(&self) -> Result<Option<u64>, StorageError> {
         let last_known_index = self.0.first_index();
         let first_entry = self.first_entry()?;
         let offset = first_entry.map(|entry| entry.index - last_known_index);

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -197,7 +197,7 @@ impl Persistent {
         Ok(state)
     }
 
-    fn load(path: PathBuf) -> Result<Self, StorageError> {
+    pub fn load(path: PathBuf) -> Result<Self, StorageError> {
         let file = File::open(&path)?;
         let mut state: Self = serde_cbor::from_reader(&file)?;
         state.path = path;

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -197,7 +197,7 @@ impl Persistent {
         Ok(state)
     }
 
-    pub fn load(path: PathBuf) -> Result<Self, StorageError> {
+    fn load(path: PathBuf) -> Result<Self, StorageError> {
         let file = File::open(&path)?;
         let mut state: Self = serde_cbor::from_reader(&file)?;
         state.path = path;

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -5,6 +5,7 @@ use collection::operations::CollectionUpdateOperations;
 use collection::wal::SerdeWal;
 use storage::content_manager::consensus::consensus_wal::ConsensusOpWal;
 use storage::content_manager::consensus::persistent::Persistent;
+use storage::content_manager::consensus_ops::ConsensusOperations;
 use wal::WalOptions;
 
 /// Executable to inspect the content of a write ahead log folder (collection OR consensus WAL).
@@ -48,11 +49,14 @@ fn print_consensus_wal(wal_path: &Path) {
         .unwrap();
     for entry in entries {
         println!("==========================");
-        let data = entry.data;
-        println!(
-            "Entry ID:{} term:{} entry_type:{} data:{:?}",
-            entry.index, entry.term, entry.entry_type, data
-        );
+        let command = ConsensusOperations::try_from(&entry);
+        match command {
+            Ok(command) => println!("Command: {:?}", command),
+            Err(_) => println!(
+                "Entry ID:{} term:{} entry_type:{} data:{:?}",
+                entry.index, entry.term, entry.entry_type, entry.data
+            ),
+        }
     }
 }
 

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -4,11 +4,14 @@ use std::path::Path;
 use collection::operations::CollectionUpdateOperations;
 use collection::wal::SerdeWal;
 use storage::content_manager::consensus::consensus_wal::ConsensusOpWal;
+use storage::content_manager::consensus::persistent::Persistent;
 use wal::WalOptions;
 
 /// Executable to inspect the content of a write ahead log folder (collection OR consensus WAL).
-/// e.g `cargo run --bin wal_inspector storage/collections/test-collection/0/wal/ collection`
-/// e.g `cargo run --bin wal_inspector -- storage/node4/wal/ consensus`
+/// e.g:
+/// `cargo run --bin wal_inspector storage/collections/test-collection/0/wal/ collection`
+/// `cargo run --bin wal_inspector -- storage/node4/wal/ consensus` (needs collections_meta_wal folder)
+/// `cargo run --bin wal_inspector -- storage/node4/raft_state raft_state`
 fn main() {
     let args: Vec<String> = env::args().collect();
     let wal_path = Path::new(&args[1]);
@@ -16,8 +19,15 @@ fn main() {
     match wal_type {
         "collection" => print_collection_wal(wal_path),
         "consensus" => print_consensus_wal(wal_path),
+        "raft_state" => print_raft_state(wal_path),
         _ => eprintln!("Unknown wal type: {}", wal_type),
     }
+}
+
+fn print_raft_state(raft_state: &Path) {
+    let state = Persistent::load(raft_state.to_path_buf()).unwrap();
+    println!("==========================");
+    println!("Raft state: {:?}", state.state);
 }
 
 fn print_consensus_wal(wal_path: &Path) {

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -3,13 +3,50 @@ use std::path::Path;
 
 use collection::operations::CollectionUpdateOperations;
 use collection::wal::SerdeWal;
+use storage::content_manager::consensus::consensus_wal::ConsensusOpWal;
 use wal::WalOptions;
 
-/// Executable to inspect the content of a write ahead log folder.
-/// e.g `cargo run --bin wal_inspector storage/collections/test-collection/0/wal/`
+/// Executable to inspect the content of a write ahead log folder (collection OR consensus WAL).
+/// e.g `cargo run --bin wal_inspector storage/collections/test-collection/0/wal/ collection`
+/// e.g `cargo run --bin wal_inspector -- storage/node4/wal/ consensus`
 fn main() {
     let args: Vec<String> = env::args().collect();
     let wal_path = Path::new(&args[1]);
+    let wal_type = args[2].as_str();
+    match wal_type {
+        "collection" => print_collection_wal(wal_path),
+        "consensus" => print_consensus_wal(wal_path),
+        _ => eprintln!("Unknown wal type: {}", wal_type),
+    }
+}
+
+fn print_consensus_wal(wal_path: &Path) {
+    // must live within a folder named `collections_meta_wal`
+    let wal = ConsensusOpWal::new(wal_path.to_str().unwrap());
+    println!("==========================");
+    let first_index = wal.first_entry().unwrap();
+    println!("First entry: {:?}", first_index);
+    let last_index = wal.last_entry().unwrap();
+    println!("Last entry: {:?}", last_index);
+    println!("Offset of first entry: {:?}", wal.index_offset().unwrap());
+    let entries = wal
+        .entries(
+            first_index.map(|f| f.index).unwrap_or(1),
+            last_index.map(|f| f.index).unwrap_or(1),
+            None,
+        )
+        .unwrap();
+    for entry in entries {
+        println!("==========================");
+        let data = entry.data;
+        println!(
+            "Entry ID:{} term:{} entry_type:{} data:{:?}",
+            entry.index, entry.term, entry.entry_type, data
+        );
+    }
+}
+
+fn print_collection_wal(wal_path: &Path) {
     let wal: Result<SerdeWal<CollectionUpdateOperations>, _> =
         SerdeWal::new(wal_path.to_str().unwrap(), WalOptions::default());
 


### PR DESCRIPTION
This PR adds support for the consensus WAL to the wal_inspector.

It comes in handy to debug diverging histories.

Example of output:

```
cargo run --bin wal_inspector -- ~/Downloads/qdrant_raft_issue_1662/storage_node0 consensus
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/wal_inspector /home/agourlay/debug/storage_node0 consensus`
==========================
First entry: Some(Entry { entry_type: EntryNormal, term: 1, index: 1, data: [], context: [], sync_log: false })
Last entry: Some(Entry { entry_type: EntryNormal, term: 2, index: 142, data: [], context: [], sync_log: false })
Offset of first entry: Some(1)
==========================
Entry ID:1
term:1
entry_type:0
data:"[]"
==========================
Entry ID:2
term:1
entry_type:2
data:"[18, 11, 8, 2, 16, 239, 237, 166, 190, 177, 199, 179, 9]"
==========================
Entry ID:3
term:1
entry_type:2
data:"[18, 9, 16, 239, 237, 166, 190, 177, 199, 179, 9]"
==========================
Entry ID:4
term:1
entry_type:2
data:"[18, 11, 8, 2, 16, 198, 174, 183, 227, 142, 189, 172, 5]"
==========================
Entry ID:5
term:1
entry_type:2
data:"[18, 9, 16, 198, 174, 183, 227, 142, 189, 172, 5]"
==========================
Entry ID:6
term:1
entry_type:0
data:"CollectionMeta(DeleteCollection(DeleteCollectionOperation(\"test_collection\")))"
==========================
Entry ID:7
term:1
entry_type:0
data:"CollectionMeta(CreateCollection(CreateCollectionOperation { collection_name: \"test_collection\", create_collection: CreateCollection { vectors: Single(VectorParams { size: 4, distance: Dot, hnsw_config: None, quantization_config: None, on_disk: None }), shard_number: Some(3), replication_factor: Some(1), write_consistency_factor: None, on_disk_payload: None, hnsw_config: None, wal_config: None, optimizers_config: None, init_from: None, quantization_config: None }, distribution: Some(ShardDistributionProposal { distribution: [(0, [3010363724257094]), (1, [4826122942869202]), (2, [5293302778279663])] }) }))"
==========================
Entry ID:8
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 1, peer_id: 4826122942869202, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:9
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 0, peer_id: 3010363724257094, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:10
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 2, peer_id: 5293302778279663, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:11
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 2, peer_id: 5293302778279663, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:12
term:1
entry_type:0
data:"CollectionMeta(DeleteCollection(DeleteCollectionOperation(\"test_collection\")))"
==========================
Entry ID:13
term:1
entry_type:0
data:"CollectionMeta(CreateCollection(CreateCollectionOperation { collection_name: \"test_collection\", create_collection: CreateCollection { vectors: Single(VectorParams { size: 4, distance: Dot, hnsw_config: None, quantization_config: None, on_disk: None }), shard_number: Some(3), replication_factor: Some(1), write_consistency_factor: None, on_disk_payload: None, hnsw_config: None, wal_config: None, optimizers_config: None, init_from: None, quantization_config: None }, distribution: Some(ShardDistributionProposal { distribution: [(0, [3010363724257094]), (1, [4826122942869202]), (2, [5293302778279663])] }) }))"
==========================
Entry ID:14
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 1, peer_id: 4826122942869202, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:15
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 1, peer_id: 4826122942869202, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:16
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 2, peer_id: 5293302778279663, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:17
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 0, peer_id: 3010363724257094, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:18
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 2, peer_id: 5293302778279663, state: Active, from_state: Some(Initializing) }))"
==========================
```