### PR TITLE
add pre-commit hook for python formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
 1. [ ] Does your submission pass tests?
 2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
 3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?
+3. [ ] Have you checked your code using `pre-commit` command?
 
 ### Changes to Core Features:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+#default_language_version:
+#   python: python3.8
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        name: "Black: The uncompromising Python code formatter"
+        args: ["--line-length", "99"]
+        files: '\.py$'
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: "Sort Imports"
+        args: ["--profile", "black"]
+        files: '\.py$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ The project uses [rustfmt](https://github.com/rust-lang/rustfmt) formatter. Plea
 ```cargo +nightly fmt --all``` command. The project also use [clippy](https://github.com/rust-lang/rust-clippy) lint collection,
 so please ensure running ``cargo clippy --all --all-features`` before submitting the PR.
 
+This project uses git hooks to run python code formatters.
+Install `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`.
+> pre-commit requires python>=3.8
+
 ## License
 By contributing, you agree that your contributions will be licensed under its Apache License 2.0.
-


### PR DESCRIPTION
Tracking issue: https://github.com/qdrant/qdrant/issues/2451
Add pre-commit hook for Python formatting. Modify CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md to reflect this change.
This change doesn't involve formatting current files and modifying Git Action. Which is planning to address in a separate PR.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
