### PR TITLE
Improve flaky stopable task test

### DIFF
--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -104,7 +104,10 @@ mod tests {
         // Expect task counter to be between [15, 25], we cannot be exact on busy systems
         if let Some(handle) = handle.stop() {
             if let Some(count) = handle.await.unwrap() {
-                assert!((15..=25).contains(&count), "Stoppable task should have count between [15, 25], but it is {count}");
+                assert!(
+                    (15..=25).contains(&count),
+                    "Stoppable task should have count between [15, 25], but it is {count}",
+                );
             }
         }
     }
@@ -113,18 +116,25 @@ mod tests {
     async fn test_task_stop_many() {
         const TASKS: usize = 64;
 
-        let handles = (0..TASKS).map(|_| spawn_stoppable(counting_task)).collect::<Vec<_>>();
+        let handles = (0..TASKS)
+            .map(|_| spawn_stoppable(counting_task))
+            .collect::<Vec<_>>();
 
         // Signal tasks to stop after ~20 steps
         sleep(STEP * 20).await;
-        handles.iter().for_each(|handle| assert!(!handle.is_finished()));
+        handles
+            .iter()
+            .for_each(|handle| assert!(!handle.is_finished()));
         handles.iter().for_each(|handle| handle.ask_to_stop());
 
         // Expect task counters to be between [10, 30], we cannot be exact on busy systems
         for handle in handles {
             if let Some(handle) = handle.stop() {
                 if let Some(count) = handle.await.unwrap() {
-                    assert!((10..=30).contains(&count), "Stoppable task should have count between [10, 30], but it is {count}");
+                    assert!(
+                        (10..=30).contains(&count),
+                        "Stoppable task should have count between [10, 30], but it is {count}",
+                    );
                 }
             }
         }

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -108,4 +108,25 @@ mod tests {
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_task_stop_many() {
+        const TASKS: usize = 64;
+
+        let handles = (0..TASKS).map(|_| spawn_stoppable(counting_task)).collect::<Vec<_>>();
+
+        // Signal tasks to stop after ~20 steps
+        sleep(STEP * 20).await;
+        handles.iter().for_each(|handle| assert!(!handle.is_finished()));
+        handles.iter().for_each(|handle| handle.ask_to_stop());
+
+        // Expect task counters to be between [10, 30], we cannot be exact on busy systems
+        for handle in handles {
+            if let Some(handle) = handle.stop() {
+                if let Some(count) = handle.await.unwrap() {
+                    assert!((10..=30).contains(&count), "Stoppable task should have count between [10, 30], but it is {count}");
+                }
+            }
+        }
+    }
 }

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -122,10 +122,10 @@ mod tests {
 
         // Signal tasks to stop after ~20 steps
         sleep(STEP * 20).await;
-        handles
-            .iter()
-            .for_each(|handle| assert!(!handle.is_finished()));
-        handles.iter().for_each(|handle| handle.ask_to_stop());
+        for handle in &handles {
+            assert!(!handle.is_finished());
+            handle.ask_to_stop();
+        }
 
         // Expect task counters to be between [10, 30], we cannot be exact on busy systems
         for handle in handles {

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -101,12 +101,12 @@ mod tests {
         sleep(Duration::from_secs(1)).await;
         assert!(handle.is_finished());
 
-        // Expect task counter to be between [15, 25], we cannot be exact on busy systems
+        // Expect task counter to be between [5, 25], we cannot be exact on busy systems
         if let Some(handle) = handle.stop() {
             if let Some(count) = handle.await.unwrap() {
                 assert!(
-                    (15..=25).contains(&count),
-                    "Stoppable task should have count between [15, 25], but it is {count}",
+                    (5..=25).contains(&count),
+                    "Stoppable task should have count between [5, 25], but it is {count}",
                 );
             }
         }
@@ -127,13 +127,13 @@ mod tests {
             handle.ask_to_stop();
         }
 
-        // Expect task counters to be between [10, 30], we cannot be exact on busy systems
+        // Expect task counters to be between [5, 30], we cannot be exact on busy systems
         for handle in handles {
             if let Some(handle) = handle.stop() {
                 if let Some(count) = handle.await.unwrap() {
                     assert!(
-                        (10..=30).contains(&count),
-                        "Stoppable task should have count between [10, 30], but it is {count}",
+                        (5..=30).contains(&count),
+                        "Stoppable task should have count between [5, 30], but it is {count}",
                     );
                 }
             }

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -63,36 +63,48 @@ where
 #[cfg(test)]
 mod tests {
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    use tokio::time::sleep;
 
     use super::*;
 
     const STEP: Duration = Duration::from_millis(5);
 
-    fn long_task(stop: &AtomicBool) -> i32 {
-        let mut n = 0;
-        for i in 0..10 {
-            n = i;
-            if stop.load(Ordering::Relaxed) {
-                break;
+    /// Simple stoppable task counting steps until stopped. Panics after 1 minute.
+    fn counting_task(stop: &AtomicBool) -> usize {
+        let mut count = 0;
+        let start = Instant::now();
+
+        while !stop.load(Ordering::Relaxed) {
+            count += 1;
+
+            if start.elapsed() > Duration::from_secs(60) {
+                panic!("Task is not stopped within 60 seconds");
             }
+
             thread::sleep(STEP);
         }
-        n
+
+        count
     }
 
     #[tokio::test]
     async fn test_task_stop() {
-        let handle = spawn_stoppable(long_task);
-        tokio::time::sleep(STEP * 5).await;
+        let handle = spawn_stoppable(counting_task);
+
+        // Signal task to stop after ~20 steps
+        sleep(STEP * 20).await;
         assert!(!handle.is_finished());
         handle.ask_to_stop();
-        tokio::time::sleep(STEP * 3).await;
+
+        sleep(Duration::from_secs(1)).await;
         assert!(handle.is_finished());
 
+        // Expect task counter to be between [15, 25], we cannot be exact on busy systems
         if let Some(handle) = handle.stop() {
-            if let Some(res) = handle.await.unwrap() {
-                assert!(res < 10);
+            if let Some(count) = handle.await.unwrap() {
+                assert!((15..=25).contains(&count), "Stoppable task should have count between [15, 25], but it is {count}");
             }
         }
     }

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -67,7 +67,7 @@ mod tests {
 
     use super::*;
 
-    const STEP_MILLIS: u64 = 5;
+    const STEP: Duration = Duration::from_millis(5);
 
     fn long_task(stop: &AtomicBool) -> i32 {
         let mut n = 0;
@@ -76,7 +76,7 @@ mod tests {
             if stop.load(Ordering::Relaxed) {
                 break;
             }
-            thread::sleep(Duration::from_millis(STEP_MILLIS));
+            thread::sleep(STEP);
         }
         n
     }
@@ -84,10 +84,10 @@ mod tests {
     #[tokio::test]
     async fn test_task_stop() {
         let handle = spawn_stoppable(long_task);
-        tokio::time::sleep(Duration::from_millis(STEP_MILLIS * 5)).await;
+        tokio::time::sleep(STEP * 5).await;
         assert!(!handle.is_finished());
         handle.ask_to_stop();
-        tokio::time::sleep(Duration::from_millis(STEP_MILLIS * 3)).await;
+        tokio::time::sleep(STEP * 3).await;
         assert!(handle.is_finished());
 
         if let Some(handle) = handle.stop() {


### PR DESCRIPTION
This improves the stoppable task test which was flaky. It loosens the test requirements a bit to make it less time sensitive. This also adds a test for 64 concurrent stoppable tasks.

We'll have to see if this consistently succeeds on CI, but can easily tweak this again if not.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?