### PR TITLE
CI: improve automatic issue creation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.ci]
 # Retry tests before failing them.
-retries = { backoff = "exponential", count = 3, delay = "2s" }
+retries = { backoff = "exponential", count = 2, delay = "2s" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
 # Print out output for failing tests as soon as they fail, and also at the end

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -12,7 +12,9 @@ title: Flaky test `{{ env.TEST_NAME }}`
 
 ### Context
 
-[Flaky failure run](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }})
+Date: {{ date | date('DD.MM.YYYY HH:mm') }}
+
+[Flaky failure run](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }}/job/{{ env.JOB_ID }})
 
 [Commit](https://github.com/{{ env.REPOSITORY }}/tree/{{ env.SHA }})
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
+    - run: echo ${{ github.event.pull_request.author_association }}
     - name: Install minimal stable
       uses: dtolnay/rust-toolchain@stable
     - uses: actions/checkout@v4
@@ -47,7 +48,7 @@ jobs:
     permissions:
       contents: read
       issues: write 
-    if: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) || github.event.pull_request == null }}
+    if: ${{ contains(fromJSON('["COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association) || github.event.pull_request == null }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest  ]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,14 +41,13 @@ jobs:
         
   # After tests are run, this hacky script will process the JUnit output of nextest
   # and will create a GH Issue if there is a test marked as flaky, 
-  # only if the PR is from a member of qdrant team, otherwise, permissions to edit issues will fail.
+  # Failure of updating an issue is ignored because it fails for external contributors.
   process-results:
     runs-on: ubuntu-latest
     needs: test
     permissions:
       contents: read
       issues: write 
-    if: ${{ contains(fromJSON('["COLLABORATOR", "OWNER"]'), github.event.pull_request.author_association) || github.event.pull_request == null }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest  ]
@@ -81,6 +80,7 @@ jobs:
             .github/ISSUE_TEMPLATE/flaky_test.md
           sparse-checkout-cone-mode: false
       - name: Create issue for flaky tests
+        continue-on-error: true
         id: create-issue
         if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
         uses: JasonEtco/create-an-issue@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,6 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-    - run: echo ${{ github.event.pull_request.author_association }}
     - name: Install minimal stable
       uses: dtolnay/rust-toolchain@stable
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,13 +39,15 @@ jobs:
         path: target/nextest/ci/junit.xml
         
   # After tests are run, this hacky script will process the JUnit output of nextest
-  # and will create a GH Issue if there is a test marked as flaky
+  # and will create a GH Issue if there is a test marked as flaky, 
+  # only if the PR is from a member of qdrant team, otherwise, permissions to edit issues will fail.
   process-results:
     runs-on: ubuntu-latest
     needs: test
     permissions:
       contents: read
       issues: write 
+    if: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) || github.event.pull_request == null }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest  ]
@@ -71,12 +73,12 @@ jobs:
           echo "$(jq '[.flakyFailure] | flatten | .[0]["system-err"]' flaky_tests.json -r)" >> $GITHUB_OUTPUT
           echo $delimiter >> $GITHUB_OUTPUT
       - name: pull issue template
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/ISSUE_TEMPLATE/flaky_test.md
           sparse-checkout-cone-mode: false
-        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
       - name: Create issue for flaky tests
         id: create-issue
         if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
@@ -87,6 +89,7 @@ jobs:
           SYSTEM_ERROR: ${{ steps.get-flaky-tests.outputs.content }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ github.job }}
           SHA: ${{ github.sha }}
           WORKFLOW: ${{ github.workflow }}
           JOB: ${{ github.job }}


### PR DESCRIPTION
## Changes

- ~restrict to only create automatic issues on PRs of authors of the org, or on dev/main.~ Edit: Don't fail the workflow if the issue posting/update fails. This may happen when an already open issue of a test flakes again, and tries to update with the credentials of an external contributor.
- modify link to failed job, currently this only applies to the issue reporting job, because it's hard to link them to the actual flaky failure run, but it already improves it.
- add last flaky failure date.
- reduce retries to only 2. Having 3 tries in total feels more than enough.