### PR TITLE
Fix flaky snapshot creation test

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -17,7 +17,7 @@ use segment::types::{
 };
 use semver::Version;
 use tar::Builder as TarBuilder;
-use tokio::fs::{copy, create_dir_all, remove_dir_all, remove_file, rename};
+use tokio::fs::{copy, create_dir_all, remove_file, rename};
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 use validator::Validate;
@@ -1598,13 +1598,6 @@ impl Collection {
             Ok::<_, CollectionError>(())
         });
         archiving.await??;
-
-        // Remove temporary snapshot directory (automatically dropped on previous error)
-        log::debug!(
-            "Removing temporary snapshot data {:?}",
-            snapshot_temp_dir_path
-        );
-        remove_dir_all(&snapshot_temp_dir_path).await?;
 
         // Move snapshot to permanent location.
         // We can't move right away, because snapshot folder can be on another mounting point.


### PR DESCRIPTION
This PR attempts to fix https://github.com/qdrant/qdrant/issues/2574

After a lot of trial and error running `test_snapshot_collection` on CI, I finally found something that appears to fix the test for good.

It seems that deleting manually a temporary file from its path, instead of relying on `drop` causes mysterious issues.

The test does two passes, the assumption is that the first pass interferes with the second

```rust
async fn test_snapshot_collection() {
    init_logger();
    _test_snapshot_collection(NodeType::Normal).await;
    _test_snapshot_collection(NodeType::Listener).await;
}
```

Given that this removal is not strictly required, we can safely remove it.

