### PR TITLE
Improve description of vector parameters in update collection REST call

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6775,7 +6775,7 @@
         "type": "object",
         "properties": {
           "vectors": {
-            "description": "Vector data parameters to update. It is possible to provide one config for single vector mode and list of configs for multiple vectors mode.",
+            "description": "Map of vector data parameters to update for each named vector. To update parameters in a collection having a single unnamed vector, use an empty string as name.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/VectorsConfigDiff"

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -180,8 +180,8 @@ impl CreateCollectionOperation {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateCollection {
-    /// Vector data parameters to update.
-    /// It is possible to provide one config for single vector mode and list of configs for multiple vectors mode.
+    /// Map of vector data parameters to update for each named vector.
+    /// To update parameters in a collection having a single unnamed vector, use an empty string as name.
     #[validate]
     pub vectors: Option<VectorsConfigDiff>,
     /// Custom params for Optimizers.  If none - it is left unchanged.


### PR DESCRIPTION
Updates the description of the vector parameters map in the update collection REST call. This changes our OpenAPI specification, but only modifies the description.

Here, users must provide a map of named vectors. Therefore, the current description is wrong. It was also confusing how to update parameters in a collection with a single unnamed vector.

This changes the description from:

> Vector data parameters to update. It is possible to provide one config for single vector mode and list of configs for multiple vectors mode.

to:

> Map of vector data parameters to update for each named vector. To update parameters in a collection having a single unnamed vector, use an empty string as name.

The description is presented here (`vectors` field): <https://qdrant.github.io/qdrant/redoc/index.html#tag/collections/operation/update_collection>

Requested in Discord: <https://discord.com/channels/907569970500743200/1151909233793704068/1159432223049662496>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?