### PR TITLE
fix usage of try_reserve_exact

### DIFF
--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -9,6 +9,7 @@ pub mod operation_time_statistics;
 pub mod rocksdb_buffered_delete_wrapper;
 pub mod rocksdb_wrapper;
 pub mod utils;
+pub mod vector_utils;
 pub mod version;
 
 use crate::data_types::named_vectors::NamedVectors;

--- a/lib/segment/src/common/vector_utils.rs
+++ b/lib/segment/src/common/vector_utils.rs
@@ -1,0 +1,25 @@
+use std::collections::TryReserveError;
+
+pub trait TrySetCapacity {
+    fn try_set_capacity(&mut self, capacity: usize) -> Result<(), TryReserveError>;
+}
+
+pub trait TrySetCapacityExact {
+    fn try_set_capacity_exact(&mut self, capacity: usize) -> Result<(), TryReserveError>;
+}
+
+impl<T> TrySetCapacity for Vec<T> {
+    fn try_set_capacity(&mut self, capacity: usize) -> Result<(), TryReserveError> {
+        let current_capacity = self.capacity();
+        let additional_capacity = capacity.saturating_sub(current_capacity);
+        self.try_reserve(additional_capacity)
+    }
+}
+
+impl<T> TrySetCapacityExact for Vec<T> {
+    fn try_set_capacity_exact(&mut self, capacity: usize) -> Result<(), TryReserveError> {
+        let current_capacity = self.capacity();
+        let additional_capacity = capacity.saturating_sub(current_capacity);
+        self.try_reserve_exact(additional_capacity)
+    }
+}

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use memmap2::{Mmap, MmapMut};
 
 use crate::common::mmap_ops;
+use crate::common::vector_utils::TrySetCapacityExact;
 use crate::entry::entry_point::{OperationError, OperationResult};
 use crate::madvise;
 use crate::types::PointOffsetType;
@@ -403,25 +404,19 @@ impl GraphLinksRam {
         let mut reindex: Vec<PointOffsetType> = Vec::new();
 
         let link_slice = get_links_slice(data, &header);
-        let additional_capacity = link_slice.len().saturating_sub(links.capacity());
-        links.try_reserve_exact(additional_capacity)?;
+        links.try_set_capacity_exact(link_slice.len())?;
         links.extend_from_slice(link_slice);
 
         let offsets_slice = get_offsets_slice(data, &header);
-        let additional_capacity = offsets_slice.len().saturating_sub(offsets.capacity());
-        offsets.try_reserve_exact(additional_capacity)?;
+        offsets.try_set_capacity_exact(offsets_slice.len())?;
         offsets.extend_from_slice(offsets_slice);
 
         let level_offsets_slice = get_level_offsets(data, &header);
-        let additional_capacity = level_offsets_slice
-            .len()
-            .saturating_sub(level_offsets.capacity());
-        level_offsets.try_reserve_exact(additional_capacity)?;
+        level_offsets.try_set_capacity_exact(level_offsets_slice.len())?;
         level_offsets.extend_from_slice(level_offsets_slice);
 
         let reindex_slice = get_reindex_slice(data, &header);
-        let additional_capacity = reindex_slice.len().saturating_sub(reindex.capacity());
-        reindex.try_reserve_exact(additional_capacity)?;
+        reindex.try_set_capacity_exact(reindex_slice.len())?;
         reindex.extend_from_slice(reindex_slice);
 
         let graph_links = Self {

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -403,19 +403,25 @@ impl GraphLinksRam {
         let mut reindex: Vec<PointOffsetType> = Vec::new();
 
         let link_slice = get_links_slice(data, &header);
-        links.try_reserve_exact(link_slice.len())?;
+        let additional_capacity = link_slice.len().saturating_sub(links.capacity());
+        links.try_reserve_exact(additional_capacity)?;
         links.extend_from_slice(link_slice);
 
         let offsets_slice = get_offsets_slice(data, &header);
-        offsets.try_reserve_exact(offsets_slice.len())?;
+        let additional_capacity = offsets_slice.len().saturating_sub(offsets.capacity());
+        offsets.try_reserve_exact(additional_capacity)?;
         offsets.extend_from_slice(offsets_slice);
 
         let level_offsets_slice = get_level_offsets(data, &header);
-        level_offsets.try_reserve_exact(level_offsets_slice.len())?;
+        let additional_capacity = level_offsets_slice
+            .len()
+            .saturating_sub(level_offsets.capacity());
+        level_offsets.try_reserve_exact(additional_capacity)?;
         level_offsets.extend_from_slice(level_offsets_slice);
 
         let reindex_slice = get_reindex_slice(data, &header);
-        reindex.try_reserve_exact(reindex_slice.len())?;
+        let additional_capacity = reindex_slice.len().saturating_sub(reindex.capacity());
+        reindex.try_reserve_exact(additional_capacity)?;
         reindex.extend_from_slice(reindex_slice);
 
         let graph_links = Self {

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::path::Path;
 
 use super::div_ceil;
+use crate::common::vector_utils::{TrySetCapacity, TrySetCapacityExact};
 use crate::types::PointOffsetType;
 
 // chunk size in bytes
@@ -58,29 +59,6 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
         Ok(new_id)
     }
 
-    pub fn try_reserve_size(&mut self, num_vectors: usize) -> Result<(), TryReserveError> {
-        let num_chunks = div_ceil(num_vectors, self.chunk_capacity);
-        let last_chunk_idx = num_vectors / self.chunk_capacity;
-        let current_chunks_capacity = self.chunks.capacity();
-        let additional_chunks_capacity = num_chunks.saturating_sub(current_chunks_capacity);
-        self.chunks.try_reserve_exact(additional_chunks_capacity)?;
-        self.chunks.resize(num_chunks, vec![]);
-        for chunk_idx in 0..num_chunks {
-            if chunk_idx == last_chunk_idx {
-                let desired_capacity = (num_vectors % self.chunk_capacity) * self.dim;
-                let additional_capacity =
-                    desired_capacity.saturating_sub(self.chunks[chunk_idx].capacity());
-                self.chunks[chunk_idx].try_reserve_exact(additional_capacity)?;
-            } else {
-                let desired_capacity = self.chunk_capacity * self.dim;
-                let additional_capacity =
-                    desired_capacity.saturating_sub(self.chunks[chunk_idx].capacity());
-                self.chunks[chunk_idx].try_reserve_exact(additional_capacity)?;
-            }
-        }
-        Ok(())
-    }
-
     pub fn insert(&mut self, key: PointOffsetType, vector: &[T]) -> Result<(), TryReserveError> {
         let key = key as usize;
         self.len = max(self.len, key + 1);
@@ -95,14 +73,12 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
                 // Do not overallocate the first chunk, because it is likely to be small
                 // and we don't want to waste memory.
                 let desired_capacity = idx + self.dim;
-                let additional_capacity = desired_capacity.saturating_sub(chunk_data.capacity());
-                chunk_data.try_reserve(additional_capacity)?;
+                chunk_data.try_set_capacity(desired_capacity)?;
             } else {
                 // Once we have more than one chunk, we don't want to overallocate
                 // and we keep the exact capacity of each chunk.
                 let desired_capacity = self.chunk_capacity * self.dim;
-                let additional_capacity = desired_capacity.saturating_sub(chunk_data.capacity());
-                chunk_data.try_reserve_exact(additional_capacity)?;
+                chunk_data.try_set_capacity_exact(desired_capacity)?;
             }
             chunk_data.resize(idx + self.dim, T::default());
         }
@@ -123,12 +99,14 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
         vectors_count: usize,
     ) -> std::io::Result<Self> {
         let mut vectors = Self::new(quantized_vector_size);
-        vectors.try_reserve_size(vectors_count).map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::OutOfMemory,
-                format!("Failed to load quantized vectors from file: {err}"),
-            )
-        })?;
+        vectors
+            .try_set_capacity_exact(vectors_count)
+            .map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::OutOfMemory,
+                    format!("Failed to load quantized vectors from file: {err}"),
+                )
+            })?;
         let mut file = File::open(path)?;
         let mut buffer = vec![0u8; quantized_vector_size];
         while file.read_exact(&mut buffer).is_ok() {
@@ -158,6 +136,25 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
             buffer.write_all(self.get(i))?;
         }
         buffer.flush()?;
+        Ok(())
+    }
+}
+
+impl<T: Clone> TrySetCapacityExact for ChunkedVectors<T> {
+    fn try_set_capacity_exact(&mut self, capacity: usize) -> Result<(), TryReserveError> {
+        let num_chunks = div_ceil(capacity, self.chunk_capacity);
+        let last_chunk_idx = capacity / self.chunk_capacity;
+        self.chunks.try_set_capacity_exact(num_chunks)?;
+        self.chunks.resize(num_chunks, vec![]);
+        for chunk_idx in 0..num_chunks {
+            if chunk_idx == last_chunk_idx {
+                let desired_capacity = (capacity % self.chunk_capacity) * self.dim;
+                self.chunks[chunk_idx].try_set_capacity_exact(desired_capacity)?;
+            } else {
+                let desired_capacity = self.chunk_capacity * self.dim;
+                self.chunks[chunk_idx].try_set_capacity_exact(desired_capacity)?;
+            }
+        }
         Ok(())
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -240,7 +240,7 @@ impl QuantizedVectors {
         let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
         if in_ram {
             let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_reserve_exact(vector_parameters.count)?;
+            storage_builder.try_reserve_size(vector_parameters.count)?;
             Ok(QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::encode(
                 vectors,
                 storage_builder,
@@ -285,7 +285,7 @@ impl QuantizedVectors {
         let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
         if in_ram {
             let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_reserve_exact(vector_parameters.count)?;
+            storage_builder.try_reserve_size(vector_parameters.count)?;
             Ok(QuantizedVectorStorage::PQRam(EncodedVectorsPQ::encode(
                 vectors,
                 storage_builder,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::quantized_raw_scorer::QuantizedRawScorer;
 use crate::common::file_operations::{atomic_save_json, read_json};
+use crate::common::vector_utils::TrySetCapacityExact;
 use crate::data_types::vectors::VectorElementType;
 use crate::entry::entry_point::OperationResult;
 use crate::types::{
@@ -240,7 +241,7 @@ impl QuantizedVectors {
         let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
         if in_ram {
             let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_reserve_size(vector_parameters.count)?;
+            storage_builder.try_set_capacity_exact(vector_parameters.count)?;
             Ok(QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::encode(
                 vectors,
                 storage_builder,
@@ -285,7 +286,7 @@ impl QuantizedVectors {
         let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
         if in_ram {
             let mut storage_builder = ChunkedVectors::<u8>::new(quantized_vector_size);
-            storage_builder.try_reserve_size(vector_parameters.count)?;
+            storage_builder.try_set_capacity_exact(vector_parameters.count)?;
             Ok(QuantizedVectorStorage::PQRam(EncodedVectorsPQ::encode(
                 vectors,
                 storage_builder,


### PR DESCRIPTION
This PR fixes usage of `try_reserve_exact` function in chunked vectors which leads to over-allocation.

Rust really should allow specifying param names during function calls.
This naming is very confusing, no wonder this happened.

Also renamed `try_reserve_exact` -> `try_reserve_size` for custom method to avoid mixing semantics.