### PR TITLE
Add healthz, livez and readyz endpoints for Kubernetes

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -232,7 +232,7 @@
     },
     "/healthz": {
       "get": {
-        "summary": "Kubernets healthz endpoint",
+        "summary": "Kubernetes healthz endpoint",
         "description": "An endpoint for health checking used in Kubernetes.",
         "operationId": "healthz",
         "tags": [
@@ -258,7 +258,7 @@
     },
     "/livez": {
       "get": {
-        "summary": "Kubernets livez endpoint",
+        "summary": "Kubernetes livez endpoint",
         "description": "An endpoint for health checking used in Kubernetes.",
         "operationId": "livez",
         "tags": [
@@ -284,7 +284,7 @@
     },
     "/readyz": {
       "get": {
-        "summary": "Kubernets readyz endpoint",
+        "summary": "Kubernetes readyz endpoint",
         "description": "An endpoint for health checking used in Kubernetes.",
         "operationId": "readyz",
         "tags": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -230,6 +230,84 @@
         }
       }
     },
+    "/healthz": {
+      "get": {
+        "summary": "Kubernets healthz endpoint",
+        "description": "An endpoint for health checking used in Kubernetes.",
+        "operationId": "healthz",
+        "tags": [
+          "service"
+        ],
+        "responses": {
+          "200": {
+            "description": "Healthz response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "healthz check passed"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error"
+          }
+        }
+      }
+    },
+    "/livez": {
+      "get": {
+        "summary": "Kubernets livez endpoint",
+        "description": "An endpoint for health checking used in Kubernetes.",
+        "operationId": "livez",
+        "tags": [
+          "service"
+        ],
+        "responses": {
+          "200": {
+            "description": "Healthz response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "healthz check passed"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error"
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "summary": "Kubernets readyz endpoint",
+        "description": "An endpoint for health checking used in Kubernetes.",
+        "operationId": "readyz",
+        "tags": [
+          "service"
+        ],
+        "responses": {
+          "200": {
+            "description": "Healthz response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "healthz check passed"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "error"
+          }
+        }
+      }
+    },
     "/cluster": {
       "get": {
         "tags": [

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -73,3 +73,57 @@ paths:
       tags:
         - service
       responses: #@ response(reference("LocksOption"))
+
+  /healthz:
+    get:
+      summary: Kubernets healthz endpoint
+      description: An endpoint for health checking used in Kubernetes.
+      operationId: healthz
+      tags:
+        - service
+      responses:
+        '200':
+          description: Healthz response
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: healthz check passed
+        '4XX':
+          description: error
+
+  /livez:
+    get:
+      summary: Kubernets livez endpoint
+      description: An endpoint for health checking used in Kubernetes.
+      operationId: livez
+      tags:
+        - service
+      responses:
+        '200':
+          description: Healthz response
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: healthz check passed
+        '4XX':
+          description: error
+
+  /readyz:
+    get:
+      summary: Kubernets readyz endpoint
+      description: An endpoint for health checking used in Kubernetes.
+      operationId: readyz
+      tags:
+        - service
+      responses:
+        '200':
+          description: Healthz response
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: healthz check passed
+        '4XX':
+          description: error

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -76,7 +76,7 @@ paths:
 
   /healthz:
     get:
-      summary: Kubernets healthz endpoint
+      summary: Kubernetes healthz endpoint
       description: An endpoint for health checking used in Kubernetes.
       operationId: healthz
       tags:
@@ -94,7 +94,7 @@ paths:
 
   /livez:
     get:
-      summary: Kubernets livez endpoint
+      summary: Kubernetes livez endpoint
       description: An endpoint for health checking used in Kubernetes.
       operationId: livez
       tags:
@@ -112,7 +112,7 @@ paths:
 
   /readyz:
     get:
-      summary: Kubernets readyz endpoint
+      summary: Kubernetes readyz endpoint
       description: An endpoint for health checking used in Kubernetes.
       operationId: readyz
       tags:

--- a/openapi/tests/openapi_integration/test_k8s_health.py
+++ b/openapi/tests/openapi_integration/test_k8s_health.py
@@ -1,0 +1,15 @@
+import json
+
+import pytest
+
+from .helpers.helpers import request_with_validation
+
+
+@pytest.mark.parametrize("endpoint", ["/healthz", "/livez", "/readyz"])
+def test_k8s_health(endpoint):
+    response = request_with_validation(
+        api=endpoint,
+        method="GET",
+    )
+    assert response.ok
+    assert response.text == "healthz check passed"

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -95,11 +95,36 @@ async fn get_stacktrace() -> impl Responder {
     process_response(Ok(result), timing)
 }
 
+#[get("/healthz")]
+async fn healthz() -> impl Responder {
+    kubernetes_healthz().await
+}
+
+#[get("/livez")]
+async fn livez() -> impl Responder {
+    kubernetes_healthz().await
+}
+
+#[get("/readyz")]
+async fn readyz() -> impl Responder {
+    kubernetes_healthz().await
+}
+
+/// Basic Kubernetes healthz endpoint
+async fn kubernetes_healthz() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type(ContentType::plaintext())
+        .body("healthz check passed")
+}
+
 // Configure services
 pub fn config_service_api(cfg: &mut web::ServiceConfig) {
     cfg.service(telemetry)
         .service(metrics)
         .service(put_locks)
         .service(get_locks)
-        .service(get_stacktrace);
+        .service(get_stacktrace)
+        .service(healthz)
+        .service(livez)
+        .service(readyz);
 }

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -82,7 +82,12 @@ pub fn init(
             false
         };
 
-        let mut api_key_whitelist = vec![WhitelistItem::exact("/")];
+        let mut api_key_whitelist = vec![
+            WhitelistItem::exact("/"),
+            WhitelistItem::exact("/healthz"),
+            WhitelistItem::prefix("/readyz"),
+            WhitelistItem::prefix("/livez"),
+        ];
         if web_ui_available {
             api_key_whitelist.push(WhitelistItem::prefix(WEB_UI_PATH));
         }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2401>. Depends on <https://github.com/qdrant/qdrant/pull/2407>.

This implements health checking endpoints for Kubernetes, more specifically `healthz`, `livez` and `readyz`.

These are implemented in the most basic fashion at this time, simply returning HTTP 200 with `healthz check passed`. All three are whitelisted and always accessible regardless of whether an API key is configured.

Once merged, these can be properly incorporated into our [helm chart](https://github.com/qdrant/qdrant-helm).

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/2407>
- [x] Rebase on `dev`
- [x] Point PR to `dev`
- [x] Undraft

### Tasks after merging
- [ ] Update [helm chart](https://github.com/qdrant/qdrant-helm) to use these new endpoints

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
