### PR TITLE
Raw scorer with operation result

### DIFF
--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -32,7 +32,7 @@ fn build_index<TMetric: Metric>(
     let fake_filter_context = FakeFilterContext {};
     for idx in 0..(num_vectors as PointOffsetType) {
         let added_vector = vector_holder.vectors.get(idx).to_vec();
-        let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+        let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(&mut rng);
         graph_layers_builder.set_levels(idx, level);
@@ -55,7 +55,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             graph_layers.search(TOP, EF, scorer, None);
         })
@@ -64,7 +64,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
     for _ in 0..10 {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
-        let raw_scorer = vector_holder.get_raw_scorer(query);
+        let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         graph_layers.search(TOP, EF, scorer, None);
     }
@@ -75,7 +75,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             graph_layers.search(TOP, EF, scorer, None);
         })
@@ -85,7 +85,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             let mut points_to_score = (0..1500)
@@ -98,7 +98,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
     for _ in 0..10 {
         let fake_filter_context = FakeFilterContext {};
         let query = random_vector(&mut rng, DIM);
-        let raw_scorer = vector_holder.get_raw_scorer(query);
+        let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         graph_layers.search(TOP, EF, scorer, None);
     }
@@ -117,7 +117,7 @@ fn scoring_vectors(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)
@@ -134,7 +134,7 @@ fn scoring_vectors(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)
@@ -151,7 +151,7 @@ fn scoring_vectors(c: &mut Criterion) {
         b.iter(|| {
             let fake_filter_context = FakeFilterContext {};
             let query = random_vector(&mut rng, DIM);
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             let mut points_to_score = (0..points_per_cycle)

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -29,7 +29,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
             let fake_filter_context = FakeFilterContext {};
             for idx in 0..(NUM_VECTORS as PointOffsetType) {
                 let added_vector = vector_holder.vectors.get(idx).to_vec();
-                let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+                let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
                 let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
                 let level = graph_layers_builder.get_random_layer(&mut rng);
                 graph_layers_builder.set_levels(idx, level);

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -30,7 +30,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);
     for idx in 0..(NUM_VECTORS as PointOffsetType) {
         let added_vector = vector_holder.vectors.get(idx).to_vec();
-        let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+        let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(&mut rng);
         graph_layers_builder.set_levels(idx, level);
@@ -44,7 +44,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
 
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             graph_layers.search(TOP, EF, scorer, None);
@@ -57,7 +57,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
 
-            let raw_scorer = vector_holder.get_raw_scorer(query);
+            let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
             let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
             let mut top_score = 0.;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -68,6 +68,7 @@ fn benchmark_naive(c: &mut Criterion) {
                 &borrowed_storage,
                 borrowed_id_tracker.deleted_point_bitslice(),
             )
+            .unwrap()
             .peek_top_all(10)
         })
     });
@@ -90,7 +91,8 @@ fn random_access_benchmark(c: &mut Criterion) {
         vector,
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
-    );
+    )
+    .unwrap();
 
     let mut total_score = 0.;
     group.bench_function("storage vector search", |b| {

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -126,7 +126,7 @@ where
         }
     }
 
-    pub fn get_raw_scorer(&self, query: VectorType) -> Box<dyn RawScorer + '_> {
+    pub fn get_raw_scorer(&self, query: VectorType) -> OperationResult<Box<dyn RawScorer + '_>> {
         let query = TMetric::preprocess(query).into();
         raw_scorer_impl(
             query,

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -318,7 +318,7 @@ mod tests {
         graph: &GraphLayers<TGraphLinks>,
     ) -> Vec<ScoredPointOffset> {
         let fake_filter_context = FakeFilterContext {};
-        let raw_scorer = vector_storage.get_raw_scorer(query.to_owned());
+        let raw_scorer = vector_storage.get_raw_scorer(query.to_owned()).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         graph.search(top, ef, scorer, None)
@@ -358,7 +358,7 @@ mod tests {
 
         let fake_filter_context = FakeFilterContext {};
         let added_vector = vector_holder.vectors.get(linking_idx).to_vec();
-        let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+        let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 
         let nearest_on_level = graph_layers.search_on_level(

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -538,7 +538,7 @@ mod tests {
                 .for_each(|idx| {
                     let fake_filter_context = FakeFilterContext {};
                     let added_vector = vector_holder.vectors.get(idx).to_vec();
-                    let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+                    let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
                     let scorer =
                         FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
                     graph_layers.link_new_point(idx, scorer);
@@ -580,7 +580,7 @@ mod tests {
         for idx in 0..(num_vectors as PointOffsetType) {
             let fake_filter_context = FakeFilterContext {};
             let added_vector = vector_holder.vectors.get(idx).to_vec();
-            let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone());
+            let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             graph_layers.link_new_point(idx, scorer);
         }
@@ -649,7 +649,7 @@ mod tests {
             .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
-        let raw_scorer = vector_holder.get_raw_scorer(query.clone());
+        let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
@@ -732,7 +732,7 @@ mod tests {
             .unwrap();
 
         let fake_filter_context = FakeFilterContext {};
-        let raw_scorer = vector_holder.get_raw_scorer(query);
+        let raw_scorer = vector_holder.get_raw_scorer(query).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let ef = 16;
         let graph_search = graph.search(top, ef, scorer, None);
@@ -757,7 +757,7 @@ mod tests {
         let fake_filter_context = FakeFilterContext {};
         for idx in 0..(NUM_VECTORS as PointOffsetType) {
             let added_vector = vector_holder.vectors.get(idx).to_vec();
-            let raw_scorer = vector_holder.get_raw_scorer(added_vector);
+            let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(idx, level);
@@ -805,7 +805,7 @@ mod tests {
 
         let new_vector_to_insert = random_vector(&mut rng, DIM);
 
-        let scorer = vector_holder.get_raw_scorer(new_vector_to_insert);
+        let scorer = vector_holder.get_raw_scorer(new_vector_to_insert).unwrap();
 
         for i in 0..NUM_VECTORS {
             candidates.push(ScoredPointOffset {

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -40,7 +40,7 @@ where
     for idx in 0..(num_vectors as PointOffsetType) {
         let fake_filter_context = FakeFilterContext {};
         let added_vector = vector_holder.vectors.get(idx).to_vec();
-        let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone());
+        let raw_scorer = vector_holder.get_raw_scorer(added_vector.clone()).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(rng);
         graph_layers_builder.set_levels(idx, level);

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -60,7 +60,7 @@ fn test_compact_graph_layers() {
     let reference_results = queries
         .iter()
         .map(|query| {
-            let raw_scorer = vector_holder.get_raw_scorer(query.clone());
+            let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
             search_in_builder(&graph_layers_builder, top, ef, scorer)
         })
@@ -73,7 +73,7 @@ fn test_compact_graph_layers() {
     let results = queries
         .iter()
         .map(|query| {
-            let raw_scorer = vector_holder.get_raw_scorer(query.clone());
+            let raw_scorer = vector_holder.get_raw_scorer(query.clone()).unwrap();
             let scorer = FilteredScorer::new(raw_scorer.as_ref(), None);
             graph_layers.search(top, ef, scorer, None)
         })

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -228,7 +228,7 @@ impl VectorIndex for PlainIndex {
         top: usize,
         _params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match filter {
             Some(filter) => {
                 let _timer = ScopeDurationMeasurer::new(&self.filtered_searches_telemetry);
@@ -245,7 +245,9 @@ impl VectorIndex for PlainIndex {
                             id_tracker.deleted_point_bitslice(),
                             is_stopped,
                         )
-                        .peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
+                        .map(|scorer| {
+                            scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
+                        })
                     })
                     .collect()
             }
@@ -262,7 +264,7 @@ impl VectorIndex for PlainIndex {
                             id_tracker.deleted_point_bitslice(),
                             is_stopped,
                         )
-                        .peek_top_all(top)
+                        .map(|scorer| scorer.peek_top_all(top))
                     })
                     .collect()
             }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -21,7 +21,7 @@ pub trait VectorIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-    ) -> Vec<Vec<ScoredPointOffset>>;
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>>;
 
     /// Force internal index rebuild.
     fn build_index(&mut self, stopped: &AtomicBool) -> OperationResult<()>;
@@ -61,7 +61,7 @@ impl VectorIndex for VectorIndexEnum {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-    ) -> Vec<Vec<ScoredPointOffset>> {
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match self {
             VectorIndexEnum::Plain(index) => index.search(vectors, filter, top, params, is_stopped),
             VectorIndexEnum::HnswRam(index) => {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -752,11 +752,13 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<Vec<ScoredPoint>> {
         check_vector(vector_name, vector, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
-        let internal_result =
-            &vector_data
-                .vector_index
-                .borrow()
-                .search(&[vector], filter, top, params, is_stopped)[0];
+        let internal_result = &vector_data.vector_index.borrow().search(
+            &[vector],
+            filter,
+            top,
+            params,
+            is_stopped,
+        )?[0];
 
         check_stopped(is_stopped)?;
         self.process_search_result(internal_result, with_payload, with_vector)
@@ -781,7 +783,7 @@ impl SegmentEntry for Segment {
             top,
             params,
             is_stopped,
-        );
+        )?;
 
         check_stopped(is_stopped)?;
 

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -311,7 +311,8 @@ mod tests {
             points[2].as_slice().into(),
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
-        );
+        )
+        .unwrap();
         let res = raw_scorer.peek_top_all(2);
 
         assert_eq!(res.len(), 2);
@@ -388,6 +389,7 @@ mod tests {
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
+        .unwrap()
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
@@ -415,6 +417,7 @@ mod tests {
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
+        .unwrap()
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
         assert_eq!(closest[0].idx, 4);
@@ -440,6 +443,7 @@ mod tests {
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
+        .unwrap()
         .peek_top_all(5);
         assert!(closest.is_empty(), "must have no results, all deleted");
     }
@@ -501,6 +505,7 @@ mod tests {
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
         )
+        .unwrap()
         .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
@@ -569,7 +574,8 @@ mod tests {
             query,
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
-        );
+        )
+        .unwrap();
 
         let mut res = vec![ScoredPointOffset { idx: 0, score: 0. }; query_points.len()];
         let res_count = scorer.score_points(&query_points, &mut res);
@@ -654,17 +660,20 @@ mod tests {
 
         {
             let borrowed_quantized_vectors = quantized_vectors.borrow();
-            let scorer_quant = borrowed_quantized_vectors.raw_scorer(
-                query.clone(),
-                borrowed_id_tracker.deleted_point_bitslice(),
-                borrowed_storage.deleted_vector_bitslice(),
-                &stopped,
-            );
+            let scorer_quant = borrowed_quantized_vectors
+                .raw_scorer(
+                    query.clone(),
+                    borrowed_id_tracker.deleted_point_bitslice(),
+                    borrowed_storage.deleted_vector_bitslice(),
+                    &stopped,
+                )
+                .unwrap();
             let scorer_orig = new_raw_scorer(
                 query.clone(),
                 &borrowed_storage,
                 borrowed_id_tracker.deleted_point_bitslice(),
-            );
+            )
+            .unwrap();
             for i in 0..5 {
                 let quant = scorer_quant.score_point(i);
                 let orig = scorer_orig.score_point(i);
@@ -684,17 +693,20 @@ mod tests {
         assert_eq!(quantization_files, quantized_vectors.borrow().files());
 
         let borrowed_quantized_vectors = quantized_vectors.borrow();
-        let scorer_quant = borrowed_quantized_vectors.raw_scorer(
-            query.clone(),
-            borrowed_id_tracker.deleted_point_bitslice(),
-            borrowed_storage.deleted_vector_bitslice(),
-            &stopped,
-        );
+        let scorer_quant = borrowed_quantized_vectors
+            .raw_scorer(
+                query.clone(),
+                borrowed_id_tracker.deleted_point_bitslice(),
+                borrowed_storage.deleted_vector_bitslice(),
+                &stopped,
+            )
+            .unwrap();
         let scorer_orig = new_raw_scorer(
             query,
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
-        );
+        )
+        .unwrap();
 
         for i in 0..5 {
             let quant = scorer_quant.score_point(i);

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -6,6 +6,7 @@ use quantization::EncodedVectors;
 use super::quantized_custom_query_scorer::QuantizedCustomQueryScorer;
 use super::quantized_query_scorer::QuantizedQueryScorer;
 use super::quantized_vectors::QuantizedVectorStorage;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, VectorType};
 use crate::types::Distance;
 use crate::vector_storage::query::context_query::ContextQuery;
@@ -41,7 +42,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
         }
     }
 
-    pub fn build(self) -> Box<dyn RawScorer + 'a> {
+    pub fn build(self) -> OperationResult<Box<dyn RawScorer + 'a>> {
         match self.quantized_storage {
             QuantizedVectorStorage::ScalarRam(storage) => self.new_quantized_scorer(storage),
             QuantizedVectorStorage::ScalarMmap(storage) => self.new_quantized_scorer(storage),
@@ -56,7 +57,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
     fn new_quantized_scorer<TEncodedQuery: 'a>(
         self,
         quantized_storage: &'a impl EncodedVectors<TEncodedQuery>,
-    ) -> Box<dyn RawScorer + 'a> {
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         let Self {
             quantized_storage: _same_as_quantized_storage_in_args,
             query,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -64,7 +64,7 @@ impl QuantizedVectors {
         point_deleted: &'a BitSlice,
         vec_deleted: &'a BitSlice,
         is_stopped: &'a AtomicBool,
-    ) -> Box<dyn RawScorer + 'a> {
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
         QuantizedScorerBuilder::new(
             &self.storage_impl,
             query,

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -96,7 +96,7 @@ fn test_random_score(
         .collect_vec()
         .into();
 
-    let raw_scorer = new_raw_scorer(query.clone(), storage, deleted_points);
+    let raw_scorer = new_raw_scorer(query.clone(), storage, deleted_points).unwrap();
 
     let is_stopped = AtomicBool::new(false);
     let async_raw_scorer = if let VectorStorageEnum::Memmap(storage) = storage {

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -243,18 +243,23 @@ fn scoring_equivalency(
             query.clone(),
             &raw_storage,
             id_tracker.deleted_point_bitslice(),
-        );
+        )
+        .unwrap();
 
         let is_stopped = AtomicBool::new(false);
 
         let other_scorer = match &quantized_vectors {
-            Some(quantized_storage) => quantized_storage.raw_scorer(
-                query,
-                id_tracker.deleted_point_bitslice(),
-                other_storage.deleted_vector_bitslice(),
-                &is_stopped,
-            ),
-            None => new_raw_scorer(query, &other_storage, id_tracker.deleted_point_bitslice()),
+            Some(quantized_storage) => quantized_storage
+                .raw_scorer(
+                    query,
+                    id_tracker.deleted_point_bitslice(),
+                    other_storage.deleted_vector_bitslice(),
+                    &is_stopped,
+                )
+                .unwrap(),
+            None => {
+                new_raw_scorer(query, &other_storage, id_tracker.deleted_point_bitslice()).unwrap()
+            }
         };
 
         let points =

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -59,6 +59,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+    .unwrap()
     .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
@@ -85,6 +86,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+    .unwrap()
     .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
     assert_eq!(closest[0].idx, 4);
@@ -110,6 +112,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+    .unwrap()
     .peek_top_all(5);
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
@@ -168,6 +171,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+    .unwrap()
     .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
@@ -217,6 +221,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+    .unwrap()
     .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
     let top_idx = match closest.get(0) {
@@ -235,7 +240,8 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         query,
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
-    );
+    )
+    .unwrap();
     let closest = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
     let query_points = vec![0, 1, 2, 3, 4];
@@ -304,17 +310,20 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     {
         let borrowed_quantized_vectors = quantized_vectors.borrow();
-        let scorer_quant = borrowed_quantized_vectors.raw_scorer(
-            query.clone(),
-            borrowed_id_tracker.deleted_point_bitslice(),
-            borrowed_storage.deleted_vector_bitslice(),
-            &stopped,
-        );
+        let scorer_quant = borrowed_quantized_vectors
+            .raw_scorer(
+                query.clone(),
+                borrowed_id_tracker.deleted_point_bitslice(),
+                borrowed_storage.deleted_vector_bitslice(),
+                &stopped,
+            )
+            .unwrap();
         let scorer_orig = new_raw_scorer(
             query.clone(),
             &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
-        );
+        )
+        .unwrap();
         for i in 0..5 {
             let quant = scorer_quant.score_point(i);
             let orig = scorer_orig.score_point(i);
@@ -334,17 +343,20 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     assert_eq!(quantization_files, quantized_vectors.borrow().files());
 
     let borrowed_quantized_vectors = quantized_vectors.borrow();
-    let scorer_quant = borrowed_quantized_vectors.raw_scorer(
-        query.clone(),
-        borrowed_id_tracker.deleted_point_bitslice(),
-        borrowed_storage.deleted_vector_bitslice(),
-        &stopped,
-    );
+    let scorer_quant = borrowed_quantized_vectors
+        .raw_scorer(
+            query.clone(),
+            borrowed_id_tracker.deleted_point_bitslice(),
+            borrowed_storage.deleted_vector_bitslice(),
+            &stopped,
+        )
+        .unwrap();
     let scorer_orig = new_raw_scorer(
         query,
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
-    );
+    )
+    .unwrap();
     for i in 0..5 {
         let quant = scorer_quant.score_point(i);
         let orig = scorer_orig.score_point(i);

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -164,19 +164,23 @@ fn test_batch_and_single_request_equivalency() {
             payload_value.into(),
         )));
 
-        let search_res_1 =
-            hnsw_index.search(&[&query_vector_1], Some(&filter), 10, None, &false.into());
+        let search_res_1 = hnsw_index
+            .search(&[&query_vector_1], Some(&filter), 10, None, &false.into())
+            .unwrap();
 
-        let search_res_2 =
-            hnsw_index.search(&[&query_vector_2], Some(&filter), 10, None, &false.into());
+        let search_res_2 = hnsw_index
+            .search(&[&query_vector_2], Some(&filter), 10, None, &false.into())
+            .unwrap();
 
-        let batch_res = hnsw_index.search(
-            &[&query_vector_1, &query_vector_2],
-            Some(&filter),
-            10,
-            None,
-            &false.into(),
-        );
+        let batch_res = hnsw_index
+            .search(
+                &[&query_vector_1, &query_vector_2],
+                Some(&filter),
+                10,
+                None,
+                &false.into(),
+            )
+            .unwrap();
 
         assert_eq!(search_res_1[0], batch_res[0]);
         assert_eq!(search_res_2[0], batch_res[1]);

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -142,21 +142,24 @@ fn exact_search_test() {
     for _i in 0..attempts {
         let query = random_vector(&mut rnd, dim).into();
 
-        let index_result = hnsw_index.search(
-            &[&query],
-            None,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                exact: true,
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_result = hnsw_index
+            .search(
+                &[&query],
+                None,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    exact: true,
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into());
+            .search(&[&query], None, top, None, &false.into())
+            .unwrap();
 
         assert_eq!(
             index_result, plain_result,
@@ -178,21 +181,24 @@ fn exact_search_test() {
         )));
 
         let filter_query = Some(&filter);
-        let index_result = hnsw_index.search(
-            &[&query],
-            filter_query,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                exact: true,
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    exact: true,
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into());
+            .search(&[&query], filter_query, top, None, &false.into())
+            .unwrap();
 
         assert_eq!(
             index_result, plain_result,

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -220,16 +220,18 @@ fn _test_filterable_hnsw(
 
         let filter_query = Some(&filter);
 
-        let index_result = hnsw_index.search(
-            &[&query],
-            filter_query,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
 
         // check that search was performed using HNSW index
         assert_eq!(
@@ -243,7 +245,8 @@ fn _test_filterable_hnsw(
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into());
+            .search(&[&query], filter_query, top, None, &false.into())
+            .unwrap();
 
         if plain_result == index_result {
             hits += 1;

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -119,21 +119,24 @@ fn hnsw_discover_precision() {
     for _i in 0..attempts {
         let query: QueryVector = random_discovery_query(&mut rnd, dim);
 
-        let index_discovery_result = hnsw_index.search(
-            &[&query],
-            None,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_discovery_result = hnsw_index
+            .search(
+                &[&query],
+                None,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
 
         let plain_discovery_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into());
+            .search(&[&query], None, top, None, &false.into())
+            .unwrap();
 
         if plain_discovery_result == index_discovery_result {
             discovery_hits += 1;
@@ -241,21 +244,24 @@ fn filtered_hnsw_discover_precision() {
 
         let query: QueryVector = random_discovery_query(&mut rnd, dim);
 
-        let index_discovery_result = hnsw_index.search(
-            &[&query],
-            filter_query,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_discovery_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
 
         let plain_discovery_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into());
+            .search(&[&query], filter_query, top, None, &false.into())
+            .unwrap();
 
         if plain_discovery_result == index_discovery_result {
             discovery_hits += 1;

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -184,22 +184,25 @@ fn check_matches(
                 .vector_index
                 .borrow()
                 .search(&[&query], filter, top, None, &false.into())
+                .unwrap()
         })
         .collect::<Vec<_>>();
 
     let mut sames: usize = 0;
     let attempts = query_vectors.len();
     for (query, plain_result) in query_vectors.iter().zip(exact_search_results.iter()) {
-        let index_result = hnsw_index.search(
-            &[query],
-            filter,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+        let index_result = hnsw_index
+            .search(
+                &[query],
+                filter,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
         sames += sames_count(&index_result, plain_result);
     }
     let acc = 100.0 * sames as f64 / (attempts * top) as f64;
@@ -217,38 +220,42 @@ fn check_oversampling(
     for query in query_vectors {
         let ef_oversampling = ef / 8;
 
-        let oversampling_1_result = hnsw_index.search(
-            &[query],
-            filter,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef_oversampling),
-                quantization: Some(QuantizationSearchParams {
-                    rescore: Some(true),
+        let oversampling_1_result = hnsw_index
+            .search(
+                &[query],
+                filter,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef_oversampling),
+                    quantization: Some(QuantizationSearchParams {
+                        rescore: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+                &false.into(),
+            )
+            .unwrap();
         let best_1 = oversampling_1_result[0][0];
         let worst_1 = oversampling_1_result[0].last().unwrap();
 
-        let oversampling_2_result = hnsw_index.search(
-            &[&query],
-            None,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef_oversampling),
-                quantization: Some(QuantizationSearchParams {
-                    oversampling: Some(4.0),
-                    rescore: Some(true),
+        let oversampling_2_result = hnsw_index
+            .search(
+                &[&query],
+                None,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef_oversampling),
+                    quantization: Some(QuantizationSearchParams {
+                        oversampling: Some(4.0),
+                        rescore: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+                &false.into(),
+            )
+            .unwrap();
         let best_2 = oversampling_2_result[0][0];
         let worst_2 = oversampling_2_result[0].last().unwrap();
 
@@ -270,20 +277,22 @@ fn check_rescoring(
     top: usize,
 ) {
     for query in query_vectors.iter() {
-        let index_result = hnsw_index.search(
-            &[query],
-            filter,
-            top,
-            Some(&SearchParams {
-                hnsw_ef: Some(ef),
-                quantization: Some(QuantizationSearchParams {
-                    rescore: Some(true),
+        let index_result = hnsw_index
+            .search(
+                &[query],
+                filter,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    quantization: Some(QuantizationSearchParams {
+                        rescore: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
-                ..Default::default()
-            }),
-            &false.into(),
-        );
+                &false.into(),
+            )
+            .unwrap();
         for result in &index_result[0] {
             assert!(result.score < ScoreType::EPSILON);
         }


### PR DESCRIPTION
Sparse vector index integration step.

This is a preparation step before removing temporary Sparse-Dense conversion:
https://github.com/qdrant/qdrant/blob/dev/lib/segment/src/data_types/vectors.rs#L36

To remove this conversion, raw scorer constructor should return `Result` with scorer

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
