### PR TITLE
Fix truncation of last element of consensus WAL

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -147,7 +147,8 @@ impl ConsensusOpWal {
                     "Expected no index skip: {index} <= {current_index} + {offset}"
                 );
 
-                if index < current_index + offset {
+                // check if truncation is needed
+                if index <= current_index + offset {
                     // If there is a conflict, example:
                     // Offset = 1
                     // raft index = 10
@@ -391,9 +392,93 @@ mod tests {
         drop(wal);
         let wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
         assert_eq!(wal.0.num_segments(), 1);
-        assert_eq!(wal.0.num_entries(), 4); // fails here because we lost data!
+        assert_eq!(wal.0.num_entries(), 4);
         assert_eq!(wal.index_offset().unwrap(), Some(1));
         assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
         assert_eq!(wal.last_entry().unwrap().unwrap().index, 4);
+    }
+    #[test]
+    fn test_log_rewrite_last() {
+        init_logger();
+        let entries_orig = vec![
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 1,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 2,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+            Entry {
+                entry_type: 0,
+                term: 1,
+                index: 3,
+                data: vec![1, 1, 1],
+                context: vec![],
+                sync_log: false,
+            },
+        ];
+
+        // change only the last entry
+        let entries_new = vec![Entry {
+            entry_type: 0,
+            term: 1,
+            index: 3,
+            data: vec![2, 2, 2],
+            context: vec![],
+            sync_log: false,
+        }];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+
+        // append original entries
+        wal.append_entries(entries_orig).unwrap();
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 3);
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 3);
+
+        let result_entries = wal.entries(1, 4, None).unwrap();
+        assert_eq!(result_entries.len(), 3);
+        assert_eq!(result_entries[0].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[1].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[2].data, vec![1, 1, 1]);
+
+        // drop wal to check persistence
+        drop(wal);
+        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+
+        // append overlapping entries
+        wal.append_entries(entries_new).unwrap();
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 3);
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 3);
+
+        let result_entries = wal.entries(1, 4, None).unwrap();
+        assert_eq!(result_entries.len(), 3);
+        assert_eq!(result_entries[0].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[1].data, vec![1, 1, 1]);
+        assert_eq!(result_entries[2].data, vec![2, 2, 2]); // value updated
+
+        // drop wal to check persistence
+        drop(wal);
+        let wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        assert_eq!(wal.0.num_segments(), 1);
+        assert_eq!(wal.0.num_entries(), 3);
+        assert_eq!(wal.index_offset().unwrap(), Some(1));
+        assert_eq!(wal.first_entry().unwrap().unwrap().index, 1);
+        assert_eq!(wal.last_entry().unwrap().unwrap().index, 3);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/1662

Analyzing the raft_state of a broken cluster shows that the consensus WALs diverged.

Using a [custom reader](https://github.com/qdrant/qdrant/pull/2244) I am able to see that the the last index for node0 is incorrect.

### node0

```
==========================
Entry ID:141
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 0, peer_id: 3010363724257094, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:142
term:1
entry_type:0
data:"CollectionMeta(DeleteCollection(DeleteCollectionOperation(\"test_collection\")))"
```

### node1

```
==========================
Entry ID:141
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 0, peer_id: 3010363724257094, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:142
term:2
entry_type:0
data:"[]"
==========================
Entry ID:143
term:2
entry_type:0
data:"CollectionMeta(CreateCollection(CreateCollectionOperation { collection_name: \"test_collection\", create_collection: CreateCollection { vectors: Single(VectorParams { size: 4, distance: Dot, hnsw_config: None, quantization_config: None, on_disk: None }), shard_number: Some(3), replication_factor: Some(1), write_consistency_factor: None, on_disk_payload: None, hnsw_config: None, wal_config: None, optimizers_config: None, init_from: None, quantization_config: None }, distribution: Some(ShardDistributionProposal { distribution: [(0, [3010363724257094]), (1, [4826122942869202]), (2, [5293302778279663])] }) }))"
==========================
```

### node2

```
==========================
Entry ID:141
term:1
entry_type:0
data:"CollectionMeta(SetShardReplicaState(SetShardReplicaState { collection_name: \"test_collection\", shard_id: 0, peer_id: 3010363724257094, state: Active, from_state: Some(Initializing) }))"
==========================
Entry ID:142
term:2
entry_type:0
data:"[]"
==========================
Entry ID:143
term:2
entry_type:0
data:"CollectionMeta(CreateCollection(CreateCollectionOperation { collection_name: \"test_collection\", create_collection: CreateCollection { vectors: Single(VectorParams { size: 4, distance: Dot, hnsw_config: None, quantization_config: None, on_disk: None }), shard_number: Some(3), replication_factor: Some(1), write_consistency_factor: None, on_disk_payload: None, hnsw_config: None, wal_config: None, optimizers_config: None, init_from: None, quantization_config: None }, distribution: Some(ShardDistributionProposal { distribution: [(0, [3010363724257094]), (1, [4826122942869202]), (2, [5293302778279663])] }) }))"
==========================
...
```

Although the conflict resolution for node0 says it fixed it

```
node0  | [2023-08-24T14:45:52.622Z INFO  raft::raft_log] found conflict at index 142, raft_id: 4826122942869202, conflicting term: 2, existing term: 1, index: 142
node0  | [2023-08-24T14:45:52.622Z DEBUG qdrant::consensus] Appending 1 entries to raft log
node0  | [2023-08-24T14:45:52.622Z DEBUG storage::content_manager::consensus::consensus_wal] Appending entry: Entry { entry_type: EntryNormal, term: 2, index: 142, data: [], context: [], sync_log: false }
```

In practice it appears the log is not written to disk.

In that case, the entry to replace is the last one.

Writing a unit test, I was able to see that the truncation logic did not handle this case.