### PR TITLE
Revert reducing depth of temporary snapshot directories

### DIFF
--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -23,6 +23,7 @@ use tokio::fs::{copy, create_dir_all, remove_dir_all};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock as TokioRwLock};
+use uuid::Uuid;
 use wal::{Wal, WalOptions};
 
 use crate::collection_manager::collection_updater::CollectionUpdater;
@@ -563,7 +564,8 @@ impl LocalShard {
             rx.await?;
         }
 
-        let temp_path = temp_path.to_owned();
+        let temp_path = temp_path.join(format!("shard-{}", Uuid::new_v4()));
+        create_dir_all(&temp_path).await?;
 
         tokio::task::spawn_blocking(move || {
             let segments_read = segments.read();


### PR DESCRIPTION
In 90127771817ef9cb7faa75d7a5b4bfcccb0f8f67 (<https://github.com/qdrant/qdrant/pull/2528#issuecomment-1699556098>) we removed a level of temporary snapshot directories. This would produce shorter paths on Windows, preventing us from reaching the path length limit.

Around the time we implemented this change, weird IO errors started popping up. Even after extensive investigation the root cause wasn't found. @agourlay and I have a suspicion that this change introduced the problem.

Related issues:
- https://github.com/qdrant/qdrant/issues/2574
- https://github.com/qdrant/qdrant/issues/2678

This reverts the linked commit. After merging we'll be able to see if the issue pops up again. Then we can investigate further.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?