### PR TITLE
Revert "Bump lukemathwalker/cargo-chef from latest-rust-1.72.1 to latest-rust-1.73.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} tonistiigi/xx AS xx
 # Utilizing Docker layer caching with `cargo-chef`.
 #
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.73.0 AS chef
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.72.1 AS chef
 
 
 FROM chef AS planner


### PR DESCRIPTION
Reverts qdrant/qdrant#2781

New rust version causes 
```
(signal: 11, SIGSEGV: invalid memory reference)
```

during compilation in docker