### PR TITLE
Use long timeout for shard snapshot recovery process

### DIFF
--- a/lib/api/src/grpc/transport_channel_pool.rs
+++ b/lib/api/src/grpc/transport_channel_pool.rs
@@ -30,7 +30,7 @@ pub const DEFAULT_POOL_SIZE: usize = 2;
 /// GOAWAY/ENHANCE_YOUR_CALM errors from occurring.
 /// More info: <https://github.com/qdrant/qdrant/issues/1907>
 const MAX_CONNECTIONS_PER_CHANNEL: usize = 1024;
-const DEFAULT_RETRIES: usize = 2;
+pub const DEFAULT_RETRIES: usize = 2;
 const DEFAULT_BACKOFF: Duration = Duration::from_millis(100);
 
 /// How long to wait for response from server, before checking health of the server

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::grpc::transport_channel_pool::MAX_GRPC_CHANNEL_TIMEOUT;
 use common::defaults;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,9 @@ use crate::shards::CollectionId;
 const TRANSFER_BATCH_SIZE: usize = 100;
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 pub(crate) const MAX_RETRY_COUNT: usize = 3;
+
+/// Timeout for transferring and recovering a shard snapshot on a remote peer.
+const SNAPSHOT_TRANSFER_RECOVER_TIMEOUT: Duration = MAX_GRPC_CHANNEL_TIMEOUT;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransfer {
@@ -316,6 +320,8 @@ async fn transfer_snapshot(
             shard_id,
             &shard_download_url,
             SnapshotPriority::ShardTransfer,
+            Some(SNAPSHOT_TRANSFER_RECOVER_TIMEOUT),
+            api::grpc::transport_channel_pool::DEFAULT_RETRIES,
         )
         .await
         .map_err(|err| {

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -6,7 +6,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::grpc::transport_channel_pool::MAX_GRPC_CHANNEL_TIMEOUT;
 use common::defaults;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -27,9 +26,6 @@ use crate::shards::CollectionId;
 const TRANSFER_BATCH_SIZE: usize = 100;
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 pub(crate) const MAX_RETRY_COUNT: usize = 3;
-
-/// Timeout for transferring and recovering a shard snapshot on a remote peer.
-const SNAPSHOT_TRANSFER_RECOVER_TIMEOUT: Duration = MAX_GRPC_CHANNEL_TIMEOUT;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransfer {
@@ -320,8 +316,6 @@ async fn transfer_snapshot(
             shard_id,
             &shard_download_url,
             SnapshotPriority::ShardTransfer,
-            Some(SNAPSHOT_TRANSFER_RECOVER_TIMEOUT),
-            api::grpc::transport_channel_pool::DEFAULT_RETRIES,
         )
         .await
         .map_err(|err| {


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.
Depends on <https://github.com/qdrant/qdrant/pull/2771>.

Before, the shard snapshot transfer recovery process could only take 60 seconds because a global gRPC timeout enforced this.

This change allows the snapshot transferring and recovery process to take much longer. Now it allows to take up to 24 hours useful for very large snapshots with slow connections.

This number is arbitrary, though it would allow transferring 100GB over a 10Mbps link (taking ~22 hours).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?