### PR TITLE
nullable recommendation strategy

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6311,7 +6311,15 @@
             }
           },
           "strategy": {
-            "$ref": "#/components/schemas/RecommendStrategy"
+            "description": "How to use positive and negative vectors to find the results",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RecommendStrategy"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "filter": {
             "description": "Look only for points which satisfies this conditions",
@@ -9139,7 +9147,16 @@
             }
           },
           "strategy": {
-            "$ref": "#/components/schemas/RecommendStrategy"
+            "description": "How to use positive and negative vectors to find the results",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RecommendStrategy"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "filter": {
             "description": "Look only for points which satisfies this conditions",

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -973,16 +973,13 @@ impl From<api::grpc::qdrant::RecommendStrategy> for RecommendStrategy {
     }
 }
 
-impl TryFrom<Option<i32>> for RecommendStrategy {
+impl TryFrom<i32> for RecommendStrategy {
     type Error = Status;
 
-    fn try_from(value: Option<i32>) -> Result<Self, Self::Error> {
-        let strategy = match value {
-            None => api::grpc::qdrant::RecommendStrategy::AverageVector,
-            Some(i) => api::grpc::qdrant::RecommendStrategy::from_i32(i).ok_or_else(|| {
-                Status::invalid_argument(format!("Unknown recommend strategy: {}", i))
-            })?,
-        };
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        let strategy = api::grpc::qdrant::RecommendStrategy::from_i32(value).ok_or_else(|| {
+            Status::invalid_argument(format!("Unknown recommend strategy: {}", value))
+        })?;
         Ok(strategy.into())
     }
 }
@@ -1026,7 +1023,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPoints> for RecommendRequest {
         Ok(RecommendRequest {
             positive,
             negative,
-            strategy: value.strategy.try_into()?,
+            strategy: value.strategy.map(|s| s.try_into()).transpose()?,
             filter: value.filter.map(|f| f.try_into()).transpose()?,
             params: value.params.map(|p| p.into()),
             limit: value.limit as usize,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -382,7 +382,7 @@ impl From<u64> for RecommendExample {
 /// - `BestScore` - Uses custom search objective. Each candidate is compared against all
 ///   examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`.
 ///   If the `max_neg_score` is chosen then it is squared and negated.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum RecommendStrategy {
     #[default]
@@ -434,8 +434,7 @@ pub struct RecommendRequest {
     pub negative: Vec<RecommendExample>,
 
     /// How to use positive and negative vectors to find the results
-    #[serde(default)]
-    pub strategy: RecommendStrategy,
+    pub strategy: Option<RecommendStrategy>,
 
     /// Look only for points which satisfies this conditions
     pub filter: Option<Filter>,
@@ -497,7 +496,7 @@ pub struct RecommendGroupsRequest {
 
     /// How to use positive and negative vectors to find the results
     #[serde(default)]
-    pub strategy: RecommendStrategy,
+    pub strategy: Option<RecommendStrategy>,
 
     /// Look only for points which satisfies this conditions
     pub filter: Option<Filter>,

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -160,7 +160,7 @@ where
 
     for request in &request_batch.searches {
         // Validate amount of examples
-        match request.strategy {
+        match request.strategy.unwrap_or_default() {
             RecommendStrategy::AverageVector => {
                 if request.positive.is_empty() {
                     return Err(CollectionError::BadRequest {
@@ -363,11 +363,13 @@ fn batch_by_strategy(
             None => None,
             Some(req) => {
                 // start new batch
-                let strategy = req.strategy.clone();
+                let strategy = req.strategy.unwrap_or_default();
                 let mut batch = vec![req];
 
                 // continue until we see a different strategy
-                batch.extend(iter.take_while_ref(|req| req.strategy == strategy));
+                batch.extend(
+                    iter.take_while_ref(|req| req.strategy.unwrap_or_default() == strategy),
+                );
 
                 Some((strategy, batch))
             }
@@ -492,27 +494,27 @@ mod tests {
     fn test_batch_by_strategy() {
         let requests = vec![
             RecommendRequest {
-                strategy: RecommendStrategy::AverageVector,
+                strategy: Some(RecommendStrategy::AverageVector),
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::AverageVector,
+                strategy: None,
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::BestScore,
+                strategy: Some(RecommendStrategy::BestScore),
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::BestScore,
+                strategy: Some(RecommendStrategy::BestScore),
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::BestScore,
+                strategy: Some(RecommendStrategy::BestScore),
                 ..Default::default()
             },
             RecommendRequest {
-                strategy: RecommendStrategy::AverageVector,
+                strategy: Some(RecommendStrategy::AverageVector),
                 ..Default::default()
             },
         ];

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -882,7 +882,7 @@ pub async fn recommend(
     let request = collection::operations::types::RecommendRequest {
         positive,
         negative,
-        strategy: strategy.try_into()?,
+        strategy: strategy.map(|s| s.try_into()).transpose()?,
         filter: filter.map(|f| f.try_into()).transpose()?,
         params: params.map(|p| p.into()),
         limit: limit as usize,


### PR DESCRIPTION
Allow `strategy: null` in reco REST API
