### PR TITLE
Use sync WAL flush, because our async flush was blocking

### DIFF
--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
-use std::thread::JoinHandle;
 
 use segment::common::file_operations::{atomic_save_json, read_json};
 use serde::de::DeserializeOwned;
@@ -206,11 +205,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn flush(&mut self) -> Result<()> {
         self.wal
             .flush_open_segment()
-            .map_err(|err| WalError::WriteWalError(format!("{err:?}")))
-    }
-
-    pub fn flush_async(&mut self) -> JoinHandle<std::io::Result<()>> {
-        self.wal.flush_open_segment_async()
+            .map_err(|err| WalError::WriteWalError(format!("WAL flush error: {err:?}")))
     }
 
     pub fn path(&self) -> &Path {


### PR DESCRIPTION
I believe we can switch to sync WAL flushing, as the behavior is exactly the same.

With our async flush, we immediately waited on the flushing thread handle, blocking the current thread.

Then, using sync directly is better because we don't spawn an extra thread.

This also removes the async flushing function, because it has no usages anymore.

Please review this with care. I don't want to have missed something important here.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
