### PR TITLE
2753 log gprc requests

### DIFF
--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -44,6 +44,7 @@ where
 
         let method_name = request.uri().path().to_string();
         let instant = std::time::Instant::now();
+        log::trace!("gRPC request starting: {}", method_name);
         let future = inner.call(request);
         Box::pin(async move {
             let response = future.await;

--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -44,7 +44,7 @@ where
 
         let method_name = request.uri().path().to_string();
         let instant = std::time::Instant::now();
-        log::info!("gRPC request starting: {} on port {}", method_name, request.uri().port());
+        log::info!("gRPC request start {}", method_name);
         let future = inner.call(request);
         Box::pin(async move {
             let response = future.await;

--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -44,7 +44,7 @@ where
 
         let method_name = request.uri().path().to_string();
         let instant = std::time::Instant::now();
-        log::trace!("gRPC request starting: {}", method_name);
+        log::info!("gRPC request starting: {} on port {}", method_name, request.uri().port());
         let future = inner.call(request);
         Box::pin(async move {
             let response = future.await;


### PR DESCRIPTION
Fixes qdrant/qdrant#2753

* Added logging of all gprc requests irrespective of result
* Checked for a logging configuration but since tonic is based on hyperium and there is already a default log level for hyper in /tracing.rs I was not sure that is was necessary to add another. I can still add if necessary a specific flag in the configuration for logging all grpc requests.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?: yes see https://github.com/yenwel/qdrantgprctest
