### PR TITLE
Weekly dependabot update for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,18 @@ updates:
     target-branch: "dev"
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels: [dependencies]
   - package-ecosystem: "github-actions"
     target-branch: "dev"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
   - package-ecosystem: docker
     target-branch: "dev"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
The daily update of Rust dependencies is creating a bit too much churn for my taste.

I propose to set it up to once a week in order to decrease the noise during the week and possibly batch several updates together (clap, serde, anyhow etc...)

This might have to be pushed to master to take effect.