### PR TITLE
Add internal gRPC call to request remote HTTP port

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -174,6 +174,8 @@
 - [qdrant.proto](#qdrant-proto)
     - [HealthCheckReply](#qdrant-HealthCheckReply)
     - [HealthCheckRequest](#qdrant-HealthCheckRequest)
+    - [HttpPortRequest](#qdrant-HttpPortRequest)
+    - [HttpPortResponse](#qdrant-HttpPortResponse)
   
     - [Qdrant](#qdrant-Qdrant)
   
@@ -2953,6 +2955,31 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+
+<a name="qdrant-HttpPortRequest"></a>
+
+### HttpPortRequest
+
+
+
+
+
+
+
+<a name="qdrant-HttpPortResponse"></a>
+
+### HttpPortResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| port | [int32](#int32) |  |  |
+
+
+
+
+
  
 
  
@@ -2968,6 +2995,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | HealthCheck | [HealthCheckRequest](#qdrant-HealthCheckRequest) | [HealthCheckReply](#qdrant-HealthCheckReply) |  |
+| GetHttpPort | [HttpPortRequest](#qdrant-HttpPortRequest) | [HttpPortResponse](#qdrant-HttpPortResponse) | Get HTTP port for remote host. |
 
  
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -174,10 +174,14 @@
 - [qdrant.proto](#qdrant-proto)
     - [HealthCheckReply](#qdrant-HealthCheckReply)
     - [HealthCheckRequest](#qdrant-HealthCheckRequest)
+  
+    - [Qdrant](#qdrant-Qdrant)
+  
+- [qdrant_internal_service.proto](#qdrant_internal_service-proto)
     - [HttpPortRequest](#qdrant-HttpPortRequest)
     - [HttpPortResponse](#qdrant-HttpPortResponse)
   
-    - [Qdrant](#qdrant-Qdrant)
+    - [QdrantInternal](#qdrant-QdrantInternal)
   
 - [snapshots_service.proto](#snapshots_service-proto)
     - [CreateFullSnapshotRequest](#qdrant-CreateFullSnapshotRequest)
@@ -2955,6 +2959,32 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+ 
+
+ 
+
+ 
+
+
+<a name="qdrant-Qdrant"></a>
+
+### Qdrant
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| HealthCheck | [HealthCheckRequest](#qdrant-HealthCheckRequest) | [HealthCheckReply](#qdrant-HealthCheckReply) |  |
+
+ 
+
+
+
+<a name="qdrant_internal_service-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## qdrant_internal_service.proto
+
+
 
 <a name="qdrant-HttpPortRequest"></a>
 
@@ -2987,14 +3017,13 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
  
 
 
-<a name="qdrant-Qdrant"></a>
+<a name="qdrant-QdrantInternal"></a>
 
-### Qdrant
+### QdrantInternal
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| HealthCheck | [HealthCheckRequest](#qdrant-HealthCheckRequest) | [HealthCheckReply](#qdrant-HealthCheckReply) |  |
 | GetHttpPort | [HttpPortRequest](#qdrant-HttpPortRequest) | [HttpPortResponse](#qdrant-HttpPortResponse) | Get HTTP port for remote host. |
 
  

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -4,6 +4,7 @@ import "collections_service.proto";
 import "collections_internal_service.proto";
 import "points_service.proto";
 import "points_internal_service.proto";
+import "qdrant_internal_service.proto";
 import "raft_service.proto";
 import "snapshots_service.proto";
 
@@ -11,10 +12,6 @@ package qdrant;
 
 service Qdrant {
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckReply) {}
-  /*
-  Get HTTP port for remote host.
-   */
-  rpc GetHttpPort (HttpPortRequest) returns (HttpPortResponse) {}
 }
 
 message HealthCheckRequest {}
@@ -22,10 +19,4 @@ message HealthCheckRequest {}
 message HealthCheckReply {
   string title = 1;
   string version = 2;
-}
-
-message HttpPortRequest {}
-
-message HttpPortResponse {
-  int32 port = 1;
 }

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -11,12 +11,21 @@ package qdrant;
 
 service Qdrant {
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckReply) {}
+  /*
+  Get HTTP port for remote host.
+   */
+  rpc GetHttpPort (HttpPortRequest) returns (HttpPortResponse) {}
 }
 
-message HealthCheckRequest {
-}
+message HealthCheckRequest {}
 
 message HealthCheckReply {
   string title = 1;
   string version = 2;
+}
+
+message HttpPortRequest {}
+
+message HttpPortResponse {
+  int32 port = 1;
 }

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package qdrant;
+
+service QdrantInternal {
+  /*
+  Get HTTP port for remote host.
+   */
+  rpc GetHttpPort (HttpPortRequest) returns (HttpPortResponse) {}
+}
+
+message HttpPortRequest {}
+
+message HttpPortResponse {
+  int32 port = 1;
+}

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7422,6 +7422,312 @@ pub mod points_internal_server {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpPortRequest {}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpPortResponse {
+    #[prost(int32, tag = "1")]
+    pub port: i32,
+}
+/// Generated client implementations.
+pub mod qdrant_internal_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct QdrantInternalClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QdrantInternalClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QdrantInternalClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QdrantInternalClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            QdrantInternalClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Get HTTP port for remote host.
+        pub async fn get_http_port(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HttpPortRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::HttpPortResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.QdrantInternal/GetHttpPort",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.QdrantInternal", "GetHttpPort"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod qdrant_internal_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with QdrantInternalServer.
+    #[async_trait]
+    pub trait QdrantInternal: Send + Sync + 'static {
+        /// Get HTTP port for remote host.
+        async fn get_http_port(
+            &self,
+            request: tonic::Request<super::HttpPortRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::HttpPortResponse>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct QdrantInternalServer<T: QdrantInternal> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: QdrantInternal> QdrantInternalServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for QdrantInternalServer<T>
+    where
+        T: QdrantInternal,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/qdrant.QdrantInternal/GetHttpPort" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetHttpPortSvc<T: QdrantInternal>(pub Arc<T>);
+                    impl<
+                        T: QdrantInternal,
+                    > tonic::server::UnaryService<super::HttpPortRequest>
+                    for GetHttpPortSvc<T> {
+                        type Response = super::HttpPortResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HttpPortRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).get_http_port(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetHttpPortSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: QdrantInternal> Clone for QdrantInternalServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: QdrantInternal> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: QdrantInternal> tonic::server::NamedService for QdrantInternalServer<T> {
+        const NAME: &'static str = "qdrant.QdrantInternal";
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RaftMessage {
     #[prost(bytes = "vec", tag = "1")]
     pub message: ::prost::alloc::vec::Vec<u8>,
@@ -8763,17 +9069,6 @@ pub struct HealthCheckReply {
     #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
 }
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HttpPortRequest {}
-#[derive(serde::Serialize)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HttpPortResponse {
-    #[prost(int32, tag = "1")]
-    pub port: i32,
-}
 /// Generated client implementations.
 pub mod qdrant_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -8883,31 +9178,6 @@ pub mod qdrant_client {
             req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
             self.inner.unary(req, path, codec).await
         }
-        /// Get HTTP port for remote host.
-        pub async fn get_http_port(
-            &mut self,
-            request: impl tonic::IntoRequest<super::HttpPortRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HttpPortResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/qdrant.Qdrant/GetHttpPort",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "GetHttpPort"));
-            self.inner.unary(req, path, codec).await
-        }
     }
 }
 /// Generated server implementations.
@@ -8922,14 +9192,6 @@ pub mod qdrant_server {
             request: tonic::Request<super::HealthCheckRequest>,
         ) -> std::result::Result<
             tonic::Response<super::HealthCheckReply>,
-            tonic::Status,
-        >;
-        /// Get HTTP port for remote host.
-        async fn get_http_port(
-            &self,
-            request: tonic::Request<super::HttpPortRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HttpPortResponse>,
             tonic::Status,
         >;
     }
@@ -9043,50 +9305,6 @@ pub mod qdrant_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = HealthCheckSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/qdrant.Qdrant/GetHttpPort" => {
-                    #[allow(non_camel_case_types)]
-                    struct GetHttpPortSvc<T: Qdrant>(pub Arc<T>);
-                    impl<T: Qdrant> tonic::server::UnaryService<super::HttpPortRequest>
-                    for GetHttpPortSvc<T> {
-                        type Response = super::HttpPortResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::HttpPortRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                (*inner).get_http_port(request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = GetHttpPortSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8763,6 +8763,17 @@ pub struct HealthCheckReply {
     #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpPortRequest {}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpPortResponse {
+    #[prost(int32, tag = "1")]
+    pub port: i32,
+}
 /// Generated client implementations.
 pub mod qdrant_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -8872,6 +8883,31 @@ pub mod qdrant_client {
             req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "HealthCheck"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get HTTP port for remote host.
+        pub async fn get_http_port(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HttpPortRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::HttpPortResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Qdrant/GetHttpPort",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Qdrant", "GetHttpPort"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -8886,6 +8922,14 @@ pub mod qdrant_server {
             request: tonic::Request<super::HealthCheckRequest>,
         ) -> std::result::Result<
             tonic::Response<super::HealthCheckReply>,
+            tonic::Status,
+        >;
+        /// Get HTTP port for remote host.
+        async fn get_http_port(
+            &self,
+            request: tonic::Request<super::HttpPortRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::HttpPortResponse>,
             tonic::Status,
         >;
     }
@@ -8999,6 +9043,50 @@ pub mod qdrant_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = HealthCheckSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Qdrant/GetHttpPort" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetHttpPortSvc<T: Qdrant>(pub Arc<T>);
+                    impl<T: Qdrant> tonic::server::UnaryService<super::HttpPortRequest>
+                    for GetHttpPortSvc<T> {
+                        type Response = super::HttpPortResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HttpPortRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).get_http_port(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetHttpPortSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1141,13 +1141,7 @@ impl ShardReplicaSet {
     ) -> CollectionResult<Option<UpdateResult>> {
         if let Some(local_shard) = &*self.local.read().await {
             match self.peer_state(&self.this_peer_id()) {
-                Some(ReplicaState::Active) => {
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
-                }
-                Some(ReplicaState::Partial) => {
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
-                }
-                Some(ReplicaState::Initializing) => {
+                Some(ReplicaState::Active | ReplicaState::Partial | ReplicaState::Initializing) => {
                     Ok(Some(local_shard.get().update(operation, wait).await?))
                 }
                 Some(ReplicaState::Listener) => {

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -27,7 +27,7 @@ pub struct ShardTransfer {
     pub shard_id: ShardId,
     pub from: PeerId,
     pub to: PeerId,
-    /// If this flag is true, the is a replication related transfer of shard from 1 peer to another
+    /// If this flag is true, this is a replication related transfer of shard from 1 peer to another
     /// Shard on original peer will not be deleted in this case
     pub sync: bool,
 }
@@ -77,8 +77,7 @@ async fn transfer_batches(
     }
 
     // Transfer contents batch by batch
-    let initial_offset = None;
-    let mut offset = initial_offset;
+    let mut offset = None;
     loop {
         if stopped.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(CollectionError::Cancelled {
@@ -219,7 +218,8 @@ pub async fn transfer_shard(
                 "Shard {shard_id} cannot be proxied because it does not exist"
             )));
         }
-    };
+    }
+
     // Transfer contents batch by batch
     transfer_batches(shard_holder.clone(), shard_id, stopped.clone()).await
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -72,9 +72,9 @@ impl Consensus {
     ) -> anyhow::Result<JoinHandle<std::io::Result<()>>> {
         let tls_client_config = helpers::load_tls_client_config(&settings)?;
 
-        let p2p_host = settings.service.host;
+        let p2p_host = settings.service.host.clone();
         let p2p_port = settings.cluster.p2p.port.expect("P2P port is not set");
-        let config = settings.cluster.consensus;
+        let config = settings.cluster.consensus.clone();
 
         let (mut consensus, message_sender) = Self::new(
             logger,
@@ -119,6 +119,7 @@ impl Consensus {
         let server_tls = if settings.cluster.p2p.enable_tls {
             let tls_config = settings
                 .tls
+                .clone()
                 .ok_or_else(Settings::tls_config_is_undefined_error)?;
 
             Some(helpers::load_tls_internal_server_config(&tls_config)?)
@@ -133,6 +134,7 @@ impl Consensus {
                     toc,
                     state_ref,
                     telemetry_collector,
+                    settings,
                     p2p_host,
                     p2p_port,
                     server_tls,

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -12,9 +12,12 @@ use ::api::grpc::qdrant::collections_internal_server::CollectionsInternalServer;
 use ::api::grpc::qdrant::collections_server::CollectionsServer;
 use ::api::grpc::qdrant::points_internal_server::PointsInternalServer;
 use ::api::grpc::qdrant::points_server::PointsServer;
+use ::api::grpc::qdrant::qdrant_internal_server::{QdrantInternal, QdrantInternalServer};
 use ::api::grpc::qdrant::qdrant_server::{Qdrant, QdrantServer};
 use ::api::grpc::qdrant::snapshots_server::SnapshotsServer;
-use ::api::grpc::qdrant::{HttpPortRequest, HttpPortResponse, HealthCheckReply, HealthCheckRequest};
+use ::api::grpc::qdrant::{
+    HealthCheckReply, HealthCheckRequest, HttpPortRequest, HttpPortResponse,
+};
 use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
@@ -33,18 +36,8 @@ use crate::tonic::api::points_api::PointsService;
 use crate::tonic::api::points_internal_api::PointsInternalService;
 use crate::tonic::api::snapshots_api::SnapshotsService;
 
-pub struct QdrantService {
-    /// HTTP port accessible from inside the cluster
-    http_port: u16,
-}
-
-impl QdrantService {
-    fn new(internal_http_port: u16) -> Self {
-        Self {
-            http_port: internal_http_port,
-        }
-    }
-}
+#[derive(Default)]
+pub struct QdrantService {}
 
 #[tonic::async_trait]
 impl Qdrant for QdrantService {
@@ -54,12 +47,28 @@ impl Qdrant for QdrantService {
     ) -> Result<Response<HealthCheckReply>, Status> {
         Ok(Response::new(VersionInfo::default().into()))
     }
+}
 
+pub struct QdrantInternalService {
+    /// HTTP port accessible from inside the cluster
+    http_port: u16,
+}
+
+impl QdrantInternalService {
+    fn new(internal_http_port: u16) -> Self {
+        Self {
+            http_port: internal_http_port,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl QdrantInternal for QdrantInternalService {
     async fn get_http_port(
         &self,
         _request: Request<HttpPortRequest>,
     ) -> Result<Response<HttpPortResponse>, Status> {
-        Ok(Response::new(HttpPortResponse  {
+        Ok(Response::new(HttpPortResponse {
             port: self.http_port as i32,
         }))
     }
@@ -93,7 +102,7 @@ pub fn init(
         let socket =
             SocketAddr::from((settings.service.host.parse::<IpAddr>().unwrap(), grpc_port));
 
-        let qdrant_service = QdrantService::new(settings.service.http_port);
+        let qdrant_service = QdrantService::default();
         let collections_service = CollectionsService::new(dispatcher.clone());
         let points_service = PointsService::new(dispatcher.toc().clone());
         let snapshot_service = SnapshotsService::new(dispatcher.clone());
@@ -184,7 +193,8 @@ pub fn init_internal(
         .block_on(async {
             let socket = SocketAddr::from((host.parse::<IpAddr>().unwrap(), internal_grpc_port));
 
-            let qdrant_service = QdrantService::new(settings.service.http_port);
+            let qdrant_service = QdrantService::default();
+            let qdrant_internal_service = QdrantInternalService::new(settings.service.http_port);
             let collections_internal_service = CollectionsInternalService::new(toc.clone());
             let points_internal_service = PointsInternalService::new(toc.clone());
             let raft_service = RaftService::new(to_consensus, consensus_state);
@@ -221,6 +231,12 @@ pub fn init_internal(
                 .layer(middleware_layer)
                 .add_service(
                     QdrantServer::new(qdrant_service)
+                        .send_compressed(CompressionEncoding::Gzip)
+                        .accept_compressed(CompressionEncoding::Gzip)
+                        .max_decoding_message_size(usize::MAX),
+                )
+                .add_service(
+                    QdrantInternalServer::new(qdrant_internal_service)
                         .send_compressed(CompressionEncoding::Gzip)
                         .accept_compressed(CompressionEncoding::Gzip)
                         .max_decoding_message_size(usize::MAX),

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -165,8 +165,6 @@ $docker_grpcurl -d '{
   "ids": [{ "num": 1 }]
 }' $QDRANT_HOST qdrant.Points/Get
 
-$docker_grpcurl $QDRANT_HOST qdrant.Qdrant/GetHttpPort
-
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
 #[[ "$SAVED_VECTORS_COUNT" == "6" ]] || {
 #  echo 'check failed'

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -165,6 +165,8 @@ $docker_grpcurl -d '{
   "ids": [{ "num": 1 }]
 }' $QDRANT_HOST qdrant.Points/Get
 
+$docker_grpcurl $QDRANT_HOST qdrant.Qdrant/GetHttpPort
+
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
 #[[ "$SAVED_VECTORS_COUNT" == "6" ]] || {
 #  echo 'check failed'

--- a/tests/basic_internal_grpc_test.sh
+++ b/tests/basic_internal_grpc_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+# Ensure current path is project root
+cd "$(dirname "$0")/../"
+
+QDRANT_HOST='localhost:6335'
+
+docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+
+$docker_grpcurl $QDRANT_HOST qdrant.QdrantInternal/GetHttpPort

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -55,3 +55,7 @@ fi
 ./tests/basic_api_test.sh
 
 ./tests/basic_grpc_test.sh
+
+if [ $MODE == "distributed" ]; then
+  ./tests/basic_internal_grpc_test.sh
+fi


### PR DESCRIPTION
Tracking issue: https://github.com/qdrant/qdrant/issues/2432

This adds an internal gRPC call so a node can request the HTTP port of some other node.

This is one of the building blocks to achieve shard snapshot transfers.

```bash
$docker_grpcurl $QDRANT_HOST qdrant.QdrantInternal/GetHttpPort | jq
{
    "port": 6333,
}
```

## Questions

- [x] **Do we want this to be configurable?**
     Should a user be able to configure a custom HTTP port for internal communication? Or should the user be able to disable this HTTP port for internal use all together? This may be useful for specialized cluster configurations where the HTTP is not forwarded, or bound to a different port.
     _A: not needed right now_

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
