### PR TITLE
Fix docker release job

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,35 +22,34 @@ jobs:
       env:
         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
       run: |
+        # Create build container
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker buildx create --use
 
+        # Authenticate on registries
         docker login --username generall --password ${{ secrets.DOCKERHUB_TOKEN }}
+        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
 
+        # Build regular image for Docker Hub
         DOCKERHUB_TAG="qdrant/qdrant:${{ github.ref_name }}"
-        TAGS="-t ${DOCKERHUB_TAG}"
-
         DOCKERHUB_TAG_LATEST="qdrant/qdrant:latest"
-        TAGS="${TAGS} -t ${DOCKERHUB_TAG_LATEST}"
-
+        TAGS="-t ${DOCKERHUB_TAG} -t ${DOCKERHUB_TAG_LATEST}"
         GITHUB_TAG="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}"
 
+        # Pull, retag and push to GitHub packages
         docker buildx build --platform='linux/amd64,linux/arm64' $TAGS --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
-
         docker pull $DOCKERHUB_TAG
-
-        docker login https://docker.pkg.github.com -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
         docker tag $DOCKERHUB_TAG $GITHUB_TAG
         docker push $GITHUB_TAG
 
+        # Build unprivileged image for Docker Hub
         DOCKERHUB_TAG_UNPRIVILEGED="qdrant/qdrant:${{ github.ref_name }}-unprivileged"
-        TAGS_UNPRIVILEGED="-t ${DOCKERHUB_TAG_UNPRIVILEGED}"
         DOCKERHUB_TAG_LATEST_UNPRIVILEGED="qdrant/qdrant:latest-unprivileged"
-        TAGS_UNPRIVILEGED="${TAGS_UNPRIVILEGED} -t ${DOCKERHUB_TAG_LATEST_UNPRIVILEGED}"
+        TAGS_UNPRIVILEGED="-t ${DOCKERHUB_TAG_UNPRIVILEGED} -t ${DOCKERHUB_TAG_LATEST_UNPRIVILEGED}"
         GITHUB_TAG_UNPRIVILEGED="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}-unprivileged"
 
+        # Pull, retag and push to GitHub packages
         docker buildx build --build-arg='USER_ID=1000' --platform='linux/amd64,linux/arm64' $TAGS_UNPRIVILEGED --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
-
         docker pull $DOCKERHUB_TAG_UNPRIVILEGED
         docker tag $DOCKERHUB_TAG_UNPRIVILEGED $GITHUB_TAG_UNPRIVILEGED
         docker push $GITHUB_TAG_UNPRIVILEGED

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,5 +50,7 @@ jobs:
         GITHUB_TAG_UNPRIVILEGED="docker.pkg.github.com/qdrant/qdrant/qdrant:${{ github.ref_name }}-unprivileged"
 
         docker buildx build --build-arg='USER_ID=1000' --platform='linux/amd64,linux/arm64' $TAGS_UNPRIVILEGED --push --label "org.opencontainers.image.version"=$RELEASE_VERSION .
+
+        docker pull $DOCKERHUB_TAG_UNPRIVILEGED
         docker tag $DOCKERHUB_TAG_UNPRIVILEGED $GITHUB_TAG_UNPRIVILEGED
         docker push $GITHUB_TAG_UNPRIVILEGED


### PR DESCRIPTION
Our Docker release job on CI is broken. It fails near the end: https://github.com/qdrant/qdrant/actions/runs/6161250399/job/16730823202

A `pull` step was missing near the bottom. Therefore the `-unprivileged` image was never pushed to [GitHub packages](https://github.com/qdrant/qdrant/pkgs/container/qdrant%2Fqdrant). This command has now been added.

I've also restructured the job a bit to clarify what is happening. I found it super confusing before.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?