### PR TITLE
refactor: use generic `Batch<TRequest>` for batch requests

### DIFF
--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
-use collection::operations::types::{SearchRequest, SearchRequestBatch, VectorParams};
+use collection::operations::types::{Batch, SearchRequest, VectorParams};
 use collection::operations::CollectionUpdateOperations;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::local_shard::LocalShard;
@@ -146,7 +146,7 @@ fn batch_search_bench(c: &mut Criterion) {
                         };
                         let result = shard
                             .search(
-                                Arc::new(SearchRequestBatch {
+                                Arc::new(Batch {
                                     searches: vec![search_query],
                                 }),
                                 search_runtime_handle,
@@ -179,7 +179,7 @@ fn batch_search_bench(c: &mut Criterion) {
                         searches.push(search_query);
                     }
 
-                    let search_query = SearchRequestBatch { searches };
+                    let search_query = Batch { searches };
                     let result = shard
                         .search(Arc::new(search_query), search_runtime_handle)
                         .await

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -37,9 +37,9 @@ use crate::operations::snapshot_ops::{
     get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
 };
 use crate::operations::types::{
-    CollectionClusterInfo, CollectionError, CollectionInfo, CollectionResult, CountRequest,
+    Batch, CollectionClusterInfo, CollectionError, CollectionInfo, CollectionResult, CountRequest,
     CountResult, LocalShardInfo, NodeType, PointRequest, Record, RemoteShardInfo, ScrollRequest,
-    ScrollResult, SearchRequest, SearchRequestBatch, UpdateResult, VectorsConfigDiff,
+    ScrollResult, SearchRequest, UpdateResult, VectorsConfigDiff,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::OptimizersConfig;
@@ -821,7 +821,7 @@ impl Collection {
 
     pub async fn search_batch(
         &self,
-        request: SearchRequestBatch,
+        request: Batch<SearchRequest>,
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
@@ -871,7 +871,7 @@ impl Collection {
                 without_payload_request.with_vector = None;
                 without_payload_requests.push(without_payload_request);
             }
-            let without_payload_batch = SearchRequestBatch {
+            let without_payload_batch = Batch {
                 searches: without_payload_requests,
             };
             let without_payload_results = self
@@ -900,7 +900,7 @@ impl Collection {
 
     pub async fn _search_batch(
         &self,
-        request: SearchRequestBatch,
+        request: Batch<SearchRequest>,
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
@@ -923,7 +923,7 @@ impl Collection {
     async fn merge_from_shards(
         &self,
         mut all_searches_res: Vec<Vec<Vec<ScoredPoint>>>,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         shard_selection: Option<u32>,
     ) -> Result<Vec<Vec<ScoredPoint>>, CollectionError> {
         let batch_size = request.searches.len();
@@ -1028,7 +1028,7 @@ impl Collection {
             return Ok(vec![]);
         }
         // search is a special case of search_batch with a single batch
-        let request_batch = SearchRequestBatch {
+        let request_batch = Batch {
             searches: vec![request],
         };
         let results = self

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -22,7 +22,7 @@ use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentH
 use crate::collection_manager::probabilistic_segment_search_sampling::find_search_sampling_over_point_distribution;
 use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
 use crate::operations::types::{
-    CollectionError, CollectionResult, CoreSearchRequestBatch, QueryEnum, Record,
+    Batch, CollectionError, CollectionResult, CoreSearchRequest, QueryEnum, Record,
 };
 
 type BatchOffset = usize;
@@ -151,7 +151,7 @@ impl SegmentsSearcher {
 
     pub async fn search(
         segments: &RwLock<SegmentHolder>,
-        batch_request: Arc<CoreSearchRequestBatch>,
+        batch_request: Arc<Batch<CoreSearchRequest>>,
         runtime_handle: &Handle,
         sampling_enabled: bool,
         is_stopped: Arc<AtomicBool>,
@@ -230,7 +230,7 @@ impl SegmentsSearcher {
                 let mut res = vec![];
                 for (segment_id, batch_ids) in searches_to_rerun.iter() {
                     let segment = locked_segments[*segment_id].clone();
-                    let partial_batch_request = Arc::new(CoreSearchRequestBatch {
+                    let partial_batch_request = Arc::new(Batch {
                         searches: batch_ids
                             .iter()
                             .map(|batch_id| batch_request.searches[*batch_id].clone())
@@ -396,7 +396,7 @@ fn effective_limit(limit: usize, ef_limit: usize, poisson_sampling: usize) -> us
 /// * Vector of boolean indicating if the segment have further points to search
 fn search_in_segment(
     segment: LockedSegment,
-    request: Arc<CoreSearchRequestBatch>,
+    request: Arc<Batch<CoreSearchRequest>>,
     total_points: usize,
     use_sampling: bool,
     is_stopped: &AtomicBool,
@@ -652,7 +652,7 @@ mod tests {
             offset: 0,
         };
 
-        let batch_request = CoreSearchRequestBatch {
+        let batch_request = Batch {
             searches: vec![req],
         };
 
@@ -716,7 +716,7 @@ mod tests {
                 score_threshold: None,
             };
 
-            let batch_request = CoreSearchRequestBatch {
+            let batch_request = Batch {
                 searches: vec![req1.into(), req2.into()],
             };
 

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -12,8 +12,8 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::types::{
-    CollectionError, CollectionResult, PointRequest, RecommendRequest, RecommendRequestBatch,
-    Record, SearchRequest, SearchRequestBatch, UsingVector,
+    Batch, CollectionError, CollectionResult, PointRequest, RecommendRequest, Record,
+    SearchRequest, UsingVector,
 };
 
 fn avg_vectors<'a>(
@@ -53,7 +53,7 @@ where
         return Ok(vec![]);
     }
     // `recommend_by` is a special case of recommend_by_batch with a single batch
-    let request_batch = RecommendRequestBatch {
+    let request_batch = Batch {
         searches: vec![request],
     };
     let results = recommend_batch_by(
@@ -136,7 +136,7 @@ fn get_search_vector_name(request: &RecommendRequest) -> String {
 /// * `collection_by_name` - function to retrieve collection by name, used to retrieve points from other collections
 ///
 pub async fn recommend_batch_by<'a, F, Fut>(
-    request_batch: RecommendRequestBatch,
+    request_batch: Batch<RecommendRequest>,
     collection: &Collection,
     collection_by_name: F,
     read_consistency: Option<ReadConsistency>,
@@ -306,7 +306,7 @@ where
         searches.push(search_request)
     }
 
-    let search_batch_request = SearchRequestBatch { searches };
+    let search_batch_request = Batch { searches };
 
     collection
         .search_batch(search_batch_request, read_consistency, None)

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -8,8 +8,8 @@ use segment::types::{
 use tokio::runtime::Handle;
 
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
-    Record, SearchRequestBatch, UpdateResult,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult,
+    PointRequest, Record, SearchRequest, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::shard_trait::ShardOperation;
@@ -82,7 +82,7 @@ impl ShardOperation for DummyShard {
 
     async fn search(
         &self,
-        _: Arc<SearchRequestBatch>,
+        _: Arc<Batch<SearchRequest>>,
         _: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.dummy()

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -11,8 +11,8 @@ use tokio::sync::Mutex;
 
 use crate::operations::point_ops::{PointOperations, PointStruct, PointSyncOperation};
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
-    Record, SearchRequestBatch, UpdateResult,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult,
+    PointRequest, Record, SearchRequest, UpdateResult,
 };
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::shards::local_shard::LocalShard;
@@ -192,7 +192,7 @@ impl ShardOperation for ForwardProxyShard {
 
     async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -12,8 +12,8 @@ use tokio::sync::oneshot;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
-    CountResult, PointRequest, Record, SearchRequestBatch, UpdateResult, UpdateStatus,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CoreSearchRequest, CountRequest,
+    CountResult, PointRequest, Record, SearchRequest, UpdateResult, UpdateStatus,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
@@ -118,7 +118,7 @@ impl ShardOperation for LocalShard {
 
     async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let (collection_params, indexing_threshold_kb) = {
@@ -132,7 +132,7 @@ impl ShardOperation for LocalShard {
             )
         };
 
-        let core_request = Arc::new(CoreSearchRequestBatch::from(request.as_ref().clone()));
+        let core_request: Arc<Batch<CoreSearchRequest>> = Arc::new(request.as_ref().clone().into());
 
         // check vector names existing
         for req in &core_request.searches {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -17,8 +17,8 @@ use crate::operations::operation_effect::{
     EstimateOperationEffectArea, OperationEffectArea, PointsOperationEffect,
 };
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
-    Record, SearchRequestBatch, UpdateResult,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult,
+    PointRequest, Record, SearchRequest, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::LocalShard;
@@ -199,7 +199,7 @@ impl ShardOperation for ProxyShard {
     /// Forward read-only `search` to `wrapped_shard`
     async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -12,8 +12,8 @@ use tokio::sync::Mutex;
 use super::remote_shard::RemoteShard;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{
-    CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
-    SearchRequestBatch, UpdateResult,
+    Batch, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
+    SearchRequest, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::LocalShard;
@@ -206,7 +206,7 @@ impl ShardOperation for QueueProxyShard {
     /// Forward read-only `search` to `wrapped_shard`
     async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let local_shard = &self.wrapped_shard;

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -28,8 +28,8 @@ use crate::operations::conversions::try_record_from_grpc;
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{PointOperations, WriteOrdering};
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
-    Record, SearchRequest, SearchRequestBatch, UpdateResult,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult,
+    PointRequest, Record, SearchRequest, UpdateResult,
 };
 use crate::operations::vector_ops::VectorOperations;
 use crate::operations::{CollectionUpdateOperations, FieldIndexOperations};
@@ -480,7 +480,7 @@ impl ShardOperation for RemoteShard {
 
     async fn search(
         &self,
-        batch_request: Arc<SearchRequestBatch>,
+        batch_request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -31,8 +31,8 @@ use crate::operations::consistency_params::{ReadConsistency, ReadConsistencyType
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest,
-    Record, SearchRequestBatch, UpdateResult,
+    Batch, CollectionError, CollectionInfo, CollectionResult, CountRequest, CountResult,
+    PointRequest, Record, SearchRequest, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::save_on_disk::SaveOnDisk;
@@ -1740,7 +1740,7 @@ impl ShardReplicaSet {
 
     pub async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         read_consistency: Option<ReadConsistency>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.execute_and_resolve_read_operation(

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -7,8 +7,8 @@ use segment::types::{
 use tokio::runtime::Handle;
 
 use crate::operations::types::{
-    CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
-    SearchRequestBatch, UpdateResult,
+    Batch, CollectionInfo, CollectionResult, CountRequest, CountResult, PointRequest, Record,
+    SearchRequest, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 
@@ -35,7 +35,7 @@ pub trait ShardOperation {
 
     async fn search(
         &self,
-        request: Arc<SearchRequestBatch>,
+        request: Arc<Batch<SearchRequest>>,
         search_runtime_handle: &Handle,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>>;
 

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -19,9 +19,9 @@ use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::point_ops::WriteOrdering;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
-    AliasDescription, CollectionResult, CountRequest, CountResult, GroupsResult, PointRequest,
-    RecommendRequest, RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchRequest,
-    SearchRequestBatch, UpdateResult, VectorsConfig,
+    AliasDescription, Batch, CollectionResult, CountRequest, CountResult, GroupsResult,
+    PointRequest, RecommendRequest, Record, ScrollRequest, ScrollResult, SearchRequest,
+    UpdateResult, VectorsConfig,
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::{recommend_batch_by, recommend_by};
@@ -1131,7 +1131,7 @@ impl TableOfContent {
     /// # Arguments
     ///
     /// * `collection_name` - for what collection do we recommend
-    /// * `request` - [`RecommendRequestBatch`]
+    /// * `request` - [`Batch<RecommendRequest>`]
     ///
     /// # Result
     ///
@@ -1139,7 +1139,7 @@ impl TableOfContent {
     pub async fn recommend_batch(
         &self,
         collection_name: &str,
-        request: RecommendRequestBatch,
+        request: Batch<RecommendRequest>,
         read_consistency: Option<ReadConsistency>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
@@ -1184,7 +1184,7 @@ impl TableOfContent {
     /// # Arguments
     ///
     /// * `collection_name` - in what collection do we search
-    /// * `request` - [`SearchRequestBatch`]
+    /// * `request` - [`Batch<SearchRequest>`]
     /// * `shard_selection` - which local shard to use
     /// # Result
     ///
@@ -1192,7 +1192,7 @@ impl TableOfContent {
     pub async fn search_batch(
         &self,
         collection_name: &str,
-        request: SearchRequestBatch,
+        request: Batch<SearchRequest>,
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -2,9 +2,7 @@ use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::consistency_params::ReadConsistency;
-use collection::operations::types::{
-    RecommendGroupsRequest, RecommendRequest, RecommendRequestBatch,
-};
+use collection::operations::types::{Batch, RecommendGroupsRequest, RecommendRequest};
 use segment::types::ScoredPoint;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
@@ -46,7 +44,7 @@ async fn recommend_points(
 async fn do_recommend_batch_points(
     toc: &TableOfContent,
     collection_name: &str,
-    request: RecommendRequestBatch,
+    request: Batch<RecommendRequest>,
     read_consistency: Option<ReadConsistency>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.recommend_batch(collection_name, request, read_consistency)
@@ -57,7 +55,7 @@ async fn do_recommend_batch_points(
 async fn recommend_batch_points(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
-    request: Json<RecommendRequestBatch>,
+    request: Json<Batch<RecommendRequest>>,
     params: Query<ReadParams>,
 ) -> impl Responder {
     let timing = Instant::now();

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -1,7 +1,7 @@
 use actix_web::rt::time::Instant;
 use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
-use collection::operations::types::{SearchGroupsRequest, SearchRequest, SearchRequestBatch};
+use collection::operations::types::{Batch, SearchGroupsRequest, SearchRequest};
 use storage::content_manager::toc::TableOfContent;
 
 use super::read_params::ReadParams;
@@ -34,7 +34,7 @@ async fn search_points(
 async fn batch_search_points(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
-    request: Json<SearchRequestBatch>,
+    request: Json<Batch<SearchRequest>>,
     params: Query<ReadParams>,
 ) -> impl Responder {
     let timing = Instant::now();

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -4,9 +4,8 @@ use collection::operations::point_ops::{
     PointInsertOperations, PointOperations, PointsSelector, WriteOrdering,
 };
 use collection::operations::types::{
-    CountRequest, CountResult, GroupsResult, PointRequest, RecommendGroupsRequest, Record,
-    ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest, SearchRequestBatch,
-    UpdateResult,
+    Batch, CountRequest, CountResult, GroupsResult, PointRequest, RecommendGroupsRequest, Record,
+    ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest, UpdateResult,
 };
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors, VectorOperations};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
@@ -472,7 +471,7 @@ pub async fn do_search_points(
 pub async fn do_search_batch_points(
     toc: &TableOfContent,
     collection_name: &str,
-    request: SearchRequestBatch,
+    request: Batch<SearchRequest>,
     read_consistency: Option<ReadConsistency>,
     shard_selection: Option<ShardId>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -7,10 +7,10 @@ use collection::operations::snapshot_ops::{
     ShardSnapshotRecover, SnapshotDescription, SnapshotRecover,
 };
 use collection::operations::types::{
-    AliasDescription, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
+    AliasDescription, Batch, CollectionClusterInfo, CollectionInfo, CollectionsAliasesResponse,
     CountRequest, CountResult, GroupsResult, PointGroup, PointRequest, RecommendGroupsRequest,
-    RecommendRequest, RecommendRequestBatch, Record, ScrollRequest, ScrollResult,
-    SearchGroupsRequest, SearchRequest, SearchRequestBatch, UpdateResult,
+    RecommendRequest, Record, ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest,
+    UpdateResult,
 };
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::gen::SchemaSettings;
@@ -59,8 +59,8 @@ struct AllDefinitions {
     ap: CollectionClusterInfo,
     aq: TelemetryData,
     ar: ClusterOperations,
-    at: SearchRequestBatch,
-    au: RecommendRequestBatch,
+    at: Batch<SearchRequest>,
+    au: Batch<RecommendRequest>,
     av: LocksOption,
     aw: SnapshotRecover,
     ax: CollectionsAliasesResponse,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -19,8 +19,7 @@ use collection::operations::point_ops::{
     self, PointInsertOperations, PointOperations, PointSyncOperation,
 };
 use collection::operations::types::{
-    default_exact_count, PointRequest, RecommendRequestBatch, ScrollRequest, SearchRequest,
-    SearchRequestBatch,
+    default_exact_count, Batch, PointRequest, ScrollRequest, SearchRequest,
 };
 use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVectors};
 use collection::operations::CollectionUpdateOperations;
@@ -730,7 +729,7 @@ pub async fn search_batch(
         .map(|search_point| search_point.try_into())
         .collect();
 
-    let search_requests = SearchRequestBatch {
+    let search_requests = Batch {
         searches: searches?,
     };
 
@@ -867,7 +866,7 @@ pub async fn recommend_batch(
         .into_iter()
         .map(|recommend_point| recommend_point.try_into())
         .collect();
-    let recommend_batch = RecommendRequestBatch {
+    let recommend_batch = Batch {
         searches: searches?,
     };
 


### PR DESCRIPTION
Encapsulates the Batch request logic into a single generic struct. Main motivation is that I am going to add more of these batch structs in subsequent PRs, and would be nice to use less boilerplate for them.

## Changes
- Introduce `Batch<TRequest>`, which only has a `Vec<TRequest>`.
- `SearchRequestBatch` -> `Batch<SearchRequest>`
- `RecommendRequestBatch` -> `Batch<RecommendRequest>`
- openapi schema is untouched by using `#[serde(rename = "{TRequest}Batch")]`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
