### PR TITLE
Improve logging for shard transfers

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -115,6 +115,9 @@ impl QueueProxyShard {
     /// This method helps with safely destructing the queue proxy shard, ensuring that remaining
     /// queue updates are transferred to the remote shard, and only unwrapping the local shard
     /// on success. It also releases the max acknowledged WAL version.
+    ///
+    /// Because we have ownership (`self`) we have exclusive access to the internals. It guarantees
+    /// that we will not process new operations on the shard while finalization is happening.
     pub async fn finalize(self) -> Result<(LocalShard, RemoteShard), (CollectionError, Self)> {
         // Transfer all updates, do not unwrap on failure but return error with self
         match self.transfer_all_missed_updates().await {

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -267,7 +267,7 @@ async fn transfer_snapshot(
     );
 
     // Create shard snapshot
-    log::trace!("Creating snapshot of shard {shard_id} for shard snapshot transfer...");
+    log::trace!("Creating snapshot of shard {shard_id} for shard snapshot transfer");
     let snapshot_description = shard_holder_read
         .create_shard_snapshot(snapshots_path, collection_name, shard_id, temp_dir)
         .await?;
@@ -290,7 +290,7 @@ async fn transfer_snapshot(
     ));
 
     log::debug!(
-        "Transferring and recovering shard {shard_id} snapshot on peer {}...",
+        "Transferring and recovering shard {shard_id} snapshot on peer {}",
         transfer_config.to
     );
     remote_shard
@@ -312,7 +312,7 @@ async fn transfer_snapshot(
     }
 
     // Set shard state to Partial
-    log::debug!("Shard {shard_id} snapshot recovered on {} for snapshot transfer, switching into next stage through consensus...", transfer_config.to);
+    log::debug!("Shard {shard_id} snapshot recovered on {} for snapshot transfer, switching into next stage through consensus", transfer_config.to);
     consensus
         .snapshot_recovered_switch_to_partial_confirm_remote(
             &transfer_config,
@@ -381,14 +381,14 @@ async fn await_consensus_sync(
     let timeout = sleep(defaults::CONSENSUS_META_OP_WAIT);
 
     log::trace!(
-        "Waiting on {peer_count} peer(s) to reach consensus before finalizing shard snapshot transfer..."
+        "Waiting on {peer_count} peer(s) to reach consensus before finalizing shard snapshot transfer"
     );
     tokio::select! {
         Ok(_) = sync_consensus => {
             log::trace!("All peers reached consensus");
         }
         _ = timeout => {
-            log::warn!("All peers failed to synchronize consensus, continuing after timeout...");
+            log::warn!("All peers failed to synchronize consensus, continuing after timeout");
         }
     }
 }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -392,6 +392,7 @@ async fn await_consensus_sync(
         "Waiting on {peer_count} peer(s) to reach consensus before finalizing shard snapshot transfer"
     );
     tokio::select! {
+        biased;
         Ok(_) = sync_consensus => {
             log::trace!("All peers reached consensus");
         }


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

Improves logging for the logic that is driving shard transfers. Contains no logic changes.

This logs steps in both streaming records and snapshot transfer methods. This should help debugging remote machines by giving us a better idea of what stage a transfer is in. We could benefit from this if users would enable debug/trace logging.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?