### PR TITLE
fix flaky oversampling test

### DIFF
--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
 
-use rand::thread_rng;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -39,7 +40,7 @@ fn hnsw_quantized_search_test(
     let ef = 64;
     let ef_construct = 64;
 
-    let mut rnd = thread_rng();
+    let mut rnd = StdRng::seed_from_u64(42);
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
@@ -156,7 +157,9 @@ fn hnsw_quantized_search_test(
         );
         let best_2 = oversampling_2_result[0][0];
 
-        assert!(best_2.idx == best_1.idx || best_2 >= best_1);
+        let acceptable_range = (best_1.score - oversampling_1_result[0][1].score).abs();
+        let low_bound = best_1.score - acceptable_range;
+        assert!(best_2.score > low_bound);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/2486

I changed the check with the fact that quantization is not exact. Oversampling can produce a worse score because of a lack of quantization accuracy. Also changed random from seed for stability on CI.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
