### PR TITLE
Allow JsonPath for PayloadSelector

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -202,6 +202,7 @@ fn focus_array_path<'a>(
 /// path: "arr[].a"   => Vec![Value::Array[ 1, 2, 3], 4]
 /// path: "arr[].a[]" => Vec![ 1, 2, 3, 4]
 ///
+/// performance: the function could be improved by using the Entry API instead of BTreeMap.get
 pub fn get_value_from_json_map<'a>(
     path: &str,
     json_map: &'a serde_json::Map<String, Value>,
@@ -282,6 +283,9 @@ fn delete_array_path(
     MultiValue::default()
 }
 
+/// Remove value at a given JSON path from JSON map
+///
+/// performance: the function could be improved by using the Entry API instead of BTreeMap.get_mut
 pub fn remove_value_from_json_map(
     path: &str,
     json_map: &mut serde_json::Map<String, Value>,

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -421,7 +421,7 @@ pub fn filter_json_values(
     } else {
         // This should never happen, because _filter_json_values always returns same
         // type as input
-        panic!("Unexpected value type")
+        unreachable!("Unexpected value type")
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2889,9 +2889,9 @@ mod tests {
         });
         assert_eq!(selected_payload, expected.into());
 
-        // with implicit array traversal
+        // with explicit array traversal ([] notation)
         let selector = PayloadSelector::new_include(vec!["b.c[].d".to_string()]);
-        let selected_payload = selector.process(payload.into());
+        let selected_payload = selector.process(payload.clone().into());
 
         let expected = json!({
             "b": {
@@ -2899,6 +2899,17 @@ mod tests {
                     {"d": 1},
                     {"d": 3}
                 ]
+            }
+        });
+        assert_eq!(selected_payload, expected.into());
+
+        // shortcuts implicit array traversal
+        let selector = PayloadSelector::new_include(vec!["b.c.d".to_string()]);
+        let selected_payload = selector.process(payload.into());
+
+        let expected = json!({
+            "b": {
+                "c": []
             }
         });
         assert_eq!(selected_payload, expected.into());

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1855,7 +1855,7 @@ impl PayloadSelector {
                     }
                 }
                 MultiValue::Multiple(elements) => {
-                    let array = elements.iter().cloned().cloned().collect();
+                    let array = elements.into_iter().cloned().collect();
                     insert_at_path(path, &mut new_json_map, Value::Array(array));
                 }
             }

--- a/openapi/tests/openapi_integration/test_payload_selector.py
+++ b/openapi/tests/openapi_integration/test_payload_selector.py
@@ -259,7 +259,7 @@ def test_payload_selectors():
         }
     }
 
-    # Search with payload selector include at array index
+    # Search with payload selector exclude at array index
     response = request_with_validation(
         api='/collections/{collection_name}/points/scroll',
         method="POST",

--- a/openapi/tests/openapi_integration/test_payload_selector.py
+++ b/openapi/tests/openapi_integration/test_payload_selector.py
@@ -1,0 +1,310 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+from .test_nested_payload_indexing import nested_payload_collection_setup
+
+collection_name = 'test_collection_nested_payload_query'
+
+
+@pytest.fixture(autouse=True)
+def setup(on_disk_vectors, on_disk_payload):
+    nested_payload_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors, on_disk_payload=on_disk_payload)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_payload_selectors():
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    # Search without payload selector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": False,
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']['points']) == 1
+    assert response.json()['result']['points'][0]['payload'] is None
+
+    # Search with payload selector ALL
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": True,
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "name": "Germany",
+            "capital": "Berlin",
+            "cities": [
+                {
+                    "name": "Berlin",
+                    "population": 3.7,
+                    "location": {
+                        "lon": 13.76116,
+                        "lat": 52.33826,
+                    },
+                    "sightseeing": ["Brandenburg Gate", "Reichstag"]
+                },
+                {
+                    "name": "Munich",
+                    "population": 1.5,
+                    "location": {
+                        "lon": 11.57549,
+                        "lat": 48.13743,
+                    },
+                    "sightseeing": ["Marienplatz", "Olympiapark"]
+                },
+                {
+                    "name": "Hamburg",
+                    "population": 1.8,
+                    "location": {
+                        "lon": 9.99368,
+                        "lat": 53.55108,
+                    },
+                    "sightseeing": ["Reeperbahn", "Elbphilharmonie"]
+                }
+            ],
+        }
+    }
+
+    # Search with payload selector include paths
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "include": ["country.name", "country.capital"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "name": "Germany",
+            "capital": "Berlin",
+        }
+    }
+
+    # Search with payload selector include paths
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "include": ["country.cities"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "cities": [
+                {
+                    "name": "Berlin",
+                    "population": 3.7,
+                    "location": {
+                        "lon": 13.76116,
+                        "lat": 52.33826,
+                    },
+                    "sightseeing": ["Brandenburg Gate", "Reichstag"]
+                },
+                {
+                    "name": "Munich",
+                    "population": 1.5,
+                    "location": {
+                        "lon": 11.57549,
+                        "lat": 48.13743,
+                    },
+                    "sightseeing": ["Marienplatz", "Olympiapark"]
+                },
+                {
+                    "name": "Hamburg",
+                    "population": 1.8,
+                    "location": {
+                        "lon": 9.99368,
+                        "lat": 53.55108,
+                    },
+                    "sightseeing": ["Reeperbahn", "Elbphilharmonie"]
+                }
+            ],
+        }
+    }
+
+    # Search with payload selector include at array index
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "include": ["country.cities[0]"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "cities": [
+                {
+                    "name": "Berlin",
+                    "population": 3.7,
+                    "location": {
+                        "lon": 13.76116,
+                        "lat": 52.33826,
+                    },
+                    "sightseeing": ["Brandenburg Gate", "Reichstag"]
+                },
+            ],
+        }
+    }
+
+    # Search with payload selector exclude paths
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "exclude": ["country.cities"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "name": "Germany",
+            "capital": "Berlin",
+        }
+    }
+
+    # Search with payload selector include at array index
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "exclude": ["country.name", "country.capital", "country.cities[1]"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "cities": [
+                {
+                    "name": "Berlin",
+                    "population": 3.7,
+                    "location": {
+                        "lon": 13.76116,
+                        "lat": 52.33826,
+                    },
+                    "sightseeing": ["Brandenburg Gate", "Reichstag"]
+                },
+                {
+                    "name": "Hamburg",
+                    "population": 1.8,
+                    "location": {
+                        "lon": 9.99368,
+                        "lat": 53.55108,
+                    },
+                    "sightseeing": ["Reeperbahn", "Elbphilharmonie"]
+                }
+            ],
+        }
+    }
+
+

--- a/openapi/tests/openapi_integration/test_payload_selector.py
+++ b/openapi/tests/openapi_integration/test_payload_selector.py
@@ -190,6 +190,45 @@ def test_payload_selectors():
         }
     }
 
+    # Search with payload selector include paths
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "country.name",
+                        "match": {
+                            "value": "Germany",
+                        }
+                    }
+                ]
+            },
+            "limit": 3,
+            "with_payload": {
+                "include": ["country.cities[].name"],
+            },
+        }
+    )
+    assert response.ok
+    assert response.json()['result']['points'][0]['payload'] == {
+        "country": {
+            "cities": [
+                {
+                    "name": "Berlin",
+                },
+                {
+                    "name": "Munich"
+                },
+                {
+                    "name": "Hamburg"
+                }
+            ],
+        }
+    }
+
     # Search with payload selector exclude paths
     response = request_with_validation(
         api='/collections/{collection_name}/points/scroll',

--- a/openapi/tests/openapi_integration/test_payload_selector.py
+++ b/openapi/tests/openapi_integration/test_payload_selector.py
@@ -190,45 +190,6 @@ def test_payload_selectors():
         }
     }
 
-    # Search with payload selector include at array index
-    response = request_with_validation(
-        api='/collections/{collection_name}/points/scroll',
-        method="POST",
-        path_params={'collection_name': collection_name},
-        body={
-            "filter": {
-                "must": [
-                    {
-                        "key": "country.name",
-                        "match": {
-                            "value": "Germany",
-                        }
-                    }
-                ]
-            },
-            "limit": 3,
-            "with_payload": {
-                "include": ["country.cities[0]"],
-            },
-        }
-    )
-    assert response.ok
-    assert response.json()['result']['points'][0]['payload'] == {
-        "country": {
-            "cities": [
-                {
-                    "name": "Berlin",
-                    "population": 3.7,
-                    "location": {
-                        "lon": 13.76116,
-                        "lat": 52.33826,
-                    },
-                    "sightseeing": ["Brandenburg Gate", "Reichstag"]
-                },
-            ],
-        }
-    }
-
     # Search with payload selector exclude paths
     response = request_with_validation(
         api='/collections/{collection_name}/points/scroll',
@@ -277,7 +238,7 @@ def test_payload_selectors():
             },
             "limit": 3,
             "with_payload": {
-                "exclude": ["country.name", "country.capital", "country.cities[1]"],
+                "exclude": ["country.name", "country.capital"],
             },
         }
     )
@@ -295,6 +256,15 @@ def test_payload_selectors():
                     "sightseeing": ["Brandenburg Gate", "Reichstag"]
                 },
                 {
+                    "name": "Munich",
+                    "population": 1.5,
+                    "location": {
+                        "lon": 11.57549,
+                        "lat": 48.13743,
+                    },
+                    "sightseeing": ["Marienplatz", "Olympiapark"]
+                },
+                {
                     "name": "Hamburg",
                     "population": 1.8,
                     "location": {
@@ -306,5 +276,3 @@ def test_payload_selectors():
             ],
         }
     }
-
-


### PR DESCRIPTION
Context: #2336 

This PR adds support for `JsonPath` in payload selector to enable users to fetch exactly when they need.

This was implemented using our existing `JsonPath` infrastructure plus a new method for inserting at a given path.

The new feature is covered with unit and integration tests.