### PR TITLE
Block shard transfer to itself with validation

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -137,7 +137,6 @@ fn configure_validation(builder: Builder) -> Builder {
             "Disabled",
             "QuantizationConfigDiff",
             "quantization_config_diff::Quantization",
-            "MoveShard",
             "Replica",
         ])
         // Service: collections_internal.proto

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -124,6 +124,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("QuantizationConfig.quantization", ""),
             ("QuantizationConfigDiff.quantization", ""),
             ("ScalarQuantization.quantile", "custom = \"crate::grpc::validate::validate_f32_range_min_0_5_max_1\""),
+            ("UpdateCollectionClusterSetupRequest.operation", ""),
         ], &[
             "ListCollectionsRequest",
             "CollectionParamsDiff",
@@ -134,7 +135,9 @@ fn configure_validation(builder: Builder) -> Builder {
             "BinaryQuantization",
             "Disabled",
             "QuantizationConfigDiff",
-            "quantization_config_diff::Quantization"
+            "quantization_config_diff::Quantization",
+            "MoveShard",
+            "Replica",
         ])
         // Service: collections_internal.proto
         .validates(&[

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -124,6 +124,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("QuantizationConfig.quantization", ""),
             ("QuantizationConfigDiff.quantization", ""),
             ("ScalarQuantization.quantile", "custom = \"crate::grpc::validate::validate_f32_range_min_0_5_max_1\""),
+            ("UpdateCollectionClusterSetupRequest.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
             ("UpdateCollectionClusterSetupRequest.operation", ""),
         ], &[
             "ListCollectionsRequest",

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -815,6 +815,7 @@ pub struct CollectionClusterInfoResponse {
     #[prost(message, repeated, tag = "5")]
     pub shard_transfers: ::prost::alloc::vec::Vec<ShardTransferInfo>,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -827,6 +828,7 @@ pub struct MoveShard {
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -851,6 +853,7 @@ pub struct UpdateCollectionClusterSetupRequest {
         oneof = "update_collection_cluster_setup_request::Operation",
         tags = "2, 3, 4, 5"
     )]
+    #[validate]
     pub operation: ::core::option::Option<
         update_collection_cluster_setup_request::Operation,
     >,

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -848,6 +848,7 @@ pub struct UpdateCollectionClusterSetupRequest {
     pub collection_name: ::prost::alloc::string::String,
     /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
     #[prost(uint64, optional, tag = "6")]
+    #[validate(custom = "crate::grpc::validate::validate_u64_range_min_1")]
     pub timeout: ::core::option::Option<u64>,
     #[prost(
         oneof = "update_collection_cluster_setup_request::Operation",

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -815,7 +815,6 @@ pub struct CollectionClusterInfoResponse {
     #[prost(message, repeated, tag = "5")]
     pub shard_transfers: ::prost::alloc::vec::Vec<ShardTransferInfo>,
 }
-#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -116,6 +116,18 @@ impl Validate for crate::grpc::qdrant::quantization_config_diff::Quantization {
     }
 }
 
+impl Validate for crate::grpc::qdrant::update_collection_cluster_setup_request::Operation {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        use crate::grpc::qdrant::update_collection_cluster_setup_request::Operation;
+        match self {
+            Operation::MoveShard(op) => op.validate(),
+            Operation::ReplicateShard(op) => op.validate(),
+            Operation::AbortTransfer(op) => op.validate(),
+            Operation::DropReplica(op) => op.validate(),
+        }
+    }
+}
+
 impl Validate for crate::grpc::qdrant::condition::ConditionOneOf {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use crate::grpc::qdrant::condition::ConditionOneOf;

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use common::validation::validate_range_generic;
+use common::validation::{validate_move_shard_different_peers, validate_range_generic};
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::qdrant::{GeoLineString, NamedVectors};
@@ -130,25 +130,7 @@ impl Validate for crate::grpc::qdrant::update_collection_cluster_setup_request::
 
 impl Validate for crate::grpc::qdrant::MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        // Custom struct validator: source and target peer may not be the same
-        // Matches implementation in: lib/collection/src/operations/cluster_ops.rs
-        if self.to_peer_id == self.from_peer_id {
-            let mut errors = ValidationErrors::new();
-            errors.add("to_peer_id", {
-                let mut error = ValidationError::new("must_not_match");
-                error.add_param(Cow::from("value"), &self.to_peer_id.to_string());
-                error.add_param(Cow::from("other_field"), &"from_peer_id");
-                error.add_param(Cow::from("other_value"), &self.from_peer_id.to_string());
-                error.add_param(
-                    Cow::from("message"),
-                    &format!("cannot move shard to itself, \"to_peer_id\" must be different than {} in \"from_peer_id\"", self.from_peer_id),
-                );
-                error
-            });
-            return Err(errors);
-        }
-
-        Ok(())
+        validate_move_shard_different_peers(self.from_peer_id, self.to_peer_id)
     }
 }
 

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -5,8 +5,7 @@ use validator::Validate;
 use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum ClusterOperations {
     /// Move shard to a different peer
     MoveShard(MoveShardOperation),
@@ -18,27 +17,42 @@ pub enum ClusterOperations {
     DropReplica(DropReplicaOperation),
 }
 
+impl Validate for ClusterOperations {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            ClusterOperations::MoveShard(op) => op.validate(),
+            ClusterOperations::ReplicateShard(op) => op.validate(),
+            ClusterOperations::AbortTransfer(op) => op.validate(),
+            ClusterOperations::DropReplica(op) => op.validate(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct MoveShardOperation {
+    #[validate]
     pub move_shard: MoveShard,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct ReplicateShardOperation {
+    #[validate]
     pub replicate_shard: MoveShard,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct DropReplicaOperation {
+    #[validate]
     pub drop_replica: Replica,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AbortTransferOperation {
+    #[validate]
     pub abort_transfer: MoveShard,
 }
 
@@ -55,15 +69,4 @@ pub struct MoveShard {
 pub struct Replica {
     pub shard_id: ShardId,
     pub peer_id: PeerId,
-}
-
-impl Validate for ClusterOperations {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            ClusterOperations::MoveShard(op) => op.validate(),
-            ClusterOperations::ReplicateShard(op) => op.validate(),
-            ClusterOperations::AbortTransfer(op) => op.validate(),
-            ClusterOperations::DropReplica(op) => op.validate(),
-        }
-    }
 }

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -76,6 +76,10 @@ impl Validate for MoveShard {
                 error.add_param(Cow::from("value"), &self.to_peer_id.to_string());
                 error.add_param(Cow::from("other_field"), &"from_peer_id");
                 error.add_param(Cow::from("other_value"), &self.from_peer_id.to_string());
+                error.add_param(
+                    Cow::from("message"),
+                    &format!("cannot move shard to itself, \"to_peer_id\" must be different than {} in \"from_peer_id\"", self.from_peer_id),
+                );
                 error
             });
             return Err(errors);

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -1,8 +1,7 @@
-use std::borrow::Cow;
-
+use common::validation::validate_move_shard_different_peers;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use validator::{Validate, ValidationError, ValidationErrors};
+use validator::{Validate, ValidationErrors};
 
 use crate::shards::shard::{PeerId, ShardId};
 
@@ -68,24 +67,7 @@ pub struct MoveShard {
 
 impl Validate for MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        // Custom struct validator: source and target peer may not be the same
-        if self.to_peer_id == self.from_peer_id {
-            let mut errors = ValidationErrors::new();
-            errors.add("to_peer_id", {
-                let mut error = ValidationError::new("must_not_match");
-                error.add_param(Cow::from("value"), &self.to_peer_id.to_string());
-                error.add_param(Cow::from("other_field"), &"from_peer_id");
-                error.add_param(Cow::from("other_value"), &self.from_peer_id.to_string());
-                error.add_param(
-                    Cow::from("message"),
-                    &format!("cannot move shard to itself, \"to_peer_id\" must be different than {} in \"from_peer_id\"", self.from_peer_id),
-                );
-                error
-            });
-            return Err(errors);
-        }
-
-        Ok(())
+        validate_move_shard_different_peers(self.from_peer_id, self.to_peer_id)
     }
 }
 

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use validator::Validate;
+use validator::{Validate, ValidationError, ValidationErrors};
 
 use crate::shards::shard::{PeerId, ShardId};
 
@@ -56,12 +58,31 @@ pub struct AbortTransferOperation {
     pub abort_transfer: MoveShard,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct MoveShard {
     pub shard_id: ShardId,
     pub to_peer_id: PeerId,
     pub from_peer_id: PeerId,
+}
+
+impl Validate for MoveShard {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        // Custom struct validator: source and target peer may not be the same
+        if self.to_peer_id == self.from_peer_id {
+            let mut errors = ValidationErrors::new();
+            errors.add("to_peer_id", {
+                let mut error = ValidationError::new("must_not_match");
+                error.add_param(Cow::from("value"), &self.to_peer_id.to_string());
+                error.add_param(Cow::from("other_field"), &"from_peer_id");
+                error.add_param(Cow::from("other_value"), &self.from_peer_id.to_string());
+                error
+            });
+            return Err(errors);
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -1,4 +1,5 @@
 use actix_web_validator::error::flatten_errors;
+use serde_json::Value;
 use validator::{ValidationError, ValidationErrors};
 
 /// Warn about validation errors in the log.
@@ -44,6 +45,8 @@ fn describe_error(
 ) -> String {
     // Prefer to return message if set
     if let Some(message) = message {
+        return message.to_string();
+    } else if let Some(Value::String(message)) = params.get("message") {
         return message.to_string();
     }
 

--- a/lib/collection/src/operations/validation.rs
+++ b/lib/collection/src/operations/validation.rs
@@ -78,6 +78,28 @@ fn describe_error(
                 None => msg,
             }
         }
+        "must_not_match" => {
+            match (
+                params.get("value"),
+                params.get("other_field"),
+                params.get("other_value"),
+            ) {
+                (Some(value), Some(other_field), Some(other_value)) => {
+                    format!("value {value} must not match {other_value} in {other_field}")
+                }
+                (Some(value), Some(other_field), None) => {
+                    format!("value {value} must not match value in {other_field}")
+                }
+                (None, Some(other_field), Some(other_value)) => {
+                    format!("must not match {other_value} in {other_field}")
+                }
+                (None, Some(other_field), None) => {
+                    format!("must not match value in {other_field}")
+                }
+                // Should be unreachable
+                _ => err.to_string(),
+            }
+        }
         "does_not_contain" => match params.get("pattern") {
             Some(pattern) => format!("cannot contain {pattern}"),
             None => err.to_string(),

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -111,6 +111,19 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
     shard_id = collection_cluster_info["local_shards"][0]["shard_id"]
     source_peer_id = collection_cluster_info["peer_id"]
 
+    # Test that we cannot move shard to ourselves
+    r = requests.post(
+        f"{source_uri}/collections/test_collection/cluster", json={
+            "move_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": source_peer_id,
+                "to_peer_id": source_peer_id
+            }
+        })
+    assert not r.ok
+    assert r.status_code == 422
+    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot move shard to itself")
+
     # Move shard `shard_id` to peer `target_peer_id`
     r = requests.post(
         f"{source_uri}/collections/test_collection/cluster", json={


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/2805

Before, we could send a shard to the same node as it came from by using the same _from_ and _to_ peer ID. This brought Qdrant into a weird state.

This PR prevents this by blocking this at the validation level. Now the source and target address must be different in both REST and gRPC.

The following validation error is now returned:

```
Validation error in JSON body: [move_shard.to_peer_id: cannot move shard to itself, "to_peer_id" must be different than 0 in "from_peer_id"]
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
