### PR TITLE
Report optimizer status and history in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7532,6 +7532,7 @@
       "OptimizerTelemetry": {
         "type": "object",
         "required": [
+          "log",
           "optimizations",
           "status"
         ],
@@ -7541,8 +7542,89 @@
           },
           "optimizations": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
+          },
+          "log": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackerTelemetry"
+            }
           }
         }
+      },
+      "TrackerTelemetry": {
+        "description": "Tracker object used in telemetry",
+        "type": "object",
+        "required": [
+          "name",
+          "segment_ids",
+          "start_at",
+          "status"
+        ],
+        "properties": {
+          "name": {
+            "description": "Name of the optimizer",
+            "type": "string"
+          },
+          "segment_ids": {
+            "description": "Segment IDs being optimized",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "status": {
+            "$ref": "#/components/schemas/TrackerStatus"
+          },
+          "start_at": {
+            "description": "Start time of the optimizer",
+            "type": "string",
+            "format": "date-time"
+          },
+          "end_at": {
+            "description": "End time of the optimizer",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "TrackerStatus": {
+        "description": "Represents the current state of the optimizer being tracked",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "optimizing",
+              "done"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "cancelled"
+            ],
+            "properties": {
+              "cancelled": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "RemoteShardTelemetry": {
         "type": "object",

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -191,6 +191,10 @@ impl ConfigMismatchOptimizer {
 }
 
 impl SegmentOptimizer for ConfigMismatchOptimizer {
+    fn name(&self) -> &str {
+        "config mismatch optimizer"
+    }
+
     fn collection_path(&self) -> &Path {
         self.segments_path.as_path()
     }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -192,7 +192,7 @@ impl ConfigMismatchOptimizer {
 
 impl SegmentOptimizer for ConfigMismatchOptimizer {
     fn name(&self) -> &str {
-        "config mismatch optimizer"
+        "config mismatch"
     }
 
     fn collection_path(&self) -> &Path {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -191,6 +191,10 @@ impl IndexingOptimizer {
 }
 
 impl SegmentOptimizer for IndexingOptimizer {
+    fn name(&self) -> &str {
+        "indexing optimizer"
+    }
+
     fn collection_path(&self) -> &Path {
         self.segments_path.as_path()
     }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -192,7 +192,7 @@ impl IndexingOptimizer {
 
 impl SegmentOptimizer for IndexingOptimizer {
     fn name(&self) -> &str {
-        "indexing optimizer"
+        "indexing"
     }
 
     fn collection_path(&self) -> &Path {

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -59,6 +59,10 @@ impl MergeOptimizer {
 }
 
 impl SegmentOptimizer for MergeOptimizer {
+    fn name(&self) -> &str {
+        "merge optimizer"
+    }
+
     fn collection_path(&self) -> &Path {
         self.segments_path.as_path()
     }

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -60,7 +60,7 @@ impl MergeOptimizer {
 
 impl SegmentOptimizer for MergeOptimizer {
     fn name(&self) -> &str {
-        "merge optimizer"
+        "merge"
     }
 
     fn collection_path(&self) -> &Path {

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -32,7 +32,7 @@ impl TrackerLog {
         self.truncate();
     }
 
-    /// Truncate and forget old trackers for succesful/cancelled optimizations
+    /// Truncate and forget old trackers for successful/cancelled optimizations
     ///
     /// Will never remove older trackers with failed or still ongoing optimizations.
     ///

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -1,5 +1,107 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+
+use super::holders::segment_holder::SegmentId;
+
 pub mod config_mismatch_optimizer;
 pub mod indexing_optimizer;
 pub mod merge_optimizer;
 pub mod segment_optimizer;
 pub mod vacuum_optimizer;
+
+/// A log of optimizer trackers holding their status
+#[derive(Default, Clone, Debug)]
+pub struct TrackerLog {
+    descriptions: VecDeque<Tracker>,
+}
+
+impl TrackerLog {
+    /// Register a new optimizer tracker
+    pub fn register(&mut self, description: Tracker) {
+        self.descriptions.push_back(description);
+    }
+}
+
+/// Tracks the state of an optimizer
+#[derive(Clone, Debug)]
+pub struct Tracker {
+    /// Name of the optimizer
+    pub name: String,
+    /// Segment IDs being optimized
+    pub segment_ids: Vec<SegmentId>,
+    /// Start time of the optimizer
+    pub start_at: DateTime<Utc>,
+    /// Latest state of the optimizer
+    pub state: Arc<Mutex<TrackerState>>,
+}
+
+impl Tracker {
+    /// Start a new optimizer tracker
+    pub fn start(name: impl Into<String>, segment_ids: Vec<SegmentId>) -> Self {
+        Self {
+            name: name.into(),
+            segment_ids,
+            state: Default::default(),
+            start_at: Utc::now(),
+        }
+    }
+
+    /// Get handle to this tracker, allows updating state
+    pub fn handle(&self) -> TrackerHandle {
+        self.state.clone().into()
+    }
+}
+
+/// Handle to an optimizer tracker, allows updating its state
+#[derive(Clone)]
+pub struct TrackerHandle {
+    handle: Arc<Mutex<TrackerState>>,
+}
+
+impl TrackerHandle {
+    pub fn update(&self, status: TrackerStatus) {
+        self.handle.lock().update(status);
+    }
+}
+
+impl From<Arc<Mutex<TrackerState>>> for TrackerHandle {
+    fn from(state: Arc<Mutex<TrackerState>>) -> Self {
+        Self { handle: state }
+    }
+}
+
+/// Mutable state of an optimizer tracker
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TrackerState {
+    pub status: TrackerStatus,
+    pub end_at: Option<DateTime<Utc>>,
+}
+
+impl TrackerState {
+    /// Update the tracker state to the given `status`
+    pub fn update(&mut self, status: TrackerStatus) {
+        match status {
+            TrackerStatus::Done | TrackerStatus::Cancelled(_) | TrackerStatus::Error(_) => {
+                self.end_at.replace(Utc::now());
+            }
+            TrackerStatus::Optimizing => {
+                self.end_at.take();
+            }
+        }
+        self.status = status;
+    }
+}
+
+/// Represents the current state of the optimizer being tracked
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, Default, Eq, PartialEq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum TrackerStatus {
+    #[default]
+    Optimizing,
+    Done,
+    Cancelled(String),
+    Error(String),
+}

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -44,6 +44,9 @@ pub struct OptimizerThresholds {
 /// The selection of the candidates for optimization and the configuration
 /// of resulting segment are up to concrete implementations.
 pub trait SegmentOptimizer {
+    /// Get name describing this optimizer
+    fn name(&self) -> &str;
+
     /// Get path of the whole collection
     fn collection_path(&self) -> &Path;
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -165,6 +165,10 @@ impl VacuumOptimizer {
 }
 
 impl SegmentOptimizer for VacuumOptimizer {
+    fn name(&self) -> &str {
+        "vacuum optimizer"
+    }
+
     fn collection_path(&self) -> &Path {
         self.segments_path.as_path()
     }

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -166,7 +166,7 @@ impl VacuumOptimizer {
 
 impl SegmentOptimizer for VacuumOptimizer {
     fn name(&self) -> &str {
-        "vacuum optimizer"
+        "vacuum"
     }
 
     fn collection_path(&self) -> &Path {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -28,6 +28,7 @@ use wal::{Wal, WalOptions};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
+use crate::collection_manager::optimizers::TrackerLog;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
@@ -58,6 +59,7 @@ pub struct LocalShard {
     pub(super) update_sender: ArcSwap<Sender<UpdateSignal>>,
     pub(super) path: PathBuf,
     pub(super) optimizers: Arc<Vec<Arc<Optimizer>>>,
+    pub(super) optimizers_log: Arc<ParkingMutex<TrackerLog>>,
     update_runtime: Handle,
 }
 
@@ -110,10 +112,12 @@ impl LocalShard {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = collection_config.read().await;
         let locked_wal = Arc::new(ParkingMutex::new(wal));
+        let optimizers_log = Arc::new(ParkingMutex::new(Default::default()));
 
         let mut update_handler = UpdateHandler::new(
             shared_storage_config.clone(),
             optimizers.clone(),
+            optimizers_log.clone(),
             update_runtime.clone(),
             segment_holder.clone(),
             locked_wal.clone(),
@@ -137,6 +141,7 @@ impl LocalShard {
             path: shard_path.to_owned(),
             update_runtime,
             optimizers,
+            optimizers_log,
         }
     }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -699,6 +699,7 @@ impl LocalShard {
             optimizations: OptimizerTelemetry {
                 status: optimizer_status,
                 optimizations,
+                log: self.optimizers_log.lock().to_telemetry(),
             },
         }
     }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
@@ -38,17 +37,6 @@ pub struct LocalShardTelemetry {
 pub struct OptimizerTelemetry {
     pub status: OptimizersStatus,
     pub optimizations: OperationDurationStatistics,
-}
-
-impl std::ops::Add for OptimizerTelemetry {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self {
-        Self {
-            status: max(self.status, other.status),
-            optimizations: self.optimizations + other.optimizations,
-        }
-    }
 }
 
 impl Anonymize for OptimizerTelemetry {

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -6,6 +6,7 @@ use segment::common::operation_time_statistics::OperationDurationStatistics;
 use segment::telemetry::SegmentTelemetry;
 use serde::{Deserialize, Serialize};
 
+use crate::collection_manager::optimizers::TrackerTelemetry;
 use crate::operations::types::OptimizersStatus;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -37,6 +38,7 @@ pub struct LocalShardTelemetry {
 pub struct OptimizerTelemetry {
     pub status: OptimizersStatus,
     pub optimizations: OperationDurationStatistics,
+    pub log: Vec<TrackerTelemetry>,
 }
 
 impl Anonymize for OptimizerTelemetry {
@@ -44,6 +46,7 @@ impl Anonymize for OptimizerTelemetry {
         Self {
             status: self.status.clone(),
             optimizations: self.optimizations.anonymize(),
+            log: self.log.anonymize(),
         }
     }
 }
@@ -54,6 +57,18 @@ impl Anonymize for LocalShardTelemetry {
             variant_name: self.variant_name.clone(),
             segments: self.segments.anonymize(),
             optimizations: self.optimizations.anonymize(),
+        }
+    }
+}
+
+impl Anonymize for TrackerTelemetry {
+    fn anonymize(&self) -> Self {
+        TrackerTelemetry {
+            name: self.name.clone(),
+            segment_ids: self.segment_ids.anonymize(),
+            status: self.status.clone(),
+            start_at: self.start_at.anonymize(),
+            end_at: self.end_at.anonymize(),
         }
     }
 }

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -46,14 +46,23 @@ async fn test_optimization_process() {
     let optimizers = Arc::new(vec![merge_optimizer, indexing_optimizer]);
 
     let segments: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
-    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
+    let handles = UpdateHandler::launch_optimization(
+        optimizers.clone(),
+        Default::default(),
+        segments.clone(),
+        |_| {},
+    );
 
     assert_eq!(handles.len(), 2);
 
     let join_res = join_all(handles.into_iter().map(|x| x.join_handle).collect_vec()).await;
 
-    let handles_2 =
-        UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
+    let handles_2 = UpdateHandler::launch_optimization(
+        optimizers.clone(),
+        Default::default(),
+        segments.clone(),
+        |_| {},
+    );
 
     assert_eq!(handles_2.len(), 0);
 
@@ -91,7 +100,12 @@ async fn test_cancel_optimization() {
     let now = Instant::now();
 
     let segments: Arc<RwLock<_>> = Arc::new(RwLock::new(holder));
-    let handles = UpdateHandler::launch_optimization(optimizers.clone(), segments.clone(), |_| {});
+    let handles = UpdateHandler::launch_optimization(
+        optimizers.clone(),
+        Default::default(),
+        segments.clone(),
+        |_| {},
+    );
 
     sleep(Duration::from_millis(100)).await;
 

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -63,9 +63,9 @@ async fn test_optimization_process() {
     {
         let log = optimizers_log.lock().to_telemetry();
         assert_eq!(log.len(), 2);
-        assert_eq!(log[0].name, "indexing");
+        assert!(["indexing", "merge"].contains(&log[0].name.as_str()));
         assert_eq!(log[0].status, TrackerStatus::Done);
-        assert_eq!(log[1].name, "merge");
+        assert!(["indexing", "merge"].contains(&log[1].name.as_str()));
         assert_eq!(log[1].status, TrackerStatus::Done);
     }
 

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -63,9 +63,9 @@ async fn test_optimization_process() {
     {
         let log = optimizers_log.lock().to_telemetry();
         assert_eq!(log.len(), 2);
-        assert_eq!(log[0].name, "indexing optimizer");
+        assert_eq!(log[0].name, "indexing");
         assert_eq!(log[0].status, TrackerStatus::Done);
-        assert_eq!(log[1].name, "merge optimizer");
+        assert_eq!(log[1].name, "merge");
         assert_eq!(log[1].status, TrackerStatus::Done);
     }
 
@@ -139,7 +139,7 @@ async fn test_cancel_optimization() {
         let log = optimizers_log.lock().to_telemetry();
         assert_eq!(log.len(), 3);
         for status in log {
-            assert_eq!(status.name, "indexing optimizer");
+            assert_eq!(status.name, "indexing");
             assert!(matches!(status.status, TrackerStatus::Cancelled(_)));
         }
     }


### PR DESCRIPTION
Report the current and historical optimizer status in telemetry. The status for the last 16 optimizations is kept. And statuses for ongoing or errored optimizations are always kept.

It gives us some insight of the optimization behavior in the of a remote instance. It hopefully helps us resolve issues where weird optimization loops are happening.

The implementation is rather simple. These _logs_ are not stored across restarts.

Here's an example snippet, the last optimization is at the top:

```json
{
  "optimizations": {
    "status": "ok",
    "log": [
      {
        "name": "vacuum",
        "segment_ids": [ 14390250694980796000 ],
        "status": "optimizing",
        "start_at": "2023-08-21T11:28:43.405555595Z",
        "end_at": null
      },
      {
        "name": "merge",
        "segment_ids": [ 8162121629578494000, 14793682371326910000, 11018504688338340000 ],
        "status": "done",
        "start_at": "2023-08-21T11:27:42.773611869Z",
        "end_at": "2023-08-21T11:28:15.855012486Z"
      },
      {
        "name": "config mismatch",
        "segment_ids": [ 2232598688197433000 ],
        "status": "done",
        "start_at": "2023-08-21T11:27:05.876051765Z",
        "end_at": "2023-08-21T11:27:42.773299812Z"
      },
      {
        "name": "config mismatch",
        "segment_ids": [ 3187952675436419600 ],
        "status": { "cancelled": "process cancelled by service" },
        "start_at": "2023-08-21T11:27:01.048127327Z",
        "end_at": "2023-08-21T11:27:05.875598739Z"
      },
      {
        "name": "indexing",
        "segment_ids": [ 9424519612371952000, 14127887256942530000 ],
        "status": "done",
        "start_at": "2023-08-21T11:24:53.322379209Z",
        "end_at": "2023-08-21T11:26:10.681480214Z"
      },
      {
        "name": "indexing",
        "segment_ids": [ 10396035176380555000, 12278422092606028000 ],
        "status": "done",
        "start_at": "2023-08-21T11:23:35.214060140Z",
        "end_at": "2023-08-21T11:24:53.322197221Z"
      },
      {
        "name": "indexing",
        "segment_ids": [ 18095898389532342000 ],
        "status": "done",
        "start_at": "2023-08-21T11:22:46.584024331Z",
        "end_at": "2023-08-21T11:23:22.757913864Z"
      }
    ],
    "optimizations": {
      "count": 3,
      "avg_duration_micros": 52398400,
      "min_duration_micros": 36173860,
      "max_duration_micros": 78108110,
      "last_responded": "2023-08-21T11:26:10.680Z"
    }
  }
}
```

We may extend this interface in the future with more details as we desire.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
