### PR TITLE
Fix formatting of new gRPC health check

### DIFF
--- a/lib/api/src/grpc/grpc.health.v1.rs
+++ b/lib/api/src/grpc/grpc.health.v1.rs
@@ -14,8 +14,8 @@ pub struct HealthCheckResponse {
 }
 /// Nested message and enum types in `HealthCheckResponse`.
 pub mod health_check_response {
+    #[derive(serde::Serialize)]
     #[derive(
-        serde::Serialize,
         Clone,
         Copy,
         Debug,
@@ -24,7 +24,7 @@ pub mod health_check_response {
         Hash,
         PartialOrd,
         Ord,
-        ::prost::Enumeration,
+        ::prost::Enumeration
     )]
     #[repr(i32)]
     pub enum ServingStatus {
@@ -62,8 +62,8 @@ pub mod health_check_response {
 /// Generated client implementations.
 pub mod health_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct HealthClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -107,8 +107,9 @@ pub mod health_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             HealthClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -146,16 +147,23 @@ pub mod health_client {
         pub async fn check(
             &mut self,
             request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> std::result::Result<tonic::Response<super::HealthCheckResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/grpc.health.v1.Health/Check");
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.health.v1.Health/Check",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("grpc.health.v1.Health", "Check"));
@@ -173,7 +181,10 @@ pub mod health_server {
         async fn check(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> std::result::Result<tonic::Response<super::HealthCheckResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct HealthServer<T: Health> {
@@ -198,7 +209,10 @@ pub mod health_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -254,15 +268,23 @@ pub mod health_server {
                 "/grpc.health.v1.Health/Check" => {
                     #[allow(non_camel_case_types)]
                     struct CheckSvc<T: Health>(pub Arc<T>);
-                    impl<T: Health> tonic::server::UnaryService<super::HealthCheckRequest> for CheckSvc<T> {
+                    impl<
+                        T: Health,
+                    > tonic::server::UnaryService<super::HealthCheckRequest>
+                    for CheckSvc<T> {
                         type Response = super::HealthCheckResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Health>::check(&inner, request).await };
+                            let fut = async move {
+                                <T as Health>::check(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -289,14 +311,18 @@ pub mod health_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -5,6 +5,7 @@ pub mod models;
 pub mod qdrant;
 pub mod dynamic_channel_pool;
 pub mod dynamic_pool;
+#[rustfmt::skip] // tonic uses `prettyplease` to format its output
 #[path = "grpc.health.v1.rs"]
 pub mod grpc_health_v1;
 pub mod transport_channel_pool;


### PR DESCRIPTION
The auto generated file keeps on being reformatted locally.

We usually tag those with `#[rustfmt::skip]`