### PR TITLE
Rename sparse vector values

### DIFF
--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -5,22 +5,22 @@ use crate::common::types::{DimId, DimWeight};
 #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct SparseVector {
     pub indices: Vec<DimId>,
-    pub weights: Vec<DimWeight>,
+    pub values: Vec<DimWeight>,
 }
 
 impl SparseVector {
-    pub fn new(indices: Vec<DimId>, weights: Vec<DimWeight>) -> SparseVector {
-        SparseVector { indices, weights }
+    pub fn new(indices: Vec<DimId>, values: Vec<DimWeight>) -> SparseVector {
+        SparseVector { indices, values }
     }
 }
 impl From<Vec<(i32, f64)>> for SparseVector {
     fn from(v: Vec<(i32, f64)>) -> Self {
         let mut indices = Vec::with_capacity(v.len());
-        let mut weights = Vec::with_capacity(v.len());
+        let mut values = Vec::with_capacity(v.len());
         for (i, w) in v {
             indices.push(i as u32);
-            weights.push(w as f32);
+            values.push(w as f32);
         }
-        SparseVector { indices, weights }
+        SparseVector { indices, values }
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -44,7 +44,7 @@ impl InvertedIndexRam {
 
     /// Upsert a vector into the inverted index.
     pub fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {
-        for (dim_id, weight) in vector.indices.into_iter().zip(vector.weights.into_iter()) {
+        for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             match self.postings.get_mut(dim_id) {
                 Some(posting) => {

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -93,7 +93,7 @@ impl<'a> SearchContext<'a> {
                 if record_id == min_record_id {
                     let element = posting_iterator.posting_list_iterator.next().unwrap();
                     score +=
-                        element.weight * self.query.weights[posting_iterator.query_weight_offset];
+                        element.weight * self.query.values[posting_iterator.query_weight_offset];
                 }
             }
         }
@@ -175,7 +175,7 @@ impl<'a> SearchContext<'a> {
         if let Some(element) = posting_iterator.posting_list_iterator.peek() {
             let max_weight_from_list = element.weight.max(element.max_next_weight);
             let max_score_contribution =
-                max_weight_from_list * self.query.weights[posting_query_offset];
+                max_weight_from_list * self.query.values[posting_query_offset];
             if max_score_contribution < min_score {
                 return match skip_to {
                     None => {
@@ -206,7 +206,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             10,
             inverted_index,
@@ -262,7 +262,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             10,
             inverted_index,
@@ -321,7 +321,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             10,
             &inverted_index_ram,
@@ -351,13 +351,13 @@ mod tests {
             4,
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![40.0, 40.0, 40.0],
+                values: vec![40.0, 40.0, 40.0],
             },
         );
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             10,
             &inverted_index_ram,
@@ -392,7 +392,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             3,
             inverted_index,
@@ -420,7 +420,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             4,
             inverted_index,
@@ -486,7 +486,7 @@ mod tests {
         let mut search_context = SearchContext::new(
             SparseVector {
                 indices: vec![1, 2, 3],
-                weights: vec![1.0, 1.0, 1.0],
+                values: vec![1.0, 1.0, 1.0],
             },
             3,
             inverted_index,


### PR DESCRIPTION
This PR renames the sparse vector field `weights` to `values`.

Rational:
- weights is kinda SPLADE/ML specific
- weights is more prone to typos
- values is a more general and already used by other systems