### PR TITLE
Extract shard snapshot logic from collection into shard holder

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -1575,7 +1575,7 @@ impl Collection {
         self.shards_holder
             .read()
             .await
-            .create_shard_snapshot(shard_id, temp_dir, &self.snapshots_path, &self.name())
+            .create_shard_snapshot(&self.snapshots_path, &self.name(), shard_id, temp_dir)
             .await
     }
 
@@ -1592,7 +1592,11 @@ impl Collection {
         shard_id: ShardId,
         snapshot_file_name: impl AsRef<Path>,
     ) -> CollectionResult<PathBuf> {
-        self.shards_holder.read().await.get_shard_snapshot_path(shard_id, &self.snapshots_path, snapshot_file_name).await
+        self.shards_holder
+            .read()
+            .await
+            .get_shard_snapshot_path(&self.snapshots_path, shard_id, snapshot_file_name)
+            .await
     }
 
     pub async fn restore_shard_snapshot(
@@ -1607,9 +1611,9 @@ impl Collection {
             .read()
             .await
             .restore_shard_snapshot(
-                shard_id,
                 snapshot_path,
                 &self.name(),
+                shard_id,
                 this_peer_id,
                 is_distributed,
                 temp_dir,

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -563,6 +563,16 @@ impl ShardHolder {
         }
         Ok(())
     }
+
+    pub async fn get_shard_snapshot_path(
+        &self,
+        shard_id: ShardId,
+        snapshots_path: &Path,
+        snapshot_file_name: impl AsRef<Path>,
+    ) -> CollectionResult<PathBuf> {
+        self.assert_shard_is_local(shard_id).await?;
+        self.shard_snapshot_path_unchecked(shard_id, snapshots_path, snapshot_file_name)
+    }
 }
 
 pub(crate) fn shard_not_found_error(shard_id: ShardId) -> CollectionError {


### PR DESCRIPTION
Tracking issue <https://github.com/qdrant/qdrant/issues/2432>.

The shard snapshot functions and the logic around it are currently placed in `Collection`. Instead, these should be placed into `ShardHolder`. This PR is a refactoring effort to move the functions.

Refactoring is desired because of the shard snapshot transfer feature (<https://github.com/qdrant/qdrant/issues/2432>). In the logic for transferring, we don't have access to `Collection`, but do have access to `ShardHolder` (<https://github.com/qdrant/qdrant/pull/2467>).

I've kept some shard snapshot functions as transient in `Collection`, because they still have some usages else where. They now forward the call to `ShardSnapshot`. Now, this is a bit messy. Maybe this is a good place to open some discussion on it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?