### PR TITLE
fix: Include binary index on match value

### DIFF
--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -199,6 +199,16 @@ impl BinaryIndex {
     pub fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
         self.values_count(point_id) == 0
     }
+
+    /// Check if the point has a true value
+    pub fn values_has_true(&self, point_id: PointOffsetType) -> bool {
+        self.memory.get(point_id).has_true()
+    }
+
+    /// Check if the point has a false value
+    pub fn values_has_false(&self, point_id: PointOffsetType) -> bool {
+        self.memory.get(point_id).has_false()
+    }
 }
 
 impl PayloadFieldIndex for BinaryIndex {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -234,6 +234,15 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
                         .map_or(false, |values| values.iter().any(|i| i == &value))
                 }))
             }
+            (ValueVariants::Bool(is_true), FieldIndex::BinaryIndex(index)) => {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    if is_true {
+                        index.values_has_true(point_id)
+                    } else {
+                        index.values_has_false(point_id)
+                    }
+                }))
+            }
             _ => None,
         },
         Match::Text(MatchText { text }) => match index {


### PR DESCRIPTION
Fixes #2743 
I missed to use the binary index when doing match by value 🤦 

The issue uses count API to get the unwanted behavior because `exact` defaults to `true`, with this fix it gets 1 or 2 orders of magnitude faster.

I checked with `exact=false` and it can be 4 orders of magnitude faster (works correctly without this fix)
