### PR TITLE
Fix incorrect file URI handling in snapshot recovery

### DIFF
--- a/openapi/tests/openapi_integration/test_snapshot.py
+++ b/openapi/tests/openapi_integration/test_snapshot.py
@@ -224,3 +224,41 @@ def test_snapshot_operations_non_wait():
             # wait for snapshot to be deleted
             sleep(0.1)
             continue
+
+
+def test_snapshot_invalid_file_uri():
+    # Invalid file:// host
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/recover',
+        method="PUT",
+        path_params={'collection_name': "somethingthatdoesnotexist"},
+        body={
+            "location": "file://whatever.snapshot",
+        }
+    )
+    assert response.status_code == 400
+    assert response.json()["status"]["error"] == "Bad request: Invalid snapshot URI, file path must be absolute or on localhost"
+
+    # Absolute path that does not exist
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/recover',
+        method="PUT",
+        path_params={'collection_name': "somethingthatdoesnotexist"},
+        body={
+            "location": "file:///whatever.snapshot",
+        }
+    )
+    assert response.status_code == 400
+    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
+
+    # Path that does not exist
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/recover',
+        method="PUT",
+        path_params={'collection_name': "somethingthatdoesnotexist"},
+        body={
+            "location": "file://localhost/whatever.snapshot",
+        }
+    )
+    assert response.status_code == 400
+    assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2412>.

Fixes incorrect `file://` URI handling in snapshot recovery logic. This now returns a proper HTTP 400 error when an invalid location is given.

Non existent path:
```json
curl -v -X PUT --header 'Content-Type: application/json' --data '{"location": "file:///whatever.snapshot"}' http://localhost:6333/collections/whatever/snapshots/recover
{"status":{"error":"Bad request: Snapshot file \"/whatever.snapshot\" does not exist"},"time":0.000361689}

curl -v -X PUT --header 'Content-Type: application/json' --data '{"location": "file://localhost/whatever.snapshot"}' http://localhost:6333/collections/whatever/snapshots/recover
{"status":{"error":"Bad request: Snapshot file \"/whatever.snapshot\" does not exist"},"time":0.000361689}
```

Invalid `file://` host:
```json
curl -v -X PUT --header 'Content-Type: application/json' --data '{"location": "file://blah/whatever.snapshot"}' http://localhost:6333/collections/whatever/snapshots/recover
{"status":{"error":"Bad request: Invalid snapsot URI, file path must be absolute or on localhost"},"time":0.000300289}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
