### PR TITLE
Add `ShardTransfer` snapshot priority

### DIFF
--- a/lib/api/src/grpc/proto/shard_snapshots_service.proto
+++ b/lib/api/src/grpc/proto/shard_snapshots_service.proto
@@ -43,7 +43,7 @@ message RecoverShardSnapshotRequest {
   string collection_name = 1; // Name of the collection
   uint32 shard_id = 2; // Id of the shard
   ShardSnapshotLocation snapshot_location = 3; // Location of the shard snapshot
-  SnapshotPriority snapshot_priority = 4; // Priority of the shard snapshot
+  ShardSnapshotPriority snapshot_priority = 4; // Priority of the shard snapshot
 }
 
 message ShardSnapshotLocation {
@@ -53,10 +53,11 @@ message ShardSnapshotLocation {
   }
 }
 
-enum SnapshotPriority {
-    SnapshotPriorityNoSync = 0; // Restore snapshot without *any* additional synchronization
-    SnapshotPrioritySnapshot = 1; // Prefer snapshot data over the current state
-    SnapshotPriorityReplica = 2; // Prefer existing data over the snapshot
+enum ShardSnapshotPriority {
+    ShardSnapshotPriorityNoSync = 0; // Restore snapshot without *any* additional synchronization
+    ShardSnapshotPrioritySnapshot = 1; // Prefer snapshot data over the current state
+    ShardSnapshotPriorityReplica = 2; // Prefer existing data over the snapshot
+    ShardSnapshotPriorityShardTransfer = 3; // Internal priority to use during snapshot shard transfer
 }
 
 message RecoverSnapshotResponse {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -9724,7 +9724,7 @@ pub struct RecoverShardSnapshotRequest {
     #[prost(message, optional, tag = "3")]
     pub snapshot_location: ::core::option::Option<ShardSnapshotLocation>,
     /// Priority of the shard snapshot
-    #[prost(enumeration = "SnapshotPriority", tag = "4")]
+    #[prost(enumeration = "ShardSnapshotPriority", tag = "4")]
     pub snapshot_priority: i32,
 }
 #[derive(serde::Serialize)]
@@ -9759,32 +9759,36 @@ pub struct RecoverSnapshotResponse {
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum SnapshotPriority {
+pub enum ShardSnapshotPriority {
     /// Restore snapshot without *any* additional synchronization
     NoSync = 0,
     /// Prefer snapshot data over the current state
     Snapshot = 1,
     /// Prefer existing data over the snapshot
     Replica = 2,
+    /// Internal priority to use during snapshot shard transfer
+    ShardTransfer = 3,
 }
-impl SnapshotPriority {
+impl ShardSnapshotPriority {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            SnapshotPriority::NoSync => "SnapshotPriorityNoSync",
-            SnapshotPriority::Snapshot => "SnapshotPrioritySnapshot",
-            SnapshotPriority::Replica => "SnapshotPriorityReplica",
+            ShardSnapshotPriority::NoSync => "ShardSnapshotPriorityNoSync",
+            ShardSnapshotPriority::Snapshot => "ShardSnapshotPrioritySnapshot",
+            ShardSnapshotPriority::Replica => "ShardSnapshotPriorityReplica",
+            ShardSnapshotPriority::ShardTransfer => "ShardSnapshotPriorityShardTransfer",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "SnapshotPriorityNoSync" => Some(Self::NoSync),
-            "SnapshotPrioritySnapshot" => Some(Self::Snapshot),
-            "SnapshotPriorityReplica" => Some(Self::Replica),
+            "ShardSnapshotPriorityNoSync" => Some(Self::NoSync),
+            "ShardSnapshotPrioritySnapshot" => Some(Self::Snapshot),
+            "ShardSnapshotPriorityReplica" => Some(Self::Replica),
+            "ShardSnapshotPriorityShardTransfer" => Some(Self::ShardTransfer),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -21,24 +21,28 @@ pub enum SnapshotPriority {
     Snapshot,
     #[default]
     Replica,
+    // `ShardTransfer` is for internal use only, and should not be exposed/used in public API
+    #[serde(skip)]
+    ShardTransfer,
 }
 
 impl TryFrom<i32> for SnapshotPriority {
     type Error = tonic::Status;
 
     fn try_from(snapshot_priority: i32) -> Result<Self, Self::Error> {
-        api::grpc::qdrant::SnapshotPriority::from_i32(snapshot_priority)
+        api::grpc::qdrant::ShardSnapshotPriority::from_i32(snapshot_priority)
             .map(Into::into)
-            .ok_or_else(|| tonic::Status::invalid_argument("Malformed snapshot priority"))
+            .ok_or_else(|| tonic::Status::invalid_argument("Malformed shard snapshot priority"))
     }
 }
 
-impl From<api::grpc::qdrant::SnapshotPriority> for SnapshotPriority {
-    fn from(snapshot_priority: api::grpc::qdrant::SnapshotPriority) -> Self {
+impl From<api::grpc::qdrant::ShardSnapshotPriority> for SnapshotPriority {
+    fn from(snapshot_priority: api::grpc::qdrant::ShardSnapshotPriority) -> Self {
         match snapshot_priority {
-            api::grpc::qdrant::SnapshotPriority::NoSync => Self::NoSync,
-            api::grpc::qdrant::SnapshotPriority::Snapshot => Self::Snapshot,
-            api::grpc::qdrant::SnapshotPriority::Replica => Self::Replica,
+            api::grpc::qdrant::ShardSnapshotPriority::NoSync => Self::NoSync,
+            api::grpc::qdrant::ShardSnapshotPriority::Snapshot => Self::Snapshot,
+            api::grpc::qdrant::ShardSnapshotPriority::Replica => Self::Replica,
+            api::grpc::qdrant::ShardSnapshotPriority::ShardTransfer => Self::ShardTransfer,
         }
     }
 }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -258,6 +258,7 @@ async fn _do_recover_from_snapshot(
                             }
                         }
                     }
+
                     SnapshotPriority::Replica => {
                         // Replica is the source of truth, we need to sync recovered data with this replica
                         let (replica_peer_id, _state) =
@@ -278,6 +279,10 @@ async fn _do_recover_from_snapshot(
                             true,
                         )?;
                     }
+
+                    // `ShardTransfer` is only used during snapshot *shard transfer*.
+                    // It is only exposed in internal gRPC API and only used for *shard* snapshot recovery.
+                    SnapshotPriority::ShardTransfer => unreachable!(),
                 }
             }
         }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -163,6 +163,10 @@ pub async fn recover_shard_snapshot_impl(
                     None,
                 )?;
             }
+
+            // `ShardTransfer` is only used during snapshot *shard transfer*.
+            // State transitions are performed as part of shard transfer *later*, so this simply does *nothing*.
+            SnapshotPriority::ShardTransfer => (),
         }
     }
 


### PR DESCRIPTION
Add `ShardTransfer` snapshot priority and expose it in internal shard snapshot gRPC API.

The implementation is a little bit "tricky":
- instead of introducing an additional `ShardSnapshotPriority` type to `Collection` crate
- I simply added `ShardTransfer` variant to the existing `SnapshotPriority` type
- and excluded it from public HTTP API with `#[serde(skip)]`
  - this way it should be excluded from OpenAPI schema
  - and won't be deserialized by the API if user tries to pass it in the request
- and we only use snapshot priority in *internal **shard** snapshot gRPC API*, so no issues with gRPC API as well
- though, I can refactor it to be more explicit if requested

This PR is currently based on #2825. It will be rebased onto `dev` once #2825 is merged.

(This is required for the #2432.)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
