### PR TITLE
Add consensus interface to shard transfer, repurpose dispatcher

### DIFF
--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,10 +1,12 @@
+use crate::operations::types::CollectionResult;
+
 pub mod shard_transfer;
 pub mod transfer_tasks_pool;
 
 /// Interface to consensus for shard transfer operations.
 pub trait ShardTransferConsensus: Send + Sync {
-    /// Get the current consensus state.
+    /// Get the current consensus commit and term state.
     ///
     /// Returns `(commit, term)`.
-    fn consensus_state(&self) -> (usize, usize);
+    fn consensus_commit_term(&self) -> CollectionResult<(u64, u64)>;
 }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,2 +1,10 @@
 pub mod shard_transfer;
 pub mod transfer_tasks_pool;
+
+/// Interface to consensus for shard transfer operations.
+pub trait ShardTransferConsensus: Send + Sync {
+    /// Get the current consensus state.
+    ///
+    /// Returns `(commit, term)`.
+    fn consensus_state(&self) -> (usize, usize);
+}

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,5 +1,3 @@
-use crate::operations::types::CollectionResult;
-
 pub mod shard_transfer;
 pub mod transfer_tasks_pool;
 
@@ -8,5 +6,5 @@ pub trait ShardTransferConsensus: Send + Sync {
     /// Get the current consensus commit and term state.
     ///
     /// Returns `(commit, term)`.
-    fn consensus_commit_term(&self) -> CollectionResult<(u64, u64)>;
+    fn consensus_commit_term(&self) -> (u64, u64);
 }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use url::Url;
 
+use super::ShardTransferConsensus;
 use crate::common::stoppable_task_async::{spawn_async_stoppable, StoppableAsyncTaskHandle};
 use crate::operations::snapshot_ops::SnapshotPriority;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -77,6 +78,7 @@ pub enum ShardTransferMethod {
 pub async fn transfer_shard(
     transfer_config: ShardTransfer,
     shard_holder: Arc<LockedShardHolder>,
+    consensus: &dyn ShardTransferConsensus,
     collection_id: CollectionId,
     collection_name: &str,
     peer_id: PeerId,
@@ -115,6 +117,7 @@ pub async fn transfer_shard(
                 shard_holder.clone(),
                 shard_id,
                 remote_shard,
+                consensus,
                 snapshots_path,
                 collection_name,
                 local_rest_address,
@@ -182,6 +185,7 @@ async fn transfer_snapshot(
     shard_holder: Arc<LockedShardHolder>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
+    consensus: &dyn ShardTransferConsensus,
     snapshots_path: &Path,
     collection_name: &str,
     local_rest_address: Url,
@@ -586,6 +590,7 @@ pub fn suggest_peer_to_remove_replica(
 pub fn spawn_transfer_task<T, F>(
     shards_holder: Arc<LockedShardHolder>,
     transfer: ShardTransfer,
+    consensus: Box<dyn ShardTransferConsensus>,
     collection_id: CollectionId,
     channel_service: ChannelService,
     snapshots_path: PathBuf,
@@ -605,6 +610,7 @@ where
             let transfer_result = transfer_shard(
                 transfer.clone(),
                 shards_holder.clone(),
+                consensus.as_ref(),
                 collection_id.clone(),
                 &collection_name,
                 transfer.to,

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -185,7 +185,7 @@ async fn transfer_snapshot(
     shard_holder: Arc<LockedShardHolder>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
-    consensus: &dyn ShardTransferConsensus,
+    _consensus: &dyn ShardTransferConsensus,
     snapshots_path: &Path,
     collection_name: &str,
     local_rest_address: Url,

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -287,9 +287,22 @@ impl TableOfContent {
                     }
                 };
 
+                let Some(shard_transfer_consensus) = self.shard_transfer_consensus.as_ref() else {
+                    return Err(StorageError::service_error(
+                        "Can't handle transfer, this is a single node deployment",
+                    ));
+                };
+                let shard_consensus = Box::new(shard_transfer_consensus.clone());
+
                 let temp_dir = self.optional_temp_or_storage_temp_path()?;
                 collection
-                    .start_shard_transfer(transfer, temp_dir, on_finish, on_failure)
+                    .start_shard_transfer(
+                        transfer,
+                        shard_consensus,
+                        temp_dir,
+                        on_finish,
+                        on_failure,
+                    )
                     .await?;
             }
             ShardTransferOperations::Finish(transfer) => {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -287,12 +287,14 @@ impl TableOfContent {
                     }
                 };
 
-                let Some(shard_transfer_consensus) = self.shard_transfer_consensus.as_ref() else {
-                    return Err(StorageError::service_error(
-                        "Can't handle transfer, this is a single node deployment",
-                    ));
+                let shard_consensus = match self.shard_transfer_dispatcher.lock().as_ref() {
+                    Some(consensus) => Box::new(consensus.clone()),
+                    None => {
+                        return Err(StorageError::service_error(
+                            "Can't handle transfer, this is a single node deployment",
+                        ))
+                    }
                 };
-                let shard_consensus = Box::new(shard_transfer_consensus.clone());
 
                 let temp_dir = self.optional_temp_or_storage_temp_path()?;
                 collection

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -34,13 +34,13 @@ use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
 use tonic::transport::Channel;
 use tonic::Status;
 
+use self::transfer::ShardTransferDispatcher;
 use crate::content_manager::alias_mapping::AliasPersistence;
 use crate::content_manager::collection_meta_ops::CreateCollectionOperation;
 use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
-use crate::dispatcher::Dispatcher;
 use crate::types::{PeerAddressById, StorageConfig};
 use crate::ConsensusOperations;
 
@@ -74,7 +74,7 @@ pub struct TableOfContent {
     /// Effectively, this lock ensures that `create_collection` is called sequentially.
     collection_create_lock: Mutex<()>,
     /// Dispatcher for shard transfer to access consensus.
-    shard_transfer_dispatcher: parking_lot::Mutex<Option<Dispatcher>>,
+    shard_transfer_dispatcher: parking_lot::Mutex<Option<ShardTransferDispatcher>>,
 }
 
 impl TableOfContent {
@@ -630,7 +630,7 @@ impl TableOfContent {
     }
 
     /// Insert dispatcher into table of contents for shard transfer.
-    pub fn with_shard_transfer_dispatcher(&self, dispatcher: Dispatcher) {
+    pub fn with_shard_transfer_dispatcher(&self, dispatcher: ShardTransferDispatcher) {
         self.shard_transfer_dispatcher.lock().replace(dispatcher);
     }
 }

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -5,6 +5,7 @@ mod locks;
 mod point_ops;
 mod snapshots;
 mod temp_directories;
+pub mod transfer;
 
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,22 +1,15 @@
-use crate::content_manager::consensus::operation_sender::OperationSender;
+use collection::operations::types::{CollectionError, CollectionResult};
+use collection::shards::transfer::ShardTransferConsensus;
 
-/// Interface to consensus for shard transfer operations.
-#[derive(Clone)]
-pub struct ShardTransferConsensus {
-    // Will be used later for shard transfer to propose consensus updates
-    _consensus_proposal_sender: Option<OperationSender>,
-}
+use crate::dispatcher::Dispatcher;
 
-impl ShardTransferConsensus {
-    pub fn new(consensus_proposal_sender: Option<OperationSender>) -> Self {
-        Self {
-            _consensus_proposal_sender: consensus_proposal_sender,
-        }
-    }
-}
-
-impl collection::shards::transfer::ShardTransferConsensus for ShardTransferConsensus {
-    fn consensus_state(&self) -> (usize, usize) {
-        todo!()
+impl ShardTransferConsensus for Dispatcher {
+    fn consensus_commit_term(&self) -> CollectionResult<(u64, u64)> {
+        self.consensus_state()
+            .map(|consensus| {
+                let state = consensus.hard_state();
+                (state.commit, state.term)
+            })
+            .ok_or_else(|| CollectionError::service_error("Consensus is not available"))
     }
 }

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,15 +1,28 @@
-use collection::operations::types::{CollectionError, CollectionResult};
+use std::sync::Weak;
+
 use collection::shards::transfer::ShardTransferConsensus;
 
-use crate::dispatcher::Dispatcher;
+use super::TableOfContent;
+use crate::content_manager::consensus_manager::ConsensusStateRef;
 
-impl ShardTransferConsensus for Dispatcher {
-    fn consensus_commit_term(&self) -> CollectionResult<(u64, u64)> {
-        self.consensus_state()
-            .map(|consensus| {
-                let state = consensus.hard_state();
-                (state.commit, state.term)
-            })
-            .ok_or_else(|| CollectionError::service_error("Consensus is not available"))
+#[derive(Clone)]
+pub struct ShardTransferDispatcher {
+    _toc: Weak<TableOfContent>,
+    consensus_state: ConsensusStateRef,
+}
+
+impl ShardTransferDispatcher {
+    pub fn new(toc: Weak<TableOfContent>, consensus_state: ConsensusStateRef) -> Self {
+        Self {
+            _toc: toc,
+            consensus_state,
+        }
+    }
+}
+
+impl ShardTransferConsensus for ShardTransferDispatcher {
+    fn consensus_commit_term(&self) -> (u64, u64) {
+        let state = self.consensus_state.hard_state();
+        (state.commit, state.term)
     }
 }

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,0 +1,22 @@
+use crate::content_manager::consensus::operation_sender::OperationSender;
+
+/// Interface to consensus for shard transfer operations.
+#[derive(Clone)]
+pub struct ShardTransferConsensus {
+    // Will be used later for shard transfer to propose consensus updates
+    _consensus_proposal_sender: Option<OperationSender>,
+}
+
+impl ShardTransferConsensus {
+    pub fn new(consensus_proposal_sender: Option<OperationSender>) -> Self {
+        Self {
+            _consensus_proposal_sender: consensus_proposal_sender,
+        }
+    }
+}
+
+impl collection::shards::transfer::ShardTransferConsensus for ShardTransferConsensus {
+    fn consensus_state(&self) -> (usize, usize) {
+        todo!()
+    }
+}

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -7,6 +7,11 @@ use crate::content_manager::consensus_manager::ConsensusStateRef;
 
 #[derive(Clone)]
 pub struct ShardTransferDispatcher {
+    /// Reference to table of contents
+    ///
+    /// This dispatcher is stored inside the table of contents after construction. It therefore
+    /// uses a weak reference to avoid a reference cycle which would prevent dropping the table of
+    /// contents on exit.
     _toc: Weak<TableOfContent>,
     consensus_state: ConsensusStateRef,
 }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -11,6 +11,7 @@ use crate::{
     TableOfContent,
 };
 
+#[derive(Clone)]
 pub struct Dispatcher {
     toc: Arc<TableOfContent>,
     consensus_state: Option<ConsensusStateRef>,
@@ -145,14 +146,5 @@ impl Deref for Dispatcher {
 
     fn deref(&self) -> &Self::Target {
         self.toc.deref()
-    }
-}
-
-impl Clone for Dispatcher {
-    fn clone(&self) -> Self {
-        Self {
-            toc: self.toc.clone(),
-            consensus_state: self.consensus_state.clone(),
-        }
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1163,6 +1163,7 @@ mod tests {
             ChannelService::new(settings.service.http_port),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),
+            None,
         );
         let toc_arc = Arc::new(toc);
         let storage_path = toc_arc.storage_path();

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1163,7 +1163,6 @@ mod tests {
             ChannelService::new(settings.service.http_port),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),
-            None,
         );
         let toc_arc = Arc::new(toc);
         let storage_path = toc_arc.storage_path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
 use storage::content_manager::consensus::persistent::Persistent;
 use storage::content_manager::consensus_manager::{ConsensusManager, ConsensusStateRef};
-use storage::content_manager::toc::transfer::ShardTransferConsensus;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 #[cfg(not(target_env = "msvc"))]
@@ -197,16 +196,13 @@ fn main() -> anyhow::Result<()> {
     // Create a signal sender and receiver. It is used to communicate with the consensus thread.
     let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
 
-    // We don't need sender for the single-node mode
-    let mut propose_operation_sender = None;
-    let mut shard_transfer_consensus = None;
-    if settings.cluster.enabled {
+    let propose_operation_sender = if settings.cluster.enabled {
         // High-level channel which could be used to send User-space consensus operations
-        propose_operation_sender.replace(OperationSender::new(propose_sender));
-        shard_transfer_consensus.replace(ShardTransferConsensus::new(
-            propose_operation_sender.clone(),
-        ));
-    }
+        Some(OperationSender::new(propose_sender))
+    } else {
+        // We don't need sender for the single-node mode
+        None
+    };
 
     // Channel service is used to manage connections between peers.
     // It allocates required number of channels and manages proper reconnection handling
@@ -239,7 +235,6 @@ fn main() -> anyhow::Result<()> {
         channel_service.clone(),
         persistent_consensus_state.this_peer_id(),
         propose_operation_sender.clone(),
-        shard_transfer_consensus,
     );
 
     toc.clear_all_tmp_directories()?;
@@ -272,6 +267,8 @@ fn main() -> anyhow::Result<()> {
         let is_new_deployment = consensus_state.is_new_deployment();
 
         dispatcher = dispatcher.with_consensus(consensus_state.clone());
+
+        toc_arc.with_shard_transfer_dispatcher(dispatcher.clone());
 
         let dispatcher_arc = Arc::new(dispatcher);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
 use storage::content_manager::consensus::persistent::Persistent;
 use storage::content_manager::consensus_manager::{ConsensusManager, ConsensusStateRef};
+use storage::content_manager::toc::transfer::ShardTransferDispatcher;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 #[cfg(not(target_env = "msvc"))]
@@ -268,7 +269,9 @@ fn main() -> anyhow::Result<()> {
 
         dispatcher = dispatcher.with_consensus(consensus_state.clone());
 
-        toc_arc.with_shard_transfer_dispatcher(dispatcher.clone());
+        let shard_transfer_dispatcher =
+            ShardTransferDispatcher::new(Arc::downgrade(&toc_arc), consensus_state.clone());
+        toc_arc.with_shard_transfer_dispatcher(shard_transfer_dispatcher);
 
         let dispatcher_arc = Arc::new(dispatcher);
 


### PR DESCRIPTION
Tracked in https://github.com/qdrant/qdrant/issues/2432.

Merges into https://github.com/qdrant/qdrant/pull/2467.

Adds a consensus interface as trait to be passed into shard transfer. This gives the shard transfer logic access to consensus operations through specialized functions. This is required for shard snapshot transfer.

This PR simply defines the interface (trait) and brings it from our table of contents up to our shard transfer logic. For this I've repurposed `Dispatcher` as it gives access to the consensus proposal channel and the current consensus state.

The implementation is a bit hacky, but it seems to be the best we can do. I've attempted some big refactoring operations but these failed. The other option to achieve this is to merge `storage` and `collection` together, which I like even less.
I suggest to merge it like this. We can look into improving it later, when the shard snapshot transfer feature is complete.

Will merge into https://github.com/qdrant/qdrant/pull/2467 as it requires these changes for approval. The next PR will integrate this change.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?