### PR TITLE
Reduce flakiness of `test_building_cancellation` with larger base seg…

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -135,7 +135,7 @@ fn test_building_cancellation() {
     let mut segment = empty_segment(dir.path());
     let mut segment_2 = empty_segment(dir_2.path());
 
-    for idx in 0..5000 {
+    for idx in 0..2000 {
         baseline_segment
             .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
@@ -147,12 +147,12 @@ fn test_building_cancellation() {
             .unwrap();
     }
     // Get normal build time
-    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
+    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 30000);
     assert!(!was_cancelled_baseline);
 
     // Checks that optimization with longer cancellation delay will also finish fast
-    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 20);
-    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 200);
+    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 30);
+    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 300);
 
     assert!(was_cancelled_early);
     assert!(time_fast < time_baseline / 4);

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -135,7 +135,7 @@ fn test_building_cancellation() {
     let mut segment = empty_segment(dir.path());
     let mut segment_2 = empty_segment(dir_2.path());
 
-    for idx in 0..1000 {
+    for idx in 0..5000 {
         baseline_segment
             .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2680>. Supersedes <https://github.com/qdrant/qdrant/pull/2681>.

The `test_building_cancellation` test flaky. It depends on timings which are currently too close together causing false negatives.

This doubles the number of points for the test collection, increasing the difference between the timings, reducing flakiness.

I've tested this change 100 times locally and did not see a false negative again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?