### PR TITLE
CI: reference PR number in flaky test issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -19,3 +19,5 @@ title: Flaky test `{{ env.TEST_NAME }}`
 OS: {{ env.OS }}
 
 Branch: {{ env.BRANCH }}
+
+{{ env.PR }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,9 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install nextest
       uses: taiki-e/install-action@nextest
-    - name: Build and run tests
+    - name: Build
+      run: cargo build --tests --workspace
+    - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci
     - name: Upload test report
@@ -90,6 +92,7 @@ jobs:
           JOB: ${{ github.job }}
           BRANCH: ${{ github.ref }}
           OS: ${{ matrix.os }}
+          PR: "#${{ github.event.pull_request.number }}"
         with:
           filename: .github/ISSUE_TEMPLATE/flaky_test.md
           update_existing: true


### PR DESCRIPTION
Following up on #2677, this tags the PR number in the issue description to create a reference so that PR author can see more clearly when a test is flaking on their PR. 

As a side improvement, I've separated the build and test stages so we can have better metrics in build and run times
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
