### PR TITLE
Sync cargo.lock file for rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,7 +5367,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.21.6",
- "rustls-webpki 0.100.1",
+ "rustls-webpki 0.100.2",
  "url",
  "webpki-roots 0.23.1",
 ]
@@ -5640,7 +5640,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki 0.100.1",
+ "rustls-webpki 0.100.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Everytime I build `dev` the cargo.lock file is changed to this.

Most likely an aftermath of https://github.com/qdrant/qdrant/pull/2489/files

Let's keep it stable.

