### PR TITLE
Add checksum to `SnapshotDescription`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytestring"
@@ -1066,6 +1066,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "atomicwrites",
+ "bytes",
  "cancel",
  "chrono",
  "common",
@@ -1074,6 +1075,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "hashring",
+ "hex",
  "indicatif",
  "io",
  "itertools 0.12.0",
@@ -1092,6 +1094,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "sha2",
  "sparse",
  "tar",
  "tempfile",
@@ -1517,9 +1520,9 @@ checksum = "8c1bba4f227a4a53d12b653f50ca7bf10c9119ae2aba56aff9e0338b5c98f36a"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -4663,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,6 @@ dependencies = [
  "fs_extra",
  "futures",
  "hashring",
- "hex",
  "indicatif",
  "io",
  "itertools 0.12.0",

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3817,7 +3817,7 @@ When using target (with or without context), the score behaves a little differen
 | name | [string](#string) |  | Name of the snapshot |
 | creation_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Creation time of the snapshot |
 | size | [int64](#int64) |  | Size of the snapshot in bytes |
-| checksum | [string](#string) |  | SHA256 digest of the snapshot file |
+| checksum | [string](#string) | optional | SHA256 digest of the snapshot file |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3817,6 +3817,7 @@ When using target (with or without context), the score behaves a little differen
 | name | [string](#string) |  | Name of the snapshot |
 | creation_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Creation time of the snapshot |
 | size | [int64](#int64) |  | Size of the snapshot in bytes |
+| checksum | [string](#string) |  | SHA256 digest of the snapshot file |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8079,6 +8079,7 @@
       "SnapshotDescription": {
         "type": "object",
         "required": [
+          "checksum",
           "name",
           "size"
         ],
@@ -8095,6 +8096,9 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
+          },
+          "checksum": {
+            "type": "string"
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8079,7 +8079,6 @@
       "SnapshotDescription": {
         "type": "object",
         "required": [
-          "checksum",
           "name",
           "size"
         ],
@@ -8098,7 +8097,8 @@
             "minimum": 0
           },
           "checksum": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -57,7 +57,7 @@ message SnapshotDescription {
   string name = 1; // Name of the snapshot
   google.protobuf.Timestamp creation_time = 2; // Creation time of the snapshot
   int64 size = 3; // Size of the snapshot in bytes
-  string checksum = 4; // SHA256 digest of the snapshot file
+  optional string checksum = 4; // SHA256 digest of the snapshot file
 }
 
 message CreateSnapshotResponse {

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -57,6 +57,7 @@ message SnapshotDescription {
   string name = 1; // Name of the snapshot
   google.protobuf.Timestamp creation_time = 2; // Creation time of the snapshot
   int64 size = 3; // Size of the snapshot in bytes
+  string checksum = 4; // SHA256 digest of the snapshot file
 }
 
 message CreateSnapshotResponse {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -9885,8 +9885,8 @@ pub struct SnapshotDescription {
     #[prost(int64, tag = "3")]
     pub size: i64,
     /// SHA256 digest of the snapshot file
-    #[prost(string, tag = "4")]
-    pub checksum: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "4")]
+    pub checksum: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -9884,6 +9884,9 @@ pub struct SnapshotDescription {
     /// Size of the snapshot in bytes
     #[prost(int64, tag = "3")]
     pub size: i64,
+    /// SHA256 digest of the snapshot file
+    #[prost(string, tag = "4")]
+    pub checksum: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -65,6 +65,9 @@ tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.20"
 tempfile = "3.8.1"
+sha2 = "0.10.8"
+bytes = "1.5.0"
+hex = "0.4.3"
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -67,7 +67,6 @@ semver = "1.0.20"
 tempfile = "3.8.1"
 sha2 = "0.10.8"
 bytes = "1.5.0"
-hex = "0.4.3"
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -5,9 +5,11 @@ use io::file_operations::read_json;
 use segment::common::version::StorageVersion as _;
 use tempfile::TempPath;
 use tokio::fs;
+use tokio::io::AsyncWriteExt;
 
 use super::Collection;
 use crate::collection::CollectionVersion;
+use crate::common::sha_256::hash_file;
 use crate::config::{CollectionConfig, ShardingMethod};
 use crate::operations::snapshot_ops::{self, SnapshotDescription};
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
@@ -133,12 +135,20 @@ impl Collection {
         // Ensure that the temporary file is deleted on error
         let _temp_path = TempPath::from_path(&snapshot_path_tmp_move);
         fs::copy(&snapshot_temp_arc_file.path(), &snapshot_path_tmp_move).await?;
+
+        // compute and store the file's checksum before the final snapshot file is saved
+        // to avoid making snapshot available without checksum
+        let checksum_path = snapshot_ops::get_checksum_path(snapshot_path.as_path());
+        let checksum = hash_file(&snapshot_path_tmp_move).await?;
+        let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;
+        file.write_all(checksum.as_bytes()).await?;
+
         fs::rename(&snapshot_path_tmp_move, &snapshot_path).await?;
 
         log::info!(
             "Collection snapshot {} completed into {:?}",
             snapshot_name,
-            snapshot_path
+            snapshot_path,
         );
         snapshot_ops::get_snapshot_description(&snapshot_path).await
     }

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -138,7 +138,7 @@ impl Collection {
         // compute and store the file's checksum before the final snapshot file is saved
         // to avoid making snapshot available without checksum
         log::debug!("Computing checksum for snapshot: {snapshot_path_tmp_move:?}");
-        let checksum_path = snapshot_ops::get_checksum_path(snapshot_path.as_path());
+        let checksum_path = snapshot_ops::get_checksum_path(&snapshot_path);
         let checksum = hash_file(&snapshot_path_tmp_move).await?;
         let checksum_file = tempfile::TempPath::from_path(&checksum_path);
         let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -138,7 +138,7 @@ impl Collection {
 
         // compute and store the file's checksum before the final snapshot file is saved
         // to avoid making snapshot available without checksum
-        log::debug!("Computing checksum for snapshot: {:?}", snapshot_path_tmp_move);
+        log::debug!("Computing checksum for snapshot: {snapshot_path_tmp_move:?}");
         let checksum_path = snapshot_ops::get_checksum_path(snapshot_path.as_path());
         let checksum = hash_file(&snapshot_path_tmp_move).await?;
         let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -138,6 +138,7 @@ impl Collection {
 
         // compute and store the file's checksum before the final snapshot file is saved
         // to avoid making snapshot available without checksum
+        log::debug!("Computing checksum for snapshot: {:?}", snapshot_path_tmp_move);
         let checksum_path = snapshot_ops::get_checksum_path(snapshot_path.as_path());
         let checksum = hash_file(&snapshot_path_tmp_move).await?;
         let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -45,10 +45,9 @@ impl Collection {
         this_peer_id: PeerId,
     ) -> CollectionResult<SnapshotDescription> {
         let snapshot_name = format!(
-            "{}-{}-{}.snapshot",
+            "{}-{this_peer_id}-{}.snapshot",
             self.name(),
-            this_peer_id,
-            chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S")
+            chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S"),
         );
 
         // Final location of snapshot
@@ -114,7 +113,7 @@ impl Collection {
             .tempfile_in(global_temp_dir)?;
 
         // Archive snapshot folder into a single file
-        log::debug!("Archiving snapshot {:?}", &snapshot_temp_target_dir_path);
+        log::debug!("Archiving snapshot {snapshot_temp_target_dir_path:?}");
         let archiving = tokio::task::spawn_blocking(move || -> CollectionResult<_> {
             let mut builder = tar::Builder::new(snapshot_temp_arc_file.as_file_mut());
             // archive recursively collection directory `snapshot_path_with_arc_extension` into `snapshot_path`
@@ -152,11 +151,7 @@ impl Collection {
         snapshot_file.keep()?;
         checksum_file.keep()?;
 
-        log::info!(
-            "Collection snapshot {} completed into {:?}",
-            snapshot_name,
-            snapshot_path,
-        );
+        log::info!("Collection snapshot {snapshot_name} completed into {snapshot_path:?}");
         snapshot_ops::get_snapshot_description(&snapshot_path).await
     }
 

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -3,6 +3,7 @@ pub mod fetch_vectors;
 pub mod file_utils;
 pub mod is_ready;
 pub mod retrieve_request_trait;
+pub mod sha_256;
 pub mod stoppable_task;
 pub mod stoppable_task_async;
 pub mod stopping_guard;

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -1,10 +1,11 @@
+use std::io;
 use std::path::Path;
 
 use bytes::BytesMut;
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
-pub async fn hash_file(file_path: &Path) -> std::io::Result<String> {
+pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     const ONE_MB: usize = 1024 * 1024;
     let input_file = tokio::fs::File::open(file_path).await?;
     let mut reader = tokio::io::BufReader::new(input_file);

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
 pub async fn hash_file(file_path: &Path) -> std::io::Result<String> {
-    const ONE_MB: usize = 1048576;
+    const ONE_MB: usize = 1024 * 1024;
     let input_file = tokio::fs::File::open(file_path).await?;
     let mut reader = tokio::io::BufReader::new(input_file);
     let mut sha = Sha256::new();
@@ -19,5 +19,5 @@ pub async fn hash_file(file_path: &Path) -> std::io::Result<String> {
         sha.update(&buf[0..len]);
     }
     let hash = sha.finalize();
-    Ok(hex::encode(hash))
+    Ok(format!("{hash:x}"))
 }

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use bytes::BytesMut;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+
+pub async fn hash_file(file_path: &Path) -> std::io::Result<String> {
+    const ONE_MB: usize = 1048576;
+    let input_file = tokio::fs::File::open(file_path).await?;
+    let mut reader = tokio::io::BufReader::new(input_file);
+    let mut sha = Sha256::new();
+    let mut buf = BytesMut::with_capacity(ONE_MB);
+    loop {
+        buf.clear();
+        let len = reader.read_buf(&mut buf).await?;
+        if len == 0 {
+            break;
+        }
+        sha.update(&buf[0..len]);
+    }
+    let hash = sha.finalize();
+    Ok(hex::encode(hash))
+}

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -116,10 +116,7 @@ pub async fn get_snapshot_description(path: &Path) -> CollectionResult<SnapshotD
 
 async fn read_checksum_for_snapshot(snapshot_path: &Path) -> Option<String> {
     let checksum_path = get_checksum_path(snapshot_path);
-    match tokio::fs::read_to_string(&checksum_path).await {
-        Ok(content) => Some(content),
-        Err(_) => None,
-    }
+    tokio::fs::read_to_string(&checksum_path).await.ok()
 }
 
 pub fn get_checksum_path(snapshot_path: &Path) -> PathBuf {

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -77,6 +77,7 @@ pub struct SnapshotDescription {
     pub name: String,
     pub creation_time: Option<NaiveDateTime>,
     pub size: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
 }
 

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -114,13 +114,13 @@ pub async fn get_snapshot_description(path: &Path) -> CollectionResult<SnapshotD
     })
 }
 
-async fn read_checksum_for_snapshot(snapshot_path: &Path) -> Option<String> {
+async fn read_checksum_for_snapshot(snapshot_path: impl Into<PathBuf>) -> Option<String> {
     let checksum_path = get_checksum_path(snapshot_path);
     tokio::fs::read_to_string(&checksum_path).await.ok()
 }
 
-pub fn get_checksum_path(snapshot_path: &Path) -> PathBuf {
-    let mut checksum_path = snapshot_path.to_path_buf().into_os_string();
+pub fn get_checksum_path(snapshot_path: impl Into<PathBuf>) -> PathBuf {
+    let mut checksum_path = snapshot_path.into().into_os_string();
     checksum_path.push(".checksum");
     checksum_path.into()
 }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -756,7 +756,7 @@ impl ShardHolder {
         }
 
         // Compute and store the file's checksum
-        let checksum_path = get_checksum_path(temp_file.path());
+        let checksum_path = get_checksum_path(&snapshot_path);
         let checksum = hash_file(temp_file.path()).await?;
         let checksum_file = tempfile::TempPath::from_path(&checksum_path);
         let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -6,17 +6,19 @@ use itertools::Itertools;
 // TODO rename ReplicaShard to ReplicaSetShard
 use segment::types::ShardKey;
 use tar::Builder as TarBuilder;
+use tokio::io::AsyncWriteExt;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 use super::replica_set::AbortShardTransfer;
 use crate::common::file_utils::move_file;
+use crate::common::sha_256::hash_file;
 use crate::config::{CollectionConfig, ShardingMethod};
 use crate::hash_ring::HashRing;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::snapshot_ops::{
-    get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
+    get_checksum_path, get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
 };
 use crate::operations::types::{CollectionError, CollectionResult, ShardTransferInfo};
 use crate::operations::{OperationToShard, SplitByShard};
@@ -753,7 +755,13 @@ impl ShardHolder {
             }
         }
 
-        // Remove partially moved `snapshot_path`, if `move_file` fails
+        // Compute and store the file's checksum
+        let checksum_path = get_checksum_path(temp_file.path());
+        let checksum = hash_file(temp_file.path()).await?;
+        let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;
+        file.write_all(checksum.as_bytes()).await?;
+
+        // Remove partially moved `snapshot_path` or checksum, if `move_file` fails
         let snapshot_file = tempfile::TempPath::from_path(&snapshot_path);
 
         // `tempfile::NamedTempFile::persist` does not work if destination file is on another

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod sha_256_test;
 mod snapshot_test;
 mod sparse_vectors_validation_tests;
 mod wal_recovery_test;

--- a/lib/collection/src/tests/sha_256_test.rs
+++ b/lib/collection/src/tests/sha_256_test.rs
@@ -1,0 +1,17 @@
+use std::io::Write;
+
+use tempfile::NamedTempFile;
+
+use crate::common::sha_256::hash_file;
+
+#[tokio::test]
+async fn test_sha_256_digest() -> std::io::Result<()> {
+    let mut file = NamedTempFile::new()?;
+    write!(file, "This tests if the hashing a file works correctly.")?;
+    let result_hash = hash_file(file.path()).await?;
+    assert_eq!(
+        result_hash,
+        "735e3ec1b05d901d07e84b1504518442aba2395fe3f945a1c962e81a8e152b2d"
+    );
+    Ok(())
+}

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -112,6 +112,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         .await
         .unwrap();
 
+    assert_eq!(snapshot_description.checksum.len(), 64);
     // Do not recover in local mode if some shards are remote
     assert!(Collection::restore_snapshot(
         &snapshots_path.path().join(&snapshot_description.name),

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -112,7 +112,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         .await
         .unwrap();
 
-    assert_eq!(snapshot_description.checksum.len(), 64);
+    assert_eq!(snapshot_description.checksum.unwrap().len(), 64);
     // Do not recover in local mode if some shards are remote
     assert!(Collection::restore_snapshot(
         &snapshots_path.path().join(&snapshot_description.name),

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -148,6 +148,16 @@ impl From<FileStorageError> for StorageError {
     }
 }
 
+impl From<tempfile::PathPersistError> for StorageError {
+    fn from(err: tempfile::PathPersistError) -> Self {
+        Self::service_error(format!(
+            "failed to persist temporary file path {}: {}",
+            err.path.display(),
+            err.error,
+        ))
+    }
+}
+
 impl<Guard> From<std::sync::PoisonError<Guard>> for StorageError {
     fn from(err: std::sync::PoisonError<Guard>) -> Self {
         StorageError::ServiceError {

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -60,7 +60,7 @@ async fn _do_delete_full_snapshot(
     snapshot_name: &str,
 ) -> Result<bool, StorageError> {
     let snapshot_dir = get_full_snapshot_path(dispatcher.toc(), snapshot_name).await?;
-    let checksum_path = get_checksum_path(snapshot_dir.as_path());
+    let checksum_path = get_checksum_path(&snapshot_dir);
     log::info!("Deleting full storage snapshot {:?}", snapshot_dir);
     let (delete_snapshot, delete_checksum) = tokio::join!(
         tokio::fs::remove_file(snapshot_dir),
@@ -104,7 +104,7 @@ async fn _do_delete_collection_snapshot(
 ) -> Result<bool, StorageError> {
     let collection = dispatcher.get_collection(collection_name).await?;
     let file_name = collection.get_snapshot_path(snapshot_name).await?;
-    let checksum_path = get_checksum_path(file_name.as_path());
+    let checksum_path = get_checksum_path(&file_name);
     log::info!("Deleting collection snapshot {:?}", file_name);
     let (delete_snapshot, delete_checksum) = tokio::join!(
         tokio::fs::remove_file(file_name),
@@ -209,7 +209,7 @@ async fn _do_create_full_snapshot(
             std::fs::remove_file(&snapshot_path)?;
 
             // Remove associated checksum if there is one
-            let snapshot_checksum = get_checksum_path(snapshot_path.as_path());
+            let snapshot_checksum = get_checksum_path(&snapshot_path);
             if let Err(err) = std::fs::remove_file(snapshot_checksum) {
                 log::warn!("Failed to delete checksum file for snapshot, ignoring: {err}");
             }
@@ -223,7 +223,7 @@ async fn _do_create_full_snapshot(
 
     // Compute and store the file's checksum
     log::debug!("Computing checksum for snapshot: {full_snapshot_path:?}");
-    let checksum_path = get_checksum_path(full_snapshot_path.as_path());
+    let checksum_path = get_checksum_path(&full_snapshot_path);
     let checksum = hash_file(full_snapshot_path.as_path()).await?;
     let checksum_file = tempfile::TempPath::from_path(&checksum_path);
     let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -221,7 +221,7 @@ async fn _do_create_full_snapshot(
     archiving.await??;
 
     // Compute and store the file's checksum
-    log::debug!("Computing checksum for snapshot: {:?}", full_snapshot_path);
+    log::debug!("Computing checksum for snapshot: {full_snapshot_path:?}");
     let checksum_path = get_checksum_path(full_snapshot_path.as_path());
     let checksum = hash_file(full_snapshot_path.as_path()).await?;
     let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -155,7 +155,7 @@ async fn _do_create_full_snapshot(
     }
     let current_time = chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S").to_string();
 
-    let snapshot_name = format!("{}-{}.snapshot", FULL_SNAPSHOT_FILE_NAME, &current_time);
+    let snapshot_name = format!("{FULL_SNAPSHOT_FILE_NAME}-{current_time}.snapshot");
 
     let collection_name_to_snapshot_path: HashMap<_, _> = created_snapshots
         .iter()

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -221,6 +221,7 @@ async fn _do_create_full_snapshot(
     archiving.await??;
 
     // Compute and store the file's checksum
+    log::debug!("Computing checksum for snapshot: {:?}", full_snapshot_path);
     let checksum_path = get_checksum_path(full_snapshot_path.as_path());
     let checksum = hash_file(full_snapshot_path.as_path()).await?;
     let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -136,7 +136,7 @@ pub async fn do_create_snapshot(
             name: "".to_string(),
             creation_time: None,
             size: 0,
-            checksum: "".to_string(),
+            checksum: None,
         })
     }
 }

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -136,6 +136,7 @@ pub async fn do_create_snapshot(
             name: "".to_string(),
             creation_time: None,
             size: 0,
+            checksum: "".to_string(),
         })
     }
 }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use collection::collection::Collection;
 use collection::operations::snapshot_ops::{
-    ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
+    get_checksum_path, ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
 };
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::ShardId;
@@ -57,9 +57,19 @@ pub async fn delete_shard_snapshot(
     let snapshot_path = collection
         .get_shard_snapshot_path(shard_id, &snapshot_name)
         .await?;
+    let checksum_path = get_checksum_path(snapshot_path.as_path());
 
     check_shard_snapshot_file_exists(&snapshot_path)?;
-    tokio::fs::remove_file(&snapshot_path).await?;
+    let (delete_snapshot, delete_checksum) = tokio::join!(
+        tokio::fs::remove_file(snapshot_path),
+        tokio::fs::remove_file(checksum_path)
+    );
+    delete_snapshot?;
+
+    // We might not have a checksum file for the snapshot, ignore deletion errors in that case
+    if let Err(err) = delete_checksum {
+        log::warn!("Failed to delete checksum file for snapshot, ignoring: {err}");
+    }
 
     Ok(())
 }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -57,7 +57,7 @@ pub async fn delete_shard_snapshot(
     let snapshot_path = collection
         .get_shard_snapshot_path(shard_id, &snapshot_name)
         .await?;
-    let checksum_path = get_checksum_path(snapshot_path.as_path());
+    let checksum_path = get_checksum_path(&snapshot_path);
 
     check_shard_snapshot_file_exists(&snapshot_path)?;
     let (delete_snapshot, delete_checksum) = tokio::join!(


### PR DESCRIPTION
Adds a `checksum` field as suggested in #2830 
This implementation calculates an index file checksum on the fly. Because of this, one thing that's still up for discussion is the buffer size for calculating the checksum. Currently, the intermediate buffer is set to 1MB which might be too little if the snapshot files are big.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
