### PR TITLE
fix: remove replaced id when db corrupted

### DIFF
--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -97,7 +97,7 @@ impl SimpleIdTracker {
                     external_id,
                     replaced_id
                 );
-                match external_id {
+                match replaced_id {
                     PointIdType::NumId(idx) => {
                         external_to_internal_num.remove(&idx);
                     }


### PR DESCRIPTION
When the database is corrupted, id processing is a bit strange

The external_id removed here will be inserted repeatedly below

I think we should remove the replaced id, because duplicate data will not be used