### PR TITLE
Fix Clippy lints 1.73

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -141,7 +141,7 @@ impl SegmentsSearcher {
                         // without sampling on that segment.
                         searches_to_rerun
                             .entry(segment_id)
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push(batch_id);
                     }
                 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -127,10 +127,7 @@ where
     let mut op_vec_by_shard: HashMap<ShardId, Vec<O>> = HashMap::new();
     for operation in iter {
         let shard_id = point_to_shard(id_extractor(&operation), ring);
-        op_vec_by_shard
-            .entry(shard_id)
-            .or_insert_with(Vec::new)
-            .push(operation);
+        op_vec_by_shard.entry(shard_id).or_default().push(operation);
     }
     OperationToShard::by_shard(op_vec_by_shard)
 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -370,10 +370,7 @@ impl SplitByShard for Batch {
                         for (name, vector) in named_vector {
                             let name = name.into_owned();
                             let vector = vector.into_owned();
-                            batch_vectors
-                                .entry(name)
-                                .or_insert_with(Vec::new)
-                                .push(vector);
+                            batch_vectors.entry(name).or_default().push(vector);
                         }
                         batch.payloads.as_mut().unwrap().push(payload);
                     }
@@ -411,10 +408,7 @@ impl SplitByShard for Batch {
                         for (name, vector) in named_vector {
                             let name = name.into_owned();
                             let vector = vector.into_owned();
-                            batch_vectors
-                                .entry(name)
-                                .or_insert_with(Vec::new)
-                                .push(vector);
+                            batch_vectors.entry(name).or_default().push(vector);
                         }
                     }
                 }

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -92,10 +92,13 @@ impl SplitByShard for VectorOperations {
                         let shard_id = point_to_shard(point.id, ring);
                         (shard_id, point)
                     })
-                    .fold(HashMap::new(), |mut map, (shard_id, points)| {
-                        map.entry(shard_id).or_insert(vec![]).push(points);
-                        map
-                    });
+                    .fold(
+                        HashMap::new(),
+                        |mut map: HashMap<u32, Vec<PointVectors>>, (shard_id, points)| {
+                            map.entry(shard_id).or_default().push(points);
+                            map
+                        },
+                    );
                 let shard_ops = shard_points.into_iter().map(|(shard_id, points)| {
                     (
                         shard_id,

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -397,7 +397,7 @@ impl GeoMapIndex {
         for geo_hash in &geo_hashes {
             self.points_map
                 .entry(geo_hash.to_owned())
-                .or_insert_with(HashSet::new)
+                .or_default()
                 .insert(idx);
 
             self.increment_hash_value_counts(geo_hash);

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -136,7 +136,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         let mut message_send_failures = self.message_send_failures.write();
         let entry = message_send_failures
             .entry(peer_address.to_string())
-            .or_insert_with(Default::default);
+            .or_default();
         // Log only first error
         if entry.count == 0 {
             log::warn!("Failed to send message to {peer_address} with error: {error}")

--- a/src/common/telemetry_ops/requests_telemetry.rs
+++ b/src/common/telemetry_ops/requests_telemetry.rs
@@ -136,9 +136,7 @@ impl WebApiTelemetry {
         for (method, status_codes) in &other.responses {
             let status_codes_map = self.responses.entry(method.clone()).or_default();
             for (status_code, statistics) in status_codes {
-                let entry = status_codes_map
-                    .entry(*status_code)
-                    .or_insert_with(OperationDurationStatistics::default);
+                let entry = status_codes_map.entry(*status_code).or_default();
                 *entry = entry.clone() + statistics.clone();
             }
         }


### PR DESCRIPTION
Rust 1.73 is around the corner, it is time to fix proactively new Clippy lints to not block our CI.

Only one lint was triggered this time https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_or_default