### PR TITLE
Remove unused debug setting

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,3 @@
-debug: false
 log_level: INFO
 
 storage:

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,4 +1,3 @@
-debug: true
 log_level: DEBUG
 
 service:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,5 +1,3 @@
-
-debug: false
 log_level: INFO
 
 service:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,8 +114,6 @@ pub struct TlsConfig {
 
 #[derive(Debug, Deserialize, Clone, Validate)]
 pub struct Settings {
-    #[serde(default = "default_debug")]
-    pub debug: bool,
     #[serde(default = "default_log_level")]
     pub log_level: String,
     #[validate]
@@ -182,10 +180,6 @@ const fn default_telemetry_disabled() -> bool {
 
 const fn default_cors() -> bool {
     true
-}
-
-const fn default_debug() -> bool {
-    false
 }
 
 fn default_log_level() -> String {


### PR DESCRIPTION
It seems the `debug` flag is completely unused and I have no re-collection what it used to do.

This PR proposes to simply remove it.