### PR TITLE
Fix recommend `best_score` formula

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,19 +3555,19 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.3.3",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.6.28",
+ "regex-syntax 0.7.2",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4505,6 +4505,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "procfs",
+ "proptest",
  "quantization",
  "rand 0.8.5",
  "rand_distr",

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -78,7 +78,9 @@ impl LocalShard {
                             scored_point.score = distance.postprocess_score(scored_point.score);
                         }
                         // Don't post-process if we are dealing with custom scoring
-                        QueryEnum::RecommendBestScore(_) => {}
+                        QueryEnum::RecommendBestScore(_)
+                        | QueryEnum::Discover(_)
+                        | QueryEnum::Context(_) => {}
                     };
                     scored_point
                 });

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -73,13 +73,13 @@ impl LocalShard {
                     .unwrap()
                     .distance;
                 let processed_res = vector_res.into_iter().map(|mut scored_point| {
-                    // Don't post-process if we are dealing with custom scoring
-                    // TODO(luis): add discovery variant here too
-                    if matches!(req.query, QueryEnum::RecommendBestScore(_)) {
-                        return scored_point;
-                    }
-
-                    scored_point.score = distance.postprocess_score(scored_point.score);
+                    match req.query {
+                        QueryEnum::Nearest(_) => {
+                            scored_point.score = distance.postprocess_score(scored_point.score);
+                        }
+                        // Don't post-process if we are dealing with custom scoring
+                        QueryEnum::RecommendBestScore(_) => {}
+                    };
                     scored_point
                 });
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -20,6 +20,7 @@ rmp-serde = "~1.1"
 rand_distr = "0.4.3"
 walkdir = "2.4.0"
 rstest = "0.18.2"
+proptest = "1.3.1"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -158,9 +158,8 @@ mod test {
             assert_eq!(ordering_before, ordering_after);
         }
 
-        /// Guarantees that if the positive and negative chosen points yield within (-50, 50)
-        /// similarities, the point that was chosen from positive is always preferred on
-        /// the candidate list
+        /// Guarantees that the point that was chosen from positive is always preferred on
+        /// the candidate list over a point that was chosen from negatives
         #[test]
         fn correct_positive_and_negative_order(p in -100f32..=100f32, n in -100f32..=100f32) {
             let dummy_similarity = |x: &f32| *x as ScoreType;

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -1,3 +1,4 @@
+use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 
 use super::{Query, TransformInto};
@@ -61,9 +62,9 @@ fn merge_similarities(
         .unwrap_or(ScoreType::NEG_INFINITY);
 
     if max_positive > max_negative {
-        max_positive
+        scaled_fast_sigmoid(max_positive)
     } else {
-        -(max_negative * max_negative)
+        -scaled_fast_sigmoid(max_negative)
     }
 }
 
@@ -75,33 +76,101 @@ impl From<RecoQuery<Vector>> for QueryVector {
 
 #[cfg(test)]
 mod test {
+    use common::math::scaled_fast_sigmoid;
     use common::types::ScoreType;
+    use proptest::prelude::*;
     use rstest::rstest;
 
     use super::RecoQuery;
     use crate::vector_storage::query::Query;
 
+    enum Chosen {
+        Positive,
+        Negative,
+    }
+
     #[rstest]
-    #[case::higher_positive(vec![42], vec![4], 42.0)]
-    #[case::higher_negative(vec![4], vec![42], -(42.0 * 42.0))]
-    #[case::negative_zero(vec![-1], vec![0], 0.0)]
-    #[case::positive_zero(vec![0], vec![-1], 0.0)]
-    #[case::both_under_zero(vec![-42], vec![-84], -42.0)]
-    #[case::both_under_zero_but_negative_is_higher(vec![-84], vec![-42], -(42.0 * 42.0))]
-    #[case::multiple_with_negative_best(vec![1, 2, 3], vec![4, 5, 6], -(6.0 * 6.0))]
-    #[case::multiple_with_positive_best(vec![10, 2, 3], vec![4, 5, 6], 10.0)]
-    #[case::no_input(vec![], vec![], ScoreType::NEG_INFINITY)]
+    #[case::higher_positive(vec![42], vec![4], Chosen::Positive, 42.0)]
+    #[case::higher_negative(vec![4], vec![42], Chosen::Negative, 42.0)]
+    #[case::negative_zero(vec![-1], vec![0], Chosen::Negative, 0.0)]
+    #[case::positive_zero(vec![0], vec![-1], Chosen::Positive, 0.0)]
+    #[case::both_under_zero(vec![-42], vec![-84], Chosen::Positive, -42.0)]
+    #[case::both_under_zero_but_negative_is_higher(vec![-84], vec![-42], Chosen::Negative, -42.0)]
+    #[case::multiple_with_negative_best(vec![1, 2, 3], vec![4, 5, 6], Chosen::Negative, 6.0)]
+    #[case::multiple_with_positive_best(vec![10, 2, 3], vec![4, 5, 6], Chosen::Positive, 10.0)]
     fn score_query(
         #[case] positives: Vec<isize>,
         #[case] negatives: Vec<isize>,
+        #[case] chosen: Chosen,
         #[case] expected: ScoreType,
     ) {
         let query = RecoQuery::new(positives, negatives);
 
         let dummy_similarity = |x: &isize| *x as ScoreType;
 
+        let positive_transformation = scaled_fast_sigmoid;
+        let negative_transformation = |x| -scaled_fast_sigmoid(x);
+
         let score = query.score_by(dummy_similarity);
 
-        assert_eq!(score, expected);
+        match chosen {
+            Chosen::Positive => {
+                assert_eq!(score, positive_transformation(expected));
+            }
+            Chosen::Negative => {
+                assert_eq!(score, negative_transformation(expected));
+            }
+        }
+    }
+
+    proptest! {
+        /// Checks that the negative-chosen scores invert the order of the candidates
+        #[test]
+        fn correct_negative_order(a in -100f32..=100f32, b in -100f32..=100f32) {
+            let dummy_similarity = |x: &f32| *x as ScoreType;
+
+            let positive_ordering = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
+
+            let query_a = RecoQuery::new(vec![], vec![a]);
+            let query_b = RecoQuery::new(vec![], vec![b]);
+
+            let negative_ordering = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
+
+            if positive_ordering == std::cmp::Ordering::Equal {
+                assert_eq!(positive_ordering, negative_ordering);
+            } else {
+                assert!(positive_ordering != negative_ordering)
+            }
+        }
+
+        /// Checks that the positive-chosen scores preserve the order of the candidates
+        #[test]
+        fn correct_positive_order(a in -100f32..=100f32, b in -100f32..=100f32) {
+            let dummy_similarity = |x: &f32| *x as ScoreType;
+
+            let positive_ordering = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
+
+            let query_a = RecoQuery::new(vec![a], vec![]);
+            let query_b = RecoQuery::new(vec![b], vec![]);
+
+            let positive_ordering_after = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
+
+            assert_eq!(positive_ordering, positive_ordering_after);
+        }
+
+        /// Guarantees that if the positive and negative chosen points yield within (-50, 50)
+        /// similarities, the point that was chosen from positive is always preferred on
+        /// the candidate list
+        #[test]
+        fn correct_positive_and_negative_order(p in -100f32..=100f32, n in -100f32..=100f32) {
+            let dummy_similarity = |x: &f32| *x as ScoreType;
+
+            let query_p = RecoQuery::new(vec![p], vec![]);
+            let query_n = RecoQuery::new(vec![], vec![n]);
+
+            let ordering = query_p.score_by(dummy_similarity).total_cmp(&query_n.score_by(dummy_similarity));
+
+            assert!(ordering == std::cmp::Ordering::Equal || ordering == std::cmp::Ordering::Greater);
+        }
     }
 }

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -129,17 +129,17 @@ mod test {
         fn correct_negative_order(a in -100f32..=100f32, b in -100f32..=100f32) {
             let dummy_similarity = |x: &f32| *x as ScoreType;
 
-            let positive_ordering = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
+            let ordering_before = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
 
             let query_a = RecoQuery::new(vec![], vec![a]);
             let query_b = RecoQuery::new(vec![], vec![b]);
 
-            let negative_ordering = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
+            let ordering_after = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
 
-            if positive_ordering == std::cmp::Ordering::Equal {
-                assert_eq!(positive_ordering, negative_ordering);
+            if ordering_before == std::cmp::Ordering::Equal {
+                assert_eq!(ordering_before, ordering_after);
             } else {
-                assert!(positive_ordering != negative_ordering)
+                assert_ne!(ordering_before, ordering_after)
             }
         }
 
@@ -148,14 +148,14 @@ mod test {
         fn correct_positive_order(a in -100f32..=100f32, b in -100f32..=100f32) {
             let dummy_similarity = |x: &f32| *x as ScoreType;
 
-            let positive_ordering = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
+            let ordering_before = dummy_similarity(&a).total_cmp(&dummy_similarity(&b));
 
             let query_a = RecoQuery::new(vec![a], vec![]);
             let query_b = RecoQuery::new(vec![b], vec![]);
 
-            let positive_ordering_after = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
+            let ordering_after = query_a.score_by(dummy_similarity).total_cmp(&query_b.score_by(dummy_similarity));
 
-            assert_eq!(positive_ordering, positive_ordering_after);
+            assert_eq!(ordering_before, ordering_after);
         }
 
         /// Guarantees that if the positive and negative chosen points yield within (-50, 50)
@@ -170,7 +170,7 @@ mod test {
 
             let ordering = query_p.score_by(dummy_similarity).total_cmp(&query_n.score_by(dummy_similarity));
 
-            assert!(ordering == std::cmp::Ordering::Equal || ordering == std::cmp::Ordering::Greater);
+            assert_ne!(ordering, std::cmp::Ordering::Less);
         }
     }
 }

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -257,13 +257,12 @@ fn scoring_equivalency(
                     &is_stopped,
                 )
                 .unwrap(),
-            None => {
-                new_raw_scorer(
+            None => new_raw_scorer(
                 query.clone(),
                 &other_storage,
                 id_tracker.deleted_point_bitslice(),
-            ).unwrap()
-            }
+            )
+            .unwrap(),
         };
 
         let points =
@@ -306,7 +305,7 @@ fn scoring_equivalency(
 
             assert!(
                 (intersection as f32 / top as f32) >= 0.7, // at least 70% of top 10% results should be shared
-                "Top results from scorers are not similar, attempt {_i}:
+                "Top results from scorers are not similar, attempt {i}:
                 top raw: {raw_top:?},
                 top other: {other_top:?}
                 only {intersection} of {top} top results are shared",

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -236,7 +236,7 @@ fn scoring_equivalency(
     let quantized_vectors = quantized_vectors.as_ref().map(|q| q.borrow());
 
     let attempts = 50;
-    for _i in 0..attempts {
+    for i in 0..attempts {
         let query = random_query(&query_variant, &mut rng, &mut sampler);
 
         let raw_scorer = new_raw_scorer(
@@ -278,7 +278,7 @@ fn scoring_equivalency(
             assert_eq!(
                 raw_scores, other_scores,
                 "Scorer results are not equal, attempt: {}, query: {:?}",
-                _i, query
+                i, query
             );
         } else {
             // Quantization is used for the other storage, so score should be similar

--- a/openapi/tests/openapi_integration/test_recommend.py
+++ b/openapi/tests/openapi_integration/test_recommend.py
@@ -8,21 +8,19 @@ collection_name = "test_recommend"
 
 @pytest.fixture(autouse=True, scope="module")
 def setup(on_disk_vectors):
-    basic_collection_setup(
-        collection_name=collection_name, on_disk_vectors=on_disk_vectors
-    )
+    basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
     yield
     drop_collection(collection_name=collection_name)
 
 
 def test_default_is_avg_vector():
     params = {
-            "positive": [1, 2],
-            "negative": [3, 4],
-            "exact": True,
-            "limit": 10,
-        }
-    
+        "positive": [1, 2],
+        "negative": [3, 4],
+        "exact": True,
+        "limit": 10,
+    }
+
     default_response = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
         method="POST",
@@ -32,11 +30,10 @@ def test_default_is_avg_vector():
         },
     )
     assert default_response.ok
-    
+
     # we should only get 4 because there are 8 vectors and we used 4 as examples
-    assert len(default_response.json()["result"]) == 4 
-    
-    
+    assert len(default_response.json()["result"]) == 4
+
     avg_response = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
         method="POST",
@@ -48,10 +45,10 @@ def test_default_is_avg_vector():
     )
     assert avg_response.ok
     assert len(avg_response.json()["result"]) == 4
-    
+
     assert default_response.json()["result"] == avg_response.json()["result"]
-    
-    
+
+
 def test_single_vs_batch():
     # Bunch of valid examples
     params_list = [
@@ -91,21 +88,19 @@ def test_single_vs_batch():
             "exact": True,
             "strategy": "average_vector",
             "limit": 1,
-        }
+        },
     ]
-    
+
     batch_response = request_with_validation(
-            api="/collections/{collection_name}/points/recommend/batch",
-            method="POST",
-            path_params={"collection_name": collection_name},
-            body={
-                "searches": params_list
-            },
-        )
-    
+        api="/collections/{collection_name}/points/recommend/batch",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={"searches": params_list},
+    )
+
     assert batch_response.ok
     assert len(batch_response.json()["result"]) == len(params_list)
-    
+
     # Compare against sequential single searches
     for i, params in enumerate(params_list):
         single_response = request_with_validation(
@@ -118,13 +113,13 @@ def test_single_vs_batch():
         assert single_response.json()["result"] == batch_response.json()["result"][i]
 
 
-def test_without_positives():   
-    def req_with_positives(positive, strategy= None):
+def test_without_positives():
+    def req_with_positives(positive, strategy=None):
         if strategy is None:
             strat_dict = {}
         else:
             strat_dict = {"strategy": strategy}
-        
+
         return request_with_validation(
             api="/collections/{collection_name}/points/recommend",
             method="POST",
@@ -135,23 +130,23 @@ def test_without_positives():
                 "limit": 2,
             },
         )
-    
-    
+
     # Assert this is valid
     response = req_with_positives([1, 2])
     assert response.ok
-    
+
     # But all these are not
     response = req_with_positives([])
     assert response.status_code == 400
-    
+
     response = req_with_positives([], "average_vector")
     assert response.status_code == 400
-    
+
     # Also no negative and no positive is invalid with best_score
     response = req_with_positives([], "best_score")
     assert response.status_code == 400
-    
+
+
 def test_best_score_works_with_only_negatives():
     response = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
@@ -165,14 +160,15 @@ def test_best_score_works_with_only_negatives():
     )
     assert response.ok
     assert len(response.json()["result"]) == 5
-    
+
     # All scores should be negative
     for result in response.json()["result"]:
         assert result["score"] < 0
-        
+
+
 def test_only_1_positive_in_best_score_is_equivalent_to_normal_search():
     limit = 4
-    
+
     # recommendation response
     reco_response = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
@@ -187,10 +183,10 @@ def test_only_1_positive_in_best_score_is_equivalent_to_normal_search():
     )
     assert reco_response.ok
     assert len(reco_response.json()["result"]) == limit
-    
+
     # Get vector from point 1
     vector = get_points([1])[0]["vector"]
-    
+
     # Use normal search with that vector
     search_response = request_with_validation(
         api="/collections/{collection_name}/points/search",
@@ -198,22 +194,20 @@ def test_only_1_positive_in_best_score_is_equivalent_to_normal_search():
         path_params={"collection_name": collection_name},
         body={
             "vector": vector,
-            "filter": {
-                "must_not": [
-                    {
-                        "has_id": [1]
-                    }
-                ]
-            },
+            "filter": {"must_not": [{"has_id": [1]}]},
             "limit": limit,
             "exact": True,
         },
     )
-    
+
     assert search_response.ok
     assert len(search_response.json()["result"]) == limit
-    
-    assert reco_response.json()["result"] == search_response.json()["result"]
+
+    # Scores can be different, but the ids and order should be the same
+    reco_ids = [result["id"] for result in reco_response.json()["result"]]
+    search_ids = [result["id"] for result in search_response.json()["result"]]
+
+    assert reco_ids == search_ids
 
 
 def get_points(ids: list):
@@ -246,7 +240,7 @@ def test_raw_vectors():
     )
     assert response_ids.ok
     assert len(response_ids.json()["result"]) == 4
-    
+
     response_raw = request_with_validation(
         api="/collections/{collection_name}/points/recommend",
         method="POST",
@@ -262,12 +256,10 @@ def test_raw_vectors():
                         "has_id": [point["id"] for point in points[:4]]
                     }
                 ]
-            }
+            },
         },
     )
     assert response_raw.ok
     assert len(response_raw.json()["result"]) == 4
-    
+
     assert response_ids.json()["result"] == response_raw.json()["result"]
-    
-    


### PR DESCRIPTION
Reported in Discord:
https://discord.com/channels/907569970500743200/1168571201828946022

In short, using only one negative example would yield the same results as using only the same point but as a positive example when dealing with euclidean distance.

Why was this?
Euclidean distances are negated during search, so that the logic for keeping best candidates always considers higher is better for scores. For positive examples, our formula is basically pass-through, since it just chooses the similarity score without extra modifications. However, when choosing a similarity from a negative example, the choice was to square it and negate it, e.g. `-(max_negative * max_negative)`.
With this report we discovered that this formula fails to invert the order of candidates when their similarities are negative. 

Now, after some discussion, the formula was decided to be:
```rust
if max_positive > max_negative {
     scaled_fast_sigmoid(max_positive)
} else {
     -scaled_fast_sigmoid(max_negative)
}
```
such that it fulfills these 3 properties:
1. Choosing two points from positives preserves their similarity order
2. Choosing two points from negatives inverts their similarity order
3. When choosing one point from positive and one point from negative, the former is preferred over the latter

## Changes

- Changes RecommendBestScore formula to the above formula
- Introduces checks for testing the mentioned properties

## Caveats

- Previously, similarities to positive examples were unchanged, so scores would be the same between using search vs recommend with `best_score` strategy. Now similarities are still taken with consideration of chosen distance metric, but scores will not display the distance. This is a **BREAKING CHANGE** if the applications used the positive scoring afterwards.
- For the same reason `score_threshold` would also need to be adjusted appropriately. For reference, ranges will always be (-1, 0) for negative scoring, and (0, 1) for positive scoring. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
