### PR TITLE
Whitelist root endpoint to not require API key

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -28,7 +28,7 @@ use crate::actix::api::search_api::config_search_api;
 use crate::actix::api::service_api::config_service_api;
 use crate::actix::api::snapshot_api::config_snapshots_api;
 use crate::actix::api::update_api::config_update_api;
-use crate::actix::api_key::ApiKey;
+use crate::actix::api_key::{ApiKey, WhitelistItem};
 use crate::common::telemetry::TelemetryCollector;
 use crate::settings::{max_web_workers, Settings};
 
@@ -81,8 +81,8 @@ pub fn init(
             // not enabled
             false
         };
-        let skip_api_key_prefixes = if web_ui_available {
-            vec![WEB_UI_PATH.to_string()]
+        let api_key_whitelist = if web_ui_available {
+            vec![WhitelistItem::prefix(WEB_UI_PATH)]
         } else {
             vec![]
         };
@@ -108,7 +108,7 @@ pub fn init(
                     api_key.is_some(),
                     ApiKey::new(
                         &api_key.clone().unwrap_or_default(),
-                        skip_api_key_prefixes.clone(),
+                        api_key_whitelist.clone(),
                     ),
                 ))
                 .wrap(Condition::new(settings.service.enable_cors, cors))

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -1,7 +1,7 @@
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod actix_telemetry;
 pub mod api;
-pub mod api_key;
+mod api_key;
 mod certificate_helpers;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -81,11 +81,11 @@ pub fn init(
             // not enabled
             false
         };
-        let api_key_whitelist = if web_ui_available {
-            vec![WhitelistItem::prefix(WEB_UI_PATH)]
-        } else {
-            vec![]
-        };
+
+        let mut api_key_whitelist = vec![WhitelistItem::exact("/")];
+        if web_ui_available {
+            api_key_whitelist.push(WhitelistItem::prefix(WEB_UI_PATH));
+        }
 
         let mut server = HttpServer::new(move || {
             let cors = Cors::default()


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2401>.

This whitelists the root endpoint (`/`) to not require an API key.

It fixes the [readiness probe](https://github.com/qdrant/qdrant-helm/blob/3b360aec89573262ae4dfb4e45357a77816c8bee/templates/statefulset.yaml#L67-L83) in [our](https://github.com/qdrant/qdrant-helm/tree/main) helm chart when an API key is used.

As a bonus this enriches our internal interface a bit for whitelisting paths.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
