### PR TITLE
Upsert operation on Sparse RAM index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ dependencies = [
  "io",
  "memmap2 0.7.1",
  "memory",
+ "ordered-float 4.1.1",
  "serde",
  "serde_json",
  "tempfile",

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -17,3 +17,4 @@ memmap2 = "0.7.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3.8.0"
+ordered-float = "4.1"

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
+use common::types::PointOffsetType;
+
+use crate::common::sparse_vector::SparseVector;
 use crate::common::types::DimId;
-use crate::index::posting_list::PostingList;
+use crate::index::posting_list::{PostingBuilder, PostingElement, PostingList};
 
 /// Inverted flatten index from dimension id to posting list
 
@@ -14,6 +17,29 @@ pub struct InvertedIndexRam {
 impl InvertedIndexRam {
     pub fn get(&self, id: &DimId) -> Option<&PostingList> {
         self.postings.get((*id) as usize)
+    }
+
+    /// Upsert a vector into the inverted index.
+    pub fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {
+        for (index, dim_id) in vector.indices.into_iter().enumerate() {
+            let dim_id = dim_id as usize;
+            let weight = vector.weights[index];
+            match self.postings.get_mut(dim_id) {
+                Some(posting) => {
+                    // update existing posting list
+                    let posting_element = PostingElement::new(id, weight);
+                    posting.upsert(posting_element);
+                }
+                None => {
+                    // initialize new posting for dimension
+                    let mut posting_builder = PostingBuilder::new();
+                    posting_builder.add(id, weight);
+                    // resize postings vector
+                    self.postings.resize(dim_id + 1, PostingList::default());
+                    self.postings[dim_id] = posting_builder.build();
+                }
+            }
+        }
     }
 }
 
@@ -48,5 +74,66 @@ impl InvertedIndexBuilder {
             postings[key as usize] = self.postings.remove(&key).unwrap();
         }
         InvertedIndexRam { postings }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_same_dimension_inverted_index_ram() {
+        let mut inverted_index_ram = InvertedIndexBuilder::new()
+            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .build();
+
+        inverted_index_ram.upsert(4, SparseVector::new(vec![1, 2, 3], vec![40.0, 40.0, 40.0]));
+        for i in 1..4 {
+            let posting_list = inverted_index_ram.get(&i).unwrap();
+            let posting_list = posting_list.elements.as_slice();
+            assert_eq!(posting_list.len(), 4);
+            assert_eq!(posting_list.get(0).unwrap().weight, 10.0);
+            assert_eq!(posting_list.get(1).unwrap().weight, 20.0);
+            assert_eq!(posting_list.get(2).unwrap().weight, 30.0);
+            assert_eq!(posting_list.get(3).unwrap().weight, 40.0);
+        }
+    }
+
+    #[test]
+    fn upsert_new_dimension_inverted_index_ram() {
+        let mut inverted_index_ram = InvertedIndexBuilder::new()
+            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .build();
+
+        // 4 postings, 0th empty
+        assert_eq!(inverted_index_ram.postings.len(), 4);
+
+        inverted_index_ram.upsert(4, SparseVector::new(vec![1, 2, 30], vec![40.0, 40.0, 40.0]));
+
+        // new dimension resized postings
+        assert_eq!(inverted_index_ram.postings.len(), 31);
+
+        // updated existing dimension
+        for i in 1..3 {
+            let posting_list = inverted_index_ram.get(&i).unwrap();
+            let posting_list = posting_list.elements.as_slice();
+            assert_eq!(posting_list.len(), 4);
+            assert_eq!(posting_list.get(0).unwrap().weight, 10.0);
+            assert_eq!(posting_list.get(1).unwrap().weight, 20.0);
+            assert_eq!(posting_list.get(2).unwrap().weight, 30.0);
+            assert_eq!(posting_list.get(3).unwrap().weight, 40.0);
+        }
+
+        // fetch 30th posting
+        let postings = inverted_index_ram.get(&30).unwrap();
+        let postings = postings.elements.as_slice();
+        assert_eq!(postings.len(), 1);
+        let posting = postings.get(0).unwrap();
+        assert_eq!(posting.record_id, 4);
+        assert_eq!(posting.weight, 40.0);
     }
 }

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -68,11 +68,12 @@ impl PostingList {
                 let element = &mut self.elements[found_index];
                 if element.weight == posting_element.weight {
                     // no need to update anything
-                    return;
+                    None
+                } else {
+                    // the structure of the posting list is not changed, no need to update max_next_weight
+                    element.weight = posting_element.weight;
+                    Some(found_index)
                 }
-                // the structure of the posting list is not changed, no need to update max_next_weight
-                element.weight = posting_element.weight;
-                found_index
             }
             Err(insert_index) => {
                 // Insert new element by shifting elements to the right
@@ -80,15 +81,17 @@ impl PostingList {
                 // the structure of the posting list is changed, need to update max_next_weight
                 if insert_index == self.elements.len() - 1 {
                     // inserted at the end
-                    insert_index
+                    Some(insert_index)
                 } else {
                     // inserted in the middle - need to propagated max_next_weight from the right
-                    insert_index + 1
+                    Some(insert_index + 1)
                 }
             }
         };
         // Propagate max_next_weight update to the previous entries
-        self.propagate_max_next_weight_to_the_left(modified_index);
+        if let Some(modified_index) = modified_index {
+            self.propagate_max_next_weight_to_the_left(modified_index);
+        }
     }
 
     /// Propagates `max_next_weight` from the entry at `up_to_index` to previous entries.


### PR DESCRIPTION
Enable adding new records to the sparse index in RAM.

A fair amount of complexity is due to the `max_next_weight` flag propagation.  