### PR TITLE
only forward update from shard to another shard

### DIFF
--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -154,7 +154,6 @@ impl RemoteShard {
         wait: bool,
         ordering: WriteOrdering,
     ) -> CollectionResult<UpdateResult> {
-        // the target shard is None because the operation is forwarded as if it came from the client
         self.execute_update_operation(
             Some(self.id),
             self.collection_id.clone(),

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -156,7 +156,7 @@ impl RemoteShard {
     ) -> CollectionResult<UpdateResult> {
         // the target shard is None because the operation is forwarded as if it came from the client
         self.execute_update_operation(
-            None,
+            Some(self.id),
             self.collection_id.clone(),
             operation,
             wait,

--- a/tests/consensus_tests/test_write_ordering.py
+++ b/tests/consensus_tests/test_write_ordering.py
@@ -69,6 +69,25 @@ def test_write_ordering(tmp_path: pathlib.Path):
     # succeeds as Medium selects an Alive peer
     assert_http_ok(r)
 
+    # Write ordering with filter update operation
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/test_collection/points/delete?wait=true&ordering=medium", json={
+            "filter": {
+                "must": [
+                    {
+                        "key": "a",
+                        "match": {
+                            "value": 100
+                        }
+                    }
+                ]
+            }
+        }
+    )
+
+    # succeeds as Medium selects an Alive peer
+    assert_http_ok(r)
+
     # write ordering strong
     r = requests.put(
         f"{peer_api_uris[0]}/collections/test_collection/points?wait=true&ordering=strong", json={


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/2751


Main change: always specify shard selection if the request was made from the remote shard structure.

