### PR TITLE
Make point, vector and indexed vector counts optional in collection info

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -385,12 +385,12 @@
 | ----- | ---- | ----- | ----------- |
 | status | [CollectionStatus](#qdrant-CollectionStatus) |  | operating condition of the collection |
 | optimizer_status | [OptimizerStatus](#qdrant-OptimizerStatus) |  | status of collection optimizers |
-| vectors_count | [uint64](#uint64) | optional | number of vectors in the collection |
+| vectors_count | [uint64](#uint64) | optional | Deprecated - number of vectors in the collection |
 | segments_count | [uint64](#uint64) |  | Number of independent segments |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
-| points_count | [uint64](#uint64) | optional | number of points in the collection |
-| indexed_vectors_count | [uint64](#uint64) | optional | number of indexed vectors in the collection. |
+| points_count | [uint64](#uint64) | optional | Deprecated - number of points in the collection |
+| indexed_vectors_count | [uint64](#uint64) | optional | Deprecated - number of indexed vectors in the collection. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -385,12 +385,12 @@
 | ----- | ---- | ----- | ----------- |
 | status | [CollectionStatus](#qdrant-CollectionStatus) |  | operating condition of the collection |
 | optimizer_status | [OptimizerStatus](#qdrant-OptimizerStatus) |  | status of collection optimizers |
-| vectors_count | [uint64](#uint64) | optional | Deprecated - number of vectors in the collection |
+| vectors_count | [uint64](#uint64) | optional | Approximate number of vectors in the collection |
 | segments_count | [uint64](#uint64) |  | Number of independent segments |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
-| points_count | [uint64](#uint64) | optional | Deprecated - number of points in the collection |
-| indexed_vectors_count | [uint64](#uint64) | optional | Deprecated - number of indexed vectors in the collection. |
+| points_count | [uint64](#uint64) | optional | Approximate number of points in the collection |
+| indexed_vectors_count | [uint64](#uint64) | optional | Approximate number of indexed vectors in the collection. |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -385,11 +385,11 @@
 | ----- | ---- | ----- | ----------- |
 | status | [CollectionStatus](#qdrant-CollectionStatus) |  | operating condition of the collection |
 | optimizer_status | [OptimizerStatus](#qdrant-OptimizerStatus) |  | status of collection optimizers |
-| vectors_count | [uint64](#uint64) |  | number of vectors in the collection |
+| vectors_count | [uint64](#uint64) | optional | number of vectors in the collection |
 | segments_count | [uint64](#uint64) |  | Number of independent segments |
 | config | [CollectionConfig](#qdrant-CollectionConfig) |  | Configuration |
 | payload_schema | [CollectionInfo.PayloadSchemaEntry](#qdrant-CollectionInfo-PayloadSchemaEntry) | repeated | Collection data types |
-| points_count | [uint64](#uint64) |  | number of points in the collection |
+| points_count | [uint64](#uint64) | optional | number of points in the collection |
 | indexed_vectors_count | [uint64](#uint64) | optional | number of indexed vectors in the collection. |
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5287,13 +5287,10 @@
         "type": "object",
         "required": [
           "config",
-          "indexed_vectors_count",
           "optimizer_status",
           "payload_schema",
-          "points_count",
           "segments_count",
-          "status",
-          "vectors_count"
+          "status"
         ],
         "properties": {
           "status": {
@@ -5306,19 +5303,22 @@
             "description": "Number of vectors in collection All vectors in collection are available for querying Calculated as `points_count x vectors_per_point` Where `vectors_per_point` is a number of named vectors in schema",
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "indexed_vectors_count": {
             "description": "Number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in vector index (HNSW)",
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "points_count": {
             "description": "Number of points (vectors + payloads) in collection Each point could be accessed by unique id",
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "segments_count": {
             "description": "Number of segments in collection. Each segment has independent vector as payload indexes",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5300,21 +5300,21 @@
             "$ref": "#/components/schemas/OptimizersStatus"
           },
           "vectors_count": {
-            "description": "Number of vectors in collection All vectors in collection are available for querying Calculated as `points_count x vectors_per_point` Where `vectors_per_point` is a number of named vectors in schema",
+            "description": "Deprecated - Number of vectors in collection. All vectors in collection are available for querying. Calculated as `points_count x vectors_per_point`. Where `vectors_per_point` is a number of named vectors in schema.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "indexed_vectors_count": {
-            "description": "Number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in vector index (HNSW)",
+            "description": "Deprecated - Number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in vector index (HNSW).",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "points_count": {
-            "description": "Number of points (vectors + payloads) in collection Each point could be accessed by unique id",
+            "description": "Deprecated - Number of points (vectors + payloads) in collection. Each point could be accessed by unique id.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5300,21 +5300,21 @@
             "$ref": "#/components/schemas/OptimizersStatus"
           },
           "vectors_count": {
-            "description": "Deprecated - Number of vectors in collection. All vectors in collection are available for querying. Calculated as `points_count x vectors_per_point`. Where `vectors_per_point` is a number of named vectors in schema.",
+            "description": "Approximate number of vectors in collection. All vectors in collection are available for querying. Calculated as `points_count x vectors_per_point`. Where `vectors_per_point` is a number of named vectors in schema.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "indexed_vectors_count": {
-            "description": "Deprecated - Number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in vector index (HNSW).",
+            "description": "Approximate umber of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in vector index (HNSW).",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "points_count": {
-            "description": "Deprecated - Number of points (vectors + payloads) in collection. Each point could be accessed by unique id.",
+            "description": "Approximate number of points (vectors + payloads) in collection. Each point could be accessed by unique id.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -358,14 +358,14 @@ message PayloadSchemaInfo {
 message CollectionInfo {
   CollectionStatus status = 1; // operating condition of the collection
   OptimizerStatus optimizer_status = 2; // status of collection optimizers
-  optional uint64 vectors_count = 3; // number of vectors in the collection
+  optional uint64 vectors_count = 3; // Deprecated - number of vectors in the collection
   uint64 segments_count = 4; // Number of independent segments
   reserved 5; // Deprecated
   reserved 6; // Deprecated
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
-  optional uint64 points_count = 9; // number of points in the collection
-  optional uint64 indexed_vectors_count = 10; // number of indexed vectors in the collection.
+  optional uint64 points_count = 9; // Deprecated - number of points in the collection
+  optional uint64 indexed_vectors_count = 10; // Deprecated - number of indexed vectors in the collection.
 }
 
 message ChangeAliases {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -358,14 +358,14 @@ message PayloadSchemaInfo {
 message CollectionInfo {
   CollectionStatus status = 1; // operating condition of the collection
   OptimizerStatus optimizer_status = 2; // status of collection optimizers
-  optional uint64 vectors_count = 3; // Deprecated - number of vectors in the collection
+  optional uint64 vectors_count = 3; // Approximate number of vectors in the collection
   uint64 segments_count = 4; // Number of independent segments
   reserved 5; // Deprecated
   reserved 6; // Deprecated
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
-  optional uint64 points_count = 9; // Deprecated - number of points in the collection
-  optional uint64 indexed_vectors_count = 10; // Deprecated - number of indexed vectors in the collection.
+  optional uint64 points_count = 9; // Approximate number of points in the collection
+  optional uint64 indexed_vectors_count = 10; // Approximate number of indexed vectors in the collection.
 }
 
 message ChangeAliases {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -358,13 +358,13 @@ message PayloadSchemaInfo {
 message CollectionInfo {
   CollectionStatus status = 1; // operating condition of the collection
   OptimizerStatus optimizer_status = 2; // status of collection optimizers
-  uint64 vectors_count = 3; // number of vectors in the collection
+  optional uint64 vectors_count = 3; // number of vectors in the collection
   uint64 segments_count = 4; // Number of independent segments
   reserved 5; // Deprecated
   reserved 6; // Deprecated
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
-  uint64 points_count = 9; // number of points in the collection
+  optional uint64 points_count = 9; // number of points in the collection
   optional uint64 indexed_vectors_count = 10; // number of indexed vectors in the collection.
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -641,7 +641,7 @@ pub struct CollectionInfo {
     /// status of collection optimizers
     #[prost(message, optional, tag = "2")]
     pub optimizer_status: ::core::option::Option<OptimizerStatus>,
-    /// Deprecated - number of vectors in the collection
+    /// Approximate number of vectors in the collection
     #[prost(uint64, optional, tag = "3")]
     pub vectors_count: ::core::option::Option<u64>,
     /// Number of independent segments
@@ -656,10 +656,10 @@ pub struct CollectionInfo {
         ::prost::alloc::string::String,
         PayloadSchemaInfo,
     >,
-    /// Deprecated - number of points in the collection
+    /// Approximate number of points in the collection
     #[prost(uint64, optional, tag = "9")]
     pub points_count: ::core::option::Option<u64>,
-    /// Deprecated - number of indexed vectors in the collection.
+    /// Approximate number of indexed vectors in the collection.
     #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -641,7 +641,7 @@ pub struct CollectionInfo {
     /// status of collection optimizers
     #[prost(message, optional, tag = "2")]
     pub optimizer_status: ::core::option::Option<OptimizerStatus>,
-    /// number of vectors in the collection
+    /// Deprecated - number of vectors in the collection
     #[prost(uint64, optional, tag = "3")]
     pub vectors_count: ::core::option::Option<u64>,
     /// Number of independent segments
@@ -656,10 +656,10 @@ pub struct CollectionInfo {
         ::prost::alloc::string::String,
         PayloadSchemaInfo,
     >,
-    /// number of points in the collection
+    /// Deprecated - number of points in the collection
     #[prost(uint64, optional, tag = "9")]
     pub points_count: ::core::option::Option<u64>,
-    /// number of indexed vectors in the collection.
+    /// Deprecated - number of indexed vectors in the collection.
     #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -642,8 +642,8 @@ pub struct CollectionInfo {
     #[prost(message, optional, tag = "2")]
     pub optimizer_status: ::core::option::Option<OptimizerStatus>,
     /// number of vectors in the collection
-    #[prost(uint64, tag = "3")]
-    pub vectors_count: u64,
+    #[prost(uint64, optional, tag = "3")]
+    pub vectors_count: ::core::option::Option<u64>,
     /// Number of independent segments
     #[prost(uint64, tag = "4")]
     pub segments_count: u64,
@@ -657,8 +657,8 @@ pub struct CollectionInfo {
         PayloadSchemaInfo,
     >,
     /// number of points in the collection
-    #[prost(uint64, tag = "9")]
-    pub points_count: u64,
+    #[prost(uint64, optional, tag = "9")]
+    pub points_count: ::core::option::Option<u64>,
     /// number of indexed vectors in the collection.
     #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -230,8 +230,8 @@ impl Collection {
             .collect();
 
         let mut info = match requests.try_next().await? {
-            None => CollectionInfo::empty(self.collection_config.read().await.clone()),
             Some(info) => info,
+            None => CollectionInfo::empty(self.collection_config.read().await.clone()),
         };
 
         while let Some(response) = requests.try_next().await? {

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -237,9 +237,18 @@ impl Collection {
         while let Some(response) = requests.try_next().await? {
             info.status = cmp::max(info.status, response.status);
             info.optimizer_status = cmp::max(info.optimizer_status, response.optimizer_status);
-            info.vectors_count += response.vectors_count;
-            info.indexed_vectors_count += response.indexed_vectors_count;
-            info.points_count += response.points_count;
+            info.vectors_count = info
+                .vectors_count
+                .zip(response.vectors_count)
+                .map(|(a, b)| a + b);
+            info.indexed_vectors_count = info
+                .indexed_vectors_count
+                .zip(response.indexed_vectors_count)
+                .map(|(a, b)| a + b);
+            info.points_count = info
+                .points_count
+                .zip(response.points_count)
+                .map(|(a, b)| a + b);
             info.segments_count += response.segments_count;
 
             for (key, response_schema) in response.payload_schema {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -344,9 +344,9 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     api::grpc::qdrant::OptimizerStatus { ok: false, error }
                 }
             }),
-            vectors_count: vectors_count as u64,
-            indexed_vectors_count: Some(indexed_vectors_count as u64),
-            points_count: points_count as u64,
+            vectors_count: vectors_count.map(|count| count as u64),
+            indexed_vectors_count: indexed_vectors_count.map(|count| count as u64),
+            points_count: points_count.map(|count| count as u64),
             segments_count: segments_count as u64,
             config: Some(api::grpc::qdrant::CollectionConfig {
                 params: Some(api::grpc::qdrant::CollectionParams {
@@ -716,11 +716,15 @@ impl TryFrom<api::grpc::qdrant::GetCollectionInfoResponse> for CollectionInfo {
                         }
                     }
                 },
-                vectors_count: collection_info_response.vectors_count as usize,
+                vectors_count: collection_info_response
+                    .vectors_count
+                    .map(|count| count as usize),
                 indexed_vectors_count: collection_info_response
                     .indexed_vectors_count
-                    .unwrap_or_default() as usize,
-                points_count: collection_info_response.points_count as usize,
+                    .map(|count| count as usize),
+                points_count: collection_info_response
+                    .points_count
+                    .map(|count| count as usize),
                 segments_count: collection_info_response.segments_count as usize,
                 config: match collection_info_response.config {
                     None => {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -137,6 +137,49 @@ impl CollectionInfo {
     }
 }
 
+impl From<CollectionInfoInternal> for CollectionInfo {
+    fn from(info: CollectionInfoInternal) -> Self {
+        Self {
+            status: info.status,
+            optimizer_status: info.optimizer_status,
+            vectors_count: Some(info.vectors_count),
+            indexed_vectors_count: Some(info.indexed_vectors_count),
+            points_count: Some(info.points_count),
+            segments_count: info.segments_count,
+            config: info.config,
+            payload_schema: info.payload_schema,
+        }
+    }
+}
+
+/// Internal statistics and configuration of the collection.
+#[derive(Debug)]
+pub struct CollectionInfoInternal {
+    /// Status of the collection
+    pub status: CollectionStatus,
+    /// Status of optimizers
+    pub optimizer_status: OptimizersStatus,
+    /// Deprecated - Number of vectors in collection.
+    /// All vectors in collection are available for querying.
+    /// Calculated as `points_count x vectors_per_point`.
+    /// Where `vectors_per_point` is a number of named vectors in schema.
+    pub vectors_count: usize,
+    /// Deprecated - Number of indexed vectors in the collection.
+    /// Indexed vectors in large segments are faster to query,
+    /// as it is stored in vector index (HNSW).
+    pub indexed_vectors_count: usize,
+    /// Deprecated - Number of points (vectors + payloads) in collection.
+    /// Each point could be accessed by unique id.
+    pub points_count: usize,
+    /// Number of segments in collection.
+    /// Each segment has independent vector as payload indexes
+    pub segments_count: usize,
+    /// Collection settings
+    pub config: CollectionConfig,
+    /// Types of stored payload
+    pub payload_schema: HashMap<PayloadKeyType, PayloadIndexInfo>,
+}
+
 /// Current clustering distribution for the collection
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CollectionClusterInfo {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -104,14 +104,14 @@ pub struct CollectionInfo {
     /// All vectors in collection are available for querying
     /// Calculated as `points_count x vectors_per_point`
     /// Where `vectors_per_point` is a number of named vectors in schema
-    pub vectors_count: usize,
+    pub vectors_count: Option<usize>,
     /// Number of indexed vectors in the collection.
     /// Indexed vectors in large segments are faster to query,
     /// as it is stored in vector index (HNSW)
-    pub indexed_vectors_count: usize,
+    pub indexed_vectors_count: Option<usize>,
     /// Number of points (vectors + payloads) in collection
     /// Each point could be accessed by unique id
-    pub points_count: usize,
+    pub points_count: Option<usize>,
     /// Number of segments in collection.
     /// Each segment has independent vector as payload indexes
     pub segments_count: usize,
@@ -127,9 +127,9 @@ impl CollectionInfo {
         Self {
             status: CollectionStatus::Green,
             optimizer_status: OptimizersStatus::Ok,
-            vectors_count: 0,
-            indexed_vectors_count: 0,
-            points_count: 0,
+            vectors_count: Some(0),
+            indexed_vectors_count: Some(0),
+            points_count: Some(0),
             segments_count: 0,
             config: collection_config,
             payload_schema: HashMap::new(),

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -100,16 +100,16 @@ pub struct CollectionInfo {
     pub status: CollectionStatus,
     /// Status of optimizers
     pub optimizer_status: OptimizersStatus,
-    /// Deprecated - Number of vectors in collection.
+    /// Approximate number of vectors in collection.
     /// All vectors in collection are available for querying.
     /// Calculated as `points_count x vectors_per_point`.
     /// Where `vectors_per_point` is a number of named vectors in schema.
     pub vectors_count: Option<usize>,
-    /// Deprecated - Number of indexed vectors in the collection.
+    /// Approximate umber of indexed vectors in the collection.
     /// Indexed vectors in large segments are faster to query,
     /// as it is stored in vector index (HNSW).
     pub indexed_vectors_count: Option<usize>,
-    /// Deprecated - Number of points (vectors + payloads) in collection.
+    /// Approximate number of points (vectors + payloads) in collection.
     /// Each point could be accessed by unique id.
     pub points_count: Option<usize>,
     /// Number of segments in collection.
@@ -159,16 +159,16 @@ pub struct CollectionInfoInternal {
     pub status: CollectionStatus,
     /// Status of optimizers
     pub optimizer_status: OptimizersStatus,
-    /// Deprecated - Number of vectors in collection.
+    /// Approximate number of vectors in collection.
     /// All vectors in collection are available for querying.
     /// Calculated as `points_count x vectors_per_point`.
     /// Where `vectors_per_point` is a number of named vectors in schema.
     pub vectors_count: usize,
-    /// Deprecated - Number of indexed vectors in the collection.
+    /// Approximate number of indexed vectors in the collection.
     /// Indexed vectors in large segments are faster to query,
     /// as it is stored in vector index (HNSW).
     pub indexed_vectors_count: usize,
-    /// Deprecated - Number of points (vectors + payloads) in collection.
+    /// Approximate number of points (vectors + payloads) in collection.
     /// Each point could be accessed by unique id.
     pub points_count: usize,
     /// Number of segments in collection.

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -100,17 +100,17 @@ pub struct CollectionInfo {
     pub status: CollectionStatus,
     /// Status of optimizers
     pub optimizer_status: OptimizersStatus,
-    /// Number of vectors in collection
-    /// All vectors in collection are available for querying
-    /// Calculated as `points_count x vectors_per_point`
-    /// Where `vectors_per_point` is a number of named vectors in schema
+    /// Deprecated - Number of vectors in collection.
+    /// All vectors in collection are available for querying.
+    /// Calculated as `points_count x vectors_per_point`.
+    /// Where `vectors_per_point` is a number of named vectors in schema.
     pub vectors_count: Option<usize>,
-    /// Number of indexed vectors in the collection.
+    /// Deprecated - Number of indexed vectors in the collection.
     /// Indexed vectors in large segments are faster to query,
-    /// as it is stored in vector index (HNSW)
+    /// as it is stored in vector index (HNSW).
     pub indexed_vectors_count: Option<usize>,
-    /// Number of points (vectors + payloads) in collection
-    /// Each point could be accessed by unique id
+    /// Deprecated - Number of points (vectors + payloads) in collection.
+    /// Each point could be accessed by unique id.
     pub points_count: Option<usize>,
     /// Number of segments in collection.
     /// Each segment has independent vector as payload indexes

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -768,7 +768,14 @@ impl LocalShard {
             })
             .sum();
 
-        vector_size * info.points_count
+        // The points count is currently always set. This provides a safeguard as we likely
+        // refactor this behavior in the future. In that case, points should be counted in a
+        // different manner.
+        debug_assert!(
+            info.points_count.is_some(),
+            "Must have points count to estimate vector data size",
+        );
+        vector_size * info.points_count.unwrap_or(0)
     }
 
     pub async fn local_shard_info(&self) -> CollectionInfo {
@@ -814,9 +821,9 @@ impl LocalShard {
         CollectionInfo {
             status,
             optimizer_status,
-            vectors_count,
-            indexed_vectors_count,
-            points_count,
+            vectors_count: Some(vectors_count),
+            indexed_vectors_count: Some(indexed_vectors_count),
+            points_count: Some(points_count),
             segments_count,
             config: collection_config,
             payload_schema: schema,

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -1,4 +1,3 @@
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::mem::size_of;
 use std::ops::Deref;
@@ -799,14 +798,10 @@ impl LocalShard {
             indexed_vectors_count += segment_info.num_indexed_vectors;
             points_count += segment_info.num_points;
             for (key, val) in segment_info.index_schema {
-                match schema.entry(key) {
-                    Entry::Occupied(o) => {
-                        o.into_mut().points += val.points;
-                    }
-                    Entry::Vacant(v) => {
-                        v.insert(val);
-                    }
-                }
+                schema
+                    .entry(key)
+                    .and_modify(|entry| entry.points += val.points)
+                    .or_insert(val);
             }
         }
         if !segments.failed_operation.is_empty() || segments.optimizer_errors.is_some() {

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -193,7 +193,7 @@ impl ShardOperation for LocalShard {
 
     /// Collect overview information about the shard
     async fn info(&self) -> CollectionResult<CollectionInfo> {
-        Ok(self.local_shard_info().await)
+        Ok(self.local_shard_info().await.into())
     }
 
     async fn core_search(

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -56,7 +56,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
             .await
             .unwrap()
             .vectors_count,
-        2
+        Some(2),
     );
 }
 


### PR DESCRIPTION
Makes the point, vector and indexed vector counts from the collection information response optional. This changes the API and allows us to potentially remove these counts in the future.

The problem is that these counts are very inaccurate due to architectural limitations. Many users have been asking questions about it. If we cannot improve these counters we may as well better remove them.

More specifically, these are now made optionally in both our REST and gRPC APIs:

```json
GET /collections/my_collection
{
    "vectors_count": 123,
    "indexed_vectors_count": 10,
    "points_count": 123
}
```

Internally we use a new structure called `CollectionInfoInternal` which doesn't have optionals. That way we ensure there won't be issues with missing counts for critical calculations.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?