### PR TITLE
allow to configure qdrant init file with env variable

### DIFF
--- a/src/startup.rs
+++ b/src/startup.rs
@@ -7,7 +7,11 @@ use log::LevelFilter;
 
 use crate::common::error_reporting::ErrorReporter;
 
-const INITIALIZED_FILE: &str = ".qdrant-initialized";
+const DEFAULT_INITIALIZED_FILE: &str = ".qdrant-initialized";
+
+fn get_init_file_path() -> String {
+    std::env::var("QDRANT_INIT_FILE_PATH").unwrap_or_else(|_| DEFAULT_INITIALIZED_FILE.to_owned())
+}
 
 pub fn setup_logger(log_level: &str) {
     let is_info = log_level.to_ascii_uppercase() == "INFO";
@@ -61,7 +65,7 @@ pub fn setup_panic_hook(reporting_enabled: bool, reporting_id: String) {
 /// Creates a file that indicates that the server has been started.
 /// This file is used to check if the server has been been successfully started before potential kill.
 pub fn touch_started_file_indicator() {
-    if let Err(err) = std::fs::write(INITIALIZED_FILE, "") {
+    if let Err(err) = std::fs::write(get_init_file_path(), "") {
         log::warn!("Failed to create init file indicator: {}", err);
     }
 }
@@ -69,8 +73,9 @@ pub fn touch_started_file_indicator() {
 /// Removes a file that indicates that the server has been started.
 /// Use before server initialization to avoid false positives.
 pub fn remove_started_file_indicator() {
-    if std::path::Path::new(INITIALIZED_FILE).exists() {
-        if let Err(err) = std::fs::remove_file(INITIALIZED_FILE) {
+    let path = get_init_file_path();
+    if std::path::Path::new(&path).exists() {
+        if let Err(err) = std::fs::remove_file(path) {
             log::warn!("Failed to remove init file indicator: {}", err);
         }
     }

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -39,14 +39,14 @@ if [ $EXIT_CODE != 137 ]; then
     exit $EXIT_CODE
 fi
 
-IS_INITIALIZED_FILE='.qdrant-initialized'
+QDRANT_INIT_FILE_PATH=${QDRANT_INIT_FILE_PATH:-'.qdrant-initialized'}
 RECOVERY_MESSAGE="Qdrant was killed during initialization. Most likely it's Out-of-Memory.
 Please check memory consumption, increase memory limit or remove some collections and restart"
 
 # Check that qdrant was initialized
-# Qdrant creates IS_INITIALIZED_FILE file after initialization
+# Qdrant creates QDRANT_INIT_FILE_PATH file after initialization
 # So if it doesn't exist, qdrant was killed during initialization
-if [ ! -f "$IS_INITIALIZED_FILE" ]; then
+if [ ! -f "$QDRANT_INIT_FILE_PATH" ]; then
     # Run qdrant in recovery mode.
     # No collection operations are allowed in recovery mode except for removing collections
     QDRANT__STORAGE__RECOVERY_MODE="$RECOVERY_MESSAGE" ./qdrant $@ &


### PR DESCRIPTION
Improvement for cloud support of recovery mode:
Allow to configure star-up indicator file path using env variable