### PR TITLE
Fix missing points, vectors and payload

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -98,8 +98,7 @@ pub(crate) fn overwrite_payload(
 ) -> CollectionResult<usize> {
     let updated_points =
         segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
-            write_segment.set_full_payload(op_num, id, payload)?;
-            Ok(true)
+            write_segment.set_full_payload(op_num, id, payload)
         })?;
 
     check_unprocessed_points(points, &updated_points)?;
@@ -124,8 +123,7 @@ pub(crate) fn set_payload(
 ) -> CollectionResult<usize> {
     let updated_points =
         segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
-            write_segment.set_payload(op_num, id, payload)?;
-            Ok(true)
+            write_segment.set_payload(op_num, id, payload)
         })?;
 
     check_unprocessed_points(points, &updated_points)?;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1992,13 +1992,13 @@ mod tests {
         assert_eq!(segment_info.num_points, 1);
         assert_eq!(segment_info.num_vectors, 2); // We don't propagate deletes to vectors at this time
 
-        // Delete vector of point 6, vector count should now be zero
-        segment
-            .delete_vector(104, 6.into(), DEFAULT_VECTOR_NAME)
-            .unwrap();
-        let segment_info = segment.info();
-        assert_eq!(segment_info.num_points, 1);
-        assert_eq!(segment_info.num_vectors, 1);
+        // // Delete vector of point 6, vector count should now be zero
+        // segment
+        //     .delete_vector(104, 6.into(), DEFAULT_VECTOR_NAME)
+        //     .unwrap();
+        // let segment_info = segment.info();
+        // assert_eq!(segment_info.num_points, 1);
+        // assert_eq!(segment_info.num_vectors, 1);
     }
 
     #[test]

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1990,7 +1990,7 @@ mod tests {
         segment.delete_point(103, 4.into()).unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 1);
-        assert_eq!(segment_info.num_vectors, 1);
+        assert_eq!(segment_info.num_vectors, 2); // We don't propagate deletes to vectors at this time
 
         // Delete vector of point 6, vector count should now be zero
         segment
@@ -1998,7 +1998,7 @@ mod tests {
             .unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 1);
-        assert_eq!(segment_info.num_vectors, 0);
+        assert_eq!(segment_info.num_vectors, 1);
     }
 
     #[test]
@@ -2071,19 +2071,19 @@ mod tests {
         segment.delete_point(105, 4.into()).unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 3);
-        assert_eq!(segment_info.num_vectors, 4);
+        assert_eq!(segment_info.num_vectors, 6); // We don't propagate deletes to vectors at this time
 
         // Delete vector 'a' of point 6, vector count should decrease by 1
         segment.delete_vector(106, 6.into(), "a").unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 3);
-        assert_eq!(segment_info.num_vectors, 3);
+        assert_eq!(segment_info.num_vectors, 5);
 
         // Deleting it again shouldn't chain anything
         segment.delete_vector(107, 6.into(), "a").unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 3);
-        assert_eq!(segment_info.num_vectors, 3);
+        assert_eq!(segment_info.num_vectors, 5);
 
         // Replace vector 'a' for point 8, counts should remain the same
         let internal_8 = segment.lookup_internal_id(8.into()).unwrap();
@@ -2092,7 +2092,7 @@ mod tests {
             .unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 3);
-        assert_eq!(segment_info.num_vectors, 3);
+        assert_eq!(segment_info.num_vectors, 5);
 
         // Replace both vectors for point 8, adding a new vector
         segment
@@ -2103,7 +2103,7 @@ mod tests {
             .unwrap();
         let segment_info = segment.info();
         assert_eq!(segment_info.num_points, 3);
-        assert_eq!(segment_info.num_vectors, 4);
+        assert_eq!(segment_info.num_vectors, 6);
     }
 
     /// Tests segment functions to ensure invalid requests do error

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -824,11 +824,17 @@ impl SegmentEntry for Segment {
                     segment.payload_index.borrow_mut().drop(internal_id)?;
                     segment.id_tracker.borrow_mut().drop(point_id)?;
 
-                    // Propagate point deletion to all its vectors
-                    for vector_data in segment.vector_data.values() {
-                        let mut vector_storage = vector_data.vector_storage.borrow_mut();
-                        vector_storage.delete_vector(internal_id)?;
-                    }
+                    // Before, we propagated point deletions to also delete its vectors. This turns
+                    // out to be problematic because this sometimes makes us loose vector data
+                    // because we cannot control the order of segment flushes.
+                    // Disabled until we properly fix it or find a better way to clean up old
+                    // vectors.
+                    //
+                    // // Propagate point deletion to all its vectors
+                    // for vector_data in segment.vector_data.values() {
+                    //     let mut vector_storage = vector_data.vector_storage.borrow_mut();
+                    //     vector_storage.delete_vector(internal_id)?;
+                    // }
 
                     Ok((true, Some(internal_id)))
                 })

--- a/openapi/tests/openapi_integration/test_delete_points.py
+++ b/openapi/tests/openapi_integration/test_delete_points.py
@@ -38,7 +38,8 @@ def test_delete_points():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['vectors_count'] == 7
+    assert response.json()['result']['points_count'] == 7
+    assert response.json()['result']['vectors_count'] == 8 # We don't propagate deletes to vectors at this time
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/delete',
@@ -58,4 +59,5 @@ def test_delete_points():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['vectors_count'] == 3
+    assert response.json()['result']['points_count'] == 3
+    assert response.json()['result']['vectors_count'] == 8


### PR DESCRIPTION
iThis fixes a data integrity issue where Qdrant could lose points, vectors and payload data on crash.

It is a two part problem: 1. losing points. 2. losing vectors.

### 1. Losing points

Sometimes points (along with their vectors and payload) were lost. This has to do with copy-on-write operations on two segments happening between the flushing of these two segments. Here I explain it more in detail:

Qdrant has appendable (mutable) and non-appendable (immutable) segments. Imagine that we want to change a point in a non-appendable segment by updating its payload.

To do this, we have a copy-on-write mechanism. The point is deleted form segment **A** (non-appendable), the updated point is written to segment **B** (appendable). This normally works fine, but _can_ be problematic if Qdrant crashes.

Because of flush ordering segment **B** (appendable) is flushed before segment **A** (non-appendable). If the copy-on-write operation happens in between, the point is deleted from **A** but the new point in **B** is not persisted. We cannot recover this state by replaying the WAL after a crash because the point in A does not exist anymore, making copy-on-write impossible as the source data is gone.

Before, segments were locked-flushed-unlocked one-by-one. To resolve the issue, all segments are now all read-locked together, then segments are flushed. This prevents any copy-on-write operation from happening between flushing of two segments. To minimize locking time, each segment by itself is immediately unlocked after it has been flushed. Note that the read-lock prevents writing to the segment but still allows reads (for searches for example).

At this time it is unclear what performance impact this might have. I did not see any problems with a simple `bfb` benchmark.

### 2. Losing vectors

Sometimes vector data of points was lost. When a point is deleted, that deletion is propagated to explicitly mark its vectors as deleted as well. The idea was that this would make vacuuming unused vectors easy. The propagation turns out to be problematic, so it is now entirely disabled. We can eventually enable it again once fixed, or might think of a different way of vacuuming old vectors.

### Test tool

I built a simple tool to repeatedly reproduce and test this issue: https://github.com/timvisee/qdrant-catch-me-if-you-can

After these changes, all problems that appeared before are now gone.

For multiple collection configurations I've run the test a [1000](https://github.com/timvisee/qdrant-catch-me-if-you-can/blob/master/test-loop.sh) times.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
