### PR TITLE
Refactor: Remove unnecessary clone() call for 'operation' in update_from_peer function

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -694,7 +694,7 @@ impl Collection {
 
         let res = match shard_holder_guard.get_shard(&shard_selection) {
             None => None,
-            Some(target_shard) => target_shard.update_local(operation.clone(), wait).await?,
+            Some(target_shard) => target_shard.update_local(operation, wait).await?,
         };
 
         if let Some(res) = res {


### PR DESCRIPTION
The clone() call for 'operation' in the update_from_peer function appears to be redundant and has been removed.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
