### PR TITLE
Simple cancellation in shard snapshot transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
+ "tokio-util",
  "tonic",
  "tower",
  "tracing",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -34,6 +34,7 @@ hashring = "0.3.2"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 tokio = {version = "~1.32", features = ["full"]}
+tokio-util = "0.7"
 futures = "0.3.28"
 atomicwrites = "0.4.1"
 log = "0.4"


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

Adds simple cancellation checks between each shard snapshot transfer step. This allows stopping half way through the shard transfer.

For this I've used [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html) rather than an atomic boolean. It is similar to <https://github.com/qdrant/qdrant/pull/2870>, which seems to be the way forward.

I've also refactored `StoppableAsyncTaskHandle` into `CancellableAsyncTaskHandle` to make use of `CancellationToken`.

This PR implements cancellation checking in just a basic way. The <ins>create snapshot</ins>, <ins>transfer/recover snapshot</ins> and <ins>transfer queue</ins> operations are currently not canceled in the middle by itself. Instead, each must run to completion before cancellation is checked again. This will be improved upon in a later PR, once <https://github.com/qdrant/qdrant/pull/2870> is merged.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?