### PR TITLE
Share keyword strings between points

### DIFF
--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -123,7 +123,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
             self.point_to_values.resize(idx as usize + 1, Vec::new())
         }
 
-        self.point_to_values[idx as usize].reserve(values.len());
+        self.point_to_values[idx as usize] = Vec::with_capacity(values.len());
         for value in values {
             let entry = self.map.entry(value.into());
             self.point_to_values[idx as usize].push(entry.key().clone());

--- a/lib/segment/src/index/field_index/map_index.rs
+++ b/lib/segment/src/index/field_index/map_index.rs
@@ -74,8 +74,10 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
                 self.indexed_points += 1;
             }
             self.values_count += 1;
-            self.point_to_values[idx as usize].push(value.clone());
-            self.map.entry(value).or_default().insert(idx);
+
+            let entry = self.map.entry(value);
+            self.point_to_values[idx as usize].push(entry.key().clone());
+            entry.or_default().insert(idx);
         }
         Ok(true)
     }
@@ -120,12 +122,13 @@ impl<N: Hash + Eq + Clone + Display + FromStr> MapIndex<N> {
         if self.point_to_values.len() <= idx as usize {
             self.point_to_values.resize(idx as usize + 1, Vec::new())
         }
-        self.point_to_values[idx as usize] = values.into_iter().map(|v| v.into()).collect();
-        for value in &self.point_to_values[idx as usize] {
-            let entry = self.map.entry(value.clone()).or_default();
-            entry.insert(idx);
 
-            let db_record = Self::encode_db_record(value, idx);
+        self.point_to_values[idx as usize].reserve(values.len());
+        for value in values {
+            let entry = self.map.entry(value.into());
+            self.point_to_values[idx as usize].push(entry.key().clone());
+            let db_record = Self::encode_db_record(entry.key(), idx);
+            entry.or_default().insert(idx);
             self.db_wrapper.put(db_record, [])?;
         }
         self.indexed_points += 1;


### PR DESCRIPTION
Shared keyword strings was introduced in https://github.com/qdrant/qdrant/pull/2388.
Shared keywords are used to avoid string duplication in bitmap. But thanks to @generall advice, we can use this mechanism also for avoiding string duplications between different points. In this PR we are reusing equal strings and allocating memory actually for unique strings for the whole map index.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
