### PR TITLE
Return visited list by drop

### DIFF
--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -1,10 +1,10 @@
 use common::types::PointOffsetType;
 
-use crate::index::visited_pool::VisitedList;
+use crate::index::visited_pool::VisitedListHandle;
 use crate::payload_storage::FilterContext;
 
 pub struct BuildConditionChecker<'a> {
-    pub filter_list: &'a VisitedList<'a>,
+    pub filter_list: &'a VisitedListHandle<'a>,
     pub current_point: PointOffsetType,
 }
 

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -4,7 +4,7 @@ use crate::index::visited_pool::VisitedList;
 use crate::payload_storage::FilterContext;
 
 pub struct BuildConditionChecker<'a> {
-    pub filter_list: &'a VisitedList,
+    pub filter_list: &'a VisitedList<'a>,
     pub current_point: PointOffsetType,
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -16,7 +16,7 @@ use crate::index::hnsw_index::entry_points::EntryPoints;
 use crate::index::hnsw_index::graph_links::GraphLinksConverter;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
-use crate::index::visited_pool::{VisitedList, VisitedPool};
+use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 
 pub type LinkContainer = Vec<PointOffsetType>;
 pub type LinkContainerRef<'a> = &'a [PointOffsetType];
@@ -50,7 +50,7 @@ pub struct GraphLayers<TGraphLinks: GraphLinks> {
 }
 
 pub trait GraphLayersBase {
-    fn get_visited_list_from_pool(&self) -> VisitedList;
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle;
 
     fn links_map<F>(&self, point_id: PointOffsetType, level: usize, f: F)
     where
@@ -64,7 +64,7 @@ pub trait GraphLayersBase {
         &self,
         searcher: &mut SearchContext,
         level: usize,
-        visited_list: &mut VisitedList,
+        visited_list: &mut VisitedListHandle,
         points_scorer: &mut FilteredScorer,
     ) {
         let limit = self.get_m(level);
@@ -146,7 +146,7 @@ pub trait GraphLayersBase {
 }
 
 impl<TGraphLinks: GraphLinks> GraphLayersBase for GraphLayers<TGraphLinks> {
-    fn get_visited_list_from_pool(&self) -> VisitedList {
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle {
         self.visited_pool.get(self.links.num_points())
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -52,8 +52,6 @@ pub struct GraphLayers<TGraphLinks: GraphLinks> {
 pub trait GraphLayersBase {
     fn get_visited_list_from_pool(&self) -> VisitedList;
 
-    fn return_visited_list_to_pool(&self, visited_list: VisitedList);
-
     fn links_map<F>(&self, point_id: PointOffsetType, level: usize, f: F)
     where
         F: FnMut(PointOffsetType);
@@ -104,8 +102,6 @@ pub trait GraphLayersBase {
         let mut search_context = SearchContext::new(level_entry, ef);
 
         self._search_on_level(&mut search_context, level, &mut visited_list, points_scorer);
-
-        self.return_visited_list_to_pool(visited_list);
         search_context.nearest
     }
 
@@ -152,10 +148,6 @@ pub trait GraphLayersBase {
 impl<TGraphLinks: GraphLinks> GraphLayersBase for GraphLayers<TGraphLinks> {
     fn get_visited_list_from_pool(&self) -> VisitedList {
         self.visited_pool.get(self.links.num_points())
-    }
-
-    fn return_visited_list_to_pool(&self, visited_list: VisitedList) {
-        self.visited_pool.return_back(visited_list);
     }
 
     fn links_map<F>(&self, point_id: PointOffsetType, level: usize, mut f: F)

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -17,7 +17,7 @@ use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LinkC
 use crate::index::hnsw_index::graph_links::GraphLinksConverter;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::hnsw_index::search_context::SearchContext;
-use crate::index::visited_pool::{VisitedList, VisitedPool};
+use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 
 pub type LockedLinkContainer = RwLock<LinkContainer>;
 pub type LockedLayersContainer = Vec<LockedLinkContainer>;
@@ -44,7 +44,7 @@ pub struct GraphLayersBuilder {
 }
 
 impl GraphLayersBase for GraphLayersBuilder {
-    fn get_visited_list_from_pool(&self) -> VisitedList {
+    fn get_visited_list_from_pool(&self) -> VisitedListHandle {
         self.visited_pool.get(self.num_points())
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -48,10 +48,6 @@ impl GraphLayersBase for GraphLayersBuilder {
         self.visited_pool.get(self.num_points())
     }
 
-    fn return_visited_list_to_pool(&self, visited_list: VisitedList) {
-        self.visited_pool.return_back(visited_list);
-    }
-
     fn links_map<F>(&self, point_id: PointOffsetType, level: usize, mut f: F)
     where
         F: FnMut(PointOffsetType),
@@ -193,7 +189,6 @@ impl GraphLayersBuilder {
         self.entry_points
             .lock()
             .merge_from_other(other.entry_points.into_inner());
-        self.visited_pool.return_back(visited_list);
     }
 
     fn num_points(&self) -> usize {
@@ -453,7 +448,6 @@ impl GraphLayersBuilder {
                             }
                         }
                     }
-                    self.return_visited_list_to_pool(visited_list);
                 }
             }
         }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -30,7 +30,7 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::visited_pool::VisitedList;
+use crate::index::visited_pool::{VisitedList, VisitedPool};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
@@ -661,7 +661,8 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             debug!("skip building main HNSW graph");
         }
 
-        let mut block_filter_list = VisitedList::new(total_vector_count);
+        let visited_pool = VisitedPool::new();
+        let mut block_filter_list = visited_pool.get(total_vector_count);
         let visits_iteration = block_filter_list.get_current_iteration_id();
 
         let payload_index = self.payload_index.borrow();

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -30,7 +30,7 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::visited_pool::{VisitedList, VisitedPool};
+use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::Condition::Field;
@@ -160,7 +160,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         stopped: &AtomicBool,
         graph_layers_builder: &mut GraphLayersBuilder,
         condition: FieldCondition,
-        block_filter_list: &mut VisitedList,
+        block_filter_list: &mut VisitedListHandle,
     ) -> OperationResult<()> {
         block_filter_list.next_iteration();
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -436,9 +436,6 @@ impl PayloadIndex for StructPayloadIndex {
                 .filter(|&id| !visited_list.check_and_update_visited(id))
                 .filter(move |&i| struct_filtered_context.check(i))
                 .collect();
-
-            self.visited_pool.return_back(visited_list);
-
             preselected
         }
     }


### PR DESCRIPTION
This PR introduces automatically returning the visited list to the visited pool.

It's safer because currently developer has to return the list back manually when we stop usage of it.

I made this change because I want to try to fix this TODO:
https://github.com/qdrant/qdrant/blob/e686e71b9f514e9f8723c29591003f87b495ae87/lib/segment/src/index/struct_payload_index.rs#L416
If I'm going to add an iterator over filtered points, I have to have some mechanism for returning the visited list by the iterator end or drop.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
