### PR TITLE
Implement dynamic read operation fan out on local update (#2717, #2728)

### DIFF
--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -9,6 +9,7 @@ use segment::types::{
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
+use super::update_tracker::UpdateTracker;
 use crate::operations::point_ops::{PointOperations, PointStruct, PointSyncOperation};
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
@@ -141,8 +142,8 @@ impl ForwardProxyShard {
         self.wrapped_shard.get_telemetry_data()
     }
 
-    pub fn is_update_in_progress(&self) -> bool {
-        self.wrapped_shard.is_update_in_progress()
+    pub fn update_tracker(&self) -> &UpdateTracker {
+        self.wrapped_shard.update_tracker()
     }
 }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -67,10 +67,6 @@ pub struct LocalShard {
 
 /// Shard holds information about segments and WAL.
 impl LocalShard {
-    pub fn is_update_in_progress(&self) -> bool {
-        self.update_tracker.is_update_in_progress()
-    }
-
     pub async fn move_data(from: &Path, to: &Path) -> CollectionResult<()> {
         let wal_from = Self::wal_path(from);
         let wal_to = Self::wal_path(to);
@@ -801,6 +797,10 @@ impl LocalShard {
             config: collection_config,
             payload_schema: schema,
         }
+    }
+
+    pub fn update_tracker(&self) -> &UpdateTracker {
+        &self.update_tracker
     }
 }
 

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -46,7 +46,7 @@ impl LocalShard {
         let is_stopped = StoppingGuard::new();
 
         let search_request = SegmentsSearcher::search(
-            self.segments(),
+            self.segments.clone(),
             core_request.clone(),
             search_runtime_handle,
             true,

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -13,6 +13,7 @@ use tokio::runtime::Handle;
 use tokio::sync::{oneshot, RwLock};
 use tokio::time::timeout;
 
+use super::update_tracker::UpdateTracker;
 use crate::operations::operation_effect::{
     EstimateOperationEffectArea, OperationEffectArea, PointsOperationEffect,
 };
@@ -120,8 +121,8 @@ impl ProxyShard {
         self.wrapped_shard.get_telemetry_data()
     }
 
-    pub fn is_update_in_progress(&self) -> bool {
-        self.wrapped_shard.is_update_in_progress()
+    pub fn update_tracker(&self) -> &UpdateTracker {
+        self.wrapped_shard.update_tracker()
     }
 }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -10,6 +10,7 @@ use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
 use super::remote_shard::RemoteShard;
+use super::update_tracker::UpdateTracker;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest, CountResult,
@@ -158,8 +159,8 @@ impl QueueProxyShard {
         self.wrapped_shard.get_telemetry_data()
     }
 
-    pub fn is_update_in_progress(&self) -> bool {
-        self.wrapped_shard.is_update_in_progress()
+    pub fn update_tracker(&self) -> &UpdateTracker {
+        self.wrapped_shard.update_tracker()
     }
 }
 

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -871,12 +871,12 @@ impl ShardReplicaSet {
 
         let (local, is_local_ready, update_watcher) = match self.local.try_read() {
             Ok(local) => {
+                let update_watcher = local.deref().as_ref().map(Shard::watch_for_update);
+
                 let is_local_ready = local
                     .deref()
                     .as_ref()
                     .map_or(false, |local| !local.is_update_in_progress());
-
-                let update_watcher = local.deref().as_ref().map(Shard::watch_for_update);
 
                 (
                     future::ready(local).left_future(),

--- a/lib/collection/src/shards/update_tracker.rs
+++ b/lib/collection/src/shards/update_tracker.rs
@@ -27,10 +27,10 @@ impl UpdateTracker {
     }
 
     pub fn watch_for_update(&self) -> impl Future<Output = ()> {
-        let mut update_notifier = self.update_notifier.subscribe();
+        let mut update_subscriber = self.update_notifier.subscribe();
 
         async move {
-            match update_notifier.changed().await {
+            match update_subscriber.changed().await {
                 Ok(()) => (),
                 Err(_) => future::pending().await,
             }

--- a/lib/collection/src/shards/update_tracker.rs
+++ b/lib/collection/src/shards/update_tracker.rs
@@ -1,9 +1,24 @@
+use std::future::{self, Future};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Default)]
+use tokio::sync::watch;
+
+#[derive(Clone, Debug)]
 pub struct UpdateTracker {
     update_operations: Arc<AtomicUsize>,
+    update_notifier: Arc<watch::Sender<()>>,
+}
+
+impl Default for UpdateTracker {
+    fn default() -> Self {
+        let (update_notifier, _) = watch::channel(());
+
+        Self {
+            update_operations: Default::default(),
+            update_notifier: Arc::new(update_notifier),
+        }
+    }
 }
 
 impl UpdateTracker {
@@ -11,7 +26,22 @@ impl UpdateTracker {
         self.update_operations.load(Ordering::Relaxed) > 0
     }
 
+    pub fn watch_for_update(&self) -> impl Future<Output = ()> {
+        let mut update_notifier = self.update_notifier.subscribe();
+
+        async move {
+            match update_notifier.changed().await {
+                Ok(()) => (),
+                Err(_) => future::pending().await,
+            }
+        }
+    }
+
     pub fn update(&self) -> UpdateGuard {
+        if self.update_operations.fetch_add(1, Ordering::Relaxed) == 0 {
+            self.update_notifier.send_replace(());
+        }
+
         UpdateGuard::new(self.update_operations.clone())
     }
 }
@@ -23,7 +53,6 @@ pub struct UpdateGuard {
 
 impl UpdateGuard {
     fn new(update_operations: Arc<AtomicUsize>) -> Self {
-        update_operations.fetch_add(1, Ordering::Relaxed);
         Self { update_operations }
     }
 }

--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -134,5 +134,5 @@ def test_collection_shard_update(tmp_path: pathlib.Path):
     assert r.status_code == 400
     error = r.json()["status"]["error"]
     assert error.__contains__("Wrong input: 1 out of 2 shards failed to apply operation")
-    assert error.__contains__("Wrong input: InvalidArgument")
+    assert error.__contains__("Wrong input: Vector inserting error: expected dim")
 


### PR DESCRIPTION
Asynchronously watch for the start of local update operation and fan-out to one additional shard (if there's one) if local update operation started _and local read operation still pending_.

Resolves #2717.

__TODO:__
- [x] code is kinda ugly
- [x] only fan-out if _local_ read operation has not finished yet at the moment when update started? 🤔

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
