### PR TITLE
Migrate `raft_state` from cbor to JSON

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -76,14 +76,14 @@ impl Persistent {
         first_peer: bool,
     ) -> Result<Self, StorageError> {
         create_dir_all(storage_path.as_ref())?;
-        let path = storage_path.as_ref().join(STATE_FILE_NAME_CBOR);
+        let path_legacy = storage_path.as_ref().join(STATE_FILE_NAME_CBOR);
         let path_json = storage_path.as_ref().join(STATE_FILE_NAME);
         let state = if path_json.exists() {
             log::info!("Loading raft state from {}", path_json.display());
             Self::load_json(path_json)?
-        } else if path.exists() {
-            log::info!("Loading raft state from {}", path.display());
-            let mut state = Self::load(path)?;
+        } else if path_legacy.exists() {
+            log::info!("Loading raft state from {}", path_legacy.display());
+            let mut state = Self::load(path_legacy)?;
             // migrate to json
             state.path = path_json;
             state.save()?;

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -17,8 +17,10 @@ use crate::content_manager::consensus::entry_queue::{EntryApplyProgressQueue, En
 use crate::types::PeerAddressById;
 use crate::StorageError;
 
-const STATE_FILE_NAME: &str = "raft_state";
-const STATE_FILE_NAME_JSON: &str = "raft_state.json";
+// Deprecated, use `STATE_FILE_NAME` instead
+const STATE_FILE_NAME_CBOR: &str = "raft_state";
+
+const STATE_FILE_NAME: &str = "raft_state.json";
 
 /// State of the Raft consensus, which should be saved between restarts.
 /// State of the collections, aliases and transfers are stored as regular storage.
@@ -74,8 +76,8 @@ impl Persistent {
         first_peer: bool,
     ) -> Result<Self, StorageError> {
         create_dir_all(storage_path.as_ref())?;
-        let path = storage_path.as_ref().join(STATE_FILE_NAME);
-        let path_json = storage_path.as_ref().join(STATE_FILE_NAME_JSON);
+        let path = storage_path.as_ref().join(STATE_FILE_NAME_CBOR);
+        let path_json = storage_path.as_ref().join(STATE_FILE_NAME);
         let state = if path_json.exists() {
             log::info!("Loading raft state from {}", path_json.display());
             Self::load_json(path_json)?

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -193,6 +193,15 @@ impl From<serde_cbor::Error> for StorageError {
     }
 }
 
+impl From<serde_json::Error> for StorageError {
+    fn from(err: serde_json::Error) -> Self {
+        StorageError::ServiceError {
+            description: format!("json (de)serialization error: {err}"),
+            backtrace: Some(Backtrace::force_capture().to_string()),
+        }
+    }
+}
+
 impl From<prost::EncodeError> for StorageError {
     fn from(err: prost::EncodeError) -> Self {
         StorageError::ServiceError {


### PR DESCRIPTION
`raft_state` file have a valuable information about consensus. It might be required to change some parameters for debug purposes.
It is much simpler to edit JSON. 
Serialization overhead considered negligible.


This PR will migrate `raft_state` into `raft_state.json`, while keeping backward compatibility with the original file
