### PR TITLE
Always run our Docker build CI job on our self hosted runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,9 +10,8 @@ on:
 jobs:
 
   build:
-
-    runs-on: ubuntu-latest
-
+    # Run build on our self-hosted runner, we had trouble with shared runners
+    runs-on: [self-hosted, linux, x64]
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -43,13 +42,13 @@ jobs:
         docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
         docker tag $DOCKERHUB_TAG $GITHUB_TAG
         docker push $GITHUB_TAG
-        
+
         DOCKERHUB_TAG_UNPRIVILEGED="qdrant/qdrant:${{ github.ref_name }}-unprivileged"
         TAGS_UNPRIVILEGED="-t ${DOCKERHUB_TAG_UNPRIVILEGED}"
         DOCKERHUB_TAG_LATEST_UNPRIVILEGED="qdrant/qdrant:latest-unprivileged"
         TAGS_UNPRIVILEGED="${TAGS_UNPRIVILEGED} -t ${DOCKERHUB_TAG_LATEST_UNPRIVILEGED}"
         GITHUB_TAG_UNPRIVILEGED="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}-unprivileged"
-      
+
         docker buildx build --build-arg='USER_ID=1000' --platform='linux/amd64,linux/arm64' $TAGS_UNPRIVILEGED --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
         docker tag $DOCKERHUB_TAG_UNPRIVILEGED $GITHUB_TAG_UNPRIVILEGED
         docker push $GITHUB_TAG_UNPRIVILEGED


### PR DESCRIPTION
Run our Docker release job on our self-hosted GitHub Actions runner.

We want to change this before our next patch release, as we had trouble with this specific job before when it is executed on shared runners.

These tags match those from our runner:
![image](https://github.com/qdrant/qdrant/assets/856222/cd66cbd7-7472-4d7b-8dd3-7afc84d93bbb)
