### PR TITLE
sync-web-ui.sh: Remove dist zip after unzipping it

### DIFF
--- a/tools/sync-web-ui.sh
+++ b/tools/sync-web-ui.sh
@@ -14,6 +14,7 @@ wget -O dist-qdrant.zip $DOWNLOAD_LINK
 
 rm -rf "${STATIC_DIR}/"*
 unzip -o dist-qdrant.zip -d "${STATIC_DIR}"
+rm dist-qdrant.zip
 cp -r "${STATIC_DIR}/dist/"* "${STATIC_DIR}"
 rm -rf "${STATIC_DIR}/dist"
 


### PR DESCRIPTION
Updates `sync-web-ui.sh` to remove the downloaded `dist-qdrant.zip` file after unzipping it, as it is not needed further and requires excluding it from git if not removed.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
