### PR TITLE
SparseVectorIndex implements VectorIndex

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8333,9 +8333,11 @@
           "filtered_large_cardinality",
           "filtered_plain",
           "filtered_small_cardinality",
+          "filtered_sparse",
           "unfiltered_exact",
           "unfiltered_hnsw",
-          "unfiltered_plain"
+          "unfiltered_plain",
+          "unfiltered_sparse"
         ],
         "properties": {
           "index_name": {
@@ -8348,6 +8350,9 @@
           "unfiltered_hnsw": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
           },
+          "unfiltered_sparse": {
+            "$ref": "#/components/schemas/OperationDurationStatistics"
+          },
           "filtered_plain": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
           },
@@ -8358,6 +8363,9 @@
             "$ref": "#/components/schemas/OperationDurationStatistics"
           },
           "filtered_exact": {
+            "$ref": "#/components/schemas/OperationDurationStatistics"
+          },
+          "filtered_sparse": {
             "$ref": "#/components/schemas/OperationDurationStatistics"
           },
           "unfiltered_exact": {

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
+use sparse::common::sparse_vector::SparseVector;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::{
@@ -115,6 +116,43 @@ pub fn random_bool_payload<R: Rng + ?Sized>(
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
     (0..size).map(|_| rnd_gen.gen()).collect()
+}
+
+/// Generates a non empty sparse vector
+pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_size: usize) -> SparseVector {
+    let size = rnd_gen.gen_range(1..max_size);
+    let mut tuples: Vec<(i32, f64)> = vec![];
+
+    for i in 1..=size {
+        let no_skip = rnd_gen.gen_bool(0.5);
+        if no_skip {
+            tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+        }
+    }
+
+    // make sure we have at least one vector
+    if tuples.is_empty() {
+        tuples.push((
+            rnd_gen.gen_range(1..max_size) as i32,
+            rnd_gen.gen_range(0.0..100.0),
+        ));
+    }
+
+    SparseVector::from(tuples)
+}
+
+/// Generates a sparse vector with all dimensions filled
+pub fn random_full_sparse_vector<R: Rng + ?Sized>(
+    rnd_gen: &mut R,
+    max_size: usize,
+) -> SparseVector {
+    let mut tuples: Vec<(i32, f64)> = vec![];
+
+    for i in 1..=max_size {
+        tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+    }
+
+    SparseVector::from(tuples)
 }
 
 pub fn random_uncommon_condition<R: Rng + ?Sized>(rnd_gen: &mut R) -> Condition {

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -4,7 +4,6 @@ use itertools::Itertools;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
-use sparse::common::sparse_vector::SparseVector;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::{
@@ -116,43 +115,6 @@ pub fn random_bool_payload<R: Rng + ?Sized>(
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
     (0..size).map(|_| rnd_gen.gen()).collect()
-}
-
-/// Generates a non empty sparse vector
-pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_size: usize) -> SparseVector {
-    let size = rnd_gen.gen_range(1..max_size);
-    let mut tuples: Vec<(i32, f64)> = vec![];
-
-    for i in 1..=size {
-        let no_skip = rnd_gen.gen_bool(0.5);
-        if no_skip {
-            tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
-        }
-    }
-
-    // make sure we have at least one vector
-    if tuples.is_empty() {
-        tuples.push((
-            rnd_gen.gen_range(1..max_size) as i32,
-            rnd_gen.gen_range(0.0..100.0),
-        ));
-    }
-
-    SparseVector::from(tuples)
-}
-
-/// Generates a sparse vector with all dimensions filled
-pub fn random_full_sparse_vector<R: Rng + ?Sized>(
-    rnd_gen: &mut R,
-    max_size: usize,
-) -> SparseVector {
-    let mut tuples: Vec<(i32, f64)> = vec![];
-
-    for i in 1..=max_size {
-        tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
-    }
-
-    SparseVector::from(tuples)
 }
 
 pub fn random_uncommon_condition<R: Rng + ?Sized>(rnd_gen: &mut R) -> Condition {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -800,6 +800,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             filtered_small_cardinality: tm.small_cardinality.lock().get_statistics(),
             filtered_large_cardinality: tm.large_cardinality.lock().get_statistics(),
             filtered_exact: tm.exact_filtered.lock().get_statistics(),
+            filtered_sparse: Default::default(),
             unfiltered_exact: tm.exact_unfiltered.lock().get_statistics(),
             unfiltered_sparse: Default::default(),
         }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -61,10 +61,10 @@ pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     config: HnswGraphConfig,
     path: PathBuf,
     graph: Option<GraphLayers<TGraphLinks>>,
-    searches_telemetry: SearchesTelemetry,
+    searches_telemetry: HNSWSearchesTelemetry,
 }
 
-struct SearchesTelemetry {
+struct HNSWSearchesTelemetry {
     unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_hnsw: Arc<Mutex<OperationDurationsAggregator>>,
     small_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
@@ -110,7 +110,6 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         } else {
             None
         };
-
         Ok(HNSWIndex {
             id_tracker,
             vector_storage,
@@ -119,7 +118,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
             config,
             path: path.to_owned(),
             graph,
-            searches_telemetry: SearchesTelemetry {
+            searches_telemetry: HNSWSearchesTelemetry {
                 unfiltered_hnsw: OperationDurationsAggregator::new(),
                 unfiltered_plain: OperationDurationsAggregator::new(),
                 small_cardinality: OperationDurationsAggregator::new(),
@@ -793,7 +792,6 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
 
     fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
         let tm = &self.searches_telemetry;
-
         VectorIndexSearchesTelemetry {
             index_name: None,
             unfiltered_plain: tm.unfiltered_plain.lock().get_statistics(),
@@ -803,6 +801,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
             filtered_large_cardinality: tm.large_cardinality.lock().get_statistics(),
             filtered_exact: tm.exact_filtered.lock().get_statistics(),
             unfiltered_exact: tm.exact_unfiltered.lock().get_statistics(),
+            unfiltered_sparse: Default::default(),
         }
     }
 

--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -7,7 +7,7 @@ pub mod plain_payload_index;
 pub mod query_estimator;
 mod query_optimization;
 mod sample_estimation;
-mod sparse_index;
+pub mod sparse_index;
 mod struct_filter_context;
 pub mod struct_payload_index;
 mod vector_index_base;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -285,6 +285,7 @@ impl VectorIndex for PlainIndex {
             filtered_large_cardinality: OperationDurationStatistics::default(),
             filtered_exact: OperationDurationStatistics::default(),
             unfiltered_exact: OperationDurationStatistics::default(),
+            unfiltered_sparse: OperationDurationStatistics::default(),
         }
     }
 

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -284,6 +284,7 @@ impl VectorIndex for PlainIndex {
             filtered_small_cardinality: OperationDurationStatistics::default(),
             filtered_large_cardinality: OperationDurationStatistics::default(),
             filtered_exact: OperationDurationStatistics::default(),
+            filtered_sparse: Default::default(),
             unfiltered_exact: OperationDurationStatistics::default(),
             unfiltered_sparse: OperationDurationStatistics::default(),
         }

--- a/lib/segment/src/index/sparse_index/mod.rs
+++ b/lib/segment/src/index/sparse_index/mod.rs
@@ -1,2 +1,3 @@
 #![allow(dead_code)]
-mod sparse_vector_index;
+pub mod sparse_search_telemetry;
+pub mod sparse_vector_index;

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
+use crate::telemetry::VectorIndexSearchesTelemetry;
 
 pub struct SparseSearchesTelemetry {
     pub filtered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
@@ -21,5 +22,22 @@ impl SparseSearchesTelemetry {
 impl Default for SparseSearchesTelemetry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
+    fn from(value: &SparseSearchesTelemetry) -> Self {
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: Default::default(),
+            filtered_plain: Default::default(),
+            unfiltered_hnsw: Default::default(),
+            filtered_small_cardinality: Default::default(),
+            filtered_large_cardinality: Default::default(),
+            filtered_exact: Default::default(),
+            filtered_sparse: value.filtered_sparse.lock().get_statistics(),
+            unfiltered_sparse: value.unfiltered_sparse.lock().get_statistics(),
+            unfiltered_exact: Default::default(),
+        }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::common::operation_time_statistics::OperationDurationsAggregator;
+
+pub struct SparseSearchesTelemetry {
+    pub unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
+    pub unfiltered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
+    pub small_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
+    pub large_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+impl SparseSearchesTelemetry {
+    pub fn new() -> Self {
+        SparseSearchesTelemetry {
+            unfiltered_plain: OperationDurationsAggregator::new(),
+            unfiltered_sparse: OperationDurationsAggregator::new(),
+            small_cardinality: OperationDurationsAggregator::new(),
+            large_cardinality: OperationDurationsAggregator::new(),
+        }
+    }
+}
+
+impl Default for SparseSearchesTelemetry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -5,19 +5,15 @@ use parking_lot::Mutex;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 
 pub struct SparseSearchesTelemetry {
-    pub unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
+    pub filtered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
     pub unfiltered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
-    pub small_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
-    pub large_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
 impl SparseSearchesTelemetry {
     pub fn new() -> Self {
         SparseSearchesTelemetry {
-            unfiltered_plain: OperationDurationsAggregator::new(),
+            filtered_sparse: OperationDurationsAggregator::new(),
             unfiltered_sparse: OperationDurationsAggregator::new(),
-            small_cardinality: OperationDurationsAggregator::new(),
-            large_cardinality: OperationDurationsAggregator::new(),
         }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -170,6 +170,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             ram_index.upsert(id, vector.to_owned());
         }
         self.max_point_id = available_point_count as PointOffsetType - 1;
+        // TODO(sparse) this operation loads the entire index into memory which can cause OOM on large storage
         self.inverted_index = TInvertedIndex::from_ram_index(ram_index, &self.path)?;
         Ok(())
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -65,7 +65,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             check_process_stopped(is_stopped)?;
             // measure time according to filter
             if with_filter {
-                let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+                let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.filtered_sparse);
             } else {
                 let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_sparse);
             }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -19,6 +19,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::sparse_raw_scorer::sparse_check_vector;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
@@ -131,14 +132,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         let deleted_vectors = vector_storage.deleted_vector_bitslice();
         // filter for deleted points
         let not_deleted_condition = |idx: PointOffsetType| -> bool {
-            !deleted_point_bitslice
-                .get(idx as usize)
-                .map(|x| *x)
-                .unwrap_or(false)
-                && !deleted_vectors
-                    .get(idx as usize)
-                    .map(|x| *x)
-                    .unwrap_or(false)
+            sparse_check_vector(idx, deleted_point_bitslice, deleted_vectors)
         };
         match filter {
             Some(filter) => {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,23 +1,32 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::types::ScoredPointOffset;
+use common::types::{PointOffsetType, ScoredPointOffset};
 use sparse::common::sparse_vector::SparseVector;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::search_context::SearchContext;
 
+use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
+use crate::common::operation_time_statistics::ScopeDurationMeasurer;
+use crate::data_types::vectors::QueryVector;
 use crate::id_tracker::IdTrackerSS;
+use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::vector_storage::VectorStorageEnum;
+use crate::index::{PayloadIndex, VectorIndex};
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
-    id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+    pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    pub payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     path: PathBuf,
-    inverted_index: TInvertedIndex,
+    pub inverted_index: TInvertedIndex,
+    searches_telemetry: SparseSearchesTelemetry,
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -26,28 +35,150 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
         payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-        path: PathBuf,
+        path: &Path, // TODO(sparse) use path to load/save index
         inverted_index: TInvertedIndex,
     ) -> Self {
+        let searches_telemetry = SparseSearchesTelemetry::new();
+        let path = path.to_path_buf();
         Self {
             id_tracker,
             vector_storage,
             payload_index,
             path,
             inverted_index,
+            searches_telemetry,
         }
     }
 
     /// Search index using sparse vector query
     pub fn search_sparse(
         &self,
-        query: SparseVector,
+        vectors: &[&QueryVector],
         top: usize,
         is_stopped: &AtomicBool,
-    ) -> Vec<ScoredPointOffset> {
-        let mut search_context = SearchContext::new(query, top, &self.inverted_index, is_stopped);
-        search_context.search()
+        with_filter: bool,
+        condition: impl Fn(PointOffsetType) -> bool,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let mut result = vec![];
+
+        for vector in vectors {
+            check_process_stopped(is_stopped)?;
+            // measure time according to filter
+            if with_filter {
+                let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+            } else {
+                let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_sparse);
+            }
+            let vector = match vector {
+                QueryVector::Nearest(vector) => vector,
+                QueryVector::Recommend(_) => {
+                    return Err(OperationError::ValidationError {
+                        description: "Cannot recommend sparse vectors".to_string(),
+                    })
+                }
+                QueryVector::Discovery(_) => {
+                    return Err(OperationError::ValidationError {
+                        description: "Cannot discovery sparse vectors".to_string(),
+                    })
+                }
+                QueryVector::Context(_) => {
+                    return Err(OperationError::ValidationError {
+                        description: "Cannot context query sparse vectors".to_string(),
+                    })
+                }
+            };
+            let sparse_vector: &SparseVector = vector.to_vec_ref().try_into()?;
+            let mut search_context = SearchContext::new(
+                sparse_vector.to_owned(),
+                top,
+                &self.inverted_index,
+                is_stopped,
+            );
+            let points = search_context.search(&condition);
+            result.push(points);
+        }
+
+        Ok(result)
     }
 }
 
-// TODO impl VectorIndex for SparseVectorIndex
+impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedIndex> {
+    fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        _params: Option<&SearchParams>,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let deleted_point_bitslice = id_tracker.deleted_point_bitslice();
+        let deleted_vectors = vector_storage.deleted_vector_bitslice();
+        // filter for deleted points
+        let not_deleted_condition = |idx: PointOffsetType| -> bool {
+            !deleted_point_bitslice
+                .get(idx as usize)
+                .map(|x| *x)
+                .unwrap_or(false)
+                && !deleted_vectors
+                    .get(idx as usize)
+                    .map(|x| *x)
+                    .unwrap_or(false)
+        };
+        match filter {
+            Some(filter) => {
+                let payload_index = self.payload_index.borrow();
+                // TODO(sparse) check cardinality and fall back to payload index scan of low cardinality (needs benchmarks)
+                let filter_context = payload_index.filter_context(filter);
+                let matches_filter_condition =
+                    |idx: PointOffsetType| -> bool { filter_context.check(idx) };
+                self.search_sparse(vectors, top, is_stopped, true, |idx| {
+                    not_deleted_condition(idx) && matches_filter_condition(idx)
+                })
+            }
+            None => {
+                // query sparse index directly
+                self.search_sparse(vectors, top, is_stopped, false, not_deleted_condition)
+            }
+        }
+    }
+
+    fn build_index(&mut self, _stopped: &AtomicBool) -> OperationResult<()> {
+        let borrowed_vector_storage = self.vector_storage.borrow();
+        let borrowed_id_tracker = self.id_tracker.borrow();
+        let points_count = borrowed_vector_storage.total_vector_count();
+        let mut ram_index = InvertedIndexRam::empty();
+        for id in 0..points_count as PointOffsetType {
+            // do not add deleted points to the index
+            if borrowed_id_tracker.is_deleted_point(id) {
+                continue;
+            }
+            let vector: &SparseVector = borrowed_vector_storage.get_vector(id).try_into()?;
+            ram_index.upsert(id, vector.to_owned());
+        }
+
+        self.inverted_index = TInvertedIndex::from_ram_index(ram_index, &self.path)?;
+        Ok(())
+    }
+
+    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
+        let tm = &self.searches_telemetry;
+        tm.into()
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        self.inverted_index.files()
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.inverted_index.indexed_vector_count()
+    }
+
+    fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        let vector_storage = self.vector_storage.borrow();
+        let vector: &SparseVector = vector_storage.get_vector(id).try_into()?;
+        self.inverted_index.upsert(id, vector.clone());
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -34,17 +34,17 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Create new sparse vector index
-    pub fn new(
+    pub fn open(
         id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
         payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-        path: &Path, // TODO(sparse) use path to load/save index
-        inverted_index: TInvertedIndex,
-    ) -> Self {
+        path: &Path,
+    ) -> OperationResult<Self> {
         let searches_telemetry = SparseSearchesTelemetry::new();
-        let path = path.to_path_buf();
         let max_point_id = 0;
-        Self {
+        let inverted_index = TInvertedIndex::open(path)?;
+        let path = path.to_path_buf();
+        let index = Self {
             id_tracker,
             vector_storage,
             payload_index,
@@ -52,7 +52,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             inverted_index,
             searches_telemetry,
             max_point_id,
-        }
+        };
+        Ok(index)
     }
 
     /// Search index using sparse vector query

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -102,6 +103,20 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         }
 
         Ok(result)
+    }
+
+    /// Returns the maximum number of results that can be returned by the index for a given sparse vector
+    /// Warning: the cost of this function grows with the number of dimensions in the query vector
+    pub fn max_result_count(&self, query_vector: &SparseVector) -> usize {
+        let mut unique_record_ids = HashSet::new();
+        for dim_id in query_vector.indices.iter() {
+            if let Some(posting_list) = self.inverted_index.get(dim_id) {
+                for element in posting_list.elements.iter() {
+                    unique_record_ids.insert(element.record_id);
+                }
+            }
+        }
+        unique_record_ids.len()
     }
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -91,13 +91,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     })
                 }
             };
-            let sparse_vector: &SparseVector = vector.to_vec_ref().try_into()?;
-            let mut search_context = SearchContext::new(
-                sparse_vector.to_owned(),
-                top,
-                &self.inverted_index,
-                is_stopped,
-            );
+            let sparse_vector: SparseVector = vector.clone().try_into()?;
+            let mut search_context =
+                SearchContext::new(sparse_vector, top, &self.inverted_index, is_stopped);
             let points = search_context.search(&condition);
             result.push(points);
         }

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::anonymize::Anonymize;
 use crate::common::operation_time_statistics::OperationDurationStatistics;
-use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
 use crate::types::{
     PayloadIndexInfo, SegmentConfig, SegmentInfo, VectorDataConfig, VectorDataInfo,
 };
@@ -70,23 +69,6 @@ pub struct VectorIndexSearchesTelemetry {
 
     #[serde(skip_serializing_if = "OperationDurationStatistics::is_empty")]
     pub unfiltered_exact: OperationDurationStatistics,
-}
-
-impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
-    fn from(value: &SparseSearchesTelemetry) -> Self {
-        VectorIndexSearchesTelemetry {
-            index_name: None,
-            unfiltered_plain: Default::default(),
-            filtered_plain: Default::default(),
-            unfiltered_hnsw: Default::default(),
-            filtered_small_cardinality: Default::default(),
-            filtered_large_cardinality: Default::default(),
-            filtered_exact: Default::default(),
-            filtered_sparse: value.filtered_sparse.lock().get_statistics(),
-            unfiltered_sparse: value.unfiltered_sparse.lock().get_statistics(),
-            unfiltered_exact: Default::default(),
-        }
-    }
 }
 
 impl Anonymize for SegmentTelemetry {

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -66,6 +66,9 @@ pub struct VectorIndexSearchesTelemetry {
     pub filtered_exact: OperationDurationStatistics,
 
     #[serde(skip_serializing_if = "OperationDurationStatistics::is_empty")]
+    pub filtered_sparse: OperationDurationStatistics,
+
+    #[serde(skip_serializing_if = "OperationDurationStatistics::is_empty")]
     pub unfiltered_exact: OperationDurationStatistics,
 }
 
@@ -73,14 +76,15 @@ impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
     fn from(value: &SparseSearchesTelemetry) -> Self {
         VectorIndexSearchesTelemetry {
             index_name: None,
-            unfiltered_plain: value.unfiltered_plain.lock().get_statistics(),
+            unfiltered_plain: Default::default(),
             filtered_plain: Default::default(),
             unfiltered_hnsw: Default::default(),
-            filtered_small_cardinality: value.small_cardinality.lock().get_statistics(),
-            filtered_large_cardinality: value.large_cardinality.lock().get_statistics(),
+            filtered_small_cardinality: Default::default(),
+            filtered_large_cardinality: Default::default(),
             filtered_exact: Default::default(),
-            unfiltered_exact: Default::default(),
+            filtered_sparse: value.filtered_sparse.lock().get_statistics(),
             unfiltered_sparse: value.unfiltered_sparse.lock().get_statistics(),
+            unfiltered_exact: Default::default(),
         }
     }
 }
@@ -165,6 +169,7 @@ impl Anonymize for VectorIndexSearchesTelemetry {
             filtered_small_cardinality: self.filtered_small_cardinality.anonymize(),
             filtered_large_cardinality: self.filtered_large_cardinality.anonymize(),
             filtered_exact: self.filtered_exact.anonymize(),
+            filtered_sparse: self.filtered_sparse.anonymize(),
             unfiltered_exact: self.filtered_exact.anonymize(),
         }
     }

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -23,6 +23,7 @@ pub mod common;
 pub mod query;
 mod query_scorer;
 pub mod simple_sparse_vector_storage;
+mod sparse_raw_scorer;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -22,8 +22,7 @@ mod bitvec;
 pub mod common;
 pub mod query;
 mod query_scorer;
-mod simple_sparse_vector_storage;
-mod sparse_raw_scorer;
+pub mod simple_sparse_vector_storage;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -23,7 +23,7 @@ pub mod common;
 pub mod query;
 mod query_scorer;
 pub mod simple_sparse_vector_storage;
-mod sparse_raw_scorer;
+pub mod sparse_raw_scorer;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -14,4 +14,5 @@ pub mod payload_index_test;
 pub mod scroll_filtering_test;
 pub mod segment_builder_test;
 pub mod segment_tests;
+mod sparse_vector_index_search_tests;
 pub mod utils;

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -8,9 +8,7 @@ use rand::{Rng, SeedableRng};
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::data_types::vectors::QueryVector;
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
-use segment::fixtures::payload_fixtures::{
-    random_full_sparse_vector, random_sparse_vector, STR_KEY,
-};
+use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::{PayloadIndex, VectorIndex};
@@ -22,6 +20,7 @@ use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_ve
 use segment::vector_storage::VectorStorage;
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
+use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use tempfile::Builder;
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -1,0 +1,339 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::types::PointOffsetType;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use segment::data_types::vectors::QueryVector;
+use segment::fixtures::payload_context_fixture::FixtureIdTracker;
+use segment::fixtures::payload_fixtures::{
+    random_full_sparse_vector, random_sparse_vector, STR_KEY,
+};
+use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use segment::index::struct_payload_index::StructPayloadIndex;
+use segment::index::{PayloadIndex, VectorIndex};
+use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use segment::types::PayloadFieldSchema::FieldType;
+use segment::types::PayloadSchemaType::Keyword;
+use segment::types::{Condition, Distance, FieldCondition, Filter, Payload};
+use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::VectorStorage;
+use serde_json::json;
+use sparse::common::sparse_vector::SparseVector;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use sparse::index::inverted_index::InvertedIndex;
+use tempfile::Builder;
+
+/// Max dimension of sparse vectors used in tests
+const MAX_SPARSE_DIM: usize = 1024;
+
+/// Prepares a sparse vector index with random sparse vectors
+fn fixture_sparse_index<R: Rng + ?Sized>(
+    rnd: &mut R,
+    max_dim: usize,
+    stopped: &AtomicBool,
+) -> SparseVectorIndex<InvertedIndexRam> {
+    // test params
+    let num_vectors = 1000;
+
+    // temp dirs
+    let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let index_dir = Builder::new().prefix("index_dir").tempdir().unwrap();
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+
+    // setup
+    let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num_vectors)));
+    let payload_storage = InMemoryPayloadStorage::default();
+    let wrapped_payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
+    let payload_index = StructPayloadIndex::open(
+        wrapped_payload_storage,
+        id_tracker.clone(),
+        payload_dir.path(),
+        true,
+    )
+    .unwrap();
+    let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
+
+    let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let vector_storage =
+        open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+
+    let inverted_index_ram = InvertedIndexRam::empty();
+
+    let mut sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = SparseVectorIndex::new(
+        id_tracker,
+        vector_storage.clone(),
+        wrapped_payload_index,
+        index_dir.path(),
+        inverted_index_ram,
+    );
+
+    // add points to storage
+    for idx in 0..num_vectors {
+        let vec = &random_sparse_vector(rnd, max_dim);
+        vector_storage
+            .borrow_mut()
+            .insert_vector(idx as PointOffsetType, vec.into())
+            .unwrap();
+    }
+    assert_eq!(
+        vector_storage.borrow().available_vector_count(),
+        num_vectors
+    );
+
+    // build index
+    sparse_vector_index.build_index(stopped).unwrap();
+    assert_eq!(sparse_vector_index.indexed_vector_count(), num_vectors);
+    sparse_vector_index
+}
+
+#[test]
+fn sparse_vector_index_no_filter_search() {
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let sparse_vector_index = fixture_sparse_index(&mut rnd, MAX_SPARSE_DIM, &stopped);
+
+    // random query vectors
+    let attempts = 100;
+    let query_vectors = (0..attempts)
+        .map(|_| random_sparse_vector(&mut rnd, MAX_SPARSE_DIM))
+        .collect::<Vec<_>>();
+
+    // filter matches everything
+    let filter = Filter::new_must_not(Condition::Field(FieldCondition::new_match(
+        STR_KEY,
+        STR_KEY.to_owned().into(),
+    )));
+
+    // compares results with and without filters
+    // expects the filter to have no effect on the results because the filter matches everything
+    for query in query_vectors.into_iter() {
+        // top to get all results
+        let top = sparse_vector_index.inverted_index.max_result_count(&query);
+        assert!(top > 0);
+        let query_vector: QueryVector = query.into();
+        // with filter
+        let index_results_filter = sparse_vector_index
+            .search(&[&query_vector], Some(&filter), top, None, &stopped)
+            .unwrap();
+
+        // without filter
+        let index_results_no_filter = sparse_vector_index
+            .search(&[&query_vector], None, top, None, &stopped)
+            .unwrap();
+
+        assert_eq!(index_results_filter.len(), index_results_no_filter.len());
+
+        for (filter_result, no_filter_result) in index_results_filter
+            .iter()
+            .zip(index_results_no_filter.iter())
+        {
+            assert_eq!(filter_result.len(), top);
+            assert_eq!(filter_result.len(), no_filter_result.len());
+            for (filter_result, no_filter_result) in
+                filter_result.iter().zip(no_filter_result.iter())
+            {
+                assert_eq!(filter_result, no_filter_result);
+            }
+        }
+    }
+}
+
+#[test]
+fn sparse_vector_index_consistent_with_storage() {
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let sparse_vector_index = fixture_sparse_index(&mut rnd, MAX_SPARSE_DIM, &stopped);
+    let borrowed_vector_storage = sparse_vector_index.vector_storage.borrow();
+    let point_count = borrowed_vector_storage.available_vector_count();
+    for id in 0..point_count as PointOffsetType {
+        // assuming no deleted points
+        let vector: &SparseVector = borrowed_vector_storage.get_vector(id).try_into().unwrap();
+        // check posting lists are consistent with storage
+        for (dim_id, dim_value) in vector.indices.iter().zip(vector.values.iter()) {
+            let posting_list = sparse_vector_index.inverted_index.get(dim_id).unwrap();
+            // assert posting list sorted  by record id
+            assert!(posting_list
+                .elements
+                .windows(2)
+                .all(|w| w[0].record_id < w[1].record_id));
+            // assert posted list contains record id
+            assert!(posting_list
+                .elements
+                .iter()
+                .any(|e| e.record_id == id && e.weight == *dim_value));
+        }
+        // check the vector can be found via search using large top
+        let top = sparse_vector_index.inverted_index.max_result_count(vector);
+        let query_vector: QueryVector = vector.to_owned().into();
+        let results = sparse_vector_index
+            .search(&[&query_vector], None, top, None, &stopped)
+            .unwrap();
+        assert!(results[0].iter().any(|s| s.idx == id));
+    }
+}
+
+#[test]
+fn sparse_vector_index_deleted_points_search() {
+    let stopped = AtomicBool::new(false);
+    let top = 10;
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let mut sparse_vector_index = fixture_sparse_index(&mut rnd, MAX_SPARSE_DIM, &stopped);
+
+    // sanity check (all indexed, no deleted points)
+    assert_eq!(
+        sparse_vector_index
+            .id_tracker
+            .borrow()
+            .available_point_count(),
+        sparse_vector_index.indexed_vector_count()
+    );
+    assert_eq!(
+        sparse_vector_index
+            .id_tracker
+            .borrow()
+            .deleted_point_count(),
+        0
+    );
+
+    // query index
+    let query_vector: QueryVector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM).into();
+    let before_deletion_results: Vec<_> = sparse_vector_index
+        .search(&[&query_vector], None, top, None, &stopped)
+        .unwrap();
+
+    // pick a point to delete
+    let deleted_idx = before_deletion_results[0][0].idx;
+
+    // delete a point
+    let deleted_external = sparse_vector_index
+        .id_tracker
+        .borrow_mut()
+        .external_id(deleted_idx)
+        .unwrap();
+    sparse_vector_index
+        .id_tracker
+        .borrow_mut()
+        .drop(deleted_external)
+        .unwrap();
+
+    assert!(sparse_vector_index
+        .id_tracker
+        .borrow()
+        .is_deleted_point(deleted_idx));
+    assert_eq!(
+        sparse_vector_index
+            .id_tracker
+            .borrow()
+            .deleted_point_count(),
+        1
+    );
+    // still need to update index
+    assert_eq!(
+        sparse_vector_index
+            .id_tracker
+            .borrow()
+            .available_point_count(),
+        sparse_vector_index.indexed_vector_count() - 1
+    );
+
+    // refresh index to remove point
+    sparse_vector_index.build_index(&stopped).unwrap();
+    assert_eq!(
+        sparse_vector_index
+            .id_tracker
+            .borrow()
+            .available_point_count(),
+        sparse_vector_index.indexed_vector_count()
+    );
+
+    // assert that the deleted point is no longer in the index
+    let after_deletion_results: Vec<_> = sparse_vector_index
+        .search(&[&query_vector], None, top, None, &stopped)
+        .unwrap();
+    assert_ne!(before_deletion_results, after_deletion_results);
+    assert!(after_deletion_results
+        .iter()
+        .all(|x| x.iter().all(|y| y.idx != deleted_idx)));
+}
+
+#[test]
+fn sparse_vector_index_filtered_search() {
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+    let field_name = "field";
+    let field_value = "important value";
+
+    // setup index
+    let sparse_vector_index = fixture_sparse_index(&mut rnd, MAX_SPARSE_DIM, &stopped);
+
+    // query index by payload
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        field_name,
+        field_value.to_owned().into(),
+    )));
+
+    // query all sparse dimension to get all points
+    let query_vector: QueryVector = random_full_sparse_vector(&mut rnd, MAX_SPARSE_DIM).into();
+    let before_result = sparse_vector_index
+        .search(&[&query_vector], Some(&filter), 10, None, &stopped)
+        .unwrap();
+    assert_eq!(before_result.len(), 1);
+    assert_eq!(before_result[0].len(), 0);
+
+    // create payload field index
+    let mut payload_index = sparse_vector_index.payload_index.borrow_mut();
+    payload_index
+        .set_indexed(field_name, Keyword.into())
+        .unwrap();
+    drop(payload_index);
+
+    // assert payload field index created and empty
+    let payload_index = sparse_vector_index.payload_index.borrow();
+    let indexed_fields = payload_index.indexed_fields();
+    assert_eq!(*indexed_fields.get(field_name).unwrap(), FieldType(Keyword));
+
+    let field_indexes = &payload_index.field_indexes;
+    let field_index = field_indexes.get(field_name).unwrap();
+    assert_eq!(field_index[0].count_indexed_points(), 0);
+    drop(payload_index);
+
+    // add payload on the first half of the points
+    let half_indexed_count = sparse_vector_index.indexed_vector_count() / 2;
+    let payload: Payload = json!({
+        field_name: field_value,
+    })
+    .into();
+    let mut payload_index = sparse_vector_index.payload_index.borrow_mut();
+    for idx in 0..half_indexed_count {
+        payload_index
+            .assign(idx as PointOffsetType, &payload)
+            .unwrap();
+    }
+    drop(payload_index);
+
+    // assert payload index updated
+    let payload_index = sparse_vector_index.payload_index.borrow();
+    let field_indexes = &payload_index.field_indexes;
+    let field_index = field_indexes.get(field_name).unwrap();
+    assert_eq!(field_index[0].count_indexed_points(), half_indexed_count);
+    drop(payload_index);
+
+    // request all points with payload
+    let after_result = sparse_vector_index
+        .search(
+            &[&query_vector],
+            Some(&filter),
+            half_indexed_count * 2, // original top
+            None,
+            &stopped,
+        )
+        .unwrap();
+    assert_eq!(after_result.len(), 1);
+    assert_eq!(after_result[0].len(), half_indexed_count); // expect half of the points
+}

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -23,7 +23,6 @@ use segment::vector_storage::VectorStorage;
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
-use sparse::index::inverted_index::InvertedIndex;
 use tempfile::Builder;
 
 /// Max dimension of sparse vectors used in tests
@@ -112,7 +111,7 @@ fn sparse_vector_index_no_filter_search() {
     // expects the filter to have no effect on the results because the filter matches everything
     for query in query_vectors.into_iter() {
         // top to get all results
-        let top = sparse_vector_index.inverted_index.max_result_count(&query);
+        let top = sparse_vector_index.max_result_count(&query);
         assert!(top > 0);
         let query_vector: QueryVector = query.into();
         // with filter
@@ -168,7 +167,7 @@ fn sparse_vector_index_consistent_with_storage() {
                 .any(|e| e.record_id == id && e.weight == *dim_value));
         }
         // check the vector can be found via search using large top
-        let top = sparse_vector_index.inverted_index.max_result_count(vector);
+        let top = sparse_vector_index.max_result_count(vector);
         let query_vector: QueryVector = vector.to_owned().into();
         let results = sparse_vector_index
             .search(&[&query_vector], None, top, None, &stopped)

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -18,6 +18,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3.8.0"
 ordered-float = "4.1"
-
-[dev-dependencies]
 rand = "0.8.5"

--- a/lib/sparse/src/common/mod.rs
+++ b/lib/sparse/src/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod sparse_vector;
+pub mod sparse_vector_fixture;
 pub mod types;

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -1,0 +1,40 @@
+use rand::Rng;
+
+use crate::common::sparse_vector::SparseVector;
+
+/// Generates a non empty sparse vector
+pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_size: usize) -> SparseVector {
+    let size = rnd_gen.gen_range(1..max_size);
+    let mut tuples: Vec<(i32, f64)> = vec![];
+
+    for i in 1..=size {
+        let no_skip = rnd_gen.gen_bool(0.5);
+        if no_skip {
+            tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+        }
+    }
+
+    // make sure we have at least one vector
+    if tuples.is_empty() {
+        tuples.push((
+            rnd_gen.gen_range(1..max_size) as i32,
+            rnd_gen.gen_range(0.0..100.0),
+        ));
+    }
+
+    SparseVector::from(tuples)
+}
+
+/// Generates a sparse vector with all dimensions filled
+pub fn random_full_sparse_vector<R: Rng + ?Sized>(
+    rnd_gen: &mut R,
+    max_size: usize,
+) -> SparseVector {
+    let mut tuples: Vec<(i32, f64)> = vec![];
+
+    for i in 1..=max_size {
+        tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+    }
+
+    SparseVector::from(tuples)
+}

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -41,6 +41,13 @@ struct PostingListFileHeader {
 }
 
 impl InvertedIndex for InvertedIndexMmap {
+    fn open(path: &Path) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        Self::load(path)
+    }
+
     fn get(&self, id: &DimId) -> Option<PostingListIterator> {
         self.get(id).map(PostingListIterator::new)
     }

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -2,6 +2,7 @@ use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
 use memmap2::{Mmap, MmapMut};
 use memory::madvise;
@@ -11,6 +12,7 @@ use memory::mmap_ops::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::common::sparse_vector::SparseVector;
 use crate::common::types::DimId;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::inverted_index::InvertedIndex;
@@ -52,6 +54,17 @@ impl InvertedIndex for InvertedIndexMmap {
 
     fn indexed_vector_count(&self) -> usize {
         self.file_header.posting_count
+    }
+
+    fn upsert(&mut self, _id: PointOffsetType, _vector: SparseVector) {
+        panic!("Cannot upsert into a read-only Mmap inverted index")
+    }
+
+    fn from_ram_index<P: AsRef<Path>>(
+        ram_index: InvertedIndexRam,
+        path: P,
+    ) -> std::io::Result<Self> {
+        Self::convert_and_save(&ram_index, path)
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -52,10 +52,6 @@ impl InvertedIndex for InvertedIndexMmap {
         ]
     }
 
-    fn indexed_vector_count(&self) -> usize {
-        self.file_header.posting_count
-    }
-
     fn upsert(&mut self, _id: PointOffsetType, _vector: SparseVector) {
         panic!("Cannot upsert into a read-only Mmap inverted index")
     }

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
 
@@ -25,7 +25,24 @@ impl InvertedIndex for InvertedIndexRam {
     }
 
     fn indexed_vector_count(&self) -> usize {
-        self.postings.len()
+        // TODO(sparse) not super efficient
+        let ids = self
+            .postings
+            .iter()
+            .flat_map(|posting| posting.elements.iter().map(|e| e.record_id))
+            .collect::<HashSet<PointOffsetType>>();
+        ids.len()
+    }
+
+    fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {
+        self.upsert(id, vector);
+    }
+
+    fn from_ram_index<P: AsRef<Path>>(
+        ram_index: InvertedIndexRam,
+        _path: P,
+    ) -> std::io::Result<Self> {
+        Ok(ram_index)
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -22,16 +22,6 @@ impl InvertedIndex for InvertedIndexRam {
 
     fn files(&self) -> Vec<PathBuf> {
         vec![]
-    }
-
-    fn indexed_vector_count(&self) -> usize {
-        // TODO(sparse) not super efficient
-        let ids = self
-            .postings
-            .iter()
-            .flat_map(|posting| posting.elements.iter().map(|e| e.record_id))
-            .collect::<HashSet<PointOffsetType>>();
-        ids.len()
     }
 
     fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -15,6 +15,14 @@ pub struct InvertedIndexRam {
 }
 
 impl InvertedIndex for InvertedIndexRam {
+    //TODO(sparse) Ram index is not persisted
+    fn open(_path: &Path) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(InvertedIndexRam::empty())
+    }
+
     fn get(&self, id: &DimId) -> Option<PostingListIterator> {
         self.get(id)
             .map(|posting_list| PostingListIterator::new(&posting_list.elements))

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,6 +1,11 @@
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
+use common::types::PointOffsetType;
+
+use crate::common::sparse_vector::SparseVector;
 use crate::common::types::DimId;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::posting_list::PostingListIterator;
 
 pub mod inverted_index_mmap;
@@ -15,4 +20,28 @@ pub trait InvertedIndex {
 
     /// The number of indexed vectors, currently accessible
     fn indexed_vector_count(&self) -> usize;
+
+    /// Upsert a vector into the inverted index.
+    fn upsert(&mut self, id: PointOffsetType, vector: SparseVector);
+
+    /// Create inverted index from ram index
+    fn from_ram_index<P: AsRef<Path>>(
+        ram_index: InvertedIndexRam,
+        path: P,
+    ) -> std::io::Result<Self>
+    where
+        Self: Sized;
+
+    /// Returns the maximum number of results that can be returned by the index for a given sparse vector
+    fn max_result_count(&self, query_vector: &SparseVector) -> usize {
+        let mut possible_ids = HashSet::new();
+        for dim_id in query_vector.indices.iter() {
+            if let Some(posting_list) = self.get(dim_id) {
+                for element in posting_list.elements.iter() {
+                    possible_ids.insert(element.record_id);
+                }
+            }
+        }
+        possible_ids.len()
+    }
 }

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -18,9 +18,6 @@ pub trait InvertedIndex {
     /// Files used by this index
     fn files(&self) -> Vec<PathBuf>;
 
-    /// The number of indexed vectors, currently accessible
-    fn indexed_vector_count(&self) -> usize;
-
     /// Upsert a vector into the inverted index.
     fn upsert(&mut self, id: PointOffsetType, vector: SparseVector);
 

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -11,6 +11,11 @@ pub mod inverted_index_mmap;
 pub mod inverted_index_ram;
 
 pub trait InvertedIndex {
+    /// Open existing index based on path
+    fn open(path: &Path) -> std::io::Result<Self>
+    where
+        Self: Sized;
+
     /// Get posting list for dimension id
     fn get(&self, id: &DimId) -> Option<PostingListIterator>;
 

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -28,17 +27,4 @@ pub trait InvertedIndex {
     ) -> std::io::Result<Self>
     where
         Self: Sized;
-
-    /// Returns the maximum number of results that can be returned by the index for a given sparse vector
-    fn max_result_count(&self, query_vector: &SparseVector) -> usize {
-        let mut possible_ids = HashSet::new();
-        for dim_id in query_vector.indices.iter() {
-            if let Some(posting_list) = self.get(dim_id) {
-                for element in posting_list.elements.iter() {
-                    possible_ids.insert(element.record_id);
-                }
-            }
-        }
-        possible_ids.len()
-    }
 }

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
 
 pub mod inverted_index;
-mod posting_list;
+pub mod posting_list;
 pub mod search_context;

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -36,7 +36,7 @@ pub struct PostingList {
 }
 
 impl PostingList {
-    #[cfg(test)]
+    /// used for testing
     pub fn from(records: Vec<(PointOffsetType, DimWeight)>) -> PostingList {
         let mut posting_list = PostingBuilder::new();
         for (id, weight) in records {
@@ -172,7 +172,7 @@ impl PostingBuilder {
 
 /// Iterator over posting list elements offering skipping abilities to avoid full iteration.
 pub struct PostingListIterator<'a> {
-    elements: &'a [PostingElement],
+    pub elements: &'a [PostingElement],
     current_index: usize,
 }
 

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -215,6 +215,7 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     use super::*;
+    use crate::common::sparse_vector_fixture::random_sparse_vector;
     use crate::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
     use crate::index::inverted_index::inverted_index_ram::{
         InvertedIndexBuilder, InvertedIndexRam,
@@ -622,29 +623,6 @@ mod tests {
         let inverted_index_mmap =
             InvertedIndexMmap::convert_and_save(&inverted_index_ram, &tmp_dir_path).unwrap();
         _prune_test(&inverted_index_mmap);
-    }
-
-    /// Generates a non empty sparse vector
-    pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_size: usize) -> SparseVector {
-        let size = rnd_gen.gen_range(1..max_size);
-        let mut tuples: Vec<(i32, f64)> = vec![];
-
-        for i in 1..=size {
-            let no_skip = rnd_gen.gen_bool(0.5);
-            if no_skip {
-                tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
-            }
-        }
-
-        // make sure we have at least one vector
-        if tuples.is_empty() {
-            tuples.push((
-                rnd_gen.gen_range(1..max_size) as i32,
-                rnd_gen.gen_range(0.0..100.0),
-            ));
-        }
-
-        SparseVector::from(tuples)
     }
 
     /// Generates a random inverted index with `num_vectors` vectors


### PR DESCRIPTION
This PR adds an implementation of `VectorIndex` for the sparse vector index.

Handles:
- deleted points
- query filter
- search telemetry

Includes new unit tests to make sure everything is working.