### PR TITLE
Delete temp snapshot files on error

### DIFF
--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 
 [dev-dependencies]
-tempfile = "3.8.0"
 criterion = "0.5"
 rstest = "0.18.2"
 
@@ -61,6 +60,7 @@ num_cpus = "1.16.0"
 tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.18"
+tempfile = "3.8.0"
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1509,9 +1509,22 @@ impl Collection {
         Ok(snapshot_path)
     }
 
+    /// Creates a snapshot of the collection.
+    ///
+    /// The snapshot is created in three steps:
+    /// 1. Create a temporary directory and create a snapshot of each shard in it.
+    /// 2. Archive the temporary directory into a single file.
+    /// 3. Move the archive to the final location.
+    ///
+    /// # Arguments
+    ///
+    /// * `global_temp_dir`: directory used to host snapshots while they are being created
+    /// * `this_peer_id`: current peer id
+    ///
+    /// returns: Result<SnapshotDescription, CollectionError>
     pub async fn create_snapshot(
         &self,
-        temp_dir: &Path,
+        global_temp_dir: &Path,
         this_peer_id: PeerId,
     ) -> CollectionResult<SnapshotDescription> {
         let snapshot_name = format!(
@@ -1520,64 +1533,77 @@ impl Collection {
             this_peer_id,
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S")
         );
+
+        // Final location of snapshot
         let snapshot_path = self.snapshots_path.join(&snapshot_name);
         log::info!(
             "Creating collection snapshot {} into {:?}",
             snapshot_name,
             snapshot_path
         );
-        let snapshot_path_tmp = snapshot_path.with_extension("tmp");
 
-        let snapshot_path_with_tmp_extension = temp_dir.join(&snapshot_name).with_extension("tmp");
-        let snapshot_path_with_arc_extension = temp_dir.join(&snapshot_name).with_extension("arc");
-
-        create_dir_all(&snapshot_path_with_tmp_extension).await?;
-
+        // Dedicated temporary directory for this snapshot (deleted on drop)
+        let snapshot_temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{snapshot_name}-temp-"))
+            .tempdir_in(global_temp_dir)?;
+        let snapshot_temp_dir_path = snapshot_temp_dir.path().to_path_buf();
+        // Create snapshot of each shard
         {
             let shards_holder = self.shards_holder.read().await;
             // Create snapshot of each shard
             for (shard_id, replica_set) in shards_holder.get_shards() {
                 let shard_snapshot_path =
-                    versioned_shard_path(&snapshot_path_with_tmp_extension, *shard_id, 0);
+                    versioned_shard_path(&snapshot_temp_dir_path, *shard_id, 0);
                 create_dir_all(&shard_snapshot_path).await?;
                 // If node is listener, we can save whatever currently is in the storage
                 let save_wal = self.shared_storage_config.node_type != NodeType::Listener;
                 replica_set
-                    .create_snapshot(temp_dir, &shard_snapshot_path, save_wal)
+                    .create_snapshot(&snapshot_temp_dir_path, &shard_snapshot_path, save_wal)
                     .await?;
             }
         }
 
-        CollectionVersion::save(&snapshot_path_with_tmp_extension)?;
+        // Save collection config and version
+        CollectionVersion::save(&snapshot_temp_dir_path)?;
         self.collection_config
             .read()
             .await
-            .save(&snapshot_path_with_tmp_extension)?;
+            .save(&snapshot_temp_dir_path)?;
 
-        let snapshot_path_with_arc_extension_clone = snapshot_path_with_arc_extension.clone();
-        let snapshot_path_with_tmp_extension_clone = snapshot_path_with_tmp_extension.clone();
-        log::debug!("Archiving snapshot {:?}", snapshot_path_with_tmp_extension);
+        // Dedicated temporary file for archiving this snapshot (deleted on drop)
+        let snapshot_temp_arc_file = tempfile::Builder::new()
+            .prefix(&format!("{snapshot_name}-arc-"))
+            .tempfile_in(global_temp_dir)?;
+
+        // Archive snapshot folder into a single file
+        let snapshot_temp_arc_file_arc = Arc::new(snapshot_temp_arc_file);
+        let snapshot_arc_file_path_clone = snapshot_temp_arc_file_arc.clone();
+        let snapshot_temp_dir_path_clone = snapshot_temp_dir_path.clone();
+        log::debug!("Archiving snapshot {:?}", snapshot_temp_dir_path);
         let archiving = tokio::task::spawn_blocking(move || {
-            // have to use std here, cause TarBuilder is not async
-            let file = std::fs::File::create(&snapshot_path_with_arc_extension_clone)?;
-            let mut builder = TarBuilder::new(file);
+            let mut builder = TarBuilder::new(snapshot_arc_file_path_clone.as_ref());
             // archive recursively collection directory `snapshot_path_with_arc_extension` into `snapshot_path`
-            builder.append_dir_all(".", &snapshot_path_with_tmp_extension_clone)?;
+            builder.append_dir_all(".", &snapshot_temp_dir_path_clone)?;
             builder.finish()?;
             Ok::<_, CollectionError>(())
         });
-
         archiving.await??;
 
-        // remove temporary snapshot directory
-        remove_dir_all(&snapshot_path_with_tmp_extension).await?;
+        // Remove temporary snapshot directory (automatically dropped on previous error)
+        log::debug!(
+            "Removing temporary snapshot data {:?}",
+            snapshot_temp_dir_path
+        );
+        remove_dir_all(&snapshot_temp_dir_path).await?;
 
-        // move snapshot to permanent location
+        // Move snapshot to permanent location.
         // We can't move right away, because snapshot folder can be on another mounting point.
-        // We can't copy to the target location directly, cause copy is not atomic.
-        copy(&snapshot_path_with_arc_extension, &snapshot_path_tmp).await?;
-        rename(&snapshot_path_tmp, &snapshot_path).await?;
-        remove_file(snapshot_path_with_arc_extension).await?;
+        // We can't copy to the target location directly, because copy is not atomic.
+        // So we copy to the final location with a temporary name and then rename atomically.
+        let snapshot_path_tmp_move = snapshot_path.with_extension("tmp");
+        copy(snapshot_temp_arc_file_arc.path(), &snapshot_path_tmp_move).await?;
+        rename(&snapshot_path_tmp_move, &snapshot_path).await?;
+        remove_file(snapshot_temp_arc_file_arc.path()).await?;
 
         log::info!(
             "Collection snapshot {} completed into {:?}",

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -23,7 +23,6 @@ use tokio::fs::{copy, create_dir_all, remove_dir_all};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock as TokioRwLock};
-use uuid::Uuid;
 use wal::{Wal, WalOptions};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
@@ -561,8 +560,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let temp_path = temp_path.join(format!("shard-{}", Uuid::new_v4()));
-        create_dir_all(&temp_path).await?;
+        let temp_path = temp_path.to_owned();
 
         tokio::task::spawn_blocking(move || {
             let segments_read = segments.read();

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -561,7 +561,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let temp_path = temp_path.join(format!("shard-snapshot-{}", Uuid::new_v4()));
+        let temp_path = temp_path.join(format!("shard-{}", Uuid::new_v4()));
         create_dir_all(&temp_path).await?;
 
         tokio::task::spawn_blocking(move || {

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -561,7 +561,7 @@ impl LocalShard {
             rx.await?;
         }
 
-        let temp_path = temp_path.join(format!("snapshot-{}", Uuid::new_v4()));
+        let temp_path = temp_path.join(format!("shard-snapshot-{}", Uuid::new_v4()));
         create_dir_all(&temp_path).await?;
 
         tokio::task::spawn_blocking(move || {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -33,6 +33,10 @@ pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
     Arc::new(move |_transfer| {})
 }
 
+fn init_logger() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 async fn _test_snapshot_collection(node_type: NodeType) {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
@@ -155,6 +159,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_snapshot_collection() {
+    init_logger();
     _test_snapshot_collection(NodeType::Normal).await;
     _test_snapshot_collection(NodeType::Listener).await;
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1401,7 +1401,8 @@ impl SegmentEntry for Segment {
         // flush segment to capture latest state
         self.flush(true)?;
 
-        let temp_path = temp_path.join(format!("snapshot-{}", Uuid::new_v4()));
+        // use temp_path for intermediary files
+        let temp_path = temp_path.join(format!("segment-snapshot-{}", Uuid::new_v4()));
         let db_backup_path = temp_path.join(DB_BACKUP_PATH);
         let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1402,7 +1402,7 @@ impl SegmentEntry for Segment {
         self.flush(true)?;
 
         // use temp_path for intermediary files
-        let temp_path = temp_path.join(format!("segment-snapshot-{}", Uuid::new_v4()));
+        let temp_path = temp_path.join(format!("segment-{}", Uuid::new_v4()));
         let db_backup_path = temp_path.join(DB_BACKUP_PATH);
         let payload_index_db_backup_path = temp_path.join(PAYLOAD_DB_BACKUP_PATH);
 


### PR DESCRIPTION
Tackles https://github.com/qdrant/qdrant/issues/2497

Relies on `tempfile` crate to automate cleanup.