### PR TITLE
Shutdown on conflicting interface ports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod consensus;
 mod greeting;
 mod migrations;
+mod ports;
 mod settings;
 mod snapshots;
 mod startup;
@@ -41,6 +42,7 @@ use crate::common::telemetry::TelemetryCollector;
 use crate::common::telemetry_reporting::TelemetryReporter;
 use crate::greeting::welcome;
 use crate::migrations::single_to_cluster::handle_existing_collections;
+use crate::ports::validate_port_available;
 use crate::settings::Settings;
 use crate::snapshots::{recover_full_snapshot, recover_snapshots};
 use crate::startup::{remove_started_file_indicator, touch_started_file_indicator};
@@ -376,6 +378,7 @@ fn main() -> anyhow::Result<()> {
     {
         let dispatcher_arc = dispatcher_arc.clone();
         let settings = settings.clone();
+        validate_port_available(settings.service.http_port, "REST")?;
         let handle = thread::Builder::new()
             .name("web".to_string())
             .spawn(move || {
@@ -394,6 +397,7 @@ fn main() -> anyhow::Result<()> {
 
     if let Some(grpc_port) = settings.service.grpc_port {
         let settings = settings.clone();
+        validate_port_available(grpc_port, "gRPC")?;
         let handle = thread::Builder::new()
             .name("grpc".to_string())
             .spawn(move || {

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1,0 +1,19 @@
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
+
+fn check_port_available(port: u16) -> bool {
+    let ipv4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
+    TcpListener::bind(ipv4).is_ok()
+}
+
+pub fn validate_port_available(port: u16, server_name: &str) -> anyhow::Result<()> {
+    if check_port_available(port) {
+        Ok(())
+    } else {
+        let message = format!(
+            "Could not start {} server because the port {} is already in use",
+            server_name, port
+        );
+        log::error!("{}", message);
+        Err(anyhow::anyhow!(message))
+    }
+}


### PR DESCRIPTION
This PR is done in the context of https://github.com/qdrant/qdrant/issues/2610 but does not solve the issue yet.

Currently the server boots up successfully even if the HTTP or/and gRPC ports are already used.

The only hint for the operator is a single log line and it is even more confusing if one of the port is correct.

With this PR, the server simply refuses to start if it detects any port conflicts.

Given that the servers gets started in different threads, it is pretty difficult to catch the error without waiting.

The proposed solution is to check the port just before starting the respective servers.

e.g.

```
2023-09-07T13:56:48.078936Z  INFO storage::content_manager::consensus::persistent: Loading raft state from ./storage/raft_state.json    
2023-09-07T13:56:48.079517Z DEBUG storage::content_manager::consensus::persistent: State: Persistent { state: RaftState { hard_state: HardState { term: 0, vote: 0, commit: 0 }, conf_state: ConfState { voters: [4189242522808721], learners: [], voters_outgoing: [], learners_next: [], auto_leave: false } }, latest_snapshot_meta: SnapshotMetadataSer { term: 0, index: 0 }, apply_progress_queue: EntryApplyProgressQueue(None), peer_address_by_id: RwLock { data: {} }, this_peer_id: 4189242522808721, path: "./storage/raft_state.json", dirty: false }    
2023-09-07T13:56:48.085531Z  INFO qdrant: Distributed mode disabled    
2023-09-07T13:56:48.085631Z  INFO qdrant: Telemetry reporting disabled    
2023-09-07T13:56:48.085706Z ERROR qdrant::ports: Could not start REST server because the port 8000 is already in use    
Error: Could not start REST server because the port 8000 is already in use
agourlay@agourlay-thinkpad:~/Workspace/qdrant$ echo $?
1

``` 