### PR TITLE
Run `test_building_cancellation` five times, allow one failure

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -124,7 +124,7 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: u64) -> (u64, bool)
 
 #[test]
 fn test_building_cancellation() {
-    // This test has flakyness on some platforms. We therefore run it multiple times and allow the
+    // This test has flakiness on some platforms. We therefore run it multiple times and allow the
     // specified number of failures.
     const RUNS: usize = 5;
     const ALLOW_FAILURES: usize = 1;


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2680>.

The `test_building_cancellation` test flaky. Since it is caused by timing issues I'm afraid we can't easily fix this.

This PR runs the test 5 times, and allows one failure. The second failure will panic in the same way as the test did before with the assertion.

Note that only the last assertion was behaving flaky. Only this condition is tested with allowance of one failure. The other assertions are kept intact.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?