### PR TITLE
Fix `test_building_cancellation` flakiness with different delays

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -149,7 +149,6 @@ fn test_building_cancellation() {
 
     // Get normal build time
     let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
-    dbg!(time_baseline);
     assert!(!was_cancelled_baseline);
 
     // Checks that optimization with longer cancellation delay will also finish fast

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -135,7 +135,7 @@ fn test_building_cancellation() {
     let mut segment = empty_segment(dir.path());
     let mut segment_2 = empty_segment(dir_2.path());
 
-    for idx in 0..2000 {
+    for idx in 0..5000 {
         baseline_segment
             .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
@@ -146,13 +146,14 @@ fn test_building_cancellation() {
             .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
     }
+
     // Get normal build time
-    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 30000);
+    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
     assert!(!was_cancelled_baseline);
 
     // Checks that optimization with longer cancellation delay will also finish fast
-    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 30);
-    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 300);
+    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 20);
+    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 200);
 
     assert!(was_cancelled_early);
     assert!(time_fast < time_baseline / 4);
@@ -165,6 +166,6 @@ fn test_building_cancellation() {
         "time_early: {}, time_later: {}, was_cancelled_later: {}",
         time_fast,
         time_long,
-        was_cancelled_later
+        was_cancelled_later,
     );
 }

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -135,7 +135,7 @@ fn test_building_cancellation() {
     let mut segment = empty_segment(dir.path());
     let mut segment_2 = empty_segment(dir_2.path());
 
-    for idx in 0..5000 {
+    for idx in 0..2000 {
         baseline_segment
             .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
             .unwrap();
@@ -149,17 +149,22 @@ fn test_building_cancellation() {
 
     // Get normal build time
     let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
+    dbg!(time_baseline);
     assert!(!was_cancelled_baseline);
 
     // Checks that optimization with longer cancellation delay will also finish fast
-    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, 20);
-    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, 200);
+    let early_stop_delay = time_baseline / 20;
+    let (time_fast, was_cancelled_early) = estimate_build_time(&segment, early_stop_delay);
+    let late_stop_delay = time_baseline / 5;
+    let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, late_stop_delay);
+
+    let acceptable_stopping_delay = 400; // millis
 
     assert!(was_cancelled_early);
-    assert!(time_fast < time_baseline / 4);
+    assert!(time_fast < early_stop_delay + acceptable_stopping_delay);
 
     assert!(was_cancelled_later);
-    assert!(time_long < time_baseline / 4);
+    assert!(time_long < late_stop_delay + acceptable_stopping_delay);
 
     assert!(
         time_fast < time_long,


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2695>.

Similar to <https://github.com/qdrant/qdrant/pull/2682>, but with 5k points as 2k was not large enough.

The `test_building_cancellation` test flaky. It depends on timings which are currently too close together causing false negatives.

This changes the delays to be in relation to baseline, and using an acceptable stopping threshold

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?