### PR TITLE
Add missing assertion to shard transfer test

### DIFF
--- a/tests/consensus_tests/downscale_cluster.py
+++ b/tests/consensus_tests/downscale_cluster.py
@@ -57,6 +57,7 @@ for local_shards in collection_cluster_status["result"]["local_shards"]:
             "to_peer_id": to_peer
         }
     })
+    assert_http_ok(r)
 
 max_wait = 60
 


### PR DESCRIPTION
Tiny PR adding a missing test assertion to the downscaling cluster test.

The absence of assertion created confusion when we changed the transfer API semantic in https://github.com/qdrant/qdrant/pull/2246