### PR TITLE
Add method to wait for commit/term on other peers

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -181,6 +181,8 @@
 - [qdrant_internal_service.proto](#qdrant_internal_service-proto)
     - [HttpPortRequest](#qdrant-HttpPortRequest)
     - [HttpPortResponse](#qdrant-HttpPortResponse)
+    - [WaitOnConsensusCommitRequest](#qdrant-WaitOnConsensusCommitRequest)
+    - [WaitOnConsensusCommitResponse](#qdrant-WaitOnConsensusCommitResponse)
   
     - [QdrantInternal](#qdrant-QdrantInternal)
   
@@ -3029,6 +3031,37 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 
 
+
+<a name="qdrant-WaitOnConsensusCommitRequest"></a>
+
+### WaitOnConsensusCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [int64](#int64) |  | Raft commit as u64 |
+| term | [int64](#int64) |  | Raft term as u64 |
+
+
+
+
+
+
+<a name="qdrant-WaitOnConsensusCommitResponse"></a>
+
+### WaitOnConsensusCommitResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ok | [bool](#bool) |  | False if commit/term is diverged and never reached. |
+
+
+
+
+
  
 
  
@@ -3044,6 +3077,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | GetHttpPort | [HttpPortRequest](#qdrant-HttpPortRequest) | [HttpPortResponse](#qdrant-HttpPortResponse) | Get HTTP port for remote host. |
+| WaitOnConsensusCommit | [WaitOnConsensusCommitRequest](#qdrant-WaitOnConsensusCommitRequest) | [WaitOnConsensusCommitResponse](#qdrant-WaitOnConsensusCommitResponse) | Wait until the target node reached the given commit ID. |
 
  
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3042,6 +3042,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | commit | [int64](#int64) |  | Raft commit as u64 |
 | term | [int64](#int64) |  | Raft term as u64 |
+| timeout | [int64](#int64) |  | Timeout in seconds |
 
 
 
@@ -3056,7 +3057,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| ok | [bool](#bool) |  | False if commit/term is diverged and never reached. |
+| ok | [bool](#bool) |  | False if commit/term is diverged and never reached or if timed out. |
 
 
 

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -23,8 +23,9 @@ message HttpPortResponse {
 message WaitOnConsensusCommitRequest {
   int64 commit = 1; // Raft commit as u64
   int64 term = 2; // Raft term as u64
+  int64 timeout = 3; // Timeout in seconds
 }
 
 message WaitOnConsensusCommitResponse {
-  bool ok = 1; // False if commit/term is diverged and never reached.
+  bool ok = 1; // False if commit/term is diverged and never reached or if timed out.
 }

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -7,10 +7,24 @@ service QdrantInternal {
   Get HTTP port for remote host.
    */
   rpc GetHttpPort (HttpPortRequest) returns (HttpPortResponse) {}
+
+  /*
+  Wait until the target node reached the given commit ID.
+   */
+  rpc WaitOnConsensusCommit (WaitOnConsensusCommitRequest) returns (WaitOnConsensusCommitResponse) {}
 }
 
 message HttpPortRequest {}
 
 message HttpPortResponse {
   int32 port = 1;
+}
+
+message WaitOnConsensusCommitRequest {
+  int64 commit = 1; // Raft commit as u64
+  int64 term = 2; // Raft term as u64
+}
+
+message WaitOnConsensusCommitResponse {
+  bool ok = 1; // False if commit/term is diverged and never reached.
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7724,6 +7724,7 @@ pub mod qdrant_internal_client {
                 .insert(GrpcMethod::new("qdrant.QdrantInternal", "GetHttpPort"));
             self.inner.unary(req, path, codec).await
         }
+        ///
         /// Wait until the target node reached the given commit ID.
         pub async fn wait_on_consensus_commit(
             &mut self,
@@ -7770,6 +7771,7 @@ pub mod qdrant_internal_server {
             tonic::Response<super::HttpPortResponse>,
             tonic::Status,
         >;
+        ///
         /// Wait until the target node reached the given commit ID.
         async fn wait_on_consensus_commit(
             &self,
@@ -7922,7 +7924,11 @@ pub mod qdrant_internal_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).wait_on_consensus_commit(request).await
+                                <T as QdrantInternal>::wait_on_consensus_commit(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7600,12 +7600,15 @@ pub struct WaitOnConsensusCommitRequest {
     /// Raft term as u64
     #[prost(int64, tag = "2")]
     pub term: i64,
+    /// Timeout in seconds
+    #[prost(int64, tag = "3")]
+    pub timeout: i64,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WaitOnConsensusCommitResponse {
-    /// False if commit/term is diverged and never reached.
+    /// False if commit/term is diverged and never reached or if timed out.
     #[prost(bool, tag = "1")]
     pub ok: bool,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7590,6 +7590,25 @@ pub struct HttpPortResponse {
     #[prost(int32, tag = "1")]
     pub port: i32,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WaitOnConsensusCommitRequest {
+    /// Raft commit as u64
+    #[prost(int64, tag = "1")]
+    pub commit: i64,
+    /// Raft term as u64
+    #[prost(int64, tag = "2")]
+    pub term: i64,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WaitOnConsensusCommitResponse {
+    /// False if commit/term is diverged and never reached.
+    #[prost(bool, tag = "1")]
+    pub ok: bool,
+}
 /// Generated client implementations.
 pub mod qdrant_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -7702,6 +7721,34 @@ pub mod qdrant_internal_client {
                 .insert(GrpcMethod::new("qdrant.QdrantInternal", "GetHttpPort"));
             self.inner.unary(req, path, codec).await
         }
+        /// Wait until the target node reached the given commit ID.
+        pub async fn wait_on_consensus_commit(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WaitOnConsensusCommitRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::WaitOnConsensusCommitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.QdrantInternal/WaitOnConsensusCommit",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("qdrant.QdrantInternal", "WaitOnConsensusCommit"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -7718,6 +7765,14 @@ pub mod qdrant_internal_server {
             request: tonic::Request<super::HttpPortRequest>,
         ) -> std::result::Result<
             tonic::Response<super::HttpPortResponse>,
+            tonic::Status,
+        >;
+        /// Wait until the target node reached the given commit ID.
+        async fn wait_on_consensus_commit(
+            &self,
+            request: tonic::Request<super::WaitOnConsensusCommitRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::WaitOnConsensusCommitResponse>,
             tonic::Status,
         >;
     }
@@ -7831,6 +7886,52 @@ pub mod qdrant_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetHttpPortSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.QdrantInternal/WaitOnConsensusCommit" => {
+                    #[allow(non_camel_case_types)]
+                    struct WaitOnConsensusCommitSvc<T: QdrantInternal>(pub Arc<T>);
+                    impl<
+                        T: QdrantInternal,
+                    > tonic::server::UnaryService<super::WaitOnConsensusCommitRequest>
+                    for WaitOnConsensusCommitSvc<T> {
+                        type Response = super::WaitOnConsensusCommitResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WaitOnConsensusCommitRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).wait_on_consensus_commit(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = WaitOnConsensusCommitSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -566,9 +566,9 @@ impl CollectionError {
         }
     }
 
-    pub fn service_error(error: String) -> CollectionError {
+    pub fn service_error(error: impl Into<String>) -> CollectionError {
         CollectionError::ServiceError {
-            error,
+            error: error.into(),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -586,6 +586,38 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         }
     }
 
+    /// Wait and block until consensus reaches a `commit` and `term`
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if successful.
+    /// Returns `false` on failure, if we have diverged commit/term for example.
+    pub async fn wait_for_consensus_commit(
+        &self,
+        commit: u64,
+        term: u64,
+        consensus_tick: Duration,
+    ) -> bool {
+        // TODO: naive approach with spinlock for waiting on commit/term, find better way
+        loop {
+            let state = &self.hard_state();
+
+            // Okay if we're on a newer term, or if commit is reached within same term
+            let is_ok = state.term > term || (state.term == term && state.commit >= commit);
+            if is_ok {
+                return true;
+            }
+
+            // Fail if commit is reached but we're on an older term
+            let is_fail = state.term < term && state.commit >= commit;
+            if is_fail {
+                return false;
+            }
+
+            tokio::time::sleep(consensus_tick).await
+        }
+    }
+
     /// Send operation to the consensus thread and listen for the result.
     ///
     /// # Arguments

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -605,14 +605,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         while start.elapsed() < timeout {
             let state = &self.hard_state();
 
-            // Okay if we're on a newer term, or if commit is reached within same term
-            let is_ok = state.term > term || (state.term == term && state.commit >= commit);
+            // Okay if on the same term and have at least the specified commit
+            let is_ok = state.term == term && state.commit >= commit;
             if is_ok {
                 return true;
             }
 
-            // Fail if commit is reached but we're on an older term
-            let is_fail = state.term < term && state.commit >= commit;
+            // Fail if on a different term
+            let is_fail = state.term != term;
             if is_fail {
                 return false;
             }

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1673,11 +1673,15 @@ impl TableOfContent {
 
     /// Wait until the given peer reaches the given commit
     ///
+    /// # Warning
+    ///
+    /// This has no timeout and therefore may run indefinitely.
+    ///
     /// # Errors
     ///
     /// This errors if the given peer has a diverged commit/term and the specified commit can never
     /// be reached. Also errors if the peer cannot be reached.
-    pub async fn await_commit_on_peer(
+    async fn await_commit_on_peer(
         &self,
         peer_id: PeerId,
         commit: u64,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1645,7 +1645,7 @@ impl TableOfContent {
     /// # Errors
     ///
     /// This errors if:
-    /// - any of the peers has a diverged commit/term and the specified commit can never be reached
+    /// - any of the peers is not on the same term
     /// - waiting takes longer than the specified timeout
     /// - any of the peers cannot be reached
     pub async fn await_commit_on_all_peers(
@@ -1678,8 +1678,7 @@ impl TableOfContent {
     ///
     /// # Errors
     ///
-    /// This errors if the given peer has a diverged commit/term and the specified commit can never
-    /// be reached. Also errors if the peer cannot be reached.
+    /// This errors if the given peer is on a different term. Also errors if the peer cannot be reached.
     async fn await_commit_on_peer(
         &self,
         peer_id: PeerId,

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -1668,10 +1668,10 @@ impl TableOfContent {
         // Handle requests with timeout
         tokio::time::timeout(timeout, responses)
             .await
+            .map(|_| ())
             .map_err(|_elapsed| StorageError::Timeout {
                 description: "Failed to wait for consensus commit on all peers, timed out.".into(),
-            })?
-            .map(|_oks| ())
+            })
     }
 
     /// Wait until the given peer reaches the given commit

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -86,10 +86,11 @@ impl QdrantInternal for QdrantInternalService {
         let request = request.into_inner();
         let commit = request.commit as u64;
         let term = request.term as u64;
+        let timeout = Duration::from_secs(request.timeout as u64);
         let consensus_tick = Duration::from_millis(self.settings.cluster.consensus.tick_period_ms);
         let ok = self
             .consensus_state
-            .wait_for_consensus_commit(commit, term, consensus_tick)
+            .wait_for_consensus_commit(commit, term, consensus_tick, timeout)
             .await;
         Ok(Response::new(WaitOnConsensusCommitResponse { ok }))
     }

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -95,7 +95,7 @@ impl QdrantInternal for QdrantInternalService {
 ///
 /// # Returns
 ///
-/// Returns `true` if succesful.
+/// Returns `true` if successful.
 /// Returns `false` on failure, if we have diverged commit/term for example.
 async fn wait_for_consensus_commit(
     consensus_state: &ConsensusStateRef,


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/2406>. Tracking issue: https://github.com/qdrant/qdrant/issues/2432

This adds a method for waiting on all other peers to reach a given commit. It can be used to guarantee a node reached a certain consensus state.

This is implemented in an internal gRPC call to a node, in which you specify what commit/term to wait on.

The current implementation is naive, as a spin lock is used to wait for the specified commit. It can be improved upon in the future. To cancel, you can drop the gRPC request.

All in all, this is how it is used:

```rust
toc.await_commit_on_all_peers(commit, term, Duration::from_secs(10)).await;
```

Once merged, we can eventually integrate this in various parts of the code base where such synchronization is useful.

### Tasks
- [x] Merge https://github.com/qdrant/qdrant/pull/2406
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
