### PR TITLE
Split flaky test for snasphot creation

### DIFF
--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -158,8 +158,13 @@ async fn _test_snapshot_collection(node_type: NodeType) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_snapshot_collection() {
+async fn test_snapshot_collection_normal() {
     init_logger();
     _test_snapshot_collection(NodeType::Normal).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_snapshot_collection_listener() {
+    init_logger();
     _test_snapshot_collection(NodeType::Listener).await;
 }


### PR DESCRIPTION
context: https://github.com/qdrant/qdrant/issues/2574

I have a suspicion that those two tests are somehow interfering with each other via the file system or the shared Tokio runtime.

This PR separate them into dedicate test entry points.