### PR TITLE
Add discovery context scorer

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod fixed_length_priority_queue;
+pub mod math;
 pub mod types;
 pub mod validation;

--- a/lib/common/common/src/math.rs
+++ b/lib/common/common/src/math.rs
@@ -1,0 +1,18 @@
+use crate::types::ScoreType;
+
+/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
+///
+/// Range of output is (-1, 1)
+#[inline]
+pub fn fast_sigmoid(x: ScoreType) -> ScoreType {
+    // from https://stackoverflow.com/questions/10732027/fast-sigmoid-algorithm
+    x / (1.0 + x.abs())
+}
+
+/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
+///
+/// Scales the output to fit within (0, 1)
+#[inline]
+pub fn scaled_fast_sigmoid(x: ScoreType) -> ScoreType {
+    0.5 * (fast_sigmoid(x) + 1.0)
+}

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -37,23 +37,23 @@ pub fn check_vector(
     segment_config: &SegmentConfig,
 ) -> OperationResult<()> {
     let vector_config = get_vector_config_or_error(vector_name, segment_config)?;
-    _check_query_vector(query_vector, vector_config)
+    check_query_vector(query_vector, vector_config)
 }
 
-fn _check_query_vector(
+fn check_query_vector(
     query_vector: &QueryVector,
     vector_config: &VectorDataConfig,
 ) -> OperationResult<()> {
     match query_vector {
         QueryVector::Nearest(vector) => check_vector_against_config(vector, vector_config)?,
         QueryVector::Recommend(reco_query) => reco_query
-            .iter_all()
+            .flat_iter()
             .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
         QueryVector::Discovery(discovery_query) => discovery_query
-            .iter_all()
+            .flat_iter()
             .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
         QueryVector::Context(discovery_context_query) => discovery_context_query
-            .iter_all()
+            .flat_iter()
             .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
     }
 
@@ -71,7 +71,7 @@ pub fn check_query_vectors(
     let vector_config = get_vector_config_or_error(vector_name, segment_config)?;
     query_vectors
         .iter()
-        .try_for_each(|qv| _check_query_vector(qv, vector_config))?;
+        .try_for_each(|qv| check_query_vector(qv, vector_config))?;
     Ok(())
 }
 

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -52,6 +52,9 @@ fn _check_query_vector(
         QueryVector::Discovery(discovery_query) => discovery_query
             .iter_all()
             .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
+        QueryVector::Context(discovery_context_query) => discovery_context_query
+            .iter_all()
+            .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
     }
 
     Ok(())

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::named_vectors::NamedVectors;
 use crate::common::utils::transpose_map_into_named_vector;
+use crate::vector_storage::query::context_query::ContextQuery;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query::reco_query::RecoQuery;
 
@@ -234,6 +235,7 @@ pub enum QueryVector {
     Nearest(VectorType),
     Recommend(RecoQuery<VectorType>),
     Discovery(DiscoveryQuery<VectorType>),
+    Context(ContextQuery<VectorType>),
 }
 
 impl From<VectorType> for QueryVector {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -295,6 +295,17 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     is_stopped.unwrap_or(&DEFAULT_STOPPED),
                 ))
             }
+            QueryVector::Context(context_query) => {
+                let query_scorer = CustomQueryScorer::<TMetric, _, _>::new(context_query, storage);
+                Box::new(AsyncRawScorerImpl::new(
+                    points_count,
+                    query_scorer,
+                    storage.get_mmap_vectors(),
+                    point_deleted,
+                    vec_deleted,
+                    is_stopped.unwrap_or(&DEFAULT_STOPPED),
+                ))
+            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -78,6 +78,14 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     QuantizedCustomQueryScorer::new(discovery_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
+            QueryVector::Context(discovery_context_query) => {
+                let query_scorer = QuantizedCustomQueryScorer::new(
+                    discovery_context_query,
+                    quantized_storage,
+                    *distance,
+                );
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -1,5 +1,3 @@
-use std::cmp::min_by;
-
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 
@@ -26,12 +24,16 @@ impl<T> DiscoveryPair<T> {
     ///
     /// Output will always be in the range (-1, 0]
     pub fn loss_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
-        let positive = scaled_fast_sigmoid(similarity(&self.positive));
-        let negative = scaled_fast_sigmoid(similarity(&self.negative));
+        let positive = similarity(&self.positive);
+        let negative = similarity(&self.negative);
 
-        min_by(positive - negative - ScoreType::EPSILON, 0.0, |a, b| {
-            a.total_cmp(b)
-        })
+        const MARGIN: ScoreType = ScoreType::EPSILON;
+
+        if positive > negative + MARGIN {
+            0.0
+        } else {
+            scaled_fast_sigmoid(positive) - scaled_fast_sigmoid(negative)
+        }
     }
 }
 

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -92,15 +92,15 @@ mod test {
     /// Test that the score is calculated correctly
     ///
     /// for reference:
-    /// scaled_fast_sigmoid(0.0) = 0.5
-    /// scaled_fast_sigmoid(1.0) = 0.75
     #[rstest]
     #[case::no_pairs(vec![], 0.0)] // having no input always scores 0
-    #[case::on_negative(vec![(0, 1)], -0.25)]
+    #[case::on_negative(vec![(0, 1)], -1.0)]
     #[case::on_positive(vec![(1, 0)], 0.0)]
-    #[case::on_both(vec![(1, 0), (0, 1)], -0.25)]
-    #[case::positive_positive_negative(vec![(1,0),(1,0),(0,1)], -0.25)]
-    #[case::positive_negative_negative(vec![(1,0),(0,1),(0,1)], -0.5)]
+    #[case::on_both(vec![(1, 0), (0, 1)], -1.0)]
+    #[case::positive_positive_negative(vec![(1,0),(1,0),(0,1)], -1.0)]
+    #[case::positive_negative_negative(vec![(1,0),(0,1),(0,1)], -2.0)]
+    #[case::only_positives(vec![(2,-1),(-1,-3),(4,0)], 0.0)]
+    #[case::only_negatives(vec![(-5,-4),(-1,3),(0,2)], -7.0)]
     fn scoring(#[case] pairs: Vec<(i32, i32)>, #[case] expected: f32) {
         let pairs = pairs.into_iter().map(DiscoveryPair::from).collect();
 

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -1,0 +1,119 @@
+use std::cmp::min_by;
+
+use common::math::scaled_fast_sigmoid;
+use common::types::ScoreType;
+
+use super::discovery_query::DiscoveryPair;
+use super::{Query, TransformInto};
+use crate::data_types::vectors::{QueryVector, VectorType};
+
+impl<T> DiscoveryPair<T> {
+    /// In the first stage of discovery search, the objective is to get the best entry point
+    /// for the search. This is done by using a smooth loss function instead of hard ranking
+    /// to approach the best zone, once the best zone is reached, score will be same for all
+    /// points inside that zone.
+    ///
+    ///                   │
+    ///                   │         
+    ///                   │    +0
+    ///                   │             +0
+    ///                   │
+    ///         n         │         p
+    ///                   │
+    ///   ─►          ─►  │
+    ///  -0.4        -0.1 │   +0
+    ///                   │
+    ///
+    /// Output will always be in the range (-1, 0]
+    pub fn loss_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
+        let positive = scaled_fast_sigmoid(similarity(&self.positive));
+        let negative = scaled_fast_sigmoid(similarity(&self.negative));
+
+        min_by(positive - negative - ScoreType::EPSILON, 0.0, |a, b| {
+            a.total_cmp(b)
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextQuery<T> {
+    pub pairs: Vec<DiscoveryPair<T>>,
+}
+
+impl<T> ContextQuery<T> {
+    pub fn new(pairs: Vec<DiscoveryPair<T>>) -> Self {
+        Self { pairs }
+    }
+
+    pub fn iter_all(&self) -> impl Iterator<Item = &T> {
+        self.pairs.iter().flat_map(|pair| pair.iter())
+    }
+}
+
+impl<T, U> TransformInto<ContextQuery<U>, T, U> for ContextQuery<T> {
+    fn transform<F>(self, mut f: F) -> ContextQuery<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        ContextQuery::new(
+            self.pairs
+                .into_iter()
+                .map(|pair| pair.transform(&mut f))
+                .collect(),
+        )
+    }
+}
+
+impl<T> Query<T> for ContextQuery<T> {
+    fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
+        self.pairs
+            .iter()
+            .map(|pair| pair.loss_by(&similarity))
+            .sum()
+    }
+}
+
+impl From<ContextQuery<VectorType>> for QueryVector {
+    fn from(query: ContextQuery<VectorType>) -> Self {
+        QueryVector::Context(query)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cmp::Ordering;
+
+    use common::types::ScoreType;
+    use rstest::rstest;
+
+    use super::*;
+
+    fn dummy_similarity(x: &isize) -> ScoreType {
+        *x as ScoreType
+    }
+
+    /// Compares the score of a query against a fixed score
+    ///
+    //TODO(luis): set actual cases
+    #[rstest]
+    #[case::no_pairs(vec![], Ordering::Less)]
+    #[case::just_above(vec![(1,0),(1,0)], Ordering::Greater)]
+    #[case::just_below(vec![(1,0),(1,0)], Ordering::Less)]
+    #[case::bad_target_good_context(vec![(1,0),(1,0),(1, 0)], Ordering::Greater)]
+    #[case::good_target_bad_context(vec![(1,0),(0,1)], Ordering::Less)]
+    fn score_better(#[case] pairs: Vec<(isize, isize)>, #[case] expected: Ordering) {
+        let fixed_score: f32 = -0.5;
+
+        let pairs = pairs.into_iter().map(DiscoveryPair::from).collect();
+
+        let query = ContextQuery::new(pairs);
+
+        let score = query.score_by(dummy_similarity);
+
+        assert_eq!(
+            score.total_cmp(&fixed_score),
+            expected,
+            "Comparison is incorrect, expected {expected:?} for {score} against {fixed_score}"
+        );
+    }
+}

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -1,8 +1,4 @@
-use std::cmp::min;
-
-use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
-use ordered_float::OrderedFloat;
 
 use super::discovery_query::DiscoveryPair;
 use super::{Query, TransformInto};
@@ -25,16 +21,15 @@ impl<T> DiscoveryPair<T> {
     ///  -0.4        -0.1 │   +0
     ///                   │
     ///
-    /// Output will always be in the range (-1, 0]
     pub fn loss_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         const MARGIN: ScoreType = ScoreType::EPSILON;
 
-        let positive = scaled_fast_sigmoid(similarity(&self.positive));
-        let negative = scaled_fast_sigmoid(similarity(&self.negative));
+        let positive = similarity(&self.positive);
+        let negative = similarity(&self.negative);
 
-        let difference = OrderedFloat(positive - negative - MARGIN);
+        let difference = positive - negative - MARGIN;
 
-        *min(difference, OrderedFloat(0.0))
+        ScoreType::min(difference, 0.0)
     }
 }
 
@@ -48,7 +43,7 @@ impl<T> ContextQuery<T> {
         Self { pairs }
     }
 
-    pub fn iter_all(&self) -> impl Iterator<Item = &T> {
+    pub fn flat_iter(&self) -> impl Iterator<Item = &T> {
         self.pairs.iter().flat_map(|pair| pair.iter())
     }
 }

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -1,3 +1,4 @@
+use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 
 use super::{Query, TransformInto};
@@ -26,22 +27,19 @@ impl<T> DiscoveryPair<T> {
         }
     }
 
+    /// Calculates on which side of the space the point is, with respect to this pair
     pub fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
         let positive_similarity = similarity(&self.positive);
         let negative_similarity = similarity(&self.negative);
 
         // if closer to positive, return 1, else -1
-        if positive_similarity > negative_similarity {
-            1
-        } else {
-            -1
-        }
+        positive_similarity.total_cmp(&negative_similarity) as RankType
     }
 }
 
 #[cfg(test)]
-impl From<(isize, isize)> for DiscoveryPair<isize> {
-    fn from(pair: (isize, isize)) -> Self {
+impl<T> From<(T, T)> for DiscoveryPair<T> {
+    fn from(pair: (T, T)) -> Self {
         Self {
             positive: pair.0,
             negative: pair.1,
@@ -101,23 +99,6 @@ impl<T> Query<T> for DiscoveryQuery<T> {
     }
 }
 
-/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
-///
-/// Scales the output to fit within (0, 1)
-#[inline]
-fn scaled_fast_sigmoid(x: ScoreType) -> ScoreType {
-    0.5 * (fast_sigmoid(x) + 1.0)
-}
-
-/// Acts as a substitute for sigmoid function, but faster because it doesn't do exponent.
-///
-/// Range of output is (-1, 1)
-#[inline]
-fn fast_sigmoid(x: ScoreType) -> ScoreType {
-    // from https://stackoverflow.com/questions/10732027/fast-sigmoid-algorithm
-    x / (1.0 + x.abs())
-}
-
 impl From<DiscoveryQuery<VectorType>> for QueryVector {
     fn from(query: DiscoveryQuery<VectorType>) -> Self {
         QueryVector::Discovery(query)
@@ -143,7 +124,7 @@ mod test {
     #[case::no_pairs(vec![], 0)]
     #[case::closer_to_positive(vec![(10, 4)], 1)]
     #[case::closer_to_negative(vec![(4, 10)], -1)]
-    #[case::equal_scores(vec![(11, 11)], -1)]
+    #[case::equal_scores(vec![(11, 11)], 0)]
     #[case::neutral_zone(vec![(10, 4), (4, 10)], 0)]
     #[case::best_zone(vec![(10, 4), (4, 2)], 2)]
     #[case::worst_zone(vec![(4, 10), (2, 4)], -2)]

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -58,7 +58,7 @@ impl<T> DiscoveryQuery<T> {
         Self { target, pairs }
     }
 
-    pub fn iter_all(&self) -> impl Iterator<Item = &T> {
+    pub fn flat_iter(&self) -> impl Iterator<Item = &T> {
         let pairs_iter = self.pairs.iter().flat_map(|pair| pair.iter());
 
         std::iter::once(&self.target).chain(pairs_iter)

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -2,6 +2,7 @@ use common::types::ScoreType;
 
 use crate::data_types::vectors::VectorType;
 
+pub mod context_query;
 pub mod discovery_query;
 pub mod reco_query;
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -17,7 +17,7 @@ impl<T> RecoQuery<T> {
         }
     }
 
-    pub fn iter_all(&self) -> impl Iterator<Item = &T> {
+    pub fn flat_iter(&self) -> impl Iterator<Item = &T> {
         self.positives.iter().chain(self.negatives.iter())
     }
 }

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -178,6 +178,12 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             vec_deleted,
             is_stopped,
         ),
+        QueryVector::Context(discovery_context_query) => raw_scorer_from_query_scorer(
+            CustomQueryScorer::<TMetric, _, _>::new(discovery_context_query, vector_storage),
+            point_deleted,
+            vec_deleted,
+            is_stopped,
+        ),
     }
 }
 


### PR DESCRIPTION
Adds a new type of query: `ContextQuery`. It only uses pairs to guide the search towards what could be the "best" zone, which would be where the most positive areas would overlap.

The algorithm is inspired by the triplet loss function used in deep learning:
```rust 
let positive = similarity(&self.positive);
let negative = similarity(&self.negative);

let difference = positive - negative - MARGIN;

min(difference, 0.0)
```

If a point and its neighbors are already on a "best" zone, this algorithm won't be helpful to keep guiding the search, because all scores would yield 0.0, so it should end there.

Also adds this new query as new variant: `QueryVector::Context`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
