### PR TITLE
Support API-token authentication through Http Authorization Bearer header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d613edf08a42ccc6864c941d30fe14e1b676a77d16f1dbadc1174d065a0a775"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64 0.21.0",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-web-validator"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,6 +3730,7 @@ dependencies = [
  "actix-files",
  "actix-multipart",
  "actix-web",
+ "actix-web-httpauth",
  "actix-web-validator",
  "anyhow",
  "api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tokio = { version = "~1.32", features = ["full"] }
 actix-web = { version = "4.3.1", optional = true, features = ["rustls-0_21", "actix-tls"] }
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
+actix-web-httpauth = "0.8.1"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"
 tower = "0.4.13"


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2845>.

Add support for using a `Authorization: Bearer my_token` header for API-key authentication. Our authentication logic will try to fall back to this header if no `Api-key` header is provided. This is implemented for both our REST and gRPC API.

More specifically, this does not implement additional authorization endpoints which is common with Bearer to generate unique tokens. Instead this accepts the user defined API-key directly.

A malformed Authorization Bearer header is currently simply ignored.

Similar to <https://github.com/qdrant/qdrant/pull/2007> but using a standardized approach.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?