### PR TITLE
Fix unused import and implementation in release builds

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+#[cfg(debug_assertions)]
 use std::thread;
 
 use async_trait::async_trait;
@@ -106,6 +107,7 @@ impl QueueProxyShard {
     }
 
     /// Check if the queue proxy shard is already finalized
+    #[cfg(debug_assertions)]
     fn is_finalized(&self) -> bool {
         self.inner.is_none()
     }


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

An unused import and implementation in release builds slipped through when <https://github.com/qdrant/qdrant/pull/2467> was merged.

This fixes:
```rust
warning: unused import: `std::thread`
 --> lib/collection/src/shards/queue_proxy_shard.rs:4:5
  |
4 | use std::thread;
  |     ^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: method `is_finalized` is never used
   --> lib/collection/src/shards/queue_proxy_shard.rs:109:8
    |
53  | impl QueueProxyShard {
    | -------------------- method in this implementation
...
109 |     fn is_finalized(&self) -> bool {
    |        ^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

 ### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?