### PR TITLE
Shard snapshot API

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -192,4 +192,5 @@ jobs:
         run: |
           cargo run &
           trap 'kill $(jobs -p) &>/dev/null || :' EXIT
-          ./tests/shard-snapshot-api.sh
+          sleep 10
+          ./tests/shard-snapshot-api.sh all

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,3 +174,22 @@ jobs:
         working-directory: ./tests/low-ram
         shell: bash
         run: ./low-ram.sh
+
+  test-shard-snapshot-api:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get install clang protobuf-compiler jq
+      - name: Build
+        run: cargo build --bin qdrant
+      - name: Run Shard Snapshot API Tests
+        shell: bash
+        run: |
+          cargo run &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          ./tests/shard-snapshot-api.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -193,4 +193,4 @@ jobs:
           cargo run &
           trap 'kill $(jobs -p) &>/dev/null || :' EXIT
           sleep 10
-          ./tests/shard-snapshot-api.sh all
+          ./tests/shard-snapshot-api.sh test-all

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8038,9 +8038,10 @@
         }
       },
       "SnapshotPriority": {
-        "description": "Defines source of truth for snapshot recovery `Snapshot` means - prefer snapshot data over the current state `Replica` means - prefer existing data over the snapshot",
+        "description": "Defines source of truth for snapshot recovery `LocalOnly` means - restore snapshot without *any* additional synchronization `Snapshot` means - prefer snapshot data over the current state `Replica` means - prefer existing data over the snapshot",
         "type": "string",
         "enum": [
+          "local_only",
           "snapshot",
           "replica"
         ]

--- a/lib/api/src/grpc/models.rs
+++ b/lib/api/src/grpc/models.rs
@@ -29,7 +29,7 @@ pub enum ApiStatus {
 
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct ApiResponse<D: Serialize + Debug> {
+pub struct ApiResponse<D> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<D>,
     pub status: ApiStatus,

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 
 [dev-dependencies]
-tempfile = "3.8.0"
 criterion = "0.5"
 rstest = "0.18.2"
 
@@ -61,6 +60,7 @@ num_cpus = "1.16.0"
 tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.18"
+tempfile = "3.8.0"
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 
 [dev-dependencies]
-tempfile = "3.7.1"
 criterion = "0.5"
 rstest = "0.18.2"
 
@@ -61,6 +60,7 @@ num_cpus = "1.16.0"
 tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.18"
+tempfile = "3.7.1"
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1588,6 +1588,32 @@ impl Collection {
         get_snapshot_description(&snapshot_path).await
     }
 
+    pub async fn list_shard_snapshots(
+        &self,
+        shard: ShardId,
+    ) -> CollectionResult<Vec<SnapshotDescription>> {
+        todo!()
+    }
+
+    pub async fn get_shard_snapshot_path(
+        &self,
+        shard: ShardId,
+        snapshot: &str,
+    ) -> CollectionResult<PathBuf> {
+        todo!()
+    }
+
+    pub fn snapshots_path_for_shard(&self, shard: ShardId) -> CollectionResult<PathBuf> {
+        todo!()
+    }
+
+    pub async fn create_shard_snapshot(
+        &self,
+        shard: ShardId,
+    ) -> CollectionResult<SnapshotDescription> {
+        todo!()
+    }
+
     pub async fn recover_local_shard_from(
         &self,
         snapshot_shard_path: &Path,

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1590,28 +1590,202 @@ impl Collection {
 
     pub async fn list_shard_snapshots(
         &self,
-        shard: ShardId,
+        shard_id: ShardId,
     ) -> CollectionResult<Vec<SnapshotDescription>> {
-        todo!()
-    }
+        self.assert_is_shard_local(shard_id).await?;
 
-    pub async fn get_shard_snapshot_path(
-        &self,
-        shard: ShardId,
-        snapshot: &str,
-    ) -> CollectionResult<PathBuf> {
-        todo!()
-    }
+        let snapshots_path = self.snapshots_path_for_shard_unchecked(shard_id);
 
-    pub fn snapshots_path_for_shard(&self, shard: ShardId) -> CollectionResult<PathBuf> {
-        todo!()
+        if !snapshots_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        list_snapshots_in_directory(&snapshots_path).await
     }
 
     pub async fn create_shard_snapshot(
         &self,
-        shard: ShardId,
+        shard_id: ShardId,
+        temp_dir: &Path,
     ) -> CollectionResult<SnapshotDescription> {
-        todo!()
+        let shards_holder = self.shards_holder.read().await;
+        let shard =
+            shards_holder
+                .get_shard(&shard_id)
+                .ok_or_else(|| CollectionError::NotFound {
+                    what: format!("Shard {shard_id}"),
+                })?;
+
+        if !shard.is_local().await {
+            return Err(CollectionError::bad_input(format!(
+                "Shard {shard_id} is not a local shard"
+            )));
+        }
+
+        let snapshot_file_name = format!(
+            "{}-shard-{shard_id}-{}.snapshot",
+            self.name(),
+            chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S"),
+        );
+
+        let snapshot_temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{snapshot_file_name}-temp"))
+            .tempdir_in(temp_dir)?;
+
+        let snapshot_target_dir = tempfile::Builder::new()
+            .prefix(&format!("{snapshot_file_name}-target"))
+            .tempdir_in(temp_dir)?;
+
+        shard
+            .create_snapshot(snapshot_temp_dir.path(), snapshot_target_dir.path(), false)
+            .await?;
+
+        if let Err(err) = snapshot_temp_dir.close() {
+            log::error!("Failed to remove temporary directory: {err}");
+        }
+
+        let mut temp_file = tempfile::Builder::new()
+            .prefix(&snapshot_file_name)
+            .tempfile_in(temp_dir)?;
+
+        let task = {
+            let snapshot_target_dir = snapshot_target_dir.path().to_path_buf();
+
+            tokio::task::spawn_blocking(move || -> CollectionResult<_> {
+                let mut tar = TarBuilder::new(temp_file.as_file_mut());
+                tar.append_dir_all(".", &snapshot_target_dir)?;
+                tar.finish()?;
+                drop(tar);
+
+                Ok(temp_file)
+            })
+        };
+
+        let task_result = task.await;
+
+        if let Err(err) = snapshot_target_dir.close() {
+            log::error!("Failed to remove temporary directory: {err}");
+        }
+
+        let temp_file = task_result??;
+
+        let snapshot_path = self.shard_snapshot_path_unchecked(shard_id, snapshot_file_name)?;
+
+        if let Some(snapshot_dir) = snapshot_path.parent() {
+            std::fs::create_dir_all(snapshot_dir)?;
+        }
+
+        let _ = temp_file.persist(&snapshot_path).map_err(|err| {
+            if let Err(err) = err.file.close() {
+                log::error!("Failed to remove temporary file: {err}");
+            }
+
+            CollectionError::service_error(err.error.to_string())
+        })?;
+
+        get_snapshot_description(&snapshot_path).await
+    }
+
+    pub async fn get_snapshots_path_for_shard(
+        &self,
+        shard_id: ShardId,
+    ) -> CollectionResult<PathBuf> {
+        self.assert_is_shard_local(shard_id).await?;
+        Ok(self.snapshots_path_for_shard_unchecked(shard_id))
+    }
+
+    pub async fn get_shard_snapshot_path(
+        &self,
+        shard_id: ShardId,
+        snapshot_file_name: impl AsRef<Path>,
+    ) -> CollectionResult<PathBuf> {
+        self.assert_is_shard_local(shard_id).await?;
+        self.shard_snapshot_path_unchecked(shard_id, snapshot_file_name)
+    }
+
+    pub async fn restore_shard_snapshot(
+        &self,
+        shard_id: ShardId,
+        snapshot_path: &Path,
+        temp_dir: &Path,
+    ) -> CollectionResult<bool> {
+        self.assert_is_shard_local(shard_id).await?;
+
+        let snapshot = std::fs::File::open(snapshot_path)?;
+
+        let snapshot_file_name = snapshot_path.file_name().unwrap().to_string_lossy();
+
+        let snapshot_temp_dir = tempfile::Builder::new()
+            .prefix(&format!(
+                "{}-shard-{shard_id}-{}",
+                self.name(),
+                snapshot_file_name
+            ))
+            .tempdir_in(temp_dir)?;
+
+        let task = {
+            let snapshot_temp_dir = snapshot_temp_dir.path().to_path_buf();
+
+            tokio::task::spawn_blocking(move || -> CollectionResult<_> {
+                let mut tar = tar::Archive::new(snapshot);
+                tar.unpack(snapshot_temp_dir)?;
+                Ok(())
+            })
+        };
+
+        task.await??;
+
+        let recover_result = self
+            .recover_local_shard_from(snapshot_temp_dir.path(), shard_id)
+            .await;
+
+        if let Err(err) = snapshot_temp_dir.close() {
+            log::error!("Failed to remove temporary directory: {err}");
+        }
+
+        recover_result
+    }
+
+    async fn assert_is_shard_local(&self, shard_id: ShardId) -> CollectionResult<()> {
+        let is_shard_local =
+            self.is_shard_local(&shard_id)
+                .await
+                .ok_or_else(|| CollectionError::NotFound {
+                    what: format!("Shard {shard_id}"),
+                })?;
+
+        if is_shard_local {
+            Ok(())
+        } else {
+            Err(CollectionError::bad_input(format!(
+                "Shard {shard_id} is not a local shard"
+            )))
+        }
+    }
+
+    fn snapshots_path_for_shard_unchecked(&self, shard_id: ShardId) -> PathBuf {
+        self.snapshots_path.join(format!("shards/{shard_id}"))
+    }
+
+    fn shard_snapshot_path_unchecked(
+        &self,
+        shard_id: ShardId,
+        snapshot_file_name: impl AsRef<Path>,
+    ) -> CollectionResult<PathBuf> {
+        let snapshots_path = self.snapshots_path_for_shard_unchecked(shard_id);
+
+        let snapshot_file_name = snapshot_file_name.as_ref();
+
+        if snapshot_file_name.file_name() != Some(snapshot_file_name.as_os_str()) {
+            return Err(CollectionError::bad_input(format!(
+                "Invalid snapshot file name {}",
+                snapshot_file_name.display(),
+            )));
+        }
+
+        let snapshot_path = snapshots_path.join(snapshot_file_name);
+
+        Ok(snapshot_path)
     }
 
     pub async fn recover_local_shard_from(

--- a/lib/collection/src/common/file_utils.rs
+++ b/lib/collection/src/common/file_utils.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use fs_extra::dir::CopyOptions;
+
+use crate::operations::types::{CollectionError, CollectionResult};
+
+/// Move directory from one location to another.
+/// Handles the case when the source and destination are on different filesystems.
+pub async fn move_dir(from: impl Into<PathBuf>, to: impl Into<PathBuf>) -> CollectionResult<()> {
+    // Try to rename first and fallback to copy to prevert TOCTOU
+    let from = from.into();
+    let to = to.into();
+
+    if let Err(_err) = tokio::fs::rename(&from, &to).await {
+        // If rename failed, try to copy.
+        // It is possible that the source and destination are on different filesystems.
+        let task = tokio::task::spawn_blocking(move || {
+            let options = CopyOptions::new().copy_inside(true);
+            fs_extra::dir::move_dir(&from, &to, &options).map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Can't move dir from {} to {} due to {}",
+                    from.display(),
+                    to.display(),
+                    err
+                ))
+            })
+        });
+        task.await??;
+    }
+    Ok(())
+}

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod file_utils;
 pub mod is_ready;
 pub mod stoppable_task;
 pub mod stoppable_task_async;

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -74,14 +74,16 @@ pub async fn get_snapshot_description(path: &Path) -> CollectionResult<SnapshotD
 pub async fn list_snapshots_in_directory(
     directory: &Path,
 ) -> CollectionResult<Vec<SnapshotDescription>> {
-    let mut snapshots = Vec::new();
     let mut entries = tokio::fs::read_dir(directory).await?;
+    let mut snapshots = Vec::new();
+
     while let Some(entry) = entries.next_entry().await? {
-        let entry = entry;
         let path = entry.path();
-        if !path.is_dir() && path.extension().map(|s| s == "snapshot").unwrap_or(false) {
+
+        if !path.is_dir() && path.extension().map_or(false, |ext| ext == "snapshot") {
             snapshots.push(get_snapshot_description(&path).await?);
         }
     }
+
     Ok(snapshots)
 }

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -11,11 +11,13 @@ use validator::Validate;
 use crate::operations::types::CollectionResult;
 
 /// Defines source of truth for snapshot recovery
+/// `LocalOnly` means - restore snapshot without *any* additional synchronization
 /// `Snapshot` means - prefer snapshot data over the current state
 /// `Replica` means - prefer existing data over the snapshot
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SnapshotPriority {
+    LocalOnly,
     Snapshot,
     #[default]
     Replica,

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -76,7 +76,7 @@ impl LocalShard {
         if let Err(_err) = tokio::fs::rename(&wal_from, &wal_to).await {
             // If rename failed, try to copy WAL and segments
             let task = tokio::task::spawn_blocking(move || {
-                let options = CopyOptions::new();
+                let options = CopyOptions::new().copy_inside(true);
                 fs_extra::dir::move_dir(&wal_from, &wal_to, &options).map_err(|err| {
                     CollectionError::service_error(format!(
                         "Can't move WAL from {} to {} due to {}",
@@ -92,7 +92,7 @@ impl LocalShard {
         if let Err(_err) = tokio::fs::rename(&segments_from, &segments_to).await {
             // If rename failed, try to copy WAL and segments
             let task = tokio::task::spawn_blocking(move || {
-                let options = CopyOptions::new();
+                let options = CopyOptions::new().copy_inside(true);
                 fs_extra::dir::move_dir(&segments_from, &segments_to, &options).map_err(|err| {
                     CollectionError::service_error(format!(
                         "Can't move segments from {} to {} due to {}",

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -2,13 +2,12 @@ use std::cmp;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
-use std::future::Future;
-use std::ops::Deref;
+use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::future::{join, join_all};
+use futures::future::{join, join_all, BoxFuture};
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
@@ -698,19 +697,16 @@ impl ShardReplicaSet {
     /// 2 - Otherwise uses `read_fan_out_ratio` to compute list of active remote shards.
     /// 3 - Fallbacks to all remaining shards if the optimisations fails.
     /// It does not report failing peer_ids to the consensus.
-    pub async fn execute_read_operation<'a, F, Fut, Res>(
-        &self,
-        read_operation: F,
-        local: &'a Option<Shard>,
-        remotes: &'a [RemoteShard],
-    ) -> CollectionResult<Res>
+    pub async fn execute_read_operation<F, Res>(&self, read_operation: F) -> CollectionResult<Res>
     where
-        F: Fn(&'a (dyn ShardOperation + Send + Sync)) -> Fut,
-        Fut: Future<Output = CollectionResult<Res>>,
+        F: Fn(&(dyn ShardOperation + Send + Sync)) -> BoxFuture<'_, CollectionResult<Res>>,
     {
+        let remotes = self.remotes.read().await;
+        let local = self.local.read().await;
+
         let mut local_result = None;
         // 1 - prefer the local shard if it is active
-        if let Some(local) = local {
+        if let Some(local) = local.deref() {
             if self.peer_is_active(&self.this_peer_id()) {
                 let read_operation_res = read_operation(local.get()).await;
                 match &read_operation_res {
@@ -803,30 +799,31 @@ impl ShardReplicaSet {
         captured_error.expect("at this point `captured_error` must be defined by construction")
     }
 
-    pub async fn execute_and_resolve_read_operation<'a, F, Fut, Res>(
+    pub async fn execute_and_resolve_read_operation<F, Res>(
         &self,
         read_operation: F,
-        local: &'a Option<Shard>,
-        remotes: &'a [RemoteShard],
         read_consistency: ReadConsistency,
     ) -> CollectionResult<Res>
     where
-        F: Fn(&'a (dyn ShardOperation + Send + Sync)) -> Fut,
-        Fut: Future<Output = CollectionResult<Res>>,
+        F: Fn(&(dyn ShardOperation + Send + Sync)) -> BoxFuture<'_, CollectionResult<Res>>,
         Res: Resolve,
     {
-        let local_count = usize::from(local.is_some());
-        let remotes_count = remotes.len();
+        let remotes = self.remotes.read().await;
 
-        let active_local = local
-            .as_ref()
-            .filter(|_| self.peer_is_active(&self.this_peer_id()));
+        let (local, is_local_ready) = match self.local.try_read() {
+            Ok(local) => (futures::future::ready(local).left_future(), true),
+            Err(_) => (self.local.read().right_future(), false),
+        };
+
+        let local_count = usize::from(self.peer_state(&self.this_peer_id()).is_some());
+        let active_local_count = usize::from(self.peer_is_active(&self.this_peer_id()));
+
+        let remotes_count = remotes.len();
 
         let active_remotes_iter = remotes
             .iter()
             .filter(|remote| self.peer_is_active(&remote.peer_id));
 
-        let active_local_count = usize::from(active_local.is_some());
         let active_remotes_count = active_remotes_iter.clone().count();
 
         let total_count = local_count + remotes_count;
@@ -859,23 +856,44 @@ impl ShardReplicaSet {
         let mut active_remotes: Vec<_> = active_remotes_iter.collect();
         active_remotes.shuffle(&mut rand::thread_rng());
 
-        let local_operations = active_local
-            .into_iter()
-            .map(|local| read_operation(local.get()).left_future());
+        let local_operation = if active_local_count > 0 {
+            let local_operation = async {
+                let local = local.await;
+
+                let Some(local) = local.deref() else {
+                    return Err(CollectionError::service_error(format!(
+                        "Local shard {} not found",
+                        self.shard_id
+                    )));
+                };
+
+                read_operation(local.get()).await
+            };
+
+            Some(local_operation.left_future())
+        } else {
+            None
+        };
+
+        let local_operation = local_operation.into_iter();
 
         let remote_operations = active_remotes
             .into_iter()
             .map(|remote| read_operation(remote).right_future());
 
-        let mut operations = local_operations.chain(remote_operations);
+        let mut operations = local_operation.chain(remote_operations);
 
-        let required_reads = if active_local_count > 0 {
+        let mut required_reads = if active_local_count > 0 {
             // If there is a local shard, we can ignore fan-out `read_remote_replicas` param,
             // as we already know that the local peer is working.
             factor
         } else {
             max(factor, usize::try_from(self.read_remote_replicas).unwrap())
         };
+
+        if !is_local_ready {
+            required_reads += 1;
+        }
 
         let mut pending_operations: FuturesUnordered<_> =
             operations.by_ref().take(required_reads).collect();
@@ -1343,8 +1361,8 @@ impl ShardReplicaSet {
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
         let all_res: Vec<Result<_, _>> = {
-            let local = self.local.read().await;
             let remotes = self.remotes.read().await;
+            let local = self.local.read().await;
             let this_peer_id = self.this_peer_id();
 
             // target all remote peers that can receive updates
@@ -1488,32 +1506,38 @@ impl ShardReplicaSet {
         filter: Option<&Filter>,
         read_consistency: Option<ReadConsistency>,
     ) -> CollectionResult<Vec<Record>> {
-        let local = self.local.read().await;
-        let remotes = self.remotes.read().await;
+        let with_payload_interface = Arc::new(with_payload_interface.clone());
+        let with_vector = Arc::new(with_vector.clone());
+        let filter = filter.map(|filter| Arc::new(filter.clone()));
 
         self.execute_and_resolve_read_operation(
             |shard| {
-                shard.scroll_by(
-                    offset,
-                    limit,
-                    with_payload_interface,
-                    with_vector,
-                    filter,
-                    &self.search_runtime,
-                )
+                let with_payload_interface = with_payload_interface.clone();
+                let with_vector = with_vector.clone();
+                let filter = filter.clone();
+                let search_runtime = self.search_runtime.clone();
+
+                async move {
+                    shard
+                        .scroll_by(
+                            offset,
+                            limit,
+                            &with_payload_interface,
+                            &with_vector,
+                            filter.as_deref(),
+                            &search_runtime,
+                        )
+                        .await
+                }
+                .boxed()
             },
-            &local,
-            &remotes,
             read_consistency.unwrap_or_default(),
         )
         .await
     }
 
     pub async fn info(&self) -> CollectionResult<CollectionInfo> {
-        let local = self.local.read().await;
-        let remotes = self.remotes.read().await;
-
-        self.execute_read_operation(|shard| shard.info(), &local, &remotes)
+        self.execute_read_operation(|shard| async move { shard.info().await }.boxed())
             .await
     }
 
@@ -1522,13 +1546,13 @@ impl ShardReplicaSet {
         request: Arc<SearchRequestBatch>,
         read_consistency: Option<ReadConsistency>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let local = self.local.read().await;
-        let remotes = self.remotes.read().await;
-
         self.execute_and_resolve_read_operation(
-            |shard| shard.search(request.clone(), &self.search_runtime),
-            &local,
-            &remotes,
+            |shard| {
+                let request = request.clone();
+                let search_runtime = self.search_runtime.clone();
+
+                async move { shard.search(request, &search_runtime).await }.boxed()
+            },
             read_consistency.unwrap_or_default(),
         )
         .await
@@ -1546,11 +1570,11 @@ impl ShardReplicaSet {
     }
 
     pub async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
-        let local = self.local.read().await;
-        let remotes = self.remotes.read().await;
-
-        self.execute_read_operation(|shard| shard.count(request.clone()), &local, &remotes)
-            .await
+        self.execute_read_operation(|shard| {
+            let request = request.clone();
+            async move { shard.count(request).await }.boxed()
+        })
+        .await
     }
 
     pub async fn retrieve(
@@ -1560,13 +1584,17 @@ impl ShardReplicaSet {
         with_vector: &WithVector,
         read_consistency: Option<ReadConsistency>,
     ) -> CollectionResult<Vec<Record>> {
-        let local = self.local.read().await;
-        let remotes = self.remotes.read().await;
+        let with_payload = Arc::new(with_payload.clone());
+        let with_vector = Arc::new(with_vector.clone());
 
         self.execute_and_resolve_read_operation(
-            |shard| shard.retrieve(request.clone(), with_payload, with_vector),
-            &local,
-            &remotes,
+            |shard| {
+                let request = request.clone();
+                let with_payload = with_payload.clone();
+                let with_vector = with_vector.clone();
+
+                async move { shard.retrieve(request, &with_payload, &with_vector).await }.boxed()
+            },
             read_consistency.unwrap_or_default(),
         )
         .await

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -34,15 +34,15 @@ impl StorageError {
         }
     }
 
-    pub fn bad_request(description: &str) -> StorageError {
+    pub fn bad_request(description: impl Into<String>) -> StorageError {
         StorageError::BadRequest {
-            description: description.to_string(),
+            description: description.into(),
         }
     }
 
-    pub fn bad_input(description: &str) -> StorageError {
+    pub fn bad_input(description: impl Into<String>) -> StorageError {
         StorageError::BadInput {
-            description: description.to_string(),
+            description: description.into(),
         }
     }
 

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -32,7 +32,7 @@ async fn download_file(url: &Url, path: &Path) -> Result<(), StorageError> {
     let response = reqwest::get(url.clone()).await?;
 
     if !response.status().is_success() {
-        return Err(StorageError::bad_input(&format!(
+        return Err(StorageError::bad_input(format!(
             "Failed to download snapshot from {}: status - {}",
             url,
             response.status()
@@ -60,7 +60,7 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
                 )
             })?;
             if !local_path.exists() {
-                return Err(StorageError::bad_request(&format!(
+                return Err(StorageError::bad_request(format!(
                     "Snapshot file {local_path:?} does not exist"
                 )));
             }
@@ -72,7 +72,7 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
             download_file(&url, &download_to).await?;
             Ok(download_to)
         }
-        _ => Err(StorageError::bad_request(&format!(
+        _ => Err(StorageError::bad_request(format!(
             "URL {} with schema {} is not supported",
             url,
             url.scheme()

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -13,7 +13,7 @@ use crate::content_manager::snapshots::download::{download_snapshot, downloaded_
 use crate::dispatcher::Dispatcher;
 use crate::{StorageError, TableOfContent};
 
-async fn activate_shard(
+pub async fn activate_shard(
     toc: &TableOfContent,
     collection: &Collection,
     peer_id: PeerId,

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -143,14 +143,14 @@ async fn _do_recover_from_snapshot(
     // Check config compatibility
     // Check vectors config
     if snapshot_config.params.vectors != state.config.params.vectors {
-        return Err(StorageError::bad_input(&format!(
+        return Err(StorageError::bad_input(format!(
             "Snapshot is not compatible with existing collection: Collection vectors: {:?} Snapshot Vectors: {:?}",
             state.config.params.vectors, snapshot_config.params.vectors
         )));
     }
     // Check shard number
     if snapshot_config.params.shard_number != state.config.params.shard_number {
-        return Err(StorageError::bad_input(&format!(
+        return Err(StorageError::bad_input(format!(
             "Snapshot is not compatible with existing collection: Collection shard number: {:?} Snapshot shard number: {:?}",
             state.config.params.shard_number, snapshot_config.params.shard_number
         )));

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -225,6 +225,10 @@ async fn _do_recover_from_snapshot(
                 activate_shard(toc, &collection, this_peer_id, shard_id).await?;
             } else {
                 match priority {
+                    SnapshotPriority::LocalOnly => {
+                        activate_shard(toc, &collection, this_peer_id, shard_id).await?;
+                    }
+
                     SnapshotPriority::Snapshot => {
                         // Snapshot is the source of truth, we need to remove all other replicas
                         activate_shard(toc, &collection, this_peer_id, shard_id).await?;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -272,7 +272,7 @@ impl TableOfContent {
 
         if path.exists() {
             if CollectionConfig::check(&path) {
-                return Err(StorageError::bad_input(&format!(
+                return Err(StorageError::bad_input(format!(
                     "Can't create collection with name {collection_name}. Collection data already exists at {path}",
                     collection_name = collection_name,
                     path = path.display(),
@@ -366,7 +366,7 @@ impl TableOfContent {
             .await
             .check_alias_exists(collection_name)
         {
-            return Err(StorageError::bad_input(&format!(
+            return Err(StorageError::bad_input(format!(
                 "Can't create collection with name {collection_name}. Alias with the same name already exists",
             )));
         }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -313,8 +313,8 @@ async fn create_shard_snapshot(
     helpers::time_or_accept(future, query.wait.unwrap_or(true)).await
 }
 
-// TODO: `POST` or `PUT` (same as `recover_from_snapshot`)!?
-#[post("/collections/{collection}/shards/{shard}/snapshots/recover")]
+// TODO: `PUT` (same as `recover_from_snapshot`) or `POST`!?
+#[put("/collections/{collection}/shards/{shard}/snapshots/recover")]
 async fn recover_shard_snapshot(
     toc: web::Data<TableOfContent>,
     path: web::Path<(String, ShardId)>,
@@ -326,7 +326,7 @@ async fn recover_shard_snapshot(
         let collection = toc.get_collection(&collection).await?;
         let snapshots_dir = collection.get_snapshots_path_for_shard(shard).await?;
 
-        // TODO: Handle cleanup on download failure (e.g., using `tempfile`)!
+        // TODO: Handle cleanup on download failure (e.g., using `tempfile`)!?
 
         let snapshot_path =
             snapshots::download::download_snapshot(request.location, &snapshots_dir).await?;
@@ -346,8 +346,8 @@ async fn recover_shard_snapshot(
     helpers::time_or_accept(future, query.wait.unwrap_or(true)).await
 }
 
-// TODO: `PUT` or `POST` (same as `upload_snapshot`)!?
-#[put("/collections/{collection}/shards/{shard}/snapshots/upload")]
+// TODO: `POST` (same as `upload_snapshot`) or `PUT`!?
+#[post("/collections/{collection}/shards/{shard}/snapshots/upload")]
 async fn upload_shard_snapshot(
     toc: web::Data<TableOfContent>,
     path: web::Path<(String, ShardId, String)>,

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -333,7 +333,12 @@ async fn recover_shard_snapshot(
         let snapshot_path = match request.location {
             ShardSnapshotLocation::Url(url) => {
                 if !matches!(url.scheme(), "http" | "https") {
-                    return Err(StorageError::bad_input("TODO").into());
+                    let description = format!(
+                        "Invalid snapshot URL {url}: URLs with {} scheme are not supported",
+                        url.scheme(),
+                    );
+
+                    return Err(StorageError::bad_input(description).into());
                 }
 
                 let downloaded_snapshots_dir = downloaded_snapshots_dir(toc.snapshots_path());

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -330,7 +330,7 @@ async fn recover_shard_snapshot(
 
         // TODO: Handle cleanup on download failure (e.g., using `tempfile`)!?
 
-        let snapshot_path= match request.location {
+        let snapshot_path = match request.location {
             ShardSnapshotLocation::Url(url) => {
                 if !matches!(url.scheme(), "http" | "https") {
                     return Err(StorageError::bad_input("TODO").into());

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -496,6 +496,10 @@ async fn recover_shard_snapshot_impl(
         activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
     } else {
         match priority {
+            SnapshotPriority::LocalOnly => {
+                activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
+            }
+
             SnapshotPriority::Snapshot => {
                 activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -302,6 +302,7 @@ async fn create_shard_snapshot(
         let snapshot = collection
             .create_shard_snapshot(shard, &toc.temp_snapshots_path().join(SNAPSHOTS_TEMP_DIR))
             .await?;
+
         Ok(snapshot)
     };
 
@@ -384,6 +385,8 @@ async fn restore_shard_snapshot(
             .restore_shard_snapshot(
                 shard,
                 &snapshot_path,
+                toc.this_peer_id,
+                toc.is_distributed(),
                 &toc.temp_snapshots_path().join(SNAPSHOTS_TEMP_DIR),
             )
             .await?;
@@ -410,5 +413,6 @@ pub fn config_snapshots_api(cfg: &mut web::ServiceConfig) {
         .service(create_shard_snapshot)
         .service(delete_shard_snapshot)
         .service(download_shard_snapshot)
-        .service(upload_shard_snapshot);
+        .service(upload_shard_snapshot)
+        .service(restore_shard_snapshot);
 }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -15,6 +15,7 @@ use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::errors::StorageError;
+use storage::content_manager::snapshots::download::downloaded_snapshots_dir;
 use storage::content_manager::snapshots::recover::{activate_shard, do_recover_from_snapshot};
 use storage::content_manager::snapshots::{
     self, do_create_full_snapshot, do_delete_collection_snapshot, do_delete_full_snapshot,
@@ -325,7 +326,9 @@ async fn recover_shard_snapshot(
     let future = async move {
         let (collection, shard) = path.into_inner();
         let collection = toc.get_collection(&collection).await?;
-        let snapshots_dir = collection.get_snapshots_path_for_shard(shard).await?;
+
+        let snapshot_download_path = downloaded_snapshots_dir(toc.snapshots_path());
+        tokio::fs::create_dir_all(&snapshot_download_path).await?;
 
         // TODO: Handle cleanup on download failure (e.g., using `tempfile`)!?
 
@@ -335,7 +338,7 @@ async fn recover_shard_snapshot(
                     return Err(StorageError::bad_input("TODO").into());
                 }
 
-                snapshots::download::download_snapshot(url, &snapshots_dir).await?
+                snapshots::download::download_snapshot(url, &snapshot_download_path).await?
             }
 
             ShardSnapshotLocation::Path(path) => {

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -326,7 +326,9 @@ async fn recover_shard_snapshot(
     let future = async move {
         let (collection, shard) = path.into_inner();
         let collection = toc.get_collection(&collection).await?;
-        let snapshots_dir = collection.get_snapshots_path_for_shard(shard).await?;
+
+        let snapshot_download_path = downloaded_snapshots_dir(toc.snapshots_path());
+        tokio::fs::create_dir_all(&snapshot_download_path).await?;
 
         // TODO: Handle cleanup on download failure (e.g., using `tempfile`)!?
 
@@ -336,19 +338,7 @@ async fn recover_shard_snapshot(
                     return Err(StorageError::bad_input("TODO").into());
                 }
 
-                let downloaded_snapshots_dir = downloaded_snapshots_dir(toc.snapshots_path());
-                tokio::fs::create_dir_all(&downloaded_snapshots_dir).await?;
-
-                let downloaded_snapshot_path =
-                    snapshots::download::download_snapshot(url, &downloaded_snapshots_dir).await?;
-
-                let snapshot_path =
-                    snapshots_dir.join(downloaded_snapshot_path.file_name().unwrap());
-
-                tokio::fs::create_dir_all(&snapshots_dir).await?;
-                tokio::fs::rename(&downloaded_snapshot_path, &snapshot_path).await?;
-
-                snapshot_path
+                snapshots::download::download_snapshot(url, &snapshot_download_path).await?
             }
 
             ShardSnapshotLocation::Path(path) => {

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -350,7 +350,8 @@ async fn download_shard_snapshot(
     Ok(NamedFile::open(snapshot_path))
 }
 
-#[put("/collections/{collection}/shards/{shard}/snapshots/{snapshot}")]
+// TODO: `PUT` or `POST` (same as `upload_snapshot`)!?
+#[put("/collections/{collection}/shards/{shard}/snapshots/upload")]
 async fn upload_shard_snapshot(
     toc: web::Data<TableOfContent>,
     path: web::Path<(String, ShardId, String)>,
@@ -390,8 +391,9 @@ async fn upload_shard_snapshot(
     helpers::time_or_accept(future, wait.unwrap_or(true)).await
 }
 
-#[post("/collections/{collection}/shards/{shard}/snapshots")]
-async fn restore_shard_snapshot(
+// TODO: `POST` or `PUT` (same as `recover_from_snapshot`)!?
+#[post("/collections/{collection}/shards/{shard}/snapshots/recover")]
+async fn recover_shard_snapshot(
     toc: web::Data<TableOfContent>,
     path: web::Path<(String, ShardId)>,
     query: web::Query<SnapshottingParam>,
@@ -422,7 +424,7 @@ async fn restore_shard_snapshot(
     helpers::time_or_accept(future, query.wait.unwrap_or(true)).await
 }
 
-async fn restore_shard_snapshot_impl(
+async fn recover_shard_snapshot_impl(
     toc: &TableOfContent,
     collection: &RwLockReadGuard<'_, Collection>,
     shard: ShardId,

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -475,6 +475,9 @@ async fn recover_shard_snapshot_impl(
                 let mut other_active_replicas = other_active_replicas.iter().copied();
 
                 for (peer, _) in other_active_replicas.by_ref().take(replicas_to_remove) {
+                    // Is it right to remove *active* replicas!?
+                    // Why not remove some `Dead` or `Partial` replica instead?
+                    // What if there's no active replicas? Are we going *over* the replication factor then?
                     toc.request_remove_replica(collection.name(), shard, peer)?;
                 }
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -1,6 +1,5 @@
-use std::fmt;
-use std::io;
 use std::path::{Path, PathBuf};
+use std::{fmt, io};
 
 use actix_files::NamedFile;
 use actix_multipart::form::tempfile::TempFile;
@@ -332,7 +331,7 @@ async fn recover_shard_snapshot(
 
         let snapshot_path = match request.location {
             ShardSnapshotLocation::Url(url) => {
-                if ! matches!(url.scheme(), "http" | "https") {
+                if !matches!(url.scheme(), "http" | "https") {
                     return Err(StorageError::bad_input("TODO").into());
                 }
 
@@ -441,10 +440,7 @@ async fn delete_shard_snapshot(
 
 fn check_shard_snapshot_file_exists(snapshot_path: &Path) -> Result<(), StorageError> {
     let snapshot_path_display = snapshot_path.display();
-
-    let snapshot_file_name = snapshot_path
-        .file_name()
-        .and_then(|str| str.to_str());
+    let snapshot_file_name = snapshot_path.file_name().and_then(|str| str.to_str());
 
     let snapshot: &dyn fmt::Display = snapshot_file_name
         .as_ref()

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -33,7 +33,7 @@ pub fn accepted_response(timing: Instant) -> HttpResponse {
 
 pub fn process_response<D>(response: Result<D, StorageError>, timing: Instant) -> HttpResponse
 where
-    D: Serialize + Debug,
+    D: Serialize,
 {
     match response {
         Ok(res) => HttpResponse::Ok().json(ApiResponse {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -165,6 +165,6 @@ impl From<CollectionError> for HttpError {
 
 impl From<io::Error> for HttpError {
     fn from(err: io::Error) -> Self {
-        todo!()
+        StorageError::from(err).into() // TODO: Is this good enough?.. 🤔
     }
 }

--- a/tests/shard-snapshot-api.sh
+++ b/tests/shard-snapshot-api.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+declare URL="${URL:-localhost:6333}"
+
+declare COLLECTION_CREATED=0
+declare POINTS_UPSERTED=0
+
+declare SNAPSHOT=''
+
+
+function main {
+	load-collection-status
+	"$@"
+}
+
+function load-collection-status {
+	declare POINTS_COUNT
+
+	if POINTS_COUNT="$(curl-ok "$(url)" | jq .result.points_count)" || true
+	then
+		COLLECTION_CREATED=1
+
+		if (( POINTS_COUNT > 0 ))
+		then
+			POINTS_UPSERTED=1
+		fi
+	fi
+
+	return 0
+}
+
+
+declare TESTS=(
+	list-snapshots
+	list-snapshots-wrong-collection
+	list-snapshots-wrong-shard
+
+	create-snapshot
+	create-snapshot-concurrent
+	create-snapshot-wrong-collection
+	create-snapshot-wrong-shard
+
+	# recover-local-snapshot
+	# recover-local-concurrent
+	recover-local-snapshot-wrong-collection
+	recover-local-snapshot-wrong-shard
+	# recover-local-snapshot-wrong-snapshot
+
+	# recover-remote
+	# recover-remote-concurrent
+	recover-remote-wrong-collection
+	recover-remote-wrong-shard
+	# recover-remote-wrong-snapshot
+
+	upload
+	upload-concurrent
+	upload-invalid-collection
+	upload-invalid-shard
+
+	download-snapshot
+	download-snapshot-wrong-collection
+	download-snapshot-wrong-shard
+	download-snapshot-wrong-snapshot
+
+	delete-snapshot
+	delete-snapshot-wrong-collection
+	delete-snapshot-wrong-shard
+	delete-snapshot-wrong-snapshot
+)
+
+function all {
+	for TEST in "${TESTS[@]}"
+	do
+		echo "Running $TEST..."
+		"$TEST"
+	done
+}
+
+
+function list-snapshots {
+	fixture-with-collection
+	curl-ok "$(url - -)"
+}
+
+function list-snapshots-wrong-collection {
+	curl-status 404 "$(url invalid-collection -)"
+}
+
+function list-snapshots-wrong-shard {
+	fixture-with-collection
+	curl-status 404 "$(url - 1)"
+}
+
+
+function create-snapshot {
+	fixture-with-points
+	curl-ok -X POST "$(url - -)"
+}
+
+function create-snapshot-concurrent {
+	fixture-with-points
+	:
+}
+
+function create-snapshot-wrong-collection {
+	curl-status 404 -X POST "$(url invalid-collection -)"
+}
+
+function create-snapshot-wrong-shard {
+	fixture-with-collection
+	curl-status 404 -X POST "$(url - 1)"
+}
+
+
+# TODO: Switch from `file://` URL to simple snapshot filename
+function recover-local-snapshot {
+	fixture-with-snapshot
+	fixture-with-empty-collection
+
+	curl-ok \
+		-X PUT "$(url - -)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw "{ \"location\": \"$SNAPSHOT\" }"
+}
+
+function recover-local-concurrent {
+	fixture-with-snapshot
+	fixture-with-empty-collection
+	:
+}
+
+# TODO: Switch from `file://` URL to simple snapshot filename
+function recover-local-snapshot-wrong-collection {
+	curl-status 404 \
+		-X PUT "$(url invalid-collection -)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "file:///invalid.snapshot" }'
+}
+
+# TODO: Switch from `file://` URL to simple snapshot filename
+function recover-local-snapshot-wrong-shard {
+	fixture-with-collection
+
+	curl-status 404 \
+		-X PUT "$(url - 1)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "file:///invalid.snapshot" }'
+}
+
+# TODO: Switch from `file://` URL to simple snapshot filename
+# TODO: `file:///invalid.snapshot` returns `400`, not `404`? 🤔
+function recover-local-snapshot-wrong-snapshot {
+	fixture-with-collection
+
+	curl-status 404 \
+		-X PUT "$(url - -)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "invalid.snapshot" }'
+}
+
+
+function recover-remote {
+	fixture-with-remote-snapshot
+	fixture-with-empty-collection
+	:
+}
+
+function recover-remote-concurrent {
+	fixture-with-remote-snapshot
+	fixture-with-empty-collection
+	:
+}
+
+function recover-remote-wrong-collection {
+	curl-status 404 \
+		-X PUT "$(url invalid-collection -)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "http://invalid-host/invalid.snapshot" }'
+}
+
+function recover-remote-wrong-shard {
+	fixture-with-collection
+
+	curl-status 404 \
+		-X PUT "$(url - 1)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "http://localhost:8080/invalid.snapshot" }'
+}
+
+function recover-remote-wrong-snapshot {
+	fixture-with-collection
+
+	curl-status 404 \
+		-X PUT "$(url - 1)"/recover \
+		-H 'Content-Type: application/json' \
+		--data-raw '{ "location": "http://localhost:8080/invalid.snapshot" }'
+}
+
+
+function upload {
+	fixture-with-downloaded-snapshot
+	fixture-with-empty-collection
+	:
+}
+
+function upload-concurrent {
+	fixture-with-downloaded-snapshot
+	fixture-with-empty-collection
+	:
+}
+
+function upload-invalid-collection {
+	:
+}
+
+function upload-invalid-shard {
+	fixture-with-collection
+	:
+}
+
+
+function download-snapshot {
+	fixture-with-collection
+	fixture-with-snapshot
+	curl-ok "$(url - - -)" -o /dev/null
+}
+
+function download-snapshot-wrong-collection {
+	curl-status 404 "$(url invalid-collection - invalid.snapshot)"
+}
+
+function download-snapshot-wrong-shard {
+	fixture-with-collection
+	curl-status 404 "$(url - 1 invalid.snapshot)"
+}
+
+function download-snapshot-wrong-snapshot {
+	fixture-with-collection
+	curl-status 404 "$(url - - invalid.snapshot)"
+}
+
+
+function delete-snapshot {
+	fixture-with-collection
+	fixture-with-snapshot
+	curl-ok -X DELETE "$(url - - -)"
+}
+
+function delete-snapshot-wrong-collection {
+	curl-status 404 -X DELETE "$(url invalid-collection - invalid.snapshot)"
+}
+
+function delete-snapshot-wrong-shard {
+	fixture-with-collection
+	curl-status 404 -X DELETE "$(url - 1 invalid.snapshot)"
+}
+
+function delete-snapshot-wrong-snapshot {
+	fixture-with-collection
+	curl-status 404 -X DELETE "$(url - - invalid.snapshot)"
+}
+
+
+function fixture-with-collection {
+	if (( ! COLLECTION_CREATED ))
+	then
+		curl-ok \
+			-X PUT "$(url)" \
+			-H 'Content-Type: application/json' \
+			--data-raw '{
+				"vectors": {
+					"size": 4,
+					"distance": "Cosine"
+				}
+			}'
+
+		COLLECTION_CREATED=1
+	fi
+}
+
+function fixture-with-points {
+	fixture-with-collection
+
+	if (( ! POINTS_UPSERTED ))
+	then
+		curl-ok \
+			-X PUT "$(url)/points" \
+			-H 'Content-Type: application/json' \
+			--data-raw '{
+				"points": [
+					{ "id": 1, "vector": [0.1, 0.1, 0.1, 0.1] },
+					{ "id": 2, "vector": [0.2, 0.2, 0.2, 0.2] },
+					{ "id": 3, "vector": [0.3, 0.3, 0.3, 0.3] },
+					{ "id": 4, "vector": [0.4, 0.4, 0.4, 0.4] }
+				]
+			}'
+
+		POINTS_UPSERTED=1
+	fi
+}
+
+function fixture-with-snapshot {
+	if [[ ! $SNAPSHOT ]]
+	then
+		fixture-with-points
+		SNAPSHOT="$(curl-ok -X POST "$(url - -)" | jq -r .result.name)"
+	fi
+}
+
+function fixture-without-collection {
+	if (( COLLECTION_CREATED ))
+	then
+		curl-ok -X DELETE "$(url)"
+		COLLECTION_CREATED=0
+		POINTS_UPSERTED=0
+	fi
+}
+
+function fixture-with-empty-collection {
+	if (( POINTS_UPSERTED ))
+	then
+		fixture-without-collection
+	fi
+
+	fixture-with-collection
+}
+
+function fixture-with-downloaded-snapshot {
+	fixture-with-collection
+	fixture-with-snapshot
+
+	:
+}
+
+function fixture-with-remote-snapshot {
+	fixture-with-downloaded-snapshot
+
+	:
+}
+
+
+function curl-ok {
+	curl -sS --fail-with-body "$@" | jq # TODO!?
+}
+
+function curl-status {
+	declare EXPECTED="$1"
+	declare ARGS=( "${@:2}" )
+
+	declare STATUS ; STATUS="$(curl -sS -w '%{http_code}' -o /dev/null "${ARGS[@]}")"
+	[[ $STATUS == "$EXPECTED" ]]
+}
+
+function curl-status-with-body {
+	declare EXPECTED="$1"
+	declare ARGS=( "${@:2}" )
+
+	echo "curl-status-with-body: unimplemented" >&2
+	return 1
+}
+
+
+function url {
+	declare COLLECTION=test-collection
+	declare SHARD=0
+	declare SNAPSHOT="${SNAPSHOT-}"
+
+	if (( $# >= 1 ))
+	then
+		COLLECTION="$(or-default "$1" "$COLLECTION")"
+	fi
+
+	if (( $# >= 2 ))
+	then
+		SHARD="$(or-default "$2" "$SHARD")"
+	fi
+
+	if (( $# >= 3 ))
+	then
+		SNAPSHOT="$(or-default "$3" "$SNAPSHOT")"
+	fi
+
+	if (( $# <= 1 ))
+	then
+		echo "$URL/collections/$COLLECTION"
+	elif (( $# == 2 ))
+	then
+		echo "$URL/collections/$COLLECTION/shards/$SHARD/snapshots"
+	elif (( $# == 3 ))
+	then
+		echo "$URL/collections/$COLLECTION/shards/$SHARD/snapshots/$SNAPSHOT"
+	else
+		echo "url: expected no more than 3 arguments (collection, shard, snapshot), but received $# (${*:4})" >&2
+		return 1
+	fi
+}
+
+function or-default {
+	declare ARG="$1"
+	declare DEFAULT="$2"
+
+	if [[ ! $ARG ]]
+	then
+		echo 'or-default: ARG is null' >&2
+		return 1
+	elif [[ $ARG != - ]]
+	then
+		echo "$ARG"
+	elif [[ ! $DEFAULT ]]
+	then
+		echo 'or-default: DEFAULT is null' >&2
+		return 2
+	else
+		echo "$DEFAULT"
+	fi
+}
+
+
+main "$@"

--- a/tests/shard-snapshot-api.sh
+++ b/tests/shard-snapshot-api.sh
@@ -15,7 +15,7 @@ declare BFB="${BFB-}"
 declare FILESERVER_ADDR="${FILESERVER_ADDR:-127.0.0.1}"
 declare FILESERVER_PORT="${FILESERVER_PORT:-8080}"
 
-# When running Docker on macOS, use `host.docker.internal` to access *macOS* localhost
+# When running Qdrant in Docker on macOS, use `host.docker.internal` to access *macOS* localhost from inside the container
 declare FILESERVER_URL="${FILESEVER_URL:-http://localhost:8080}"
 
 
@@ -25,7 +25,6 @@ declare POINTS_UPSERTED=0
 declare SNAPSHOT=''
 
 declare DOWNLOADED_SNAPSHOT=''
-
 
 declare FILESERVER_PID=''
 
@@ -53,15 +52,16 @@ function load-collection-status {
 }
 
 function cleanup {
+	kill-jobs
+
 	if [[ $DOWNLOADED_SNAPSHOT && -f $DOWNLOADED_SNAPSHOT ]]
 	then
 		rm "$DOWNLOADED_SNAPSHOT"
 	fi
+}
 
-	if [[ $FILESERVER_PID ]]
-	then
-		kill -TERM "$FILESERVER_PID"
-	fi
+function kill-jobs {
+	kill $(jobs -p) &>/dev/null || :
 }
 
 


### PR DESCRIPTION
Tracking issue: https://github.com/qdrant/qdrant/issues/2432

__TODO:__
- [x] Implement remote (URL-based) shard snapshot recovery
- [x] Copy shard state transition logic from [`_do_recover_from_snapshot`]
- [x] Add automatic shard snapshot recovery on shard snapshot upload (trivial, just braindead already to do it today)
- [x] Test ___everything___ 😵🔫
- [x] Implement integration tests ☠️🪦
- [x] _Always_ spawn a future for create/recover/upload APIs (e.g., see `helpers::time*` functions)? 🤔
- [x] Do not require shard to be _local_, when recovering shard snapshot 🤦‍♀️
  - I think `upload_shard_snapshot` would fail, if you'd try to recover a shard, that is not _local_ on the node
- [x] Return error `404`, if trying to restore a shard, that _does not exist in the replica set_
- [x] Move uploaded and remote-downloaded shard snapshots from the temporary/downloads directory to the shard snapshot directory
  - after _upload/download_, if shard is _local_ on the node
  - or after recovery, if local shard is created on the node during recovery
  - the logic for this is
    - if local shard exists, then user can list/retry/delete uploaded/downloaded snapshot using the API
    - and if local shard does not exist, then we remove failed snapshot automatically to prevent polluting temp/downloads directory
  - `std::fs::rename`/`tokio::fs::rename` only works if source and destination paths are on the same file system
    - [x] so `move` have to be implemented using `rename`/`copy`/`delete`
  - __UPD:__ This is currently done for shard upload, but temporarily reversed for remote shard download

[`_do_recover_from_snapshot`]: https://github.com/qdrant/qdrant/blob/master/lib/storage/src/content_manager/snapshots/recover.rs#L67-L288

__Further Improvements:__
- [ ] Test concurrent API calls and add write-locks if/where required
- [ ] Check for blocking calls in shard snapshot API implementation and replace them with async/`tokio::task::spawn_blocking`
- [ ] Unify and deduplicate `_do_recover_from_snapshot` logic with shard snapshot API
- [ ] Implement proper _pytest_ integration tests instead of `shard-snapshot-api.sh`
- [ ] Store basic collection config (e.g., ___vector size___) in shard snapshot and check them during recovery to prevent errors 🤔

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
