### PR TITLE
clear temp segments directory while shard loading

### DIFF
--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -17,6 +17,8 @@ use crate::update_handler::Optimizer;
 
 const DEFAULT_MAX_SEGMENT_PER_CPU_KB: usize = 200_000;
 const DEFAULT_INDEXING_THRESHOLD_KB: usize = 20_000;
+const SEGMENTS_PATH: &str = "segments";
+const TEMP_SEGMENTS_PATH: &str = "temp_segments";
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 pub struct OptimizersConfig {
@@ -109,6 +111,20 @@ impl OptimizersConfig {
     }
 }
 
+pub fn clear_temp_segments(shard_path: &Path) {
+    let temp_segments_path = shard_path.join(TEMP_SEGMENTS_PATH);
+    if temp_segments_path.exists() {
+        log::debug!("Removing temp_segments directory: {:?}", temp_segments_path);
+        if let Err(err) = std::fs::remove_dir_all(&temp_segments_path) {
+            log::warn!(
+                "Failed to remove temp_segments directory: {:?}, error: {:?}",
+                temp_segments_path,
+                err
+            );
+        }
+    }
+}
+
 pub fn build_optimizers(
     shard_path: &Path,
     collection_params: &CollectionParams,
@@ -116,8 +132,8 @@ pub fn build_optimizers(
     hnsw_config: &HnswConfig,
     quantization_config: &Option<QuantizationConfig>,
 ) -> Arc<Vec<Arc<Optimizer>>> {
-    let segments_path = shard_path.join("segments");
-    let temp_segments_path = shard_path.join("temp_segments");
+    let segments_path = shard_path.join(SEGMENTS_PATH);
+    let temp_segments_path = shard_path.join(TEMP_SEGMENTS_PATH);
 
     let indexing_threshold = match optimizers_config.indexing_threshold {
         None => DEFAULT_INDEXING_THRESHOLD_KB, // default value

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -35,7 +35,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CollectionStatus, OptimizersStatus,
 };
 use crate::operations::CollectionUpdateOperations;
-use crate::optimizers_builder::build_optimizers;
+use crate::optimizers_builder::{build_optimizers, clear_temp_segments};
 use crate::shards::shard::ShardId;
 use crate::shards::shard_config::{ShardConfig, SHARD_CONFIG_FILE};
 use crate::shards::telemetry::{LocalShardTelemetry, OptimizerTelemetry};
@@ -216,6 +216,7 @@ impl LocalShard {
             log::debug!("Deduplicated {} points", res);
         }
 
+        clear_temp_segments(shard_path);
         let optimizers = build_optimizers(
             shard_path,
             &collection_config_read.params,


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/2317.

If qdrant is stopped while indexing, temp segment will not be removed. I propose to clear temp directory while local shard loading.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
