### PR TITLE
Stacktrace API

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         key: clippy
     - name: Install dependencies
-      run: sudo apt-get install clang protobuf-compiler
+      run: sudo apt-get install clang protobuf-compiler libunwind-dev
     - name: Check code formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check cargo clippy warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1733,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3618,6 +3651,7 @@ dependencies = [
  "raft",
  "raft-proto",
  "reqwest",
+ "rstack-self",
  "rustls 0.20.7",
  "rustls-pemfile",
  "rusty-hook",
@@ -3998,6 +4032,33 @@ checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
+name = "rstack"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "unwind",
+]
+
+[[package]]
+name = "rstack-self"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+dependencies = [
+ "antidote",
+ "backtrace",
+ "bincode",
+ "lazy_static",
+ "libc",
+ "rstack",
  "serde",
 ]
 
@@ -5264,6 +5325,27 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "unwind"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+dependencies = [
+ "foreign-types",
+ "libc",
+ "unwind-sys",
+]
+
+[[package]]
+name = "unwind-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ console-subscriber = ["tracing", "dep:console-subscriber"]
 tracy = ["tracing-tracy"]
 tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
+stacktrace = ["rstack-self"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"
@@ -41,7 +42,7 @@ rusty-hook = "^0.11.2"
 
 [dependencies]
 
-parking_lot = { version = "0.12.1", features=["deadlock_detection"], optional = true }
+parking_lot = { version = "0.12.1", features = ["deadlock_detection"], optional = true }
 
 num_cpus = "1.16"
 thiserror = "1.0"
@@ -57,7 +58,7 @@ anyhow = "1.0.74"
 futures = "0.3.28"
 futures-util = "0.3.27"
 clap = { version = "4.3.21", features = ["derive"] }
-serde_cbor = { version = "0.11.2"}
+serde_cbor = { version = "0.11.2" }
 uuid = { version = "1.4", features = ["v4", "serde"] }
 sys-info = "0.9.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "a32f6a38acf7ffd761df83b0790eaefeb107cd60" }
@@ -86,7 +87,7 @@ raft = { version = "0.7.0", features = ["prost-codec"], default-features = false
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
 prost = "0.11.9"
-raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false}
+raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }
@@ -101,6 +102,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 console-subscriber = { version = "0.1", default-features = false, features = ["parking_lot"], optional = true }
 tracing-tracy = { version = "0.10.3", features = ["ondemand"], optional = true }
+
+# Backtrace
+rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 use crate::actix::helpers::process_response;
 use crate::common::helpers::LocksOption;
 use crate::common::metrics::MetricsData;
+use crate::common::stacktrace::get_stack_trace;
 use crate::common::telemetry::TelemetryCollector;
 
 #[derive(Deserialize, Serialize, JsonSchema)]
@@ -87,10 +88,18 @@ async fn get_locks(toc: web::Data<TableOfContent>) -> impl Responder {
     process_response(Ok(result), timing)
 }
 
+#[get("/stacktrace")]
+async fn get_stacktrace() -> impl Responder {
+    let timing = Instant::now();
+    let result = get_stack_trace();
+    process_response(Ok(result), timing)
+}
+
 // Configure services
 pub fn config_service_api(cfg: &mut web::ServiceConfig) {
     cfg.service(telemetry)
         .service(metrics)
         .service(put_locks)
-        .service(get_locks);
+        .service(get_locks)
+        .service(get_stacktrace);
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,3 +12,5 @@ pub mod telemetry;
 pub mod telemetry_ops;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod telemetry_reporting;
+#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
+pub mod stacktrace;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,9 +8,9 @@ pub mod metrics;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod points;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
+pub mod stacktrace;
+#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod telemetry;
 pub mod telemetry_ops;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod telemetry_reporting;
-#[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
-pub mod stacktrace;

--- a/src/common/stacktrace.rs
+++ b/src/common/stacktrace.rs
@@ -50,7 +50,8 @@ pub fn get_stack_trace() -> StackTrace {
     #[cfg(feature = "stacktrace")]
     {
         let exe = std::env::current_exe().unwrap();
-        let trace = rstack_self::trace(std::process::Command::new(exe).arg("--stacktrace")).unwrap();
+        let trace =
+            rstack_self::trace(std::process::Command::new(exe).arg("--stacktrace")).unwrap();
         StackTrace {
             threads: trace
                 .threads()

--- a/src/common/stacktrace.rs
+++ b/src/common/stacktrace.rs
@@ -1,0 +1,85 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug)]
+struct StackTraceSymbol {
+    name: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug)]
+struct StackTraceFrame {
+    symbols: Vec<StackTraceSymbol>,
+}
+
+impl StackTraceFrame {
+    pub fn render(&self) -> String {
+        let mut result = String::new();
+        for symbol in &self.symbols {
+            let symbol_string = format!(
+                "{}:{} - {} ",
+                symbol.file.as_deref().unwrap_or_default(),
+                symbol.line.unwrap_or_default(),
+                symbol.name.as_deref().unwrap_or_default(),
+            );
+            result.push_str(&symbol_string);
+        }
+        result
+    }
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug)]
+pub struct ThreadStackTrace {
+    id: u32,
+    name: String,
+    frames: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug)]
+pub struct StackTrace {
+    threads: Vec<ThreadStackTrace>,
+}
+
+pub fn get_stack_trace() -> StackTrace {
+    #[cfg(not(feature = "stacktrace"))]
+    {
+        StackTrace { threads: vec![] }
+    }
+
+    #[cfg(feature = "stacktrace")]
+    {
+        let exe = std::env::current_exe().unwrap();
+        let trace = rstack_self::trace(std::process::Command::new(exe).arg("--stacktrace")).unwrap();
+        StackTrace {
+            threads: trace
+                .threads()
+                .iter()
+                .map(|thread| ThreadStackTrace {
+                    id: thread.id(),
+                    name: thread.name().to_string(),
+                    frames: thread
+                        .frames()
+                        .iter()
+                        .map(|frame| {
+                            let frame = StackTraceFrame {
+                                symbols: frame
+                                    .symbols()
+                                    .iter()
+                                    .map(|symbol| StackTraceSymbol {
+                                        name: symbol.name().map(|name| name.to_string()),
+                                        file: symbol.file().map(|file| {
+                                            file.to_str().unwrap_or_default().to_string()
+                                        }),
+                                        line: symbol.line(),
+                                    })
+                                    .collect(),
+                            };
+                            frame.render()
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,12 +104,26 @@ struct Args {
     /// Read more: <https://qdrant.tech/documentation/guides/telemetry>
     #[arg(long, action, default_value_t = false)]
     disable_telemetry: bool,
+
+    /// Run stacktrace collector. Used for debugging.
+    #[arg(long, action, default_value_t = false)]
+    stacktrace: bool,
 }
 
 fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    // Run backtrace collector, expected to used by `rstack` crate
+    if args.stacktrace {
+        #[cfg(feature = "stacktrace")]
+        {
+            let _ = rstack_self::child();
+        }
+        return Ok(());
+    }
+
     remove_started_file_indicator();
 
-    let args = Args::parse();
     let settings = Settings::new(args.config_path)?;
 
     let reporting_enabled = !settings.telemetry_disabled && !args.disable_telemetry;


### PR DESCRIPTION
This PR introduces a debug API, which returns stacktrace of all threads in Qdrant - `/stacktrace`.

This API have some limitations:

- it works only on Linux
- requires dynamically linked lib to work (libunwind8)
- the size of the stack is limited and I didn't find a way to configure it

Cause of those limitations, this API:

- disabled in OpenAPI on-purpose
- feature-flagged (but enabled in Docker by default)


Hopefully will be useful for further bug-hunting


