### PR TITLE
Deduplicate search logic: Add core search internal endpoint

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -44,14 +44,11 @@ where
     #[inline]
     #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
-        let errors = self
-            .iter()
-            .filter_map(|v| v.validate().err())
-            .fold(Err(ValidationErrors::new()), |bag, err| {
-                ValidationErrors::merge(bag, "?", Err(err))
-            })
-            .unwrap_err();
-        errors.errors().is_empty().then_some(()).ok_or(errors)
+        let mut bag = ValidationErrors::new();
+        if let Some(errs) = self.iter().find_map(|v| v.validate().err()) {
+            bag = ValidationErrors::merge(Err(bag), "?", Err(errs)).unwrap_err();
+        }
+        bag.errors().is_empty().then_some(()).ok_or(bag)
     }
 }
 

--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -768,77 +768,10 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        // shortcuts batch if all requests with limit=0
-        if request.searches.iter().all(|s| s.limit == 0) {
-            return Ok(vec![]);
-        }
-        // A factor which determines if we need to use the 2-step search or not
-        // Should be adjusted based on usage statistics.
-        const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
-
-        let is_payload_required = request.searches.iter().all(|s| {
-            s.with_payload
-                .clone()
-                .map(|p| p.is_required())
-                .unwrap_or_default()
-        });
-        let with_vectors = request.searches.iter().all(|s| {
-            s.with_vector
-                .as_ref()
-                .map(|wv| wv.is_some())
-                .unwrap_or(false)
-        });
-
-        let metadata_required = is_payload_required || with_vectors;
-
-        let sum_limits: usize = request.searches.iter().map(|s| s.limit).sum();
-        let sum_offsets: usize = request.searches.iter().map(|s| s.offset).sum();
-
-        // Number of records we need to retrieve to fill the search result.
-        let require_transfers = self.shards_holder.read().await.len() * (sum_limits + sum_offsets);
-        // Actually used number of records.
-        let used_transfers = sum_limits;
-
-        let is_required_transfer_large_enough =
-            require_transfers > used_transfers * PAYLOAD_TRANSFERS_FACTOR_THRESHOLD;
-
-        if metadata_required && is_required_transfer_large_enough {
-            // If there is a significant offset, we need to retrieve the whole result
-            // set without payload first and then retrieve the payload.
-            // It is required to do this because the payload might be too large to send over the
-            // network.
-            let mut without_payload_requests = Vec::with_capacity(request.searches.len());
-            for search in &request.searches {
-                let mut without_payload_request = search.clone();
-                without_payload_request.with_payload = None;
-                without_payload_request.with_vector = None;
-                without_payload_requests.push(without_payload_request);
-            }
-            let without_payload_batch = SearchRequestBatch {
-                searches: without_payload_requests,
-            };
-            let without_payload_results = self
-                ._search_batch(without_payload_batch, read_consistency, shard_selection)
-                .await?;
-            let filled_results = without_payload_results
-                .into_iter()
-                .zip(request.clone().searches.into_iter())
-                .map(|(without_payload_result, req)| {
-                    self.fill_search_result_with_payload(
-                        without_payload_result,
-                        req.with_payload.clone(),
-                        req.with_vector.unwrap_or_default(),
-                        read_consistency,
-                        shard_selection,
-                    )
-                });
-            try_join_all(filled_results).await
-        } else {
-            let result = self
-                ._search_batch(request, read_consistency, shard_selection)
-                .await?;
-            Ok(result)
-        }
+        // Transform legacy search request into newer core type
+        let core_request = request.into();
+        self.core_search_batch(core_request, read_consistency, shard_selection)
+            .await
     }
 
     pub async fn core_search_batch(
@@ -926,23 +859,9 @@ impl Collection {
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let request = Arc::new(request);
-
-        // query all shards concurrently
-        let all_searches_res = {
-            let shard_holder = self.shards_holder.read().await;
-            let target_shards = shard_holder.target_shard(shard_selection)?;
-            let all_searches = target_shards
-                .iter()
-                .map(|shard| shard.search(request.clone(), read_consistency));
-            try_join_all(all_searches).await?
-        };
-
-        let request = Arc::into_inner(request)
-            .expect("We have already dropped all of the Arc clones at this point")
-            .into();
-
-        self.merge_from_shards(all_searches_res, request, shard_selection)
+        // Transform legacy search request into newer core type
+        let core_request = request.into();
+        self._core_search_batch(core_request, read_consistency, shard_selection)
             .await
     }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1159,10 +1159,18 @@ pub struct BaseGroupRequest {
 impl From<SearchRequestBatch> for CoreSearchRequestBatch {
     fn from(batch: SearchRequestBatch) -> Self {
         CoreSearchRequestBatch {
+            searches: batch.searches.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&SearchRequestBatch> for CoreSearchRequestBatch {
+    fn from(batch: &SearchRequestBatch) -> Self {
+        CoreSearchRequestBatch {
             searches: batch
                 .searches
-                .into_iter()
-                .map(CoreSearchRequest::from)
+                .iter()
+                .map(|search| search.clone().into())
                 .collect(),
         }
     }


### PR DESCRIPTION
Merges into <https://github.com/qdrant/qdrant/pull/2661>.

Deduplicates search logic by routing all legacy search requests through our new core search interface.

Please review with care. Maybe there's a good reason not to do this in some cases.