### PR TITLE
Fix cardinality estimation for Any matcher

### DIFF
--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -363,7 +363,14 @@ impl PayloadFieldIndex for MapIndex<SmolStr> {
             })) => {
                 let estimations = keywords
                     .iter()
-                    .map(|keyword| self.match_cardinality(keyword.as_str()))
+                    .map(|keyword| {
+                        let keyword_condition = FieldCondition::new_match(
+                            condition.key.clone(),
+                            keyword.to_owned().into(),
+                        );
+                        self.match_cardinality(keyword.as_str())
+                            .with_primary_clause(PrimaryCondition::Condition(keyword_condition))
+                    })
                     .collect::<Vec<_>>();
                 Some(combine_should_estimations(
                     &estimations,
@@ -450,7 +457,14 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             })) => {
                 let estimations = integers
                     .iter()
-                    .map(|integer| self.match_cardinality(integer))
+                    .map(|integer| {
+                        let integer_condition = FieldCondition::new_match(
+                            condition.key.clone(),
+                            integer.to_owned().into(),
+                        );
+                        self.match_cardinality(integer)
+                            .with_primary_clause(PrimaryCondition::Condition(integer_condition))
+                    })
                     .collect::<Vec<_>>();
                 Some(combine_should_estimations(
                     &estimations,

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -46,7 +46,6 @@ pub struct CardinalityEstimation {
 }
 
 impl CardinalityEstimation {
-    #[allow(dead_code)]
     pub fn exact(count: usize) -> Self {
         CardinalityEstimation {
             primary_clauses: vec![],


### PR DESCRIPTION
Fix for https://github.com/qdrant/qdrant/issues/2707

When calculating the cardinality estimation for the any matcher, we actually forgot to set primary clauses for it.

This means the condition was never used upstream to restrict to working set of the query resulting into a full scan.