### PR TITLE
Update ordered float to 4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
  "log",
  "merge",
  "num_cpus",
- "ordered-float 3.9.1",
+ "ordered-float 3.9.2",
  "parking_lot",
  "pprof",
  "rand 0.8.5",
@@ -1103,7 +1103,7 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
- "ordered-float 3.9.1",
+ "ordered-float 3.9.2",
  "serde",
  "validator",
 ]
@@ -3136,18 +3136,18 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "3.9.1"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
 ]
@@ -4485,7 +4485,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_cpus",
- "ordered-float 3.9.1",
+ "ordered-float 3.9.2",
  "parking_lot",
  "pprof",
  "procfs",
@@ -4537,7 +4537,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float 2.10.1",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
  "log",
  "merge",
  "num_cpus",
- "ordered-float 3.9.2",
+ "ordered-float 4.1.1",
  "parking_lot",
  "pprof",
  "rand 0.8.5",
@@ -1103,7 +1103,7 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
- "ordered-float 3.9.2",
+ "ordered-float 4.1.1",
  "serde",
  "validator",
 ]
@@ -3145,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
 dependencies = [
  "num-traits",
 ]
@@ -4485,7 +4485,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_cpus",
- "ordered-float 3.9.2",
+ "ordered-float 4.1.1",
  "parking_lot",
  "pprof",
  "procfs",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "a32f6a38acf7ffd761df83b0790eaefeb107cd60"}
-ordered-float = "3.9"
+ordered-float = "4.1"
 hashring = "0.3.2"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ordered-float = "3.7.0"
+ordered-float = "4.1"
 serde = { version = "~1.0", features = ["derive"] }
 validator = { version = "0.16", features = ["derive"] }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_json = "~1.0"
 serde_cbor = "0.11.2"
 serde-value = "0.7"
-ordered-float = "3.9"
+ordered-float = "4.1"
 thiserror = "1.0"
 atomic_refcell = "0.1.11"
 atomicwrites = "0.4.1"


### PR DESCRIPTION
Bump `ordered-float` dependency to 4.1.1 to include the following optimization: https://github.com/reem/rust-ordered-float/pull/144

Thanks @agourlay for finding this!

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?