### PR TITLE
Fix Clippy 1.73 for consistent Ord impl in NumericIndex

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -85,21 +85,20 @@ impl<T> From<Point<T>> for NumericIndexKey<T> {
 
 impl<T: PartialEq + PartialOrd + Encodable> PartialOrd for NumericIndexKey<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(match self.key.cmp_encoded(&other.key) {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: PartialEq + PartialOrd + Encodable> Ord for NumericIndexKey<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.key.cmp_encoded(&other.key) {
             std::cmp::Ordering::Equal => self.idx.cmp(&other.idx),
             ord => ord,
-        })
+        }
     }
 }
 
 impl<T: PartialEq + PartialOrd + Encodable> Eq for NumericIndexKey<T> {}
-
-impl<T: PartialEq + PartialOrd + Encodable> Ord for NumericIndexKey<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other)
-            .expect("Numeric index key is not comparable")
-    }
-}
 
 impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
     fn from_btree_map(map: BTreeMap<Vec<u8>, u32>) -> Self {


### PR DESCRIPTION
New code failing against Clippy on Rust 1.73

Discovered in https://github.com/qdrant/qdrant/pull/2666#discussion_r1347623278

```
error: incorrect implementation of `partial_cmp` on an `Ord` type
  --> lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs:86:1
   |
86 | /  impl<T: PartialEq + PartialOrd + Encodable> PartialOrd for NumericIndexKey<T> {
87 | |      fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
   | | _______________________________________________________________________-
88 | ||         Some(match self.key.cmp_encoded(&other.key) {
89 | ||             std::cmp::Ordering::Equal => self.idx.cmp(&other.idx),
90 | ||             ord => ord,
91 | ||         })
92 | ||     }
   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
93 | |  }
   | |__^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
   = note: `#[deny(clippy::incorrect_partial_ord_impl_on_ord_type)]` on by default
```

https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type

```
If both PartialOrd and Ord are implemented, they must agree. This is commonly done by wrapping the result of cmp in Some for partial_cmp. Not doing this may silently introduce an error upon refactoring.
```