### PR TITLE
Fix capture stdout for consensus tests to build archive

### DIFF
--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -90,7 +90,7 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, ext
     this_peer_consensus_uri = get_uri(p2p_port)
     processes.append(
         Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri, "--uri", this_peer_consensus_uri], env=env,
-              cwd=peer_dir, stderr=log_file))
+              cwd=peer_dir, stderr=log_file, stdout=log_file))
     return get_uri(http_port)
 
 


### PR DESCRIPTION
The change to our logging infrastructure to output all logs on `stdout` made the logs available in the Github action UI for consensus tests.

The flip side is that we are now uploading empty log archives to Github in case of failure.

The two approach seem incompatible.

This PR proposes to restore the previous behavior by capture stdout in the test runs.

We need to decide what solution we prefer (and potentially remove the other one).