### PR TITLE
Add `SnapshotPriority::LocalOnly` variant

### DIFF
--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -16,6 +16,7 @@ use crate::operations::types::CollectionResult;
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SnapshotPriority {
+    LocalOnly,
     Snapshot,
     #[default]
     Replica,

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -225,6 +225,10 @@ async fn _do_recover_from_snapshot(
                 activate_shard(toc, &collection, this_peer_id, shard_id).await?;
             } else {
                 match priority {
+                    SnapshotPriority::LocalOnly => {
+                        activate_shard(toc, &collection, this_peer_id, shard_id).await?;
+                    }
+
                     SnapshotPriority::Snapshot => {
                         // Snapshot is the source of truth, we need to remove all other replicas
                         activate_shard(toc, &collection, this_peer_id, shard_id).await?;

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -493,6 +493,10 @@ async fn recover_shard_snapshot_impl(
         activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
     } else {
         match priority {
+            SnapshotPriority::LocalOnly => {
+                activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
+            }
+
             SnapshotPriority::Snapshot => {
                 activate_shard(toc, collection, toc.this_peer_id, &shard).await?;
 


### PR DESCRIPTION
Add `SnapshotPriority::LocalOnly` variant, that simply adds and activates local shard without any additional synchronization.

Based on #2410.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
