### PR TITLE
Simplify aloha random write, after first try, lock on one random forever

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -370,18 +370,9 @@ impl<'s> SegmentHolder {
         }
 
         let mut rng = rand::thread_rng();
-        let mut timeout = Duration::from_nanos(100);
-        loop {
-            let (segment_id, segment_lock) = entries.choose(&mut rng).unwrap();
-            let opt_segment_guard = segment_lock.try_write_for(timeout);
-
-            match opt_segment_guard {
-                None => timeout = timeout.saturating_mul(2), // Wait longer next time
-                Some(mut lock) => {
-                    return apply(*segment_id, &mut lock);
-                }
-            }
-        }
+        let (segment_id, segment_lock) = entries.choose(&mut rng).unwrap();
+        let mut segment_write = segment_lock.write();
+        apply(*segment_id, &mut segment_write)
     }
 
     /// Update function wrapper, which ensures that updates are not applied written to un-appendable segment.


### PR DESCRIPTION
Our lock acquiring mechanism in `aloha_random_write` seems to introduce a deadlock, and is therefore problematic.

Replacing the last bit, that randomly tried to lock any appendable segment with exponential timeout, with a call that tries to lock just one random appendable segment forever, fixes the problem in our test case.

Sadly, we're still short an explanation on what the exact problem is here.

More details: https://github.com/qdrant/qdrant/pull/2733#issuecomment-1737214030

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
