### PR TITLE
Add discovery query scorer

### DIFF
--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -1,3 +1,4 @@
+mod quantized_discovery_query_scorer;
 mod quantized_mmap_storage;
 mod quantized_query_scorer;
 mod quantized_reco_query_scorer;

--- a/lib/segment/src/vector_storage/quantized/quantized_discovery_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_discovery_query_scorer.rs
@@ -1,0 +1,65 @@
+use common::types::{PointOffsetType, ScoreType};
+
+use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::types::Distance;
+use crate::vector_storage::query::discovery_query::DiscoveryQuery;
+use crate::vector_storage::query_scorer::QueryScorer;
+
+pub struct QuantizedDiscoveryQueryScorer<'a, TEncodedQuery, TEncodedVectors>
+where
+    TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
+{
+    original_query: DiscoveryQuery<VectorType>,
+    query: DiscoveryQuery<TEncodedQuery>,
+    quantized_storage: &'a TEncodedVectors,
+    distance: Distance,
+}
+
+impl<'a, TEncodedQuery, TEncodedVectors>
+    QuantizedDiscoveryQueryScorer<'a, TEncodedQuery, TEncodedVectors>
+where
+    TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
+{
+    #[allow(dead_code)] // TODO: remove once integrated
+    pub fn new(
+        raw_query: DiscoveryQuery<VectorType>,
+        quantized_storage: &'a TEncodedVectors,
+        distance: Distance,
+    ) -> Self {
+        let original_query = raw_query.transform(|v| distance.preprocess_vector(v));
+        let query = original_query
+            .clone()
+            .transform(|v| quantized_storage.encode_query(&v));
+
+        Self {
+            original_query,
+            query,
+            quantized_storage,
+            distance,
+        }
+    }
+}
+
+impl<TEncodedQuery, TEncodedVectors> QueryScorer
+    for QuantizedDiscoveryQueryScorer<'_, TEncodedQuery, TEncodedVectors>
+where
+    TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
+{
+    fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
+        self.query
+            .score_by(|this| self.quantized_storage.score_point(this, idx))
+    }
+
+    fn score(&self, v2: &[VectorElementType]) -> ScoreType {
+        debug_assert!(
+            false,
+            "This method is not expected to be called for quantized scorer"
+        );
+        self.original_query
+            .score_by(|this| self.distance.similarity(this, v2))
+    }
+
+    fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {
+        unimplemented!("Discovery scorer compares against multiple vectors, not just one")
+    }
+}

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -1,0 +1,103 @@
+use common::types::ScoreType;
+
+type RankType = i32;
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryPair<T> {
+    positive: T,
+    negative: T,
+}
+
+impl<T> DiscoveryPair<T> {
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        std::iter::once(&self.positive).chain(std::iter::once(&self.negative))
+    }
+
+    pub fn transform<F, U>(self, mut f: F) -> DiscoveryPair<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        DiscoveryPair {
+            positive: f(self.positive),
+            negative: f(self.negative),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryQuery<T> {
+    pub target: T,
+    pub pairs: Vec<DiscoveryPair<T>>,
+}
+
+impl<T> DiscoveryQuery<T> {
+    pub fn new(target: T, pairs: Vec<DiscoveryPair<T>>) -> Self {
+        Self { target, pairs }
+    }
+
+    pub fn iter_all(&self) -> impl Iterator<Item = &T> {
+        let pairs_iter = self.pairs.iter().flat_map(|pair| pair.iter());
+
+        std::iter::once(&self.target).chain(pairs_iter)
+    }
+
+    pub fn transform<F, U>(self, mut f: F) -> DiscoveryQuery<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        DiscoveryQuery::new(
+            f(self.target),
+            self.pairs
+                .into_iter()
+                .map(|pair| pair.transform(&mut f))
+                .collect(),
+        )
+    }
+
+    /// Compares the query against a single vector using a similarity function.
+    ///
+    /// Similarity function must be able to compare one vector against another to produce an intermediate score.
+    ///
+    /// Returns the score with regards to this query
+    pub fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
+        let rank = self.rank_by(&similarity);
+
+        let target_similarity = similarity(&self.target);
+        let sigmoid_similarity = 0.5 * (fast_sigmoid(target_similarity) + 1.0);
+
+        rank as ScoreType + sigmoid_similarity
+    }
+
+    pub fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
+        self.pairs
+            .iter()
+            .map(|pair| {
+                // get similarity to positive and negative
+                let positive_similarity = similarity(&pair.positive);
+                let negative_similarity = similarity(&pair.negative);
+
+                // if closer to positive, return 1, else -1
+                if positive_similarity > negative_similarity {
+                    1
+                } else {
+                    -1
+                }
+            })
+            // get overall rank
+            .sum()
+    }
+}
+
+/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
+///
+/// Range of output is (-1, 1)
+fn fast_sigmoid(x: ScoreType) -> ScoreType {
+    // from https://stackoverflow.com/questions/10732027/fast-sigmoid-algorithm
+    x / (1.0 + x.abs())
+}
+
+// impl From<DiscoveryQuery<VectorType>> for QueryVector {
+//     fn from(query: DiscoveryQuery<VectorType>) -> Self {
+//         QueryVector::Discovery(query)
+//     }
+// }

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -22,6 +22,28 @@ impl<T> DiscoveryPair<T> {
             negative: f(self.negative),
         }
     }
+
+    pub fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
+        let positive_similarity = similarity(&self.positive);
+        let negative_similarity = similarity(&self.negative);
+
+        // if closer to positive, return 1, else -1
+        if positive_similarity > negative_similarity {
+            1
+        } else {
+            -1
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<(isize, isize)> for DiscoveryPair<isize> {
+    fn from(pair: (isize, isize)) -> Self {
+        Self {
+            positive: pair.0,
+            negative: pair.1,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -54,43 +76,36 @@ impl<T> DiscoveryQuery<T> {
         )
     }
 
-    /// Compares the query against a single vector using a similarity function.
-    ///
-    /// Similarity function must be able to compare one vector against another to produce an intermediate score.
-    ///
-    /// Returns the score with regards to this query
+    fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
+        self.pairs
+            .iter()
+            .map(|pair| pair.rank_by(&similarity))
+            // get overall rank
+            .sum()
+    }
+
     pub fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         let rank = self.rank_by(&similarity);
 
         let target_similarity = similarity(&self.target);
-        let sigmoid_similarity = 0.5 * (fast_sigmoid(target_similarity) + 1.0);
+        let sigmoid_similarity = scaled_fast_sigmoid(target_similarity);
 
         rank as ScoreType + sigmoid_similarity
-    }
-
-    pub fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
-        self.pairs
-            .iter()
-            .map(|pair| {
-                // get similarity to positive and negative
-                let positive_similarity = similarity(&pair.positive);
-                let negative_similarity = similarity(&pair.negative);
-
-                // if closer to positive, return 1, else -1
-                if positive_similarity > negative_similarity {
-                    1
-                } else {
-                    -1
-                }
-            })
-            // get overall rank
-            .sum()
     }
 }
 
 /// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
 ///
+/// Scales the output to fit within (0, 1)
+#[inline]
+fn scaled_fast_sigmoid(x: ScoreType) -> ScoreType {
+    0.5 * (fast_sigmoid(x) + 1.0)
+}
+
+/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
+///
 /// Range of output is (-1, 1)
+#[inline]
 fn fast_sigmoid(x: ScoreType) -> ScoreType {
     // from https://stackoverflow.com/questions/10732027/fast-sigmoid-algorithm
     x / (1.0 + x.abs())
@@ -101,3 +116,71 @@ fn fast_sigmoid(x: ScoreType) -> ScoreType {
 //         QueryVector::Discovery(query)
 //     }
 // }
+
+#[cfg(test)]
+mod test {
+    use std::cmp::Ordering;
+
+    use common::types::ScoreType;
+    use rstest::rstest;
+
+    use super::*;
+
+    fn dummy_similarity(x: &isize) -> ScoreType {
+        *x as ScoreType
+    }
+
+    /// Considers each "vector" as the actual score from the similarity function by
+    /// using a dummy identity function.
+    #[rstest]
+    #[case::no_pairs(vec![], 0)]
+    #[case::closer_to_positive(vec![(10, 4)], 1)]
+    #[case::closer_to_negative(vec![(4, 10)], -1)]
+    #[case::equal_scores(vec![(11, 11)], -1)]
+    #[case::neutral_zone(vec![(10, 4), (4, 10)], 0)]
+    #[case::best_zone(vec![(10, 4), (4, 2)], 2)]
+    #[case::worst_zone(vec![(4, 10), (2, 4)], -2)]
+    #[case::many_pairs(vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (0, 4)], 4)]
+    fn context_ranking(#[case] pairs: Vec<(isize, isize)>, #[case] expected: RankType) {
+        let pairs = pairs.into_iter().map(DiscoveryPair::from).collect();
+
+        let _target = 42;
+
+        let query = DiscoveryQuery::new(_target, pairs);
+
+        let rank = query.rank_by(dummy_similarity);
+
+        assert_eq!(
+            rank, expected,
+            "Ranking is incorrect, expected {}, but got {rank}",
+            expected
+        );
+    }
+
+    /// Compares the score of a query against a fixed score
+    #[rstest]
+    #[case::no_pairs(1, vec![], Ordering::Less)]
+    #[case::just_above(1, vec![(1,0),(1,0)], Ordering::Greater)]
+    #[case::just_below(-1, vec![(1,0),(1,0)], Ordering::Less)]
+    #[case::bad_target_good_context(-1000, vec![(1,0),(1,0),(1, 0)], Ordering::Greater)]
+    #[case::good_target_bad_context(1000, vec![(1,0),(0,1)], Ordering::Less)]
+    fn score_better(
+        #[case] target: isize,
+        #[case] pairs: Vec<(isize, isize)>,
+        #[case] expected: Ordering,
+    ) {
+        let fixed_score: f32 = 2.5;
+
+        let pairs = pairs.into_iter().map(DiscoveryPair::from).collect();
+
+        let query = DiscoveryQuery::new(target, pairs);
+
+        let score = query.score_by(dummy_similarity);
+
+        assert_eq!(
+            score.total_cmp(&fixed_score),
+            expected,
+            "Comparison is incorrect, expected {expected:?} for {score} against {fixed_score}"
+        );
+    }
+}

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -1,1 +1,2 @@
+pub mod discovery_query;
 pub mod reco_query;

--- a/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
@@ -20,6 +20,7 @@ pub struct DiscoveryQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStora
 impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     DiscoveryQueryScorer<'a, TMetric, TVectorStorage>
 {
+    #[allow(dead_code)] // TODO(luis): remove once integrated
     pub fn new(query: DiscoveryQuery<VectorType>, vector_storage: &'a TVectorStorage) -> Self {
         let query = query.transform(|vector| TMetric::preprocess(vector));
 

--- a/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
@@ -1,0 +1,52 @@
+use std::marker::PhantomData;
+
+use common::types::{PointOffsetType, ScoreType};
+
+use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::spaces::metric::Metric;
+use crate::vector_storage::query::discovery_query::DiscoveryQuery;
+use crate::vector_storage::query_scorer::QueryScorer;
+use crate::vector_storage::VectorStorage;
+
+// TODO(luis): maybe find a way to generalize DiscoveryQueryScorer and RecoQueryScorer by
+//     using a single Query trait. The crux is that `transform` function is hard to convert
+//     nicely into a trait function
+pub struct DiscoveryQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage> {
+    vector_storage: &'a TVectorStorage,
+    query: DiscoveryQuery<VectorType>,
+    metric: PhantomData<TMetric>,
+}
+
+impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
+    DiscoveryQueryScorer<'a, TMetric, TVectorStorage>
+{
+    pub fn new(query: DiscoveryQuery<VectorType>, vector_storage: &'a TVectorStorage) -> Self {
+        let query = query.transform(|vector| TMetric::preprocess(vector));
+
+        Self {
+            query,
+            vector_storage,
+            metric: PhantomData,
+        }
+    }
+}
+
+impl<'a, TMetric: Metric, TVectorStorage: VectorStorage> QueryScorer
+    for DiscoveryQueryScorer<'a, TMetric, TVectorStorage>
+{
+    #[inline]
+    fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
+        let stored = self.vector_storage.get_vector(idx);
+        self.score(stored)
+    }
+
+    #[inline]
+    fn score(&self, against: &[VectorElementType]) -> ScoreType {
+        self.query
+            .score_by(|example| TMetric::similarity(example, against))
+    }
+
+    fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {
+        unimplemented!("Custom scorer compares against multiple vectors, not just one")
+    }
+}

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -2,6 +2,7 @@ use common::types::{PointOffsetType, ScoreType};
 
 use crate::data_types::vectors::VectorElementType;
 
+pub mod discovery_query_scorer;
 pub mod metric_query_scorer;
 pub mod reco_query_scorer;
 


### PR DESCRIPTION
Complete feature tracked by #2790 

Adds a new scorer for discovery api. How it works:

- Combines rank (with respect to pairs) with similarity to a target.
- Rank is determined by a round number. If the candidate is closer to the positive side of a pair, it is +1, else it is -1. Final rank is the sum of these interactions with all pairs.
- Rank has higher priority, and increases in steps of 1. We need to make the score component to fit in the range (0, 1), so that we can just sum rank + score as the final output of this scorer. We chose to use a sigmoid function approximation to do this.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
