### PR TITLE
Tag OpenAPI integration test image, run in interactive mode

### DIFF
--- a/tests/openapi_integration_test.sh
+++ b/tests/openapi_integration_test.sh
@@ -7,8 +7,10 @@ cd "$(dirname "$0")/../"
 
 cp docs/redoc/master/openapi.json openapi/tests/openapi.json
 
+docker buildx build --load -q ./openapi/tests --tag=qdrant_openapi_test
+
 docker run --rm \
             --network=host \
             -e OPENAPI_FILE='openapi.json' \
             -v "${PWD}"/openapi/tests:/code \
-            "$(docker buildx build --load -q ./openapi/tests)" sh -c /code/run_docker.sh
+            qdrant_openapi_test sh -c /code/run_docker.sh

--- a/tests/openapi_integration_test.sh
+++ b/tests/openapi_integration_test.sh
@@ -9,8 +9,10 @@ cp docs/redoc/master/openapi.json openapi/tests/openapi.json
 
 docker buildx build --load -q ./openapi/tests --tag=qdrant_openapi_test
 
-docker run --rm \
-            --network=host \
-            -e OPENAPI_FILE='openapi.json' \
-            -v "${PWD}"/openapi/tests:/code \
-            qdrant_openapi_test sh -c /code/run_docker.sh
+DOCKER_ARGS=$([ -t 0 ] && echo "-it" || echo "")
+docker run $DOCKER_ARGS \
+    --rm \
+    --network=host \
+    -e OPENAPI_FILE='openapi.json' \
+    -v "${PWD}"/openapi/tests:/code \
+    qdrant_openapi_test sh -c /code/run_docker.sh


### PR DESCRIPTION
The OpenAPI integration test image that is built through `docker buildx` should be tagged so it is added to the Docker engine on the host system.

If we don't tag this image the integration test might fail with:

```bash
$ tests/openapi_integration_test.sh
++ dirname tests/openapi_integration_test.sh
+ cd tests/../
+ cp docs/redoc/master/openapi.json openapi/tests/openapi.json
++ docker buildx build --load -q ./openapi/tests
+ docker run --rm --network=host -e OPENAPI_FILE=openapi.json -v /home/timvisee/git/qdrant/openapi/tests:/code sha256:4c9144e7590aca012178585a317494023f862cbf96bbe7b7261f9d590c42a795 sh -c /code/run_docker.sh
docker: Error response from daemon: No such image: sha256:4c9144e7590aca012178585a317494023f862cbf96bbe7b7261f9d590c42a795.
See 'docker run --help'.
```

Also adds `-it` flag if in a TTY to run the integration test in interactive mode. That allows you to interrupt the tests with SIGINT (ignored before) and shows colorful output.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
