### PR TITLE
Limit snapshot recovery file URIs to snapshots directory

### DIFF
--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -14,6 +14,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::NotFound { .. } => tonic::Code::NotFound,
         StorageError::ServiceError { .. } => tonic::Code::Internal,
         StorageError::BadRequest { .. } => tonic::Code::InvalidArgument,
+        StorageError::Forbidden { .. } => tonic::Code::PermissionDenied,
         StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
         StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
     };

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -20,6 +20,8 @@ pub enum StorageError {
     },
     #[error("Bad request: {description}")]
     BadRequest { description: String },
+    #[error("Forbidden: {description}")]
+    Forbidden { description: String },
     #[error("Storage locked: {description}")]
     Locked { description: String },
     #[error("Timeout: {description}")]
@@ -36,6 +38,12 @@ impl StorageError {
 
     pub fn bad_request(description: &str) -> StorageError {
         StorageError::BadRequest {
+            description: description.to_string(),
+        }
+    }
+
+    pub fn forbidden(description: &str) -> StorageError {
+        StorageError::Forbidden {
             description: description.to_string(),
         }
     }

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -64,6 +64,21 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
                     "Snapshot file {local_path:?} does not exist"
                 )));
             }
+
+            // Try to canonicalize paths so we can more reliably compare with required prefix
+            let snapshots_dir = snapshots_dir
+                .canonicalize()
+                .unwrap_or_else(|_| snapshots_dir.to_path_buf());
+            let local_path = local_path.canonicalize().unwrap_or(local_path);
+
+            // Prevent using arbitrary files from our file system, enforce the file to be in the
+            // snapshots directory
+            if !local_path.starts_with(snapshots_dir) {
+                return Err(StorageError::bad_request(&format!(
+                    "Snapshot file {local_path:?} must be inside snapshots dir"
+                )));
+            }
+
             Ok(local_path)
         }
         "http" | "https" => {

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -74,7 +74,7 @@ pub async fn download_snapshot(url: Url, snapshots_dir: &Path) -> Result<PathBuf
             // Prevent using arbitrary files from our file system, enforce the file to be in the
             // snapshots directory
             if !local_path.starts_with(snapshots_dir) {
-                return Err(StorageError::bad_request(&format!(
+                return Err(StorageError::forbidden(&format!(
                     "Snapshot file {local_path:?} must be inside snapshots dir"
                 )));
             }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -50,13 +50,13 @@ pub async fn do_recover_from_snapshot(
     collection_name: &str,
     source: SnapshotRecover,
     wait: bool,
+    strict_file: bool,
 ) -> Result<bool, StorageError> {
     let dispatch = dispatcher.clone();
     let collection_name = collection_name.to_string();
-    let recovery =
-        tokio::spawn(
-            async move { _do_recover_from_snapshot(dispatch, &collection_name, source).await },
-        );
+    let recovery = tokio::spawn(async move {
+        _do_recover_from_snapshot(dispatch, &collection_name, source, strict_file).await
+    });
     if wait {
         Ok(recovery.await??)
     } else {
@@ -68,6 +68,7 @@ async fn _do_recover_from_snapshot(
     dispatcher: Dispatcher,
     collection_name: &str,
     source: SnapshotRecover,
+    strict_file: bool,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location, priority } = source;
     let toc = dispatcher.toc();
@@ -85,7 +86,7 @@ async fn _do_recover_from_snapshot(
         snapshot_download_path.display()
     );
 
-    let snapshot_path = download_snapshot(location, &snapshot_download_path).await?;
+    let snapshot_path = download_snapshot(location, &snapshot_download_path, strict_file).await?;
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 

--- a/openapi/tests/openapi_integration/test_snapshot.py
+++ b/openapi/tests/openapi_integration/test_snapshot.py
@@ -262,3 +262,15 @@ def test_snapshot_invalid_file_uri():
     )
     assert response.status_code == 400
     assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
+
+    # Path must be inside snapshots directory
+    response = request_with_validation(
+        api='/collections/{collection_name}/snapshots/recover',
+        method="PUT",
+        path_params={'collection_name': "somethingthatdoesnotexist"},
+        body={
+            "location": "file:///etc/shadow",
+        }
+    )
+    assert response.status_code == 403
+    assert response.json()["status"]["error"] == "Forbidden: Snapshot file \"/etc/shadow\" must be inside snapshots dir"

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -163,6 +163,7 @@ async fn upload_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
+        false,
     )
     .await;
     match response {
@@ -188,6 +189,7 @@ async fn recover_from_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
+        true,
     )
     .await;
     match response {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -18,6 +18,7 @@ pub fn storage_into_actix_error(err: StorageError) -> Error {
         StorageError::NotFound { .. } => error::ErrorNotFound(format!("{err}")),
         StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{err}")),
         StorageError::BadRequest { .. } => error::ErrorBadRequest(format!("{err}")),
+        StorageError::Forbidden { .. } => error::ErrorForbidden(format!("{err}")),
         StorageError::Locked { .. } => error::ErrorForbidden(format!("{err}")),
         StorageError::Timeout { .. } => error::ErrorRequestTimeout(format!("{err}")),
     }
@@ -58,6 +59,7 @@ where
                     HttpResponse::InternalServerError()
                 }
                 StorageError::BadRequest { .. } => HttpResponse::BadRequest(),
+                StorageError::Forbidden { .. } => HttpResponse::Forbidden(),
                 StorageError::Locked { .. } => HttpResponse::Forbidden(),
                 StorageError::Timeout { .. } => HttpResponse::RequestTimeout(),
             };


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/2414>.

Fixes a potential security issue where arbitrary files from the file system could be read as snapshot.

This limits recovering snapshots with the `file://` URI to the snapshots directory.

```json
curl -v -X PUT --header 'Content-Type: application/json' --data '{"location": "file:///etc/shadow"}' http://localhost:6333/collections/whatever/snapshots/recover
{"status":{"error":"Forbidden: Snapshot file \"/etc/shadow\" must be inside snapshots dir"},"time":0.00030464}
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?