### PR TITLE
refactor: Make `preprocess()` own its vector argument

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -4,7 +4,7 @@ mod prof;
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
-use segment::data_types::vectors::VectorElementType;
+use segment::data_types::vectors::{VectorElementType, VectorType};
 use segment::fixtures::index_fixtures::{random_vector, FakeFilterContext, TestRawScorerProducer};
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
@@ -117,8 +117,8 @@ impl Metric for FakeMetric {
         v1[0] + v2[0]
     }
 
-    fn preprocess(_vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> {
-        None
+    fn preprocess(vector: VectorType) -> VectorType {
+        vector
     }
 
     fn postprocess(score: ScoreType) -> ScoreType {

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -101,9 +101,8 @@ impl<'a> NamedVectors<'a> {
     {
         for (name, vector) in self.map.iter_mut() {
             let distance = distance_map(name);
-            if let Some(preprocessed_vector) = distance.preprocess_vector(vector) {
-                *vector = CowValue::Owned(preprocessed_vector);
-            }
+            let preprocessed_vector = distance.preprocess_vector(vector.to_vec());
+            *vector = CowValue::Owned(preprocessed_vector);
         }
     }
 }

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -7,7 +7,7 @@ use bitvec::prelude::{BitSlice, BitVec};
 use rand::Rng;
 
 use crate::common::Flusher;
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::entry::entry_point::OperationResult;
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
@@ -130,7 +130,7 @@ where
         let mut vectors = ChunkedVectors::new(dim);
         for _ in 0..num_vectors {
             let rnd_vec = random_vector(rng, dim);
-            let rnd_vec = TMetric::preprocess(&rnd_vec).unwrap_or(rnd_vec);
+            let rnd_vec = TMetric::preprocess(rnd_vec);
             vectors.push(&rnd_vec).unwrap();
         }
         TestRawScorerProducer::<TMetric> {
@@ -141,8 +141,8 @@ where
         }
     }
 
-    pub fn get_raw_scorer(&self, query: Vec<VectorElementType>) -> Box<dyn RawScorer + '_> {
-        let query = TMetric::preprocess(&query).unwrap_or(query);
+    pub fn get_raw_scorer(&self, query: VectorType) -> Box<dyn RawScorer + '_> {
+        let query = TMetric::preprocess(query);
         raw_scorer_impl(
             query,
             self,

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -438,7 +438,7 @@ mod tests {
 
         let top = 5;
         let query = random_vector(&mut rng, dim);
-        let processed_query = M::preprocess(&query).unwrap_or_else(|| query.clone());
+        let processed_query = M::preprocess(query.clone());
         let mut reference_top = FixedLengthPriorityQueue::new(top);
         for idx in 0..vector_holder.vectors.len() as PointOffsetType {
             let vec = &vector_holder.vectors.get(idx);

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -612,7 +612,7 @@ mod tests {
 
         let top = 5;
         let query = random_vector(&mut rng, dim);
-        let processed_query = M::preprocess(&query).unwrap_or_else(|| query.clone());
+        let processed_query = M::preprocess(query.clone());
         let mut reference_top = FixedLengthPriorityQueue::new(top);
         for idx in 0..vector_holder.vectors.len() as PointOffsetType {
             let vec = &vector_holder.vectors.get(idx);
@@ -627,7 +627,7 @@ mod tests {
             .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
-        let raw_scorer = vector_holder.get_raw_scorer(query);
+        let raw_scorer = vector_holder.get_raw_scorer(query.clone());
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer);
@@ -695,7 +695,7 @@ mod tests {
 
         let top = 5;
         let query = random_vector(&mut rng, dim);
-        let processed_query = M::preprocess(&query).unwrap_or_else(|| query.clone());
+        let processed_query = M::preprocess(query.clone());
         let mut reference_top = FixedLengthPriorityQueue::new(top);
         for idx in 0..vector_holder.vectors.len() as PointOffsetType {
             let vec = &vector_holder.vectors.get(idx);

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -188,7 +188,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
                             quantized_storage.raw_scorer(
-                                &vector,
+                                vector.to_owned(),
                                 id_tracker.deleted_point_bitslice(),
                                 deleted_bitslice,
                                 stopped,
@@ -239,7 +239,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             // If `quantization_params` is `Some`, then quantization is *not* ignored
             Some(quantized_storage) if !quantization_params.ignore => {
                 let scorer = quantized_storage.raw_scorer(
-                    vector,
+                    vector.to_owned(),
                     id_tracker.deleted_point_bitslice(),
                     vector_storage.deleted_vector_bitslice(),
                     is_stopped,
@@ -349,7 +349,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     if let Some(quantized_storage) = vector_storage.quantized_storage() {
                         quantized_storage
                             .raw_scorer(
-                                vector,
+                                vector.to_vec(),
                                 id_tracker.deleted_point_bitslice(),
                                 vector_storage.deleted_vector_bitslice(),
                                 is_stopped,
@@ -555,7 +555,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     let raw_scorer =
                         if let Some(quantized_storage) = vector_storage.quantized_storage() {
                             quantized_storage.raw_scorer(
-                                &vector,
+                                vector.to_owned(),
                                 id_tracker.deleted_point_bitslice(),
                                 vector_storage.deleted_vector_bitslice(),
                                 stopped,

--- a/lib/segment/src/spaces/metric.rs
+++ b/lib/segment/src/spaces/metric.rs
@@ -9,7 +9,7 @@ pub trait Metric {
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType;
 
     /// Necessary vector transformations performed before adding it to the collection (like normalization)
-    /// Return None if metric does not required preprocessing
+    /// If no transformation is needed - returns the same vector
     fn preprocess(vector: VectorType) -> VectorType;
 
     /// correct metric score for displaying

--- a/lib/segment/src/spaces/metric.rs
+++ b/lib/segment/src/spaces/metric.rs
@@ -1,4 +1,4 @@
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::types::{Distance, ScoreType};
 
 /// Defines how to compare vectors
@@ -10,7 +10,7 @@ pub trait Metric {
 
     /// Necessary vector transformations performed before adding it to the collection (like normalization)
     /// Return None if metric does not required preprocessing
-    fn preprocess(vector: &[VectorElementType]) -> Option<Vec<VectorElementType>>;
+    fn preprocess(vector: VectorType) -> VectorType;
 
     /// correct metric score for displaying
     fn postprocess(score: ScoreType) -> ScoreType;

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -1,6 +1,6 @@
 use std::arch::x86_64::*;
 
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::types::ScoreType;
 
 #[target_feature(enable = "avx")]
@@ -61,9 +61,7 @@ pub(crate) unsafe fn euclid_similarity_avx(
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
-pub(crate) unsafe fn cosine_preprocess_avx(
-    vector: &[VectorElementType],
-) -> Option<Vec<VectorElementType>> {
+pub(crate) unsafe fn cosine_preprocess_avx(vector: VectorType) -> VectorType {
     let n = vector.len();
     let m = n - (n % 32);
     let mut ptr: *const f32 = vector.as_ptr();
@@ -97,10 +95,10 @@ pub(crate) unsafe fn cosine_preprocess_avx(
         length += (*ptr.add(i)).powi(2);
     }
     if length < f32::EPSILON {
-        return None;
+        return vector;
     }
     length = length.sqrt();
-    Some(vector.iter().map(|x| x / length).collect())
+    vector.into_iter().map(|x| x / length).collect()
 }
 
 #[target_feature(enable = "avx")]
@@ -183,8 +181,8 @@ mod tests {
             let dot = dot_similarity(&v1, &v2);
             assert_eq!(dot_simd, dot);
 
-            let cosine_simd = unsafe { cosine_preprocess_avx(&v1) };
-            let cosine = cosine_preprocess(&v1);
+            let cosine_simd = unsafe { cosine_preprocess_avx(v1.clone()) };
+            let cosine = cosine_preprocess(v1);
             assert_eq!(cosine_simd, cosine);
         } else {
             println!("avx test skipped");

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -3,6 +3,7 @@ use std::arch::aarch64::*;
 
 #[cfg(target_feature = "neon")]
 use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::VectorType;
 #[cfg(target_feature = "neon")]
 use crate::types::ScoreType;
 
@@ -46,9 +47,7 @@ pub(crate) unsafe fn euclid_similarity_neon(
 }
 
 #[cfg(target_feature = "neon")]
-pub(crate) unsafe fn cosine_preprocess_neon(
-    vector: &[VectorElementType],
-) -> Option<Vec<VectorElementType>> {
+pub(crate) unsafe fn cosine_preprocess_neon(vector: VectorType) -> VectorType {
     let n = vector.len();
     let m = n - (n % 16);
     let mut ptr: *const f32 = vector.as_ptr();
@@ -79,10 +78,10 @@ pub(crate) unsafe fn cosine_preprocess_neon(
         length += v.powi(2);
     }
     if length < f32::EPSILON {
-        return None;
+        return vector;
     }
     let length = length.sqrt();
-    Some(vector.iter().map(|x| x / length).collect())
+    vector.into_iter().map(|x| x / length).collect()
 }
 
 #[cfg(target_feature = "neon")]
@@ -142,8 +141,8 @@ mod tests {
             let dot = dot_similarity(&v1, &v2);
             assert_eq!(dot_simd, dot);
 
-            let cosine_simd = unsafe { cosine_preprocess_neon(&v1) };
-            let cosine = cosine_preprocess(&v1);
+            let cosine_simd = unsafe { cosine_preprocess_neon(v1.clone()) };
+            let cosine = cosine_preprocess(v1);
             assert_eq!(cosine_simd, cosine);
         } else {
             println!("neon test skipped");

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -3,7 +3,7 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::types::ScoreType;
 
 #[target_feature(enable = "sse")]
@@ -56,9 +56,7 @@ pub(crate) unsafe fn euclid_similarity_sse(
 }
 
 #[target_feature(enable = "sse")]
-pub(crate) unsafe fn cosine_preprocess_sse(
-    vector: &[VectorElementType],
-) -> Option<Vec<VectorElementType>> {
+pub(crate) unsafe fn cosine_preprocess_sse(vector: VectorType) -> VectorType {
     let n = vector.len();
     let m = n - (n % 16);
     let mut ptr: *const f32 = vector.as_ptr();
@@ -93,10 +91,10 @@ pub(crate) unsafe fn cosine_preprocess_sse(
         length += (*ptr.add(i)).powi(2);
     }
     if length < f32::EPSILON {
-        return None;
+        return vector;
     }
     length = length.sqrt();
-    Some(vector.iter().map(|x| x / length).collect())
+    vector.into_iter().map(|x| x / length).collect()
 }
 
 #[target_feature(enable = "sse")]
@@ -176,8 +174,8 @@ mod tests {
             let dot = dot_similarity(&v1, &v2);
             assert_eq!(dot_simd, dot);
 
-            let cosine_simd = unsafe { cosine_preprocess_sse(&v1) };
-            let cosine = cosine_preprocess(&v1);
+            let cosine_simd = unsafe { cosine_preprocess_sse(v1.clone()) };
+            let cosine = cosine_preprocess(v1);
             assert_eq!(cosine_simd, cosine);
         } else {
             println!("sse test skipped");

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -21,7 +21,7 @@ use validator::{Validate, ValidationErrors};
 use crate::common::utils;
 use crate::common::utils::MultiValue;
 use crate::data_types::text_index::TextIndexParams;
-use crate::data_types::vectors::{VectorElementType, VectorStruct};
+use crate::data_types::vectors::{VectorElementType, VectorStruct, VectorType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 
@@ -124,10 +124,7 @@ pub enum Distance {
 }
 
 impl Distance {
-    pub fn preprocess_vector(
-        &self,
-        vector: &[VectorElementType],
-    ) -> Option<Vec<VectorElementType>> {
+    pub fn preprocess_vector(&self, vector: VectorType) -> VectorType {
         match self {
             Distance::Cosine => CosineMetric::preprocess(vector),
             Distance::Euclid => EuclidMetric::preprocess(vector),

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -665,7 +665,7 @@ mod tests {
 
         {
             let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
-                &query,
+                query.clone(),
                 borrowed_id_tracker.deleted_point_bitslice(),
                 borrowed_storage.deleted_vector_bitslice(),
                 &stopped,
@@ -690,7 +690,7 @@ mod tests {
         borrowed_storage.load_quantization(dir.path()).unwrap();
 
         let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
-            &query,
+            query.clone(),
             borrowed_id_tracker.deleted_point_bitslice(),
             borrowed_storage.deleted_vector_bitslice(),
             &stopped,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::file_operations::{atomic_save_json, read_json};
 use crate::common::vector_utils::TrySetCapacityExact;
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::entry::entry_point::OperationResult;
 use crate::types::{
     BinaryQuantization, BinaryQuantizationConfig, CompressionRatio, Distance, ProductQuantization,
@@ -50,15 +50,12 @@ pub struct QuantizedVectors {
 impl QuantizedVectors {
     pub fn raw_scorer<'a>(
         &'a self,
-        query: &[VectorElementType],
+        query: VectorType,
         point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
         is_stopped: &'a AtomicBool,
     ) -> Box<dyn RawScorer + 'a> {
-        let query = self
-            .distance
-            .preprocess_vector(query)
-            .unwrap_or_else(|| query.to_vec());
+        let query = self.distance.preprocess_vector(query);
         match &self.storage_impl {
             QuantizedVectorStorage::ScalarRam(storage) => {
                 let encoded_query = storage.encode_query(&query);

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::spaces::metric::Metric;
 use crate::types::{PointOffsetType, ScoreType};
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -15,9 +15,9 @@ pub struct MetricQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage>
 impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     MetricQueryScorer<'a, TMetric, TVectorStorage>
 {
-    pub fn new(query: Vec<VectorElementType>, vector_storage: &'a TVectorStorage) -> Self {
+    pub fn new(query: VectorType, vector_storage: &'a TVectorStorage) -> Self {
         Self {
-            query: TMetric::preprocess(&query).unwrap_or(query),
+            query: TMetric::preprocess(query),
             vector_storage,
             metric: PhantomData,
         }

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -300,7 +300,7 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     {
         let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
-            &query,
+            query.clone(),
             borrowed_id_tracker.deleted_point_bitslice(),
             borrowed_storage.deleted_vector_bitslice(),
             &stopped,
@@ -327,7 +327,7 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     assert_eq!(files, borrowed_storage.files());
 
     let scorer_quant = borrowed_storage.quantized_storage().unwrap().raw_scorer(
-        &query,
+        query.clone(),
         borrowed_id_tracker.deleted_point_bitslice(),
         borrowed_storage.deleted_vector_bitslice(),
         &stopped,


### PR DESCRIPTION
Current behavior is that `Metric::preprocess` has a signature of 
```rust
fn preprocess(vector: &[VectorElementType]) -> Option<Vec<VectorElementType>> 
```
which means that it takes a slice, and (if needed) makes a copy and preprocesses it, returning a `Vec<_>` in the end. This behavior causes the cloning to be implicit within the function, allowing a possible optimization for when there is nothing to preprocess (e.g. when it outputs `None`).
In practice, however, since the function returns an optional `Vec<_>` instead of a slice, we always have to convert the input slice to a `Vec<_>` even if the preprocessing returned `None` to be able to use it further. 

This PR changes the signature to 
```rust
fn preprocess(vector: VectorType) -> VectorType
```

This forces us to do explicit cloning when we need to do it and simplifies usage. The optimization provided by the `Option` is still present without it because in case there is no preprocessing, then ownership of the vector is transferred back to the caller without any extra work/allocation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
