### PR TITLE
Make GeoPolygon interiors optional

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6054,8 +6054,7 @@
         "description": "Geo filter request\n\nMatches coordinates inside the polygon, defined by `exterior` and `interiors`",
         "type": "object",
         "required": [
-          "exterior",
-          "interiors"
+          "exterior"
         ],
         "properties": {
           "exterior": {
@@ -6066,7 +6065,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GeoLineString"
-            }
+            },
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -958,7 +958,7 @@ impl TryFrom<GeoPolygon> for segment::types::GeoPolygon {
                 interiors,
             } => Ok(Self {
                 exterior: e.into(),
-                interiors: interiors.into_iter().map(Into::into).collect(),
+                interiors: Some(interiors.into_iter().map(Into::into).collect()),
             }),
             _ => Err(Status::invalid_argument("Malformed GeoPolygon type")),
         }
@@ -969,7 +969,12 @@ impl From<segment::types::GeoPolygon> for GeoPolygon {
     fn from(value: segment::types::GeoPolygon) -> Self {
         Self {
             exterior: Some(value.exterior.into()),
-            interiors: value.interiors.into_iter().map(Into::into).collect(),
+            interiors: value
+                .interiors
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -879,7 +879,7 @@ mod tests {
 
         let europe_no_berlin = GeoPolygon {
             exterior: europe.clone(),
-            interiors: vec![berlin.clone()],
+            interiors: Some(vec![berlin.clone()]),
         };
         check_cardinality_match(
             polygon_hashes(&europe_no_berlin, GEO_QUERY_MAX_REGION).unwrap(),

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -649,9 +649,11 @@ fn test_struct_payload_geo_polygon_index() {
     }
 
     let exterior = generate_ring(polygon_edge);
-    let interiors = std::iter::repeat_with(|| generate_ring(polygon_edge))
-        .take(interiors_num)
-        .collect();
+    let interiors = Some(
+        std::iter::repeat_with(|| generate_ring(polygon_edge))
+            .take(interiors_num)
+            .collect(),
+    );
 
     let geo_polygon = GeoPolygon {
         exterior,

--- a/openapi/tests/openapi_integration/test_geo_filter.py
+++ b/openapi/tests/openapi_integration/test_geo_filter.py
@@ -285,28 +285,28 @@ def test_geo_polygon_multiple():
                     {
                         "key": "location",
                         "geo_polygon": {
-                            "exterior":{
-                                    "points": [
-                                        {"lon": 55.0, "lat": 55.0},
-                                        {"lon": 65.0, "lat": 55.0},
-                                        {"lon": 65.0, "lat": 65.0},
-                                        {"lon": 55.0, "lat": 65.0},
-                                        {"lon": 55.0, "lat": 55.0},
-                                    ]
+                            "exterior": {
+                                "points": [
+                                    {"lon": 55.0, "lat": 55.0},
+                                    {"lon": 65.0, "lat": 55.0},
+                                    {"lon": 65.0, "lat": 65.0},
+                                    {"lon": 55.0, "lat": 65.0},
+                                    {"lon": 55.0, "lat": 55.0},
+                                ]
                             },
                         },
                     },
                     {
                         "key": "location",
                         "geo_polygon": {
-                            "exterior":{
-                                    "points": [
-                                        {"lon": 75.0, "lat": 75.0},
-                                        {"lon": 85.0, "lat": 75.0},
-                                        {"lon": 85.0, "lat": 85.0},
-                                        {"lon": 75.0, "lat": 85.0},
-                                        {"lon": 75.0, "lat": 75.0},
-                                    ]
+                            "exterior": {
+                                "points": [
+                                    {"lon": 75.0, "lat": 75.0},
+                                    {"lon": 85.0, "lat": 75.0},
+                                    {"lon": 85.0, "lat": 85.0},
+                                    {"lon": 75.0, "lat": 85.0},
+                                    {"lon": 75.0, "lat": 75.0},
+                                ]
                             },
                         },
                     }
@@ -336,28 +336,28 @@ def test_geo_polygon_multiple():
                     {
                         "key": "location",
                         "geo_polygon": {
-                            "exterior":{
-                                    "points": [
-                                        {"lon": 55.0, "lat": 55.0},
-                                        {"lon": 65.0, "lat": 55.0},
-                                        {"lon": 65.0, "lat": 65.0},
-                                        {"lon": 55.0, "lat": 65.0},
-                                        {"lon": 55.0, "lat": 55.0},
-                                    ]
+                            "exterior": {
+                                "points": [
+                                    {"lon": 55.0, "lat": 55.0},
+                                    {"lon": 65.0, "lat": 55.0},
+                                    {"lon": 65.0, "lat": 65.0},
+                                    {"lon": 55.0, "lat": 65.0},
+                                    {"lon": 55.0, "lat": 55.0},
+                                ]
                             },
                         },
                     },
                     {
                         "key": "location",
                         "geo_polygon": {
-                            "exterior":{
-                                    "points": [
-                                        {"lon": 75.0, "lat": 75.0},
-                                        {"lon": 85.0, "lat": 75.0},
-                                        {"lon": 85.0, "lat": 85.0},
-                                        {"lon": 75.0, "lat": 85.0},
-                                        {"lon": 75.0, "lat": 75.0},
-                                    ]
+                            "exterior": {
+                                "points": [
+                                    {"lon": 75.0, "lat": 75.0},
+                                    {"lon": 85.0, "lat": 75.0},
+                                    {"lon": 85.0, "lat": 85.0},
+                                    {"lon": 75.0, "lat": 85.0},
+                                    {"lon": 75.0, "lat": 75.0},
+                                ]
                             },
                         },
                     }


### PR DESCRIPTION
In https://github.com/qdrant/qdrant/pull/2315 we made the `interiors` field of geo polygons effectively optional by performing the validation in a shadow type.

We have tests showing that it works fine **but** we forgot to propagate the change to the type which provided the JSON schema.

Issue discovered while updating the Python client https://github.com/qdrant/qdrant-client/pull/325