### PR TITLE
Sparse index persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,7 +4756,6 @@ dependencies = [
  "io",
  "memmap2 0.7.1",
  "memory",
- "ordered-float 3.9.1",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,13 @@ name = "sparse"
 version = "0.1.0"
 dependencies = [
  "common",
+ "io",
+ "memmap2 0.7.1",
+ "memory",
+ "ordered-float 3.9.1",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/lib/common/io/src/file_operations.rs
+++ b/lib/common/io/src/file_operations.rs
@@ -72,3 +72,9 @@ impl From<bincode::Error> for Error {
         Self::Bincode(*err)
     }
 }
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, err.to_string())
+    }
+}

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -92,6 +92,7 @@ where
     );
 }
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
+    debug_assert_eq!(v.len(), size_of::<T>());
     unsafe { &*(v.as_ptr() as *const T) }
 }
 

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -91,6 +91,9 @@ where
         instant.elapsed()
     );
 }
+pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
+    unsafe { &*(v.as_ptr() as *const T) }
+}
 
 pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v as *const T as *const u8, mem::size_of_val(v)) }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -17,4 +17,3 @@ memmap2 = "0.7.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3.8.0"
-ordered-float = "3.7.0"

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -11,3 +11,10 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common/common" }
+io = { path = "../common/io" }
+memory = { path = "../common/memory" }
+memmap2 = "0.7.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3.8.0"
+ordered-float = "3.7.0"

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -1,0 +1,228 @@
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use io::file_operations::{atomic_save_json, read_json};
+use memmap2::{Mmap, MmapMut};
+use memory::madvise;
+use memory::mmap_ops::{
+    create_and_ensure_length, open_read_mmap, open_write_mmap, transmute_from_u8,
+    transmute_from_u8_to_slice, transmute_to_u8, transmute_to_u8_slice,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::common::types::DimId;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use crate::index::posting_list::PostingElement;
+
+const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
+const INDEX_FILE_NAME: &str = "index.data";
+const INDEX_CONFIG_FILE_NAME: &str = "index_config.json";
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct InvertedIndexFileHeader {
+    pub posting_count: usize,
+}
+
+/// Inverted flatten index from dimension id to posting list
+pub struct InvertedIndexMmap {
+    mmap: Arc<Mmap>,
+    file_header: InvertedIndexFileHeader,
+}
+
+#[derive(Debug, Default, Clone)]
+struct PostingListFileHeader {
+    pub start_offset: u64,
+    pub end_offset: u64,
+}
+
+impl InvertedIndexMmap {
+    pub fn index_file_path(path: &Path) -> PathBuf {
+        path.join(INDEX_FILE_NAME)
+    }
+
+    pub fn index_config_file_path(path: &Path) -> PathBuf {
+        path.join(INDEX_CONFIG_FILE_NAME)
+    }
+
+    pub fn get(&self, id: &DimId) -> Option<&[PostingElement]> {
+        // check that the id is not out of bounds (posting_count includes the empty zeroth entry)
+        if *id >= self.file_header.posting_count as DimId {
+            return None;
+        }
+
+        let header = transmute_from_u8::<PostingListFileHeader>(
+            &self.mmap
+                [*id as usize * POSTING_HEADER_SIZE..(*id as usize + 1) * POSTING_HEADER_SIZE],
+        )
+        .clone();
+        let elements_bytes = &self.mmap[header.start_offset as usize..header.end_offset as usize];
+        Some(transmute_from_u8_to_slice(elements_bytes))
+    }
+
+    pub fn convert_and_save<P: AsRef<Path>>(
+        inverted_index_ram: &InvertedIndexRam,
+        path: P,
+    ) -> std::io::Result<Self> {
+        let (total_posting_headers_size, total_posting_elements_size) =
+            Self::calculate_file_length(inverted_index_ram);
+        let file_length = total_posting_headers_size + total_posting_elements_size;
+        let file_path = Self::index_file_path(path.as_ref());
+        create_and_ensure_length(file_path.as_ref(), file_length)?;
+
+        let mut mmap = open_write_mmap(file_path.as_ref())?;
+        madvise::madvise(&mmap, madvise::get_global())?;
+
+        // file index data
+        Self::save_posting_headers(&mut mmap, inverted_index_ram, total_posting_headers_size);
+        Self::save_posting_elements(&mut mmap, inverted_index_ram, total_posting_headers_size);
+
+        let posting_count = inverted_index_ram.postings.len();
+
+        // finalize data with index file.
+        let file_header = InvertedIndexFileHeader { posting_count };
+        let config_file_path = Self::index_config_file_path(path.as_ref());
+        atomic_save_json(&config_file_path, &file_header)?;
+
+        Ok(Self {
+            mmap: Arc::new(mmap.make_read_only()?),
+            file_header,
+        })
+    }
+
+    pub fn load<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let file_path = Self::index_file_path(path.as_ref());
+        let mmap = open_read_mmap(file_path.as_ref())?;
+        madvise::madvise(&mmap, madvise::get_global())?;
+        // read from index file
+        let config_file_path = Self::index_config_file_path(path.as_ref());
+        // if the file header does not exist, the index is malformed (TODO delete data if no file)
+        let file_header: InvertedIndexFileHeader = read_json(&config_file_path)?;
+        Ok(Self {
+            mmap: Arc::new(mmap),
+            file_header,
+        })
+    }
+
+    /// Calculate file length in bytes
+    /// Returns (posting headers size, posting elements size)
+    fn calculate_file_length(inverted_index_ram: &InvertedIndexRam) -> (usize, usize) {
+        let total_posting_headers_size = inverted_index_ram.postings.len() * POSTING_HEADER_SIZE;
+
+        let mut total_posting_elements_size = 0;
+        for posting in &inverted_index_ram.postings {
+            total_posting_elements_size += posting.elements.len() * size_of::<PostingElement>();
+        }
+
+        (total_posting_headers_size, total_posting_elements_size)
+    }
+
+    fn save_posting_headers(
+        mmap: &mut MmapMut,
+        inverted_index_ram: &InvertedIndexRam,
+        total_posting_headers_size: usize,
+    ) {
+        let mut elements_offset: usize = total_posting_headers_size;
+        for (id, posting) in inverted_index_ram.postings.iter().enumerate() {
+            let posting_elements_size = posting.elements.len() * size_of::<PostingElement>();
+            let posting_header = PostingListFileHeader {
+                start_offset: elements_offset as u64,
+                end_offset: (elements_offset + posting_elements_size) as u64,
+            };
+            elements_offset = posting_header.end_offset as usize;
+
+            // save posting header
+            let posting_header_bytes = transmute_to_u8(&posting_header);
+            let start_posting_offset = id * POSTING_HEADER_SIZE;
+            let end_posting_offset = (id + 1) * POSTING_HEADER_SIZE;
+            mmap[start_posting_offset..end_posting_offset].copy_from_slice(posting_header_bytes);
+        }
+    }
+
+    fn save_posting_elements(
+        mmap: &mut MmapMut,
+        inverted_index_ram: &InvertedIndexRam,
+        total_posting_headers_size: usize,
+    ) {
+        let mut offset = total_posting_headers_size;
+        for posting in &inverted_index_ram.postings {
+            // save posting element
+            let posting_elements_bytes = transmute_to_u8_slice(&posting.elements);
+            mmap[offset..offset + posting_elements_bytes.len()]
+                .copy_from_slice(posting_elements_bytes);
+            offset += posting_elements_bytes.len();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::index::inverted_index::inverted_index_ram::InvertedIndexBuilder;
+    use crate::index::posting_list::PostingList;
+
+    fn compare_indexes(
+        inverted_index_ram: &InvertedIndexRam,
+        inverted_index_mmap: &InvertedIndexMmap,
+    ) {
+        for id in 0..inverted_index_ram.postings.len() as DimId {
+            let posting_list_ram = inverted_index_ram.get(&id).unwrap().elements.as_slice();
+            let posting_list_mmap = inverted_index_mmap.get(&id).unwrap();
+            assert_eq!(posting_list_ram.len(), posting_list_mmap.len());
+            for i in 0..posting_list_ram.len() {
+                assert_eq!(posting_list_ram[i], posting_list_mmap[i]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_inverted_index_mmap() {
+        let inverted_index_ram = InvertedIndexBuilder::new()
+            .add(
+                1,
+                PostingList::from(vec![
+                    (1, 10.0),
+                    (2, 20.0),
+                    (3, 30.0),
+                    (4, 1.0),
+                    (5, 2.0),
+                    (6, 3.0),
+                    (7, 4.0),
+                    (8, 5.0),
+                    (9, 6.0),
+                ]),
+            )
+            .add(
+                2,
+                PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0), (4, 1.0)]),
+            )
+            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(5, PostingList::from(vec![(1, 10.0), (2, 20.0)])) // skip 4
+            .build();
+
+        let tmp_dir_path = Builder::new().prefix("test_index_dir").tempdir().unwrap();
+
+        {
+            let inverted_index_mmap =
+                InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
+
+            compare_indexes(&inverted_index_ram, &inverted_index_mmap);
+        }
+        let inverted_index_mmap = InvertedIndexMmap::load(&tmp_dir_path).unwrap();
+
+        compare_indexes(&inverted_index_ram, &inverted_index_mmap);
+
+        assert!(inverted_index_mmap.get(&0).unwrap().is_empty()); // the first entry is always empty as dimension ids start at 1
+        assert_eq!(inverted_index_mmap.get(&1).unwrap().len(), 9);
+        assert_eq!(inverted_index_mmap.get(&2).unwrap().len(), 4);
+        assert_eq!(inverted_index_mmap.get(&3).unwrap().len(), 3);
+        assert!(inverted_index_mmap.get(&4).unwrap().is_empty()); // return empty posting list info for intermediary empty ids
+        assert_eq!(inverted_index_mmap.get(&5).unwrap().len(), 2);
+        // index after the last values are None
+        assert!(inverted_index_mmap.get(&6).is_none());
+        assert!(inverted_index_mmap.get(&7).is_none());
+        assert!(inverted_index_mmap.get(&100).is_none());
+    }
+}

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -4,11 +4,14 @@ use crate::common::types::DimId;
 use crate::index::posting_list::PostingList;
 
 /// Inverted flatten index from dimension id to posting list
-pub struct InvertedIndex {
+
+/// Inverted flatten index from dimension id to posting list
+#[derive(Debug, Clone)]
+pub struct InvertedIndexRam {
     pub postings: Vec<PostingList>,
 }
 
-impl InvertedIndex {
+impl InvertedIndexRam {
     pub fn get(&self, id: &DimId) -> Option<&PostingList> {
         self.postings.get((*id) as usize)
     }
@@ -30,13 +33,12 @@ impl InvertedIndexBuilder {
         self
     }
 
-    pub fn build(&mut self) -> InvertedIndex {
+    pub fn build(&mut self) -> InvertedIndexRam {
         // Get sorted keys
         let mut keys: Vec<u32> = self.postings.keys().copied().collect();
         keys.sort_unstable();
 
         let last_key = *keys.last().unwrap_or(&0);
-
         // Allocate postings of max key size
         let mut postings = Vec::new();
         postings.resize(last_key as usize + 1, PostingList::default());
@@ -45,6 +47,6 @@ impl InvertedIndexBuilder {
         for key in keys {
             postings[key as usize] = self.postings.remove(&key).unwrap();
         }
-        InvertedIndex { postings }
+        InvertedIndexRam { postings }
     }
 }

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,0 +1,23 @@
+use crate::common::types::DimId;
+use crate::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use crate::index::posting_list::PostingListIterator;
+
+pub mod inverted_index_mmap;
+pub mod inverted_index_ram;
+
+pub enum InvertedIndex {
+    Ram(InvertedIndexRam),
+    Mmap(InvertedIndexMmap),
+}
+
+impl InvertedIndex {
+    pub fn get(&self, id: &DimId) -> Option<PostingListIterator> {
+        match self {
+            InvertedIndex::Ram(index) => index
+                .get(id)
+                .map(|posting_list| PostingListIterator::new(&posting_list.elements)),
+            InvertedIndex::Mmap(index) => index.get(id).map(PostingListIterator::new),
+        }
+    }
+}

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -2,7 +2,7 @@ use common::types::PointOffsetType;
 
 use crate::common::types::DimWeight;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PostingElement {
     pub record_id: PointOffsetType,
     pub weight: DimWeight,
@@ -76,7 +76,7 @@ impl PostingBuilder {
 
 /// Iterator over posting list elements offering skipping abilities to avoid full iteration.
 pub struct PostingListIterator<'a> {
-    posting_list: &'a PostingList,
+    pub elements: &'a [PostingElement],
     current_index: usize,
 }
 
@@ -84,8 +84,8 @@ impl<'a> Iterator for PostingListIterator<'a> {
     type Item = &'a PostingElement;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_index < self.posting_list.elements.len() {
-            let element = &self.posting_list.elements[self.current_index];
+        if self.current_index < self.elements.len() {
+            let element = &self.elements[self.current_index];
             self.current_index += 1;
             Some(element)
         } else {
@@ -95,21 +95,21 @@ impl<'a> Iterator for PostingListIterator<'a> {
 }
 
 impl<'a> PostingListIterator<'a> {
-    pub fn new(posting_list: &'a PostingList) -> PostingListIterator<'a> {
+    pub fn new(elements: &'a [PostingElement]) -> PostingListIterator<'a> {
         PostingListIterator {
-            posting_list,
+            elements,
             current_index: 0,
         }
     }
 
     /// Returns the next element without advancing the iterator.
     pub fn peek(&self) -> Option<&PostingElement> {
-        self.posting_list.elements.get(self.current_index)
+        self.elements.get(self.current_index)
     }
 
     /// Returns the number of elements from the current position to the end of the list.
     pub fn len_to_end(&self) -> usize {
-        self.posting_list.elements.len() - self.current_index
+        self.elements.len() - self.current_index
     }
 
     /// Tries to find the element with ID == id and returns it.
@@ -119,18 +119,18 @@ impl<'a> PostingListIterator<'a> {
     /// If the iterator skipped to the end, None is returned and current index is set to the length of the list.
     /// Uses binary search.
     pub fn skip_to(&mut self, id: PointOffsetType) -> Option<&PostingElement> {
-        if self.current_index >= self.posting_list.elements.len() {
+        if self.current_index >= self.elements.len() {
             return None;
         }
 
         // Use binary search to find the next element with ID > id
-        let next_element = self.posting_list.elements[self.current_index..]
-            .binary_search_by(|e| e.record_id.cmp(&id));
+        let next_element =
+            self.elements[self.current_index..].binary_search_by(|e| e.record_id.cmp(&id));
 
         match next_element {
             Ok(found_offset) => {
                 self.current_index += found_offset;
-                Some(&self.posting_list.elements[self.current_index])
+                Some(&self.elements[self.current_index])
             }
             Err(insert_index) => {
                 self.current_index += insert_index;
@@ -141,7 +141,7 @@ impl<'a> PostingListIterator<'a> {
 
     /// Skips to the end of the posting list and returns None.
     pub fn skip_to_end(&mut self) -> Option<&PostingElement> {
-        self.current_index = self.posting_list.elements.len();
+        self.current_index = self.elements.len();
         None
     }
 }
@@ -165,7 +165,7 @@ mod tests {
 
         let posting_list = builder.build();
 
-        let mut iter = PostingListIterator::new(&posting_list);
+        let mut iter = PostingListIterator::new(&posting_list.elements);
 
         assert_eq!(iter.peek().unwrap().record_id, 1);
 

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -76,7 +76,7 @@ impl PostingBuilder {
 
 /// Iterator over posting list elements offering skipping abilities to avoid full iteration.
 pub struct PostingListIterator<'a> {
-    pub elements: &'a [PostingElement],
+    elements: &'a [PostingElement],
     current_index: usize,
 }
 


### PR DESCRIPTION
This PR adds memmap persistence for the sparse vector index.

The idea is to persist the flatten index `Vec<PostingList>` as a memmap file.

which is
`Vec<Vec<PostingElement>>`

which is
`Vec<Vec<(u32, f32, f32)>>`

There is an extra file header saved as JSON containing the total number of posting lists in the file.

Its presence informs us if the index data is well formed.

The index data itself is prefixed by a series of  header for deserialization purpose containing the offsets of each posting list.

Example for `n` posting lists.

`index.data` = `n * [posting header] | n * [posting index data]`

Retrieving a posting list by id means:

1. retrieve header information (based on the fixed length of header
2. get offsets from header to get posting list as a slice 