### PR TITLE
Implement logging into a file on disk

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -10,6 +10,8 @@ use super::*;
 pub struct LoggerConfig {
     #[serde(flatten)]
     pub default: default::Config,
+    #[serde(default)]
+    pub on_disk: on_disk::Config,
 }
 
 impl LoggerConfig {
@@ -29,6 +31,7 @@ impl LoggerConfig {
 
     pub fn merge(&mut self, other: Self) {
         self.default.merge(other.default);
+        self.on_disk.merge(other.on_disk);
     }
 }
 

--- a/src/tracing/on_disk.rs
+++ b/src/tracing/on_disk.rs
@@ -49,7 +49,7 @@ where
         Ok(layer) => layer,
         Err(err) => {
             eprintln!(
-                "failed to enable loggin into {} log-file: {err}",
+                "failed to enable logging into {} log-file: {err}",
                 config.log_file.as_deref().unwrap_or(""),
             );
 

--- a/src/tracing/on_disk.rs
+++ b/src/tracing/on_disk.rs
@@ -74,7 +74,7 @@ where
     }
 
     let Some(log_file) = &config.log_file else {
-        return Ok(None);
+        return Err(anyhow::format_err!("log file is not specified"));
     };
 
     let writer = fs::OpenOptions::new()

--- a/src/tracing/on_disk.rs
+++ b/src/tracing/on_disk.rs
@@ -1,0 +1,95 @@
+use std::collections::HashSet;
+use std::fs;
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{filter, fmt, registry};
+
+use super::*;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Config {
+    pub enabled: Option<bool>,
+    pub log_file: Option<String>,
+    pub log_level: Option<String>,
+    pub span_events: Option<HashSet<config::SpanEvent>>,
+}
+
+impl Config {
+    pub fn merge(&mut self, other: Self) {
+        self.enabled = other.enabled.or(self.enabled.take());
+        self.log_file = other.log_file.or(self.log_file.take());
+        self.log_level = other.log_level.or(self.log_level.take());
+        self.span_events = other.span_events.or(self.span_events.take());
+    }
+}
+
+#[rustfmt::skip] // `rustfmt` formats this into unreadable single line :/
+pub type Logger<S> = filter::Filtered<
+    Option<Layer<S>>,
+    filter::EnvFilter,
+    S,
+>;
+
+#[rustfmt::skip] // `rustfmt` formats this into unreadable single line :/
+pub type Layer<S> = fmt::Layer<
+    S,
+    fmt::format::DefaultFields,
+    fmt::format::Format,
+    fs::File,
+>;
+
+pub fn new_logger<S>(config: &mut Config) -> Logger<S>
+where
+    S: tracing::Subscriber + for<'span> registry::LookupSpan<'span>,
+{
+    let layer = match new_layer(config) {
+        Ok(layer) => layer,
+        Err(err) => {
+            eprintln!(
+                "failed to enable loggin into {} log-file: {err}",
+                config.log_file.as_deref().unwrap_or(""),
+            );
+
+            config.enabled = Some(false);
+            None
+        }
+    };
+
+    let filter = new_filter(config);
+    layer.with_filter(filter)
+}
+
+pub fn new_layer<S>(config: &Config) -> anyhow::Result<Option<Layer<S>>>
+where
+    S: tracing::Subscriber + for<'span> registry::LookupSpan<'span>,
+{
+    if !config.enabled.unwrap_or_default() {
+        return Ok(None);
+    }
+
+    let Some(log_file) = &config.log_file else {
+        return Ok(None);
+    };
+
+    let writer = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_file)
+        .with_context(|| format!("failed to open {} log-file", log_file))?;
+
+    let layer = fmt::Layer::default()
+        .with_writer(writer)
+        .with_span_events(config::SpanEvent::unwrap_or_default_config(
+            &config.span_events,
+        ))
+        .with_ansi(false);
+
+    Ok(Some(layer))
+}
+
+pub fn new_filter(config: &Config) -> filter::EnvFilter {
+    filter(config.log_level.as_deref().unwrap_or(""))
+}

--- a/src/tracing/test.rs
+++ b/src/tracing/test.rs
@@ -10,6 +10,13 @@ fn deseriailze_logger_config() {
         "log_level": "debug",
         "span_events": ["new", "close"],
         "color": true,
+
+        "on_disk": {
+            "enabled": true,
+            "log_file": "/logs/qdrant",
+            "log_level": "tracing",
+            "span_events": ["new", "close"],
+        }
     });
 
     let config = deserialize_config(json);
@@ -17,11 +24,21 @@ fn deseriailze_logger_config() {
     let expected = LoggerConfig {
         default: default::Config {
             log_level: Some("debug".into()),
-            span_events: Some(HashSet::from_iter([
+            span_events: Some(HashSet::from([
                 config::SpanEvent::New,
                 config::SpanEvent::Close,
             ])),
             color: Some(config::Color::Explicit(true)),
+        },
+
+        on_disk: on_disk::Config {
+            enabled: Some(true),
+            log_file: Some("/logs/qdrant".into()),
+            log_level: Some("tracing".into()),
+            span_events: Some(HashSet::from([
+                config::SpanEvent::New,
+                config::SpanEvent::Close,
+            ])),
         },
     };
 
@@ -35,11 +52,24 @@ fn deserialize_empty_config() {
 }
 
 #[test]
+fn deserialize_config_with_empty_on_disk() {
+    let config = deserialize_config(json!({ "on_disk": {} }));
+    assert_eq!(config, LoggerConfig::default());
+}
+
+#[test]
 fn deseriailze_config_with_explicit_nulls() {
     let json = json!({
         "log_level": null,
         "span_events": null,
         "color": null,
+
+        "on_disk": {
+            "enabled": null,
+            "log_file": null,
+            "log_level": null,
+            "span_events": null,
+        }
     });
 
     let config = deserialize_config(json);


### PR DESCRIPTION
Fixes #2505.

Extends logger to support logging to a file on disk.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
