### PR TITLE
Bump version to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "api"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "common",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=c981d2c063ea1af7f9277b1988913540552e9ffd
+IGNORE_UPTO=547e602ee16e039012a328b8cd9fa0f4cef975c0
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
A patch release bumping Qdrant to v1.5.1.

Most importantly, this fixes <https://github.com/qdrant/qdrant/pull/2641>.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?