### PR TITLE
Improve shard snapshot transfer replica set state synchronization

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -143,6 +143,8 @@ fn configure_validation(builder: Builder) -> Builder {
         .validates(&[
             ("GetCollectionInfoRequestInternal.get_collection_info_request", ""),
             ("InitiateShardTransferRequest.collection_name", "length(min = 1, max = 255)"),
+            ("WaitForShardStateRequest.collection_name", "length(min = 1, max = 255)"),
+            ("WaitForShardStateRequest.timeout", "range(min = 1)"),
         ], &[])
         // Service: points.proto
         .validates(&[

--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -6,8 +6,8 @@ package qdrant;
 
 service CollectionsInternal {
   /*
- Get collection info
- */
+  Get collection info
+  */
   rpc Get (GetCollectionInfoRequestInternal) returns (GetCollectionInfoResponse) {}
   /*
   Initiate shard transfer

--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -13,6 +13,10 @@ service CollectionsInternal {
   Initiate shard transfer
   */
   rpc Initiate (InitiateShardTransferRequest) returns (CollectionOperationResponse) {}
+  /**
+  Wait for a shard to get into the given state
+  */
+  rpc WaitForShardState (WaitForShardStateRequest) returns (CollectionOperationResponse) {}
 }
 
 message GetCollectionInfoRequestInternal {
@@ -23,4 +27,11 @@ message GetCollectionInfoRequestInternal {
 message InitiateShardTransferRequest {
   string collection_name = 1; // Name of the collection
   uint32 shard_id = 2; // Id of the temporary shard
+}
+
+message WaitForShardStateRequest {
+  string collection_name = 1; // Name of the collection
+  uint32 shard_id = 2; // Id of the shard
+  ReplicaState state = 3;  // Shard state to wait for
+  uint64 timeout = 4; // Timeout in seconds
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2260,6 +2260,26 @@ pub struct InitiateShardTransferRequest {
     #[prost(uint32, tag = "2")]
     pub shard_id: u32,
 }
+#[derive(validator::Validate)]
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WaitForShardStateRequest {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    #[validate(length(min = 1, max = 255))]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Id of the shard
+    #[prost(uint32, tag = "2")]
+    pub shard_id: u32,
+    /// Shard state to wait for
+    #[prost(enumeration = "ReplicaState", tag = "3")]
+    pub state: i32,
+    /// Timeout in seconds
+    #[prost(uint64, tag = "4")]
+    #[validate(range(min = 1))]
+    pub timeout: u64,
+}
 /// Generated client implementations.
 pub mod collections_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -2399,6 +2419,35 @@ pub mod collections_internal_client {
                 .insert(GrpcMethod::new("qdrant.CollectionsInternal", "Initiate"));
             self.inner.unary(req, path, codec).await
         }
+        /// *
+        /// Wait for a shard to get into the given state
+        pub async fn wait_for_shard_state(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WaitForShardStateRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.CollectionsInternal/WaitForShardState",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("qdrant.CollectionsInternal", "WaitForShardState"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2422,6 +2471,15 @@ pub mod collections_internal_server {
         async fn initiate(
             &self,
             request: tonic::Request<super::InitiateShardTransferRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CollectionOperationResponse>,
+            tonic::Status,
+        >;
+        /// *
+        /// Wait for a shard to get into the given state
+        async fn wait_for_shard_state(
+            &self,
+            request: tonic::Request<super::WaitForShardStateRequest>,
         ) -> std::result::Result<
             tonic::Response<super::CollectionOperationResponse>,
             tonic::Status,
@@ -2586,6 +2644,56 @@ pub mod collections_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = InitiateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.CollectionsInternal/WaitForShardState" => {
+                    #[allow(non_camel_case_types)]
+                    struct WaitForShardStateSvc<T: CollectionsInternal>(pub Arc<T>);
+                    impl<
+                        T: CollectionsInternal,
+                    > tonic::server::UnaryService<super::WaitForShardStateRequest>
+                    for WaitForShardStateSvc<T> {
+                        type Response = super::CollectionOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WaitForShardStateRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CollectionsInternal>::wait_for_shard_state(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = WaitForShardStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1022,6 +1022,19 @@ impl From<api::grpc::qdrant::ReplicaState> for ReplicaState {
     }
 }
 
+impl From<ReplicaState> for api::grpc::qdrant::ReplicaState {
+    fn from(value: ReplicaState) -> Self {
+        match value {
+            ReplicaState::Active => Self::Active,
+            ReplicaState::Dead => Self::Dead,
+            ReplicaState::Partial => Self::Partial,
+            ReplicaState::Initializing => Self::Initializing,
+            ReplicaState::Listener => Self::Listener,
+            ReplicaState::PartialSnapshot => Self::PartialSnapshot,
+        }
+    }
+}
+
 impl TryFrom<i32> for RecommendStrategy {
     type Error = Status;
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -42,6 +42,7 @@ use crate::operations::types::{
 };
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::{CollectionCoreSearchRequest, CollectionSearchRequest};
+use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::ShardKey;
 use crate::shards::transfer::shard_transfer::ShardTransferMethod;
 
@@ -994,6 +995,29 @@ impl From<api::grpc::qdrant::RecommendStrategy> for RecommendStrategy {
         match value {
             api::grpc::qdrant::RecommendStrategy::AverageVector => RecommendStrategy::AverageVector,
             api::grpc::qdrant::RecommendStrategy::BestScore => RecommendStrategy::BestScore,
+        }
+    }
+}
+
+impl TryFrom<i32> for ReplicaState {
+    type Error = Status;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        let replica_state = api::grpc::qdrant::ReplicaState::from_i32(value)
+            .ok_or_else(|| Status::invalid_argument(format!("Unknown replica state: {}", value)))?;
+        Ok(replica_state.into())
+    }
+}
+
+impl From<api::grpc::qdrant::ReplicaState> for ReplicaState {
+    fn from(value: api::grpc::qdrant::ReplicaState) -> Self {
+        match value {
+            api::grpc::qdrant::ReplicaState::Active => Self::Active,
+            api::grpc::qdrant::ReplicaState::Dead => Self::Dead,
+            api::grpc::qdrant::ReplicaState::Partial => Self::Partial,
+            api::grpc::qdrant::ReplicaState::Initializing => Self::Initializing,
+            api::grpc::qdrant::ReplicaState::Listener => Self::Listener,
+            api::grpc::qdrant::ReplicaState::PartialSnapshot => Self::PartialSnapshot,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -333,20 +333,17 @@ impl ShardReplicaSet {
             .await
     }
 
-    /// Wait for the replica set to reach the `Partial` state for a peer
+    /// Wait for a local shard to get into `state`
     ///
     /// Uses a blocking thread internally.
-    pub async fn wait_for_partial(
+    pub async fn wait_for_local_state(
         &self,
-        peer_id: PeerId,
+        state: ReplicaState,
         timeout: Duration,
     ) -> CollectionResult<()> {
         self.wait_for(
             move |replica_set_state| {
-                matches!(
-                    replica_set_state.get_peer_state(&peer_id),
-                    Some(ReplicaState::Partial)
-                )
+                replica_set_state.get_peer_state(&replica_set_state.this_peer_id) == Some(&state)
             },
             timeout,
         )

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -350,6 +350,22 @@ impl ShardReplicaSet {
         .await
     }
 
+    /// Wait for a peer shard to get into `state`
+    ///
+    /// Uses a blocking thread internally.
+    pub async fn wait_for_state(
+        &self,
+        peer_id: PeerId,
+        state: ReplicaState,
+        timeout: Duration,
+    ) -> CollectionResult<()> {
+        self.wait_for(
+            move |replica_set_state| replica_set_state.get_peer_state(&peer_id) == Some(&state),
+            timeout,
+        )
+        .await
+    }
+
     /// Wait for a replica set state condition to be true.
     ///
     /// Uses a blocking thread internally.

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -6,7 +6,8 @@ use tokio::time::sleep;
 
 use self::shard_transfer::ShardTransfer;
 use super::channel_service::ChannelService;
-use super::replica_set::ShardReplicaSet;
+use super::remote_shard::RemoteShard;
+use super::replica_set::ReplicaState;
 use super::shard::PeerId;
 use super::CollectionId;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -46,19 +47,21 @@ pub trait ShardTransferConsensus: Send + Sync {
         collection_name: CollectionId,
     ) -> CollectionResult<()>;
 
-    /// After snapshot recovery, propose to switch shard to `Partial` and confirm locally
+    /// After snapshot recovery, propose to switch shard to `Partial` and confirm on remote shard
     ///
     /// This is called after shard snapshot recovery has been completed on the remote. It submits a
-    /// proposal to consensus to switch the the shard state from `PartialSnapshot` to `Partial`.
+    /// proposal to consensus to switch the shard state from `PartialSnapshot` to `Partial`.
     ///
     /// This method also confirms consensus applied the operation before returning by asserting the
-    /// change is propagated locally. If it fails, it will be retried for up to
+    /// change is propagated on a remote shard. For the next stage only the remote needs to be in
+    /// `Partial` to accept updates, we therefore assert the state on the remote explicitly rather
+    /// than asserting locally. If it fails, it will be retried for up to
     /// `CONSENSUS_CONFIRM_RETRIES` times.
-    async fn snapshot_recovered_switch_to_partial_confirm(
+    async fn snapshot_recovered_switch_to_partial_confirm_remote(
         &self,
         transfer_config: &ShardTransfer,
         collection_name: &str,
-        replica_set: &ShardReplicaSet,
+        remote_shard: &RemoteShard,
     ) -> CollectionResult<()> {
         for remaining_attempts in (0..CONSENSUS_CONFIRM_RETRIES).rev() {
             // Propose consensus operation
@@ -74,12 +77,19 @@ pub trait ShardTransferConsensus: Send + Sync {
                 Err(err) => return Err(err),
             }
 
-            // Confirm local shard reached partial state
-            let confirm = replica_set
-                .wait_for_local_state(ReplicaState::Partial, CONSENSUS_CONFIRM_TIMEOUT)
+            // Confirm remote has reached Partial state
+            let partial_state = ReplicaState::Partial;
+            log::trace!("Wait for remote shard to reach {partial_state:?} state");
+            let confirm = remote_shard
+                .wait_for_shard_state(
+                    collection_name,
+                    transfer_config.shard_id,
+                    partial_state,
+                    CONSENSUS_CONFIRM_TIMEOUT,
+                )
                 .await;
             match confirm {
-                Ok(()) => return Ok(()),
+                Ok(_) => return Ok(()),
                 Err(err) if remaining_attempts > 0 => {
                     log::error!("Failed to confirm snapshot recovered operation on consensus, retrying: {err}");
                     sleep(CONSENSUS_CONFIRM_RETRY_DELAY).await;

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -76,7 +76,7 @@ pub trait ShardTransferConsensus: Send + Sync {
 
             // Confirm local shard reached partial state
             let confirm = replica_set
-                .wait_for_partial(transfer_config.to, CONSENSUS_CONFIRM_TIMEOUT)
+                .wait_for_local_state(ReplicaState::Partial, CONSENSUS_CONFIRM_TIMEOUT)
                 .await;
             match confirm {
                 Ok(()) => return Ok(()),

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use api::grpc::qdrant::collections_internal_server::CollectionsInternal;
 use api::grpc::qdrant::{
     CollectionOperationResponse, GetCollectionInfoRequestInternal, GetCollectionInfoResponse,
-    InitiateShardTransferRequest,
+    InitiateShardTransferRequest, WaitForShardStateRequest,
 };
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
@@ -67,5 +67,12 @@ impl CollectionsInternal for CollectionsInternalService {
             time: timing.elapsed().as_secs_f64(),
         };
         Ok(Response::new(response))
+    }
+
+    async fn wait_for_shard_state(
+        &self,
+        request: Request<WaitForShardStateRequest>,
+    ) -> Result<Response<CollectionOperationResponse>, Status> {
+        todo!();
     }
 }


### PR DESCRIPTION
Tracked in https://github.com/qdrant/qdrant/issues/2432.

Depends on https://github.com/qdrant/qdrant/pull/2467, https://github.com/qdrant/qdrant/pull/2881.

This improves what synchronizations are made for shard snapshot transfer. This now synchronizes to just the bare minimum to potentially improve the shard transfer time if one of the nodes is slow to respond.

The PR adds a `WaitForShardState` gRPC call to allow waiting for a remote shard to reach a specific state.

Synchronization is changed in the following way. Before we synchronized consensus right after proposing to switch the remote shard to `Partial` state. That way all nodes have reached the `Partial` state and the queue proxy could transfer all its updates to the remote.

With this PR we only wait for the remote shard to reach `Partial` state and we don't care about other nodes. Then we  transfer queue proxy updates. Before we finalize the shard snapshot transfer we do synchronize consensus to make sure all nodes have reached at least `Partial` state.

More specifically, this change allows to transfer queue proxy updates as soon as the receiving node is ready. Before, this operation could be stuck for a while if one of the nodes is slow to respond.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?