### PR TITLE
Log sucessful gRPC request as INFO

### DIFF
--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -58,7 +58,7 @@ where
                     if let Some(grpc_status) = grpc_status {
                         match grpc_status.code() {
                             Code::Ok => {
-                                log::trace!("gRPC {} Ok {:.6}", method_name, elapsed_sec);
+                                log::info!("gRPC {} Ok {:.6}", method_name, elapsed_sec);
                             }
                             Code::Cancelled => {
                                 // cluster mode generates a large amount of `stream error received: stream no longer needed`
@@ -95,7 +95,7 @@ where
                             ),
                         };
                     } else {
-                        log::trace!("gRPC {} Ok {:.6}", method_name, elapsed_sec);
+                        log::info!("gRPC {} Ok {:.6}", method_name, elapsed_sec);
                     }
                     Ok(response_tonic)
                 }


### PR DESCRIPTION
This PR logs successful gRPC requests as INFO.

The main motivation is to have consistency with the REST API which is already doing that and to enable users of cloud to see their gRPC logs.

![grpc-info](https://github.com/qdrant/qdrant/assets/606963/ac5bd942-af25-4736-9b3e-404a3c8d33e2)


One negative aspect is that the terminal will be much more active during benchmarking after this.