### PR TITLE
Shard key

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -43,6 +43,7 @@
     - [RenameAlias](#qdrant-RenameAlias)
     - [Replica](#qdrant-Replica)
     - [ScalarQuantization](#qdrant-ScalarQuantization)
+    - [ShardKey](#qdrant-ShardKey)
     - [ShardTransferInfo](#qdrant-ShardTransferInfo)
     - [TextIndexParams](#qdrant-TextIndexParams)
     - [UpdateCollection](#qdrant-UpdateCollection)
@@ -657,6 +658,7 @@
 | shard_id | [uint32](#uint32) |  | Local shard id |
 | points_count | [uint64](#uint64) |  | Number of points in the shard |
 | state | [ReplicaState](#qdrant-ReplicaState) |  | Is replica active |
+| shard_key | [ShardKey](#qdrant-ShardKey) | optional | User-defined shard key |
 
 
 
@@ -830,6 +832,7 @@ Note: 1kB = 1 vector of size 256. |
 | shard_id | [uint32](#uint32) |  | Local shard id |
 | peer_id | [uint64](#uint64) |  | Remote peer id |
 | state | [ReplicaState](#qdrant-ReplicaState) |  | Is replica active |
+| shard_key | [ShardKey](#qdrant-ShardKey) | optional | User-defined shard key |
 
 
 
@@ -879,6 +882,22 @@ Note: 1kB = 1 vector of size 256. |
 | type | [QuantizationType](#qdrant-QuantizationType) |  | Type of quantization |
 | quantile | [float](#float) | optional | Number of bits to use for quantization |
 | always_ram | [bool](#bool) | optional | If true - quantized vectors always will be stored in RAM, ignoring the config of main storage |
+
+
+
+
+
+
+<a name="qdrant-ShardKey"></a>
+
+### ShardKey
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| keyword | [string](#string) |  | String key |
+| number | [uint64](#uint64) |  | Number key |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7613,6 +7613,17 @@
             "format": "uint32",
             "minimum": 0
           },
+          "shard_key": {
+            "description": "User-defined sharding key",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "points_count": {
             "description": "Number of points in the shard",
             "type": "integer",
@@ -7623,6 +7634,18 @@
             "$ref": "#/components/schemas/ReplicaState"
           }
         }
+      },
+      "ShardKey": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        ]
       },
       "ReplicaState": {
         "description": "State of the single shard within a replica set.",
@@ -7648,6 +7671,17 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0
+          },
+          "shard_key": {
+            "description": "User-defined sharding key",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "peer_id": {
             "description": "Remote peer id",

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -392,16 +392,25 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
 }
 
+message ShardKey {
+  oneof key {
+    string keyword = 1; // String key
+    uint64 number = 2; // Number key
+  }
+}
+
 message LocalShardInfo {
   uint32 shard_id = 1; // Local shard id
   uint64 points_count = 2; // Number of points in the shard
   ReplicaState state = 3;  // Is replica active
+  optional ShardKey shard_key = 4; // User-defined shard key
 }
 
 message RemoteShardInfo {
   uint32 shard_id = 1; // Local shard id
   uint64 peer_id = 2; // Remote peer id
   ReplicaState state = 3; // Is replica active
+  optional ShardKey shard_key = 4; // User-defined shard key
 }
 
 message ShardTransferInfo {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -728,6 +728,27 @@ pub struct CollectionClusterInfoRequest {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShardKey {
+    #[prost(oneof = "shard_key::Key", tags = "1, 2")]
+    pub key: ::core::option::Option<shard_key::Key>,
+}
+/// Nested message and enum types in `ShardKey`.
+pub mod shard_key {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Key {
+        /// String key
+        #[prost(string, tag = "1")]
+        Keyword(::prost::alloc::string::String),
+        /// Number key
+        #[prost(uint64, tag = "2")]
+        Number(u64),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalShardInfo {
     /// Local shard id
     #[prost(uint32, tag = "1")]
@@ -738,6 +759,9 @@ pub struct LocalShardInfo {
     /// Is replica active
     #[prost(enumeration = "ReplicaState", tag = "3")]
     pub state: i32,
+    /// User-defined shard key
+    #[prost(message, optional, tag = "4")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -752,6 +776,9 @@ pub struct RemoteShardInfo {
     /// Is replica active
     #[prost(enumeration = "ReplicaState", tag = "3")]
     pub state: i32,
+    /// User-defined shard key
+    #[prost(message, optional, tag = "4")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -238,6 +238,8 @@ impl Collection {
             filter: None,
             exact: false, // Don't need exact count of unique ids here, only size estimation
         });
+        let shard_to_key = shards_holder.get_shard_id_to_key_mapping();
+
         // extract shards info
         for (shard_id, replica_set) in shards_holder.get_shards() {
             let shard_id = *shard_id;
@@ -257,6 +259,7 @@ impl Collection {
                     shard_id,
                     points_count,
                     state,
+                    shard_key: shard_to_key.get(&shard_id).cloned(),
                 })
             }
             for (peer_id, state) in replica_set.peers().into_iter() {
@@ -267,6 +270,7 @@ impl Collection {
                     shard_id,
                     peer_id,
                     state,
+                    shard_key: shard_to_key.get(&shard_id).cloned(),
                 });
             }
         }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -103,7 +103,7 @@ impl Collection {
             )
             .await?;
 
-            shard_holder.add_shard(shard_id, replica_set);
+            shard_holder.add_shard(shard_id, replica_set, None)?;
         }
 
         let locked_shard_holder = Arc::new(LockedShardHolder::new(shard_holder));

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -42,6 +42,7 @@ use crate::operations::types::{
 };
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::{CollectionCoreSearchRequest, CollectionSearchRequest};
+use crate::shards::shard::ShardKey;
 
 pub fn write_ordering_to_proto(ordering: WriteOrdering) -> api::grpc::qdrant::WriteOrdering {
     api::grpc::qdrant::WriteOrdering {
@@ -1135,12 +1136,26 @@ impl From<AliasDescription> for api::grpc::qdrant::AliasDescription {
     }
 }
 
+impl From<ShardKey> for api::grpc::qdrant::ShardKey {
+    fn from(value: ShardKey) -> Self {
+        match value {
+            ShardKey::Keyword(keyword) => Self {
+                key: Some(api::grpc::qdrant::shard_key::Key::Keyword(keyword)),
+            },
+            ShardKey::Number(number) => Self {
+                key: Some(api::grpc::qdrant::shard_key::Key::Number(number)),
+            },
+        }
+    }
+}
+
 impl From<LocalShardInfo> for api::grpc::qdrant::LocalShardInfo {
     fn from(value: LocalShardInfo) -> Self {
         Self {
             shard_id: value.shard_id,
             points_count: value.points_count as u64,
             state: value.state as i32,
+            shard_key: value.shard_key.map(Into::into),
         }
     }
 }
@@ -1151,6 +1166,7 @@ impl From<RemoteShardInfo> for api::grpc::qdrant::RemoteShardInfo {
             shard_id: value.shard_id,
             peer_id: value.peer_id,
             state: value.state as i32,
+            shard_key: value.shard_key.map(Into::into),
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -40,7 +40,7 @@ use crate::lookup::types::WithLookupInterface;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;
-use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard::{PeerId, ShardId, ShardKey};
 use crate::wal::WalError;
 
 /// Current state of the collection.
@@ -143,6 +143,9 @@ pub struct ShardTransferInfo {
 pub struct LocalShardInfo {
     /// Local shard id
     pub shard_id: ShardId,
+    /// User-defined sharding key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<ShardKey>,
     /// Number of points in the shard
     pub points_count: usize,
     /// Is replica active
@@ -154,6 +157,9 @@ pub struct LocalShardInfo {
 pub struct RemoteShardInfo {
     /// Remote shard id
     pub shard_id: ShardId,
+    /// User-defined sharding key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<ShardKey>,
     /// Remote peer id
     pub peer_id: PeerId,
     /// Is replica active

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -2,6 +2,9 @@ use core::marker::{Send, Sync};
 use std::future::{self, Future};
 use std::path::Path;
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use super::update_tracker::UpdateTracker;
 use crate::operations::types::CollectionResult;
 use crate::shards::dummy_shard::DummyShard;
@@ -15,6 +18,13 @@ use crate::shards::telemetry::LocalShardTelemetry;
 pub type ShardId = u32;
 
 pub type PeerId = u64;
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum ShardKey {
+    Keyword(String),
+    Number(u64),
+}
 
 /// Shard
 ///

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -19,18 +19,20 @@ use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::replica_set::{ChangePeerState, ReplicaState, ShardReplicaSet}; // TODO rename ReplicaShard to ReplicaSetShard
-use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard::{PeerId, ShardId, ShardKey};
 use crate::shards::shard_config::{ShardConfig, ShardType};
 use crate::shards::shard_versioning::latest_shard_paths;
 use crate::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::CollectionId;
 
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
+const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
 
 pub struct ShardHolder {
     shards: HashMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
     ring: HashRing<ShardId>,
+    key_mapping: SaveOnDisk<HashMap<ShardKey, HashSet<ShardId>>>,
 }
 
 pub type LockedShardHolder = RwLock<ShardHolder>;
@@ -38,22 +40,76 @@ pub type LockedShardHolder = RwLock<ShardHolder>;
 impl ShardHolder {
     pub fn new(collection_path: &Path, hashring: HashRing<ShardId>) -> CollectionResult<Self> {
         let shard_transfers = SaveOnDisk::load_or_init(collection_path.join(SHARD_TRANSFERS_FILE))?;
+        let key_mapping = SaveOnDisk::load_or_init(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
         Ok(Self {
             shards: HashMap::new(),
             shard_transfers,
             ring: hashring,
+            key_mapping,
         })
     }
 
-    pub fn add_shard(&mut self, shard_id: ShardId, shard: ShardReplicaSet) {
-        self.shards.insert(shard_id, shard);
-        self.ring.add(shard_id);
+    pub fn get_shard_id_to_key_mapping(&self) -> HashMap<ShardId, ShardKey> {
+        self.key_mapping
+            .read()
+            .iter()
+            .flat_map(|(key, shard_ids)| {
+                shard_ids
+                    .iter()
+                    .map(move |shard_id| (*shard_id, key.clone()))
+            })
+            .collect()
     }
 
-    pub fn remove_shard(&mut self, shard_id: ShardId) -> Option<ShardReplicaSet> {
-        let shard = self.shards.remove(&shard_id);
+    pub fn add_shard(
+        &mut self,
+        shard_id: ShardId,
+        shard: ShardReplicaSet,
+        shard_key: Option<ShardKey>,
+    ) -> Result<(), CollectionError> {
+        self.shards.insert(shard_id, shard);
+        self.ring.add(shard_id);
+        if let Some(shard_key) = shard_key {
+            self.key_mapping.write_optional(|key_mapping| {
+                let has_id = key_mapping
+                    .get(&shard_key)
+                    .map(|shard_ids| shard_ids.contains(&shard_id))
+                    .unwrap_or(false);
+
+                if !has_id {
+                    return None;
+                }
+                let mut copy_of_mapping = key_mapping.clone();
+                let shard_ids = copy_of_mapping.entry(shard_key).or_default();
+                shard_ids.insert(shard_id);
+                Some(copy_of_mapping)
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn remove_shard(
+        &mut self,
+        shard_id: ShardId,
+    ) -> Result<Option<ShardReplicaSet>, CollectionError> {
+        let shard_opt = self.shards.remove(&shard_id);
+        self.key_mapping.write_optional(|key_mapping| {
+            let has_id = key_mapping
+                .values()
+                .any(|shard_ids| shard_ids.contains(&shard_id));
+
+            if !has_id {
+                return None;
+            }
+
+            let mut copy_of_mapping = key_mapping.clone();
+            for shard_ids in copy_of_mapping.values_mut() {
+                shard_ids.remove(&shard_id);
+            }
+            Some(copy_of_mapping)
+        })?;
         self.ring.remove(&shard_id);
-        shard
+        Ok(shard_opt)
     }
 
     /// Take shard
@@ -63,27 +119,12 @@ impl ShardHolder {
         self.shards.remove(&shard_id)
     }
 
-    /// Replace shard
-    ///
-    /// return old shard
-    pub fn replace_shard(
-        &mut self,
-        shard_id: ShardId,
-        shard: ShardReplicaSet,
-    ) -> Option<ShardReplicaSet> {
-        self.shards.insert(shard_id, shard)
-    }
-
     pub fn contains_shard(&self, shard_id: &ShardId) -> bool {
         self.shards.contains_key(shard_id)
     }
 
     pub fn get_shard(&self, shard_id: &ShardId) -> Option<&ShardReplicaSet> {
         self.shards.get(shard_id)
-    }
-
-    pub fn get_mut_shard(&mut self, shard_id: &ShardId) -> Option<&mut ShardReplicaSet> {
-        self.shards.get_mut(shard_id)
     }
 
     pub fn get_shards(&self) -> impl Iterator<Item = (&ShardId, &ShardReplicaSet)> {
@@ -288,7 +329,7 @@ impl ShardHolder {
                         .expect("Failed to set local shard state");
                 }
 
-                self.add_shard(shard_id, replica_set);
+                self.add_shard(shard_id, replica_set, None).unwrap();
             }
         }
     }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -53,11 +53,7 @@ impl ShardHolder {
         self.key_mapping
             .read()
             .iter()
-            .flat_map(|(key, shard_ids)| {
-                shard_ids
-                    .iter()
-                    .map(move |shard_id| (*shard_id, key.clone()))
-            })
+            .flat_map(|(key, shard_ids)| shard_ids.iter().map(|shard_id| (*shard_id, key.clone())))
             .collect()
     }
 

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -72,7 +72,7 @@ impl ShardHolder {
                     .map(|shard_ids| shard_ids.contains(&shard_id))
                     .unwrap_or(false);
 
-                if !has_id {
+                if has_id {
                     return None;
                 }
                 let mut copy_of_mapping = key_mapping.clone();


### PR DESCRIPTION
Tracking issue: https://github.com/qdrant/qdrant/issues/2807

- Add `shard_key` to shard info object
- Add `key_mapping` to `ShardHolder`

Discussion:

Alternatively, I was considering to add `shard_key` to `ReplicaSet`, but it looks like ShardHolder is more appropriate.
One possible downside: shard mapping is not stored as dedicated file, and it might have some overhead if we have a lot of shards, as it would require to overwrite the whole file on each creation of the shard. But I consider it less important, on the scale of costs of creation of the shard itself.