### PR TITLE
Vector index update function

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -770,4 +770,8 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             .or_else(|| self.graph.as_ref().map(|graph| graph.num_points()))
             .unwrap_or(0)
     }
+
+    fn update_vector(&mut self, _id: PointOffsetType) -> OperationResult<()> {
+        Err(OperationError::service_error("Cannot update HNSW index"))
+    }
 }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -293,6 +293,10 @@ impl VectorIndex for PlainIndex {
     fn indexed_vector_count(&self) -> usize {
         0
     }
+
+    fn update_vector(&mut self, _id: PointOffsetType) -> OperationResult<()> {
+        Ok(())
+    }
 }
 
 pub struct PlainFilterContext<'a> {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
-use common::types::ScoredPointOffset;
+use common::types::{PointOffsetType, ScoredPointOffset};
 
 use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use super::hnsw_index::hnsw::HNSWIndex;
@@ -32,6 +32,9 @@ pub trait VectorIndex {
 
     /// The number of indexed vectors, currently accessible
     fn indexed_vector_count(&self) -> usize;
+
+    /// Update index for a single vector
+    fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()>;
 }
 
 pub enum VectorIndexEnum {
@@ -99,6 +102,14 @@ impl VectorIndex for VectorIndexEnum {
             Self::Plain(index) => index.indexed_vector_count(),
             Self::HnswRam(index) => index.indexed_vector_count(),
             Self::HnswMmap(index) => index.indexed_vector_count(),
+        }
+    }
+
+    fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        match self {
+            Self::Plain(index) => index.update_vector(id),
+            Self::HnswRam(index) => index.update_vector(id),
+            Self::HnswMmap(index) => index.update_vector(id),
         }
     }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -138,6 +138,8 @@ impl Segment {
                 Some(vector) => {
                     let mut vector_storage = vector_data.vector_storage.borrow_mut();
                     vector_storage.insert_vector(internal_id, vector.into())?;
+                    let mut vector_index = vector_data.vector_index.borrow_mut();
+                    vector_index.update_vector(internal_id)?;
                 }
                 None => {
                     // No vector provided, so we remove it
@@ -175,6 +177,10 @@ impl Segment {
                 .vector_storage
                 .borrow_mut()
                 .insert_vector(internal_id, new_vector.as_ref().into())?;
+            vector_data
+                .vector_index
+                .borrow_mut()
+                .update_vector(internal_id)?;
         }
         Ok(())
     }
@@ -195,15 +201,18 @@ impl Segment {
         for (vector_name, vector_data) in self.vector_data.iter_mut() {
             let vector_opt = vectors.get(vector_name);
             let mut vector_storage = vector_data.vector_storage.borrow_mut();
+            let mut vector_index = vector_data.vector_index.borrow_mut();
             match vector_opt {
                 None => {
                     let dim = vector_storage.vector_dim();
                     let vector = vec![1.0; dim];
                     vector_storage.insert_vector(new_index, vector.as_slice().into())?;
                     vector_storage.delete_vector(new_index)?;
+                    vector_index.update_vector(new_index)?;
                 }
                 Some(vec) => {
                     vector_storage.insert_vector(new_index, vec.into())?;
+                    vector_index.update_vector(new_index)?;
                 }
             }
         }


### PR DESCRIPTION
This PR is a part of Sparse Vector index integration. The inverted index can be updated in runtime that's why we have to provide update mechanism for the vector index when possible.
HNSW index cannot be updated and returns error, in non-appendable segment update should never be called. Plain index does nothing.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
