### PR TITLE
Fix cargo test doc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,11 +29,11 @@ jobs:
       uses: taiki-e/install-action@nextest
     - name: Build
       run: cargo build --tests --workspace
+    - name: Run doc tests # nextest does not support doc tests yet
+      run: cargo test --workspace --doc
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci
-    - name: Run doc tests # nextest does not support doc tests yet
-      run: cargo test --workspace --doc
     - name: Upload test report
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci
+    - name: Run doc tests # nextest does not support doc tests yet
+      run: cargo test --workspace --doc
     - name: Upload test report
       uses: actions/upload-artifact@v3
       with:

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -9,9 +9,9 @@ impl<T> DiscoveryPair<T> {
     /// for the search. This is done by using a smooth loss function instead of hard ranking
     /// to approach the best zone, once the best zone is reached, score will be same for all
     /// points inside that zone.
-    ///
+    /// e.g.:
     ///                   │
-    ///                   │         
+    ///                   │
     ///                   │    +0
     ///                   │             +0
     ///                   │


### PR DESCRIPTION
Running `cargo test --all` currently yield the following error.

```
---- lib/segment/src/vector_storage/query/context_query.rs - vector_storage::query::context_query::DiscoveryPair<T>::loss_by (line 13) stdout ----
error: unknown start of token: \u{2502}
 --> lib/segment/src/vector_storage/query/context_query.rs:14:1
  |
3 | │
  | ^

```

~~It does not happen on CI because we do not use `--all` but `--workspace`.~~ see https://github.com/qdrant/qdrant/pull/2856#issuecomment-1772350386

It seems the root cause is the way rustc interpret comments https://github.com/rust-lang/rust/issues/64162

This PR inserts some text to remove the completely empty line to please rustc.