### PR TITLE
Fix unprivileged Docker container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ WORKDIR ${APP}
 ARG USER_ID=0
 
 # Create the user
-RUN if [[ "$USER_ID" != "0" ]]; then (groupadd --gid $USER_ID qdrant \
+RUN if [ "$USER_ID" != "0" ]; then (groupadd --gid $USER_ID qdrant \
     && useradd --uid $USER_ID --gid $USER_ID -m qdrant \
     && chown -R $USER_ID:$USER_ID ${APP}); fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,9 +98,9 @@ RUN PKG_CONFIG="/usr/bin/$(xx-info)-pkg-config" \
     && PROFILE_DIR=$(if [ "$PROFILE" = dev ]; then echo debug; else echo $PROFILE; fi) \
     && mv target/$(xx-cargo --print-target-triple)/$PROFILE_DIR/qdrant /qdrant/qdrant
 
-
 # Download and extract web UI
 RUN mkdir /static ; STATIC_DIR='/static' ./tools/sync-web-ui.sh
+
 
 FROM debian:12-slim AS qdrant
 
@@ -110,28 +110,30 @@ RUN apt-get update \
 
 ARG APP=/qdrant
 
-RUN mkdir -p ${APP}
+RUN mkdir -p "$APP"
 
-COPY --from=builder /qdrant/qdrant ${APP}/qdrant
-COPY --from=builder /qdrant/config ${APP}/config
-COPY --from=builder /qdrant/tools/entrypoint.sh ${APP}/entrypoint.sh
-COPY --from=builder /static ${APP}/static
+COPY --from=builder /qdrant/qdrant "$APP"/qdrant
+COPY --from=builder /qdrant/config "$APP"/config
+COPY --from=builder /qdrant/tools/entrypoint.sh "$APP"/entrypoint.sh
+COPY --from=builder /static "$APP"/static
 
-WORKDIR ${APP}
+WORKDIR "$APP"
 
 ARG USER_ID=0
 
-# Create the user
-RUN if [ "$USER_ID" != "0" ]; then (groupadd --gid $USER_ID qdrant \
-    && useradd --uid $USER_ID --gid $USER_ID -m qdrant \
-    && chown -R $USER_ID:$USER_ID ${APP}); fi
+RUN if [ "$USER_ID" != 0 ]; then \
+        groupadd --gid "$USER_ID" qdrant; \
+        useradd --uid "$USER_ID" --gid "$USER_ID" -m qdrant; \
+        chown -R "$USER_ID:$USER_ID" "$APP"; \
+    fi
+
+USER "$USER_ID:$USER_ID"
 
 ENV TZ=Etc/UTC \
     RUN_MODE=production
 
 EXPOSE 6333
 EXPOSE 6334
-USER $USER_ID:$USER_ID
 
 LABEL org.opencontainers.image.title="Qdrant"
 LABEL org.opencontainers.image.description="Official Qdrant image"


### PR DESCRIPTION
Happened to need an unprivileged Docker container to test some permissions-related stuff... and discovered we weren't building it right all this time and container was not working properly! 🤦‍♀️

This PR fixes unprivileged build. (And makes some cosmetic changes to the Dockerfile.)

The core of the issue is:
- Docker uses plain `sh` when building images
- there's no `[[` built-in in `sh`
- and, as far as I can tell, there's no `[[` binary in the base Debian image that we are using for the final stage of the build
- and so the `if [[ "$USER_ID" != "0" ]]; then ...` check _always_ fails
- but because `[[` command fails as part of `if` statement, it is not considered "fatal" and does not fail image build
  - and the way Docker displays command output during container build makes it practically impossible for anyone to notice the error during image build
  - e.g., it flashes `/bin/sh: 1: [[: not found` for a tiny fraction of a second
  - and then removes all output and simply displays that build step succeeded
- and so we have a dysfunctional docker image, that is run with custom user ID, but without user being created or permissions set

I've noticed @bashofmann used `[[` in #2613, but didn't bother to check if it works. 🥲

<details>
<summary>Some pictures</summary>

Running `qdrant/qdrant:latest-unprivileged` does not work:
<img width="504" alt="Screenshot 2023-09-25 at 18 52 19" src="https://github.com/qdrant/qdrant/assets/2725918/d0992d8b-c172-4207-8e6a-9674808981ff">

Running `bash` inside `qdrant/qdrant:latest-unprivileged` tells that user has no name, and `ls` shows `/qdrant` is owned by `root`:
<img width="494" alt="Screenshot 2023-09-25 at 18 52 52" src="https://github.com/qdrant/qdrant/assets/2725918/91cfb399-23c0-4c2f-babc-51d3c79d85f1">

Checking if `[[` works in Dockerfile:
<img width="909" alt="Screenshot 2023-09-25 at 18 50 14" src="https://github.com/qdrant/qdrant/assets/2725918/38ea0ece-95c5-4329-a156-e358044b0088">

</details>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
