### PR TITLE
Fix infinite reindexing after mmap threshold patching

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -52,12 +52,11 @@ impl ConfigMismatchOptimizer {
     }
 
     /// Check if current configuration requires vectors to be stored on disk
-    fn check_if_vectors_on_disk(&self, vector_name: &str) -> bool {
+    fn check_if_vectors_on_disk(&self, vector_name: &str) -> Option<bool> {
         self.collection_params
             .vectors
             .get_params(vector_name)
             .and_then(|vector_params| vector_params.on_disk)
-            .unwrap_or_default()
     }
 
     /// Calculates and HNSW config that should be used for a given vector
@@ -141,10 +140,12 @@ impl ConfigMismatchOptimizer {
                                 }
                             }
 
-                            let is_required_on_disk = self.check_if_vectors_on_disk(vector_name);
-
-                            if is_required_on_disk != vector_data.storage_type.is_on_disk() {
-                                return true;
+                            if let Some(is_required_on_disk) =
+                                self.check_if_vectors_on_disk(vector_name)
+                            {
+                                if is_required_on_disk != vector_data.storage_type.is_on_disk() {
+                                    return true;
+                                }
                             }
 
                             // Check quantization mismatch


### PR DESCRIPTION
Fix bug https://github.com/qdrant/qdrant/issues/2404

After changing `memmap_threshold` value, vector storage is going to be mmaped but without `on_disk` flag. Infinity loop appears in config mismatch optimizer. Vector storage is mmaped but no mention of `on_disk` flag in collection parameters being `false`. After segment optimization, vector storage is still mmaped but `on_disk` flag is still absent.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
