### PR TITLE
add devcontainers to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /benches/search-points/target
 /.idea
 /.vscode
+/.devcontainer
 /storage
 /snapshots
 /consensus_test_logs


### PR DESCRIPTION
I'm going to close this PR https://github.com/qdrant/qdrant/pull/2172
Because we don't commit top-level dev files like `.idea` os `.vscode`. Also This PR is not compatible with Windows, without windows, devcontrainers don't achieve cross-platform development under docker. Also devcontainers as technology is raw and under beta.
But for users who actually uses devcontainers I propose to add devcontainers to gitignore to make more comfortable work under devcontainers

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
