### PR TITLE
Serde derive for common crate

### DIFF
--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -9,5 +9,5 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-serde = "~1.0"
+serde = { version = "~1.0", features = ["derive"] }
 validator = { version = "0.16", features = ["derive"] }


### PR DESCRIPTION
Common crate uses serde device macro. This PR adds derive feature flag.
Example of failure because of a feature missing:
In https://github.com/qdrant/qdrant/pull/2318 you cannot run test `cargo test -p sparse` because of compilation error: derive macro not defined.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
