### PR TITLE
Add shard queue proxy

### DIFF
--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -6,6 +6,7 @@ pub mod forward_proxy_shard;
 pub mod local_shard;
 pub mod local_shard_operations;
 pub mod proxy_shard;
+pub mod queue_proxy_shard;
 pub mod remote_shard;
 #[allow(dead_code)]
 pub mod replica_set;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -1,0 +1,220 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use segment::types::{
+    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
+};
+use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+
+use super::remote_shard::RemoteShard;
+use crate::operations::types::{
+    CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
+    SearchRequestBatch, UpdateResult,
+};
+use crate::operations::CollectionUpdateOperations;
+use crate::shards::local_shard::LocalShard;
+use crate::shards::shard_trait::ShardOperation;
+use crate::shards::telemetry::LocalShardTelemetry;
+
+/// ForwardQueue shard
+///
+/// ForwardQueue is a wrapper type for a LocalShard.
+///
+/// It can be used to provide all read and write operations while the wrapped shard is being
+/// snapshotted and transferred to another node. It keeps track of all collection updates since its
+/// creation, and allows to transfer these updates to a remote shard at a given time to assure
+/// consistency.
+///
+/// This keeps track of all updates through the WAL of the wrapped shard. It therefore doesn't have
+/// any memory overhead while updates are accumulated. This type is called 'queue' even though it
+/// doesn't use a real queue, just so it is easy to understand its purpose.
+pub struct QueueProxyShard {
+    pub(crate) wrapped_shard: LocalShard,
+    /// ID of the last WAL operation we consider transferred.
+    last_update_idx: AtomicU64,
+    /// Lock required to protect transfer-in-progress updates.
+    /// It should block data updating operations while the batch is being transferred.
+    update_lock: Mutex<()>,
+}
+
+/// Number of operations in batch when syncing
+const BATCH_SIZE: usize = 100;
+
+/// Number of times to retry transferring updates batch
+const BATCH_RETRIES: usize = 3;
+
+// TODO: block truncating WAL!
+impl QueueProxyShard {
+    pub fn new(wrapped_shard: LocalShard) -> Self {
+        // Remember the last update ID from WAL
+        let last_idx = wrapped_shard.wal.lock().last_index();
+
+        Self {
+            wrapped_shard,
+            last_update_idx: last_idx.into(),
+            update_lock: Default::default(),
+        }
+    }
+
+    /// Forward `create_snapshot` to `wrapped_shard`
+    pub async fn create_snapshot(
+        &self,
+        temp_path: &Path,
+        target_path: &Path,
+        save_wal: bool,
+    ) -> CollectionResult<()> {
+        self.wrapped_shard
+            .create_snapshot(temp_path, target_path, save_wal)
+            .await
+    }
+
+    /// Transfer all updates that the remote missed from WAL
+    pub async fn transfer_all_missed_updates(
+        &self,
+        remote_shard: &RemoteShard,
+    ) -> CollectionResult<()> {
+        while !self.transfer_wal_batch(remote_shard).await? {}
+        Ok(())
+    }
+
+    /// Grab and transfer single new batch of updates from the WAL
+    ///
+    /// Returns `true` if this was the last batch and we're now done. `false` if more batches must
+    /// be sent.
+    async fn transfer_wal_batch(&self, remote_shard: &RemoteShard) -> CollectionResult<bool> {
+        let shard = &self.wrapped_shard;
+        let wal = &shard.wal;
+
+        let mut update_lock = Some(self.update_lock.lock().await);
+
+        let start_index = self.last_update_idx.load(Ordering::Relaxed);
+
+        // Lock wall, count pending items to transfer, grab batch
+        let (pending_count, batch) = {
+            let wal = wal.lock();
+            let items_left = wal.last_index().saturating_sub(start_index);
+            let batch = wal.read(start_index).take(BATCH_SIZE).collect::<Vec<_>>();
+            (items_left, batch)
+        };
+
+        // Normally, we immediately release the update lock to allow new updates.
+        // On the last batch we keep the lock to prevent accumalating more updates on the WAL,
+        // so we can finalize the transfer after this batch, before accepting new updates.
+        let last_batch = pending_count <= BATCH_SIZE as u64 || batch.is_empty();
+        if !last_batch {
+            drop(update_lock.take());
+        }
+
+        // Transfer batch with retries and store last transferred ID
+        let last_idx = batch.last().map(|(idx, _)| *idx);
+        for attempts in (0..BATCH_RETRIES).rev() {
+            match Self::transfer_operations_batch(&batch, remote_shard).await {
+                Ok(()) => break,
+                Err(_) if attempts > 0 => continue,
+                Err(err) => return Err(err),
+            }
+        }
+        if let Some(idx) = last_idx {
+            self.last_update_idx.store(idx, Ordering::Relaxed);
+        }
+
+        Ok(last_batch)
+    }
+
+    /// Transfer batch of operations without retries
+    async fn transfer_operations_batch(
+        batch: &[(u64, CollectionUpdateOperations)],
+        remote_shard: &RemoteShard,
+    ) -> CollectionResult<()> {
+        // TODO: naive transfer approach, transfer batch of points instead
+        for (_idx, operation) in batch {
+            remote_shard.update(operation.clone(), true).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
+        self.wrapped_shard.on_optimizer_config_update().await
+    }
+
+    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+        self.wrapped_shard.get_telemetry_data()
+    }
+}
+
+#[async_trait]
+impl ShardOperation for QueueProxyShard {
+    /// Update `wrapped_shard` while keeping track of operations
+    async fn update(
+        &self,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+    ) -> CollectionResult<UpdateResult> {
+        let _update_lock = self.update_lock.lock().await;
+        let local_shard = &self.wrapped_shard;
+        // Shard update is within a write lock scope, because we need a way to block the shard updates
+        // during the transfer restart and finalization.
+        local_shard.update(operation.clone(), wait).await
+    }
+
+    /// Forward read-only `scroll_by` to `wrapped_shard`
+    async fn scroll_by(
+        &self,
+        offset: Option<ExtendedPointId>,
+        limit: usize,
+        with_payload_interface: &WithPayloadInterface,
+        with_vector: &WithVector,
+        filter: Option<&Filter>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<Record>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .scroll_by(
+                offset,
+                limit,
+                with_payload_interface,
+                with_vector,
+                filter,
+                search_runtime_handle,
+            )
+            .await
+    }
+
+    /// Forward read-only `info` to `wrapped_shard`
+    async fn info(&self) -> CollectionResult<CollectionInfo> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.info().await
+    }
+
+    /// Forward read-only `search` to `wrapped_shard`
+    async fn search(
+        &self,
+        request: Arc<SearchRequestBatch>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.search(request, search_runtime_handle).await
+    }
+
+    /// Forward read-only `count` to `wrapped_shard`
+    async fn count(&self, request: Arc<CountRequest>) -> CollectionResult<CountResult> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.count(request).await
+    }
+
+    /// Forward read-only `retrieve` to `wrapped_shard`
+    async fn retrieve(
+        &self,
+        request: Arc<PointRequest>,
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+    ) -> CollectionResult<Vec<Record>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard
+            .retrieve(request, with_payload, with_vector)
+            .await
+    }
+}

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -10,6 +10,7 @@ use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
 use super::remote_shard::RemoteShard;
+use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
     SearchRequestBatch, UpdateResult,
@@ -129,7 +130,9 @@ impl QueueProxyShard {
     ) -> CollectionResult<()> {
         // TODO: naive transfer approach, transfer batch of points instead
         for (_idx, operation) in batch {
-            remote_shard.update(operation.clone(), true).await?;
+            remote_shard
+                .forward_update(operation.clone(), true, WriteOrdering::Weak)
+                .await?;
         }
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -23,6 +23,7 @@ use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
 
 use super::local_shard::LocalShard;
+use super::queue_proxy_shard::QueueProxyShard;
 use super::remote_shard::RemoteShard;
 use super::resolve::{Resolve, ResolveCondition};
 use super::{create_shard_dir, CollectionId};
@@ -39,7 +40,7 @@ use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::dummy_shard::DummyShard;
 use crate::shards::forward_proxy_shard::ForwardProxyShard;
-use crate::shards::shard::Shard::{Dummy, ForwardProxy, Local};
+use crate::shards::shard::Shard::{Dummy, ForwardProxy, Local, QueueProxy};
 use crate::shards::shard::{PeerId, Shard, ShardId};
 use crate::shards::shard_config::ShardConfig;
 use crate::shards::shard_trait::ShardOperation;
@@ -1062,9 +1063,9 @@ impl ShardReplicaSet {
         let mut local_write = self.local.write().await;
 
         match &*local_write {
-            Some(Local(_)) => {
-                // Do nothing, we proceed further
-            }
+            // Expected state, continue
+            Some(Local(_)) => {}
+            // Unexpected states, error
             Some(ForwardProxy(proxy)) => {
                 return if proxy.remote_shard.peer_id == remote_shard.peer_id {
                     Ok(())
@@ -1073,13 +1074,19 @@ impl ShardReplicaSet {
                         "Cannot proxify local shard {} to peer {} because it is already proxified to peer {}",
                         self.shard_id, remote_shard.peer_id, proxy.remote_shard.peer_id
                     )))
-                }
+                };
+            }
+            Some(QueueProxy(_)) => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot proxify local shard {} to peer {} because it is already queue proxified",
+                    self.shard_id, remote_shard.peer_id,
+                )));
             }
             Some(shard) => {
                 return Err(CollectionError::service_error(format!(
                     "Cannot proxify local shard {} - {} to peer {} because it is already proxified to another peer",
                     shard.variant_name(), self.shard_id, remote_shard.peer_id
-                )))
+                )));
             }
             None => {
                 return Err(CollectionError::service_error(format!(
@@ -1105,16 +1112,16 @@ impl ShardReplicaSet {
         let mut local_write = self.local.write().await;
 
         match &*local_write {
-            Some(ForwardProxy(_)) => {
-                // Do nothing, we proceed further
-            }
+            // Expected states, continue
+            Some(ForwardProxy(_)) => {}
             Some(Local(_)) => return Ok(()),
+            // Unexpected states, error
             Some(shard) => {
                 return Err(CollectionError::service_error(format!(
                     "Cannot un-proxify local shard {} because it has unexpected type - {}",
                     self.shard_id,
                     shard.variant_name(),
-                )))
+                )));
             }
             None => {
                 return Err(CollectionError::service_error(format!(
@@ -1126,6 +1133,93 @@ impl ShardReplicaSet {
         };
 
         if let Some(ForwardProxy(proxy)) = local_write.take() {
+            let local_shard = proxy.wrapped_shard;
+            let _ = local_write.insert(Local(local_shard));
+        }
+
+        Ok(())
+    }
+
+    // TODO: remove remote_shard here?
+    pub async fn queue_proxify_local(&self, remote_shard: RemoteShard) -> CollectionResult<()> {
+        let mut local_write = self.local.write().await;
+
+        match &*local_write {
+            // Expected state, continue
+            Some(Local(_)) => {}
+            // Unexpected states, error
+            Some(QueueProxy(_)) => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot queue proxify local shard {} to peer {} because it is already queue proxified",
+                    self.shard_id, remote_shard.peer_id,
+                )));
+            }
+            Some(ForwardProxy(proxy)) => {
+                return if proxy.remote_shard.peer_id == remote_shard.peer_id {
+                    Ok(())
+                } else {
+                    Err(CollectionError::service_error(format!(
+                        "Cannot queue proxify local shard {} to peer {} because it is already proxified to peer {}",
+                        self.shard_id, remote_shard.peer_id, proxy.remote_shard.peer_id
+                    )))
+                };
+            }
+            Some(shard) => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot queue proxify local shard {} - {} to peer {} because it is already proxified to another peer",
+                    shard.variant_name(), self.shard_id, remote_shard.peer_id
+                )));
+            }
+            None => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot queue proxify local shard {} on peer {} because it is not active",
+                    self.shard_id,
+                    self.this_peer_id()
+                )));
+            }
+        };
+
+        if let Some(Local(local)) = local_write.take() {
+            let proxy_shard = QueueProxyShard::new(local);
+            let _ = local_write.insert(QueueProxy(proxy_shard));
+        }
+
+        Ok(())
+    }
+
+    /// Un-proxify local shard.
+    ///
+    /// Returns true if the replica was un-proxified, false if it was already handled
+    pub async fn queue_un_proxify_local(&self, remote_shard: &RemoteShard) -> CollectionResult<()> {
+        let mut local_write = self.local.write().await;
+
+        match &*local_write {
+            // Expected states, continue
+            Some(QueueProxy(_)) => {}
+            Some(Local(_)) => return Ok(()),
+            // Unexpected states, error
+            Some(shard) => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot un-proxify local shard {} because it has unexpected type - {}",
+                    self.shard_id,
+                    shard.variant_name(),
+                )));
+            }
+            None => {
+                return Err(CollectionError::service_error(format!(
+                    "Cannot un-proxify local shard {} on peer {} because it is not active",
+                    self.shard_id,
+                    self.this_peer_id()
+                )));
+            }
+        };
+
+        if let Some(QueueProxy(proxy)) = local_write.take() {
+            // Transfer queue to remote before unproxying
+            proxy.transfer_all_missed_updates(remote_shard).await?;
+
+            // TODO: also switch state of remote here?
+
             let local_shard = proxy.wrapped_shard;
             let _ = local_write.insert(Local(local_shard));
         }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1140,7 +1140,6 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    // TODO: remove remote_shard here?
     pub async fn queue_proxify_local(&self, remote_shard: RemoteShard) -> CollectionResult<()> {
         let mut local_write = self.local.write().await;
 
@@ -1190,7 +1189,7 @@ impl ShardReplicaSet {
     /// Un-proxify local shard.
     ///
     /// Returns true if the replica was un-proxified, false if it was already handled
-    pub async fn queue_un_proxify_local(&self, remote_shard: &RemoteShard) -> CollectionResult<()> {
+    pub async fn un_queue_proxify_local(&self, remote_shard: &RemoteShard) -> CollectionResult<()> {
         let mut local_write = self.local.write().await;
 
         match &*local_write {

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -1146,6 +1146,7 @@ impl ShardReplicaSet {
         match &*local_write {
             // Expected state, continue
             Some(Local(_)) => {}
+            Some(ForwardProxy(proxy)) if proxy.remote_shard.peer_id == remote_shard.peer_id => {}
             // Unexpected states, error
             Some(QueueProxy(_)) => {
                 return Err(CollectionError::service_error(format!(
@@ -1154,14 +1155,10 @@ impl ShardReplicaSet {
                 )));
             }
             Some(ForwardProxy(proxy)) => {
-                return if proxy.remote_shard.peer_id == remote_shard.peer_id {
-                    Ok(())
-                } else {
-                    Err(CollectionError::service_error(format!(
-                        "Cannot queue proxify local shard {} to peer {} because it is already proxified to peer {}",
-                        self.shard_id, remote_shard.peer_id, proxy.remote_shard.peer_id
-                    )))
-                };
+                return Err(CollectionError::service_error(format!(
+                    "Cannot queue proxify local shard {} to peer {} because it is already proxified to peer {}",
+                    self.shard_id, remote_shard.peer_id, proxy.remote_shard.peer_id
+                )));
             }
             Some(shard) => {
                 return Err(CollectionError::service_error(format!(

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -6,6 +6,7 @@ use crate::shards::dummy_shard::DummyShard;
 use crate::shards::forward_proxy_shard::ForwardProxyShard;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::proxy_shard::ProxyShard;
+use crate::shards::queue_proxy_shard::QueueProxyShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
 
@@ -22,6 +23,7 @@ pub enum Shard {
     Local(LocalShard),
     Proxy(ProxyShard),
     ForwardProxy(ForwardProxyShard),
+    QueueProxy(QueueProxyShard),
     Dummy(DummyShard),
 }
 
@@ -31,6 +33,7 @@ impl Shard {
             Shard::Local(_) => "local shard",
             Shard::Proxy(_) => "proxy shard",
             Shard::ForwardProxy(_) => "forward proxy shard",
+            Shard::QueueProxy(_) => "queue proxy shard",
             Shard::Dummy(_) => "dummy shard",
         }
     }
@@ -40,6 +43,7 @@ impl Shard {
             Shard::Local(local_shard) => local_shard,
             Shard::Proxy(proxy_shard) => proxy_shard,
             Shard::ForwardProxy(proxy_shard) => proxy_shard,
+            Shard::QueueProxy(proxy_shard) => proxy_shard,
             Shard::Dummy(dummy_shard) => dummy_shard,
         }
     }
@@ -49,6 +53,7 @@ impl Shard {
             Shard::Local(local_shard) => local_shard.get_telemetry_data(),
             Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data(),
             Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
+            Shard::QueueProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
             Shard::Dummy(dummy_shard) => dummy_shard.get_telemetry_data(),
         };
         telemetry.variant_name = Some(self.variant_name().to_string());
@@ -77,6 +82,11 @@ impl Shard {
                     .create_snapshot(temp_path, target_path, save_wal)
                     .await
             }
+            Shard::QueueProxy(proxy_shard) => {
+                proxy_shard
+                    .create_snapshot(temp_path, target_path, save_wal)
+                    .await
+            }
             Shard::Dummy(dummy_shard) => {
                 dummy_shard
                     .create_snapshot(temp_path, target_path, save_wal)
@@ -90,6 +100,7 @@ impl Shard {
             Shard::Local(local_shard) => local_shard.on_optimizer_config_update().await,
             Shard::Proxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
             Shard::ForwardProxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
+            Shard::QueueProxy(proxy_shard) => proxy_shard.on_optimizer_config_update().await,
             Shard::Dummy(dummy_shard) => dummy_shard.on_optimizer_config_update().await,
         }
     }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -83,7 +83,7 @@ pub struct UpdateHandler {
     /// Maximum version to acknowledge to WAL to prevent truncating too early
     /// This is used when another part still relies on part of the WAL, such as the queue proxy
     /// shard.
-    max_ack_version: Arc<TokioMutex<Option<u64>>>,
+    pub(super) max_ack_version: Arc<TokioMutex<Option<u64>>>,
     optimization_handles: Arc<TokioMutex<Vec<StoppableTaskHandle<bool>>>>,
     max_optimization_threads: usize,
 }


### PR DESCRIPTION
Tracking issue: https://github.com/qdrant/qdrant/issues/2432

This adds a new shard proxy type, namely `QueueProxyShard`. Rather than forwarding updates correctly like `ForwardProxyShard` all updates are queued. The queued updates can be transferred to a remote when a shard transfer is finished.

It is implemented in a smart way. Rather than adding a queue of operations, the existing WAL is used. A property is added to the update handler to ensure the WAL never truncates the part that is still in use by the queue proxy shard.

The process of transferring queued updates happens in batches. This is lock-free, except for the last batch, to allow for un-queueing without missing updates.

The implementation is somewhat crude, but we can improve on it when other shard transfer bits finalize.

### Tasks
- [ ] Add gRPC call to transfer batch of update operations
- [ ] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
