### PR TITLE
Put `rstack-self` dependency behind linux flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ console-subscriber = { version = "0.1", default-features = false, features = ["p
 tracing-tracy = { version = "0.10.3", features = ["ondemand"], optional = true }
 
 # Backtrace
+[target.'cfg(target_os = "linux")'.dependencies]
 rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/src/common/stacktrace.rs
+++ b/src/common/stacktrace.rs
@@ -42,12 +42,12 @@ pub struct StackTrace {
 }
 
 pub fn get_stack_trace() -> StackTrace {
-    #[cfg(not(feature = "stacktrace"))]
+    #[cfg(not(all(target_os = "linux", feature = "stacktrace")))]
     {
         StackTrace { threads: vec![] }
     }
 
-    #[cfg(feature = "stacktrace")]
+    #[cfg(all(target_os = "linux", feature = "stacktrace"))]
     {
         let exe = std::env::current_exe().unwrap();
         let trace =

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() -> anyhow::Result<()> {
 
     // Run backtrace collector, expected to used by `rstack` crate
     if args.stacktrace {
-        #[cfg(feature = "stacktrace")]
+        #[cfg(all(target_os = "linux", feature = "stacktrace"))]
         {
             let _ = rstack_self::child();
         }


### PR DESCRIPTION
Non-linux users cannot run `cargo clippy --all-features` because `rstack-self` depends on either `libunwind` or `libdw`. Both backends are exclusively for linux, it appears, so it makes sense to also feature flag it like this.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

