### PR TITLE
Synchronize consensus across all nodes for shard snapshot transfer

### DIFF
--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -53,6 +53,7 @@ impl<T: Serialize + Default + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     /// Wait for a condition on data to be true.
     ///
     /// Returns `true` if condition is true, `false` if timed out.
+    #[must_use]
     pub fn wait_for<F>(&self, check: F, timeout: Duration) -> bool
     where
         F: Fn(&T) -> bool,

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -1,8 +1,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
+use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
+use api::grpc::qdrant::WaitOnConsensusCommitRequest;
 use api::grpc::transport_channel_pool::TransportChannelPool;
-use tonic::transport::Uri;
+use futures::future::try_join_all;
+use futures::Future;
+use tonic::transport::{Channel, Uri};
+use tonic::Status;
 use url::Url;
 
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -32,6 +38,103 @@ impl ChannelService {
         if let Some(uri) = removed {
             self.channel_pool.drop_pool(&uri).await;
         }
+    }
+
+    /// Wait until all other known peers reach the given commit
+    ///
+    /// # Errors
+    ///
+    /// This errors if:
+    /// - any of the peers is not on the same term
+    /// - waiting takes longer than the specified timeout
+    /// - any of the peers cannot be reached
+    pub async fn await_commit_on_all_peers(
+        &self,
+        this_peer_id: PeerId,
+        commit: u64,
+        term: u64,
+        timeout: Duration,
+    ) -> Result<(), CollectionError> {
+        let requests = self
+            .id_to_address
+            .read()
+            .keys()
+            .filter(|id| **id != this_peer_id)
+            // The collective timeout at the bottom of this function handles actually timing out.
+            // Since an explicit timeout must be given here as well, it is multiplied by two to
+            // give the collective timeout some space.
+            .map(|peer_id| self.await_commit_on_peer(*peer_id, commit, term, timeout * 2))
+            .collect::<Vec<_>>();
+        let responses = try_join_all(requests);
+
+        // Handle requests with timeout
+        tokio::time::timeout(timeout, responses)
+            .await
+            .map(|_| ())
+            .map_err(|_elapsed| CollectionError::Timeout {
+                description: "Failed to wait for consensus commit on all peers, timed out.".into(),
+            })
+    }
+
+    /// Wait until the given peer reaches the given commit
+    ///
+    /// # Errors
+    ///
+    /// This errors if the given peer is on a different term. Also errors if the peer cannot be reached.
+    async fn await_commit_on_peer(
+        &self,
+        peer_id: PeerId,
+        commit: u64,
+        term: u64,
+        timeout: Duration,
+    ) -> Result<(), CollectionError> {
+        let response = self
+            .with_qdrant_client(peer_id, |mut client| async move {
+                let request = WaitOnConsensusCommitRequest {
+                    commit: commit as i64,
+                    term: term as i64,
+                    timeout: timeout.as_secs() as i64,
+                };
+                client
+                    .wait_on_consensus_commit(tonic::Request::new(request))
+                    .await
+            })
+            .await
+            .map_err(|err| {
+                CollectionError::service_error(format!(
+                    "Failed to wait for consensus commit on peer {peer_id}: {err}"
+                ))
+            })?
+            .into_inner();
+
+        // Create error if wait request failed
+        if !response.ok {
+            return Err(CollectionError::service_error(format!(
+                "Failed to wait for consensus commit on peer {peer_id}, has diverged commit/term or timed out."
+            )));
+        }
+        Ok(())
+    }
+
+    async fn with_qdrant_client<T, O: Future<Output = Result<T, Status>>>(
+        &self,
+        peer_id: PeerId,
+        f: impl Fn(QdrantInternalClient<Channel>) -> O,
+    ) -> Result<T, CollectionError> {
+        let address = self
+            .id_to_address
+            .read()
+            .get(&peer_id)
+            .ok_or_else(|| CollectionError::service_error("Address for peer ID is not found."))?
+            .clone();
+        self.channel_pool
+            .with_channel(&address, |channel| {
+                let client = QdrantInternalClient::new(channel);
+                let client = client.max_decoding_message_size(usize::MAX);
+                f(client)
+            })
+            .await
+            .map_err(Into::into)
     }
 
     /// Get the REST address for the current peer.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -335,6 +335,24 @@ impl ShardReplicaSet {
             .await
     }
 
+    /// Wait for a local shard to be in `Partial` state
+    ///
+    /// Uses a blocking thread internally.
+    ///
+    /// Returns `true` if initialized, `false` if timed out.
+    pub async fn wait_for_local_partial(&self, timeout: Duration) -> CollectionResult<bool> {
+        self.wait_for(
+            |replica_set_state| {
+                matches!(
+                    replica_set_state.get_peer_state(&replica_set_state.this_peer_id),
+                    Some(ReplicaState::Partial)
+                )
+            },
+            timeout,
+        )
+        .await
+    }
+
     /// Wait for a replica set state condition to be true.
     ///
     /// Uses a blocking thread internally.

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,10 +1,40 @@
+use async_trait::async_trait;
+use common::defaults;
+
+use super::channel_service::ChannelService;
+use super::shard::PeerId;
+use crate::operations::types::CollectionResult;
+
 pub mod shard_transfer;
 pub mod transfer_tasks_pool;
 
 /// Interface to consensus for shard transfer operations.
+#[async_trait]
 pub trait ShardTransferConsensus: Send + Sync {
     /// Get the current consensus commit and term state.
     ///
     /// Returns `(commit, term)`.
     fn consensus_commit_term(&self) -> (u64, u64);
+
+    /// Wait for all other peers to reach the current consensus
+    ///
+    /// This will take the current consensus state of this node. It then explicitly awaits on all
+    /// other nodes to reach this consensus state.
+    ///
+    /// # Errors
+    ///
+    /// This errors if:
+    /// - any of the peers is not on the same term
+    /// - waiting takes longer than the specified timeout
+    /// - any of the peers cannot be reached
+    async fn await_consensus_sync(
+        &self,
+        this_peer_id: PeerId,
+        channel_service: &ChannelService,
+    ) -> CollectionResult<()> {
+        let (commit, term) = self.consensus_commit_term();
+        channel_service
+            .await_commit_on_all_peers(this_peer_id, commit, term, defaults::CONSENSUS_META_OP_WAIT)
+            .await
+    }
 }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -288,6 +288,11 @@ async fn await_consensus_sync(
     channel_service: &ChannelService,
     this_peer_id: PeerId,
 ) {
+    let peer_count = channel_service.id_to_address.read().len().saturating_sub(1);
+    if peer_count == 0 {
+        return;
+    }
+
     let sync_consensus = async {
         let await_result = consensus
             .await_consensus_sync(this_peer_id, channel_service)
@@ -300,7 +305,7 @@ async fn await_consensus_sync(
     let timeout = sleep(defaults::CONSENSUS_META_OP_WAIT);
 
     log::trace!(
-        "Waiting on all peers to reach consensus before finalizing shard snapshot transfer..."
+        "Waiting on {peer_count} peer(s) to reach consensus before finalizing shard snapshot transfer..."
     );
     tokio::select! {
         Ok(_) = sync_consensus => {

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -266,10 +266,10 @@ async fn transfer_snapshot(
         log::trace!("Transfer all queue proxy updates and transform into forward proxy");
         replica_set.queue_proxy_into_forward_proxy().await?;
 
-        // Wait for local shard to reach partial state
+        // Wait for remote shard to reach partial state in our replica set
         log::trace!("Wait for local shard to reach Partial state");
         replica_set
-            .wait_for_local_partial(defaults::CONSENSUS_META_OP_WAIT)
+            .wait_for_partial(transfer_config.to, defaults::CONSENSUS_META_OP_WAIT)
             .await
             .map_err(|err| {
                 CollectionError::service_error(format!(

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -612,8 +612,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 return true;
             }
 
-            // Fail if on a different term
-            let is_fail = state.term != term;
+            // Fail if on a newer term
+            let is_fail = state.term > term;
             if is_fail {
                 return false;
             }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -589,17 +589,16 @@ impl<C: CollectionContainer> ConsensusManager<C> {
 
     /// Wait and block until consensus reaches a `commit` and `term`
     ///
-    /// # Returns
+    /// # Errors
     ///
-    /// Returns `true` if successful.
-    /// Returns `false` on failure, if we have diverged commit/term for example.
+    /// Returns an error if we have diverged commit/term for example.
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,
         term: u64,
         consensus_tick: Duration,
         timeout: Duration,
-    ) -> bool {
+    ) -> Result<(), ()> {
         let start = Instant::now();
 
         // TODO: naive approach with spinlock for waiting on commit/term, find better way
@@ -609,20 +608,20 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             // Okay if on the same term and have at least the specified commit
             let is_ok = state.term == term && state.commit >= commit;
             if is_ok {
-                return true;
+                return Ok(());
             }
 
             // Fail if on a newer term
             let is_fail = state.term > term;
             if is_fail {
-                return false;
+                return Err(());
             }
 
             tokio::time::sleep(consensus_tick).await
         }
 
         // Fail on timeout
-        false
+        Err(())
     }
 
     /// Send operation to the consensus thread and listen for the result.

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -14,10 +14,7 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
 
-use api::grpc::qdrant::qdrant_internal_client::QdrantInternalClient;
-use api::grpc::qdrant::WaitOnConsensusCommitRequest;
 use collection::collection::{Collection, RequestShardTransfer};
 use collection::config::{default_replication_factor, CollectionConfig};
 use collection::operations::types::*;
@@ -26,13 +23,9 @@ use collection::shards::replica_set;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::telemetry::CollectionTelemetry;
-use futures::future::try_join_all;
-use futures::Future;
 use segment::common::cpu::get_num_cpus;
 use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, RwLock, RwLockReadGuard, Semaphore};
-use tonic::transport::Channel;
-use tonic::Status;
 
 use self::transfer::ShardTransferDispatcher;
 use crate::content_manager::alias_mapping::AliasPersistence;
@@ -41,7 +34,7 @@ use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
-use crate::types::{PeerAddressById, StorageConfig};
+use crate::types::StorageConfig;
 use crate::ConsensusOperations;
 
 pub const ALIASES_PATH: &str = "aliases";
@@ -526,107 +519,6 @@ impl TableOfContent {
         Path::new(&self.storage_config.storage_path)
             .join(COLLECTIONS_DIR)
             .join(collection_name)
-    }
-
-    /// Wait until all other known peers reach the given commit
-    ///
-    /// # Errors
-    ///
-    /// This errors if:
-    /// - any of the peers is not on the same term
-    /// - waiting takes longer than the specified timeout
-    /// - any of the peers cannot be reached
-    pub async fn await_commit_on_all_peers(
-        &self,
-        commit: u64,
-        term: u64,
-        timeout: Duration,
-    ) -> Result<(), StorageError> {
-        let requests = self
-            .peer_address_by_id()
-            .keys()
-            .filter(|id| **id != self.this_peer_id)
-            // The collective timeout at the bottom of this function handles actually timing out.
-            // Since an explicit timeout must be given here as well, it is multiplied by two to
-            // give the collective timeout some space.
-            .map(|peer_id| self.await_commit_on_peer(*peer_id, commit, term, timeout * 2))
-            .collect::<Vec<_>>();
-        let responses = try_join_all(requests);
-
-        // Handle requests with timeout
-        tokio::time::timeout(timeout, responses)
-            .await
-            .map(|_| ())
-            .map_err(|_elapsed| StorageError::Timeout {
-                description: "Failed to wait for consensus commit on all peers, timed out.".into(),
-            })
-    }
-
-    fn peer_address_by_id(&self) -> PeerAddressById {
-        self.channel_service.id_to_address.read().clone()
-    }
-
-    /// Wait until the given peer reaches the given commit
-    ///
-    /// # Errors
-    ///
-    /// This errors if the given peer is on a different term. Also errors if the peer cannot be reached.
-    async fn await_commit_on_peer(
-        &self,
-        peer_id: PeerId,
-        commit: u64,
-        term: u64,
-        timeout: Duration,
-    ) -> Result<(), StorageError> {
-        let response = self
-            .with_qdrant_client(peer_id, |mut client| async move {
-                let request = WaitOnConsensusCommitRequest {
-                    commit: commit as i64,
-                    term: term as i64,
-                    timeout: timeout.as_secs() as i64,
-                };
-                client
-                    .wait_on_consensus_commit(tonic::Request::new(request))
-                    .await
-            })
-            .await
-            .map_err(|err| {
-                StorageError::service_error(format!(
-                    "Failed to wait for consensus commit on peer {peer_id}: {err}"
-                ))
-            })?
-            .into_inner();
-
-        // Create error if wait request failed
-        if !response.ok {
-            return Err(StorageError::service_error(format!(
-                "Failed to wait for consensus commit on peer {peer_id}, has diverged commit/term or timed out."
-            )));
-        }
-        Ok(())
-    }
-
-    async fn with_qdrant_client<T, O: Future<Output = Result<T, Status>>>(
-        &self,
-        peer_id: PeerId,
-        f: impl Fn(QdrantInternalClient<Channel>) -> O,
-    ) -> Result<T, CollectionError> {
-        let address = self
-            .channel_service
-            .id_to_address
-            .read()
-            .get(&peer_id)
-            .ok_or_else(|| CollectionError::service_error("Address for peer ID is not found."))?
-            .clone();
-        self.channel_service
-            .channel_pool
-            .with_channel(&address, |channel| {
-                let client = QdrantInternalClient::new(channel);
-                let client = client.max_decoding_message_size(usize::MAX);
-                f(client)
-            })
-            .await
-            .map_err(Into::into)
     }
 
     /// Insert dispatcher into table of contents for shard transfer.

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,5 +1,6 @@
 use std::sync::Weak;
 
+use async_trait::async_trait;
 use collection::shards::transfer::ShardTransferConsensus;
 
 use super::TableOfContent;
@@ -25,6 +26,7 @@ impl ShardTransferDispatcher {
     }
 }
 
+#[async_trait]
 impl ShardTransferConsensus for ShardTransferDispatcher {
     fn consensus_commit_term(&self) -> (u64, u64) {
         let state = self.consensus_state.hard_state();

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -116,7 +116,8 @@ impl QdrantInternal for QdrantInternalService {
         let ok = self
             .consensus_state
             .wait_for_consensus_commit(commit, term, consensus_tick, timeout)
-            .await;
+            .await
+            .is_ok();
         Ok(Response::new(WaitOnConsensusCommitResponse { ok }))
     }
 }


### PR DESCRIPTION
Tracked in https://github.com/qdrant/qdrant/issues/2432.

Merges into https://github.com/qdrant/qdrant/pull/2467.

Adds a call to the shard snapshot transfer logic to synchronize all peers with the consensus state of the current node. It is one of the required synchronization steps for shard snapshot transfer.

More specifically, this synchronization will happen right before the shard snapshot transfer is finalized. We do that to make sure all nodes have at least reached the `Partial` state for the shard. That way we are sure that all nodes will include the shard for operations. This logic awaits on all nodes explicitly and falls back to a 10 second timeout on failure. This timeout matches the consensus timeout.

It also:
- moves methods for awaiting a consensus commit from ToC into the channel service, seems to be a better place
- fixes error handling for awaiting a consensus commit on all peers, some errors were ignored before
- fixes wait conditions for consensus, see comment below
- waits for replica set to reach partial state for the remote peer
- defines some TODOs in the shard snapshot transfer function to clearly define what's left to do in #2432 to be approved.

I've manually tested this locally.

A future PR will implement setting the shard state from `PartialSnapshot` to `Partial`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?