### PR TITLE
Enable `max_level_trace` and `release_max_level_trace` features of the `slog` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ actix-web-validator = "5.0.1"
 
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
-slog = "2.7.0"
+slog = { version="2.7.0", features = ["max_level_trace", "release_max_level_trace"] }
 slog-stdlog = "4.1.1"
 prost = "0.11.9"
 raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }


### PR DESCRIPTION
By default, `slog` disables `tracing` logs for debug builds and `tracing` and `debug` logs for release builds __from being emitted__ during compilation.

So, these logs won't be printed regardless of the log level filters that are configured in runtime.

This PR enables `tracing` logs for both debug and release builds by enabling `max_level_trace` and `release_max_level_trace` features of the `slog` crate.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] ~~Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?~~
3. [ ] ~~Have you checked your code using `cargo clippy --all --all-features` command?~~

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your core changes, as applicable?~~
* [ ] Have you successfully ran tests with your changes locally?
