### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "api"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "common",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.5.1"
+version = "1.6.0"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/docs/redoc/default_version.js
+++ b/docs/redoc/default_version.js
@@ -1,1 +1,1 @@
-const defaultApiVersion = 'v1.5.x';
+const defaultApiVersion = 'v1.6.x';

--- a/docs/redoc/index.html
+++ b/docs/redoc/index.html
@@ -39,6 +39,7 @@
         </button>
         <div class="dropdown-menu dropdown-menu-right">
             <a href="?v=master" class="dropdown-item" type="button">master</a>
+            <a href="?v=v1.6.x" class="dropdown-item" type="button">v1.6.x</a>
             <a href="?v=v1.5.x" class="dropdown-item" type="button">v1.5.x</a>
             <a href="?v=v1.4.x" class="dropdown-item" type="button">v1.4.x</a>
             <a href="?v=v1.3.x" class="dropdown-item" type="button">v1.3.x</a>

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.5.1"
+version = "1.6.0"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=547e602ee16e039012a328b8cd9fa0f4cef975c0
+IGNORE_UPTO=fac083f71571c7c437fc3c0a7b56555bda9d9a86
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
A feature release bumping Qdrant to v1.6.0.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?