### PR TITLE
Cleanup data of failed snapshot creation

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1583,18 +1583,20 @@ impl Collection {
             builder.append_dir_all(".", &snapshot_path_with_tmp_extension_clone)?;
             builder.finish()?;
             Ok::<_, CollectionError>(())
-        });
+        })
+        .await?;
 
         // always remove temporary snapshot directory
         remove_dir_all(&snapshot_path_with_tmp_extension).await?;
 
         // cleanup temporary archive data if archiving failed
-        match archiving.await? {
+        match archiving {
             Ok(_) => {}
             Err(err) => {
                 log::debug!(
-                    "Failed to archive snapshot - deleting temporary archive data {:?}",
-                    snapshot_path_with_arc_extension
+                    "Failed to archive snapshot - deleting temporary archive data {:?} {}",
+                    snapshot_path_with_arc_extension,
+                    err
                 );
                 remove_dir_all(&snapshot_path_with_arc_extension).await?;
                 return Err(err);


### PR DESCRIPTION
https://github.com/qdrant/qdrant/issues/2497

TODO:
- find a way to test this
- apply similar strategy to whole storage snapshot?

Possible alternative, rely on the tmp_dir crate to cleanup things on drop in all cases.