### PR TITLE
Fix gRPC validation panic on list with multiple failing items

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -42,16 +42,11 @@ where
     V: Validate,
 {
     #[inline]
-    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
-        let errors = self
-            .iter()
-            .filter_map(|v| v.validate().err())
-            .fold(Err(ValidationErrors::new()), |bag, err| {
-                ValidationErrors::merge(bag, "?", Err(err))
-            })
-            .unwrap_err();
-        errors.errors().is_empty().then_some(()).ok_or(errors)
+        match self.iter().find_map(|v| v.validate().err()) {
+            Some(err) => ValidationErrors::merge(Err(Default::default()), "[]", Err(err)),
+            None => Ok(()),
+        }
     }
 }
 
@@ -60,16 +55,11 @@ where
     V: Validate,
 {
     #[inline]
-    #[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
     fn validate(&self) -> Result<(), ValidationErrors> {
-        let errors = self
-            .values()
-            .filter_map(|v| v.validate().err())
-            .fold(Err(ValidationErrors::new()), |bag, err| {
-                ValidationErrors::merge(bag, "?", Err(err))
-            })
-            .unwrap_err();
-        errors.errors().is_empty().then_some(()).ok_or(errors)
+        match self.values().find_map(|v| v.validate().err()) {
+            Some(err) => ValidationErrors::merge(Err(Default::default()), "[]", Err(err)),
+            None => Ok(()),
+        }
     }
 }
 

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -58,19 +58,6 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Search
 
-
-$docker_grpcurl -d '{
-  "collection_name": "test_collection",
-  "recommend_points": [
-    {
-      "positive": [{ "num": 1 }]
-    },
-    {
-      "positive": [{ "num": 1 }]
-    }
-  ]
-}' $QDRANT_HOST qdrant.Points/RecommendBatch
-
 $docker_grpcurl -d '{
   "collection_name": "test_collection",
   "filter": {
@@ -177,6 +164,27 @@ $docker_grpcurl -d '{
   },
   "ids": [{ "num": 1 }]
 }' $QDRANT_HOST qdrant.Points/Get
+
+# The following must return a validation error
+set +e
+response=$(
+    $docker_grpcurl -d '{
+        "collection_name": "test_collection",
+        "recommend_points": [
+            {
+                "positive": [{ "num": 1 }]
+            },
+            {
+                "positive": [{ "num": 1 }]
+            }
+        ]
+    }' $QDRANT_HOST qdrant.Points/RecommendBatch 2>&1
+)
+if [[ $response != *"Validation error in body"* ]]; then
+    echo Unexpected response, expected validation error: $response
+    exit 1
+fi
+set -e
 
 # use the reflection service to inspect the full API
 $docker_grpcurl $QDRANT_HOST describe

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -58,6 +58,19 @@ $docker_grpcurl -d '{
   "limit": 3
 }' $QDRANT_HOST qdrant.Points/Search
 
+
+$docker_grpcurl -d '{
+  "collection_name": "test_collection",
+  "recommend_points": [
+    {
+      "positive": [{ "num": 1 }]
+    },
+    {
+      "positive": [{ "num": 1 }]
+    }
+  ]
+}' $QDRANT_HOST qdrant.Points/RecommendBatch
+
 $docker_grpcurl -d '{
   "collection_name": "test_collection",
   "filter": {


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant/issues/2880.

Our custom validation handling on gRPC, done through `ValidateExt`, can panic when validating lists. This happens when there is more than one item having validation errors.

Sadly, the `validator` [type](https://docs.rs/validator/0.16.1/validator/struct.ValidationErrors.html) holding field errors is limited. We cannot use the item index at runtime because field names must be static string slices. Nor can we merge multiple errors into the same field name.

To mitigate panics and satisfy the limitation this PR now returns on the first error it comes across when validating list types in gRPC.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?