### PR TITLE
Fix for updating vector-specific config params

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5917,17 +5917,10 @@
       },
       "VectorsConfigDiff": {
         "description": "Vector update params separator for single and multiple vector modes\n\nSingle mode:\n\n{ \"hnsw_config\": { \"m\": 8 } }\n\nor multiple mode:\n\n{ \"default\": { \"hnsw_config\": { \"m\": 8 } } }",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/VectorParamsDiff"
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/VectorParamsDiff"
-            }
-          }
-        ]
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/VectorParamsDiff"
+        }
       },
       "VectorParamsDiff": {
         "type": "object",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5916,7 +5916,7 @@
         }
       },
       "VectorsConfigDiff": {
-        "description": "Vector update params separator for single and multiple vector modes\n\nSingle mode:\n\n{ \"hnsw_config\": { \"m\": 8 } }\n\nor multiple mode:\n\n{ \"default\": { \"hnsw_config\": { \"m\": 8 } } }",
+        "description": "Vector update params for multiple vectors\n\n{ \"vector_name\": { \"hnsw_config\": { \"m\": 8 } } }",
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/VectorParamsDiff"

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1140,6 +1140,7 @@ impl Collection {
         update_vectors_diff: &VectorsConfigDiff,
     ) -> CollectionResult<()> {
         let mut config = self.collection_config.write().await;
+        update_vectors_diff.check_vector_names(&config.params)?;
         config
             .params
             .update_vectors_from_diff(update_vectors_diff)?;

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -183,7 +183,7 @@ impl CollectionParams {
         &mut self,
         update_vectors_diff: &VectorsConfigDiff,
     ) -> CollectionResult<()> {
-        for (vector_name, update_params) in update_vectors_diff.params_iter() {
+        for (vector_name, update_params) in update_vectors_diff.0.iter() {
             let vector_params = self.get_vector_params_mut(vector_name)?;
 
             // Update and replace vector params from vector specific diff

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -362,14 +362,15 @@ impl TryFrom<api::grpc::qdrant::vectors_config_diff::Config> for VectorsConfigDi
     ) -> Result<Self, Self::Error> {
         Ok(match value {
             api::grpc::qdrant::vectors_config_diff::Config::Params(vector_params) => {
-                VectorsConfigDiff::Single(vector_params.try_into()?)
+                let diff: VectorParamsDiff = vector_params.try_into()?;
+                VectorsConfigDiff::from(diff)
             }
             api::grpc::qdrant::vectors_config_diff::Config::ParamsMap(vectors_params) => {
                 let mut params_map = BTreeMap::new();
                 for (name, params) in vectors_params.map {
                     params_map.insert(name, params.try_into()?);
                 }
-                VectorsConfigDiff::Multi(params_map)
+                VectorsConfigDiff(params_map)
             }
         })
     }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -995,34 +995,15 @@ pub struct VectorParamsDiff {
     pub hnsw_config: Option<HnswConfigDiff>,
 }
 
-/// Vector update params separator for single and multiple vector modes
-///
-/// Single mode:
-///
-/// { "hnsw_config": { "m": 8 } }
-///
-/// or multiple mode:
+/// Vector update params for multiple vectors
 ///
 /// {
-///     "default": {
+///     "vector_name": {
 ///         "hnsw_config": { "m": 8 }
 ///     }
 /// }
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 pub struct VectorsConfigDiff(pub BTreeMap<String, VectorParamsDiff>);
-
-impl VectorsConfigDiff {
-    pub fn get_params(&self, name: &str) -> Option<&VectorParamsDiff> {
-        self.0.get(name)
-    }
-
-    /// Iterate over the named vector parameters.
-    ///
-    /// If this is `Single` it iterates over a single parameter named [`DEFAULT_VECTOR_NAME`].
-    pub fn params_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&str, &VectorParamsDiff)> + 'a> {
-        Box::new(self.0.iter().map(|(n, p)| (n.as_str(), p)))
-    }
-}
 
 impl Validate for VectorsConfigDiff {
     fn validate(&self) -> Result<(), ValidationErrors> {

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -3,6 +3,7 @@ import pytest
 from .helpers.helpers import request_with_validation
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 
+default_name = ""
 collection_name = 'test_collection_uuid'
 
 
@@ -20,9 +21,11 @@ def test_collection_update():
         path_params={'collection_name': collection_name},
         body={
             "vectors": {
-                "hnsw_config": {
-                    "m": 32,
-                    "ef_construct": 123,
+                default_name: {
+                    "hnsw_config": {
+                        "m": 32,
+                        "ef_construct": 123,
+                    },
                 },
             },
             "optimizers_config": {
@@ -77,8 +80,10 @@ def test_hnsw_update():
         path_params={'collection_name': collection_name},
         body={
             "vectors": {
-                "hnsw_config": {
-                    "m": 32,
+                default_name: {
+                    "hnsw_config": {
+                        "m": 32,
+                    },
                 },
             },
             "hnsw_config": {
@@ -106,9 +111,11 @@ def test_hnsw_update():
         path_params={'collection_name': collection_name},
         body={
             "vectors": {
-                "hnsw_config": {
-                    "m": 10,
-                    "ef_construct": 100,
+                default_name: {
+                    "hnsw_config": {
+                        "m": 10,
+                        "ef_construct": 100,
+                    },
                 },
             },
         }

--- a/openapi/tests/openapi_integration/test_collection_update_multivec.py
+++ b/openapi/tests/openapi_integration/test_collection_update_multivec.py
@@ -1,0 +1,135 @@
+import pytest
+
+from .helpers.helpers import request_with_validation
+from .helpers.collection_setup import drop_collection, multivec_collection_setup
+
+collection_name = 'test_collection_update_multivec'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    multivec_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_collection_update_multivec():
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "image": {
+                    "hnsw_config": {
+                        "m": 32,
+                        "ef_construct": 123,
+                    }
+                }
+            },
+            "optimizers_config": {
+                "default_segment_number": 6,
+                "indexing_threshold": 10000,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 7,
+                    "vector": {
+                        "image": [0.15, 0.31, 0.76, 0.74]
+                    },
+                    "payload": {"city": "Rome"}
+                }
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 7},
+    )
+    assert response.ok
+
+
+def test_hnsw_update():
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    config = result["config"]
+    assert "hnsw_config" not in config["params"]["vectors"]
+    assert config["hnsw_config"]["m"] == 16
+    assert config["hnsw_config"]["ef_construct"] == 100
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "text": {
+                    "hnsw_config": {
+                        "m": 32,
+                    }
+                }
+            },
+            "hnsw_config": {
+                "ef_construct": 123,
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    config = result["config"]
+    assert config["params"]["vectors"]["text"]["hnsw_config"]["m"] == 32
+    assert config["hnsw_config"]["m"] == 16
+    assert config["hnsw_config"]["ef_construct"] == 123
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "text": {
+                    "hnsw_config": {
+                        "m": 10,
+                        "ef_construct": 100,
+                    }
+                }
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+    result = response.json()["result"]
+    config = result["config"]
+    assert config["params"]["vectors"]["text"]["hnsw_config"]["m"] == 10
+    assert config["params"]["vectors"]["text"]["hnsw_config"]["ef_construct"] == 100

--- a/openapi/tests/openapi_integration/test_collection_update_multivec.py
+++ b/openapi/tests/openapi_integration/test_collection_update_multivec.py
@@ -133,3 +133,24 @@ def test_hnsw_update():
     config = result["config"]
     assert config["params"]["vectors"]["text"]["hnsw_config"]["m"] == 10
     assert config["params"]["vectors"]["text"]["hnsw_config"]["ef_construct"] == 100
+
+
+def test_invalid_vector_name():
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "i_do_no_exist": {
+                    "hnsw_config": {
+                        "m": 32,
+                    }
+                }
+            },
+        }
+    )
+    assert not response.ok
+    assert response.status_code == 400
+    error = response.json()["status"]["error"]
+    assert error == "Wrong input: Not existing vector name error: i_do_no_exist"


### PR DESCRIPTION
_Edited by @timvisee_

Fixes for <https://github.com/qdrant/qdrant/pull/2087>. Tracking issue: https://github.com/qdrant/qdrant/issues/2088

In short, this:
- adds integration test for multi vector config param updates (thanks @generall !)
- removes ability to update unnamed vector params from REST API
- add vector name validation to update collection endpoint

The core issue this fixes can be summarized like this:
- the REST API accepted both unnamed and named vector variants for updating vector parameters
- unnamed and named variants are untagged, and selected based on contents
- all parameters are optional and have default values
- unknown fields are allowed in the request object and simply ignored

Because of that, a request object can always be deserialized as both variants, because for both variants all fields can be filled with their defaults. Therefore serde cannot choose the right variant and parses incorrectly. This is further explained [here](https://github.com/qdrant/qdrant/pull/2328#issuecomment-1651393050).

This is fixed by removing the ability to provide unnamed vector parameters from the REST API. Users must now always specify a vector name. This is reasonable, because updating vector parameters on a collection with a single unnamed vector is a bad pattern. Updating collection parameters can be used instead. A user could still achieve the same by providing the `""` name if desired. The gRPC API is left unchagned.

Other parts of the API have been kept intact as much as possible. This way the structure and semantics both the create and update collection endpoint remain as similar as possible.