### PR TITLE
Add gRPC reflection server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tonic",
+ "tonic-reflection",
  "tower",
  "tower-layer",
  "tracing",
@@ -5131,6 +5132,19 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0543d7092032041fbeac1f2c84304537553421a11a623c2301b12ef0264862c7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ actix-web = { version = "4.3.1", optional = true, features = ["rustls", "actix-t
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }
+tonic-reflection = "0.9.2"
 tower = "0.4.13"
 tower-layer = "0.3.2"
 num-traits = "0.2.16"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -1,6 +1,11 @@
+use std::env;
+use std::path::PathBuf;
+
 use tonic_build::Builder;
 
 fn main() -> std::io::Result<()> {
+    let build_out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
     // Build gRPC bits from proto file
     tonic_build::configure()
         // Because we want to attach all validation rules to the generated gRPC types, we must do
@@ -8,6 +13,7 @@ fn main() -> std::io::Result<()> {
         // `Validation` for all these types and seems to be the best approach. The line below
         // configures all attributes.
         .configure_validation()
+        .file_descriptor_set_path(build_out_dir.join("qdrant_descriptor.bin"))
         .out_dir("src/grpc/") // saves generated structures at this location
         .compile(
             &["src/grpc/proto/qdrant.proto"], // proto entry point

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -11,3 +11,5 @@ pub mod validate;
 pub const fn api_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
+
+pub const QDRANT_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("qdrant_descriptor");

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -27,7 +27,6 @@ use tokio::signal;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::{Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
-use tonic_reflection;
 
 use crate::common::helpers;
 use crate::common::telemetry_ops::requests_telemetry::TonicTelemetryCollector;

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -108,8 +108,15 @@ pub fn init(
         let collections_service = CollectionsService::new(dispatcher.clone());
         let points_service = PointsService::new(dispatcher.toc().clone());
         let snapshot_service = SnapshotsService::new(dispatcher.clone());
+
+        // Only advertise the public services. By default, all services in QDRANT_DESCRIPTOR_SET
+        // will be advertised, so explicitly list the services to be included.
         let reflection_service = tonic_reflection::server::Builder::configure()
             .register_encoded_file_descriptor_set(QDRANT_DESCRIPTOR_SET)
+            .with_service_name("qdrant.Collections")
+            .with_service_name("qdrant.Points")
+            .with_service_name("qdrant.Snapshots")
+            .with_service_name("qdrant.Qdrant")
             .build()
             .unwrap();
 

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -168,10 +168,13 @@ $docker_grpcurl -d '{
 # use the reflection service to inspect the full API
 $docker_grpcurl $QDRANT_HOST describe
 
-# use the reflection service to list RPCs in the Collections service
+# use the reflection service to inspect each advertised service
 $docker_grpcurl $QDRANT_HOST describe qdrant.Collections
+$docker_grpcurl $QDRANT_HOST describe qdrant.Points
+$docker_grpcurl $QDRANT_HOST describe qdrant.Snapshots
+$docker_grpcurl $QDRANT_HOST describe qdrant.Qdrant
 
-# use the reflection service to get the shape of the UpsertPoints message
+# use the reflection service to get the shape of a specific message
 $docker_grpcurl $QDRANT_HOST describe qdrant.UpsertPoints
 
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -165,6 +165,15 @@ $docker_grpcurl -d '{
   "ids": [{ "num": 1 }]
 }' $QDRANT_HOST qdrant.Points/Get
 
+# use the reflection service to inspect the full API
+$docker_grpcurl $QDRANT_HOST describe
+
+# use the reflection service to list RPCs in the Collections service
+$docker_grpcurl $QDRANT_HOST describe qdrant.Collections
+
+# use the reflection service to get the shape of the UpsertPoints message
+$docker_grpcurl $QDRANT_HOST describe qdrant.UpsertPoints
+
 #SAVED_VECTORS_COUNT=$(curl --fail -s "http://$QDRANT_HOST/collections/test_collection" | jq '.result.vectors_count')
 #[[ "$SAVED_VECTORS_COUNT" == "6" ]] || {
 #  echo 'check failed'


### PR DESCRIPTION
This registers a gRPC reflection service so that external tools (e.g. `grpcurl`, Postman, Insomnia) can inspect the API and provide nice tooling around listing, validating, and generating sample requests.

<details>
<summary> Example grpcurl output </summary>

```
❯ grpcurl --plaintext 127.0.0.1:6334 describe
qdrant.Collections is a service:
service Collections {
  //Get cluster information for a collection
  rpc CollectionClusterInfo ( .qdrant.CollectionClusterInfoRequest ) returns ( .qdrant.CollectionClusterInfoResponse );
  //Create new collection with given parameters
  rpc Create ( .qdrant.CreateCollection ) returns ( .qdrant.CollectionOperationResponse );
  //Drop collection and all associated data
  rpc Delete ( .qdrant.DeleteCollection ) returns ( .qdrant.CollectionOperationResponse );
  //Get detailed information about specified existing collection
  rpc Get ( .qdrant.GetCollectionInfoRequest ) returns ( .qdrant.GetCollectionInfoResponse );
  //Get list name of all existing collections
  rpc List ( .qdrant.ListCollectionsRequest ) returns ( .qdrant.ListCollectionsResponse );
  //Get list of all aliases for all existing collections
  rpc ListAliases ( .qdrant.ListAliasesRequest ) returns ( .qdrant.ListAliasesResponse );
  //Get list of all aliases for a collection
  rpc ListCollectionAliases ( .qdrant.ListCollectionAliasesRequest ) returns ( .qdrant.ListAliasesResponse );
  //Update parameters of the existing collection
  rpc Update ( .qdrant.UpdateCollection ) returns ( .qdrant.CollectionOperationResponse );
  //Update Aliases of the existing collection
  rpc UpdateAliases ( .qdrant.ChangeAliases ) returns ( .qdrant.CollectionOperationResponse );
  //Update cluster setup for a collection
  rpc UpdateCollectionClusterSetup ( .qdrant.UpdateCollectionClusterSetupRequest ) returns ( .qdrant.UpdateCollectionClusterSetupResponse );
}
qdrant.CollectionsInternal is a service:
service CollectionsInternal {
  //Get collection info
  rpc Get ( .qdrant.GetCollectionInfoRequestInternal ) returns ( .qdrant.GetCollectionInfoResponse );
  //Initiate shard transfer
  rpc Initiate ( .qdrant.InitiateShardTransferRequest ) returns ( .qdrant.CollectionOperationResponse );
}
qdrant.Points is a service:
service Points {
  //Remove all payload for specified points
  rpc ClearPayload ( .qdrant.ClearPayloadPoints ) returns ( .qdrant.PointsOperationResponse );
  //Count points in collection with given filtering conditions
  rpc Count ( .qdrant.CountPoints ) returns ( .qdrant.CountResponse );
  //Create index for field in collection
  rpc CreateFieldIndex ( .qdrant.CreateFieldIndexCollection ) returns ( .qdrant.PointsOperationResponse );
  //Delete points
  rpc Delete ( .qdrant.DeletePoints ) returns ( .qdrant.PointsOperationResponse );
  //Delete field index for collection
  rpc DeleteFieldIndex ( .qdrant.DeleteFieldIndexCollection ) returns ( .qdrant.PointsOperationResponse );
  //Delete specified key payload for points
  rpc DeletePayload ( .qdrant.DeletePayloadPoints ) returns ( .qdrant.PointsOperationResponse );
  //Delete named vectors for points
  rpc DeleteVectors ( .qdrant.DeletePointVectors ) returns ( .qdrant.PointsOperationResponse );
  //Retrieve points
  rpc Get ( .qdrant.GetPoints ) returns ( .qdrant.GetResponse );
  //Overwrite payload for points
  rpc OverwritePayload ( .qdrant.SetPayloadPoints ) returns ( .qdrant.PointsOperationResponse );
  //Look for the points which are closer to stored positive examples and at the same time further to negative examples.
  rpc Recommend ( .qdrant.RecommendPoints ) returns ( .qdrant.RecommendResponse );
  //Look for the points which are closer to stored positive examples and at the same time further to negative examples.
  rpc RecommendBatch ( .qdrant.RecommendBatchPoints ) returns ( .qdrant.RecommendBatchResponse );
  //Look for the points which are closer to stored positive examples and at the same time further to negative examples, grouped by a given field
  rpc RecommendGroups ( .qdrant.RecommendPointGroups ) returns ( .qdrant.RecommendGroupsResponse );
  //Iterate over all or filtered points points
  rpc Scroll ( .qdrant.ScrollPoints ) returns ( .qdrant.ScrollResponse );
  //Retrieve closest points based on vector similarity and given filtering conditions
  rpc Search ( .qdrant.SearchPoints ) returns ( .qdrant.SearchResponse );
  //Retrieve closest points based on vector similarity and given filtering conditions
  rpc SearchBatch ( .qdrant.SearchBatchPoints ) returns ( .qdrant.SearchBatchResponse );
  //Retrieve closest points based on vector similarity and given filtering conditions, grouped by a given field
  rpc SearchGroups ( .qdrant.SearchPointGroups ) returns ( .qdrant.SearchGroupsResponse );
  //Set payload for points
  rpc SetPayload ( .qdrant.SetPayloadPoints ) returns ( .qdrant.PointsOperationResponse );
  //Perform multiple update operations in one request
  rpc UpdateBatch ( .qdrant.UpdateBatchPoints ) returns ( .qdrant.UpdateBatchResponse );
  //Update named vectors for point
  rpc UpdateVectors ( .qdrant.UpdatePointVectors ) returns ( .qdrant.PointsOperationResponse );
  //Perform insert + updates on points. If a point with a given ID already exists - it will be overwritten.
  rpc Upsert ( .qdrant.UpsertPoints ) returns ( .qdrant.PointsOperationResponse );
}
qdrant.PointsInternal is a service:
service PointsInternal {
  rpc ClearPayload ( .qdrant.ClearPayloadPointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Count ( .qdrant.CountPointsInternal ) returns ( .qdrant.CountResponse );
  rpc CreateFieldIndex ( .qdrant.CreateFieldIndexCollectionInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Delete ( .qdrant.DeletePointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc DeleteFieldIndex ( .qdrant.DeleteFieldIndexCollectionInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc DeletePayload ( .qdrant.DeletePayloadPointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc DeleteVectors ( .qdrant.DeleteVectorsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Get ( .qdrant.GetPointsInternal ) returns ( .qdrant.GetResponse );
  rpc OverwritePayload ( .qdrant.SetPayloadPointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Recommend ( .qdrant.RecommendPointsInternal ) returns ( .qdrant.RecommendResponse );
  rpc Scroll ( .qdrant.ScrollPointsInternal ) returns ( .qdrant.ScrollResponse );
  rpc Search ( .qdrant.SearchPointsInternal ) returns ( .qdrant.SearchResponse );
  rpc SearchBatch ( .qdrant.SearchBatchPointsInternal ) returns ( .qdrant.SearchBatchResponse );
  rpc SetPayload ( .qdrant.SetPayloadPointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Sync ( .qdrant.SyncPointsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc UpdateVectors ( .qdrant.UpdateVectorsInternal ) returns ( .qdrant.PointsOperationResponse );
  rpc Upsert ( .qdrant.UpsertPointsInternal ) returns ( .qdrant.PointsOperationResponse );
}
qdrant.QdrantInternal is a service:
service QdrantInternal {
  //Get HTTP port for remote host.
  rpc GetHttpPort ( .qdrant.HttpPortRequest ) returns ( .qdrant.HttpPortResponse );
}
qdrant.Raft is a service:
service Raft {
  // DEPRECATED
  // Its functionality is now included in `AddPeerToKnown`
  //
  // Send to bootstrap peer
  // Proposes to add this peer as participant of consensus
  rpc AddPeerAsParticipant ( .qdrant.PeerId ) returns ( .google.protobuf.Empty );
  // Send to bootstrap peer
  // Adds peer to the network
  // Returns all peers
  rpc AddPeerToKnown ( .qdrant.AddPeerToKnownMessage ) returns ( .qdrant.AllPeers );
  // Send Raft message to another peer
  rpc Send ( .qdrant.RaftMessage ) returns ( .google.protobuf.Empty );
  // Send to bootstrap peer
  // Returns uri by id if bootstrap knows this peer
  rpc WhoIs ( .qdrant.PeerId ) returns ( .qdrant.Uri );
}
qdrant.Snapshots is a service:
service Snapshots {
  //Create collection snapshot
  rpc Create ( .qdrant.CreateSnapshotRequest ) returns ( .qdrant.CreateSnapshotResponse );
  //Create full storage snapshot
  rpc CreateFull ( .qdrant.CreateFullSnapshotRequest ) returns ( .qdrant.CreateSnapshotResponse );
  //Delete collection snapshots
  rpc Delete ( .qdrant.DeleteSnapshotRequest ) returns ( .qdrant.DeleteSnapshotResponse );
  //List full storage snapshots
  rpc DeleteFull ( .qdrant.DeleteFullSnapshotRequest ) returns ( .qdrant.DeleteSnapshotResponse );
  //List collection snapshots
  rpc List ( .qdrant.ListSnapshotsRequest ) returns ( .qdrant.ListSnapshotsResponse );
  //List full storage snapshots
  rpc ListFull ( .qdrant.ListFullSnapshotsRequest ) returns ( .qdrant.ListSnapshotsResponse );
}
qdrant.Qdrant is a service:
service Qdrant {
  rpc HealthCheck ( .qdrant.HealthCheckRequest ) returns ( .qdrant.HealthCheckReply );
}
grpc.reflection.v1alpha.ServerReflection is a service:
service ServerReflection {
  // The reflection service is structured as a bidirectional stream, ensuring
  // all related requests go to a single server.
  rpc ServerReflectionInfo ( stream .grpc.reflection.v1alpha.ServerReflectionRequest ) returns ( stream .grpc.reflection.v1alpha.ServerReflectionResponse );
}
```
</details>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
