### PR TITLE
Fix `ConsensusWal::entries` to return as soon as `max_size` is exceeded...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,6 +4597,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "prost",
+ "protobuf",
  "raft",
  "rand 0.8.5",
  "reqwest",

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -36,6 +36,7 @@ validator = { version = "0.16", features = ["derive"] }
 atomicwrites = { version = "0.4.1" }
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 prost = { version = "0.11.9" } # version of prost used by raft
+protobuf = "2.28.0" # version of protobuf used by raft
 serde_cbor = { version = "0.11.2" }
 
 segment = { path = "../segment" }

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -89,7 +89,7 @@ impl ConsensusOpWal {
                     // It might also be reasonable to add a hard limit on the total size of returned entries here.
                     //
                     // For the same reason, that if `raft::RawNode` request some ginormous range without reasonable
-                    // `max_size` the current `entries` impelmentation will block consensus thread until the whole
+                    // `max_size` the current `entries` implementation will block consensus thread until the whole
                     // range is collected.
                     _ => return true,
                 };

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use itertools::Itertools;
 use prost::Message;
+use protobuf::Message as _;
 use raft::eraftpb::Entry as RaftEntry;
-use raft::util::limit_size;
 use wal::Wal;
 
 use crate::content_manager::consensus_manager;
@@ -56,8 +56,51 @@ impl ConsensusOpWal {
         high: u64,
         max_size: Option<u64>,
     ) -> raft::Result<Vec<RaftEntry>> {
-        let mut entries = (low..high).map(|id| self.entry(id)).try_collect()?;
-        limit_size(&mut entries, max_size);
+        let mut size = 0;
+
+        let entries = (low..high)
+            .map(|id| self.entry(id))
+            .take_while(|entry| {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(_) => return true,
+                };
+
+                // It's somewhat unclear how `max_size == Some(0)` should be treated.
+                //
+                // `raft::storage::Storage::entries` documentation and `raft::util::limit_size` implementation
+                // suggest that it means "return only a single entry", but why not request a single entry
+                // using `low`/`high` arguments in that case? 🤔
+                //
+                // Another reasonable interpretation might be "unlimited" (e.g., same as `None` and `u64::MAX`).
+                //
+                // `raft::RawNode` would request ridiculous range (e.g., 1 mil entries) with `max_size == Some(0)`,
+                // which, IMO, does not make much sense. 😕
+                //
+                // The current implementation follows `raft::storage::Storage::entries` spec,
+                // but further research/experimentation might be needed.
+                //
+                // See:
+                // - https://docs.rs/raft/latest/raft/storage/trait.Storage.html#tymethod.entries
+                // - https://github.com/tikv/raft-rs/blob/v0.7.0/src/util.rs#L56-L71
+                let max_size = match max_size {
+                    Some(max_size) if max_size < u64::MAX => max_size,
+
+                    // It might also be reasonable to add a hard limit on the total size of returned entries here.
+                    //
+                    // For the same reason, that if `raft::RawNode` request some ginormous range without reasonable
+                    // `max_size` the current `entries` impelmentation will block consensus thread until the whole
+                    // range is collected.
+                    _ => return true,
+                };
+
+                let first_entry = size == 0;
+                size += u64::from(entry.compute_size());
+
+                size <= max_size || first_entry
+            })
+            .try_collect()?;
+
         Ok(entries)
     }
 


### PR DESCRIPTION
__The bug:__
- There are 1kk commits in our Raft log, and we're adding a new node to the cluster.
- The new node has to synchronize Raft state with the cluster.
- To do so, `raft::raw_node::RawNode::step` (on a leader node) requests all 1kk log entries from our `raft::storage::Storage::entries` implementation (which is, practically, propagated to `ConsensusWal::entries`).
- And `ConsensusWal::entries` is somewhat simplistic... so it goes and copies 1kk log entries into a vector in a looooong blocking call, which "blocks" consensus thread until all entries are copied.

__The solution:__
- The `entries` method accepts `max_size` argument, that was handled by our `entries` implementation suboptimally.
  - It would _eagerly_ collect all the entries in the range first, and then truncate them to fit the requested `max_size`.
- This PR makes `entries` to calculate `max_size` _while_ collecting entries and return collected entries once `max_size` is exceeded.
- `RaftNode` seems to always call `entries` with `max_size == Some(0)` (which means "return only a single entry"), and so this change serves as the minimal solution to the bug above.

__Further improvements/optimizations/better solutions:__
- add a hard limit for the number of log entries returned from the `entries` method (`raft` crate seems to work fine with such fix)
- [raft::storage::Storage::entries](https://docs.rs/raft/latest/raft/storage/trait.Storage.html#tymethod.entries) documentation mentions there's a way to collect entries _asynchronously_ (and report the result to RaftNode later; "asynchronously" in the general sense, not with the Rust async function/method)
- make the node that lags too far behind to explicitly request Raft snapshot (instead of implicitly request every single entry in the Raft log)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo fmt` command prior to submission?
3. [x] Have you checked your code using `cargo clippy` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
