### PR TITLE
Clean up temporary snapshot after shard snapshot transfer

### DIFF
--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -307,7 +307,7 @@ async fn transfer_snapshot(
 
     if let Some(path) = snapshot_temp_path {
         if let Err(err) = path.close() {
-            log::error!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
+            log::warn!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
         }
     }
 

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -277,8 +277,7 @@ async fn transfer_snapshot(
             log::error!(
                 "Failed to determine snapshot path, will not delete file after recovery: {err}"
             );
-        })
-        .ok();
+        })?;
 
     // Recover shard snapshot on remote
     let mut shard_download_url = local_rest_address;
@@ -305,10 +304,8 @@ async fn transfer_snapshot(
             ))
         })?;
 
-    if let Some(path) = snapshot_temp_path {
-        if let Err(err) = path.close() {
-            log::warn!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
-        }
+    if let Err(err) = path.close() {
+        log::warn!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
     }
 
     // Set shard state to Partial

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -274,9 +274,9 @@ async fn transfer_snapshot(
         .await
         .map(TempPath::from_path)
         .map_err(|err| {
-            log::error!(
+            CollectionError::service_error(format!(
                 "Failed to determine snapshot path, will not delete file after recovery: {err}"
-            );
+            ))
         })?;
 
     // Recover shard snapshot on remote
@@ -304,7 +304,7 @@ async fn transfer_snapshot(
             ))
         })?;
 
-    if let Err(err) = path.close() {
+    if let Err(err) = snapshot_temp_path.close() {
         log::warn!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
     }
 

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -275,7 +275,7 @@ async fn transfer_snapshot(
         .map(TempPath::from_path)
         .map_err(|err| {
             CollectionError::service_error(format!(
-                "Failed to determine snapshot path, will not delete file after recovery: {err}"
+                "Failed to determine snapshot path, cannot continue with shard snapshot recovery: {err}"
             ))
         })?;
 


### PR DESCRIPTION
Tracked in https://github.com/qdrant/qdrant/issues/2432.

Depends on https://github.com/qdrant/qdrant/pull/2881.

The shard snapshot transfer feature creates a _temporary_ snapshot used for recovery on a remote peer. When recovery is done, this file is left behind.

This makes sure to delete the created snapshot after the snapshot is recovered or if recovering failed.

Similar to <https://github.com/qdrant/qdrant/pull/2846>, but for the sending side of things.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?