### PR TITLE
Dense vector storage

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -15,7 +15,8 @@ use crate::spaces::metric::Metric;
 use crate::types::Distance;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::{
-    raw_scorer_impl, RawScorer, VectorStorage, VectorStorageEnum, DEFAULT_STOPPED,
+    raw_scorer_impl, DenseVectorStorage, RawScorer, VectorStorage, VectorStorageEnum,
+    DEFAULT_STOPPED,
 };
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
@@ -37,6 +38,12 @@ pub struct TestRawScorerProducer<TMetric: Metric> {
     pub metric: PhantomData<TMetric>,
 }
 
+impl<TMetric: Metric> DenseVectorStorage for TestRawScorerProducer<TMetric> {
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+        self.vectors.get(key)
+    }
+}
+
 impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
     fn vector_dim(&self) -> usize {
         self.vectors.get(0).len()
@@ -55,7 +62,7 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
-        self.vectors.get(key)
+        self.get_dense(key)
     }
 
     fn insert_vector(

--- a/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
@@ -8,6 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 
+use super::DenseVectorStorage;
 use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
@@ -83,6 +84,12 @@ impl AppendableMmapVectorStorage {
     }
 }
 
+impl DenseVectorStorage for AppendableMmapVectorStorage {
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+        self.vectors.get(key)
+    }
+}
+
 impl VectorStorage for AppendableMmapVectorStorage {
     fn vector_dim(&self) -> usize {
         self.vectors.dim()
@@ -101,7 +108,7 @@ impl VectorStorage for AppendableMmapVectorStorage {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
-        self.vectors.get(key)
+        self.get_dense(key)
     }
 
     fn insert_vector(

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -10,7 +10,7 @@ use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
 use memory::mmap_ops;
 
-use super::VectorStorageEnum;
+use super::{DenseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::vectors::VectorElementType;
@@ -86,6 +86,12 @@ impl MemmapVectorStorage {
     }
 }
 
+impl DenseVectorStorage for MemmapVectorStorage {
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+        self.mmap_store.as_ref().unwrap().get_vector(key)
+    }
+}
+
 impl VectorStorage for MemmapVectorStorage {
     fn vector_dim(&self) -> usize {
         self.mmap_store.as_ref().unwrap().dim
@@ -104,7 +110,7 @@ impl VectorStorage for MemmapVectorStorage {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
-        self.mmap_store.as_ref().unwrap().get_vector(key)
+        self.get_dense(key)
     }
 
     fn insert_vector(

--- a/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/discovery_query_scorer.rs
@@ -6,18 +6,18 @@ use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::DenseVectorStorage;
 
 // TODO(luis): maybe find a way to generalize DiscoveryQueryScorer and RecoQueryScorer by
 //     using a single Query trait. The crux is that `transform` function is hard to convert
 //     nicely into a trait function
-pub struct DiscoveryQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage> {
+pub struct DiscoveryQueryScorer<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> {
     vector_storage: &'a TVectorStorage,
     query: DiscoveryQuery<VectorType>,
     metric: PhantomData<TMetric>,
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage>
     DiscoveryQueryScorer<'a, TMetric, TVectorStorage>
 {
     #[allow(dead_code)] // TODO(luis): remove once integrated
@@ -32,12 +32,12 @@ impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     }
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage> QueryScorer
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> QueryScorer
     for DiscoveryQueryScorer<'a, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_vector(idx);
+        let stored = self.vector_storage.get_dense(idx);
         self.score(stored)
     }
 

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -5,7 +5,7 @@ use common::types::{PointOffsetType, ScoreType};
 use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{DenseVectorStorage, VectorStorage};
 
 pub struct MetricQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage> {
     vector_storage: &'a TVectorStorage,
@@ -13,7 +13,7 @@ pub struct MetricQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     metric: PhantomData<TMetric>,
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage>
     MetricQueryScorer<'a, TMetric, TVectorStorage>
 {
     pub fn new(query: VectorType, vector_storage: &'a TVectorStorage) -> Self {
@@ -25,12 +25,12 @@ impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     }
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage> QueryScorer
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> QueryScorer
     for MetricQueryScorer<'a, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        TMetric::similarity(&self.query, self.vector_storage.get_vector(idx))
+        TMetric::similarity(&self.query, self.vector_storage.get_dense(idx))
     }
 
     #[inline]
@@ -39,8 +39,8 @@ impl<'a, TMetric: Metric, TVectorStorage: VectorStorage> QueryScorer
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        let v1 = self.vector_storage.get_vector(point_a);
-        let v2 = self.vector_storage.get_vector(point_b);
+        let v1 = self.vector_storage.get_dense(point_a);
+        let v2 = self.vector_storage.get_dense(point_b);
         TMetric::similarity(v1, v2)
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/reco_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/reco_query_scorer.rs
@@ -6,15 +6,15 @@ use crate::data_types::vectors::{VectorElementType, VectorType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query::reco_query::RecoQuery;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::DenseVectorStorage;
 
-pub struct RecoQueryScorer<'a, TMetric: Metric, TVectorStorage: VectorStorage> {
+pub struct RecoQueryScorer<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> {
     vector_storage: &'a TVectorStorage,
     query: RecoQuery<VectorType>,
     metric: PhantomData<TMetric>,
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage>
     RecoQueryScorer<'a, TMetric, TVectorStorage>
 {
     pub fn new(query: RecoQuery<VectorType>, vector_storage: &'a TVectorStorage) -> Self {
@@ -28,12 +28,12 @@ impl<'a, TMetric: Metric, TVectorStorage: VectorStorage>
     }
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: VectorStorage> QueryScorer
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> QueryScorer
     for RecoQueryScorer<'a, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_vector(idx);
+        let stored = self.vector_storage.get_dense(idx);
         self.score(stored)
     }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -4,7 +4,7 @@ use bitvec::prelude::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
 use super::query_scorer::reco_query_scorer::RecoQueryScorer;
-use super::{VectorStorage, VectorStorageEnum};
+use super::{DenseVectorStorage, VectorStorageEnum};
 use crate::data_types::vectors::QueryVector;
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
@@ -124,7 +124,7 @@ pub fn new_raw_scorer<'a>(
     new_stoppable_raw_scorer(vector, vector_storage, point_deleted, &DEFAULT_STOPPED)
 }
 
-pub fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
+pub fn raw_scorer_impl<'a, TVectorStorage: DenseVectorStorage>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,
@@ -152,7 +152,7 @@ pub fn raw_scorer_impl<'a, TVectorStorage: VectorStorage>(
     }
 }
 
-fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: VectorStorage>(
+fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorStorage>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,

--- a/lib/segment/src/vector_storage/simple_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_vector_storage.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use super::chunked_vectors::ChunkedVectors;
 use super::vector_storage_base::VectorStorage;
-use super::VectorStorageEnum;
+use super::{DenseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
@@ -127,6 +127,12 @@ impl SimpleVectorStorage {
     }
 }
 
+impl DenseVectorStorage for SimpleVectorStorage {
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+        self.vectors.get(key)
+    }
+}
+
 impl VectorStorage for SimpleVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
@@ -145,7 +151,7 @@ impl VectorStorage for SimpleVectorStorage {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
-        self.vectors.get(key)
+        self.get_dense(key)
     }
 
     fn insert_vector(

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -91,6 +91,10 @@ pub trait VectorStorage {
     fn deleted_vector_bitslice(&self) -> &BitSlice;
 }
 
+pub trait DenseVectorStorage: VectorStorage {
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType];
+}
+
 pub enum VectorStorageEnum {
     Simple(SimpleVectorStorage),
     Memmap(Box<MemmapVectorStorage>),


### PR DESCRIPTION
Sparse vector integration step.

Sparse vector data will be integrated as a `VectorStorageEnum` variant. And because sparse vectors aren't just `Vec<f32>`, we are going to change `get_vector` signature of `VectorStorage` trait. It will return some `enum` with sparse and dense variants. To avoid additional conversion of such `enum` in scorers, this PR introduced `DenseVectorStorage` trait with an explicit dense vector getter for scorers.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
