### PR TITLE
file cleaner for arc copy

### DIFF
--- a/lib/collection/src/collection.rs
+++ b/lib/collection/src/collection.rs
@@ -23,6 +23,7 @@ use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 use validator::Validate;
 
 use crate::collection_state::{ShardInfo, State};
+use crate::common::file_utils::FileCleaner;
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
 use crate::hash_ring::HashRing;
@@ -1664,6 +1665,9 @@ impl Collection {
         // We can't copy to the target location directly, because copy is not atomic.
         // So we copy to the final location with a temporary name and then rename atomically.
         let snapshot_path_tmp_move = snapshot_path.with_extension("tmp");
+
+        // Ensure that the temporary file is deleted on error
+        let _file_cleaner = FileCleaner::new(&snapshot_path_tmp_move);
         copy(&snapshot_temp_arc_file.path(), &snapshot_path_tmp_move).await?;
         rename(&snapshot_path_tmp_move, &snapshot_path).await?;
 

--- a/lib/collection/src/common/file_utils.rs
+++ b/lib/collection/src/common/file_utils.rs
@@ -57,3 +57,33 @@ pub async fn move_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Collecti
     }
     Ok(())
 }
+
+/// Guard, that ensures that file will be deleted on drop.
+pub struct FileCleaner {
+    path: Option<PathBuf>,
+}
+
+impl FileCleaner {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: Some(path.into()),
+        }
+    }
+
+    pub fn delete(&mut self) {
+        if let Some(path) = &self.path {
+            // Ignore errors, because file can be already deleted.
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    pub fn forget(&mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for FileCleaner {
+    fn drop(&mut self) {
+        self.delete();
+    }
+}


### PR DESCRIPTION
Resolves uncleared `.tmp` file in snapshots directory in case of failed copying process