### PR TITLE
Managing assigned ports in the consensus tests #2610

### DIFF
--- a/tests/consensus_tests/test_peer_snapshot_bootstrap.py
+++ b/tests/consensus_tests/test_peer_snapshot_bootstrap.py
@@ -23,11 +23,12 @@ def test_peer_snapshot_bootstrap(tmp_path: pathlib.Path):
     #
     # If the port changes and the peer have to report URI change,
     # *4 out of 5 times it will fail to do so*, and the test will fail.
-    first_peer_port = get_port()
 
     # Start bootstrap
     (bootstrap_api_uri, bootstrap_uri) = start_first_peer(
-        peer_dirs[0], "peer_0_0.log", port = first_peer_port)
+        peer_dirs[0], "peer_0_0.log")
+    
+    first_peer_port = processes[0].http_port
 
     peer_api_uris.append(bootstrap_api_uri)
 

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -44,9 +44,9 @@ def test_triple_replication(tmp_path: pathlib.Path):
     p = processes.pop(killed_id)
     p.kill()
     # Make sure it is completely gone to be able to reuse the data on disk
-    if p.returncode is None:
+    if p.proc.returncode is None:
         print(f"Waiting for leader peer {p.pid} to go down")
-        p.wait()
+        p.proc.wait()
     peer_api_uris.pop(killed_id)
 
     new_url = start_peer(peer_dirs[killed_id], f"peer_{killed_id}_restarted.log", bootstrap_uri)

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -14,6 +14,24 @@ from .assertions import assert_http_ok
 
 # Tracks processes that need to be killed at the end of the test
 processes = []
+busy_ports = {}
+
+class PeerProcess:
+    def __init__(self, proc, http_port, grpc_port, p2p_port):
+            self.proc = proc
+            self.http_port = http_port
+            self.grpc_port = grpc_port
+            self.p2p_port = p2p_port
+            self.pid = proc.pid
+    
+    def kill(self):
+        self.proc.kill()
+        # remove allocated ports from the dictionary
+        # so they can be used afterwards
+        busy_ports[self.http_port] = None
+        busy_ports[self.grpc_port] = None
+        busy_ports[self.p2p_port] = None
+
 
 
 @pytest.fixture(autouse=True)
@@ -27,12 +45,17 @@ def every_test():
 
 
 def get_port() -> int:
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(('', 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
-
-
+    while True:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            # get random port assigned by the OS
+            s.bind(('', 0))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            allocated_port = s.getsockname()[1]
+            if allocated_port in busy_ports:
+                continue
+            busy_ports[allocated_port] = True
+            return allocated_port
+        
 def get_env(p2p_port: int, grpc_port: int, http_port: int) -> Dict[str, str]:
     env = os.environ.copy()
     env["QDRANT__CLUSTER__ENABLED"] = "true"
@@ -89,9 +112,9 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, ext
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")
 
     this_peer_consensus_uri = get_uri(p2p_port)
-    processes.append(
-        Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri, "--uri", this_peer_consensus_uri], env=env,
-              cwd=peer_dir, stdout=log_file))
+    proc = Popen([get_qdrant_exec(), "--bootstrap", bootstrap_uri, "--uri", this_peer_consensus_uri], env=env,
+              cwd=peer_dir, stdout=log_file)
+    processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port)
 
 
@@ -112,8 +135,9 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None, extra_env=None) -
     bootstrap_uri = get_uri(p2p_port)
     print(f"\nStarting first peer with uri {bootstrap_uri},"
           f" http: http://localhost:{http_port}/cluster, p2p: {p2p_port}")
-    processes.append(
-        Popen([get_qdrant_exec(), "--uri", bootstrap_uri], env=env, cwd=peer_dir, stdout=log_file))
+
+    proc = Popen([get_qdrant_exec(), "--uri", bootstrap_uri], env=env, cwd=peer_dir, stdout=log_file)
+    processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port), bootstrap_uri
 
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -28,9 +28,9 @@ class PeerProcess:
         self.proc.kill()
         # remove allocated ports from the dictionary
         # so they can be used afterwards
-        busy_ports[self.http_port] = None
-        busy_ports[self.grpc_port] = None
-        busy_ports[self.p2p_port] = None
+        del busy_ports[self.http_port]
+        del busy_ports[self.grpc_port]
+        del busy_ports[self.p2p_port]
 
 def _occupy_port(port):
     if port in busy_ports:

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -32,6 +32,11 @@ class PeerProcess:
         busy_ports[self.grpc_port] = None
         busy_ports[self.p2p_port] = None
 
+def _occupy_port(port):
+    if port in busy_ports:
+        raise Exception(f'Port "{port}" was already allocated!')
+    busy_ports[port] = True
+    return port
 
 
 @pytest.fixture(autouse=True)
@@ -99,9 +104,9 @@ def init_pytest_log_folder() -> str:
 def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, extra_env=None) -> str:
     if extra_env is None:
         extra_env = {}
-    p2p_port = get_port() if port is None else port + 0
-    grpc_port = get_port() if port is None else port + 1
-    http_port = get_port() if port is None else port + 2
+    p2p_port = get_port() if port is None else _occupy_port(port + 0)
+    grpc_port = get_port() if port is None else _occupy_port(port + 1)
+    http_port = get_port() if port is None else _occupy_port(port + 2)
     env = {
         **get_env(p2p_port, grpc_port, http_port),
         **extra_env
@@ -123,9 +128,9 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None, extra_env=None) -
     if extra_env is None:
         extra_env = {}
 
-    p2p_port = get_port() if port is None else port + 0
-    grpc_port = get_port() if port is None else port + 1
-    http_port = get_port() if port is None else port + 2
+    p2p_port = get_port() if port is None else _occupy_port(port + 0)
+    grpc_port = get_port() if port is None else _occupy_port(port + 1)
+    http_port = get_port() if port is None else _occupy_port(port + 2)
     env = {
         **get_env(p2p_port, grpc_port, http_port),
         **extra_env


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


Hi @agourlay ! Following on the discussion on #2610 :
Would something like this work in this case? Just a simple mapping of the already allocated ports that is accessed whenever we allocate some random port and cleaned whenever the process is killed. This is meant to address the issue only on the test side.

One thing that I'm not sure about is that you mentioned `This list would have to be threadsafe and properly cleaned up when servers are shutdown.`. From what I see, the tests are run sequentially right now or is there some part that I'm missing and could mess the mapping up?
Thanks in advance for your input!