### PR TITLE
Search rescoring modes

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2149,7 +2149,7 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | ignore | [bool](#bool) | optional | If set to true, search will ignore quantized vector data |
-| rescore | [bool](#bool) | optional | If true, use original vectors to re-score top-k results. Default is true. |
+| rescore | [bool](#bool) | optional | If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not. |
 | oversampling | [double](#double) | optional | Oversampling factor for quantization.
 
 Defines how many extra vectors should be pre-selected using quantized index, and then re-scored using original vectors.

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6191,9 +6191,7 @@
             "type": "boolean"
           },
           "rescore": {
-            "description": "If true, use original vectors to re-score top-k results. Might require more time in case if original vectors are stored on disk. Default is false.",
-            "default": false,
-            "type": "boolean"
+            "$ref": "#/components/schemas/Rescoring"
           },
           "oversampling": {
             "description": "Oversampling factor for quantization. Default is 1.0.\n\nDefines how many extra vectors should be pre-selected using quantized index, and then re-scored using original vectors.\n\nFor example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index, and then top-100 will be returned after re-scoring.",
@@ -6204,6 +6202,15 @@
             "nullable": true
           }
         }
+      },
+      "Rescoring": {
+        "description": "Rescoring modes. Used to re-score top-k results using original vectors.",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "auto"
+        ]
       },
       "ScoredPoint": {
         "description": "Search result",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6191,7 +6191,10 @@
             "type": "boolean"
           },
           "rescore": {
-            "$ref": "#/components/schemas/Rescoring"
+            "description": "If true, use original vectors to re-score top-k results. Might require more time in case if original vectors are stored on disk. If not set, qdrant decides automatically apply rescoring or not.",
+            "default": null,
+            "type": "boolean",
+            "nullable": true
           },
           "oversampling": {
             "description": "Oversampling factor for quantization. Default is 1.0.\n\nDefines how many extra vectors should be pre-selected using quantized index, and then re-scored using original vectors.\n\nFor example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index, and then top-100 will be returned after re-scoring.",
@@ -6202,15 +6205,6 @@
             "nullable": true
           }
         }
-      },
-      "Rescoring": {
-        "description": "Rescoring modes. Used to re-score top-k results using original vectors.",
-        "type": "string",
-        "enum": [
-          "enabled",
-          "disabled",
-          "auto"
-        ]
       },
       "ScoredPoint": {
         "description": "Search result",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use chrono::{NaiveDateTime, Timelike};
 use segment::data_types::text_index::TextIndexType;
 use segment::data_types::vectors::VectorElementType;
-use segment::types::{default_quantization_ignore_value, default_quantization_rescore_value};
+use segment::types::{default_quantization_ignore_value, Rescoring};
 use tonic::Status;
 use uuid::Uuid;
 
@@ -343,9 +343,11 @@ impl From<QuantizationSearchParams> for segment::types::QuantizationSearchParams
     fn from(params: QuantizationSearchParams) -> Self {
         Self {
             ignore: params.ignore.unwrap_or(default_quantization_ignore_value()),
-            rescore: params
-                .rescore
-                .unwrap_or(default_quantization_rescore_value()),
+            rescore: match params.rescore {
+                Some(true) => Rescoring::Enabled,
+                Some(false) => Rescoring::Disabled,
+                None => Rescoring::Auto,
+            },
             oversampling: params.oversampling,
         }
     }
@@ -355,7 +357,11 @@ impl From<segment::types::QuantizationSearchParams> for QuantizationSearchParams
     fn from(params: segment::types::QuantizationSearchParams) -> Self {
         Self {
             ignore: Some(params.ignore),
-            rescore: Some(params.rescore),
+            rescore: match params.rescore {
+                Rescoring::Enabled => Some(true),
+                Rescoring::Disabled => Some(false),
+                Rescoring::Auto => None,
+            },
             oversampling: params.oversampling,
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use chrono::{NaiveDateTime, Timelike};
 use segment::data_types::text_index::TextIndexType;
 use segment::data_types::vectors::VectorElementType;
-use segment::types::{default_quantization_ignore_value, Rescoring};
+use segment::types::default_quantization_ignore_value;
 use tonic::Status;
 use uuid::Uuid;
 
@@ -343,11 +343,7 @@ impl From<QuantizationSearchParams> for segment::types::QuantizationSearchParams
     fn from(params: QuantizationSearchParams) -> Self {
         Self {
             ignore: params.ignore.unwrap_or(default_quantization_ignore_value()),
-            rescore: match params.rescore {
-                Some(true) => Rescoring::Enabled,
-                Some(false) => Rescoring::Disabled,
-                None => Rescoring::Auto,
-            },
+            rescore: params.rescore,
             oversampling: params.oversampling,
         }
     }
@@ -357,11 +353,7 @@ impl From<segment::types::QuantizationSearchParams> for QuantizationSearchParams
     fn from(params: segment::types::QuantizationSearchParams) -> Self {
         Self {
             ignore: Some(params.ignore),
-            rescore: match params.rescore {
-                Rescoring::Enabled => Some(true),
-                Rescoring::Disabled => Some(false),
-                Rescoring::Auto => None,
-            },
+            rescore: params.rescore,
             oversampling: params.oversampling,
         }
     }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -186,7 +186,7 @@ message QuantizationSearchParams {
   optional bool ignore = 1;
 
   /*
-  If true, use original vectors to re-score top-k results. Default is true.
+  If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
    */
   optional bool rescore = 2;
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3019,7 +3019,7 @@ pub struct QuantizationSearchParams {
     #[prost(bool, optional, tag = "1")]
     pub ignore: ::core::option::Option<bool>,
     ///
-    /// If true, use original vectors to re-score top-k results. Default is true.
+    /// If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
     #[prost(bool, optional, tag = "2")]
     pub rescore: ::core::option::Option<bool>,
     ///

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -243,9 +243,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     is_stopped,
                 );
 
-                let do_oversampling = quantization_params.rescore.unwrap_or_else(|| {
-                    quantized_storage.default_rescoring()
-                });
+                let do_oversampling = quantization_params
+                    .rescore
+                    .unwrap_or_else(|| quantized_storage.default_rescoring());
 
                 (scorer, do_oversampling)
             }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -243,11 +243,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                     is_stopped,
                 );
 
-                let do_oversampling = match quantization_params.rescore {
-                    Some(true) => true,
-                    Some(false) => false,
-                    None => quantized_storage.default_rescoring(),
-                };
+                let do_oversampling = quantization_params.rescore.unwrap_or_else(|| {
+                    quantized_storage.default_rescoring()
+                });
 
                 (scorer, do_oversampling)
             }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -35,7 +35,7 @@ use crate::types::Condition::Field;
 use crate::types::PointOffsetType;
 use crate::types::{
     default_quantization_ignore_value, FieldCondition, Filter, HnswConfig,
-    QuantizationSearchParams, Rescoring, SearchParams, VECTOR_ELEMENT_SIZE,
+    QuantizationSearchParams, SearchParams, VECTOR_ELEMENT_SIZE,
 };
 use crate::vector_storage::{
     new_raw_scorer, new_stoppable_raw_scorer, ScoredPointOffset, VectorStorage, VectorStorageEnum,
@@ -244,9 +244,9 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 );
 
                 let do_oversampling = match quantization_params.rescore {
-                    Rescoring::Enabled => true,
-                    Rescoring::Disabled => false,
-                    Rescoring::Auto => quantized_storage.default_rescoring(),
+                    Some(true) => true,
+                    Some(false) => false,
+                    None => quantized_storage.default_rescoring(),
                 };
 
                 (scorer, do_oversampling)
@@ -438,7 +438,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                         let mut params = *params;
                         params.quantization = Some(QuantizationSearchParams {
                             ignore: true,
-                            rescore: Rescoring::Disabled,
+                            rescore: Some(false),
                             oversampling: None,
                         }); // disable quantization for exact search
                         params

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -274,16 +274,6 @@ pub struct SegmentInfo {
     pub vector_data: HashMap<String, VectorDataInfo>,
 }
 
-/// Rescoring modes. Used to re-score top-k results using original vectors.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum Rescoring {
-    Enabled,
-    Disabled,
-    #[default]
-    Auto,
-}
-
 /// Additional parameters of the search
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, Copy, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -292,13 +282,11 @@ pub struct QuantizationSearchParams {
     #[serde(default = "default_quantization_ignore_value")]
     pub ignore: bool,
 
-    /// Re-score mode top-k results.
-    /// If enabled, all results will be re-scored using original vectors.
+    /// If true, use original vectors to re-score top-k results.
     /// Might require more time in case if original vectors are stored on disk.
-    /// Default mode is Auto. Qdrant decided automatically if re-scoring is required.
-    #[serde(deserialize_with = "deserialize_rescore")]
+    /// If not set, qdrant decides automatically apply rescoring or not.
     #[serde(default)]
-    pub rescore: Rescoring,
+    pub rescore: Option<bool>,
 
     /// Oversampling factor for quantization. Default is 1.0.
     ///
@@ -318,26 +306,6 @@ pub const fn default_quantization_ignore_value() -> bool {
 
 pub const fn default_quantization_oversampling_value() -> Option<f64> {
     None
-}
-
-fn deserialize_rescore<'de, D>(deserializer: D) -> Result<Rescoring, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    Ok(match serde::de::Deserialize::deserialize(deserializer)? {
-        // backward compatibility, bool was used before
-        Value::Bool(b) => {
-            if b {
-                Rescoring::Enabled
-            } else {
-                Rescoring::Disabled
-            }
-        }
-        Value::String(s) if s == "enabled" => Rescoring::Enabled,
-        Value::String(s) if s == "disabled" => Rescoring::Disabled,
-        Value::String(s) if s == "auto" => Rescoring::Auto,
-        _ => return Err(serde::de::Error::custom("invalid rescoring type")),
-    })
 }
 
 /// Additional parameters of the search
@@ -2478,55 +2446,6 @@ mod tests {
         assert!(merged.must.as_ref().unwrap().contains(&condition1));
         assert!(merged.must.as_ref().unwrap().contains(&condition2));
         assert!(merged.should.as_ref().unwrap().contains(&condition1));
-    }
-
-    #[test]
-    fn test_parse_quantization_rescoring() {
-        let query = r#"
-        {
-            "rescore": true
-        }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Enabled);
-
-        let query = r#"
-        {
-            "rescore": false
-        }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Disabled);
-
-        let query = r#"
-        { }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Auto);
-
-        let query = r#"
-        {
-            "rescore": "enabled"
-        }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Enabled);
-
-        let query = r#"
-        {
-            "rescore": "disabled"
-        }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Disabled);
-
-        let query = r#"
-        {
-            "rescore": "auto"
-        }
-        "#;
-        let params: QuantizationSearchParams = serde_json::from_str(query).unwrap();
-        assert_eq!(params.rescore, Rescoring::Auto);
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -48,6 +48,13 @@ pub struct QuantizedVectors {
 }
 
 impl QuantizedVectors {
+    pub fn default_rescoring(&self) -> bool {
+        matches!(
+            self.storage_impl,
+            QuantizedVectorStorage::BinaryRam(_) | QuantizedVectorStorage::BinaryMmap(_)
+        )
+    }
+
     pub fn raw_scorer<'a>(
         &'a self,
         query: &QueryVector,

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -134,7 +134,7 @@ fn hnsw_quantized_search_test(
             Some(&SearchParams {
                 hnsw_ef: Some(ef_oversamling),
                 quantization: Some(QuantizationSearchParams {
-                    rescore: true,
+                    rescore: segment::types::Rescoring::Enabled,
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -152,7 +152,7 @@ fn hnsw_quantized_search_test(
                 hnsw_ef: Some(ef_oversamling),
                 quantization: Some(QuantizationSearchParams {
                     oversampling: Some(4.0),
-                    rescore: true,
+                    rescore: segment::types::Rescoring::Enabled,
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -134,7 +134,7 @@ fn hnsw_quantized_search_test(
             Some(&SearchParams {
                 hnsw_ef: Some(ef_oversamling),
                 quantization: Some(QuantizationSearchParams {
-                    rescore: segment::types::Rescoring::Enabled,
+                    rescore: Some(true),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -152,7 +152,7 @@ fn hnsw_quantized_search_test(
                 hnsw_ef: Some(ef_oversamling),
                 quantization: Some(QuantizationSearchParams {
                     oversampling: Some(4.0),
-                    rescore: segment::types::Rescoring::Enabled,
+                    rescore: Some(true),
                     ..Default::default()
                 }),
                 ..Default::default()


### PR DESCRIPTION
Issue https://github.com/qdrant/qdrant/issues/2624

For binary quantization, we want to rescore search results by default. Because without rescoring plain search result will be missed, the reason is in large difference between original and quantized scores.
On the other hand, we want to disable rescoring by default. Because of performance reasons.

As a possible solution, this PR introduces an `Auto` rescoring mode which enables rescoring for binary quantization and disables for another kind.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
