### PR TITLE
Remove atty dependency, use stdlib method for this

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,6 @@ dependencies = [
  "actix-web-validator",
  "anyhow",
  "api",
- "atty",
  "chrono",
  "clap",
  "collection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ parking_lot = { version = "0.12.1", features = ["deadlock_detection"], optional 
 num_cpus = "1.16"
 thiserror = "1.0"
 log = "0.4"
-atty = "0.2"
 colored = "2"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -1,6 +1,6 @@
 use std::env;
+use std::io::{stdout, IsTerminal};
 
-use atty::Stream;
 use colored::{Color, ColoredString, Colorize};
 
 use crate::settings::Settings;
@@ -17,7 +17,7 @@ fn paint(text: &str, true_color: bool) -> ColoredString {
 #[rustfmt::skip]
 #[allow(clippy::needless_raw_string_hashes)]
 pub fn welcome(settings: &Settings) {
-    if !atty::is(Stream::Stdout) {
+    if !stdout().is_terminal()  {
         colored::control::set_override(false);
     }
 


### PR DESCRIPTION
Removes the `atty` dependency. Switch to [`IsTerminal::is_terminal()`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal) instead.

`atty` contains an unfixed vulnerability on Windows: https://github.com/advisories/GHSA-g98v-hv3f-hcfr

Fixes security alert (private): https://github.com/qdrant/qdrant/security/dependabot/44

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?