### PR TITLE
improve compatibility with existing clients

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4979,7 +4979,6 @@
           },
           "read_fan_out_factor": {
             "description": "Defines how many additional replicas should be processing read request at the same time. Default value is Auto, which means that fan-out will be determined automatically based on the busyness of the local replica. Having more than 0 might be useful to smooth latency spikes of individual nodes.",
-            "default": null,
             "type": "integer",
             "format": "uint32",
             "minimum": 0,

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -75,7 +75,7 @@ pub struct CollectionParams {
     /// Default value is Auto, which means that fan-out will be determined automatically based on
     /// the busyness of the local replica.
     /// Having more than 0 might be useful to smooth latency spikes of individual nodes.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_fan_out_factor: Option<u32>,
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.


### PR DESCRIPTION
Do not serialize fan-out if it is default.

Helps better backward compatibility with existing clients