### PR TITLE
Catch optimizer panics

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -479,6 +479,8 @@ impl<'s> SegmentHolder {
     }
 
     pub fn report_optimizer_error<E: Into<CollectionError>>(&mut self, error: E) {
+        // Save only the first error
+        // If is more likely to be the real cause of all further problems
         if self.optimizer_errors.is_none() {
             self.optimizer_errors = Some(error.into());
         }

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -103,6 +103,18 @@ where
     }
 }
 
+/// Convert a panic payload into a string
+///
+/// This converts `String` and `&str` panic payloads into a string.
+/// Other payload types are formatted as is, and may be non descriptive.
+pub(crate) fn panic_payload_into_string(payload: PanicPayload) -> String {
+    payload
+        .downcast::<&str>()
+        .map(|msg| msg.to_string())
+        .or_else(|payload| payload.downcast::<String>().map(|msg| msg.to_string()))
+        .unwrap_or_else(|payload| format!("{payload:?}"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::thread;

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -1,12 +1,16 @@
+use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 use tokio::task::JoinHandle;
 
+type PanicPayload = Box<dyn Any + Send + 'static>;
+
 pub struct StoppableTaskHandle<T> {
     pub join_handle: JoinHandle<Option<T>>,
     started: Arc<AtomicBool>,
     stopped: Weak<AtomicBool>,
+    panic_handler: Option<Box<dyn Fn(PanicPayload) + Sync + Send>>,
 }
 
 impl<T> StoppableTaskHandle<T> {
@@ -28,9 +32,47 @@ impl<T> StoppableTaskHandle<T> {
         self.ask_to_stop();
         self.is_started().then_some(self.join_handle)
     }
+
+    /// Join this stoppable task and handle any panics
+    ///
+    /// Any panics are propagated through the configured panic handler. If no handler is
+    /// configured, nothing happens.
+    ///
+    /// The task must be finished.
+    pub async fn join_and_handle_panic(self) {
+        debug_assert!(
+            self.join_handle.is_finished(),
+            "Task must be finished, we cannot block here on awaiting the join handle",
+        );
+
+        match self.join_handle.await {
+            Ok(_) => {}
+            Err(err) if err.is_cancelled() => {}
+            // Propagate panic
+            Err(err) if err.is_panic() && self.panic_handler.is_some() => {
+                log::trace!("Handling stoppable task panic through custom panic handler");
+                let panic = err.into_panic();
+                let panic_handler = self.panic_handler.unwrap();
+                panic_handler(panic);
+            }
+            Err(err) if err.is_panic() => {
+                log::debug!("Stoppable task paniced without panic handler");
+            }
+            // Log error on unknown error
+            Err(err) => {
+                log::error!("Stoppable task handle error for unknown reason: {err}");
+            }
+        }
+    }
 }
 
-pub fn spawn_stoppable<F, T>(f: F) -> StoppableTaskHandle<T>
+/// Spawn stoppable task `f`
+///
+/// An optional `panic_handler` may be given, eventually called if the task paniced.
+pub fn spawn_stoppable<F, T>(
+    f: F,
+    panic_handler: Option<Box<dyn Fn(PanicPayload) + Sync + Send>>,
+) -> StoppableTaskHandle<T>
 where
     F: FnOnce(&AtomicBool) -> T + Send + 'static,
     T: Send + 'static,
@@ -57,6 +99,7 @@ where
         }),
         started: started_c,
         stopped: stopped_w,
+        panic_handler,
     }
 }
 
@@ -91,7 +134,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_task_stop() {
-        let handle = spawn_stoppable(counting_task);
+        let handle = spawn_stoppable(counting_task, None);
 
         // Signal task to stop after ~20 steps
         sleep(STEP * 20).await;
@@ -117,7 +160,7 @@ mod tests {
         const TASKS: usize = 64;
 
         let handles = (0..TASKS)
-            .map(|_| spawn_stoppable(counting_task))
+            .map(|_| spawn_stoppable(counting_task, None))
             .collect::<Vec<_>>();
 
         // Signal tasks to stop after ~20 steps

--- a/lib/collection/src/common/stoppable_task.rs
+++ b/lib/collection/src/common/stoppable_task.rs
@@ -38,7 +38,8 @@ impl<T> StoppableTaskHandle<T> {
     /// Any panics are propagated through the configured panic handler. If no handler is
     /// configured, nothing happens.
     ///
-    /// The task must be finished.
+    /// To call this, the task must already be finished. Otherwise it panics in development, or
+    /// blocks in release.
     pub async fn join_and_handle_panic(self) {
         debug_assert!(
             self.join_handle.is_finished(),
@@ -56,7 +57,7 @@ impl<T> StoppableTaskHandle<T> {
                 panic_handler(panic);
             }
             Err(err) if err.is_panic() => {
-                log::debug!("Stoppable task paniced without panic handler");
+                log::debug!("Stoppable task panicked without panic handler");
             }
             // Log error on unknown error
             Err(err) => {
@@ -68,7 +69,7 @@ impl<T> StoppableTaskHandle<T> {
 
 /// Spawn stoppable task `f`
 ///
-/// An optional `panic_handler` may be given, eventually called if the task paniced.
+/// An optional `panic_handler` may be given, eventually called if the task panicked.
 pub fn spawn_stoppable<F, T>(
     f: F,
     panic_handler: Option<Box<dyn Fn(PanicPayload) + Sync + Send>>,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -11,6 +11,7 @@ use tokio::runtime::Handle;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::{oneshot, Mutex as TokioMutex};
 use tokio::task::JoinHandle;
+use tokio::time::error::Elapsed;
 use tokio::time::{timeout, Duration};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
@@ -373,7 +374,7 @@ impl UpdateHandler {
                 // Channel closed or stop signal
                 Ok(None | Some(OptimizerSignal::Stop)) => break,
                 // Clean up interval
-                Err(_) => continue,
+                Err(Elapsed { .. }) => continue,
                 // Optimizer signal
                 Ok(Some(signal @ (OptimizerSignal::Nop | OptimizerSignal::Operation(_)))) => {
                     // If not forcing with Nop, wait on next signal if we have too many handles

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -28,7 +28,7 @@ use crate::wal::WalError;
 
 /// Interval at which the optimizer worker cleans up old optimization handles
 ///
-/// The longer the duration, the longer it  takes for paniced tasks to be reported.
+/// The longer the duration, the longer it  takes for panicked tasks to be reported.
 const OPTIMIZER_CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
 
 pub type Optimizer = dyn SegmentOptimizer + Sync + Send;
@@ -235,9 +235,7 @@ impl UpdateHandler {
                 let optimizers_log = optimizers_log.clone();
                 let segments = segments.clone();
                 let nsi = nonoptimal_segment_ids.clone();
-                for sid in &nsi {
-                    scheduled_segment_ids.insert(*sid);
-                }
+                scheduled_segment_ids.extend(&nsi);
                 let callback = callback.clone();
 
                 let handle = spawn_stoppable(
@@ -288,12 +286,12 @@ impl UpdateHandler {
                     Some(Box::new(move |panic_payload| {
                         let panic_msg = panic_payload_into_string(panic_payload);
                         log::warn!(
-                            "Optimization task paniced, collection may be in unstable state: {panic_msg}"
+                            "Optimization task panicked, collection may be in unstable state: {panic_msg}"
                         );
                         segments
                             .write()
                             .report_optimizer_error(CollectionError::service_error(format!(
-                                "Optimization task paniced: {panic_msg}"
+                                "Optimization task panicked: {panic_msg}"
                             )));
                     })),
                 );


### PR DESCRIPTION
Catch any panics happening during optimization and handle this situation.

Now, when an optimization task panics it is reported and the collection status is marked as `red`. Before, a collection hung as `yellow` indefinitely. Now:

![image](https://github.com/qdrant/qdrant/assets/856222/3bec0602-84a6-40a5-bf28-ad7443cc6b02)

### Explanation

In short, this now catches panics as they unwind in the optimization threads. When an optimization task is done, it is now explicitly joined upon to nicely clean them up. On joining, any panic that occurred is collected. These panics are then propagated through a panic handling callback. This new callback is attached to our stoppable task structure.

So a stoppable task may now define a panic callback to handle the panic status. These stoppable tasks are used for optimization. Our optimization tasks now define a panic callback to report it, registering the error and setting the collection state to red.

We are not notified about a panicked task. Our update handler therefore periodically checks for finished (and potentially panicked) optimization tasks. It cleans them up and propagates any panic. This happens at a fixed interval of 5 seconds. So in the worst case, it may take a few seconds for the red collection status to appear.

I've rewritten the way we use our optimizer worker and task handling a bit to make all of this happen.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
