### PR TITLE
Add custom TLS certificate support for remote snapshot downloads to snapshot recover APIs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -111,6 +111,32 @@ jobs:
         run: ./test_tls.sh
         working-directory: ./tests/tls
 
+  test-tls-snapshot-shard-transfer:
+
+    name: "TLS: Snapshot Shard Transfer"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: qdrant_tls
+          cache-from: |
+            type=gha,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+          load: true
+          build-args: |
+            PROFILE=ci
+      - name: Run integration tests
+        run: ./test_tls_snapshot_shard_transfer.sh
+        working-directory: ./tests/tls
+
   test-consistency:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,6 +89,8 @@ jobs:
 
   test-tls-compose:
 
+    name: "Basic TLS/HTTPS tests"
+
     runs-on: ubuntu-latest
 
     steps:
@@ -107,35 +109,13 @@ jobs:
           load: true
           build-args: |
             PROFILE=ci
-      - name: Run integration tests
+      - name: Run basic TLS/HTTPS test
         run: ./test_tls.sh
         working-directory: ./tests/tls
-
-  test-tls-snapshot-shard-transfer:
-
-    name: "TLS: Snapshot Shard Transfer"
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          tags: qdrant_tls
-          cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
-          load: true
-          build-args: |
-            PROFILE=ci
-      - name: Run integration tests
+      - name: Run snapshot shard transfer TLS/HTTPS test
         run: ./test_tls_snapshot_shard_transfer.sh
         working-directory: ./tests/tls
+
 
   test-consistency:
 

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -28,11 +28,15 @@ fn snapshot_name(url: &Url) -> String {
 /// Returns a `TempPath` that will delete the downloaded file once it is dropped.
 /// To persist the file, use `download_file(...).keep()`.
 #[must_use = "returns a TempPath, if dropped the downloaded file is deleted"]
-async fn download_file(url: &Url, path: &Path) -> Result<TempPath, StorageError> {
+async fn download_file(
+    client: reqwest::Client,
+    url: &Url,
+    path: &Path,
+) -> Result<TempPath, StorageError> {
     let temp_path = TempPath::from_path(path);
     let mut file = File::create(path).await?;
 
-    let response = reqwest::get(url.clone()).await?;
+    let response = client.get(url.clone()).send().await?;
 
     if !response.status().is_success() {
         return Err(StorageError::bad_input(format!(
@@ -60,6 +64,7 @@ async fn download_file(url: &Url, path: &Path) -> Result<TempPath, StorageError>
 /// downloaded file is deleted automatically. To keep the file `keep()` may be used.
 #[must_use = "may return a TempPath, if dropped the downloaded file is deleted"]
 pub async fn download_snapshot(
+    client: reqwest::Client,
     url: Url,
     snapshots_dir: &Path,
 ) -> Result<(PathBuf, Option<TempPath>), StorageError> {
@@ -80,7 +85,7 @@ pub async fn download_snapshot(
         "http" | "https" => {
             let download_to = snapshots_dir.join(snapshot_name(&url));
 
-            let temp_path = download_file(&url, &download_to).await?;
+            let temp_path = download_file(client, &url, &download_to).await?;
             Ok((download_to, Some(temp_path)))
         }
         _ => Err(StorageError::bad_request(format!(

--- a/lib/storage/src/content_manager/snapshots/download.rs
+++ b/lib/storage/src/content_manager/snapshots/download.rs
@@ -29,7 +29,7 @@ fn snapshot_name(url: &Url) -> String {
 /// To persist the file, use `download_file(...).keep()`.
 #[must_use = "returns a TempPath, if dropped the downloaded file is deleted"]
 async fn download_file(
-    client: reqwest::Client,
+    client: &reqwest::Client,
     url: &Url,
     path: &Path,
 ) -> Result<TempPath, StorageError> {
@@ -64,7 +64,7 @@ async fn download_file(
 /// downloaded file is deleted automatically. To keep the file `keep()` may be used.
 #[must_use = "may return a TempPath, if dropped the downloaded file is deleted"]
 pub async fn download_snapshot(
-    client: reqwest::Client,
+    client: &reqwest::Client,
     url: Url,
     snapshots_dir: &Path,
 ) -> Result<(PathBuf, Option<TempPath>), StorageError> {

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -55,7 +55,7 @@ pub async fn do_recover_from_snapshot(
     let dispatch = dispatcher.clone();
     let collection_name = collection_name.to_string();
     let recovery = tokio::spawn(async move {
-        _do_recover_from_snapshot(dispatch, &collection_name, source, client).await
+        _do_recover_from_snapshot(dispatch, &collection_name, source, &client).await
     });
     if wait {
         Ok(recovery.await??)
@@ -68,7 +68,7 @@ async fn _do_recover_from_snapshot(
     dispatcher: Dispatcher,
     collection_name: &str,
     source: SnapshotRecover,
-    client: reqwest::Client,
+    client: &reqwest::Client,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location, priority } = source;
     let toc = dispatcher.toc();

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -50,13 +50,13 @@ pub async fn do_recover_from_snapshot(
     collection_name: &str,
     source: SnapshotRecover,
     wait: bool,
+    client: reqwest::Client,
 ) -> Result<bool, StorageError> {
     let dispatch = dispatcher.clone();
     let collection_name = collection_name.to_string();
-    let recovery =
-        tokio::spawn(
-            async move { _do_recover_from_snapshot(dispatch, &collection_name, source).await },
-        );
+    let recovery = tokio::spawn(async move {
+        _do_recover_from_snapshot(dispatch, &collection_name, source, client).await
+    });
     if wait {
         Ok(recovery.await??)
     } else {
@@ -68,6 +68,7 @@ async fn _do_recover_from_snapshot(
     dispatcher: Dispatcher,
     collection_name: &str,
     source: SnapshotRecover,
+    client: reqwest::Client,
 ) -> Result<bool, StorageError> {
     let SnapshotRecover { location, priority } = source;
     let toc = dispatcher.toc();
@@ -84,7 +85,7 @@ async fn _do_recover_from_snapshot(
     );
 
     let (snapshot_path, snapshot_temp_path) =
-        download_snapshot(location, download_dir.path()).await?;
+        download_snapshot(client, location, download_dir.path()).await?;
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -162,6 +162,11 @@ async fn upload_snapshot(
             Err(err) => return process_response::<()>(Err(err), timing),
         };
 
+    let http_client = match http_client.client() {
+        Ok(http_client) => http_client,
+        Err(err) => return process_response::<()>(Err(err.into()), timing),
+    };
+
     let snapshot_recover = SnapshotRecover {
         location: snapshot_location,
         priority: params.priority,
@@ -172,9 +177,10 @@ async fn upload_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
-        http_client.get(),
+        http_client,
     )
     .await;
+
     match response {
         Err(_) => process_response(response, timing),
         Ok(_) if wait => process_response(response, timing),
@@ -194,14 +200,20 @@ async fn recover_from_snapshot(
     let snapshot_recover = request.into_inner();
     let wait = params.wait.unwrap_or(true);
 
+    let http_client = match http_client.client() {
+        Ok(http_client) => http_client,
+        Err(err) => return process_response::<()>(Err(err.into()), timing),
+    };
+
     let response = do_recover_from_snapshot(
         dispatcher.get_ref(),
         &collection.name,
         snapshot_recover,
         wait,
-        http_client.get(),
+        http_client,
     )
     .await;
+
     match response {
         Err(_) => process_response(response, timing),
         Ok(_) if wait => process_response(response, timing),
@@ -318,16 +330,21 @@ async fn recover_shard_snapshot(
     query: web::Query<SnapshottingParam>,
     web::Json(request): web::Json<ShardSnapshotRecover>,
 ) -> impl Responder {
-    let (collection, shard) = path.into_inner();
-    let future = common::snapshots::recover_shard_snapshot(
-        toc.into_inner(),
-        collection,
-        shard,
-        request.location,
-        request.priority.unwrap_or_default(),
-        http_client.get(),
-    )
-    .map_err(Into::into);
+    let future = async move {
+        let (collection, shard) = path.into_inner();
+
+        common::snapshots::recover_shard_snapshot(
+            toc.into_inner(),
+            collection,
+            shard,
+            request.location,
+            request.priority.unwrap_or_default(),
+            http_client.get_ref(),
+        )
+        .await?;
+
+        Ok(())
+    };
 
     helpers::time_or_accept(future, query.wait.unwrap_or(true)).await
 }

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -170,6 +170,7 @@ async fn upload_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
+        todo!(),
     )
     .await;
     match response {
@@ -195,6 +196,7 @@ async fn recover_from_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
+        todo!(),
     )
     .await;
     match response {
@@ -319,6 +321,7 @@ async fn recover_shard_snapshot(
         shard,
         request.location,
         request.priority.unwrap_or_default(),
+        todo!(),
     )
     .map_err(Into::into);
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -339,7 +339,7 @@ async fn recover_shard_snapshot(
             shard,
             request.location,
             request.priority.unwrap_or_default(),
-            http_client.get_ref(),
+            http_client.as_ref().clone(),
         )
         .await?;
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -31,6 +31,7 @@ use crate::actix::helpers::{
 };
 use crate::common;
 use crate::common::collections::*;
+use crate::common::http_client::HttpClient;
 
 #[derive(Deserialize, Validate)]
 struct SnapshotPath {
@@ -146,6 +147,7 @@ async fn create_snapshot(
 #[post("/collections/{name}/snapshots/upload")]
 async fn upload_snapshot(
     dispatcher: web::Data<Dispatcher>,
+    http_client: web::Data<HttpClient>,
     collection: valid::Path<CollectionPath>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
     params: valid::Query<SnapshotUploadingParam>,
@@ -170,7 +172,7 @@ async fn upload_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
-        todo!(),
+        http_client.get(),
     )
     .await;
     match response {
@@ -183,6 +185,7 @@ async fn upload_snapshot(
 #[put("/collections/{name}/snapshots/recover")]
 async fn recover_from_snapshot(
     dispatcher: web::Data<Dispatcher>,
+    http_client: web::Data<HttpClient>,
     collection: valid::Path<CollectionPath>,
     request: valid::Json<SnapshotRecover>,
     params: valid::Query<SnapshottingParam>,
@@ -196,7 +199,7 @@ async fn recover_from_snapshot(
         &collection.name,
         snapshot_recover,
         wait,
-        todo!(),
+        http_client.get(),
     )
     .await;
     match response {
@@ -310,6 +313,7 @@ async fn create_shard_snapshot(
 #[put("/collections/{collection}/shards/{shard}/snapshots/recover")]
 async fn recover_shard_snapshot(
     toc: web::Data<TableOfContent>,
+    http_client: web::Data<HttpClient>,
     path: web::Path<(String, ShardId)>,
     query: web::Query<SnapshottingParam>,
     web::Json(request): web::Json<ShardSnapshotRecover>,
@@ -321,7 +325,7 @@ async fn recover_shard_snapshot(
         shard,
         request.location,
         request.priority.unwrap_or_default(),
-        todo!(),
+        http_client.get(),
     )
     .map_err(Into::into);
 

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -1,4 +1,4 @@
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -167,146 +167,6 @@ fn with_buf_read<T>(path: &str, f: impl FnOnce(&mut dyn BufRead) -> io::Result<T
     f(dyn_reader).map_err(|err| Error::ReadFile(err, path.into()))
 }
 
-#[derive(Debug)]
-pub struct HttpClient {
-    https_client: Option<HttpsClient>,
-}
-
-impl HttpClient {
-    pub fn from_settings(settings: &Settings) -> Result<Self> {
-        let https_client = HttpsClient::from_settings(settings)?;
-        Ok(Self { https_client })
-    }
-
-    pub fn get(&self) -> Result<reqwest::Client> {
-        match &self.https_client {
-            Some(https_client) => https_client.get_or_refresh(),
-            None => Ok(reqwest::Client::new()),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct HttpsClient {
-    client: RwLock<HttpsClientWithAge>,
-    tls_config: TlsConfig,
-    verify_https_client_certificate: bool,
-}
-
-impl HttpsClient {
-    pub fn from_settings(settings: &Settings) -> Result<Option<Self>> {
-        if !settings.service.enable_tls {
-            return Ok(None);
-        }
-
-        let Some(tls_config) = settings.tls.clone() else {
-            return Err(Error::TlsConfigUndefined);
-        };
-
-        let verify_https_client_certificate = settings.service.verify_https_client_certificate;
-
-        let client = HttpsClientWithAge::from_config(&tls_config, verify_https_client_certificate)?;
-
-        let client = Self {
-            client: client.into(),
-            tls_config,
-            verify_https_client_certificate,
-        };
-
-        Ok(Some(client))
-    }
-
-    pub fn get_or_refresh(&self) -> Result<reqwest::Client> {
-        {
-            let client = self.client.read();
-
-            if client.age() <= self.ttl() {
-                return Ok(client.client.clone());
-            }
-        }
-
-        let client = HttpsClientWithAge::from_config(
-            &self.tls_config,
-            self.verify_https_client_certificate,
-        )?;
-
-        *self.client.write() = client.clone();
-
-        Ok(client.client)
-    }
-
-    pub fn ttl(&self) -> Duration {
-        match self.tls_config.cert_ttl {
-            None | Some(0) => Duration::MAX,
-            Some(secs) => Duration::from_secs(secs),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct HttpsClientWithAge {
-    client: reqwest::Client,
-    last_update: Instant,
-}
-
-impl HttpsClientWithAge {
-    pub fn from_config(
-        tls_config: &TlsConfig,
-        verify_https_client_certificate: bool,
-    ) -> Result<Self> {
-        let client = Self {
-            client: https_client_from_config(tls_config, verify_https_client_certificate)?,
-            last_update: Instant::now(),
-        };
-
-        Ok(client)
-    }
-
-    pub fn age(&self) -> Duration {
-        self.last_update.elapsed()
-    }
-}
-
-fn https_client_from_config(
-    tls_config: &TlsConfig,
-    verify_https_client_certificate: bool,
-) -> Result<reqwest::Client> {
-    let mut builder =
-        reqwest::Client::builder().add_root_certificate(load_https_client_ca_cert(tls_config)?);
-
-    if verify_https_client_certificate {
-        builder = builder.identity(load_https_client_identity(tls_config)?);
-    }
-
-    let client = builder.build()?;
-
-    Ok(client)
-}
-
-fn load_https_client_ca_cert(tls_config: &TlsConfig) -> Result<reqwest::Certificate> {
-    let ca_cert_pem = fs::read(&tls_config.ca_cert)
-        .map_err(|err| Error::ReadFile(err, tls_config.ca_cert.clone()))?;
-
-    let ca_cert = reqwest::Certificate::from_pem(&ca_cert_pem)?;
-
-    Ok(ca_cert)
-}
-
-fn load_https_client_identity(tls_config: &TlsConfig) -> Result<reqwest::Identity> {
-    let mut identity_pem =
-        fs::read(&tls_config.cert).map_err(|err| Error::ReadFile(err, tls_config.cert.clone()))?;
-
-    let mut key_file = fs::File::open(&tls_config.key)
-        .map_err(|err| Error::OpenFile(err, tls_config.key.clone()))?;
-
-    io::copy(&mut key_file, &mut identity_pem)
-        .map_err(|err| Error::ReadFile(err, tls_config.key.clone()))?;
-
-    let identity = reqwest::Identity::from_pem(&identity_pem)?;
-
-    Ok(identity)
-}
-
 /// Actix TLS errors.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -324,14 +184,4 @@ pub enum Error {
     InvalidPrivateKey,
     #[error("TLS signing error")]
     Sign(#[source] rustls::sign::SignError),
-    #[error("TLS config is not defined in the Qdrant config file")]
-    TlsConfigUndefined,
-    #[error("failed to setup HTTPS client: {0}")]
-    Reqwest(#[from] reqwest::Error),
-}
-
-impl From<Error> for io::Error {
-    fn from(err: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, err)
-    }
 }

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -167,6 +167,22 @@ fn with_buf_read<T>(path: &str, f: impl FnOnce(&mut dyn BufRead) -> io::Result<T
     f(dyn_reader).map_err(|err| Error::ReadFile(err, path.into()))
 }
 
+pub fn reqwest_client(settings: &Settings) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+
+    if settings.service.enable_tls {
+        builder = builder.add_root_certificate(reqwest::Certificate::from_pem(todo!())?);
+
+        if settings.service.verify_https_client_certificate {
+            builder = builder.identity(reqwest::Identity::from_pem(todo!())?);
+        }
+    }
+
+    let client = builder.build()?;
+
+    Ok(client)
+}
+
 /// Actix TLS errors.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -9,6 +9,8 @@ use collection::operations::types::CollectionError;
 use serde::Serialize;
 use storage::content_manager::errors::StorageError;
 
+use crate::common::http_client;
+
 pub fn collection_into_actix_error(err: CollectionError) -> Error {
     let storage_error: StorageError = err.into();
     storage_into_actix_error(storage_error)
@@ -200,6 +202,12 @@ impl From<StorageError> for HttpError {
 impl From<CollectionError> for HttpError {
     fn from(err: CollectionError) -> Self {
         StorageError::from(err).into()
+    }
+}
+
+impl From<http_client::Error> for HttpError {
+    fn from(err: http_client::Error) -> Self {
+        StorageError::service_error(format!("failed to initialize HTTP(S) client: {err}")).into()
     }
 }
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -29,6 +29,7 @@ use crate::actix::api::service_api::config_service_api;
 use crate::actix::api::snapshot_api::config_snapshots_api;
 use crate::actix::api::update_api::config_update_api;
 use crate::actix::api_key::{ApiKey, WhitelistItem};
+use crate::common::http_client::HttpClient;
 use crate::common::telemetry::TelemetryCollector;
 use crate::settings::{max_web_workers, Settings};
 
@@ -55,6 +56,7 @@ pub fn init(
             .actix_telemetry_collector
             .clone();
         let telemetry_collector_data = web::Data::from(telemetry_collector);
+        let http_client = web::Data::new(HttpClient::from_settings(&settings)?);
         let api_key = settings.service.api_key.clone();
         let static_folder = settings
             .service
@@ -126,6 +128,7 @@ pub fn init(
                 .app_data(dispatcher_data.clone())
                 .app_data(toc_data.clone())
                 .app_data(telemetry_collector_data.clone())
+                .app_data(http_client.clone())
                 .app_data(validate_path_config)
                 .app_data(validate_query_config)
                 .app_data(validate_json_config)

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -5,6 +5,7 @@ use storage::content_manager::errors::StorageError;
 
 use crate::settings::{Settings, TlsConfig};
 
+#[derive(Clone)]
 pub struct HttpClient {
     tls_config: Option<TlsConfig>,
     verify_https_client_certificate: bool,

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -75,6 +75,7 @@ fn https_client_identity(cert: &Path, key: &Path) -> Result<reqwest::tls::Identi
 
     let mut key_file = fs::File::open(key).map_err(|err| Error::failed_to_read(err, "key", key))?;
 
+    // Concatenate certificate and key into a single PEM bytes
     io::copy(&mut key_file, &mut identity_pem)
         .map_err(|err| Error::failed_to_read(err, "key", key))?;
 

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -1,0 +1,202 @@
+use std::time::{Duration, Instant};
+use std::{fs, io, result};
+
+use crate::settings::{Settings, TlsConfig};
+
+#[derive(Debug)]
+pub struct HttpClient {
+    https_client: Option<HttpsClient>,
+}
+
+impl HttpClient {
+    pub fn from_settings(settings: &Settings) -> Result<Self> {
+        let https_client = HttpsClient::from_settings(settings)?;
+        Ok(Self { https_client })
+    }
+
+    pub fn get(&self) -> reqwest::Client {
+        match &self.https_client {
+            Some(https_client) => https_client.get_or_refresh(),
+            None => reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HttpsClient {
+    client: parking_lot::RwLock<HttpsClientWithAge>,
+    tls_config: TlsConfig,
+    verify_https_client_certificate: bool,
+}
+
+impl HttpsClient {
+    pub fn from_settings(settings: &Settings) -> Result<Option<Self>> {
+        if !settings.service.enable_tls {
+            return Ok(None);
+        }
+
+        let Some(tls_config) = settings.tls.clone() else {
+            return Err(Error::TlsConfigUndefined);
+        };
+
+        let verify_https_client_certificate = settings.service.verify_https_client_certificate;
+
+        let client = HttpsClientWithAge::from_config(&tls_config, verify_https_client_certificate)?;
+
+        let client = Self {
+            client: client.into(),
+            tls_config,
+            verify_https_client_certificate,
+        };
+
+        Ok(Some(client))
+    }
+
+    pub fn get_or_refresh(&self) -> reqwest::Client {
+        {
+            let client = self.client.read();
+
+            if client.is_valid(self.ttl()) {
+                return client.get();
+            }
+        }
+
+        let mut client = self.client.write();
+
+        if client.is_expired(self.ttl()) {
+            let res = client.refresh(&self.tls_config, self.verify_https_client_certificate);
+
+            if let Err(err) = res {
+                log::error!("Failed to refresh HTTPS client, keeping current: {err}");
+            }
+        }
+
+        client.get()
+    }
+
+    pub fn ttl(&self) -> Duration {
+        match self.tls_config.cert_ttl {
+            None | Some(0) => Duration::MAX,
+            Some(secs) => Duration::from_secs(secs),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HttpsClientWithAge {
+    client: reqwest::Client,
+    last_update: Instant,
+}
+
+impl HttpsClientWithAge {
+    pub fn from_config(
+        tls_config: &TlsConfig,
+        verify_https_client_certificate: bool,
+    ) -> Result<Self> {
+        let client = Self {
+            client: https_client_from_config(tls_config, verify_https_client_certificate)?,
+            last_update: Instant::now(),
+        };
+
+        Ok(client)
+    }
+
+    pub fn refresh(
+        &mut self,
+        tls_config: &TlsConfig,
+        verify_https_client_certificate: bool,
+    ) -> Result<()> {
+        *self = Self::from_config(tls_config, verify_https_client_certificate)?;
+        Ok(())
+    }
+
+    pub fn get(&self) -> reqwest::Client {
+        self.client.clone()
+    }
+
+    pub fn is_valid(&self, ttl: Duration) -> bool {
+        self.age() <= ttl
+    }
+
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        !self.is_valid(ttl)
+    }
+
+    pub fn age(&self) -> Duration {
+        self.last_update.elapsed()
+    }
+}
+
+fn https_client_from_config(
+    tls_config: &TlsConfig,
+    verify_https_client_certificate: bool,
+) -> Result<reqwest::Client> {
+    let mut builder =
+        reqwest::Client::builder().add_root_certificate(load_https_client_ca_cert(tls_config)?);
+
+    if verify_https_client_certificate {
+        builder = builder.identity(load_https_client_identity(tls_config)?);
+    }
+
+    let client = builder.build()?;
+
+    Ok(client)
+}
+
+fn load_https_client_ca_cert(tls_config: &TlsConfig) -> Result<reqwest::Certificate> {
+    let ca_cert_pem = fs::read(&tls_config.ca_cert).map_err(|err| {
+        Error::failed_to_read("HTTPS client CA certificate file", &tls_config.ca_cert, err)
+    })?;
+
+    let ca_cert = reqwest::Certificate::from_pem(&ca_cert_pem)?;
+
+    Ok(ca_cert)
+}
+
+fn load_https_client_identity(tls_config: &TlsConfig) -> Result<reqwest::Identity> {
+    let mut identity_pem = fs::read(&tls_config.cert).map_err(|err| {
+        Error::failed_to_read("HTTPS client certificate file", &tls_config.cert, err)
+    })?;
+
+    let mut key_file = fs::File::open(&tls_config.key)
+        .map_err(|err| Error::failed_to_open("HTTPS client key file", &tls_config.key, err))?;
+
+    io::copy(&mut key_file, &mut identity_pem)
+        .map_err(|err| Error::failed_to_read("HTTPS client key file", &tls_config.key, err))?;
+
+    let identity = reqwest::Identity::from_pem(&identity_pem)?;
+
+    Ok(identity)
+}
+
+pub type Result<T, E = Error> = result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("TLS config is not defined in the Qdrant config file")]
+    TlsConfigUndefined,
+    #[error("{0}: {1}")]
+    Io(String, io::Error),
+    #[error("failed to setup HTTPS client: {0}")]
+    Reqwest(#[from] reqwest::Error),
+}
+
+impl Error {
+    pub fn failed_to_open(what: &str, path: &str, source: io::Error) -> Self {
+        Self::Io(format!("failed to open {what} {path}"), source)
+    }
+
+    pub fn failed_to_read(what: &str, path: &str, source: io::Error) -> Self {
+        Self::Io(format!("failed to read {what} {path}"), source)
+    }
+
+    pub fn io(context: impl Into<String>, source: io::Error) -> Self {
+        Self::Io(context.into(), source)
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, err)
+    }
+}

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -12,13 +12,21 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn from_settings(settings: &Settings) -> Result<Self> {
-        if settings.service.enable_tls && settings.tls.is_none() {
-            return Err(Error::TlsConfigUndefined);
-        }
+        let tls_config = if settings.service.enable_tls {
+            let Some(tls_config) = settings.tls.clone() else {
+                return Err(Error::TlsConfigUndefined);
+            };
+
+            Some(tls_config)
+        } else {
+            None
+        };
+
+        let verify_https_client_certificate = settings.service.verify_https_client_certificate;
 
         let http_client = Self {
-            tls_config: settings.tls.clone(),
-            verify_https_client_certificate: settings.service.verify_https_client_certificate,
+            tls_config,
+            verify_https_client_certificate,
         };
 
         Ok(http_client)

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod collections;
 pub mod error_reporting;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod helpers;
+pub mod http_client;
 pub mod metrics;
 #[allow(dead_code)] // May contain functions used in different binaries. Not actually dead
 pub mod points;

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -96,7 +96,7 @@ pub async fn recover_shard_snapshot(
                         return Err(StorageError::bad_input(description));
                     }
                     let (snapshot_path, snapshot_temp_path) =
-                        snapshots::download::download_snapshot(client, url, download_dir.path()).await?;
+                        snapshots::download::download_snapshot(&client, url, download_dir.path()).await?;
                     (snapshot_path, snapshot_temp_path)
                 }
 

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -12,6 +12,8 @@ use storage::content_manager::errors::StorageError;
 use storage::content_manager::snapshots;
 use storage::content_manager::toc::TableOfContent;
 
+use super::http_client::HttpClient;
+
 /// # Cancel safety
 ///
 /// This function is cancel safe.
@@ -71,7 +73,7 @@ pub async fn recover_shard_snapshot(
     shard_id: ShardId,
     snapshot_location: ShardSnapshotLocation,
     snapshot_priority: SnapshotPriority,
-    client: reqwest::Client,
+    client: &HttpClient,
 ) -> Result<(), StorageError> {
     // - `download_dir` handled by `tempfile` and would be deleted, if request is cancelled
     //   - remote snapshot is downloaded into `download_dir` and would be deleted with it
@@ -95,8 +97,13 @@ pub async fn recover_shard_snapshot(
 
                         return Err(StorageError::bad_input(description));
                     }
+
+                    let client = client.client()?;
+
                     let (snapshot_path, snapshot_temp_path) =
-                        snapshots::download::download_snapshot(&client, url, download_dir.path()).await?;
+                        snapshots::download::download_snapshot(&client, url, download_dir.path())
+                            .await?;
+
                     (snapshot_path, snapshot_temp_path)
                 }
 

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -73,7 +73,7 @@ pub async fn recover_shard_snapshot(
     shard_id: ShardId,
     snapshot_location: ShardSnapshotLocation,
     snapshot_priority: SnapshotPriority,
-    client: &HttpClient,
+    client: HttpClient,
 ) -> Result<(), StorageError> {
     // - `download_dir` handled by `tempfile` and would be deleted, if request is cancelled
     //   - remote snapshot is downloaded into `download_dir` and would be deleted with it

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -71,6 +71,7 @@ pub async fn recover_shard_snapshot(
     shard_id: ShardId,
     snapshot_location: ShardSnapshotLocation,
     snapshot_priority: SnapshotPriority,
+    client: reqwest::Client,
 ) -> Result<(), StorageError> {
     // - `download_dir` handled by `tempfile` and would be deleted, if request is cancelled
     //   - remote snapshot is downloaded into `download_dir` and would be deleted with it
@@ -95,7 +96,7 @@ pub async fn recover_shard_snapshot(
                         return Err(StorageError::bad_input(description));
                     }
                     let (snapshot_path, snapshot_temp_path) =
-                        snapshots::download::download_snapshot(url, download_dir.path()).await?;
+                        snapshots::download::download_snapshot(client, url, download_dir.path()).await?;
                     (snapshot_path, snapshot_temp_path)
                 }
 

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -232,7 +232,7 @@ impl ShardSnapshots for ShardSnapshotsService {
             request.shard_id,
             request.snapshot_location.try_into()?,
             request.snapshot_priority.try_into()?,
-            self.http_client.get(),
+            &self.http_client,
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -22,6 +22,7 @@ use tonic::{async_trait, Request, Response, Status};
 use super::{validate, validate_and_log};
 use crate::common;
 use crate::common::collections::{do_create_snapshot, do_list_snapshots};
+use crate::common::http_client::HttpClient;
 
 pub struct SnapshotsService {
     dispatcher: Arc<Dispatcher>,
@@ -134,14 +135,14 @@ impl Snapshots for SnapshotsService {
     }
 }
 
-#[derive(Clone)]
 pub struct ShardSnapshotsService {
     toc: Arc<TableOfContent>,
+    http_client: HttpClient,
 }
 
 impl ShardSnapshotsService {
-    pub fn new(toc: Arc<TableOfContent>) -> Self {
-        Self { toc }
+    pub fn new(toc: Arc<TableOfContent>, http_client: HttpClient) -> Self {
+        Self { toc, http_client }
     }
 }
 
@@ -231,7 +232,7 @@ impl ShardSnapshots for ShardSnapshotsService {
             request.shard_id,
             request.snapshot_location.try_into()?,
             request.snapshot_priority.try_into()?,
-            todo!(),
+            self.http_client.get(),
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -231,6 +231,7 @@ impl ShardSnapshots for ShardSnapshotsService {
             request.shard_id,
             request.snapshot_location.try_into()?,
             request.snapshot_priority.try_into()?,
+            todo!(),
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -232,7 +232,7 @@ impl ShardSnapshots for ShardSnapshotsService {
             request.shard_id,
             request.snapshot_location.try_into()?,
             request.snapshot_priority.try_into()?,
-            &self.http_client,
+            self.http_client.clone(),
         )
         .await
         .map_err(error_to_status)?;

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -38,6 +38,7 @@ use tonic::transport::{Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
 use crate::common::helpers;
+use crate::common::http_client::HttpClient;
 use crate::common::telemetry_ops::requests_telemetry::TonicTelemetryCollector;
 use crate::settings::Settings;
 use crate::tonic::api::collections_api::CollectionsService;
@@ -248,6 +249,8 @@ pub fn init_internal(
 
     use crate::tonic::api::raft_api::RaftService;
 
+    let http_client = HttpClient::from_settings(&settings)?;
+
     runtime
         .block_on(async {
             let socket = SocketAddr::from((host.parse::<IpAddr>().unwrap(), internal_grpc_port));
@@ -257,7 +260,7 @@ pub fn init_internal(
                 QdrantInternalService::new(settings, consensus_state.clone());
             let collections_internal_service = CollectionsInternalService::new(toc.clone());
             let points_internal_service = PointsInternalService::new(toc.clone());
-            let shard_snapshots_service = ShardSnapshotsService::new(toc.clone());
+            let shard_snapshots_service = ShardSnapshotsService::new(toc.clone(), http_client);
             let raft_service = RaftService::new(to_consensus, consensus_state);
 
             log::debug!("Qdrant internal gRPC listening on {}", internal_grpc_port);

--- a/tests/tls/test_tls_snapshot_shard_transfer.sh
+++ b/tests/tls/test_tls_snapshot_shard_transfer.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function main {
+	declare SELF
+
+	SELF="$(realpath "$0")"
+
+	docker buildx build --load ../../ --tag=qdrant_tls --build-arg=PROFILE=ci
+	docker compose down --volumes
+	docker compose up --detach --force-recreate
+
+	function cleanup {
+		docker compose down --timeout 20
+	}
+
+	trap cleanup EXIT
+
+	sleep 10
+
+	cat "$SELF" | docker container exec -i tls-qdrant_node_1-1 bash -x -s test https://node1.qdrant:6333
+}
+
+function test {
+	declare URL="$1"
+
+	# Install curl and jq
+	apt-get update
+	apt-get install -y curl jq
+
+	# Create collection
+	curl "$URL"/collections/test-collection \
+		-X PUT \
+		-H 'Content-Type: application/json' \
+		--data-raw '{
+			"vectors": { 
+				"size": 4, 
+				"distance": "Cosine"
+			}
+		}'
+
+	# Upsert some points
+	curl "$URL"/collections/test-collection/points \
+		-X PUT \
+		-H 'Content-Type: application/json' \
+		--data-raw '{
+			"points": [
+				{ "id": 1, "vector": [0.1, 0.1, 0.1, 0.1] },
+				{ "id": 2, "vector": [0.2, 0.2, 0.2, 0.2] },
+				{ "id": 3, "vector": [0.3, 0.3, 0.3, 0.3] },
+				{ "id": 4, "vector": [0.4, 0.4, 0.4, 0.4] }
+			]
+		}'
+
+	# Get current peer ID
+	declare CURRENT_PEER_ID
+
+	CURRENT_PEER_ID="$(curl "$URL"/cluster | jq .result.peer_id)"
+
+	# Get remote shard info
+	declare INFO REMOTE_PEER_ID SHARD_ID
+
+	curl "$URL"/collections/test-collection/cluster
+
+	INFO="$(curl "$URL"/collections/test-collection/cluster | jq '.result.remote_shards[0]')"
+
+	REMOTE_PEER_ID="$(echo "$INFO" | jq .peer_id)"
+	SHARD_ID="$(echo "$INFO" | jq .shard_id)"
+
+	# Initiate snapshot shard transfer
+	curl "$URL"/collections/test-collection/cluster \
+		-X POST \
+		-H 'Content-Type: application/json' \
+		--data-raw "$(
+			cat <<-EOF
+			{
+				"replicate_shard": {
+					"to_peer_id": $CURRENT_PEER_ID,
+					"from_peer_id": $REMOTE_PEER_ID,
+					"shard_id": $SHARD_ID,
+					"method": "snapshot"
+				}
+			}
+			EOF
+		)"
+
+	sleep 5
+
+	# Check that snapshot shard transfer succeeded
+	declare POINTS
+
+	POINTS="$(curl "$URL"/collections/test-collection/cluster | jq ".result.local_shards[] | select(.shard_id == $SHARD_ID) | .points_count")"
+
+	(( POINTS > 0 ))
+}
+
+function curl {
+	declare URL="$1"
+	declare ARGS=( "${@:2}" )
+
+	declare STATUS=0
+
+	command curl -sS --fail-with-body \
+		--cacert ./tls/cacert.pem \
+		--cert ./tls/cert.pem \
+		--key ./tls/key.pem \
+		"$URL" \
+		"${ARGS[@]}" || STATUS=$?
+
+	echo && (( STATUS == 0 )) || echo >&2
+
+	return $STATUS
+}
+
+if (( $# == 0 ))
+then
+	main
+else
+	"$@"
+fi


### PR DESCRIPTION
Required for #2432.

During snapshot shard transfer, the __recipient__ of the transfer downloads a shard snapshot from __sender__ of the transfer using shard snapshot HTTP API (because there's no standard support for file downloads in gRPC).

It is possible to enable HTTPS for HTTP API, but required TLS certificates are not _yet_ propagated to the HTTP client that is used to download shard snapshot, so snapshot shard transfer fails if HTTPS is enabled.

This PR fixes this by initializing HTTP client with all required TLS magic.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
