### PR TITLE
Limit vector dimension to 65536

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ name = "api"
 version = "0.11.1"
 dependencies = [
  "chrono",
+ "common",
  "env_logger",
  "log",
  "parking_lot",
@@ -1103,6 +1104,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "validator",
 ]
 
 [[package]]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0"
 parking_lot = "0.12"
 validator = { version = "0.16", features = ["derive"] }
 
+common = {path = "../common"}
 segment = {path = "../segment"}
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -114,7 +114,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("OptimizersConfigDiff.vacuum_min_vector_number", "custom = \"crate::grpc::validate::validate_u64_range_min_100\""),
             ("VectorsConfig.config", ""),
             ("VectorsConfigDiff.config", ""),
-            ("VectorParams.size", "range(min = 1)"),
+            ("VectorParams.size", "range(min = 1, max = 65536)"),
             ("VectorParams.hnsw_config", ""),
             ("VectorParams.quantization_config", ""),
             ("VectorParamsMap.map", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5,7 +5,7 @@
 pub struct VectorParams {
     /// Size of the vectors
     #[prost(uint64, tag = "1")]
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 65536))]
     pub size: u64,
     /// Distance function used for comparing vectors
     #[prost(enumeration = "Distance", tag = "2")]

--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 
 [dependencies]
 serde = "~1.0"
+validator = { version = "0.16", features = ["derive"] }

--- a/lib/common/src/lib.rs
+++ b/lib/common/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod fixed_length_priority_queue;
+pub mod validation;

--- a/lib/common/src/validation.rs
+++ b/lib/common/src/validation.rs
@@ -1,0 +1,31 @@
+use std::borrow::Cow;
+
+use serde::Serialize;
+use validator::ValidationError;
+
+/// Validate the value is in `[min, max]`
+#[inline]
+pub fn validate_range_generic<N>(
+    value: &N,
+    min: Option<N>,
+    max: Option<N>,
+) -> Result<(), ValidationError>
+where
+    N: PartialOrd + Serialize,
+{
+    // If value is within bounds we're good
+    if min.as_ref().map(|min| value >= min).unwrap_or(true)
+        && max.as_ref().map(|max| value <= max).unwrap_or(true)
+    {
+        return Ok(());
+    }
+
+    let mut err = ValidationError::new("range");
+    if let Some(min) = min {
+        err.add_param(Cow::from("min"), &min);
+    }
+    if let Some(max) = max {
+        err.add_param(Cow::from("max"), &max);
+    }
+    Err(err)
+}

--- a/openapi/tests/openapi_integration/helpers/collection_setup.py
+++ b/openapi/tests/openapi_integration/helpers/collection_setup.py
@@ -17,12 +17,7 @@ def basic_collection_setup(
         on_disk_payload=False,
         on_disk_vectors=False,
 ):
-    response = request_with_validation(
-        api='/collections/{collection_name}',
-        method="DELETE",
-        path_params={'collection_name': collection_name},
-    )
-    assert response.ok
+    drop_collection(collection_name)
 
     response = request_with_validation(
         api='/collections/{collection_name}',

--- a/openapi/tests/openapi_integration/test_limits.py
+++ b/openapi/tests/openapi_integration/test_limits.py
@@ -1,0 +1,68 @@
+import os
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.fixtures import on_disk_vectors, on_disk_payload
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_limits'
+
+
+@pytest.fixture(autouse=True)
+def setup(on_disk_vectors):
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+# Tests vulnerability related limits, see: <https://github.com/qdrant/qdrant/pull/2544>
+def test_vector_dimension_limit():
+    dim_max = 65536
+
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": dim_max,
+                "distance": "Dot",
+            },
+        }
+    )
+    assert response.ok
+
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": dim_max + 1,
+                "distance": "Dot",
+            },
+        }
+    )
+    assert not response.ok
+    error = response.json()['status']['error']
+    assert error == f"Validation error in JSON body: [vectors.size: value {dim_max + 1} invalid, must be from 1 to {dim_max}]"
+
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 1,
+                "distance": "Dot",
+            },
+        }
+    )
+    assert response.ok
+
+    drop_collection(collection_name)


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2268>, [CVE-2023-38975](https://github.com/advisories/GHSA-j4cw-vvxw-4jcv).

Limit the maximum number of vector dimensions to 65536.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
