### PR TITLE
Hnsw parallel build accuracy

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -20,7 +20,7 @@ use crate::vector_storage::{
 };
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
-    (0..size).map(|_| rnd_gen.gen_range(0.0..1.0)).collect()
+    (0..size).map(|_| rnd_gen.gen_range(-1.0..1.0)).collect()
 }
 
 pub struct FakeFilterContext {}

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -37,11 +37,6 @@ impl EntryPoints {
             extra_entry_points: FixedLengthPriorityQueue::new(extra_entry_points),
         }
     }
-
-    pub fn iterator(&self) -> impl Iterator<Item = &EntryPoint> {
-        self.entry_points.iter()
-    }
-
     pub fn merge_from_other(&mut self, mut other: EntryPoints) {
         self.entry_points.append(&mut other.entry_points);
         // Do not merge `extra_entry_points` to prevent duplications

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -38,6 +38,10 @@ impl EntryPoints {
         }
     }
 
+    pub fn iterator(&self) -> impl Iterator<Item = &EntryPoint> {
+        self.entry_points.iter()
+    }
+
     pub fn merge_from_other(&mut self, mut other: EntryPoints) {
         self.entry_points.append(&mut other.entry_points);
         // Do not merge `extra_entry_points` to prevent duplications

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -1,6 +1,4 @@
 use std::cmp::max;
-use std::fs::File;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -261,26 +261,6 @@ where
         match try_self {
             Ok(mut slf) => {
                 let links = TGraphLinks::load_from_file(links_path)?;
-
-                eprintln!("links.levels_count() = {:#?}", links.levels_count());
-
-                let num_points = links.num_points();
-
-                eprintln!("links.num_points() = {:#?}", num_points);
-
-                // Dump all links into file
-                let mut file = File::create(links_path.with_extension("txt"))?;
-
-                for idx in 0..num_points {
-                    let links = links.links(idx as PointOffsetType, 0);
-                    let txt = format!("{:?}\n", links);
-                    file.write_all(txt.as_bytes())?;
-                }
-
-                for entry_point in slf.entry_points.iterator() {
-                    eprintln!("entry_point = {:#?}", entry_point);
-                }
-
                 slf.links = links;
                 Ok(slf)
             }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -1,4 +1,6 @@
 use std::cmp::max;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
@@ -226,7 +228,6 @@ impl<TGraphLinks: GraphLinks> GraphLayers<TGraphLinks> {
             0,
             &mut points_scorer,
         );
-
         let nearest = self.search_on_level(zero_level_entry, 0, max(top, ef), &mut points_scorer);
         nearest.into_iter().take(top).collect_vec()
     }
@@ -260,6 +261,26 @@ where
         match try_self {
             Ok(mut slf) => {
                 let links = TGraphLinks::load_from_file(links_path)?;
+
+                eprintln!("links.levels_count() = {:#?}", links.levels_count());
+
+                let num_points = links.num_points();
+
+                eprintln!("links.num_points() = {:#?}", num_points);
+
+                // Dump all links into file
+                let mut file = File::create(links_path.with_extension("txt"))?;
+
+                for idx in 0..num_points {
+                    let links = links.links(idx as PointOffsetType, 0);
+                    let txt = format!("{:?}\n", links);
+                    file.write_all(txt.as_bytes())?;
+                }
+
+                for entry_point in slf.entry_points.iterator() {
+                    eprintln!("entry_point = {:#?}", entry_point);
+                }
+
                 slf.links = links;
                 Ok(slf)
             }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -894,7 +894,7 @@ mod tests {
             GraphLayersBuilder::connect_new_point(&mut links, id, 0, level_m, scorer)
         }
         let mut result = Vec::new();
-        graph_layers_builder.links_map(0, 0, |link| result.push(link));
+        graph_layers_builder.links_layers[0][0].read().iter().for_each(|x| result.push(*x));
         assert_eq!(&result, &vec![1, 2, 3, 4, 5, 6]);
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -292,35 +292,6 @@ impl GraphLayersBuilder {
         result_list
     }
 
-    #[allow(dead_code)]
-    fn search_existing_point_on_level(
-        &self,
-        level_entry: ScoredPointOffset,
-        level: usize,
-        ef: usize,
-        points_scorer: &mut FilteredScorer,
-        point_id: PointOffsetType,
-    ) -> FixedLengthPriorityQueue<ScoredPointOffset> {
-        let mut visited_list = self.get_visited_list_from_pool();
-        visited_list.check_and_update_visited(level_entry.idx);
-        let mut search_context = SearchContext::new(level_entry, ef);
-
-        self._search_on_level(&mut search_context, level, &mut visited_list, points_scorer);
-
-        let existing_links = self.links_layers[point_id as usize][level].read();
-        for &existing_link in existing_links.iter() {
-            if !visited_list.check(existing_link) {
-                search_context.process_candidate(ScoredPointOffset {
-                    idx: existing_link,
-                    score: points_scorer.score_point(existing_link),
-                });
-            }
-        }
-
-        self.return_visited_list_to_pool(visited_list);
-        search_context.nearest
-    }
-
     /// <https://github.com/nmslib/hnswlib/issues/99>
     fn select_candidates_with_heuristic<F>(
         candidates: FixedLengthPriorityQueue<ScoredPointOffset>,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -894,7 +894,10 @@ mod tests {
             GraphLayersBuilder::connect_new_point(&mut links, id, 0, level_m, scorer)
         }
         let mut result = Vec::new();
-        graph_layers_builder.links_layers[0][0].read().iter().for_each(|x| result.push(*x));
+        graph_layers_builder.links_layers[0][0]
+            .read()
+            .iter()
+            .for_each(|x| result.push(*x));
         assert_eq!(&result, &vec![1, 2, 3, 4, 5, 6]);
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -129,7 +129,6 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         })
     }
 
-
     #[cfg(test)]
     pub(super) fn graph(&self) -> Option<&GraphLayers<TGraphLinks>> {
         self.graph.as_ref()

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -173,7 +173,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
-        let points_to_index_iter =
+        let mut points_to_index_iter =
             payload_index
                 .query_points(&filter)
                 .into_iter()
@@ -185,6 +185,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 });
 
         let first_points_to_index: Vec<_> = points_to_index_iter
+            .by_ref()
             .take(SINGLE_THREADED_HNSW_BUILD_THRESHOLD)
             .collect();
         let points_to_index: Vec<_> = points_to_index_iter.collect();
@@ -224,7 +225,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
                 FilteredScorer::new(raw_scorer.as_ref(), Some(&block_condition_checker));
 
             graph_layers_builder.link_new_point(block_point_id, points_scorer);
-            Ok(())
+            Ok::<_, OperationError>(())
         };
 
         // First index points in single thread so ensure warm start for parallel indexing process

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -12,10 +12,15 @@ mod search_context;
 #[cfg(test)]
 mod tests;
 
+// In case if we are dealing with high-CPU system, creating more than
+// this amount of threads will most likely not improve performance
+// But we still allow to override this value by setting `max_indexing_threads` to non-zero value
+const MAX_AUTO_RAYON_THREADS: usize = 16;
+
 pub fn max_rayon_threads(max_indexing_threads: usize) -> usize {
     if max_indexing_threads == 0 {
         let num_cpu = crate::common::cpu::get_num_cpus();
-        std::cmp::max(1, num_cpu - 1)
+        num_cpu.clamp(1, MAX_AUTO_RAYON_THREADS)
     } else {
         max_indexing_threads
     }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -1,4 +1,5 @@
 mod test_compact_graph_layer;
+mod test_graph_connectivity;
 
 use std::path::Path;
 

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -21,12 +21,12 @@ use crate::types::{
 fn test_graph_connectivity() {
     let stopped = AtomicBool::new(false);
 
-    let dim = 64;
+    let dim = 32;
     let m = 16;
-    let num_vectors: u64 = 10_000;
+    let num_vectors: u64 = 1_000;
     let ef_construct = 100;
     let distance = Distance::Cosine;
-    let full_scan_threshold = 1000;
+    let full_scan_threshold = 10_000;
 
     let mut rnd = thread_rng();
 
@@ -94,7 +94,6 @@ fn test_graph_connectivity() {
     }
 
     for point_id in 0..num_vectors {
-        let links = graph.links.links(point_id as PointOffsetType, 0);
-        assert!(!links.is_empty(), "Point {} has no inbound links", point_id);
+        assert!(!reverse_links[point_id as usize].is_empty(), "Point {} has no inbound links", point_id);
     }
 }

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+
+use common::types::PointOffsetType;
+use rand::thread_rng;
+use tempfile::Builder;
+
+use crate::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
+use crate::entry::entry_point::SegmentEntry;
+use crate::fixtures::index_fixtures::random_vector;
+use crate::index::hnsw_index::graph_links::{GraphLinks, GraphLinksRam};
+use crate::index::hnsw_index::hnsw::HNSWIndex;
+use crate::index::VectorIndex;
+use crate::segment_constructor::build_segment;
+use crate::types::{
+    Distance, HnswConfig, Indexes, SegmentConfig, SeqNumberType, VectorDataConfig,
+    VectorStorageType,
+};
+
+#[test]
+fn test_graph_connectivity() {
+    let stopped = AtomicBool::new(false);
+
+    let dim = 64;
+    let m = 16;
+    let num_vectors: u64 = 10_000;
+    let ef_construct = 100;
+    let distance = Distance::Cosine;
+    let full_scan_threshold = 1000;
+
+    let mut rnd = thread_rng();
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance,
+                storage_type: VectorStorageType::Memory,
+                index: Indexes::Plain {},
+                quantization_config: None,
+            },
+        )]),
+        payload_storage_type: Default::default(),
+    };
+
+    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    for n in 0..num_vectors {
+        let idx = n.into();
+        let vector = random_vector(&mut rnd, dim);
+
+        segment
+            .upsert_point(n as SeqNumberType, idx, only_default_vector(&vector))
+            .unwrap();
+    }
+
+    let payload_index_ptr = segment.payload_index.clone();
+
+    let hnsw_config = HnswConfig {
+        m,
+        ef_construct,
+        full_scan_threshold,
+        max_indexing_threads: 4,
+        on_disk: Some(false),
+        payload_m: None,
+    };
+
+    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+        hnsw_dir.path(),
+        segment.id_tracker.clone(),
+        segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_storage
+            .clone(),
+        None,
+        payload_index_ptr.clone(),
+        hnsw_config,
+    )
+    .unwrap();
+
+    hnsw_index.build_index(&stopped).unwrap();
+
+    let graph = hnsw_index.graph().unwrap();
+
+    let mut reverse_links = vec![vec![]; num_vectors as usize];
+
+    for point_id in 0..num_vectors {
+        let links = graph.links.links(point_id as PointOffsetType, 0);
+        for link in links {
+            reverse_links[*link as usize].push(point_id);
+        }
+    }
+
+    for point_id in 0..num_vectors {
+        let links = graph.links.links(point_id as PointOffsetType, 0);
+        assert!(!links.is_empty(), "Point {} has no inbound links", point_id);
+    }
+}

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -94,6 +94,10 @@ fn test_graph_connectivity() {
     }
 
     for point_id in 0..num_vectors {
-        assert!(!reverse_links[point_id as usize].is_empty(), "Point {} has no inbound links", point_id);
+        assert!(
+            !reverse_links[point_id as usize].is_empty(),
+            "Point {} has no inbound links",
+            point_id
+        );
     }
 }


### PR DESCRIPTION
This PR contains several fixes for the HNSW parallel index building process

related to: https://discord.com/channels/907569970500743200/1164130123868557392

> We have been bnechmarking recall@1 of qdrant HNSW index using 60K, 100K and 1M 1024-dimensional embeddings.
Within each benchmarking process we have been waiting for collection status to turn 'green' before running the search.
After comparing the results for different HNSW parameters (M, ef_construct, ef_search), we have discovered that the parameter 'M' works in a very unexpected way (the lower the better).
We have reproduced the same experiment for FAISS HNSW index and got the expected results for 'M' (the higher the better) with higher recall@1 values.
Shortly after, we have discovered that the problem with qdrant HNSW recall was caused by small number of unindexed vectors.
Despite that the collection status has turned 'green', we've had around 2k unindexed vectors from a total of 90k, which was the cause of drastic change in our metrics.
We have found that we can change this behaviour by switching the indexing_threshold_kb in IndexingOptimizer such that it waits for all vectors to be indexed.
In our case this change had a significant impact on our metrics, especially results for 'M' parameter and 10% higher recall@1 values (despite only ~3% change in the number of indexed vectors).
We understand that the default value of this threshold has been set to compromise index build time and searching recall, however the drop in recall metrics is significant 
and we want to ask if this behaviour is proper for the index and are there any good practices that you could recommend for getting high search recall@1 value while having reasonable index build time.
I am adding two charts to this message to give a better visualization of the problem. Both represent recall@1 values for hnsw index with ef_construct=64. 
The one with present m=8 is the one with ~3% unindexed vectors, the one without m=8 is the one with all vectors indexed.

What we discovered during investigation:

- Sometime during parallel build of HNSW it might create disconnected sub-graphs, which leads to poor search accuracy, even with very high EF value.
- The disconnection effect is observed almost always, but the size of the effect varies between runs
- Effect disappears if: single thread is used, or only one hnsw level is used

Hypothesis:

During the parallel indexing, it was possible, the under-constructed point was used as an entry point on N-1 level.
Which led to incorrect linking for some fraction of points. If those points happened to be closer to original entry point - the large chunk of the graph became disconnected.

What this PR does:

- Introduce test for HNSW graph connectivity in case of parallel building
- Introduce a new check o index building stage: allow to traverse only those points, which are completely constructed by other threads
- Introduce initial building of first `K=512` points with single threaded  builder to improve initial spread of points and ensure warm start for parallel building process 
