### PR TITLE
Expose new recommend scorer via recommend strategy

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -166,6 +166,7 @@
   
     - [FieldType](#qdrant-FieldType)
     - [ReadConsistencyType](#qdrant-ReadConsistencyType)
+    - [RecommendStrategy](#qdrant-RecommendStrategy)
     - [UpdateStatus](#qdrant-UpdateStatus)
     - [WriteOrderingType](#qdrant-WriteOrderingType)
   
@@ -2269,6 +2270,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | group_size | [uint32](#uint32) |  | Maximum amount of points to return per group |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
 | with_lookup | [WithLookup](#qdrant-WithLookup) | optional | Options for specifying how to use the group id to lookup points in another collection |
+| strategy | [RecommendStrategy](#qdrant-RecommendStrategy) | optional | How to use the example vectors to find the results |
 
 
 
@@ -2296,6 +2298,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) | optional | Options for specifying which vectors to include into response |
 | lookup_from | [LookupLocation](#qdrant-LookupLocation) | optional | Name of the collection to use for points lookup, if not specified - use current collection |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
+| strategy | [RecommendStrategy](#qdrant-RecommendStrategy) | optional | How to use the example vectors to find the results |
 
 
 
@@ -2867,6 +2870,18 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | All | 0 | Send request to all nodes and return points which are present on all of them |
 | Majority | 1 | Send requests to all nodes and return points which are present on majority of them |
 | Quorum | 2 | Send requests to half &#43; 1 nodes, return points which are present on all of them |
+
+
+
+<a name="qdrant-RecommendStrategy"></a>
+
+### RecommendStrategy
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| AverageVector | 0 |  |
+| TakeBestScore | 1 |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2876,12 +2876,12 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 <a name="qdrant-RecommendStrategy"></a>
 
 ### RecommendStrategy
-
+How to use positive and negative vectors to find the results, default is `AverageVector`:
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| AverageVector | 0 |  |
-| TakeBestScore | 1 |  |
+| AverageVector | 0 | Average positive and negative vectors and create a single query with the formula `query = avg_pos &#43; avg_pos - avg_neg`. Then performs normal search. |
+| BestScore | 1 | Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6282,12 +6282,12 @@
         "description": "Recommendation request. Provides positive and negative examples of the vectors, which are already stored in the collection.\n\nService should look for the points which are closer to positive examples and at the same time further to negative examples. The concrete way of how to compare negative and positive distances is up to implementation in `segment` crate.",
         "type": "object",
         "required": [
-          "limit",
-          "positive"
+          "limit"
         ],
         "properties": {
           "positive": {
             "description": "Look for vectors closest to those",
+            "default": [],
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExtendedPointId"
@@ -6300,6 +6300,9 @@
             "items": {
               "$ref": "#/components/schemas/ExtendedPointId"
             }
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/RecommendStrategy"
           },
           "filter": {
             "description": "Look only for points which satisfies this conditions",
@@ -6390,6 +6393,13 @@
             ]
           }
         }
+      },
+      "RecommendStrategy": {
+        "type": "string",
+        "enum": [
+          "average_vector",
+          "take_best_score"
+        ]
       },
       "UsingVector": {
         "anyOf": [
@@ -9079,12 +9089,12 @@
         "required": [
           "group_by",
           "group_size",
-          "limit",
-          "positive"
+          "limit"
         ],
         "properties": {
           "positive": {
             "description": "Look for vectors closest to those",
+            "default": [],
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExtendedPointId"
@@ -9097,6 +9107,9 @@
             "items": {
               "$ref": "#/components/schemas/ExtendedPointId"
             }
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/RecommendStrategy"
           },
           "filter": {
             "description": "Look only for points which satisfies this conditions",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6279,7 +6279,7 @@
         ]
       },
       "RecommendRequest": {
-        "description": "Recommendation request. Provides positive and negative examples of the vectors, which are already stored in the collection.\n\nService should look for the points which are closer to positive examples and at the same time further to negative examples. The concrete way of how to compare negative and positive distances is up to implementation in `segment` crate.",
+        "description": "Recommendation request. Provides positive and negative examples of the vectors, which are already stored in the collection.\n\nService should look for the points which are closer to positive examples and at the same time further to negative examples. The concrete way of how to compare negative and positive distances is up to the `strategy` chosen.",
         "type": "object",
         "required": [
           "limit"
@@ -6395,10 +6395,11 @@
         }
       },
       "RecommendStrategy": {
+        "description": "How to use positive and negative vectors to find the results, default is `AverageVector`: - `AverageVector` - Average positive and negative vectors and create a single query with the formula `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.\n\n- `BestScore` - Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated.",
         "type": "string",
         "enum": [
           "average_vector",
-          "take_best_score"
+          "best_score"
         ]
       },
       "UsingVector": {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -281,6 +281,11 @@ message ScrollPoints {
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
 }
 
+enum RecommendStrategy {
+  AverageVector = 0;
+  TakeBestScore = 1;
+}
+
 message LookupLocation {
   string collection_name = 1;
   optional string vector_name = 2; // Which vector to use for search, if not specified - use default vector
@@ -301,6 +306,7 @@ message RecommendPoints {
   optional WithVectorsSelector with_vectors = 12; // Options for specifying which vectors to include into response
   optional LookupLocation lookup_from = 13; // Name of the collection to use for points lookup, if not specified - use current collection
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
+  optional RecommendStrategy strategy = 16; // How to use the example vectors to find the results
 }
 
 message RecommendBatchPoints {
@@ -325,6 +331,7 @@ message RecommendPointGroups {
   uint32 group_size = 13; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
   optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
+  optional RecommendStrategy strategy = 17; // How to use the example vectors to find the results
 }
 
 message CountPoints {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -281,9 +281,16 @@ message ScrollPoints {
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
 }
 
+// How to use positive and negative vectors to find the results, default is `AverageVector`:
 enum RecommendStrategy {
+  // Average positive and negative vectors and create a single query with the formula 
+  // `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.
   AverageVector = 0;
-  TakeBestScore = 1;
+
+  // Uses custom search objective. Each candidate is compared against all 
+  // examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. 
+  // If the `max_neg_score` is chosen then it is squared and negated.
+  BestScore = 1;
 }
 
 message LookupLocation {

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -97,21 +97,17 @@ message SearchBatchPointsInternal {
   optional uint32 shard_id = 3;
 }
 
-/* Lets not bother with this yet
 message RecoQuery {
   repeated Vector positives = 1;
   repeated Vector negatives = 2;
 }
-*/
 
 message QueryEnum {
-  reserved 2;
   oneof query {
     Vector nearest_neighbors = 1; // ANN
-    // RecoQuery recommend_best_score = 2; // Recommend points with higher similarity to positive examples
+    RecoQuery recommend_best_score = 2; // Recommend points with higher similarity to positive examples
   }
 }
-
 
 // This is only used internally, so it makes more sense to add it here rather than in points.proto
 message CoreSearchPoints {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3268,6 +3268,9 @@ pub struct RecommendPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "14")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// How to use the example vectors to find the results
+    #[prost(enumeration = "RecommendStrategy", optional, tag = "16")]
+    pub strategy: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -3340,6 +3343,9 @@ pub struct RecommendPointGroups {
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "15")]
     pub with_lookup: ::core::option::Option<WithLookup>,
+    /// How to use the example vectors to find the results
+    #[prost(enumeration = "RecommendStrategy", optional, tag = "17")]
+    pub strategy: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -4031,6 +4037,33 @@ impl FieldType {
             "FieldTypeGeo" => Some(Self::Geo),
             "FieldTypeText" => Some(Self::Text),
             "FieldTypeBool" => Some(Self::Bool),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RecommendStrategy {
+    AverageVector = 0,
+    TakeBestScore = 1,
+}
+impl RecommendStrategy {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            RecommendStrategy::AverageVector => "AverageVector",
+            RecommendStrategy::TakeBestScore => "TakeBestScore",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "AverageVector" => Some(Self::AverageVector),
+            "TakeBestScore" => Some(Self::TakeBestScore),
             _ => None,
         }
     }
@@ -6013,8 +6046,17 @@ pub struct SearchBatchPointsInternal {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RecoQuery {
+    #[prost(message, repeated, tag = "1")]
+    pub positives: ::prost::alloc::vec::Vec<Vector>,
+    #[prost(message, repeated, tag = "2")]
+    pub negatives: ::prost::alloc::vec::Vec<Vector>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryEnum {
-    #[prost(oneof = "query_enum::Query", tags = "1")]
+    #[prost(oneof = "query_enum::Query", tags = "1, 2")]
     pub query: ::core::option::Option<query_enum::Query>,
 }
 /// Nested message and enum types in `QueryEnum`.
@@ -6026,6 +6068,9 @@ pub mod query_enum {
         /// ANN
         #[prost(message, tag = "1")]
         NearestNeighbors(super::Vector),
+        /// Recommend points with higher similarity to positive examples
+        #[prost(message, tag = "2")]
+        RecommendBestScore(super::RecoQuery),
     }
 }
 /// This is only used internally, so it makes more sense to add it here rather than in points.proto

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4041,12 +4041,18 @@ impl FieldType {
         }
     }
 }
+/// How to use positive and negative vectors to find the results, default is `AverageVector`:
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum RecommendStrategy {
+    /// Average positive and negative vectors and create a single query with the formula
+    /// `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.
     AverageVector = 0,
-    TakeBestScore = 1,
+    /// Uses custom search objective. Each candidate is compared against all
+    /// examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`.
+    /// If the `max_neg_score` is chosen then it is squared and negated.
+    BestScore = 1,
 }
 impl RecommendStrategy {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4056,14 +4062,14 @@ impl RecommendStrategy {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             RecommendStrategy::AverageVector => "AverageVector",
-            RecommendStrategy::TakeBestScore => "TakeBestScore",
+            RecommendStrategy::BestScore => "BestScore",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "AverageVector" => Some(Self::AverageVector),
-            "TakeBestScore" => Some(Self::TakeBestScore),
+            "BestScore" => Some(Self::BestScore),
             _ => None,
         }
     }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -328,14 +328,14 @@ impl SegmentsSearcher {
 pub enum SearchType {
     #[default]
     Nearest,
-    // Recommend,
+    RecommendBestScore,
 }
 
 impl From<&QueryEnum> for SearchType {
     fn from(query: &QueryEnum) -> Self {
         match query {
             QueryEnum::Nearest(_) => Self::Nearest,
-            // QueryEnum::PositiveNegative { .. } => Self::Recommend,
+            QueryEnum::RecommendBestScore(_) => Self::RecommendBestScore,
         }
     }
 }

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 
 use itertools::Itertools;
-use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use segment::data_types::vectors::{Named, DEFAULT_VECTOR_NAME};
 use segment::types::{
     AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
     WithVector,
@@ -216,6 +216,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
         let RecommendGroupsRequest {
             positive,
             negative,
+            strategy,
             filter,
             params,
             with_payload,
@@ -235,6 +236,7 @@ impl From<RecommendGroupsRequest> for GroupRequest {
         let recommend = RecommendRequest {
             positive,
             negative,
+            strategy,
             filter,
             params,
             limit: 0,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -5,13 +5,17 @@ use api::grpc::conversions::{from_grpc_dist, payload_to_proto, proto_to_payloads
 use api::grpc::qdrant::quantization_config_diff::Quantization;
 use api::grpc::qdrant::update_collection_cluster_setup_request::Operation as ClusterOperationsPb;
 use itertools::Itertools;
-use segment::data_types::vectors::{NamedVector, VectorStruct, DEFAULT_VECTOR_NAME};
+use segment::data_types::vectors::{
+    Named, NamedRecoQuery, NamedVector, VectorStruct, DEFAULT_VECTOR_NAME,
+};
 use segment::types::{Distance, QuantizationConfig};
+use segment::vector_storage::query::reco_query::RecoQuery;
 use tonic::Status;
 
 use super::types::{
     BaseGroupRequest, CoreSearchRequest, GroupsResult, PointGroup, QueryEnum,
-    RecommendGroupsRequest, SearchGroupsRequest, VectorParamsDiff, VectorsConfigDiff,
+    RecommendGroupsRequest, RecommendStrategy, SearchGroupsRequest, VectorParamsDiff,
+    VectorsConfigDiff,
 };
 use crate::config::{
     default_replication_factor, default_write_consistency_factor, CollectionConfig,
@@ -746,6 +750,24 @@ impl From<QueryEnum> for api::grpc::qdrant::QueryEnum {
                     vector.to_vector().into(),
                 )),
             },
+            QueryEnum::RecommendBestScore(named) => api::grpc::qdrant::QueryEnum {
+                query: Some(api::grpc::qdrant::query_enum::Query::RecommendBestScore(
+                    api::grpc::qdrant::RecoQuery {
+                        positives: named
+                            .query
+                            .positives
+                            .into_iter()
+                            .map(|v| api::grpc::qdrant::Vector { data: v })
+                            .collect(),
+                        negatives: named
+                            .query
+                            .negatives
+                            .into_iter()
+                            .map(|v| api::grpc::qdrant::Vector { data: v })
+                            .collect(),
+                    },
+                )),
+            },
         }
     }
 }
@@ -812,6 +834,15 @@ impl TryFrom<api::grpc::qdrant::CoreSearchPoints> for CoreSearchRequest {
                         }
                         .into(),
                         None => vector.data.into(),
+                    })
+                },
+                api::grpc::qdrant::query_enum::Query::RecommendBestScore(query) => {
+                    QueryEnum::RecommendBestScore(NamedRecoQuery {
+                        query: RecoQuery::new(
+                            query.positives.into_iter().map(|v| v.data).collect(),
+                            query.negatives.into_iter().map(|v| v.data).collect(),
+                        ),
+                        using: value.vector_name,
                     })
                 }
             })
@@ -929,6 +960,29 @@ impl From<api::grpc::qdrant::LookupLocation> for LookupLocation {
     }
 }
 
+impl From<api::grpc::qdrant::RecommendStrategy> for RecommendStrategy {
+    fn from(value: api::grpc::qdrant::RecommendStrategy) -> Self {
+        match value {
+            api::grpc::qdrant::RecommendStrategy::AverageVector => RecommendStrategy::AverageVector,
+            api::grpc::qdrant::RecommendStrategy::TakeBestScore => RecommendStrategy::TakeBestScore,
+        }
+    }
+}
+
+impl TryFrom<Option<i32>> for RecommendStrategy {
+    type Error = Status;
+
+    fn try_from(value: Option<i32>) -> Result<Self, Self::Error> {
+        let strategy = match value {
+            None => api::grpc::qdrant::RecommendStrategy::AverageVector,
+            Some(i) => api::grpc::qdrant::RecommendStrategy::from_i32(i).ok_or_else(|| {
+                Status::invalid_argument(format!("Unknown recommend strategy: {}", i))
+            })?,
+        };
+        Ok(strategy.into())
+    }
+}
+
 impl TryFrom<api::grpc::qdrant::RecommendPoints> for RecommendRequest {
     type Error = Status;
 
@@ -944,6 +998,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPoints> for RecommendRequest {
                 .into_iter()
                 .map(|p| p.try_into())
                 .collect::<Result<_, _>>()?,
+            strategy: value.strategy.try_into()?,
             filter: value.filter.map(|f| f.try_into()).transpose()?,
             params: value.params.map(|p| p.into()),
             limit: value.limit as usize,
@@ -969,6 +1024,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPointGroups> for RecommendGroupsRequest
         let recommend_points = api::grpc::qdrant::RecommendPoints {
             positive: value.positive,
             negative: value.negative,
+            strategy: value.strategy,
             using: value.using,
             lookup_from: value.lookup_from,
             filter: value.filter,
@@ -985,6 +1041,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPointGroups> for RecommendGroupsRequest
         let RecommendRequest {
             positive,
             negative,
+            strategy,
             using,
             lookup_from,
             filter,
@@ -999,6 +1056,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPointGroups> for RecommendGroupsRequest
         Ok(RecommendGroupsRequest {
             positive,
             negative,
+            strategy,
             using,
             lookup_from,
             filter,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -835,7 +835,7 @@ impl TryFrom<api::grpc::qdrant::CoreSearchPoints> for CoreSearchRequest {
                         .into(),
                         None => vector.data.into(),
                     })
-                },
+                }
                 api::grpc::qdrant::query_enum::Query::RecommendBestScore(query) => {
                     QueryEnum::RecommendBestScore(NamedRecoQuery {
                         query: RecoQuery::new(

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -964,7 +964,7 @@ impl From<api::grpc::qdrant::RecommendStrategy> for RecommendStrategy {
     fn from(value: api::grpc::qdrant::RecommendStrategy) -> Self {
         match value {
             api::grpc::qdrant::RecommendStrategy::AverageVector => RecommendStrategy::AverageVector,
-            api::grpc::qdrant::RecommendStrategy::TakeBestScore => RecommendStrategy::TakeBestScore,
+            api::grpc::qdrant::RecommendStrategy::BestScore => RecommendStrategy::BestScore,
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -353,12 +353,19 @@ pub struct PointRequest {
     pub with_vector: WithVector,
 }
 
+/// How to use positive and negative vectors to find the results, default is `AverageVector`:
+/// - `AverageVector` - Average positive and negative vectors and create a single query
+///   with the formula `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.
+///
+/// - `BestScore` - Uses custom search objective. Each candidate is compared against all
+///   examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`.
+///   If the `max_neg_score` is chosen then it is squared and negated.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RecommendStrategy {
     #[default]
     AverageVector,
-    TakeBestScore,
+    BestScore,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -392,7 +399,7 @@ pub struct LookupLocation {
 ///
 /// Service should look for the points which are closer to positive examples and at the same time
 /// further to negative examples. The concrete way of how to compare negative and positive distances
-/// is up to implementation in `segment` crate.
+/// is up to the `strategy` chosen.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Default, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct RecommendRequest {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -9,13 +9,14 @@ use std::time::SystemTimeError;
 use api::grpc::transport_channel_pool::RequestError;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
+use itertools::Itertools;
 use merge::Merge;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::data_types::groups::GroupId;
 use segment::data_types::vectors::{
-    NamedVectorStruct, QueryVector, VectorElementType, VectorStruct, VectorType,
-    DEFAULT_VECTOR_NAME,
+    Named, NamedRecoQuery, NamedVectorStruct, QueryVector, VectorElementType, VectorStruct,
+    VectorType, DEFAULT_VECTOR_NAME,
 };
 use segment::entry::entry_point::OperationError;
 use segment::types::{
@@ -260,13 +261,14 @@ pub struct SearchRequestBatch {
 #[derive(Debug, Clone)]
 pub enum QueryEnum {
     Nearest(NamedVectorStruct),
+    RecommendBestScore(NamedRecoQuery),
 }
 
 impl QueryEnum {
     pub fn get_vector_name(&self) -> &str {
         match self {
             QueryEnum::Nearest(vector) => vector.get_name(),
-            // QueryEnum::PositiveNegative { using: UsingVector::Name(name), .. } => name
+            QueryEnum::RecommendBestScore(reco_query) => reco_query.get_name(),
         }
     }
 }
@@ -351,6 +353,13 @@ pub struct PointRequest {
     pub with_vector: WithVector,
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
+pub enum RecommendStrategy {
+    #[default]
+    AverageVector,
+    TakeBestScore,
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum UsingVector {
@@ -387,37 +396,52 @@ pub struct LookupLocation {
 #[serde(rename_all = "snake_case")]
 pub struct RecommendRequest {
     /// Look for vectors closest to those
+    #[serde(default)]
     pub positive: Vec<PointIdType>,
+
     /// Try to avoid vectors like this
     #[serde(default)]
     pub negative: Vec<PointIdType>,
+
+    /// How to use positive and negative vectors to find the results
+    #[serde(default)]
+    pub strategy: RecommendStrategy,
+
     /// Look only for points which satisfies this conditions
     pub filter: Option<Filter>,
+
     /// Additional search params
     #[validate]
     pub params: Option<SearchParams>,
+
     /// Max number of result to return
     #[serde(alias = "top")]
     #[validate(range(min = 1))]
     pub limit: usize,
+
     /// Offset of the first result to return.
     /// May be used to paginate results.
     /// Note: large offset values may cause performance issues.
     #[serde(default)]
     pub offset: usize,
+
     /// Select which payload to return with the response. Default: None
     pub with_payload: Option<WithPayloadInterface>,
+
     /// Whether to return the point vector with the result?
     #[serde(default, alias = "with_vectors")]
     pub with_vector: Option<WithVector>,
+
     /// Define a minimal score threshold for the result.
     /// If defined, less similar results will not be returned.
     /// Score of the returned result might be higher or smaller than the threshold depending on the
     /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
     pub score_threshold: Option<ScoreType>,
+
     /// Define which vector to use for recommendation, if not specified - try to use default vector
     #[serde(default)]
     pub using: Option<UsingVector>,
+
     /// The location used to lookup vectors. If not specified - use current collection.
     /// Note: the other collection should have the same vector size as the current collection
     #[serde(default)]
@@ -434,11 +458,16 @@ pub struct RecommendRequestBatch {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 pub struct RecommendGroupsRequest {
     /// Look for vectors closest to those
+    #[serde(default)]
     pub positive: Vec<PointIdType>,
 
     /// Try to avoid vectors like this
     #[serde(default)]
     pub negative: Vec<PointIdType>,
+
+    /// How to use positive and negative vectors to find the results
+    #[serde(default)]
+    pub strategy: RecommendStrategy,
 
     /// Look only for points which satisfies this conditions
     pub filter: Option<Filter>,
@@ -1158,11 +1187,7 @@ pub struct BaseGroupRequest {
 impl From<SearchRequestBatch> for CoreSearchRequestBatch {
     fn from(batch: SearchRequestBatch) -> Self {
         CoreSearchRequestBatch {
-            searches: batch
-                .searches
-                .into_iter()
-                .map(CoreSearchRequest::from)
-                .collect(),
+            searches: batch.searches.into_iter().map_into().collect(),
         }
     }
 }
@@ -1185,7 +1210,8 @@ impl From<SearchRequest> for CoreSearchRequest {
 impl From<QueryEnum> for QueryVector {
     fn from(query: QueryEnum) -> Self {
         match query {
-            QueryEnum::Nearest(named_vector) => QueryVector::Nearest(named_vector.to_vector()),
+            QueryEnum::Nearest(named) => QueryVector::Nearest(named.to_vector()),
+            QueryEnum::RecommendBestScore(named) => QueryVector::Recommend(named.query),
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -354,6 +354,7 @@ pub struct PointRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum RecommendStrategy {
     #[default]
     AverageVector,

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,17 +3,22 @@ use std::future::Future;
 
 use futures::future::try_join_all;
 use itertools::Itertools;
-use segment::data_types::vectors::{NamedVector, VectorElementType, DEFAULT_VECTOR_NAME};
-use segment::types::{
-    Condition, Filter, HasIdCondition, PointIdType, ScoredPoint, WithPayloadInterface, WithVector,
+use segment::data_types::vectors::{
+    NamedRecoQuery, NamedVector, VectorElementType, VectorType, DEFAULT_VECTOR_NAME,
 };
+use segment::types::{
+    Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
+    WithPayloadInterface, WithVector,
+};
+use segment::vector_storage::query::reco_query::RecoQuery;
 use tokio::sync::RwLockReadGuard;
 
 use crate::collection::Collection;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::types::{
-    CollectionError, CollectionResult, PointRequest, RecommendRequest, RecommendRequestBatch,
-    Record, SearchRequest, SearchRequestBatch, UsingVector,
+    CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch, PointRequest,
+    QueryEnum, RecommendRequest, RecommendRequestBatch, RecommendStrategy, Record, SearchRequest,
+    SearchRequestBatch, UsingVector,
 };
 
 fn avg_vectors<'a>(
@@ -228,87 +233,245 @@ where
         }
     }
 
-    let mut searches = Vec::with_capacity(request_batch.searches.len());
+    let mut results = Vec::with_capacity(request_batch.searches.len());
 
-    for request in &request_batch.searches {
-        let vector_name = match &request.using {
-            None => DEFAULT_VECTOR_NAME,
-            Some(UsingVector::Name(name)) => name,
-        };
-
-        let lookup_vector_name = get_search_vector_name(request);
-
-        let reference_vectors_ids = request
-            .positive
-            .iter()
-            .chain(&request.negative)
-            .cloned()
-            .collect_vec();
-
-        let request_from_collection = request.lookup_from.as_ref().map(|x| &x.collection);
-
-        for &point_id in &reference_vectors_ids {
-            if !all_vectors_records_map.contains_key(&(request_from_collection, point_id)) {
-                return Err(CollectionError::PointNotFound {
-                    missed_point_id: point_id,
-                });
-            }
+    // At this point batches that include both types of requests are going to be executed
+    // sequentially in runs of requests of the same strategy
+    //
+    // [avg, avg, avg, score, score, score, avg]
+    // |------------>|------------------->|--->|
+    //      run1             run2          run3
+    //
+    // In the future we'll fix this by unify them into CoreSearchRequests and make a single batch
+    for (strategy, run) in batch_by_strategy(&request_batch.searches) {
+        let mut searches = Vec::new();
+        let mut core_searches = Vec::new();
+        match strategy {
+            RecommendStrategy::AverageVector => searches.reserve_exact(run.len()),
+            RecommendStrategy::TakeBestScore => core_searches.reserve_exact(run.len()),
         }
 
-        let avg_positive = avg_vectors(request.positive.iter().filter_map(|vid| {
-            let rec = all_vectors_records_map
-                .get(&(request_from_collection, *vid))
-                .unwrap();
-            rec.get_vector_by_name(&lookup_vector_name)
-        }));
+        for request in run {
+            let vector_name = match &request.using {
+                None => DEFAULT_VECTOR_NAME,
+                Some(UsingVector::Name(name)) => name,
+            };
 
-        let search_vector = if request.negative.is_empty() {
-            avg_positive
-        } else {
-            let avg_negative = avg_vectors(request.negative.iter().filter_map(|vid| {
-                let rec = all_vectors_records_map
-                    .get(&(request_from_collection, *vid))
-                    .unwrap();
-                rec.get_vector_by_name(&lookup_vector_name)
-            }));
+            let lookup_vector_name = get_search_vector_name(request);
 
-            avg_positive
+            let reference_vectors_ids = request
+                .positive
                 .iter()
+                .chain(&request.negative)
                 .cloned()
-                .zip(avg_negative.iter().cloned())
-                .map(|(pos, neg)| pos + pos - neg)
-                .collect()
+                .collect_vec();
+
+            let lookup_collection_name = request.lookup_from.as_ref().map(|x| &x.collection);
+
+            for &point_id in &reference_vectors_ids {
+                if !all_vectors_records_map.contains_key(&(lookup_collection_name, point_id)) {
+                    return Err(CollectionError::PointNotFound {
+                        missed_point_id: point_id,
+                    });
+                }
+            }
+
+            match strategy {
+                RecommendStrategy::AverageVector => {
+                    let search = recommend_by_avg_vector(
+                        request.clone(),
+                        &all_vectors_records_map,
+                        lookup_collection_name,
+                        lookup_vector_name,
+                        vector_name,
+                        reference_vectors_ids,
+                    );
+                    searches.push(search);
+                }
+                RecommendStrategy::TakeBestScore => {
+                    let core_search = recommend_by_best_score(
+                        request.clone(),
+                        &all_vectors_records_map,
+                        lookup_collection_name,
+                        lookup_vector_name,
+                        reference_vectors_ids,
+                    );
+                    core_searches.push(core_search);
+                }
+            };
+        }
+
+        let run_result = if !searches.is_empty() {
+            let search_batch_request = SearchRequestBatch { searches };
+            collection
+                .search_batch(search_batch_request, read_consistency, None)
+                .await?
+        } else {
+            let core_search_batch_request = CoreSearchRequestBatch {
+                searches: core_searches,
+            };
+            collection
+                .core_search_batch(core_search_batch_request, read_consistency, None)
+                .await?
         };
 
-        let search_request = SearchRequest {
-            vector: NamedVector {
-                name: vector_name.to_string(),
-                vector: search_vector,
-            }
-            .into(),
-            filter: Some(Filter {
-                should: None,
-                must: request
-                    .filter
-                    .clone()
-                    .map(|filter| vec![Condition::Filter(filter)]),
-                must_not: Some(vec![Condition::HasId(HasIdCondition {
-                    has_id: reference_vectors_ids.iter().cloned().collect(),
-                })]),
-            }),
-            with_payload: request.with_payload.clone(),
-            with_vector: request.with_vector.clone(),
-            params: request.params,
-            limit: request.limit,
-            score_threshold: request.score_threshold,
-            offset: request.offset,
-        };
-        searches.push(search_request)
+        // Push run result to final results
+        run_result.into_iter().for_each(|x| results.push(x));
     }
 
-    let search_batch_request = SearchRequestBatch { searches };
+    Ok(results)
+}
 
-    collection
-        .search_batch(search_batch_request, read_consistency, None)
-        .await
+fn batch_by_strategy(
+    requests: &[RecommendRequest],
+) -> impl Iterator<Item = (RecommendStrategy, Vec<&RecommendRequest>)> {
+    requests.iter().batching(|iter| {
+        let mut iter = iter.peekable();
+
+        let strategy = match iter.peek() {
+            Some(req) => req.strategy.clone(),
+            None => return None,
+        };
+
+        let batch = iter
+            .peeking_take_while(|req| req.strategy == strategy)
+            .collect_vec();
+
+        if batch.is_empty() {
+            None
+        } else {
+            Some((strategy, batch))
+        }
+    })
+}
+fn recommend_by_avg_vector(
+    request: RecommendRequest,
+    all_vectors_records_map: &HashMap<(Option<&String>, ExtendedPointId), Record>,
+    lookup_collection_name: Option<&String>,
+    lookup_vector_name: String,
+    vector_name: &str,
+    reference_vectors_ids: Vec<ExtendedPointId>,
+) -> SearchRequest {
+    let RecommendRequest {
+        positive,
+        negative,
+        filter,
+        with_payload,
+        with_vector,
+        params,
+        limit,
+        score_threshold,
+        offset,
+        ..
+    } = request;
+
+    let avg_positive = avg_vectors(map_ids_to_vectors(
+        positive,
+        all_vectors_records_map,
+        &lookup_vector_name,
+        lookup_collection_name,
+    ));
+    let search_vector = if negative.is_empty() {
+        avg_positive
+    } else {
+        let avg_negative = avg_vectors(map_ids_to_vectors(
+            negative,
+            all_vectors_records_map,
+            &lookup_vector_name,
+            lookup_collection_name,
+        ));
+
+        avg_positive
+            .iter()
+            .zip(avg_negative.iter())
+            .map(|(pos, neg)| pos + pos - neg)
+            .collect()
+    };
+
+    SearchRequest {
+        vector: NamedVector {
+            name: vector_name.to_string(),
+            vector: search_vector,
+        }
+        .into(),
+        filter: Some(Filter {
+            should: None,
+            must: filter.clone().map(|filter| vec![Condition::Filter(filter)]),
+            must_not: Some(vec![Condition::HasId(HasIdCondition {
+                has_id: reference_vectors_ids.iter().cloned().collect(),
+            })]),
+        }),
+        with_payload,
+        with_vector,
+        params,
+        limit,
+        score_threshold,
+        offset,
+    }
+}
+
+fn recommend_by_best_score(
+    request: RecommendRequest,
+    all_vectors_records_map: &HashMap<(Option<&String>, PointIdType), Record>,
+    lookup_collection_name: Option<&String>,
+    lookup_vector_name: String,
+    reference_vectors_ids: Vec<PointIdType>,
+) -> CoreSearchRequest {
+    let positive = map_ids_to_vectors(
+        request.positive,
+        all_vectors_records_map,
+        &lookup_vector_name,
+        lookup_collection_name,
+    )
+    .cloned()
+    .collect();
+    let negative = map_ids_to_vectors(
+        request.negative,
+        all_vectors_records_map,
+        &lookup_vector_name,
+        lookup_collection_name,
+    )
+    .cloned()
+    .collect();
+
+    let query = QueryEnum::RecommendBestScore(NamedRecoQuery {
+        query: RecoQuery::new(positive, negative),
+        using: request.using.map(|x| match x {
+            UsingVector::Name(name) => name,
+        }),
+    });
+
+    CoreSearchRequest {
+        query,
+        filter: Some(Filter {
+            should: None,
+            must: request
+                .filter
+                .clone()
+                .map(|filter| vec![Condition::Filter(filter)]),
+            must_not: Some(vec![Condition::HasId(HasIdCondition {
+                has_id: reference_vectors_ids.iter().cloned().collect(),
+            })]),
+        }),
+        params: request.params,
+        limit: request.limit,
+        offset: request.offset,
+        with_payload: request.with_payload,
+        with_vector: request.with_vector,
+        score_threshold: request.score_threshold,
+    }
+}
+
+fn map_ids_to_vectors<'a>(
+    examples: Vec<PointIdType>,
+    all_vectors_records_map: &'a HashMap<(Option<&String>, PointIdType), Record>,
+    vector_name: &'a str,
+    collection_name: Option<&'a String>,
+) -> impl Iterator<Item = &'a VectorType> + 'a {
+    examples.into_iter().filter_map(move |vid| {
+        let rec = all_vectors_records_map
+            .get(&(collection_name, vid))
+            .unwrap();
+        rec.get_vector_by_name(vector_name)
+    })
 }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -169,7 +169,7 @@ where
                     });
                 }
             }
-            RecommendStrategy::TakeBestScore => {
+            RecommendStrategy::BestScore => {
                 if request.positive.is_empty() && request.negative.is_empty() {
                     return Err(CollectionError::BadRequest {
                         description: "At least one positive or negative vector ID required with this strategy"
@@ -263,7 +263,7 @@ where
         let mut core_searches = Vec::new();
         match strategy {
             RecommendStrategy::AverageVector => searches.reserve_exact(run.len()),
-            RecommendStrategy::TakeBestScore => core_searches.reserve_exact(run.len()),
+            RecommendStrategy::BestScore => core_searches.reserve_exact(run.len()),
         }
 
         for request in run {
@@ -303,7 +303,7 @@ where
                     );
                     searches.push(search);
                 }
-                RecommendStrategy::TakeBestScore => {
+                RecommendStrategy::BestScore => {
                     let core_search = recommend_by_best_score(
                         request.clone(),
                         &all_vectors_records_map,
@@ -506,15 +506,15 @@ mod tests {
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::TakeBestScore,
+                strategy: RecommendStrategy::BestScore,
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::TakeBestScore,
+                strategy: RecommendStrategy::BestScore,
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::TakeBestScore,
+                strategy: RecommendStrategy::BestScore,
                 ..Default::default()
             },
             RecommendRequest {
@@ -531,7 +531,7 @@ mod tests {
             batches,
             vec![
                 (RecommendStrategy::AverageVector, 2),
-                (RecommendStrategy::TakeBestScore, 3),
+                (RecommendStrategy::BestScore, 3),
                 (RecommendStrategy::AverageVector, 1),
             ]
         );

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -55,10 +55,6 @@ impl DummyShard {
 
 #[async_trait]
 impl ShardOperation for DummyShard {
-    async fn info(&self) -> CollectionResult<CollectionInfo> {
-        self.dummy()
-    }
-
     async fn update(
         &self,
         _: CollectionUpdateOperations,
@@ -77,6 +73,10 @@ impl ShardOperation for DummyShard {
         _: Option<&Filter>,
         _: &Handle,
     ) -> CollectionResult<Vec<Record>> {
+        self.dummy()
+    }
+
+    async fn info(&self) -> CollectionResult<CollectionInfo> {
         self.dummy()
     }
 

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -131,6 +131,7 @@ mod group_by {
 
         let request = GroupRequest::with_limit_from_request(
             SourceRequest::Recommend(RecommendRequest {
+                strategy: Default::default(),
                 filter: None,
                 params: None,
                 limit: 4,

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -135,15 +135,20 @@ impl From<NamedVector> for NamedVectorStruct {
         NamedVectorStruct::Named(v)
     }
 }
+pub trait Named {
+    fn get_name(&self) -> &str;
+}
 
-impl NamedVectorStruct {
-    pub fn get_name(&self) -> &str {
+impl Named for NamedVectorStruct {
+    fn get_name(&self) -> &str {
         match self {
             NamedVectorStruct::Default(_) => DEFAULT_VECTOR_NAME,
             NamedVectorStruct::Named(v) => &v.name,
         }
     }
+}
 
+impl NamedVectorStruct {
     pub fn get_vector(&self) -> &VectorType {
         match self {
             NamedVectorStruct::Default(v) => v,
@@ -208,6 +213,18 @@ impl BatchVectorStruct {
                 }
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedRecoQuery {
+    pub query: RecoQuery<VectorType>,
+    pub using: Option<String>,
+}
+
+impl Named for NamedRecoQuery {
+    fn get_name(&self) -> &str {
+        self.using.as_deref().unwrap_or(DEFAULT_VECTOR_NAME)
     }
 }
 

--- a/openapi/tests/openapi_integration/test_recommend.py
+++ b/openapi/tests/openapi_integration/test_recommend.py
@@ -1,0 +1,226 @@
+import pytest
+
+from .helpers.collection_setup import basic_collection_setup, drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = "test_recommend"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(on_disk_vectors):
+    basic_collection_setup(
+        collection_name=collection_name, on_disk_vectors=on_disk_vectors
+    )
+    yield
+    drop_collection(collection_name=collection_name)
+
+def test_default_is_avg_vector():
+    params = {
+            "positive": [1, 2],
+            "negative": [3, 4],
+            "exact": True,
+            "limit": 10,
+        }
+    
+    default_response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            **params,
+        },
+    )
+    assert default_response.ok
+    
+    # we should only get 4 because there are 8 vectors and we used 4 as examples
+    assert len(default_response.json()["result"]) == 4 
+    
+    
+    avg_response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            **params,
+            "strategy": "average_vector",
+        },
+    )
+    assert avg_response.ok
+    assert len(avg_response.json()["result"]) == 4
+    
+    assert default_response.json()["result"] == avg_response.json()["result"]
+    
+    
+def test_single_vs_batch():
+    # Bunch of valid examples
+    params_list = [
+        {
+            "positive": [1, 2],
+            "negative": [3, 4],
+            "limit": 1,
+        },
+        {
+            "positive": [1],
+            "negative": [3, 4],
+            "limit": 1,
+        },
+        {
+            # no negative because it's optional with this strategy
+            "negative": [4, 5],
+            "exact": True,
+            "strategy": "take_best_score",
+            "limit": 1,
+        },
+        {
+            "positive": [2, 3],
+            "negative": [4, 5],
+            "strategy": "take_best_score",
+            "limit": 1,
+        },
+        {
+            "positive": [2, 3],
+            "negative": [4, 5],
+            "exact": True,
+            "strategy": "take_best_score",
+            "limit": 1,
+        },
+        {
+            "positive": [8],
+            "negative": [],
+            "exact": True,
+            "strategy": "average_vector",
+            "limit": 1,
+        }
+    ]
+    
+    batch_response = request_with_validation(
+            api="/collections/{collection_name}/points/recommend/batch",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "searches": params_list
+            },
+        )
+    
+    assert batch_response.ok
+    assert len(batch_response.json()["result"]) == len(params_list)
+    
+    # Compare against sequential single searches
+    for i, params in enumerate(params_list):
+        single_response = request_with_validation(
+            api="/collections/{collection_name}/points/recommend",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body=params,
+        )
+        assert single_response.ok
+        assert single_response.json()["result"] == batch_response.json()["result"][i]
+
+def test_without_positives():   
+    def req_with_positives(positive, strategy= None):
+        if strategy is None:
+            strat_dict = {}
+        else:
+            strat_dict = {"strategy": strategy}
+        
+        return request_with_validation(
+            api="/collections/{collection_name}/points/recommend",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "positive": positive,
+                **strat_dict,
+                "limit": 2,
+            },
+        )
+    
+    
+    # Assert this is valid
+    response = req_with_positives([1, 2])
+    assert response.ok
+    
+    # But all these are not
+    response = req_with_positives([])
+    assert response.status_code == 400
+    
+    response = req_with_positives([], "average_vector")
+    assert response.status_code == 400
+    
+    # Also no negative and no positive is invalid with take_best_score
+    response = req_with_positives([], "take_best_score")
+    assert response.status_code == 400
+    
+def test_take_best_score_works_with_only_negatives():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "negative": [1, 2],
+            "strategy": "take_best_score",
+            "limit": 5,
+        },
+    )
+    assert response.ok
+    assert len(response.json()["result"]) == 5
+    
+    # All scores should be negative
+    for result in response.json()["result"]:
+        assert result["score"] < 0
+        
+def test_only_1_positive_in_take_best_score_is_equivalent_to_normal_search():
+    limit = 4
+    
+    # recommendation response
+    reco_response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [1],
+            "strategy": "take_best_score",
+            "limit": limit,
+            "exact": True,
+        },
+    )
+    assert reco_response.ok
+    assert len(reco_response.json()["result"]) == limit
+    
+    # Get vector from point 1
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "ids": [1],
+            "with_vector": True,
+        },
+    )
+    assert response.ok
+    vector = response.json()["result"][0]["vector"]
+    
+    # Use normal search with that vector
+    search_response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": vector,
+            "filter": {
+                "must_not": [
+                    {
+                        "has_id": [1]
+                    }
+                ]
+            },
+            "limit": limit,
+            "exact": True,
+        },
+    )
+    
+    assert search_response.ok
+    assert len(search_response.json()["result"]) == limit
+    
+    assert reco_response.json()["result"] == search_response.json()["result"]
+
+    

--- a/openapi/tests/openapi_integration/test_recommend.py
+++ b/openapi/tests/openapi_integration/test_recommend.py
@@ -68,20 +68,20 @@ def test_single_vs_batch():
             # no negative because it's optional with this strategy
             "negative": [4, 5],
             "exact": True,
-            "strategy": "take_best_score",
+            "strategy": "best_score",
             "limit": 1,
         },
         {
             "positive": [2, 3],
             "negative": [4, 5],
-            "strategy": "take_best_score",
+            "strategy": "best_score",
             "limit": 1,
         },
         {
             "positive": [2, 3],
             "negative": [4, 5],
             "exact": True,
-            "strategy": "take_best_score",
+            "strategy": "best_score",
             "limit": 1,
         },
         {
@@ -146,18 +146,18 @@ def test_without_positives():
     response = req_with_positives([], "average_vector")
     assert response.status_code == 400
     
-    # Also no negative and no positive is invalid with take_best_score
-    response = req_with_positives([], "take_best_score")
+    # Also no negative and no positive is invalid with best_score
+    response = req_with_positives([], "best_score")
     assert response.status_code == 400
     
-def test_take_best_score_works_with_only_negatives():
+def test_best_score_works_with_only_negatives():
     response = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
         method="POST",
         path_params={"collection_name": collection_name},
         body={
             "negative": [1, 2],
-            "strategy": "take_best_score",
+            "strategy": "best_score",
             "limit": 5,
         },
     )
@@ -168,7 +168,7 @@ def test_take_best_score_works_with_only_negatives():
     for result in response.json()["result"]:
         assert result["score"] < 0
         
-def test_only_1_positive_in_take_best_score_is_equivalent_to_normal_search():
+def test_only_1_positive_in_best_score_is_equivalent_to_normal_search():
     limit = 4
     
     # recommendation response
@@ -178,7 +178,7 @@ def test_only_1_positive_in_take_best_score_is_equivalent_to_normal_search():
         path_params={"collection_name": collection_name},
         body={
             "positive": [1],
-            "strategy": "take_best_score",
+            "strategy": "best_score",
             "limit": limit,
             "exact": True,
         },

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -844,6 +844,7 @@ pub async fn recommend(
         collection_name,
         positive,
         negative,
+        strategy,
         filter,
         limit,
         offset,
@@ -865,6 +866,7 @@ pub async fn recommend(
             .into_iter()
             .map(|p| p.try_into())
             .collect::<Result<_, _>>()?,
+        strategy: strategy.try_into()?,
         filter: filter.map(|f| f.try_into()).transpose()?,
         params: params.map(|p| p.into()),
         limit: limit as usize,


### PR DESCRIPTION
Needs: #2661 

## Changes
- Exposes new recommendation scorer via `RecommendStrategy` parameter
- In both gRPC and REST
- New scorer is routed to a `CoreSearchRequest`
- There is a little performance hit on current implementation when sending batches of alternating recommendation strategies (i.e. `[avg, scorer, avg, scorer, avg, ...]`). But it will go away when we can convert normal search requests into CoreSearchRequest too.

## TODO
- [x] Tests
  - [x] Batching per strategy
  - [x] e2e (openapi)
- [ ] Get a feel of performance with some benchmarking

## Next steps
- Support for raw input vectors in recommend (instead of just IDs)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
