### PR TITLE
Replace `env_logger` with `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,7 +3583,6 @@ dependencies = [
  "config",
  "console-subscriber",
  "constant_time_eq 0.3.0",
- "env_logger",
  "futures",
  "futures-util",
  "itertools 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,26 +20,15 @@ multiling-japanese = ["segment/multiling-japanese"]
 multiling-korean = ["segment/multiling-korean"]
 service_debug = ["parking_lot", "parking_lot/deadlock_detection"]
 tracing = [
-    "dep:tracing",
     "api/tracing",
     "collection/tracing",
     "segment/tracing",
     "storage/tracing",
 ]
-tracing-log = ["tracing/log"]
-tracing-log-always = ["tracing/log-always"]
-tracing-logger = [
-    "tracing",
-    "tracing-subscriber/ansi",
-    "tracing-subscriber/env-filter",
-    "tracing-subscriber/fmt",
-    "tracing-subscriber/tracing-log",
-    "dep:tracing-log",
-]
 console = ["console-subscriber"]
-console-subscriber = ["tracing", "tracing-subscriber", "dep:console-subscriber"]
+console-subscriber = ["tracing", "dep:console-subscriber"]
 tracy = ["tracing-tracy"]
-tracing-tracy = ["tracing", "tracing-subscriber", "dep:tracing-tracy"]
+tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
 
 [dev-dependencies]
@@ -57,7 +46,6 @@ parking_lot = { version = "0.12.1", features=["deadlock_detection"], optional = 
 num_cpus = "1.16"
 thiserror = "1.0"
 log = "0.4"
-env_logger = "0.10.0"
 atty = "0.2"
 colored = "2"
 serde = { version = "~1.0", features = ["derive"] }
@@ -108,9 +96,9 @@ actix-multipart = "0.6.0"
 constant_time_eq = "0.3.0"
 
 # Profiling
-tracing = { version = "0.1", features = ["async-await"], optional = true }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
-tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"], optional = true }
+tracing = { version = "0.1", features = ["async-await"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 console-subscriber = { version = "0.1", default-features = false, features = ["parking_lot"], optional = true }
 tracing-tracy = { version = "0.10.2", features = ["ondemand"], optional = true }
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,5 +1,5 @@
 debug: true
-log_level: DEBUG
+log_level: DEBUG,hyper=INFO,h2=INFO,tower=INFO,rustls=INFO,raft=INFO
 
 service:
   host: 127.0.0.1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -140,17 +140,7 @@ Use [pprof](https://github.com/google/pprof) and the following command to genera
 Qdrant have basic [`tracing`] support with [`Tracy`] profiler and [`tokio-console`] integrations
 that can be enabled with optional features.
 
-- `tracing-log` and `tracing-log-always` features enable [`tracing/log` and `tracing/log-always`][tracing-log-features]
-  features of the `tracing` crate, which cause `tracing` crate to produce logs with the `log` crate
-  - if `tracing-log` feature enabled, the logs would only be produced if no other tracing subscriber is enabled
-    (e.g., if neither `tracy`, nor `console` feature is enabled)
-  - if `tracing-log-always` feature is enabled, the logs would _always_ be produced
-  - useful for "quick and dirty" `tracing`-enabled debugging, that does not require any additional setup
-- `tracing-logger` feature replaces default logger with an alternative "tracing-compatible" logger,
-  that also prints [tracing span] information for `tracing` logs (which is _super-useful_ in times)
-  - note, that `tracing-logger` only reads "filters" from default `RUST_LOG` env-var currently
-  - note, that if both `tracing-log-always` and `tracing-logger` features are enabled it will cause some logs
-    to be printed twice
+- [`tracing`] is an _optional_ dependency that can be enabled with `tracing` feature
 - `tracy` feature enables [`Tracy`] profiler integration
 - `console` feature enables [`tokio-console`] integration
   - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
@@ -162,15 +152,16 @@ that can be enabled with optional features.
   - note, that you'll also have to [pass `--cfg tokio_unstable` arguments to `rustc`][tokio-tracing] to enable this feature
   - this is required (and enabled automatically) by the `console` feature
   - but you can enable it explicitly with the `tracy` feature, to see Tokio traces in [`Tracy`] profiler
-- `tracing` feature simply enables optional [`tracing`] crate dependency (without any integrations)
-  - this is required (and enabled automatically) by all of the above features
 
 Qdrant code is **not** instrumented by default, so you'll have to manually add `#[tracing::instrument]` attributes
 on functions and methods that you want to profile.
 
+Qdrant uses [`tracing-log`] as the [`log`] backend, so `log` and `log-always` features of the [`tracing`] crate
+[should _not_ be enabled][tracing-log-warning]!
+
 ```rust
-// `tracing` crate is an *optional* dependency, so if you want the code to compile when `tracing`
-// feature is disabled, you have to use `#[cfg_attr(...)]`...
+// `tracing` crate is an *optional* dependency in `lib/*` crates, so if you want the code to compile
+// when `tracing` feature is disabled, you have to use `#[cfg_attr(...)]`...
 //
 // See https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute
 #[cfg_attr(feature = "tracing", tracing::instrument)]
@@ -187,12 +178,13 @@ fn some_other_function() {
 }
 ```
 
-[tracing-log-features]: https://docs.rs/tracing/latest/tracing/#emitting-log-records
-[tracing span]: https://docs.rs/tracing/latest/tracing/index.html#spans
 [`tracing`]: https://docs.rs/tracing/latest/tracing/
 [`Tracy`]: https://github.com/wolfpld/tracy
 [`tokio-console`]: https://docs.rs/tokio-console/latest/tokio_console/
 [tokio-tracing]: https://docs.rs/tokio/latest/tokio/#unstable-features
+[`tracing-log`]: https://docs.rs/tracing-log/latest/tracing_log/
+[`log`]: https://docs.rs/log/latest/log/
+[tracing-log-warning]: https://docs.rs/tracing-log/latest/tracing_log/#caution-mixing-both-conversions
 
 ## API changes
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1028,7 +1028,6 @@ mod tests {
         let mut settings = crate::Settings::new(None).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
-        tracing_log::LogTracer::init().unwrap();
         tracing_subscriber::fmt::init();
         let search_runtime =
             crate::create_search_runtime(settings.storage.performance.max_search_threads)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1028,7 +1028,7 @@ mod tests {
         let mut settings = crate::Settings::new(None).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
-        tracing_log::LogTracer::init();
+        tracing_log::LogTracer::init().unwrap();
         tracing_subscriber::fmt::init();
         let search_runtime =
             crate::create_search_runtime(settings.storage.performance.max_search_threads)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1028,7 +1028,8 @@ mod tests {
         let mut settings = crate::Settings::new(None).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
         std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
-        env_logger::init();
+        tracing_log::LogTracer::init();
+        tracing_subscriber::fmt::init();
         let search_runtime =
             crate::create_search_runtime(settings.storage.performance.max_search_threads)
                 .expect("Can't create search runtime.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use crate::greeting::welcome;
 use crate::migrations::single_to_cluster::handle_existing_collections;
 use crate::settings::Settings;
 use crate::snapshots::{recover_full_snapshot, recover_snapshots};
-use crate::startup::{remove_started_file_indicator, setup_logger, touch_started_file_indicator};
+use crate::startup::{remove_started_file_indicator, touch_started_file_indicator};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -116,11 +116,7 @@ fn main() -> anyhow::Result<()> {
 
     let reporting_id = TelemetryCollector::generate_id();
 
-    if cfg!(feature = "tracing-logger") {
-        tracing::setup(&settings.log_level)?;
-    } else {
-        setup_logger(&settings.log_level);
-    }
+    tracing::setup(&settings.log_level)?;
 
     setup_panic_hook(reporting_enabled, reporting_id.to_string());
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -4,8 +4,6 @@ use std::backtrace::Backtrace;
 use std::panic;
 use std::path::PathBuf;
 
-use log::LevelFilter;
-
 use crate::common::error_reporting::ErrorReporter;
 
 const DEFAULT_INITIALIZED_FILE: &str = ".qdrant-initialized";
@@ -14,30 +12,6 @@ fn get_init_file_path() -> PathBuf {
     std::env::var("QDRANT_INIT_FILE_PATH")
         .map(PathBuf::from)
         .unwrap_or_else(|_| DEFAULT_INITIALIZED_FILE.into())
-}
-
-pub fn setup_logger(log_level: &str) {
-    let is_info = log_level.to_ascii_uppercase() == "INFO";
-    let mut log_builder = env_logger::Builder::new();
-
-    log_builder
-        // Timestamp in millis
-        .format_timestamp_millis()
-        // Parse user defined log level configuration
-        .parse_filters(log_level)
-        // h2 is very verbose and we have many network operations,
-        // so it is limited to only errors
-        .filter_module("h2", LevelFilter::Error)
-        .filter_module("tower", LevelFilter::Warn);
-
-    if is_info {
-        // Additionally filter verbose modules if no extended logging configuration is provided
-        log_builder
-            .filter_module("wal", LevelFilter::Warn)
-            .filter_module("raft::raft", LevelFilter::Warn);
-    };
-
-    log_builder.init();
 }
 
 pub fn setup_panic_hook(reporting_enabled: bool, reporting_id: String) {


### PR DESCRIPTION
This PR replaces `env_logger` with `tracing`/`tracing-subscriber`/`tracing-log` as our `log` backend (and also removes half of the custom features added in #2187).

(Currently based on top of #2187. Would be rebased onto `dev` once #2187 is merged.)

__TODO:__
- [x] Fix `DEVELOPMENT.md` documentation after removing custom tracing-related features from `qdrant` crate
- [x] ~~Make `tracing` _required_ dependency of `lib/*` crates and remove custom `tracing` feature everywhere?~~
  - There's practically no downside to leaving `tracing` optional in `lib/*` crates, so I crossed it out.

__Further Improvements:__
- Add API to change log-level/filters when Qdrant is already running (#2383)
  - should be pretty trivial to do with [`tracing_subscriber::reload`]
- Add configuration parameter to [select "span events" to be printed][with-span-events]
  - (and an API to change this in runtime)
  - span events are rather verbose to enable them by default, but they are _extremely_ useful for debugging
  - adding configuration parameter should be trivial
  - adding an API - _moderately_ annoying
- Add file appender (and all required configuration/infrastructure), so that logs can be written to a file (#2392)
  - [`RollingFileAppender`] from [`tracing-appender`] crate does not _yet_ support _practical_ rollover strategies
    - https://github.com/tokio-rs/tracing/pull/2323 is merged, but not yet released
    - https://github.com/tokio-rs/tracing/pull/2497 is not yet merged
  - there's also [`tracing-rolling-file`], which looks fine, but I haven't tested it yet
- Implement slog drain that would convert slog records into tracing events, _preserving slog's "structured" KV pairs_ 
  - [`slog-stdlog`] (that we are currently using) is fine
    - but it does not preserve KV pairs
    - I'm not sure if `raft` crate actually emits any, but it would be kinda silly to use `slog` if it does not, so I assume it does
    - and so I'd want to capture/log these KV pairs
  - [`tracing-slog`] is mostly useless
    - it is extremely simplistic and does not preserve KV pairs
    - which is, like, the whole point of `slog` and any _specific_ "slog-to-tracing" bridge
    - because [`slog-stdlog`] is perfectly fine if you don't want/need KV pairs
- Add configuration parameter to select output format?
  - (and an API to change this in runtime)
  - I can already tell, that this will be __super__ annoying to implement, so not sure if it's worth it

[`tracing_subscriber::reload`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/reload/index.html
[with-span-events]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events
[`RollingFileAppender`]: https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.RollingFileAppender.html
[`tracing-appender`]: https://docs.rs/tracing-appender/latest/tracing_appender/index.html
[`tracing-rolling-file`]: https://docs.rs/tracing-rolling-file/latest/tracing_rolling_file/
[`slog-stdlog`]: https://docs.rs/slog-stdlog/latest/slog_stdlog/
[`tracing-slog`]: https://docs.rs/tracing-slog/latest/tracing_slog/

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
