### PR TITLE
Propagate vector type into QueryVector

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1341,7 +1341,7 @@ impl From<QueryEnum> for QueryVector {
     fn from(query: QueryEnum) -> Self {
         match query {
             QueryEnum::Nearest(named) => QueryVector::Nearest(named.into()),
-            QueryEnum::RecommendBestScore(named) => QueryVector::Recommend(named.query),
+            QueryEnum::RecommendBestScore(named) => QueryVector::Recommend(named.query.into()),
         }
     }
 }

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -48,15 +48,19 @@ fn check_query_vector(
         QueryVector::Nearest(vector) => {
             check_vector_against_config(vector.to_vec_ref().into(), vector_config)?
         }
-        QueryVector::Recommend(reco_query) => reco_query
-            .flat_iter()
-            .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
-        QueryVector::Discovery(discovery_query) => discovery_query
-            .flat_iter()
-            .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
-        QueryVector::Context(discovery_context_query) => discovery_context_query
-            .flat_iter()
-            .try_for_each(|vector| check_vector_against_config(vector, vector_config))?,
+        QueryVector::Recommend(reco_query) => reco_query.flat_iter().try_for_each(|vector| {
+            check_vector_against_config(vector.to_vec_ref().into(), vector_config)
+        })?,
+        QueryVector::Discovery(discovery_query) => {
+            discovery_query.flat_iter().try_for_each(|vector| {
+                check_vector_against_config(vector.to_vec_ref().into(), vector_config)
+            })?
+        }
+        QueryVector::Context(discovery_context_query) => {
+            discovery_context_query.flat_iter().try_for_each(|vector| {
+                check_vector_against_config(vector.to_vec_ref().into(), vector_config)
+            })?
+        }
     }
 
     Ok(())

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -334,9 +334,9 @@ impl Named for NamedRecoQuery {
 #[derive(Debug, Clone)]
 pub enum QueryVector {
     Nearest(Vector),
-    Recommend(RecoQuery<VectorType>),
-    Discovery(DiscoveryQuery<VectorType>),
-    Context(ContextQuery<VectorType>),
+    Recommend(RecoQuery<Vector>),
+    Discovery(DiscoveryQuery<Vector>),
+    Context(ContextQuery<Vector>),
 }
 
 impl From<VectorType> for QueryVector {

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -4,9 +4,12 @@ use bitvec::prelude::BitSlice;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
+use super::query::context_query::ContextQuery;
+use super::query::discovery_query::DiscoveryQuery;
+use super::query::reco_query::RecoQuery;
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, Vector};
+use crate::data_types::vectors::{QueryVector, Vector, VectorType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::types::Distance;
@@ -279,6 +282,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 }
             }
             QueryVector::Recommend(reco_query) => {
+                let reco_query: RecoQuery<VectorType> = reco_query.into();
                 let query_scorer = CustomQueryScorer::<TMetric, _, _>::new(reco_query, storage);
                 Box::new(AsyncRawScorerImpl::new(
                     points_count,
@@ -290,6 +294,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 ))
             }
             QueryVector::Discovery(discovery_query) => {
+                let discovery_query: DiscoveryQuery<VectorType> = discovery_query.into();
                 let query_scorer =
                     CustomQueryScorer::<TMetric, _, _>::new(discovery_query, storage);
                 Box::new(AsyncRawScorerImpl::new(
@@ -302,6 +307,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 ))
             }
             QueryVector::Context(context_query) => {
+                let context_query: ContextQuery<VectorType> = context_query.into();
                 let query_scorer = CustomQueryScorer::<TMetric, _, _>::new(context_query, storage);
                 Box::new(AsyncRawScorerImpl::new(
                     points_count,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -6,8 +6,11 @@ use quantization::EncodedVectors;
 use super::quantized_custom_query_scorer::QuantizedCustomQueryScorer;
 use super::quantized_query_scorer::QuantizedQueryScorer;
 use super::quantized_vectors::QuantizedVectorStorage;
-use crate::data_types::vectors::QueryVector;
+use crate::data_types::vectors::{QueryVector, VectorType};
 use crate::types::Distance;
+use crate::vector_storage::query::context_query::ContextQuery;
+use crate::vector_storage::query::discovery_query::DiscoveryQuery;
+use crate::vector_storage::query::reco_query::RecoQuery;
 use crate::vector_storage::{raw_scorer_from_query_scorer, RawScorer};
 
 pub(super) struct QuantizedScorerBuilder<'a> {
@@ -70,21 +73,21 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Recommend(reco_query) => {
+                let reco_query: RecoQuery<VectorType> = reco_query.into();
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(reco_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Discovery(discovery_query) => {
+                let discovery_query: DiscoveryQuery<VectorType> = discovery_query.into();
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(discovery_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
-            QueryVector::Context(discovery_context_query) => {
-                let query_scorer = QuantizedCustomQueryScorer::new(
-                    discovery_context_query,
-                    quantized_storage,
-                    *distance,
-                );
+            QueryVector::Context(context_query) => {
+                let context_query: ContextQuery<VectorType> = context_query.into();
+                let query_scorer =
+                    QuantizedCustomQueryScorer::new(context_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
         }

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -2,7 +2,7 @@ use common::types::ScoreType;
 
 use super::discovery_query::DiscoveryPair;
 use super::{Query, TransformInto};
-use crate::data_types::vectors::{QueryVector, VectorType};
+use crate::data_types::vectors::{QueryVector, Vector, VectorType};
 
 impl<T> DiscoveryPair<T> {
     /// In the first stage of discovery search, the objective is to get the best entry point
@@ -71,9 +71,15 @@ impl<T> Query<T> for ContextQuery<T> {
     }
 }
 
-impl From<ContextQuery<VectorType>> for QueryVector {
-    fn from(query: ContextQuery<VectorType>) -> Self {
+impl From<ContextQuery<Vector>> for QueryVector {
+    fn from(query: ContextQuery<Vector>) -> Self {
         QueryVector::Context(query)
+    }
+}
+
+impl From<ContextQuery<Vector>> for ContextQuery<VectorType> {
+    fn from(query: ContextQuery<Vector>) -> Self {
+        query.transform(|v| v.into())
     }
 }
 

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -2,7 +2,7 @@ use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 
 use super::{Query, TransformInto};
-use crate::data_types::vectors::{QueryVector, VectorType};
+use crate::data_types::vectors::{QueryVector, Vector, VectorType};
 
 type RankType = i32;
 
@@ -99,9 +99,15 @@ impl<T> Query<T> for DiscoveryQuery<T> {
     }
 }
 
-impl From<DiscoveryQuery<VectorType>> for QueryVector {
-    fn from(query: DiscoveryQuery<VectorType>) -> Self {
+impl From<DiscoveryQuery<Vector>> for QueryVector {
+    fn from(query: DiscoveryQuery<Vector>) -> Self {
         QueryVector::Discovery(query)
+    }
+}
+
+impl From<DiscoveryQuery<Vector>> for DiscoveryQuery<VectorType> {
+    fn from(query: DiscoveryQuery<Vector>) -> Self {
+        query.transform(|v| v.into())
     }
 }
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -1,7 +1,7 @@
 use common::types::ScoreType;
 
 use super::{Query, TransformInto};
-use crate::data_types::vectors::{QueryVector, VectorType};
+use crate::data_types::vectors::{QueryVector, Vector, VectorType};
 
 #[derive(Debug, Clone)]
 pub struct RecoQuery<T> {
@@ -67,9 +67,21 @@ fn merge_similarities(
     }
 }
 
-impl From<RecoQuery<VectorType>> for QueryVector {
-    fn from(query: RecoQuery<VectorType>) -> Self {
+impl From<RecoQuery<Vector>> for QueryVector {
+    fn from(query: RecoQuery<Vector>) -> Self {
         QueryVector::Recommend(query)
+    }
+}
+
+impl From<RecoQuery<Vector>> for RecoQuery<VectorType> {
+    fn from(query: RecoQuery<Vector>) -> Self {
+        query.transform(|v| v.into())
+    }
+}
+
+impl From<RecoQuery<VectorType>> for RecoQuery<Vector> {
+    fn from(query: RecoQuery<VectorType>) -> Self {
+        query.transform(|v| v.into())
     }
 }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -3,9 +3,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use bitvec::prelude::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
+use super::query::context_query::ContextQuery;
+use super::query::discovery_query::DiscoveryQuery;
+use super::query::reco_query::RecoQuery;
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::{DenseVectorStorage, VectorStorageEnum};
-use crate::data_types::vectors::QueryVector;
+use crate::data_types::vectors::{QueryVector, VectorType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -166,24 +169,33 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             vec_deleted,
             is_stopped,
         ),
-        QueryVector::Recommend(reco_query) => raw_scorer_from_query_scorer(
-            CustomQueryScorer::<TMetric, _, _>::new(reco_query, vector_storage),
-            point_deleted,
-            vec_deleted,
-            is_stopped,
-        ),
-        QueryVector::Discovery(discovery_query) => raw_scorer_from_query_scorer(
-            CustomQueryScorer::<TMetric, _, _>::new(discovery_query, vector_storage),
-            point_deleted,
-            vec_deleted,
-            is_stopped,
-        ),
-        QueryVector::Context(discovery_context_query) => raw_scorer_from_query_scorer(
-            CustomQueryScorer::<TMetric, _, _>::new(discovery_context_query, vector_storage),
-            point_deleted,
-            vec_deleted,
-            is_stopped,
-        ),
+        QueryVector::Recommend(reco_query) => {
+            let reco_query: RecoQuery<VectorType> = reco_query.into();
+            raw_scorer_from_query_scorer(
+                CustomQueryScorer::<TMetric, _, _>::new(reco_query, vector_storage),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
+        QueryVector::Discovery(discovery_query) => {
+            let discovery_query: DiscoveryQuery<VectorType> = discovery_query.into();
+            raw_scorer_from_query_scorer(
+                CustomQueryScorer::<TMetric, _, _>::new(discovery_query, vector_storage),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
+        QueryVector::Context(context_query) => {
+            let context_query: ContextQuery<VectorType> = context_query.into();
+            raw_scorer_from_query_scorer(
+                CustomQueryScorer::<TMetric, _, _>::new(context_query, vector_storage),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -65,11 +65,11 @@ fn random_reco_query<R: Rng + ?Sized>(
     let num_negatives: usize = rnd.gen_range(0..MAX_EXAMPLES);
 
     let positives = (0..num_positives)
-        .map(|_| sampler.take(DIMS).collect())
+        .map(|_| sampler.take(DIMS).collect_vec().into())
         .collect_vec();
 
     let negatives = (0..num_negatives)
-        .map(|_| sampler.take(DIMS).collect())
+        .map(|_| sampler.take(DIMS).collect_vec().into())
         .collect_vec();
 
     RecoQuery::new(positives, negatives).into()
@@ -81,12 +81,12 @@ fn random_discovery_query<R: Rng + ?Sized>(
 ) -> QueryVector {
     let num_pairs: usize = rnd.gen_range(0..MAX_EXAMPLES);
 
-    let target = sampler.take(DIMS).collect();
+    let target = sampler.take(DIMS).collect_vec().into();
 
     let pairs = (0..num_pairs)
         .map(|_| {
-            let positive = sampler.take(DIMS).collect();
-            let negative = sampler.take(DIMS).collect();
+            let positive = sampler.take(DIMS).collect_vec().into();
+            let negative = sampler.take(DIMS).collect_vec().into();
             DiscoveryPair { positive, negative }
         })
         .collect_vec();
@@ -102,8 +102,8 @@ fn random_context_query<R: Rng + ?Sized>(
 
     let pairs = (0..num_pairs)
         .map(|_| {
-            let positive = sampler.take(DIMS).collect();
-            let negative = sampler.take(DIMS).collect();
+            let positive = sampler.take(DIMS).collect_vec().into();
+            let negative = sampler.take(DIMS).collect_vec().into();
             DiscoveryPair { positive, negative }
         })
         .collect_vec();


### PR DESCRIPTION
This PR is a part of sparse vector index integration.

This PR continues `Vector` type integration. Here all variants of `QueryVector` use `Vector` instead of `VectorType`.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
