### PR TITLE
Refactor `with_channel_timeout`

### DIFF
--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -5,13 +5,18 @@ use std::time::Duration;
 
 use rand::{thread_rng, Rng};
 use tokio::select;
+use tonic::codegen::InterceptedService;
+use tonic::service::Interceptor;
 use tonic::transport::{Channel, ClientTlsConfig, Error as TonicError, Uri};
-use tonic::{Code, Status};
+use tonic::{Code, Request, Status};
 
 use crate::grpc::dynamic_channel_pool::DynamicChannelPool;
 use crate::grpc::dynamic_pool::CountedItem;
 use crate::grpc::qdrant::qdrant_client::QdrantClient;
 use crate::grpc::qdrant::HealthCheckRequest;
+
+// 1 hour should be enough for channel timeout
+pub const MAX_GRPC_CHANNEL_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 pub const DEFAULT_GRPC_TIMEOUT: Duration = Duration::from_secs(60);
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -64,6 +69,26 @@ enum RequestFailure {
     RequestConnection(TonicError),
 }
 
+/// Intercepts gRPC requests and adds a default timeout if it wasn't already set.
+pub struct AddTimeout {
+    default_timeout: Duration,
+}
+
+impl AddTimeout {
+    pub fn new(default_timeout: Duration) -> Self {
+        Self { default_timeout }
+    }
+}
+
+impl Interceptor for AddTimeout {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if request.metadata().get("grpc-timeout").is_none() {
+            request.set_timeout(self.default_timeout);
+        }
+        Ok(request)
+    }
+}
+
 /// Holds a pool of channels established for a set of URIs.
 /// Channel are shared by cloning them.
 /// Make the `pool_size` larger to increase throughput.
@@ -106,7 +131,7 @@ impl TransportChannelPool {
     async fn _init_pool_for_uri(&self, uri: Uri) -> Result<DynamicChannelPool, TonicError> {
         DynamicChannelPool::new(
             uri,
-            self.grpc_timeout,
+            MAX_GRPC_CHANNEL_TIMEOUT,
             self.connection_timeout,
             self.tls_config.clone(),
             MAX_CONNECTIONS_PER_CHANNEL,
@@ -206,10 +231,10 @@ impl TransportChannelPool {
         }
     }
 
-    async fn _make_request<T, O: Future<Output = Result<T, Status>>>(
+    async fn make_request<T, O: Future<Output = Result<T, Status>>>(
         &self,
         uri: &Uri,
-        f: &impl Fn(Channel) -> O,
+        f: &impl Fn(InterceptedService<Channel, AddTimeout>) -> O,
         timeout: Duration,
     ) -> Result<T, RequestFailure> {
         let channel = match self.get_or_create_pooled_channel(uri).await {
@@ -219,8 +244,11 @@ impl TransportChannelPool {
             }
         };
 
+        let intercepted_channel =
+            InterceptedService::new(channel.item().clone(), AddTimeout::new(timeout));
+
         let result: RequestFailure = select! {
-            res = f(channel.item().clone()) => {
+            res = f(intercepted_channel) => {
                 match res {
                     Ok(body) => {
                         channel.report_success();
@@ -231,9 +259,6 @@ impl TransportChannelPool {
             }
             res = self.check_connectability(uri) => {
                RequestFailure::HealthCheck(res)
-            }
-            _res = tokio::time::sleep(timeout) => {
-                RequestFailure::RequestError(Status::deadline_exceeded(format!("Timeout {}ms reached for uri: {}", timeout.as_millis(), uri)))
             }
         };
 
@@ -255,7 +280,7 @@ impl TransportChannelPool {
     pub async fn with_channel_timeout<T, O: Future<Output = Result<T, Status>>>(
         &self,
         uri: &Uri,
-        f: impl Fn(Channel) -> O,
+        f: impl Fn(InterceptedService<Channel, AddTimeout>) -> O,
         timeout: Option<Duration>,
         retries: usize,
     ) -> Result<T, RequestError<Status>> {
@@ -264,7 +289,7 @@ impl TransportChannelPool {
         let max_timeout = timeout.unwrap_or_else(|| self.grpc_timeout + self.connection_timeout);
 
         loop {
-            let request_result: Result<T, _> = self._make_request(uri, &f, max_timeout).await;
+            let request_result: Result<T, _> = self.make_request(uri, &f, max_timeout).await;
 
             let error_result = match request_result {
                 Ok(body) => return Ok(body),
@@ -370,7 +395,7 @@ impl TransportChannelPool {
     pub async fn with_channel<T, O: Future<Output = Result<T, Status>>>(
         &self,
         uri: &Uri,
-        f: impl Fn(Channel) -> O,
+        f: impl Fn(InterceptedService<Channel, AddTimeout>) -> O,
     ) -> Result<T, RequestError<Status>> {
         self.with_channel_timeout(uri, f, None, DEFAULT_RETRIES)
             .await

--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -15,8 +15,11 @@ use crate::grpc::dynamic_pool::CountedItem;
 use crate::grpc::qdrant::qdrant_client::QdrantClient;
 use crate::grpc::qdrant::HealthCheckRequest;
 
-// 1 hour should be enough for channel timeout
-pub const MAX_GRPC_CHANNEL_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+/// Maximum lifetime of a gRPC channel.
+///
+/// Using 1 day (24 hours) because the request with the longest timeout currently uses the same
+/// timeout value. Namely the shard recovery call used in shard snapshot transfer.
+pub const MAX_GRPC_CHANNEL_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 
 pub const DEFAULT_GRPC_TIMEOUT: Duration = Duration::from_secs(60);
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -860,8 +860,11 @@ impl From<tonic::Status> for CollectionError {
             tonic::Code::DeadlineExceeded => CollectionError::Timeout {
                 description: format!("Deadline Exceeded: {err}"),
             },
-            other => CollectionError::ServiceError {
-                error: format!("Tonic status error: {other}"),
+            tonic::Code::Cancelled => CollectionError::Cancelled {
+                description: format!("{err}"),
+            },
+            _other => CollectionError::ServiceError {
+                error: format!("Tonic status error: {err}"),
                 backtrace: Some(Backtrace::force_capture().to_string()),
             },
         }

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 
 use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
 use api::grpc::qdrant::WaitOnConsensusCommitRequest;
-use api::grpc::transport_channel_pool::TransportChannelPool;
+use api::grpc::transport_channel_pool::{AddTimeout, TransportChannelPool};
 use futures::future::try_join_all;
 use futures::Future;
+use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Uri};
 use tonic::{Request, Status};
 use url::Url;
@@ -124,7 +125,7 @@ impl ChannelService {
     async fn with_qdrant_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         peer_id: PeerId,
-        f: impl Fn(QdrantInternalClient<Channel>) -> O,
+        f: impl Fn(QdrantInternalClient<InterceptedService<Channel, AddTimeout>>) -> O,
     ) -> Result<T, CollectionError> {
         let address = self
             .id_to_address

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -14,6 +14,7 @@ use api::grpc::qdrant::{
     ScrollPoints, ScrollPointsInternal, SearchBatchPointsInternal, ShardSnapshotLocation,
     WaitForShardStateRequest,
 };
+use api::grpc::transport_channel_pool::AddTimeout;
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
@@ -23,6 +24,7 @@ use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
 use tokio::runtime::Handle;
+use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 use url::Url;
@@ -103,7 +105,7 @@ impl RemoteShard {
 
     async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(PointsInternalClient<Channel>) -> O,
+        f: impl Fn(PointsInternalClient<InterceptedService<Channel, AddTimeout>>) -> O,
     ) -> CollectionResult<T> {
         let current_address = self.current_address()?;
         self.channel_service
@@ -119,7 +121,7 @@ impl RemoteShard {
 
     async fn with_collections_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(CollectionsInternalClient<Channel>) -> O,
+        f: impl Fn(CollectionsInternalClient<InterceptedService<Channel, AddTimeout>>) -> O,
     ) -> CollectionResult<T> {
         let current_address = self.current_address()?;
         self.channel_service
@@ -135,7 +137,7 @@ impl RemoteShard {
 
     async fn with_shard_snapshots_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(ShardSnapshotsClient<Channel>) -> O,
+        f: impl Fn(ShardSnapshotsClient<InterceptedService<Channel, AddTimeout>>) -> O,
     ) -> CollectionResult<T> {
         let current_address = self.current_address()?;
         self.channel_service

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -14,7 +14,11 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::Duration;
 
+use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
+use api::grpc::qdrant::WaitOnConsensusCommitRequest;
+use api::grpc::transport_channel_pool::AddTimeout;
 use collection::collection::{Collection, RequestShardTransfer};
 use collection::config::{default_replication_factor, CollectionConfig};
 use collection::operations::types::*;
@@ -23,9 +27,14 @@ use collection::shards::replica_set;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::telemetry::CollectionTelemetry;
+use futures::future::try_join_all;
+use futures::Future;
 use segment::common::cpu::get_num_cpus;
 use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
+use tonic::codegen::InterceptedService;
+use tonic::transport::Channel;
+use tonic::Status;
 
 use self::transfer::ShardTransferDispatcher;
 use crate::content_manager::alias_mapping::AliasPersistence;
@@ -34,7 +43,7 @@ use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
-use crate::types::StorageConfig;
+use crate::types::{PeerAddressById, StorageConfig};
 use crate::ConsensusOperations;
 
 pub const ALIASES_PATH: &str = "aliases";
@@ -519,6 +528,107 @@ impl TableOfContent {
         Path::new(&self.storage_config.storage_path)
             .join(COLLECTIONS_DIR)
             .join(collection_name)
+    }
+
+    /// Wait until all other known peers reach the given commit
+    ///
+    /// # Errors
+    ///
+    /// This errors if:
+    /// - any of the peers is not on the same term
+    /// - waiting takes longer than the specified timeout
+    /// - any of the peers cannot be reached
+    pub async fn await_commit_on_all_peers(
+        &self,
+        commit: u64,
+        term: u64,
+        timeout: Duration,
+    ) -> Result<(), StorageError> {
+        let requests = self
+            .peer_address_by_id()
+            .keys()
+            .filter(|id| **id != self.this_peer_id)
+            // The collective timeout at the bottom of this function handles actually timing out.
+            // Since an explicit timeout must be given here as well, it is multiplied by two to
+            // give the collective timeout some space.
+            .map(|peer_id| self.await_commit_on_peer(*peer_id, commit, term, timeout * 2))
+            .collect::<Vec<_>>();
+        let responses = try_join_all(requests);
+
+        // Handle requests with timeout
+        tokio::time::timeout(timeout, responses)
+            .await
+            .map(|_| ())
+            .map_err(|_elapsed| StorageError::Timeout {
+                description: "Failed to wait for consensus commit on all peers, timed out.".into(),
+            })
+    }
+
+    fn peer_address_by_id(&self) -> PeerAddressById {
+        self.channel_service.id_to_address.read().clone()
+    }
+
+    /// Wait until the given peer reaches the given commit
+    ///
+    /// # Errors
+    ///
+    /// This errors if the given peer is on a different term. Also errors if the peer cannot be reached.
+    async fn await_commit_on_peer(
+        &self,
+        peer_id: PeerId,
+        commit: u64,
+        term: u64,
+        timeout: Duration,
+    ) -> Result<(), StorageError> {
+        let response = self
+            .with_qdrant_client(peer_id, |mut client| async move {
+                let request = WaitOnConsensusCommitRequest {
+                    commit: commit as i64,
+                    term: term as i64,
+                    timeout: timeout.as_secs() as i64,
+                };
+                client
+                    .wait_on_consensus_commit(tonic::Request::new(request))
+                    .await
+            })
+            .await
+            .map_err(|err| {
+                StorageError::service_error(format!(
+                    "Failed to wait for consensus commit on peer {peer_id}: {err}"
+                ))
+            })?
+            .into_inner();
+
+        // Create error if wait request failed
+        if !response.ok {
+            return Err(StorageError::service_error(format!(
+                "Failed to wait for consensus commit on peer {peer_id}, has diverged commit/term or timed out."
+            )));
+        }
+        Ok(())
+    }
+
+    async fn with_qdrant_client<T, O: Future<Output = Result<T, Status>>>(
+        &self,
+        peer_id: PeerId,
+        f: impl Fn(QdrantInternalClient<InterceptedService<Channel, AddTimeout>>) -> O,
+    ) -> Result<T, CollectionError> {
+        let address = self
+            .channel_service
+            .id_to_address
+            .read()
+            .get(&peer_id)
+            .ok_or_else(|| CollectionError::service_error("Address for peer ID is not found."))?
+            .clone();
+        self.channel_service
+            .channel_pool
+            .with_channel(&address, |channel| {
+                let client = QdrantInternalClient::new(channel);
+                let client = client.max_decoding_message_size(usize::MAX);
+                f(client)
+            })
+            .await
+            .map_err(Into::into)
     }
 
     /// Insert dispatcher into table of contents for shard transfer.


### PR DESCRIPTION
**Note**: This should only affect the inter-node channels.

- Removes the intermediate timeout implementation that was working separately from the request and channel timeouts.
- Now the channel timeout is set to a hard 1 hour (not configurable)
- All the individual requests now pass through an interceptor, which checks if they already have a timeout set, and if not, they set it to the `grpc_timeout_ms` from settings.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
