### PR TITLE
Do not always print logs during test

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1140,7 +1140,6 @@ mod tests {
         let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
         let mut settings = crate::Settings::new(None).expect("Can't read config.");
         settings.storage.storage_path = storage_dir.path().to_str().unwrap().to_string();
-        std::env::set_var("RUST_LOG", log::Level::Debug.as_str());
         tracing_subscriber::fmt::init();
         let search_runtime =
             crate::create_search_runtime(settings.storage.performance.max_search_threads)


### PR DESCRIPTION
This is the only test issuing logs by default.

It can be done manually if necessary with:

```bash
RUST_LOG=debug cargo test collection_creation_passes_consensus
```

Let's keep it quiet by default.