### PR TITLE
Set `(Partial)Snapshot` states for shard snapshot transfer through consensus

### DIFF
--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -4,6 +4,7 @@ use common::defaults;
 use self::shard_transfer::ShardTransfer;
 use super::channel_service::ChannelService;
 use super::shard::PeerId;
+use super::CollectionId;
 use crate::operations::types::CollectionResult;
 
 pub mod shard_transfer;
@@ -17,7 +18,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     /// Returns `(commit, term)`.
     fn consensus_commit_term(&self) -> (u64, u64);
 
-    /// After snapshot recovery, switch shard to `Partial`
+    /// After snapshot recovery, propose to switch shard to `Partial`
     ///
     /// This is called after shard snapshot recovery has been completed on the remote. It submits a
     /// proposal to consensus to switch the the shard state from `PartialSnapshot` to `Partial`.
@@ -29,7 +30,7 @@ pub trait ShardTransferConsensus: Send + Sync {
     fn snapshot_recovered_switch_to_partial(
         &self,
         transfer_config: &ShardTransfer,
-        collection_name: String,
+        collection: CollectionId,
     ) -> CollectionResult<()>;
 
     /// Wait for all other peers to reach the current consensus

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use common::defaults;
 
+use self::shard_transfer::ShardTransfer;
 use super::channel_service::ChannelService;
 use super::shard::PeerId;
 use crate::operations::types::CollectionResult;
@@ -15,6 +16,21 @@ pub trait ShardTransferConsensus: Send + Sync {
     ///
     /// Returns `(commit, term)`.
     fn consensus_commit_term(&self) -> (u64, u64);
+
+    /// After snapshot recovery, switch shard to `Partial`
+    ///
+    /// This is called after shard snapshot recovery has been completed on the remote. It submits a
+    /// proposal to consensus to switch the the shard state from `PartialSnapshot` to `Partial`.
+    ///
+    /// # Warning
+    ///
+    /// This only submits a proposal to consensus. Calling this does not guarantee that consensus
+    /// will actually apply the operation across the cluster.
+    fn snapshot_recovered_switch_to_partial(
+        &self,
+        transfer_config: &ShardTransfer,
+        collection_name: String,
+    ) -> CollectionResult<()>;
 
     /// Wait for all other peers to reach the current consensus
     ///

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -1,14 +1,23 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use common::defaults;
 
 use self::shard_transfer::ShardTransfer;
 use super::channel_service::ChannelService;
+use super::replica_set::ShardReplicaSet;
 use super::shard::PeerId;
 use super::CollectionId;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionError, CollectionResult};
 
 pub mod shard_transfer;
 pub mod transfer_tasks_pool;
+
+/// Number of retries for confirming a consensus operation.
+const CONSENSUS_CONFIRM_RETRIES: usize = 3;
+
+/// Time after which confirming a consensus operation times out.
+const CONSENSUS_CONFIRM_TIMEOUT: Duration = defaults::CONSENSUS_META_OP_WAIT;
 
 /// Interface to consensus for shard transfer operations.
 #[async_trait]
@@ -30,8 +39,51 @@ pub trait ShardTransferConsensus: Send + Sync {
     fn snapshot_recovered_switch_to_partial(
         &self,
         transfer_config: &ShardTransfer,
-        collection: CollectionId,
+        collection_name: CollectionId,
     ) -> CollectionResult<()>;
+
+    /// After snapshot recovery, propose to switch shard to `Partial` and confirm locally
+    ///
+    /// This is called after shard snapshot recovery has been completed on the remote. It submits a
+    /// proposal to consensus to switch the the shard state from `PartialSnapshot` to `Partial`.
+    ///
+    /// This method also confirms consensus applied the operation before returning by asserting the
+    /// change is propagated locally. If it fails, it will be retried for up to
+    /// `CONSENSUS_CONFIRM_RETRIES` times.
+    async fn snapshot_recovered_switch_to_partial_confirm(
+        &self,
+        transfer_config: &ShardTransfer,
+        collection_name: &str,
+        replica_set: &ShardReplicaSet,
+    ) -> CollectionResult<()> {
+        for attempts in (0..CONSENSUS_CONFIRM_RETRIES).rev() {
+            // Propose consensus operation
+            let proposal = self
+                .snapshot_recovered_switch_to_partial(transfer_config, collection_name.to_string());
+            match proposal {
+                Ok(()) => {}
+                Err(err) if attempts > 0 => {
+                    log::error!("Failed to propose snapshot recovered operation to consensus, retrying: {err}");
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
+
+            // Confirm local shard reached partial state
+            let confirm = replica_set
+                .wait_for_partial(transfer_config.to, CONSENSUS_CONFIRM_TIMEOUT)
+                .await;
+            match confirm {
+                Ok(()) => return Ok(()),
+                Err(err) if attempts > 0 => log::error!("Failed to confirm snapshot recovered operation on consensus, retrying: {err}"),
+                Err(err) => return Err(CollectionError::service_error(format!(
+                    "Failed to confirm snapshot recovered operation on consensus after {CONSENSUS_CONFIRM_RETRIES} retries: {err}"
+                ))),
+            }
+        }
+
+        unreachable!();
+    }
 
     /// Wait for all other peers to reach the current consensus
     ///

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -179,6 +179,57 @@ async fn transfer_batches(
     Ok(())
 }
 
+/// Orchestrate shard snapshot transfer
+///
+/// This is called on the sender and will arrange all that is needed for the shard snapshot
+/// transfer process to a receiver.
+///
+/// The order of operations here is critical for correctness. Explicit synchronization across nodes
+/// is used to ensure data consistency.
+///
+/// Before this function, this has happened:
+///
+/// - An empty shard is initialized on the remote
+/// - Set the remote shard state to `PartialSnapshot`
+///   In `PartialSnapshot` state, the remote shard will ignore all operations and other nodes will
+///   prevent sending operations to it. This is critical not to modify the shard while it is being
+///   recovered from the snapshot.
+///
+/// During this function, this happens in order:
+///
+/// - Queue proxy local shard
+///   We queue all new operations to the shard for the remote. Once the remote is ready, we can
+///   transfer all these operations to it.
+/// - Create shard snapshot
+///   Snapshot the shard after the queue proxy is initialized. This snapshot will be used to get
+///   the shard into the same state on the remote.
+/// - Recover shard snapshot on remote
+///   Instruct the remote to download the snapshot from this node over HTTP, then recover it.
+/// - Set shard state to `Partial`
+///   After recovery, we set the shard state from `PartialSnapshot` to `Partial`. We
+///   propose an operation to consensus for this. Our logic explicitly confirms that consensus has
+///   accepted our proposal and will retry three times on failure.
+///   Setting the node from `PartialSnapshot` to `Partial` is critical. The remote will only
+///   receive and accept operations in this state.
+/// - Synchronize all nodes
+///   After confirming consensus approval, we must synchronize all nodes. We explicitly need to wait
+///   on all nodes for the consensus operation to be propagated. That way, we ensure we have a
+///   consistent replica set state across all nodes. Then, all nodes will have the `Partial` state,
+///   which makes the shard participate on all nodes.
+/// - Transfer queued updates to remote, transform into forward proxy
+///   Once the remote is in `Partial` state we can transfer all accumulated updates in the queue
+///   proxy to the remote. This ensures all operations reach the recovered shard on the remote to
+///   make it consistent again. When all updates are transferred, we transform the queue proxy into
+///   a forward proxy to start forwarding new updates to the remote right away.
+///   We transfer the queue and transform into a forward proxy right now so that we can catch any
+///   errors as early as possible. The forward proxy shard we end up with will not error again once
+///   we un-proxify.
+///
+/// After this function, the following will happen:
+///
+/// - The local shard is un-proxified
+/// - The shard transfer is finished
+/// - The remote shard state is set to `Active` through consensus
 #[allow(clippy::too_many_arguments)]
 async fn transfer_snapshot(
     transfer_config: ShardTransfer,
@@ -193,44 +244,40 @@ async fn transfer_snapshot(
     _stopped: Arc<AtomicBool>,
 ) -> CollectionResult<()> {
     let shard_holder_read = shard_holder.read().await;
-
     let local_rest_address = channel_service.current_rest_address(transfer_config.from)?;
 
     let transferring_shard = shard_holder_read.get_shard(&shard_id);
     let Some(replica_set) = transferring_shard else {
         return Err(CollectionError::service_error(format!(
-            "Skard {shard_id} cannot be queue proxied because it does not exist"
+            "Shard {shard_id} cannot be queue proxied because it does not exist"
         )));
     };
 
+    // Queue proxy local shard
     replica_set
         .queue_proxify_local(remote_shard.clone())
         .await?;
-
-    // Ensure we have configured a queue proxy
-    let is_queue_proxy = match shard_holder_read.get_shard(&shard_id) {
-        Some(shard_replica_set) => shard_replica_set.is_queue_proxy().await,
-        None => false,
-    };
-    if !is_queue_proxy {
-        return Err(CollectionError::service_error(format!(
-            "Shard {shard_id} is not a queue proxy shard, cannot do shard snapshot transfer",
-        )));
-    }
+    debug_assert!(
+        replica_set.is_queue_proxy().await,
+        "Local shard must be a queue proxy"
+    );
 
     // Create shard snapshot
+    log::trace!("Creating snapshot of shard {shard_id} for shard snapshot transfer...");
     let snapshot_description = shard_holder_read
         .create_shard_snapshot(snapshots_path, collection_name, shard_id, temp_dir)
         .await?;
 
-    // Select local shard snapshot download URL
+    // Recover shard snapshot on remote
     let mut shard_download_url = local_rest_address;
     shard_download_url.set_path(&format!(
         "/collections/{collection_name}/shards/{shard_id}/snapshots/{}",
         &snapshot_description.name,
     ));
-
-    // Instruct remote to download and recover shard snapshot
+    log::debug!(
+        "Transferring and recovering shard {shard_id} snapshot on peer {}...",
+        transfer_config.to
+    );
     remote_shard
         .recover_shard_snapshot_from_url(
             collection_name,
@@ -245,7 +292,7 @@ async fn transfer_snapshot(
             ))
         })?;
 
-    // Set shard state to partial through consensus and synchronize
+    // Set shard state to Partial
     log::debug!("Shard {shard_id} snapshot recovered on {} for snapshot transfer, switching into next stage through consensus...", transfer_config.to);
     consensus
         .snapshot_recovered_switch_to_partial_confirm(
@@ -259,31 +306,14 @@ async fn transfer_snapshot(
                 "Can't switch shard {shard_id} to Partial state after snapshot transfer: {err}"
             ))
         })?;
-    // TODO: optimize: we don't have to wait on all nodes to reach consensus, only wait for
-    // receiver node to get into partial state so that it can receive queue proxy operations
+
+    // Synchronize all nodes
+    // TODO: only the receiver must be parital here, can synchronize all nodes later
     await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
-    // Transfer all updates to remote shard and transform into forward proxy shard
-    // We do this right after the shard has been restored on the remote so that we can catch any
-    // errors early. The forward proxy shard we end up with will not error again once we unproxify.
+    // Transfer queued updates to remote, transform into forward proxy
     log::trace!("Transfer all queue proxy updates and transform into forward proxy");
     replica_set.queue_proxy_into_forward_proxy().await?;
-
-    // Wait for remote shard to reach partial state in our replica set
-    log::trace!("Wait for local shard to reach Partial state");
-    replica_set
-        .wait_for_partial(transfer_config.to, defaults::CONSENSUS_META_OP_WAIT)
-        .await
-        .map_err(|err| {
-            CollectionError::service_error(format!(
-                "Shard being transferred did not reach Partial state in time: {err}"
-            ))
-        })?;
-
-    // Synchronize, make sure all nodes have reached consensus before continuing and unproxying
-    // All other nodes must consider the shard state to be at least partial so that all nodes send
-    // operations to it.
-    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
     Ok(())
 }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -308,7 +308,7 @@ async fn transfer_snapshot(
         })?;
 
     // Synchronize all nodes
-    // TODO: only the receiver must be parital here, can synchronize all nodes later
+    // TODO: only the receiver must be partial here, can synchronize all nodes later
     await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
     // Transfer queued updates to remote, transform into forward proxy

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -248,7 +248,14 @@ async fn transfer_snapshot(
             ))
         })?;
 
-    // TODO: through consensus, set replica state to partial
+    // Set shard state to partial through consensus
+    consensus
+        .snapshot_recovered_switch_to_partial(&transfer_config, collection_name.into())
+        .map_err(|err| {
+            CollectionError::service_error(format!(
+                "Can't switch shard {shard_id} to Partial state after snapshot transfer: {err}"
+            ))
+        })?;
 
     // TODO: await other node to have reached partial state
 

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -23,8 +23,8 @@ use crate::shards::shard_holder::{LockedShardHolder, ShardHolder};
 use crate::shards::CollectionId;
 
 const TRANSFER_BATCH_SIZE: usize = 100;
-const RETRY_TIMEOUT: Duration = Duration::from_secs(1);
-pub const MAX_RETRY_COUNT: usize = 3;
+const RETRY_DELAY: Duration = Duration::from_secs(1);
+pub(crate) const MAX_RETRY_COUNT: usize = 3;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransfer {
@@ -740,7 +740,7 @@ where
                     transfer.to,
                     MAX_RETRY_COUNT - tries
                 );
-                let exp_timeout = RETRY_TIMEOUT * (MAX_RETRY_COUNT - tries) as u32;
+                let exp_timeout = RETRY_DELAY * (MAX_RETRY_COUNT - tries) as u32;
                 sleep(exp_timeout).await;
             }
         }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -196,19 +196,16 @@ async fn transfer_snapshot(
 
     let local_rest_address = channel_service.current_rest_address(transfer_config.from)?;
 
-    // Queue proxify local shard
-    {
-        let transferring_shard = shard_holder_read.get_shard(&shard_id);
-        let Some(replica_set) = transferring_shard else {
-            return Err(CollectionError::service_error(format!(
-                "Shard {shard_id} cannot be queue proxied because it does not exist"
-            )));
-        };
+    let transferring_shard = shard_holder_read.get_shard(&shard_id);
+    let Some(replica_set) = transferring_shard else {
+        return Err(CollectionError::service_error(format!(
+            "Skard {shard_id} cannot be queue proxied because it does not exist"
+        )));
+    };
 
-        replica_set
-            .queue_proxify_local(remote_shard.clone())
-            .await?;
-    }
+    replica_set
+        .queue_proxify_local(remote_shard.clone())
+        .await?;
 
     // Ensure we have configured a queue proxy
     let is_queue_proxy = match shard_holder_read.get_shard(&shard_id) {
@@ -247,13 +244,6 @@ async fn transfer_snapshot(
                 "Failed to recover shard snapshot on remote: {err}"
             ))
         })?;
-
-    let shard = shard_holder_read.get_shard(&shard_id);
-    let Some(replica_set) = shard else {
-        return Err(CollectionError::service_error(format!(
-            "Shard {shard_id} cannot be transformed from queue to forward proxy because it does not exist"
-        )));
-    };
 
     // Set shard state to partial through consensus and synchronize
     log::debug!("Shard {shard_id} snapshot recovered on {} for snapshot transfer, switching into next stage through consensus...", transfer_config.to);

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -283,6 +283,11 @@ pub struct DeleteCollectionOperation(pub String);
 pub enum ShardTransferOperations {
     Start(ShardTransfer),
     Finish(ShardTransfer),
+    /// Used in `ShardTransferMethod::Snapshot`
+    ///
+    /// Called when the snapshot has successfully been recovered on the remote, brings the transfer
+    /// to the next stage.
+    SnapshotRecovered(ShardTransferKey),
     Abort {
         transfer: ShardTransferKey,
         reason: String,

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,10 +1,15 @@
 use std::sync::Weak;
 
 use async_trait::async_trait;
+use collection::operations::types::{CollectionError, CollectionResult};
+use collection::shards::replica_set::ReplicaState;
+use collection::shards::transfer::shard_transfer::ShardTransfer;
 use collection::shards::transfer::ShardTransferConsensus;
 
 use super::TableOfContent;
+use crate::content_manager::collection_meta_ops::{CollectionMetaOperations, SetShardReplicaState};
 use crate::content_manager::consensus_manager::ConsensusStateRef;
+use crate::content_manager::consensus_ops::ConsensusOperations;
 
 #[derive(Clone)]
 pub struct ShardTransferDispatcher {
@@ -13,14 +18,14 @@ pub struct ShardTransferDispatcher {
     /// This dispatcher is stored inside the table of contents after construction. It therefore
     /// uses a weak reference to avoid a reference cycle which would prevent dropping the table of
     /// contents on exit.
-    _toc: Weak<TableOfContent>,
+    toc: Weak<TableOfContent>,
     consensus_state: ConsensusStateRef,
 }
 
 impl ShardTransferDispatcher {
     pub fn new(toc: Weak<TableOfContent>, consensus_state: ConsensusStateRef) -> Self {
         Self {
-            _toc: toc,
+            toc,
             consensus_state,
         }
     }
@@ -31,5 +36,38 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     fn consensus_commit_term(&self) -> (u64, u64) {
         let state = self.consensus_state.hard_state();
         (state.commit, state.term)
+    }
+
+    fn snapshot_recovered_switch_to_partial(
+        &self,
+        transfer_config: &ShardTransfer,
+        collection_name: String,
+    ) -> CollectionResult<()> {
+        let Some(toc) = self.toc.upgrade() else {
+            return Err(CollectionError::service_error(
+                "Table of contents is dropped",
+            ));
+        };
+        let Some(proposal_sender) = toc.consensus_proposal_sender.as_ref() else {
+            return Err(CollectionError::service_error(
+                "Can't set shard state, this is a single node deployment",
+            ));
+        };
+
+        // Send operation to set shard state to partial
+        let operation = ConsensusOperations::CollectionMeta(Box::new(
+            CollectionMetaOperations::SetShardReplicaState(SetShardReplicaState {
+                collection_name,
+                shard_id: transfer_config.shard_id,
+                peer_id: transfer_config.to,
+                state: ReplicaState::Partial,
+                from_state: Some(ReplicaState::PartialSnapshot),
+            }),
+        ));
+        proposal_sender.send(operation).map_err(|err| {
+            CollectionError::service_error(format!("Failed to submit consensus proposal: {err}"))
+        })?;
+
+        Ok(())
     }
 }

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -43,7 +43,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
     fn snapshot_recovered_switch_to_partial(
         &self,
         transfer_config: &ShardTransfer,
-        collection: CollectionId,
+        collection_name: CollectionId,
     ) -> CollectionResult<()> {
         let Some(toc) = self.toc.upgrade() else {
             return Err(CollectionError::service_error(
@@ -59,7 +59,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
         // Propose operation to progress transfer, setting shard state to partial
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
-                collection,
+                collection_name,
                 ShardTransferOperations::SnapshotRecovered(transfer_config.key()),
             )));
         proposal_sender.send(operation).map_err(|err| {


### PR DESCRIPTION
Tracked in https://github.com/qdrant/qdrant/issues/2432.

Merges into https://github.com/qdrant/qdrant/pull/2467.

The three most important things this PR does are:

- When starting a shard transfer, set the target shard into `PartialSnapshot`.
- Add `ShardTransferOperations::SnapshotRecovered` operation to consensus
  We propose this operation to consensus after the shard has been recovered on the remote. The consensus operation ensures the transfer is still active, and sets the shard from `PartialSnapshot` into `Partial`.
  This operation is confirmed and retried up to 3 times if consensus rejected it.
- Consensus is synchronized explicitly on all nodes to ensure all reached the `Partial` state

This finalizes the steps required for setting `PartialSnapshot` and `Partial` states, and synchronizing nodes.

Along with that this PR reworks the snapshot transfer function a bit to make it simpler. I've also added extensive documentation to the function to explain the whole transfer process step by step.

The implementation in this PR is correct, but it can be improved upon a bit. More specifically, we don't have to synchronize consensus right after we're setting the `Partial` state. We only have to wait for the remote to reach `Partial` and can synchronize with all other nodes later. That might give us a slight performance improvement if one of the nodes is slow. I'll make this improvement in a different PR however to prevent over complicating this one.

I've tested all these changes manually.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?