### PR TITLE
Change local shard stuck in Initializing to Active on load

### DIFF
--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -20,6 +20,7 @@ pub struct SharedStorageConfig {
     pub recovery_mode: Option<String>,
     pub search_timeout: Duration,
     pub update_concurrency: Option<NonZeroUsize>,
+    pub is_distributed: bool,
 }
 
 impl Default for SharedStorageConfig {
@@ -31,6 +32,7 @@ impl Default for SharedStorageConfig {
             recovery_mode: None,
             search_timeout: DEFAULT_SEARCH_TIMEOUT,
             update_concurrency: None,
+            is_distributed: false,
         }
     }
 }
@@ -43,6 +45,7 @@ impl SharedStorageConfig {
         recovery_mode: Option<String>,
         search_timeout: Option<Duration>,
         update_concurrency: Option<NonZeroUsize>,
+        is_distributed: bool,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,
@@ -55,6 +58,7 @@ impl SharedStorageConfig {
             recovery_mode,
             search_timeout: search_timeout.unwrap_or(DEFAULT_SEARCH_TIMEOUT),
             update_concurrency,
+            is_distributed,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -738,22 +738,6 @@ impl ShardReplicaSet {
         res && !self.is_locally_disabled(peer_id)
     }
 
-    /// Determines if the given peer is local and is in `Initializing` state.
-    pub async fn peer_is_local_initializing(&self, peer_id: &PeerId) -> bool {
-        let is_local = &self.this_peer_id() == peer_id && self.is_local().await;
-        let is_initializing = match self.peer_state(peer_id) {
-            Some(ReplicaState::Initializing) => true,
-            Some(
-                ReplicaState::Active
-                | ReplicaState::Partial
-                | ReplicaState::Dead
-                | ReplicaState::Listener,
-            )
-            | None => false,
-        };
-        is_local && is_initializing
-    }
-
     pub fn peer_state(&self, peer_id: &PeerId) -> Option<ReplicaState> {
         self.replica_state.read().get_peer_state(peer_id).copied()
     }

--- a/lib/collection/src/shards/replica_set.rs
+++ b/lib/collection/src/shards/replica_set.rs
@@ -738,6 +738,22 @@ impl ShardReplicaSet {
         res && !self.is_locally_disabled(peer_id)
     }
 
+    /// Determines if the given peer is local and is in `Initializing` state.
+    pub async fn peer_is_local_initializing(&self, peer_id: &PeerId) -> bool {
+        let is_local = &self.this_peer_id() == peer_id && self.is_local().await;
+        let is_initializing = match self.peer_state(peer_id) {
+            Some(ReplicaState::Initializing) => true,
+            Some(
+                ReplicaState::Active
+                | ReplicaState::Partial
+                | ReplicaState::Dead
+                | ReplicaState::Listener,
+            )
+            | None => false,
+        };
+        is_local && is_initializing
+    }
+
     pub fn peer_state(&self, peer_id: &PeerId) -> Option<ReplicaState> {
         self.replica_state.read().get_peer_state(peer_id).copied()
     }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -276,7 +276,11 @@ impl ShardHolder {
 
                 // Change local shards stuck in Initializing state to Active
                 let local_peer_id = replica_set.this_peer_id();
-                if replica_set.peer_is_local_initializing(&local_peer_id).await {
+                let is_local =
+                    replica_set.this_peer_id() == local_peer_id && replica_set.is_local().await;
+                let is_initializing =
+                    replica_set.peer_state(&local_peer_id) == Some(ReplicaState::Initializing);
+                if is_local && is_initializing {
                     log::warn!("Local shard {collection_id}:{} stuck in Initializing state, changing to Active", replica_set.shard_id);
                     replica_set
                         .set_replica_state(&local_peer_id, ReplicaState::Active)

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -276,11 +276,12 @@ impl ShardHolder {
 
                 // Change local shards stuck in Initializing state to Active
                 let local_peer_id = replica_set.this_peer_id();
+                let not_distributed = !shared_storage_config.is_distributed;
                 let is_local =
                     replica_set.this_peer_id() == local_peer_id && replica_set.is_local().await;
                 let is_initializing =
                     replica_set.peer_state(&local_peer_id) == Some(ReplicaState::Initializing);
-                if is_local && is_initializing {
+                if not_distributed && is_local && is_initializing {
                     log::warn!("Local shard {collection_id}:{} stuck in Initializing state, changing to Active", replica_set.shard_id);
                     replica_set
                         .set_replica_state(&local_peer_id, ReplicaState::Active)

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fs::File;
 
 use collection::operations::payload_ops::{PayloadOps, SetPayload};
 use collection::operations::point_ops::{Batch, PointOperations, PointStruct, WriteOrdering};
@@ -7,6 +8,7 @@ use collection::operations::types::{
 };
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
+use collection::shards::replica_set::{ReplicaSetState, ReplicaState};
 use itertools::Itertools;
 use segment::data_types::vectors::VectorStruct;
 use segment::types::{
@@ -481,4 +483,46 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
     assert_eq!(result.points.get(0).unwrap().id, 1.into());
     assert_eq!(result.points.get(1).unwrap().id, 2.into());
     assert_eq!(result.points.get(2).unwrap().id, 4.into());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_collection_local_load_initializing_not_stuck() {
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+
+    // Create and unload collection
+    simple_collection_fixture(collection_dir.path(), 1).await;
+
+    // Modify replica state file on disk, set state to Initializing
+    // This is to simulate a situation where a collection was not fully created, we cannot create
+    // this situation through our collection interface
+    {
+        let replica_state_path = collection_dir.path().join("0/replica_state.json");
+        let replica_state_file = File::open(&replica_state_path).unwrap();
+        let mut replica_set_state: ReplicaSetState =
+            serde_json::from_reader(replica_state_file).unwrap();
+
+        for peer_id in replica_set_state.peers().into_keys() {
+            replica_set_state.set_peer_state(peer_id, ReplicaState::Initializing);
+        }
+
+        let replica_state_file = File::create(&replica_state_path).unwrap();
+        serde_json::to_writer(replica_state_file, &replica_set_state).unwrap();
+    }
+
+    // Reload collection
+    let collection_path = collection_dir.path();
+    let loaded_collection = load_local_collection(
+        "test".to_string(),
+        collection_path,
+        &collection_path.join("snapshots"),
+    )
+    .await;
+
+    // Local replica must be in Active state after loading (all replicas are local)
+    let loaded_state = loaded_collection.state().await;
+    for shard_info in loaded_state.shards.values() {
+        for replica_state in shard_info.replicas.values() {
+            assert_eq!(replica_state, &ReplicaState::Active);
+        }
+    }
 }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -159,7 +159,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     assert_eq!(count_res.count, 1);
 }
 
-// FIXME: dos not work
+// FIXME: does not work
 #[tokio::test(flavor = "multi_thread")]
 async fn test_collection_loading() {
     test_collection_loading_with_shards(1).await;

--- a/lib/storage/src/content_manager/toc.rs
+++ b/lib/storage/src/content_manager/toc.rs
@@ -120,6 +120,7 @@ impl TableOfContent {
         let collection_paths =
             read_dir(&collections_path).expect("Can't read Collections directory");
         let mut collections: HashMap<String, Collection> = Default::default();
+        let is_distributed = consensus_proposal_sender.is_some();
         for entry in collection_paths {
             let collection_path = entry
                 .expect("Can't access of one of the collection files")
@@ -150,7 +151,9 @@ impl TableOfContent {
                 this_peer_id,
                 &collection_path,
                 &collection_snapshots_path,
-                storage_config.to_shared_storage_config().into(),
+                storage_config
+                    .to_shared_storage_config(is_distributed)
+                    .into(),
                 channel_service.clone(),
                 Self::change_peer_state_callback(
                     consensus_proposal_sender.clone(),
@@ -430,7 +433,9 @@ impl TableOfContent {
             &collection_path,
             &snapshots_path,
             &collection_config,
-            self.storage_config.to_shared_storage_config().into(),
+            self.storage_config
+                .to_shared_storage_config(self.is_distributed())
+                .into(),
             collection_shard_distribution,
             self.channel_service.clone(),
             Self::change_peer_state_callback(
@@ -1471,7 +1476,9 @@ impl TableOfContent {
                         &collection_path,
                         &snapshots_path,
                         &state.config,
-                        self.storage_config.to_shared_storage_config().into(),
+                        self.storage_config
+                            .to_shared_storage_config(self.is_distributed())
+                            .into(),
                         shard_distribution,
                         self.channel_service.clone(),
                         Self::change_peer_state_callback(

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -75,7 +75,7 @@ pub struct StorageConfig {
 }
 
 impl StorageConfig {
-    pub fn to_shared_storage_config(&self) -> SharedStorageConfig {
+    pub fn to_shared_storage_config(&self, is_distributed: bool) -> SharedStorageConfig {
         SharedStorageConfig::new(
             self.update_queue_size,
             self.node_type,
@@ -85,6 +85,7 @@ impl StorageConfig {
                 .search_timeout_sec
                 .map(|x| Duration::from_secs(x as u64)),
             self.update_concurrency,
+            is_distributed,
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn main() -> anyhow::Result<()> {
     // It allocates required number of channels and manages proper reconnection handling
     let mut channel_service = ChannelService::default();
 
-    if settings.cluster.enabled {
+    if is_distributed_deployment {
         // We only need channel_service in case if cluster is enabled.
         // So we initialize it with real values here
         let p2p_grpc_timeout = Duration::from_millis(settings.cluster.grpc_timeout_ms);
@@ -256,7 +256,7 @@ fn main() -> anyhow::Result<()> {
     // It decides if query should go directly to the ToC or through the consensus.
     let mut dispatcher = Dispatcher::new(toc_arc.clone());
 
-    let (telemetry_collector, dispatcher_arc) = if settings.cluster.enabled {
+    let (telemetry_collector, dispatcher_arc) = if is_distributed_deployment {
         let consensus_state: ConsensusStateRef = ConsensusManager::new(
             persistent_consensus_state,
             toc_arc.clone(),


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2731>.

Fix a local shard in non-distributed deployment being stuck in `Initializing` bricking a collection on reboot. This could occur if Qdrant crashes while a collection is created. This now updates the local shard state from `Initializing` to `Active` on load.

When this happens, the following warning is logged:

```
WARN collection::shards::shard_holder: Local shard test:0 stuck in Initializing state, changing to Active
```

Tested this situation manually by adding a panic [here](https://github.com/qdrant/qdrant/blob/252c1026c6d726ea737fbc620720bfa56bc5e461/lib/collection/src/collection.rs#L159). Then create a collection, restart Qdrant and fetch the collection info.

Added a unit test for this. It simulates this situation by setting the `Initializing` state in the replica state file on disk directly after the collection is created.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
