### PR TITLE
Fix lints for Clippy 1.72

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -42,6 +42,7 @@ where
     V: Validate,
 {
     #[inline]
+    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
         let errors = self
             .iter()
@@ -59,6 +60,7 @@ where
     V: Validate,
 {
     #[inline]
+    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
         let errors = self
             .values()

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -795,19 +795,13 @@ impl Collection {
             join_all(shard_requests).await
         };
 
-        let with_error = results
-            .iter()
-            .filter(|result| matches!(result, Err(_)))
-            .count();
+        let with_error = results.iter().filter(|result| result.is_err()).count();
 
         // one request per shard
         let result_len = results.len();
 
         if with_error > 0 {
-            let first_err = results
-                .into_iter()
-                .find(|result| matches!(result, Err(_)))
-                .unwrap();
+            let first_err = results.into_iter().find(|result| result.is_err()).unwrap();
             // inconsistent if only a subset of the requests fail - one request per shard.
             if with_error < result_len {
                 first_err.map_err(|err| {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -429,7 +429,7 @@ impl<'s> SegmentHolder {
 
         appendable_segments
             .into_iter()
-            .chain(non_appendable_segments.into_iter())
+            .chain(non_appendable_segments)
     }
 
     /// Flushes all segments and returns maximum version to persist

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -175,7 +175,7 @@ mod tests {
         let mut holder = SegmentHolder::default();
         let dim = 256;
 
-        let _segments_to_merge = vec![
+        let _segments_to_merge = [
             holder.add(random_segment(dir.path(), 100, 40, dim)),
             holder.add(random_segment(dir.path(), 100, 50, dim)),
             holder.add(random_segment(dir.path(), 100, 60, dim)),
@@ -209,14 +209,14 @@ mod tests {
         let mut holder = SegmentHolder::default();
         let dim = 256;
 
-        let segments_to_merge = vec![
+        let segments_to_merge = [
             holder.add(random_segment(dir.path(), 100, 3, dim)),
             holder.add(random_segment(dir.path(), 100, 3, dim)),
             holder.add(random_segment(dir.path(), 100, 3, dim)),
             holder.add(random_segment(dir.path(), 100, 10, dim)),
         ];
 
-        let other_segment_ids: Vec<SegmentId> = vec![
+        let other_segment_ids = [
             holder.add(random_segment(dir.path(), 100, 20, dim)),
             holder.add(random_segment(dir.path(), 100, 20, dim)),
             holder.add(random_segment(dir.path(), 100, 20, dim)),

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -406,7 +406,7 @@ pub(crate) fn process_point_operation(
             let points: Vec<_> = match operation {
                 PointInsertOperations::PointsBatch(batch) => {
                     let all_vectors = batch.vectors.into_all_vectors(batch.ids.len());
-                    let vectors_iter = batch.ids.into_iter().zip(all_vectors.into_iter());
+                    let vectors_iter = batch.ids.into_iter().zip(all_vectors);
                     match batch.payloads {
                         None => vectors_iter
                             .map(|(id, vectors)| PointStruct {
@@ -416,7 +416,7 @@ pub(crate) fn process_point_operation(
                             })
                             .collect(),
                         Some(payloads) => vectors_iter
-                            .zip(payloads.into_iter())
+                            .zip(payloads)
                             .map(|((id, vectors), payload)| PointStruct {
                                 id,
                                 vector: vectors.into(),

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -484,20 +484,20 @@ mod tests {
             vectors: vec![].into(),
             payloads: None,
         });
-        assert!(matches!(batch.validate(), Err(_)));
+        assert!(batch.validate().is_err());
 
         let batch = PointInsertOperations::PointsBatch(Batch {
             ids: vec![PointIdType::NumId(0)],
             vectors: vec![vec![0.1]].into(),
             payloads: None,
         });
-        assert!(matches!(batch.validate(), Ok(())));
+        assert!(batch.validate().is_ok());
 
         let batch = PointInsertOperations::PointsBatch(Batch {
             ids: vec![PointIdType::NumId(0)],
             vectors: vec![vec![0.1]].into(),
             payloads: Some(vec![]),
         });
-        assert!(matches!(batch.validate(), Err(_)));
+        assert!(batch.validate().is_err());
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -961,6 +961,7 @@ impl Anonymize for VectorsConfig {
 }
 
 impl Validate for VectorsConfig {
+    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
             VectorsConfig::Single(single) => single.validate(),
@@ -1035,6 +1036,7 @@ impl VectorsConfigDiff {
 }
 
 impl Validate for VectorsConfigDiff {
+    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
         let errors = self
             .0

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -464,7 +464,7 @@ mod tests {
         assert_eq!(estimation.primary_clauses.len(), 2);
         estimation.primary_clauses.iter().for_each(|x| match x {
             PrimaryCondition::Condition(field) => {
-                assert!(vec!["price".to_owned(), "size".to_owned(),].contains(&field.key))
+                assert!(["price".to_owned(), "size".to_owned()].contains(&field.key))
             }
             _ => panic!("Should not go here"),
         });

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1899,10 +1899,7 @@ mod tests {
         assert_eq!(search_result[0].id, 6.into());
         assert_eq!(search_result[1].id, 4.into());
 
-        assert!(matches!(
-            segment.vector(DEFAULT_VECTOR_NAME, 6.into()),
-            Ok(_)
-        ));
+        assert!(segment.vector(DEFAULT_VECTOR_NAME, 6.into()).is_ok());
 
         let internal_id = segment.lookup_internal_id(6.into()).unwrap();
 

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn test_peek_top_rev() {
         let data = vec![10, 20, 40, 5, 100, 33, 84, 65, 20, 43, 44, 42];
-        let res = peek_top_smallest_iterable(data.into_iter(), 3);
+        let res = peek_top_smallest_iterable(data, 3);
         assert_eq!(res, vec![5, 10, 20]);
     }
 }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -334,7 +334,7 @@ mod tests {
 
         assert_ne!(res[0].idx, 2);
 
-        let res = raw_scorer.peek_top_iter(&mut vec![0, 1, 2, 3, 4].iter().cloned(), 2);
+        let res = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
         assert_eq!(res.len(), 2);
         assert_ne!(res[0].idx, 2);

--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -15,6 +15,7 @@ fn paint(text: &str, true_color: bool) -> ColoredString {
 
 /// Prints welcome message
 #[rustfmt::skip]
+#[allow(clippy::needless_raw_string_hashes)]
 pub fn welcome(settings: &Settings) {
     if !atty::is(Stream::Stdout) {
         colored::control::set_override(false);


### PR DESCRIPTION
Rust 1.72 is around the [corner](https://www.whatrustisit.com/) so let's make sure the CI pipelines can handle it.

New Clippy lints have been [added](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-172) and a few are being triggered.

This PR fixes the lints in order to prepare for the upcoming Rust release.  