### PR TITLE
Add generated OpenAPI definitions to .gitignore

### DIFF
--- a/openapi/.gitignore
+++ b/openapi/.gitignore
@@ -1,12 +1,7 @@
 /schemas/AllDefinitions.json
 /models.yaml
 /models.json
-/openapi-collections.yaml
-/openapi-snapshots.yaml
-/openapi-main.yaml
-/openapi-merged.yaml
 /openapi-merged.json
-/openapi-points.yaml
-/openapi-cluster.yaml
-/openapi-service.yaml
+/openapi-*.yaml
+!/openapi-*.ytt.yaml
 __pycache__/


### PR DESCRIPTION
We missed generating the OpenAPI definition for shard snapshots based on our template:

```bash
$ ./tools/generate_openapi_models.sh
```