### PR TITLE
Use enum vector type in vector storage

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -41,7 +41,7 @@ fn init_vector_storage(
         for i in 0..num {
             let vector: Vec<VectorElementType> = random_vector(dim);
             borrowed_storage
-                .insert_vector(i as PointOffsetType, &vector)
+                .insert_vector(i as PointOffsetType, vector.as_slice().into())
                 .unwrap();
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -2,11 +2,73 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sparse::common::sparse_vector::SparseVector;
 
 use super::named_vectors::NamedVectors;
 use crate::common::utils::transpose_map_into_named_vector;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query::reco_query::RecoQuery;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Vector {
+    Dense(VectorType),
+    Sparse(SparseVector),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum VectorRef<'a> {
+    Dense(&'a [VectorElementType]),
+    Sparse(&'a SparseVector),
+}
+
+// TODO(ivan) temporary conversion while sparse vectors are under development
+impl<'a> From<VectorRef<'a>> for &'a [VectorElementType] {
+    fn from(val: VectorRef<'a>) -> Self {
+        match val {
+            VectorRef::Dense(v) => v,
+            VectorRef::Sparse(_) => unreachable!(),
+        }
+    }
+}
+
+impl<'a> From<&'a [VectorElementType]> for VectorRef<'a> {
+    fn from(val: &'a [VectorElementType]) -> Self {
+        VectorRef::Dense(val)
+    }
+}
+
+impl<'a> From<&'a VectorType> for VectorRef<'a> {
+    fn from(val: &'a VectorType) -> Self {
+        VectorRef::Dense(val.as_slice())
+    }
+}
+
+impl<'a> From<&'a SparseVector> for VectorRef<'a> {
+    fn from(val: &'a SparseVector) -> Self {
+        VectorRef::Sparse(val)
+    }
+}
+
+impl From<VectorType> for Vector {
+    fn from(val: VectorType) -> Self {
+        Vector::Dense(val)
+    }
+}
+
+impl From<SparseVector> for Vector {
+    fn from(val: SparseVector) -> Self {
+        Vector::Sparse(val)
+    }
+}
+
+impl<'a> From<&'a Vector> for VectorRef<'a> {
+    fn from(val: &'a Vector) -> Self {
+        match val {
+            Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
+            Vector::Sparse(v) => VectorRef::Sparse(v),
+        }
+    }
+}
 
 /// Type of vector element.
 pub type VectorElementType = f32;
@@ -250,6 +312,13 @@ impl<'a> From<&'a [VectorElementType]> for QueryVector {
 
 impl<const N: usize> From<[VectorElementType; N]> for QueryVector {
     fn from(vec: [VectorElementType; N]) -> Self {
+        Self::Nearest(vec.to_vec())
+    }
+}
+
+impl<'a> From<VectorRef<'a>> for QueryVector {
+    fn from(vec: VectorRef<'a>) -> Self {
+        let vec: &[_] = vec.into();
         Self::Nearest(vec.to_vec())
     }
 }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -21,6 +21,15 @@ pub enum VectorRef<'a> {
     Sparse(&'a SparseVector),
 }
 
+impl Vector {
+    pub fn to_vec_ref(&self) -> VectorRef {
+        match self {
+            Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
+            Vector::Sparse(v) => VectorRef::Sparse(v),
+        }
+    }
+}
+
 // TODO(ivan) temporary conversion while sparse vectors are under development
 impl<'a> From<VectorRef<'a>> for &'a [VectorElementType] {
     fn from(val: VectorRef<'a>) -> Self {

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{VectorElementType, VectorRef, VectorType};
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
 use crate::types::Distance;
@@ -61,16 +61,12 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
         self.vectors.len()
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
-        self.get_dense(key)
+    fn get_vector(&self, key: PointOffsetType) -> VectorRef {
+        self.get_dense(key).into()
     }
 
-    fn insert_vector(
-        &mut self,
-        key: PointOffsetType,
-        vector: &[VectorElementType],
-    ) -> OperationResult<()> {
-        self.vectors.insert(key, vector)?;
+    fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
+        self.vectors.insert(key, vector.into())?;
         Ok(())
     }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -137,7 +137,7 @@ impl Segment {
             match vector {
                 Some(vector) => {
                     let mut vector_storage = vector_data.vector_storage.borrow_mut();
-                    vector_storage.insert_vector(internal_id, vector)?;
+                    vector_storage.insert_vector(internal_id, vector.into())?;
                 }
                 None => {
                     // No vector provided, so we remove it
@@ -174,7 +174,7 @@ impl Segment {
             vector_data
                 .vector_storage
                 .borrow_mut()
-                .insert_vector(internal_id, new_vector.as_ref())?;
+                .insert_vector(internal_id, new_vector.as_ref().into())?;
         }
         Ok(())
     }
@@ -198,11 +198,12 @@ impl Segment {
             match vector_opt {
                 None => {
                     let dim = vector_storage.vector_dim();
-                    vector_storage.insert_vector(new_index, &vec![1.0; dim])?;
+                    let vector = vec![1.0; dim];
+                    vector_storage.insert_vector(new_index, vector.as_slice().into())?;
                     vector_storage.delete_vector(new_index)?;
                 }
                 Some(vec) => {
-                    vector_storage.insert_vector(new_index, vec)?;
+                    vector_storage.insert_vector(new_index, vec.into())?;
                 }
             }
         }
@@ -399,7 +400,8 @@ impl Segment {
                     ),
                 })
             } else {
-                Ok(Some(vector_storage.get_vector(point_offset).to_vec()))
+                let vector: &[_] = vector_storage.get_vector(point_offset).into();
+                Ok(Some(vector.to_vec()))
             }
         } else {
             Ok(None)
@@ -417,14 +419,9 @@ impl Segment {
                 .borrow()
                 .is_deleted_vector(point_offset);
             if !is_vector_deleted {
-                vectors.insert(
-                    vector_name.clone(),
-                    vector_data
-                        .vector_storage
-                        .borrow()
-                        .get_vector(point_offset)
-                        .to_vec(),
-                );
+                let vector_storage = vector_data.vector_storage.borrow();
+                let vector: &[_] = vector_storage.get_vector(point_offset).into();
+                vectors.insert(vector_name.clone(), vector.to_vec());
             }
         }
         Ok(vectors)

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -109,7 +109,7 @@ impl QuantizedVectors {
         stopped: &AtomicBool,
     ) -> OperationResult<Arc<AtomicRefCell<Self>>> {
         let count = vector_storage.total_vector_count();
-        let vectors = (0..count as PointOffsetType).map(|i| vector_storage.get_vector(i));
+        let vectors = (0..count as PointOffsetType).map(|i| vector_storage.get_vector(i).into());
         let on_disk_vector_storage = vector_storage.is_on_disk();
         let distance = vector_storage.distance();
         let dim = vector_storage.vector_dim();

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -32,7 +32,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     for (i, vec) in points.iter().enumerate() {
         borrowed_storage
-            .insert_vector(i as PointOffsetType, vec)
+            .insert_vector(i as PointOffsetType, vec.as_slice().into())
             .unwrap();
     }
 
@@ -136,7 +136,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
             let mut borrowed_storage2 = storage2.borrow_mut();
             points.iter().enumerate().for_each(|(i, vec)| {
                 borrowed_storage2
-                    .insert_vector(i as PointOffsetType, vec)
+                    .insert_vector(i as PointOffsetType, vec.as_slice().into())
                     .unwrap();
                 if delete_mask[i] {
                     borrowed_storage2
@@ -206,7 +206,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     for (i, vec) in points.iter().enumerate() {
         borrowed_storage
-            .insert_vector(i as PointOffsetType, vec)
+            .insert_vector(i as PointOffsetType, vec.as_slice().into())
             .unwrap();
     }
 
@@ -280,7 +280,7 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     for (i, vec) in points.iter().enumerate() {
         borrowed_storage
-            .insert_vector(i as PointOffsetType, vec)
+            .insert_vector(i as PointOffsetType, vec.as_slice().into())
             .unwrap();
     }
 

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -29,7 +29,7 @@ pub fn insert_distributed_vectors(
             *item = value;
         }
 
-        storage.insert_vector(offset, &vector)?;
+        storage.insert_vector(offset, vector.as_slice().into())?;
     }
 
     Ok(())

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -9,7 +9,7 @@ use super::memmap_vector_storage::MemmapVectorStorage;
 use super::simple_vector_storage::SimpleVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::Distance;
 use crate::vector_storage::appendable_mmap_vector_storage::AppendableMmapVectorStorage;
 
@@ -41,13 +41,9 @@ pub trait VectorStorage {
     }
 
     /// Number of all stored vectors including deleted
-    fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType];
+    fn get_vector(&self, key: PointOffsetType) -> VectorRef;
 
-    fn insert_vector(
-        &mut self,
-        key: PointOffsetType,
-        vector: &[VectorElementType],
-    ) -> OperationResult<()>;
+    fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
 
     fn update_from(
         &mut self,
@@ -134,7 +130,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn get_vector(&self, key: PointOffsetType) -> &[VectorElementType] {
+    fn get_vector(&self, key: PointOffsetType) -> VectorRef {
         match self {
             VectorStorageEnum::Simple(v) => v.get_vector(key),
             VectorStorageEnum::Memmap(v) => v.get_vector(key),
@@ -142,11 +138,7 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
-    fn insert_vector(
-        &mut self,
-        key: PointOffsetType,
-        vector: &[VectorElementType],
-    ) -> OperationResult<()> {
+    fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
         match self {
             VectorStorageEnum::Simple(v) => v.insert_vector(key, vector),
             VectorStorageEnum::Memmap(v) => v.insert_vector(key, vector),


### PR DESCRIPTION
This PR introduces common type of vector and vector reference:
```
pub enum Vector {
    Dense(VectorType),
    Sparse(SparseVector),
}

pub enum VectorRef<'a> {
    Dense(&'a [VectorElementType]),
    Sparse(&'a SparseVector),
}
```

This common vector type is a part of sparse vector index integration. While this PR, `Vector` was integrated to the `VectorStorage` trait. It unblocks https://github.com/qdrant/qdrant/pull/2806

Currently, `Vector` allows converting directly to dense vector type with panic. Because error propagation is out of scope here. Also out of scope the renaming `VectorType` -> `DenseVector`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
