### PR TITLE
Quantization storage as separate entity

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::{BitSlice, BitVec};
@@ -12,9 +12,8 @@ use crate::common::Flusher;
 use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
-use crate::types::{Distance, QuantizationConfig};
+use crate::types::Distance;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{
     raw_scorer_impl, RawScorer, VectorStorage, VectorStorageEnum, DEFAULT_STOPPED,
 };
@@ -47,6 +46,10 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
         TMetric::distance()
     }
 
+    fn is_on_disk(&self) -> bool {
+        false
+    }
+
     fn total_vector_count(&self) -> usize {
         self.vectors.len()
     }
@@ -75,24 +78,6 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
 
     fn flusher(&self) -> Flusher {
         Box::new(|| Ok(()))
-    }
-
-    fn quantize(
-        &mut self,
-        _data_path: &Path,
-        _quantization_config: &QuantizationConfig,
-        _max_threads: usize,
-        _stopped: &AtomicBool,
-    ) -> OperationResult<()> {
-        Ok(())
-    }
-
-    fn load_quantization(&mut self, _data_path: &Path) -> OperationResult<()> {
-        Ok(())
-    }
-
-    fn quantized_storage(&self) -> Option<&QuantizedVectors> {
-        None
     }
 
     fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -39,6 +39,7 @@ use crate::types::{
 };
 use crate::utils;
 use crate::utils::fs::find_symlink;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
@@ -91,6 +92,7 @@ pub struct Segment {
 pub struct VectorData {
     pub vector_index: Arc<AtomicRefCell<VectorIndexEnum>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    pub quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
 }
 
 impl VectorData {
@@ -1460,6 +1462,17 @@ impl SegmentEntry for Segment {
                     &file,
                     &files,
                 )?;
+            }
+
+            if let Some(quantized_vectors) = &vector_data.quantized_vectors {
+                for file in quantized_vectors.borrow().files() {
+                    utils::tar::append_file_relative_to_base(
+                        &mut builder,
+                        &self.current_path,
+                        &file,
+                        &files,
+                    )?;
+                }
             }
         }
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -12,6 +12,7 @@ use crate::index::{PayloadIndex, VectorIndex};
 use crate::segment::Segment;
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{Indexes, PayloadFieldSchema, PayloadKeyType, SegmentConfig};
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::VectorStorage;
 
 /// Structure for constructing segment out of several other segments
@@ -191,7 +192,7 @@ impl SegmentBuilder {
                 check_process_stopped(stopped)?;
             }
 
-            Self::update_quantization(&segment, stopped)?;
+            Self::update_quantization(&mut segment, stopped)?;
 
             for vector_data in segment.vector_data.values_mut() {
                 vector_data.vector_index.borrow_mut().build_index(stopped)?;
@@ -215,29 +216,41 @@ impl SegmentBuilder {
         Ok(loaded_segment)
     }
 
-    fn update_quantization(segment: &Segment, stopped: &AtomicBool) -> OperationResult<()> {
-        let config = segment.config();
-        for (vector_name, vector_data) in &segment.vector_data {
-            if let Some(quantization) = config.quantization_config(vector_name) {
-                let segment_path = segment.current_path.as_path();
-                check_process_stopped(stopped)?;
+    fn update_quantization(segment: &mut Segment, stopped: &AtomicBool) -> OperationResult<()> {
+        let config = segment.config().clone();
 
-                let vector_storage_path = get_vector_storage_path(segment_path, vector_name);
-                let max_threads = match segment
+        let threads_count: HashMap<String, usize> =
+            HashMap::from_iter(segment.vector_data.keys().map(|vector_name| {
+                match segment
                     .config()
                     .vector_data
                     .get(vector_name)
                     .map(|config| &config.index)
                 {
-                    Some(Indexes::Hnsw(hnsw)) => max_rayon_threads(hnsw.max_indexing_threads),
-                    _ => 1,
-                };
-                vector_data.vector_storage.borrow_mut().quantize(
-                    &vector_storage_path,
+                    Some(Indexes::Hnsw(hnsw)) => (
+                        vector_name.to_owned(),
+                        max_rayon_threads(hnsw.max_indexing_threads),
+                    ),
+                    _ => (vector_name.to_owned(), 1),
+                }
+            }));
+
+        for (vector_name, vector_data) in &mut segment.vector_data {
+            if let Some(quantization) = config.quantization_config(vector_name) {
+                let segment_path = segment.current_path.as_path();
+                check_process_stopped(stopped)?;
+
+                let vector_storage_path = get_vector_storage_path(segment_path, vector_name);
+                let max_threads = threads_count[vector_name];
+
+                let vector_storage = vector_data.vector_storage.borrow();
+                vector_data.quantized_vectors = Some(QuantizedVectors::create(
+                    &vector_storage,
                     quantization,
+                    &vector_storage_path,
                     max_threads,
                     stopped,
-                )?;
+                )?);
             }
         }
         Ok(())

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -218,31 +218,21 @@ impl SegmentBuilder {
 
     fn update_quantization(segment: &mut Segment, stopped: &AtomicBool) -> OperationResult<()> {
         let config = segment.config().clone();
-
-        let threads_count: HashMap<String, usize> =
-            HashMap::from_iter(segment.vector_data.keys().map(|vector_name| {
-                match segment
-                    .config()
+        for (vector_name, vector_data) in &mut segment.vector_data {
+            if let Some(quantization) = config.quantization_config(vector_name) {
+                let max_threads = match config
                     .vector_data
                     .get(vector_name)
                     .map(|config| &config.index)
                 {
-                    Some(Indexes::Hnsw(hnsw)) => (
-                        vector_name.to_owned(),
-                        max_rayon_threads(hnsw.max_indexing_threads),
-                    ),
-                    _ => (vector_name.to_owned(), 1),
-                }
-            }));
+                    Some(Indexes::Hnsw(hnsw)) => max_rayon_threads(hnsw.max_indexing_threads),
+                    _ => 1,
+                };
 
-        for (vector_name, vector_data) in &mut segment.vector_data {
-            if let Some(quantization) = config.quantization_config(vector_name) {
                 let segment_path = segment.current_path.as_path();
                 check_process_stopped(stopped)?;
 
                 let vector_storage_path = get_vector_storage_path(segment_path, vector_name);
-                let max_threads = threads_count[vector_name];
-
                 let vector_storage = vector_data.vector_storage.borrow();
                 vector_data.quantized_vectors = Some(QuantizedVectors::create(
                     &vector_storage,

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -140,10 +140,12 @@ fn test_batch_and_single_request_equivalency() {
     };
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
+    let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
     let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
+        quantized_vectors.clone(),
         payload_index_ptr,
         hnsw_config,
     )

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -87,6 +87,9 @@ fn exact_search_test() {
         segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
+        segment.vector_data[DEFAULT_VECTOR_NAME]
+            .quantized_vectors
+            .clone(),
         payload_index_ptr.clone(),
         hnsw_config,
     )

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -83,10 +83,12 @@ fn test_filterable_hnsw() {
     };
 
     let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
+    let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
     let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
         hnsw_dir.path(),
         segment.id_tracker.clone(),
         vector_storage.clone(),
+        quantized_vectors.clone(),
         payload_index_ptr.clone(),
         hnsw_config,
     )


### PR DESCRIPTION
Currently, quantized data is a part of `VectorStorage`. However, vector storage does not use any information from quantized data and just provides access to quantized data to the higher-level logic. It makes `VectorStorage` trait overcomplicated. And if sparse vectors are integrated as a new variant of vector storage enum, it will make an integration difficulties.

So in this PR I propose to separate vector storage and quantized data as separate entities. It makes code simpler to read and support. Nice bonus, in this PR more lines were deleted than added =)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
