### PR TITLE
Sparse vector index integration

### DIFF
--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -7,9 +7,11 @@ pub mod plain_payload_index;
 pub mod query_estimator;
 mod query_optimization;
 mod sample_estimation;
+mod sparse_index;
 mod struct_filter_context;
 pub mod struct_payload_index;
 mod vector_index_base;
 mod visited_pool;
+
 pub use payload_index_base::*;
 pub use vector_index_base::*;

--- a/lib/segment/src/index/sparse_index/mod.rs
+++ b/lib/segment/src/index/sparse_index/mod.rs
@@ -1,0 +1,2 @@
+#![allow(dead_code)]
+mod sparse_vector_index;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use sparse::index::inverted_index::InvertedIndex;
+
+use crate::id_tracker::IdTrackerSS;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::vector_storage::VectorStorageEnum;
+
+pub struct SparseVectorIndex<T: InvertedIndex> {
+    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    path: PathBuf,
+    inverted_index: T,
+}
+
+impl<T: InvertedIndex> SparseVectorIndex<T> {
+    pub fn new(
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+        path: PathBuf,
+        inverted_index: T,
+    ) -> Self {
+        Self {
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path,
+            inverted_index,
+        }
+    }
+}
+
+// TODO impl VectorIndex for SparseVectorIndex

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,8 +1,12 @@
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::types::ScoredPointOffset;
+use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::InvertedIndex;
+use sparse::index::search_context::SearchContext;
 
 use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -17,6 +21,7 @@ pub struct SparseVectorIndex<T: InvertedIndex> {
 }
 
 impl<T: InvertedIndex> SparseVectorIndex<T> {
+    /// Create new sparse vector index
     pub fn new(
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
@@ -31,6 +36,17 @@ impl<T: InvertedIndex> SparseVectorIndex<T> {
             path,
             inverted_index,
         }
+    }
+
+    /// Search index using sparse vector query
+    pub fn search_sparse(
+        &self,
+        query: SparseVector,
+        top: usize,
+        is_stopped: &AtomicBool,
+    ) -> Vec<ScoredPointOffset> {
+        let mut search_context = SearchContext::new(query, top, &self.inverted_index, is_stopped);
+        search_context.search()
     }
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -12,22 +12,22 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::vector_storage::VectorStorageEnum;
 
-pub struct SparseVectorIndex<T: InvertedIndex> {
+pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     path: PathBuf,
-    inverted_index: T,
+    inverted_index: TInvertedIndex,
 }
 
-impl<T: InvertedIndex> SparseVectorIndex<T> {
+impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Create new sparse vector index
     pub fn new(
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
         payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
         path: PathBuf,
-        inverted_index: T,
+        inverted_index: TInvertedIndex,
     ) -> Self {
         Self {
             id_tracker,

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::types::DimId;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
-use crate::index::posting_list::PostingElement;
+use crate::index::inverted_index::InvertedIndex;
+use crate::index::posting_list::{PostingElement, PostingListIterator};
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
 const INDEX_FILE_NAME: &str = "index.data";
@@ -34,6 +35,12 @@ pub struct InvertedIndexMmap {
 struct PostingListFileHeader {
     pub start_offset: u64,
     pub end_offset: u64,
+}
+
+impl InvertedIndex for InvertedIndexMmap {
+    fn get(&self, id: &DimId) -> Option<PostingListIterator> {
+        self.get(id).map(PostingListIterator::new)
+    }
 }
 
 impl InvertedIndexMmap {

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -27,6 +27,7 @@ pub struct InvertedIndexFileHeader {
 
 /// Inverted flatten index from dimension id to posting list
 pub struct InvertedIndexMmap {
+    path: PathBuf,
     mmap: Arc<Mmap>,
     file_header: InvertedIndexFileHeader,
 }
@@ -40,6 +41,17 @@ struct PostingListFileHeader {
 impl InvertedIndex for InvertedIndexMmap {
     fn get(&self, id: &DimId) -> Option<PostingListIterator> {
         self.get(id).map(PostingListIterator::new)
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![
+            Self::index_file_path(&self.path),
+            Self::index_config_file_path(&self.path),
+        ]
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.file_header.posting_count
     }
 }
 
@@ -92,6 +104,7 @@ impl InvertedIndexMmap {
         atomic_save_json(&config_file_path, &file_header)?;
 
         Ok(Self {
+            path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap.make_read_only()?),
             file_header,
         })
@@ -107,6 +120,7 @@ impl InvertedIndexMmap {
         let mmap = open_read_mmap(file_path.as_ref())?;
         madvise::madvise(&mmap, madvise::get_global())?;
         Ok(Self {
+            path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap),
             file_header,
         })

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use common::types::PointOffsetType;
 
@@ -17,6 +18,14 @@ impl InvertedIndex for InvertedIndexRam {
     fn get(&self, id: &DimId) -> Option<PostingListIterator> {
         self.get(id)
             .map(|posting_list| PostingListIterator::new(&posting_list.elements))
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.postings.len()
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -4,12 +4,20 @@ use common::types::PointOffsetType;
 
 use crate::common::sparse_vector::SparseVector;
 use crate::common::types::DimId;
-use crate::index::posting_list::{PostingElement, PostingList};
+use crate::index::inverted_index::InvertedIndex;
+use crate::index::posting_list::{PostingElement, PostingList, PostingListIterator};
 
 /// Inverted flatten index from dimension id to posting list
 #[derive(Debug, Clone, PartialEq)]
 pub struct InvertedIndexRam {
     pub postings: Vec<PostingList>,
+}
+
+impl InvertedIndex for InvertedIndexRam {
+    fn get(&self, id: &DimId) -> Option<PostingListIterator> {
+        self.get(id)
+            .map(|posting_list| PostingListIterator::new(&posting_list.elements))
+    }
 }
 
 impl InvertedIndexRam {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -67,6 +67,12 @@ pub struct InvertedIndexBuilder {
     postings: HashMap<DimId, PostingList>,
 }
 
+impl Default for InvertedIndexBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InvertedIndexBuilder {
     pub fn new() -> InvertedIndexBuilder {
         InvertedIndexBuilder {

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,23 +1,10 @@
 use crate::common::types::DimId;
-use crate::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
-use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::posting_list::PostingListIterator;
 
 pub mod inverted_index_mmap;
 pub mod inverted_index_ram;
 
-pub enum InvertedIndex {
-    Ram(InvertedIndexRam),
-    Mmap(InvertedIndexMmap),
-}
-
-impl InvertedIndex {
-    pub fn get(&self, id: &DimId) -> Option<PostingListIterator> {
-        match self {
-            InvertedIndex::Ram(index) => index
-                .get(id)
-                .map(|posting_list| PostingListIterator::new(&posting_list.elements)),
-            InvertedIndex::Mmap(index) => index.get(id).map(PostingListIterator::new),
-        }
-    }
+pub trait InvertedIndex {
+    /// Get posting list for dimension id
+    fn get(&self, id: &DimId) -> Option<PostingListIterator>;
 }

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::common::types::DimId;
 use crate::index::posting_list::PostingListIterator;
 
@@ -7,4 +9,10 @@ pub mod inverted_index_ram;
 pub trait InvertedIndex {
     /// Get posting list for dimension id
     fn get(&self, id: &DimId) -> Option<PostingListIterator>;
+
+    /// Files used by this index
+    fn files(&self) -> Vec<PathBuf>;
+
+    /// The number of indexed vectors, currently accessible
+    fn indexed_vector_count(&self) -> usize;
 }

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
 
-mod inverted_index;
+pub mod inverted_index;
 mod posting_list;
 mod search_context;

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod inverted_index;
 mod posting_list;
-mod search_context;
+pub mod search_context;

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::Relaxed;
+
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::ScoredPointOffset;
 
@@ -14,6 +17,7 @@ pub struct SearchContext<'a> {
     postings_iterators: Vec<IndexedPostingListIterator<'a>>,
     query: SparseVector,
     top: usize,
+    is_stopped: &'a AtomicBool,
     result_queue: FixedLengthPriorityQueue<ScoredPointOffset>, // keep the largest elements and peek smallest
 }
 
@@ -22,6 +26,7 @@ impl<'a> SearchContext<'a> {
         query: SparseVector,
         top: usize,
         inverted_index: &'a (impl InvertedIndex + ?Sized),
+        is_stopped: &'a AtomicBool,
     ) -> SearchContext<'a> {
         let mut postings_iterators = Vec::new();
 
@@ -39,6 +44,7 @@ impl<'a> SearchContext<'a> {
             postings_iterators,
             query,
             top,
+            is_stopped,
             result_queue,
         }
     }
@@ -128,6 +134,10 @@ impl<'a> SearchContext<'a> {
             return Vec::new();
         }
         while let Some(candidate) = self.advance() {
+            // check for cancellation
+            if self.is_stopped.load(Relaxed) {
+                break;
+            }
             // push candidate to result queue
             self.result_queue.push(candidate);
 
@@ -192,6 +202,7 @@ mod tests {
     use crate::index::posting_list::PostingList;
 
     fn _advance_test(inverted_index: &dyn InvertedIndex) {
+        let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -199,6 +210,7 @@ mod tests {
             },
             10,
             inverted_index,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -246,6 +258,7 @@ mod tests {
     }
 
     fn _search_test(inverted_index: &dyn InvertedIndex) {
+        let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -253,6 +266,7 @@ mod tests {
             },
             10,
             inverted_index,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -297,6 +311,7 @@ mod tests {
 
     #[test]
     fn search_with_update_test() {
+        let is_stopped = AtomicBool::new(false);
         let mut inverted_index_ram = InvertedIndexBuilder::new()
             .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
@@ -310,6 +325,7 @@ mod tests {
             },
             10,
             &inverted_index_ram,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -345,6 +361,7 @@ mod tests {
             },
             10,
             &inverted_index_ram,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -371,6 +388,7 @@ mod tests {
     }
 
     fn _search_with_hot_key_test(inverted_index: &dyn InvertedIndex) {
+        let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -378,6 +396,7 @@ mod tests {
             },
             3,
             inverted_index,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -405,6 +424,7 @@ mod tests {
             },
             4,
             inverted_index,
+            &is_stopped,
         );
 
         assert_eq!(
@@ -462,6 +482,7 @@ mod tests {
     }
 
     fn _prune_test(inverted_index: &dyn InvertedIndex) {
+        let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -469,6 +490,7 @@ mod tests {
             },
             3,
             inverted_index,
+            &is_stopped,
         );
 
         // initial state

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -21,7 +21,7 @@ impl<'a> SearchContext<'a> {
     pub fn new(
         query: SparseVector,
         top: usize,
-        inverted_index: &'a InvertedIndex,
+        inverted_index: &'a (impl InvertedIndex + ?Sized),
     ) -> SearchContext<'a> {
         let mut postings_iterators = Vec::new();
 
@@ -191,7 +191,7 @@ mod tests {
     use crate::index::inverted_index::inverted_index_ram::InvertedIndexBuilder;
     use crate::index::posting_list::PostingList;
 
-    fn _advance_test(inverted_index: &InvertedIndex) {
+    fn _advance_test(inverted_index: &dyn InvertedIndex) {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -232,10 +232,8 @@ mod tests {
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
 
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
-
         // test with ram index
-        _advance_test(&inverted_index);
+        _advance_test(&inverted_index_ram);
 
         // test with mmap index
         let tmp_dir_path = tempfile::Builder::new()
@@ -244,11 +242,10 @@ mod tests {
             .unwrap();
         let inverted_index_mmap =
             InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
-        let inverted_index = InvertedIndex::Mmap(inverted_index_mmap);
-        _advance_test(&inverted_index);
+        _advance_test(&inverted_index_mmap);
     }
 
-    fn _search_test(inverted_index: &InvertedIndex) {
+    fn _search_test(inverted_index: &dyn InvertedIndex) {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -285,9 +282,8 @@ mod tests {
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
 
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
         // test with ram index
-        _search_test(&inverted_index);
+        _search_test(&inverted_index_ram);
 
         // test with mmap index
         let tmp_dir_path = tempfile::Builder::new()
@@ -296,8 +292,7 @@ mod tests {
             .unwrap();
         let inverted_index_mmap =
             InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
-        let inverted_index = InvertedIndex::Mmap(inverted_index_mmap);
-        _search_test(&inverted_index);
+        _search_test(&inverted_index_mmap);
     }
 
     #[test]
@@ -308,15 +303,13 @@ mod tests {
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
 
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
-
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
                 weights: vec![1.0, 1.0, 1.0],
             },
             10,
-            &inverted_index,
+            &inverted_index_ram,
         );
 
         assert_eq!(
@@ -345,15 +338,13 @@ mod tests {
                 weights: vec![40.0, 40.0, 40.0],
             },
         );
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
-
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
                 weights: vec![1.0, 1.0, 1.0],
             },
             10,
-            &inverted_index,
+            &inverted_index_ram,
         );
 
         assert_eq!(
@@ -379,7 +370,7 @@ mod tests {
         );
     }
 
-    fn _search_with_hot_key_test(inverted_index: &InvertedIndex) {
+    fn _search_with_hot_key_test(inverted_index: &dyn InvertedIndex) {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -457,9 +448,8 @@ mod tests {
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
 
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
         // test with ram index
-        _search_with_hot_key_test(&inverted_index);
+        _search_with_hot_key_test(&inverted_index_ram);
 
         // test with mmap index
         let tmp_dir_path = tempfile::Builder::new()
@@ -468,11 +458,10 @@ mod tests {
             .unwrap();
         let inverted_index_mmap =
             InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
-        let inverted_index = InvertedIndex::Mmap(inverted_index_mmap);
-        _search_with_hot_key_test(&inverted_index);
+        _search_with_hot_key_test(&inverted_index_mmap);
     }
 
-    fn _prune_test(inverted_index: &InvertedIndex) {
+    fn _prune_test(inverted_index: &dyn InvertedIndex) {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
@@ -575,10 +564,8 @@ mod tests {
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
 
-        let inverted_index = InvertedIndex::Ram(inverted_index_ram.clone());
-
         // test with ram index
-        _prune_test(&inverted_index);
+        _prune_test(&inverted_index_ram);
 
         // test with mmap index
         let tmp_dir_path = tempfile::Builder::new()
@@ -587,7 +574,6 @@ mod tests {
             .unwrap();
         let inverted_index_mmap =
             InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
-        let inverted_index = InvertedIndex::Mmap(inverted_index_mmap);
-        _prune_test(&inverted_index);
+        _prune_test(&inverted_index_mmap);
     }
 }

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -25,7 +25,7 @@ impl<'a> SearchContext<'a> {
     pub fn new(
         query: SparseVector,
         top: usize,
-        inverted_index: &'a (impl InvertedIndex + ?Sized),
+        inverted_index: &'a impl InvertedIndex,
         is_stopped: &'a AtomicBool,
     ) -> SearchContext<'a> {
         let mut postings_iterators = Vec::new();
@@ -201,7 +201,7 @@ mod tests {
     use crate::index::inverted_index::inverted_index_ram::InvertedIndexBuilder;
     use crate::index::posting_list::PostingList;
 
-    fn _advance_test(inverted_index: &dyn InvertedIndex) {
+    fn _advance_test(inverted_index: &impl InvertedIndex) {
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -257,7 +257,7 @@ mod tests {
         _advance_test(&inverted_index_mmap);
     }
 
-    fn _search_test(inverted_index: &dyn InvertedIndex) {
+    fn _search_test(inverted_index: &impl InvertedIndex) {
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -387,7 +387,7 @@ mod tests {
         );
     }
 
-    fn _search_with_hot_key_test(inverted_index: &dyn InvertedIndex) {
+    fn _search_with_hot_key_test(inverted_index: &impl InvertedIndex) {
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -481,7 +481,7 @@ mod tests {
         _search_with_hot_key_test(&inverted_index_mmap);
     }
 
-    fn _prune_test(inverted_index: &dyn InvertedIndex) {
+    fn _prune_test(inverted_index: &impl InvertedIndex) {
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
             SparseVector {


### PR DESCRIPTION
This PR continues the work to integrate the sparse vector index in the segment crate.

It introduces a new index `SparseVectorIndex<T: InvertedIndex>` following the structure of the HNSW index.

To do so the `InvertedIndex` was refactored from an enum. into a trait.

Some of the changes from https://github.com/qdrant/qdrant/pull/2779 were also backported.
- search cancellation
- trivial implementations for the future `VectorIndex` impl.
- search helper to hide the search context

In a future PR we will be able to fully implement `VectorIndex` and introduce two new index variants.

```rust
    SparseRam(SparseVectorIndex<InvertedIndexRam>),
    SparseMmap(SparseVectorIndex<InvertedIndexMmap>),
```
