### PR TITLE
Use stabilized `div_ceil` from from `std`

### DIFF
--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -28,7 +28,6 @@ use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
     PayloadKeyType, ValueVariants,
 };
-use crate::vector_storage::div_ceil;
 
 pub enum MapIndex<N: Hash + Eq + Clone + Display + FromStr> {
     Mutable(MutableMapIndex<N>),
@@ -259,7 +258,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MapIndex<N> {
 
         // Minimal amount of points, required to fit all unused values.
         // Cardinality can't be less than this value.
-        let min_not_excluded_by_values = div_ceil(non_excluded_values_count, max_values_per_point);
+        let min_not_excluded_by_values = non_excluded_values_count.div_ceil(max_values_per_point);
 
         let min = min_not_excluded_by_values.max(
             self.get_indexed_points()

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 
 use common::types::PointOffsetType;
 
-use super::div_ceil;
 use crate::common::vector_utils::TrySetCapacityExact;
 
 // chunk size in bytes
@@ -69,7 +68,7 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
         let key = key as usize;
         self.len = max(self.len, key + 1);
         self.chunks
-            .resize_with(div_ceil(self.len, self.chunk_capacity), Vec::new);
+            .resize_with(self.len.div_ceil(self.chunk_capacity), Vec::new);
 
         let chunk_idx = key / self.chunk_capacity;
         let chunk_data = &mut self.chunks[chunk_idx];
@@ -155,7 +154,7 @@ impl quantization::EncodedStorage for ChunkedVectors<u8> {
 
 impl<T: Clone> TrySetCapacityExact for ChunkedVectors<T> {
     fn try_set_capacity_exact(&mut self, capacity: usize) -> Result<(), TryReserveError> {
-        let num_chunks = div_ceil(capacity, self.chunk_capacity);
+        let num_chunks = capacity.div_ceil(self.chunk_capacity);
         let last_chunk_idx = capacity / self.chunk_capacity;
         self.chunks.try_set_capacity_exact(num_chunks)?;
         self.chunks.resize_with(num_chunks, Vec::new);

--- a/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dynamic_mmap_flags.rs
@@ -12,7 +12,6 @@ use crate::common::error_logging::LogError;
 use crate::common::mmap_type::{MmapBitSlice, MmapType};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::Flusher;
-use crate::vector_storage::div_ceil;
 
 #[cfg(debug_assertions)]
 const MINIMAL_MMAP_SIZE: usize = 128; // 128 bytes -> 1024 flags
@@ -88,7 +87,7 @@ pub struct DynamicMmapFlags {
 
 /// Based on the number of flags determines the size of the mmap file.
 fn mmap_capacity_bytes(num_flags: usize) -> usize {
-    let number_of_bytes = div_ceil(num_flags, 8);
+    let number_of_bytes = num_flags.div_ceil(8);
 
     max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
 }

--- a/lib/segment/src/vector_storage/mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/mmap_vectors.rs
@@ -10,7 +10,6 @@ use memmap2::Mmap;
 use memory::mmap_ops;
 use parking_lot::Mutex;
 
-use super::div_ceil;
 use crate::common::error_logging::LogError;
 use crate::common::mmap_type::MmapBitSlice;
 use crate::common::operation_error::OperationResult;
@@ -229,7 +228,7 @@ fn ensure_mmap_file_size(path: &Path, header: &[u8], size: Option<u64>) -> Opera
 #[inline]
 const fn deleted_mmap_data_start() -> usize {
     let align = mem::align_of::<usize>();
-    div_ceil(HEADER_SIZE, align) * align
+    HEADER_SIZE.div_ceil(align) * align
 }
 
 /// Calculate size for deleted mmap to hold the given number of vectors.
@@ -237,8 +236,8 @@ const fn deleted_mmap_data_start() -> usize {
 /// The mmap will hold a file header and an aligned `BitSlice`.
 fn deleted_mmap_size(num: usize) -> usize {
     let unit_size = mem::size_of::<usize>();
-    let num_bytes = div_ceil(num, 8);
-    let num_usizes = div_ceil(num_bytes, unit_size);
+    let num_bytes = num.div_ceil(8);
+    let num_usizes = num_bytes.div_ceil(unit_size);
     let data_size = num_usizes * unit_size;
     deleted_mmap_data_start() + data_size
 }

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -27,21 +27,3 @@ pub mod sparse_raw_scorer;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;
-
-/// Calculates the quotient of self and rhs, rounding the result towards positive infinity.
-///
-/// # Panics
-///
-/// This function will panic if rhs is zero.
-///
-/// # Overflow behavior
-///
-/// On overflow, this function will panic if overflow checks are enabled (default in debug mode)
-/// and wrap if overflow checks are disabled (default in release mode).
-// Can be replaced with stdlib once it stabilizes:
-// - <https://github.com/rust-lang/rust/issues/88581>
-// - <https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil>
-#[inline]
-pub(crate) const fn div_ceil(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/3032>.

Rust 1.73 stabilized [`div_ceil`](https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil). We can now use that instead of our own implementation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
