### PR TITLE
RocksDB deletes obsolete file more aggressively

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -12,6 +12,7 @@ use crate::entry::entry_point::{OperationError, OperationResult};
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 const DB_MAX_LOG_SIZE: usize = 1024 * 1024; // 1 mb
 const DB_MAX_OPEN_FILES: usize = 256;
+const DB_DELETE_OBSOLETE_FILES_PERIOD: u64 = 30 * 60 * 1_000_000; // 30 minutes in microseconds
 
 pub const DB_VECTOR_CF: &str = "vector";
 pub const DB_PAYLOAD_CF: &str = "payload";
@@ -42,6 +43,7 @@ pub fn db_options() -> Options {
     options.set_log_level(LogLevel::Error);
     options.set_recycle_log_file_num(2);
     options.set_max_log_file_size(DB_MAX_LOG_SIZE);
+    options.set_delete_obsolete_files_period_micros(DB_DELETE_OBSOLETE_FILES_PERIOD);
     options.create_missing_column_families(true);
     options.set_max_open_files(DB_MAX_OPEN_FILES as i32);
     #[cfg(debug_assertions)]


### PR DESCRIPTION
This PR sets RocksDB to delete obsolete files more aggressively.

We have observed that RocksDB storage directories tend to be full of `LOG.old.*` files which start representing a significant amount of space in setup with a large number of collections.

We have already configured RocksDB to keep at most 2 files but the cleanup frequency is set to 6h by default.

This PR proposes to lower the cleaning threshold explicitly to 30 minutes to free disk space more aggressively without impacting the performance.

Reference: https://github.com/facebook/rocksdb/issues/2166