### PR TITLE
Minor fixes for dynamic fan out PR (#2741, #2728)

### DIFF
--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -134,5 +134,9 @@ def test_collection_shard_update(tmp_path: pathlib.Path):
     assert r.status_code == 400
     error = r.json()["status"]["error"]
     assert error.__contains__("Wrong input: 1 out of 2 shards failed to apply operation")
+    # Update requests are applied on the local shard and propagated to the remote shards in parallel.
+    # These operations may complete (or fail) in arbitrary order, and if request fails, Qdrant returns
+    # error message of the first failed operation.
+    # Local and remote operations return different errors, so we check for both.
     assert error.__contains__("Wrong input: Vector inserting error: expected dim") or error.__contains__("Wrong input: InvalidArgument")
 

--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -134,5 +134,5 @@ def test_collection_shard_update(tmp_path: pathlib.Path):
     assert r.status_code == 400
     error = r.json()["status"]["error"]
     assert error.__contains__("Wrong input: 1 out of 2 shards failed to apply operation")
-    assert error.__contains__("Wrong input: Vector inserting error: expected dim") || error.__contains__("Wrong input: InvalidArgument")
+    assert error.__contains__("Wrong input: Vector inserting error: expected dim") or error.__contains__("Wrong input: InvalidArgument")
 

--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -134,5 +134,5 @@ def test_collection_shard_update(tmp_path: pathlib.Path):
     assert r.status_code == 400
     error = r.json()["status"]["error"]
     assert error.__contains__("Wrong input: 1 out of 2 shards failed to apply operation")
-    assert error.__contains__("Wrong input: Vector inserting error: expected dim")
+    assert error.__contains__("Wrong input: Vector inserting error: expected dim") || error.__contains__("Wrong input: InvalidArgument")
 


### PR DESCRIPTION
- Fix potentially flaky `test_collection_shard_update`
- Replace `join_all` with `FuturesUnordered` in `ShardReplicaSet::update`
- Also made some cosmetic changes in `replica_set.rs`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
