### PR TITLE
Simple sparse vector storage

### DIFF
--- a/lib/segment/src/vector_storage/bitvec.rs
+++ b/lib/segment/src/vector_storage/bitvec.rs
@@ -1,0 +1,22 @@
+use bitvec::vec::BitVec;
+use common::types::PointOffsetType;
+
+/// Set deleted state in given bitvec.
+///
+/// Grows bitvec automatically if it is not big enough.
+///
+/// Returns previous deleted state of the given point.
+#[inline]
+pub fn bitvec_set_deleted(bitvec: &mut BitVec, point_id: PointOffsetType, deleted: bool) -> bool {
+    // Set deleted flag if bitvec is large enough, no need to check bounds
+    if (point_id as usize) < bitvec.len() {
+        return unsafe { bitvec.replace_unchecked(point_id as usize, deleted) };
+    }
+
+    // Bitvec is too small; grow and set the deletion flag, no need to check bounds
+    if deleted {
+        bitvec.resize(point_id as usize + 1, false);
+        unsafe { bitvec.set_unchecked(point_id as usize, true) };
+    }
+    false
+}

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -18,9 +18,11 @@ mod tests;
 #[cfg(target_os = "linux")]
 mod async_io;
 mod async_io_mock;
+mod bitvec;
 pub mod common;
 pub mod query;
 mod query_scorer;
+mod simple_sparse_vector_storage;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -114,6 +114,7 @@ pub fn new_stoppable_raw_scorer<'a>(
         VectorStorageEnum::AppendableMemmap(vs) => {
             raw_scorer_impl(query, vs.as_ref(), point_deleted, is_stopped)
         }
+        VectorStorageEnum::SparseSimple(_vs) => todo!("sparse vector raw scorer"),
     }
 }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -114,7 +114,7 @@ pub fn new_stoppable_raw_scorer<'a>(
         VectorStorageEnum::AppendableMemmap(vs) => {
             raw_scorer_impl(query, vs.as_ref(), point_deleted, is_stopped)
         }
-        VectorStorageEnum::SparseSimple(_vs) => todo!("sparse vector raw scorer"),
+        VectorStorageEnum::SparseSimple(_vs) => panic!("sparse vector raw scorer"), // TODO(sparse)
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/mod.rs
+++ b/lib/segment/src/vector_storage/tests/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "linux")]
 mod async_raw_scorer;
 mod custom_query_scorer_equivalency;
+mod test_appendable_sparse_vector_storage;
 mod test_appendable_vector_storage;
 mod utils;

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::types::PointOffsetType;
+use sparse::common::sparse_vector::SparseVector;
+use tempfile::Builder;
+
+use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use crate::types::Distance;
+use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+
+fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
+    let points: Vec<SparseVector> = vec![
+        vec![(0, 1.0), (2, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0), (2, 1.0)].into(),
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0), (1, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0)].into(),
+    ];
+    let delete_mask = [false, false, true, true, false];
+    let mut borrowed_storage = storage.borrow_mut();
+
+    // Insert all points
+    for (i, vec) in points.iter().enumerate() {
+        borrowed_storage
+            .insert_vector(i as PointOffsetType, vec.into())
+            .unwrap();
+    }
+
+    // Check that all points are inserted
+    for (i, vec) in points.iter().enumerate() {
+        let stored_vec = borrowed_storage.get_vector(i as PointOffsetType);
+        let sparse: &SparseVector = stored_vec.try_into().unwrap();
+        assert_eq!(sparse, vec);
+    }
+
+    // Delete select number of points
+    delete_mask
+        .into_iter()
+        .enumerate()
+        .filter(|(_, d)| *d)
+        .for_each(|(i, _)| {
+            borrowed_storage
+                .delete_vector(i as PointOffsetType)
+                .unwrap();
+        });
+    assert_eq!(
+        borrowed_storage.deleted_vector_count(),
+        2,
+        "2 vectors must be deleted"
+    );
+
+    // Delete 1, re-delete 2
+    borrowed_storage
+        .delete_vector(1 as PointOffsetType)
+        .unwrap();
+    borrowed_storage
+        .delete_vector(2 as PointOffsetType)
+        .unwrap();
+    assert_eq!(
+        borrowed_storage.deleted_vector_count(),
+        3,
+        "3 vectors must be deleted"
+    );
+
+    // Delete all
+    borrowed_storage
+        .delete_vector(0 as PointOffsetType)
+        .unwrap();
+    borrowed_storage
+        .delete_vector(4 as PointOffsetType)
+        .unwrap();
+    assert_eq!(
+        borrowed_storage.deleted_vector_count(),
+        5,
+        "all vectors must be deleted"
+    );
+}
+
+fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
+    let points: Vec<SparseVector> = vec![
+        vec![(0, 1.0), (2, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0), (2, 1.0)].into(),
+        vec![(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0), (1, 1.0), (3, 1.0)].into(),
+        vec![(0, 1.0)].into(),
+    ];
+    let delete_mask = [false, false, true, true, false];
+    let mut borrowed_storage = storage.borrow_mut();
+
+    {
+        let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
+        let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
+        let storage2 = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        {
+            let mut borrowed_storage2 = storage2.borrow_mut();
+            points.iter().enumerate().for_each(|(i, vec)| {
+                borrowed_storage2
+                    .insert_vector(i as PointOffsetType, vec.into())
+                    .unwrap();
+                if delete_mask[i] {
+                    borrowed_storage2
+                        .delete_vector(i as PointOffsetType)
+                        .unwrap();
+                }
+            });
+        }
+        borrowed_storage
+            .update_from(
+                &storage2.borrow(),
+                &mut Box::new(0..points.len() as u32),
+                &Default::default(),
+            )
+            .unwrap();
+    }
+
+    assert_eq!(
+        borrowed_storage.deleted_vector_count(),
+        2,
+        "2 vectors must be deleted from other storage"
+    );
+
+    // Delete all
+    borrowed_storage
+        .delete_vector(0 as PointOffsetType)
+        .unwrap();
+    borrowed_storage
+        .delete_vector(1 as PointOffsetType)
+        .unwrap();
+    borrowed_storage
+        .delete_vector(4 as PointOffsetType)
+        .unwrap();
+    assert_eq!(
+        borrowed_storage.deleted_vector_count(),
+        5,
+        "all vectors must be deleted"
+    );
+}
+
+#[test]
+fn test_delete_points_in_simple_sparse_vector_storage() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+
+    {
+        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        do_test_delete_points(storage.clone());
+        storage.borrow().flusher()().unwrap();
+    }
+    let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+}
+
+#[test]
+fn test_update_from_delete_points_simple_sparse_vector_storage() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    {
+        let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        do_test_update_from_delete_points(storage.clone());
+        storage.borrow().flusher()().unwrap();
+    }
+
+    let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+}

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -12,6 +12,7 @@ use crate::common::Flusher;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::Distance;
 use crate::vector_storage::appendable_mmap_vector_storage::AppendableMmapVectorStorage;
+use crate::vector_storage::simple_sparse_vector_storage::SimpleSparseVectorStorage;
 
 /// Trait for vector storage
 /// El - type of vector element, expected numerical type
@@ -40,7 +41,7 @@ pub trait VectorStorage {
             .saturating_sub(self.deleted_vector_count())
     }
 
-    /// Number of all stored vectors including deleted
+    /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> VectorRef;
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
@@ -95,6 +96,7 @@ pub enum VectorStorageEnum {
     Simple(SimpleVectorStorage),
     Memmap(Box<MemmapVectorStorage>),
     AppendableMemmap(Box<AppendableMmapVectorStorage>),
+    SparseSimple(SimpleSparseVectorStorage),
 }
 
 impl VectorStorage for VectorStorageEnum {
@@ -103,6 +105,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.vector_dim(),
             VectorStorageEnum::Memmap(v) => v.vector_dim(),
             VectorStorageEnum::AppendableMemmap(v) => v.vector_dim(),
+            VectorStorageEnum::SparseSimple(v) => v.vector_dim(),
         }
     }
 
@@ -111,6 +114,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.distance(),
             VectorStorageEnum::Memmap(v) => v.distance(),
             VectorStorageEnum::AppendableMemmap(v) => v.distance(),
+            VectorStorageEnum::SparseSimple(v) => v.distance(),
         }
     }
 
@@ -119,6 +123,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.is_on_disk(),
             VectorStorageEnum::Memmap(v) => v.is_on_disk(),
             VectorStorageEnum::AppendableMemmap(v) => v.is_on_disk(),
+            VectorStorageEnum::SparseSimple(v) => v.is_on_disk(),
         }
     }
 
@@ -127,6 +132,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.total_vector_count(),
             VectorStorageEnum::Memmap(v) => v.total_vector_count(),
             VectorStorageEnum::AppendableMemmap(v) => v.total_vector_count(),
+            VectorStorageEnum::SparseSimple(v) => v.total_vector_count(),
         }
     }
 
@@ -135,6 +141,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.get_vector(key),
             VectorStorageEnum::Memmap(v) => v.get_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.get_vector(key),
+            VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
         }
     }
 
@@ -143,6 +150,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.insert_vector(key, vector),
             VectorStorageEnum::Memmap(v) => v.insert_vector(key, vector),
             VectorStorageEnum::AppendableMemmap(v) => v.insert_vector(key, vector),
+            VectorStorageEnum::SparseSimple(v) => v.insert_vector(key, vector),
         }
     }
 
@@ -156,6 +164,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::Memmap(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::AppendableMemmap(v) => v.update_from(other, other_ids, stopped),
+            VectorStorageEnum::SparseSimple(v) => v.update_from(other, other_ids, stopped),
         }
     }
 
@@ -164,6 +173,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.flusher(),
             VectorStorageEnum::Memmap(v) => v.flusher(),
             VectorStorageEnum::AppendableMemmap(v) => v.flusher(),
+            VectorStorageEnum::SparseSimple(v) => v.flusher(),
         }
     }
 
@@ -172,6 +182,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.files(),
             VectorStorageEnum::Memmap(v) => v.files(),
             VectorStorageEnum::AppendableMemmap(v) => v.files(),
+            VectorStorageEnum::SparseSimple(v) => v.files(),
         }
     }
 
@@ -180,6 +191,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.delete_vector(key),
             VectorStorageEnum::Memmap(v) => v.delete_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.delete_vector(key),
+            VectorStorageEnum::SparseSimple(v) => v.delete_vector(key),
         }
     }
 
@@ -188,6 +200,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.is_deleted_vector(key),
             VectorStorageEnum::Memmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::SparseSimple(v) => v.is_deleted_vector(key),
         }
     }
 
@@ -196,6 +209,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.deleted_vector_count(),
             VectorStorageEnum::Memmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::AppendableMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::SparseSimple(v) => v.deleted_vector_count(),
         }
     }
 
@@ -204,6 +218,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Simple(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::Memmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::AppendableMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::SparseSimple(v) => v.deleted_vector_bitslice(),
         }
     }
 }

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use crate::common::types::{DimId, DimWeight};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct SparseVector {
     pub indices: Vec<DimId>,
     pub weights: Vec<DimWeight>,
@@ -8,6 +10,17 @@ pub struct SparseVector {
 
 impl SparseVector {
     pub fn new(indices: Vec<DimId>, weights: Vec<DimWeight>) -> SparseVector {
+        SparseVector { indices, weights }
+    }
+}
+impl From<Vec<(i32, f64)>> for SparseVector {
+    fn from(v: Vec<(i32, f64)>) -> Self {
+        let mut indices = Vec::with_capacity(v.len());
+        let mut weights = Vec::with_capacity(v.len());
+        for (i, w) in v {
+            indices.push(i as u32);
+            weights.push(w as f32);
+        }
         SparseVector { indices, weights }
     }
 }

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -124,6 +124,12 @@ pub struct PostingBuilder {
     elements: Vec<PostingElement>,
 }
 
+impl Default for PostingBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PostingBuilder {
     pub fn new() -> PostingBuilder {
         PostingBuilder {


### PR DESCRIPTION
A simple storage for sparse vectors which persist original vector in RocksDB.

The implementation is a port of `SimpleVectorStorage` and some common code has been extracted.