### PR TITLE
Shard key routing for update requests

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -135,7 +135,9 @@
     - [PointsOperationResponse](#qdrant-PointsOperationResponse)
     - [PointsSelector](#qdrant-PointsSelector)
     - [PointsUpdateOperation](#qdrant-PointsUpdateOperation)
+    - [PointsUpdateOperation.ClearPayload](#qdrant-PointsUpdateOperation-ClearPayload)
     - [PointsUpdateOperation.DeletePayload](#qdrant-PointsUpdateOperation-DeletePayload)
+    - [PointsUpdateOperation.DeletePoints](#qdrant-PointsUpdateOperation-DeletePoints)
     - [PointsUpdateOperation.DeleteVectors](#qdrant-PointsUpdateOperation-DeleteVectors)
     - [PointsUpdateOperation.PointStructList](#qdrant-PointsUpdateOperation-PointStructList)
     - [PointsUpdateOperation.SetPayload](#qdrant-PointsUpdateOperation-SetPayload)
@@ -167,6 +169,7 @@
     - [SearchResponse](#qdrant-SearchResponse)
     - [SetPayloadPoints](#qdrant-SetPayloadPoints)
     - [SetPayloadPoints.PayloadEntry](#qdrant-SetPayloadPoints-PayloadEntry)
+    - [ShardKeySelector](#qdrant-ShardKeySelector)
     - [UpdateBatchPoints](#qdrant-UpdateBatchPoints)
     - [UpdateBatchResponse](#qdrant-UpdateBatchResponse)
     - [UpdatePointVectors](#qdrant-UpdatePointVectors)
@@ -1537,6 +1540,7 @@ The JSON representation for `Value` is a JSON value.
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | points | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -1678,6 +1682,7 @@ The JSON representation for `Value` is a JSON value.
 | keys | [string](#string) | repeated | List of keys to delete |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -1697,6 +1702,7 @@ The JSON representation for `Value` is a JSON value.
 | points_selector | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
 | vectors | [VectorsSelector](#qdrant-VectorsSelector) |  | List of vector names to delete |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -1715,6 +1721,7 @@ The JSON representation for `Value` is a JSON value.
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | points | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2281,13 +2288,31 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | upsert | [PointsUpdateOperation.PointStructList](#qdrant-PointsUpdateOperation-PointStructList) |  |  |
-| delete | [PointsSelector](#qdrant-PointsSelector) |  |  |
+| delete_deprecated | [PointsSelector](#qdrant-PointsSelector) |  | **Deprecated.**  |
 | set_payload | [PointsUpdateOperation.SetPayload](#qdrant-PointsUpdateOperation-SetPayload) |  |  |
 | overwrite_payload | [PointsUpdateOperation.SetPayload](#qdrant-PointsUpdateOperation-SetPayload) |  |  |
 | delete_payload | [PointsUpdateOperation.DeletePayload](#qdrant-PointsUpdateOperation-DeletePayload) |  |  |
-| clear_payload | [PointsSelector](#qdrant-PointsSelector) |  |  |
+| clear_payload_deprecated | [PointsSelector](#qdrant-PointsSelector) |  | **Deprecated.**  |
 | update_vectors | [PointsUpdateOperation.UpdateVectors](#qdrant-PointsUpdateOperation-UpdateVectors) |  |  |
 | delete_vectors | [PointsUpdateOperation.DeleteVectors](#qdrant-PointsUpdateOperation-DeleteVectors) |  |  |
+| delete_points | [PointsUpdateOperation.DeletePoints](#qdrant-PointsUpdateOperation-DeletePoints) |  |  |
+| clear_payload | [PointsUpdateOperation.ClearPayload](#qdrant-PointsUpdateOperation-ClearPayload) |  |  |
+
+
+
+
+
+
+<a name="qdrant-PointsUpdateOperation-ClearPayload"></a>
+
+### PointsUpdateOperation.ClearPayload
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| points | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2304,6 +2329,23 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | ----- | ---- | ----- | ----------- |
 | keys | [string](#string) | repeated |  |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
+
+
+
+
+
+
+<a name="qdrant-PointsUpdateOperation-DeletePoints"></a>
+
+### PointsUpdateOperation.DeletePoints
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| points | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2320,6 +2362,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | ----- | ---- | ----- | ----------- |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) |  | Affected points |
 | vectors | [VectorsSelector](#qdrant-VectorsSelector) |  | List of vector names to delete |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2335,6 +2378,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2351,6 +2395,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | ----- | ---- | ----- | ----------- |
 | payload | [PointsUpdateOperation.SetPayload.PayloadEntry](#qdrant-PointsUpdateOperation-SetPayload-PayloadEntry) | repeated |  |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2382,6 +2427,7 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2614,6 +2660,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | id | [PointId](#qdrant-PointId) |  |  |
 | payload | [RetrievedPoint.PayloadEntry](#qdrant-RetrievedPoint-PayloadEntry) | repeated |  |
 | vectors | [Vectors](#qdrant-Vectors) | optional |  |
+| shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
 
 
 
@@ -2649,6 +2696,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | score | [float](#float) |  | Similarity score |
 | version | [uint64](#uint64) |  | Last update operation applied to this point |
 | vectors | [Vectors](#qdrant-Vectors) | optional | Vectors to search |
+| shard_key | [ShardKey](#qdrant-ShardKey) | optional | Shard key |
 
 
 
@@ -2860,6 +2908,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | payload | [SetPayloadPoints.PayloadEntry](#qdrant-SetPayloadPoints-PayloadEntry) | repeated | New payload values |
 | points_selector | [PointsSelector](#qdrant-PointsSelector) | optional | Affected points |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2876,6 +2925,23 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | key | [string](#string) |  |  |
 | value | [Value](#qdrant-Value) |  |  |
+
+
+
+
+
+
+<a name="qdrant-ShardKeySelector"></a>
+
+### ShardKeySelector
+---------------------------------------------
+----------------- ShardKeySelector ----------
+---------------------------------------------
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| shard_keys | [ShardKey](#qdrant-ShardKey) | repeated | List of shard keys which should be used in the request |
 
 
 
@@ -2928,6 +2994,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | points | [PointVectors](#qdrant-PointVectors) | repeated | List of points and vectors to update |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 
@@ -2962,6 +3029,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | wait | [bool](#bool) | optional | Wait until the changes have been applied? |
 | points | [PointStruct](#qdrant-PointStruct) | repeated |  |
 | ordering | [WriteOrdering](#qdrant-WriteOrdering) | optional | Write ordering guarantees |
+| shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Option for custom sharding to specify used shard keys |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5881,6 +5881,17 @@
                 "nullable": true
               }
             ]
+          },
+          "shard_key": {
+            "description": "Shard Key",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -5907,6 +5918,18 @@
                 "format": "float"
               }
             }
+          }
+        ]
+      },
+      "ShardKey": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
         ]
       },
@@ -6581,6 +6604,17 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/VectorStruct"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "shard_key": {
+            "description": "Shard Key",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKey"
               },
               {
                 "nullable": true
@@ -7380,8 +7414,31 @@
             "items": {
               "$ref": "#/components/schemas/ExtendedPointId"
             }
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
+      },
+      "ShardKeySelector": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ShardKey"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardKey"
+            }
+          }
+        ]
       },
       "FilterSelector": {
         "type": "object",
@@ -7391,11 +7448,21 @@
         "properties": {
           "filter": {
             "$ref": "#/components/schemas/Filter"
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
       "PointInsertOperations": {
-        "oneOf": [
+        "anyOf": [
           {
             "$ref": "#/components/schemas/PointsBatch"
           },
@@ -7404,51 +7471,19 @@
           }
         ]
       },
-      "BatchVectorStruct": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "type": "number",
-                "format": "float"
-              }
-            }
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "float"
-                }
-              }
-            }
-          }
-        ]
-      },
-      "PointStruct": {
+      "PointsBatch": {
         "type": "object",
         "required": [
-          "id",
-          "vector"
+          "batch"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
+          "batch": {
+            "$ref": "#/components/schemas/Batch"
           },
-          "vector": {
-            "$ref": "#/components/schemas/VectorStruct"
-          },
-          "payload": {
-            "description": "Payload values (optional)",
+          "shard_key": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Payload"
+                "$ref": "#/components/schemas/ShardKeySelector"
               },
               {
                 "nullable": true
@@ -7489,15 +7524,32 @@
           }
         }
       },
-      "PointsBatch": {
-        "required": [
-          "batch"
-        ],
-        "properties": {
-          "batch": {
-            "$ref": "#/components/schemas/Batch"
+      "BatchVectorStruct": {
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "float"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "float"
+                }
+              }
+            }
           }
-        }
+        ]
       },
       "PointsList": {
         "type": "object",
@@ -7510,6 +7562,42 @@
             "items": {
               "$ref": "#/components/schemas/PointStruct"
             }
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
+      "PointStruct": {
+        "type": "object",
+        "required": [
+          "id",
+          "vector"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ExtendedPointId"
+          },
+          "vector": {
+            "$ref": "#/components/schemas/VectorStruct"
+          },
+          "payload": {
+            "description": "Payload values (optional)",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Payload"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -7535,6 +7623,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
               },
               {
                 "nullable": true
@@ -7569,6 +7667,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Filter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
               },
               {
                 "nullable": true
@@ -7929,18 +8037,6 @@
             "$ref": "#/components/schemas/ReplicaState"
           }
         }
-      },
-      "ShardKey": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        ]
       },
       "ReplicaState": {
         "description": "State of the single shard within a replica set.",
@@ -9380,6 +9476,16 @@
               "$ref": "#/components/schemas/PointVectors"
             },
             "minItems": 1
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -9431,6 +9537,16 @@
             },
             "minItems": 1,
             "uniqueItems": true
+          },
+          "shard_key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShardKeySelector"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7602,6 +7602,7 @@
         }
       },
       "SetPayload": {
+        "description": "This data structure is used in API interface and applied across multiple shards",
         "type": "object",
         "required": [
           "payload"
@@ -7642,6 +7643,7 @@
         }
       },
       "DeletePayload": {
+        "description": "This data structure is used in API interface and applied across multiple shards",
         "type": "object",
         "required": [
           "keys"

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -18,15 +18,15 @@ use crate::grpc::qdrant::value::Kind;
 use crate::grpc::qdrant::vectors::VectorsOptions;
 use crate::grpc::qdrant::with_payload_selector::SelectorOptions;
 use crate::grpc::qdrant::{
-    with_vectors_selector, CollectionDescription, CollectionOperationResponse, Condition, Distance,
-    FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, HasIdCondition,
-    HealthCheckReply, HnswConfigDiff, IsEmptyCondition, IsNullCondition, ListCollectionsResponse,
-    ListValue, Match, NamedVectors, NestedCondition, PayloadExcludeSelector,
-    PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo, PayloadSchemaType, PointId,
-    ProductQuantization, QuantizationConfig, QuantizationSearchParams, QuantizationType, Range,
-    RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint, SearchParams, Struct,
-    TextIndexParams, TokenizerType, Value, ValuesCount, Vector, Vectors, VectorsSelector,
-    WithPayloadSelector, WithVectorsSelector,
+    shard_key, with_vectors_selector, CollectionDescription, CollectionOperationResponse,
+    Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius,
+    HasIdCondition, HealthCheckReply, HnswConfigDiff, IsEmptyCondition, IsNullCondition,
+    ListCollectionsResponse, ListValue, Match, NamedVectors, NestedCondition,
+    PayloadExcludeSelector, PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo,
+    PayloadSchemaType, PointId, ProductQuantization, QuantizationConfig, QuantizationSearchParams,
+    QuantizationType, Range, RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint,
+    SearchParams, ShardKey, Struct, TextIndexParams, TokenizerType, Value, ValuesCount, Vector,
+    Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
 };
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {
@@ -106,6 +106,34 @@ fn proto_to_json(proto: Value) -> Result<serde_json::Value, Status> {
                 }
                 Ok(serde_json::Value::Array(list))
             }
+        },
+    }
+}
+
+pub fn convert_shard_key_to_grpc(value: segment::types::ShardKey) -> ShardKey {
+    match value {
+        segment::types::ShardKey::Keyword(keyword) => ShardKey {
+            key: Some(shard_key::Key::Keyword(keyword)),
+        },
+        segment::types::ShardKey::Number(number) => ShardKey {
+            key: Some(shard_key::Key::Number(number)),
+        },
+    }
+}
+
+pub fn convert_shard_key_from_grpc_opt(
+    value: Option<ShardKey>,
+) -> Option<segment::types::ShardKey> {
+    match value {
+        None => None,
+        Some(key) => match key.key {
+            None => None,
+            Some(key) => match key {
+                shard_key::Key::Keyword(keyword) => {
+                    Some(segment::types::ShardKey::Keyword(keyword))
+                }
+                shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
+            },
         },
     }
 }
@@ -430,6 +458,7 @@ impl From<segment::types::ScoredPoint> for ScoredPoint {
             score: point.score,
             version: point.version,
             vectors: point.vector.map(|v| v.into()),
+            shard_key: point.shard_key.map(convert_shard_key_to_grpc),
         }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -121,6 +121,16 @@ pub fn convert_shard_key_to_grpc(value: segment::types::ShardKey) -> ShardKey {
     }
 }
 
+pub fn convert_shard_key_from_grpc(value: ShardKey) -> Option<segment::types::ShardKey> {
+    match value.key {
+        None => None,
+        Some(key) => match key {
+            shard_key::Key::Keyword(keyword) => Some(segment::types::ShardKey::Keyword(keyword)),
+            shard_key::Key::Number(number) => Some(segment::types::ShardKey::Number(number)),
+        },
+    }
+}
+
 pub fn convert_shard_key_from_grpc_opt(
     value: Option<ShardKey>,
 ) -> Option<segment::types::ShardKey> {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -459,6 +459,7 @@ message ScoredPoint {
   reserved 4; // deprecated "vector" field
   uint64 version = 5; // Last update operation applied to this point
   optional Vectors vectors = 6; // Vectors to search
+  optional ShardKey shard_key = 7; // Shard key
 }
 
 message GroupId {
@@ -521,6 +522,7 @@ message RetrievedPoint {
   map<string, Value> payload = 2;
   reserved 3; // deprecated "vector" field
   optional Vectors vectors = 4;
+  optional ShardKey shard_key = 5; // Shard key
 }
 
 message GetResponse {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -46,6 +46,14 @@ message Vector {
 }
 
 // ---------------------------------------------
+// ----------------- ShardKeySelector ----------
+// ---------------------------------------------
+message ShardKeySelector {
+  repeated ShardKey shard_keys = 1; // List of shard keys which should be used in the request
+}
+
+
+// ---------------------------------------------
 // ---------------- RPC Requests ---------------
 // ---------------------------------------------
 
@@ -54,6 +62,7 @@ message UpsertPoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   repeated PointStruct points = 3;
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message DeletePoints {
@@ -61,6 +70,7 @@ message DeletePoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   PointsSelector points = 3; // Affected points
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message GetPoints {
@@ -77,6 +87,7 @@ message UpdatePointVectors {
   optional bool wait = 2; // Wait until the changes have been applied?
   repeated PointVectors points = 3; // List of points and vectors to update
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message PointVectors {
@@ -90,6 +101,7 @@ message DeletePointVectors {
   PointsSelector points_selector = 3; // Affected points
   VectorsSelector vectors = 4; // List of vector names to delete
   optional WriteOrdering ordering = 5; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 6; // Option for custom sharding to specify used shard keys
 }
 
 message SetPayloadPoints {
@@ -99,6 +111,7 @@ message SetPayloadPoints {
   reserved 4; // List of point to modify, deprecated
   optional PointsSelector points_selector = 5; // Affected points
   optional WriteOrdering ordering = 6; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 7; // Option for custom sharding to specify used shard keys
 }
 
 message DeletePayloadPoints {
@@ -108,6 +121,7 @@ message DeletePayloadPoints {
   reserved 4; // Affected points, deprecated
   optional PointsSelector points_selector = 5; // Affected points
   optional WriteOrdering ordering = 6; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 7; // Option for custom sharding to specify used shard keys
 }
 
 message ClearPayloadPoints {
@@ -115,6 +129,7 @@ message ClearPayloadPoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   PointsSelector points = 3; // Affected points
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 enum FieldType {
@@ -396,32 +411,47 @@ message CountPoints {
 message PointsUpdateOperation {
   message PointStructList {
     repeated PointStruct points = 1;
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
   message SetPayload {
       map<string, Value> payload = 1;
       optional PointsSelector points_selector = 2; // Affected points
+      optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
   }
   message DeletePayload {
       repeated string keys = 1;
       optional PointsSelector points_selector = 2; // Affected points
+      optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
   }
   message UpdateVectors {
     repeated PointVectors points = 1; // List of points and vectors to update
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
   message DeleteVectors {
     PointsSelector points_selector = 1; // Affected points
     VectorsSelector vectors = 2; // List of vector names to delete
+    optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
+  }
+  message DeletePoints {
+    PointsSelector points = 1; // Affected points
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
+  }
+  message ClearPayload {
+    PointsSelector points = 1; // Affected points
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
 
   oneof operation {
     PointStructList upsert = 1;
-    PointsSelector delete = 2;
+    PointsSelector delete_deprecated = 2 [deprecated=true];
     SetPayload set_payload = 3;
     SetPayload overwrite_payload = 4;
     DeletePayload delete_payload = 5;
-    PointsSelector clear_payload = 6;
+    PointsSelector clear_payload_deprecated = 6 [deprecated=true];
     UpdateVectors update_vectors = 7;
     DeleteVectors delete_vectors = 8;
+    DeletePoints delete_points = 9;
+    ClearPayload clear_payload = 10;
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -2908,6 +2908,17 @@ pub struct Vector {
     #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
 }
+/// ---------------------------------------------
+/// ----------------- ShardKeySelector ----------
+/// ---------------------------------------------
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShardKeySelector {
+    /// List of shard keys which should be used in the request
+    #[prost(message, repeated, tag = "1")]
+    pub shard_keys: ::prost::alloc::vec::Vec<ShardKey>,
+}
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2925,6 +2936,9 @@ pub struct UpsertPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -2944,6 +2958,9 @@ pub struct DeletePoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -2985,6 +3002,9 @@ pub struct UpdatePointVectors {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3018,6 +3038,9 @@ pub struct DeletePointVectors {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "5")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "6")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -3040,6 +3063,9 @@ pub struct SetPayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "7")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -3062,6 +3088,9 @@ pub struct DeletePayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "7")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -3081,6 +3110,9 @@ pub struct ClearPayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -3721,7 +3753,7 @@ pub struct CountPoints {
 pub struct PointsUpdateOperation {
     #[prost(
         oneof = "points_update_operation::Operation",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
     )]
     pub operation: ::core::option::Option<points_update_operation::Operation>,
 }
@@ -3733,6 +3765,9 @@ pub mod points_update_operation {
     pub struct PointStructList {
         #[prost(message, repeated, tag = "1")]
         pub points: ::prost::alloc::vec::Vec<super::PointStruct>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3746,6 +3781,9 @@ pub mod points_update_operation {
         /// Affected points
         #[prost(message, optional, tag = "2")]
         pub points_selector: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3756,6 +3794,9 @@ pub mod points_update_operation {
         /// Affected points
         #[prost(message, optional, tag = "2")]
         pub points_selector: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3764,6 +3805,9 @@ pub mod points_update_operation {
         /// List of points and vectors to update
         #[prost(message, repeated, tag = "1")]
         pub points: ::prost::alloc::vec::Vec<super::PointVectors>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3775,6 +3819,32 @@ pub mod points_update_operation {
         /// List of vector names to delete
         #[prost(message, optional, tag = "2")]
         pub vectors: ::core::option::Option<super::VectorsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+    }
+    #[derive(validator::Validate)]
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DeletePoints {
+        /// Affected points
+        #[prost(message, optional, tag = "1")]
+        pub points: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ClearPayload {
+        /// Affected points
+        #[prost(message, optional, tag = "1")]
+        pub points: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[derive(serde::Serialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3783,7 +3853,7 @@ pub mod points_update_operation {
         #[prost(message, tag = "1")]
         Upsert(PointStructList),
         #[prost(message, tag = "2")]
-        Delete(super::PointsSelector),
+        DeleteDeprecated(super::PointsSelector),
         #[prost(message, tag = "3")]
         SetPayload(SetPayload),
         #[prost(message, tag = "4")]
@@ -3791,11 +3861,15 @@ pub mod points_update_operation {
         #[prost(message, tag = "5")]
         DeletePayload(DeletePayload),
         #[prost(message, tag = "6")]
-        ClearPayload(super::PointsSelector),
+        ClearPayloadDeprecated(super::PointsSelector),
         #[prost(message, tag = "7")]
         UpdateVectors(UpdateVectors),
         #[prost(message, tag = "8")]
         DeleteVectors(DeleteVectors),
+        #[prost(message, tag = "9")]
+        DeletePoints(DeletePoints),
+        #[prost(message, tag = "10")]
+        ClearPayload(ClearPayload),
     }
 }
 #[derive(validator::Validate)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3857,6 +3857,9 @@ pub struct ScoredPoint {
     /// Vectors to search
     #[prost(message, optional, tag = "6")]
     pub vectors: ::core::option::Option<Vectors>,
+    /// Shard key
+    #[prost(message, optional, tag = "7")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3981,6 +3984,9 @@ pub struct RetrievedPoint {
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     #[prost(message, optional, tag = "4")]
     pub vectors: ::core::option::Option<Vectors>,
+    /// Shard key
+    #[prost(message, optional, tag = "5")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -5,7 +5,9 @@ use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
-use collection::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
+use collection::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStruct,
+};
 use collection::operations::types::{SearchRequest, SearchRequestBatch, VectorParams};
 use collection::operations::CollectionUpdateOperations;
 use collection::optimizers_builder::OptimizersConfig;
@@ -39,7 +41,7 @@ fn create_rnd_batch() -> CollectionUpdateOperations {
         points.push(point);
     }
     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperations::PointsList(points),
+        PointInsertOperationsInternal::PointsList(points),
     ))
 }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use segment::common::version::StorageVersion;
+use segment::types::ShardKey;
 use semver::Version;
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
@@ -247,6 +248,16 @@ impl Collection {
 
     pub fn name(&self) -> String {
         self.id.clone()
+    }
+
+    pub async fn get_shard_keys(&self) -> Vec<ShardKey> {
+        self.shards_holder
+            .read()
+            .await
+            .get_shard_key_to_ids_mapping()
+            .keys()
+            .cloned()
+            .collect()
     }
 
     /// Return a list of local shards, present on this peer

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -1,10 +1,12 @@
 use std::collections::HashSet;
 
+use segment::types::ShardKey;
+
 use crate::collection::Collection;
 use crate::config::ShardingMethod;
 use crate::operations::types::CollectionError;
 use crate::shards::replica_set::ShardReplicaSet;
-use crate::shards::shard::{PeerId, ShardId, ShardKey, ShardsPlacement};
+use crate::shards::shard::{PeerId, ShardId, ShardsPlacement};
 
 impl Collection {
     pub async fn create_replica_set(

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -81,7 +81,7 @@ mod tests {
     use crate::collection_manager::fixtures::build_test_holder;
     use crate::collection_manager::segments_searcher::SegmentsSearcher;
     use crate::collection_manager::segments_updater::upsert_points;
-    use crate::operations::payload_ops::{DeletePayload, PayloadOps, SetPayload};
+    use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
     use crate::operations::point_ops::{PointOperations, PointStruct};
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
         process_payload_operation(
             &segments,
             100,
-            PayloadOps::SetPayload(SetPayload {
+            PayloadOps::SetPayload(SetPayloadOp {
                 payload,
                 points: Some(points.clone()),
                 filter: None,
@@ -236,7 +236,7 @@ mod tests {
         process_payload_operation(
             &segments,
             101,
-            PayloadOps::DeletePayload(DeletePayload {
+            PayloadOps::DeletePayload(DeletePayloadOp {
                 points: Some(vec![3.into()]),
                 keys: vec!["color".to_string(), "empty".to_string()],
                 filter: None,

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -259,7 +259,7 @@ mod tests {
     use crate::collection_manager::segments_updater::{
         process_field_index_operation, process_point_operation,
     };
-    use crate::operations::point_ops::{Batch, PointInsertOperations, PointOperations};
+    use crate::operations::point_ops::{Batch, PointOperations};
     use crate::operations::types::{VectorParams, VectorsConfig};
     use crate::operations::{CreateIndex, FieldIndexOperations};
 
@@ -547,21 +547,21 @@ mod tests {
         }
 
         let point_payload: Payload = json!({"number":10000i64}).into();
-        let insert_point_ops =
-            PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
-                ids: vec![501.into(), 502.into(), 503.into()],
-                vectors: vec![
-                    random_vector(&mut rng, dim),
-                    random_vector(&mut rng, dim),
-                    random_vector(&mut rng, dim),
-                ]
-                .into(),
-                payloads: Some(vec![
-                    Some(point_payload.clone()),
-                    Some(point_payload.clone()),
-                    Some(point_payload),
-                ]),
-            }));
+        let insert_point_ops: PointOperations = Batch {
+            ids: vec![501.into(), 502.into(), 503.into()],
+            vectors: vec![
+                random_vector(&mut rng, dim),
+                random_vector(&mut rng, dim),
+                random_vector(&mut rng, dim),
+            ]
+            .into(),
+            payloads: Some(vec![
+                Some(point_payload.clone()),
+                Some(point_payload.clone()),
+                Some(point_payload),
+            ]),
+        }
+        .into();
 
         let smallest_size = infos
             .iter()
@@ -620,17 +620,17 @@ mod tests {
             "Testing that new segment is created if none left"
         );
 
-        let insert_point_ops =
-            PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
-                ids: vec![601.into(), 602.into(), 603.into()],
-                vectors: vec![
-                    random_vector(&mut rng, dim),
-                    random_vector(&mut rng, dim),
-                    random_vector(&mut rng, dim),
-                ]
-                .into(),
-                payloads: None,
-            }));
+        let insert_point_ops: PointOperations = Batch {
+            ids: vec![601.into(), 602.into(), 603.into()],
+            vectors: vec![
+                random_vector(&mut rng, dim),
+                random_vector(&mut rng, dim),
+                random_vector(&mut rng, dim),
+            ]
+            .into(),
+            payloads: None,
+        }
+        .into();
 
         process_point_operation(
             locked_holder.deref(),

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -331,6 +331,7 @@ impl SegmentsSearcher {
                                 Some(selected_vectors.into())
                             }
                         },
+                        shard_key: None
                     },
                 );
                 point_version.insert(id, version);

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -331,7 +331,7 @@ impl SegmentsSearcher {
                                 Some(selected_vectors.into())
                             }
                         },
-                        shard_key: None
+                        shard_key: None,
                     },
                 );
                 point_version.insert(id, version);

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -13,7 +13,7 @@ use segment::types::{
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::operations::payload_ops::PayloadOps;
-use crate::operations::point_ops::{PointInsertOperations, PointOperations, PointStruct};
+use crate::operations::point_ops::{PointInsertOperationsInternal, PointOperations, PointStruct};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::vector_ops::{PointVectors, VectorOperations};
 use crate::operations::FieldIndexOperations;
@@ -403,7 +403,7 @@ pub(crate) fn process_point_operation(
         PointOperations::DeletePoints { ids, .. } => delete_points(&segments.read(), op_num, &ids),
         PointOperations::UpsertPoints(operation) => {
             let points: Vec<_> = match operation {
-                PointInsertOperations::PointsBatch(batch) => {
+                PointInsertOperationsInternal::PointsBatch(batch) => {
                     let all_vectors = batch.vectors.into_all_vectors(batch.ids.len());
                     let vectors_iter = batch.ids.into_iter().zip(all_vectors);
                     match batch.payloads {
@@ -424,7 +424,7 @@ pub(crate) fn process_point_operation(
                             .collect(),
                     }
                 }
-                PointInsertOperations::PointsList(points) => points,
+                PointInsertOperationsInternal::PointsList(points) => points,
             };
             let res = upsert_points(&segments.read(), op_num, points.iter())?;
             Ok(res)

--- a/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
+++ b/lib/collection/src/collection_manager/tests/test_search_aggregation.rs
@@ -10,6 +10,7 @@ fn score_point(id: usize, score: ScoreType, version: SeqNumberType) -> ScoredPoi
         score,
         payload: None,
         vector: None,
+        shard_key: None,
     }
 }
 

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -196,6 +196,7 @@ mod unit_tests {
             score,
             payload: Some(Payload::from(serde_json::json!({ "docId": payloads }))),
             vector: None,
+            shard_key: None,
         }
     }
 
@@ -206,6 +207,7 @@ mod unit_tests {
             score,
             payload: None,
             vector: None,
+            shard_key: None,
         }
     }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -496,6 +496,7 @@ mod tests {
                         score: 1.0,
                         payload: None,
                         vector: None,
+                        shard_key: None,
                     },
                     ScoredPoint {
                         id: 2.into(),
@@ -503,6 +504,7 @@ mod tests {
                         score: 1.0,
                         payload: None,
                         vector: None,
+                        shard_key: None,
                     },
                 ],
             ),
@@ -515,6 +517,7 @@ mod tests {
                         score: 1.0,
                         payload: None,
                         vector: None,
+                        shard_key: None,
                     },
                     ScoredPoint {
                         id: 4.into(),
@@ -522,6 +525,7 @@ mod tests {
                         score: 1.0,
                         payload: None,
                         vector: None,
+                        shard_key: None,
                     },
                 ],
             ),
@@ -545,6 +549,7 @@ mod tests {
                 score: 1.0,
                 payload: Some(payload_a.clone()),
                 vector: None,
+                shard_key: None,
             },
             ScoredPoint {
                 id: 2.into(),
@@ -552,6 +557,7 @@ mod tests {
                 score: 1.0,
                 payload: Some(payload_a.clone()),
                 vector: None,
+                shard_key: None,
             },
             ScoredPoint {
                 id: 3.into(),
@@ -559,6 +565,7 @@ mod tests {
                 score: 1.0,
                 payload: Some(payload_b.clone()),
                 vector: None,
+                shard_key: None,
             },
             ScoredPoint {
                 id: 4.into(),
@@ -566,6 +573,7 @@ mod tests {
                 score: 1.0,
                 payload: Some(payload_b.clone()),
                 vector: None,
+                shard_key: None,
             },
         ];
 

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -71,8 +71,8 @@ mod tests {
 
         for i in 0..20 {
             match ring.get(&i) {
-                None => panic!("Key {} have no shard", i),
-                Some(x) => assert!(*x == 5 || *x == 7 || *x == 8 || *x == 20),
+                None => panic!("Key {i} has no shard"),
+                Some(x) => assert!([5, 7, 8, 20].contains(x)),
             }
         }
     }

--- a/lib/collection/src/hash_ring.rs
+++ b/lib/collection/src/hash_ring.rs
@@ -56,3 +56,24 @@ impl<T: Hash + Copy> HashRing<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_non_seq_keys() {
+        let mut ring = HashRing::fair(100);
+        ring.add(5);
+        ring.add(7);
+        ring.add(8);
+        ring.add(20);
+
+        for i in 0..20 {
+            match ring.get(&i) {
+                None => panic!("Key {} have no shard", i),
+                Some(x) => assert!(*x == 5 || *x == 7 || *x == 8 || *x == 20),
+            }
+        }
+    }
+}

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -2,10 +2,11 @@ use std::num::NonZeroU32;
 
 use common::validation::validate_move_shard_different_peers;
 use schemars::JsonSchema;
+use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationErrors};
 
-use crate::shards::shard::{PeerId, ShardId, ShardKey};
+use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::transfer::shard_transfer::ShardTransferMethod;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1499,12 +1499,16 @@ impl TryFrom<ClusterOperationsPb> for ClusterOperations {
 
 impl From<api::grpc::qdrant::ShardKeySelector> for ShardKeySelector {
     fn from(value: api::grpc::qdrant::ShardKeySelector) -> Self {
-        ShardKeySelector::ShardKeys(
-            value
-                .shard_keys
-                .into_iter()
-                .filter_map(convert_shard_key_from_grpc)
-                .collect(),
-        )
+        let shard_keys: Vec<_> = value
+            .shard_keys
+            .into_iter()
+            .filter_map(convert_shard_key_from_grpc)
+            .collect();
+
+        if shard_keys.len() == 1 {
+            ShardKeySelector::ShardKey(shard_keys.into_iter().next().unwrap())
+        } else {
+            ShardKeySelector::ShardKeys(shard_keys)
+        }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -769,7 +769,7 @@ pub fn try_points_selector_from_grpc(
                     .ids
                     .into_iter()
                     .map(|p| p.try_into())
-                    .collect::<Result<Vec<_>, _>>()?,
+                    .collect::<Result<_, _>>()?,
                 shard_key: shard_key_selector.map(ShardKeySelector::from),
             }))
         }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
-use api::grpc::conversions::{from_grpc_dist, payload_to_proto, proto_to_payloads};
+use api::grpc::conversions::{
+    convert_shard_key_from_grpc_opt, convert_shard_key_to_grpc, from_grpc_dist, payload_to_proto,
+    proto_to_payloads,
+};
 use api::grpc::qdrant::quantization_config_diff::Quantization;
 use api::grpc::qdrant::update_collection_cluster_setup_request::Operation as ClusterOperationsPb;
 use itertools::Itertools;
@@ -47,7 +50,6 @@ use crate::operations::types::{
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::remote_shard::{CollectionCoreSearchRequest, CollectionSearchRequest};
 use crate::shards::replica_set::ReplicaState;
-use crate::shards::shard::ShardKey;
 use crate::shards::transfer::shard_transfer::ShardTransferMethod;
 
 pub fn sharding_method_to_proto(sharding_method: ShardingMethod) -> i32 {
@@ -128,6 +130,7 @@ pub fn try_record_from_grpc(
         id,
         payload,
         vector,
+        shard_key: convert_shard_key_from_grpc_opt(point.shard_key),
     })
 }
 
@@ -409,6 +412,7 @@ impl From<Record> for api::grpc::qdrant::RetrievedPoint {
             id: Some(record.id.into()),
             payload: record.payload.map(payload_to_proto).unwrap_or_default(),
             vectors,
+            shard_key: record.shard_key.map(convert_shard_key_to_grpc),
         }
     }
 }
@@ -1365,26 +1369,13 @@ impl From<AliasDescription> for api::grpc::qdrant::AliasDescription {
     }
 }
 
-impl From<ShardKey> for api::grpc::qdrant::ShardKey {
-    fn from(value: ShardKey) -> Self {
-        match value {
-            ShardKey::Keyword(keyword) => Self {
-                key: Some(api::grpc::qdrant::shard_key::Key::Keyword(keyword)),
-            },
-            ShardKey::Number(number) => Self {
-                key: Some(api::grpc::qdrant::shard_key::Key::Number(number)),
-            },
-        }
-    }
-}
-
 impl From<LocalShardInfo> for api::grpc::qdrant::LocalShardInfo {
     fn from(value: LocalShardInfo) -> Self {
         Self {
             shard_id: value.shard_id,
             points_count: value.points_count as u64,
             state: value.state as i32,
-            shard_key: value.shard_key.map(Into::into),
+            shard_key: value.shard_key.map(convert_shard_key_to_grpc),
         }
     }
 }
@@ -1395,7 +1386,7 @@ impl From<RemoteShardInfo> for api::grpc::qdrant::RemoteShardInfo {
             shard_id: value.shard_id,
             peer_id: value.peer_id,
             state: value.state as i32,
-            shard_key: value.shard_key.map(Into::into),
+            shard_key: value.shard_key.map(convert_shard_key_to_grpc),
         }
     }
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -5,6 +5,7 @@ pub mod conversions;
 pub mod operation_effect;
 pub mod payload_ops;
 pub mod point_ops;
+pub mod shard_key_selector;
 pub mod shared_storage_config;
 pub mod snapshot_ops;
 pub mod types;

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -82,13 +82,13 @@ impl EstimateOperationEffectArea for vector_ops::VectorOperations {
     }
 }
 
-impl EstimateOperationEffectArea for point_ops::PointInsertOperations {
+impl EstimateOperationEffectArea for point_ops::PointInsertOperationsInternal {
     fn estimate_effect_area(&self) -> OperationEffectArea {
         match self {
-            point_ops::PointInsertOperations::PointsBatch(batch) => {
+            point_ops::PointInsertOperationsInternal::PointsBatch(batch) => {
                 OperationEffectArea::Points(batch.ids.clone())
             }
-            point_ops::PointInsertOperations::PointsList(list) => {
+            point_ops::PointInsertOperationsInternal::PointsList(list) => {
                 OperationEffectArea::Points(list.iter().map(|x| x.id).collect())
             }
         }

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -9,6 +9,7 @@ use crate::hash_ring::HashRing;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::shards::shard::ShardId;
 
+/// This data structure is used in API interface and applied across multiple shards
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(try_from = "SetPayloadShadow")]
 pub struct SetPayload {
@@ -21,6 +22,11 @@ pub struct SetPayload {
     pub shard_key: Option<ShardKeySelector>,
 }
 
+/// This data structure is used inside shard operations queue
+/// and supposed to be written into WAL of individual shard.
+///
+/// Unlike `SetPayload` it does not contain `shard_key` field
+/// as individual shard does not need to know about shard key
 #[derive(Debug, Deserialize, Serialize, Validate, Clone)]
 pub struct SetPayloadOp {
     pub payload: Payload,
@@ -66,6 +72,7 @@ impl TryFrom<SetPayloadShadow> for SetPayload {
     }
 }
 
+/// This data structure is used in API interface and applied across multiple shards
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(try_from = "DeletePayloadShadow")]
 pub struct DeletePayload {
@@ -79,6 +86,11 @@ pub struct DeletePayload {
     pub shard_key: Option<ShardKeySelector>,
 }
 
+/// This data structure is used inside shard operations queue
+/// and supposed to be written into WAL of individual shard.
+///
+/// Unlike `DeletePayload` it does not contain `shard_key` field
+/// as individual shard does not need to know about shard key
 #[derive(Debug, Deserialize, Serialize, Validate, Clone)]
 pub struct DeletePayloadOp {
     /// List of payload keys to remove from payload

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -17,8 +17,7 @@ pub struct SetPayload {
     pub points: Option<Vec<PointIdType>>,
     /// Assigns payload to each point that satisfy this filter condition
     pub filter: Option<Filter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 
@@ -76,8 +75,7 @@ pub struct DeletePayload {
     pub points: Option<Vec<PointIdType>>,
     /// Deletes values from points that satisfy this filter condition
     pub filter: Option<Filter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -6,11 +6,24 @@ use validator::Validate;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
 use crate::hash_ring::HashRing;
+use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::shards::shard::ShardId;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(try_from = "SetPayloadShadow")]
 pub struct SetPayload {
+    pub payload: Payload,
+    /// Assigns payload to each point in this list
+    pub points: Option<Vec<PointIdType>>,
+    /// Assigns payload to each point that satisfy this filter condition
+    pub filter: Option<Filter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Validate, Clone)]
+pub struct SetPayloadOp {
     pub payload: Payload,
     /// Assigns payload to each point in this list
     pub points: Option<Vec<PointIdType>>,
@@ -23,6 +36,7 @@ struct SetPayloadShadow {
     pub payload: Payload,
     pub points: Option<Vec<PointIdType>>,
     pub filter: Option<Filter>,
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 pub struct PointsSelectorValidationError;
@@ -45,6 +59,7 @@ impl TryFrom<SetPayloadShadow> for SetPayload {
                 payload: value.payload,
                 points: value.points,
                 filter: value.filter,
+                shard_key: value.shard_key,
             })
         } else {
             Err(PointsSelectorValidationError)
@@ -61,6 +76,19 @@ pub struct DeletePayload {
     pub points: Option<Vec<PointIdType>>,
     /// Deletes values from points that satisfy this filter condition
     pub filter: Option<Filter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Validate, Clone)]
+pub struct DeletePayloadOp {
+    /// List of payload keys to remove from payload
+    pub keys: Vec<PayloadKeyType>,
+    /// Deletes values from each point in this list
+    pub points: Option<Vec<PointIdType>>,
+    /// Deletes values from points that satisfy this filter condition
+    pub filter: Option<Filter>,
 }
 
 #[derive(Deserialize)]
@@ -68,6 +96,7 @@ struct DeletePayloadShadow {
     pub keys: Vec<PayloadKeyType>,
     pub points: Option<Vec<PointIdType>>,
     pub filter: Option<Filter>,
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 impl TryFrom<DeletePayloadShadow> for DeletePayload {
@@ -79,6 +108,7 @@ impl TryFrom<DeletePayloadShadow> for DeletePayload {
                 keys: value.keys,
                 points: value.points,
                 filter: value.filter,
+                shard_key: value.shard_key,
             })
         } else {
             Err(PointsSelectorValidationError)
@@ -87,19 +117,19 @@ impl TryFrom<DeletePayloadShadow> for DeletePayload {
 }
 
 /// Define operations description for point payloads manipulation
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum PayloadOps {
     /// Set payload value, overrides if it is already exists
-    SetPayload(SetPayload),
+    SetPayload(SetPayloadOp),
     /// Deletes specified payload values if they are assigned
-    DeletePayload(DeletePayload),
+    DeletePayload(DeletePayloadOp),
     /// Drops all Payload values associated with given points.
     ClearPayload { points: Vec<PointIdType> },
     /// Clear all Payload values by given filter criteria.
     ClearPayloadByFilter(Filter),
     /// Overwrite full payload with given keys
-    OverwritePayload(SetPayload),
+    OverwritePayload(SetPayloadOp),
 }
 
 impl PayloadOps {
@@ -145,12 +175,12 @@ impl SplitByShard for PayloadOps {
     }
 }
 
-impl SplitByShard for DeletePayload {
+impl SplitByShard for DeletePayloadOp {
     fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
                 split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {
-                    DeletePayload {
+                    DeletePayloadOp {
                         points: Some(points),
                         keys: self.keys.clone(),
                         filter: self.filter.clone(),
@@ -163,14 +193,16 @@ impl SplitByShard for DeletePayload {
     }
 }
 
-impl SplitByShard for SetPayload {
+impl SplitByShard for SetPayloadOp {
     fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
         match (&self.points, &self.filter) {
             (Some(_), _) => {
-                split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| SetPayload {
-                    points: Some(points),
-                    payload: self.payload.clone(),
-                    filter: self.filter.clone(),
+                split_iter_by_shard(self.points.unwrap(), |id| *id, ring).map(|points| {
+                    SetPayloadOp {
+                        points: Some(points),
+                        payload: self.payload.clone(),
+                        filter: self.filter.clone(),
+                    }
                 })
             }
             (None, Some(_)) => OperationToShard::to_all(self),

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -55,6 +55,7 @@ impl TryFrom<Record> for PointStruct {
             id,
             payload,
             vector,
+            shard_key: _,
         } = record;
 
         if vector.is_none() {

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use itertools::izip;
-use schemars::gen::SchemaGenerator;
-use schemars::schema::{ObjectValidation, Schema, SchemaObject, SubschemaValidation};
 use schemars::JsonSchema;
 use segment::common::utils::transpose_map_into_named_vector;
 use segment::data_types::named_vectors::NamedVectors;
@@ -14,6 +12,7 @@ use validator::Validate;
 
 use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
 use crate::hash_ring::HashRing;
+use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::operations::types::Record;
 use crate::shards::shard::ShardId;
 
@@ -100,11 +99,17 @@ impl Batch {
 #[serde(rename_all = "snake_case")]
 pub struct PointIdsList {
     pub points: Vec<PointIdType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 impl From<Vec<PointIdType>> for PointIdsList {
     fn from(points: Vec<PointIdType>) -> Self {
-        Self { points }
+        Self {
+            points,
+            shard_key: None,
+        }
     }
 }
 
@@ -112,6 +117,9 @@ impl From<Vec<PointIdType>> for PointIdsList {
 #[serde(rename_all = "snake_case")]
 pub struct FilterSelector {
     pub filter: Filter,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -134,10 +142,10 @@ impl Validate for PointsSelector {
 }
 
 // Structure used for deriving custom JsonSchema only
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
-struct PointsList {
-    points: Vec<PointStruct>,
-}
+// #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+// struct PointsList {
+//     points: Vec<PointStruct>,
+// }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PointSyncOperation {
@@ -148,9 +156,52 @@ pub struct PointSyncOperation {
     pub points: Vec<PointStruct>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Validate, JsonSchema)]
+pub struct PointsBatch {
+    pub batch: Batch,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, Validate)]
+pub struct PointsList {
+    pub points: Vec<PointStruct>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKeySelector>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[serde(untagged)]
+pub enum PointInsertOperations {
+    /// Inset points from a batch.
+    PointsBatch(PointsBatch),
+    /// Insert points from a list
+    PointsList(PointsList),
+}
+
+impl Validate for PointInsertOperations {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            PointInsertOperations::PointsBatch(batch) => batch.validate(),
+            PointInsertOperations::PointsList(list) => list.validate(),
+        }
+    }
+}
+
+impl PointInsertOperations {
+    pub fn decompose(self) -> (Option<ShardKeySelector>, PointInsertOperationsInternal) {
+        match self {
+            PointInsertOperations::PointsBatch(batch) => (batch.shard_key, batch.batch.into()),
+            PointInsertOperations::PointsList(list) => (list.shard_key, list.points.into()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum PointInsertOperations {
+pub enum PointInsertOperationsInternal {
     /// Inset points from a batch.
     #[serde(rename = "batch")]
     PointsBatch(Batch),
@@ -159,137 +210,105 @@ pub enum PointInsertOperations {
     PointsList(Vec<PointStruct>),
 }
 
-impl JsonSchema for PointInsertOperations {
-    fn schema_name() -> String {
-        "PointInsertOperations".to_string()
-    }
-
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        let def_path = gen.settings().definitions_path.clone();
-        let a_schema: Schema = Batch::json_schema(gen);
-        let proxy_b_schema = PointsList::json_schema(gen);
-        let definitions = gen.definitions_mut();
-        definitions.insert(Batch::schema_name(), a_schema);
-
-        let field_a_name = "batch".to_string();
-
-        let get_obj_schema = |field: String, schema_name: String| {
-            let schema_ref = Schema::Object(SchemaObject {
-                reference: Some(format!("{def_path}{schema_name}")),
-                ..Default::default()
-            });
-            Schema::Object(SchemaObject {
-                object: Some(Box::new(ObjectValidation {
-                    required: vec![field.clone()].into_iter().collect(),
-                    properties: vec![(field, schema_ref)].into_iter().collect(),
-                    ..Default::default()
-                })),
-                ..Default::default()
-            })
-        };
-
-        let proxy_a_schema = get_obj_schema(field_a_name, Batch::schema_name());
-
-        let proxy_a_name = "PointsBatch".to_string();
-
-        definitions.insert(proxy_a_name.clone(), proxy_a_schema);
-        definitions.insert(PointsList::schema_name(), proxy_b_schema);
-
-        let proxy_a_ref = Schema::Object(SchemaObject {
-            reference: Some(format!("{def_path}{proxy_a_name}")),
-            ..Default::default()
-        });
-
-        let proxy_b_ref = Schema::Object(SchemaObject {
-            reference: Some(format!("{}{}", def_path, PointsList::schema_name())),
-            ..Default::default()
-        });
-
-        Schema::Object(SchemaObject {
-            subschemas: Some(Box::new(SubschemaValidation {
-                one_of: Some(vec![proxy_a_ref, proxy_b_ref]),
-                ..Default::default()
-            })),
-            ..Default::default()
-        })
-    }
-}
-
-impl Validate for PointInsertOperations {
+impl Validate for PointInsertOperationsInternal {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            PointInsertOperations::PointsList(_) => Ok(()),
-            PointInsertOperations::PointsBatch(batch) => {
-                let bad_input_description = |ids: usize, vecs: usize| -> String {
-                    format!("number of ids and vectors must be equal ({ids} != {vecs})")
-                };
-                let create_error = |message: String| -> validator::ValidationErrors {
-                    let mut errors = validator::ValidationErrors::new();
-                    errors.add("batch", {
-                        let mut error = validator::ValidationError::new("point_insert_operation");
-                        error.message.replace(Cow::from(message));
-                        error
-                    });
-                    errors
-                };
-
-                match &batch.vectors {
-                    BatchVectorStruct::Single(vectors) => {
-                        if batch.ids.len() != vectors.len() {
-                            return Err(create_error(bad_input_description(
-                                batch.ids.len(),
-                                vectors.len(),
-                            )));
-                        }
-                    }
-                    BatchVectorStruct::Multi(named_vectors) => {
-                        for vectors in named_vectors.values() {
-                            if batch.ids.len() != vectors.len() {
-                                return Err(create_error(bad_input_description(
-                                    batch.ids.len(),
-                                    vectors.len(),
-                                )));
-                            }
-                        }
-                    }
-                }
-                if let Some(payload_vector) = &batch.payloads {
-                    if payload_vector.len() != batch.ids.len() {
-                        return Err(create_error(format!(
-                            "number of ids and payloads must be equal ({} != {})",
-                            batch.ids.len(),
-                            payload_vector.len(),
-                        )));
-                    }
-                }
-                Ok(())
-            }
+            PointInsertOperationsInternal::PointsBatch(batch) => batch.validate(),
+            PointInsertOperationsInternal::PointsList(_list) => Ok(()),
         }
     }
 }
 
-impl SplitByShard for PointInsertOperations {
+impl Validate for Batch {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        let batch = self;
+
+        let bad_input_description = |ids: usize, vecs: usize| -> String {
+            format!("number of ids and vectors must be equal ({ids} != {vecs})")
+        };
+        let create_error = |message: String| -> validator::ValidationErrors {
+            let mut errors = validator::ValidationErrors::new();
+            errors.add("batch", {
+                let mut error = validator::ValidationError::new("point_insert_operation");
+                error.message.replace(Cow::from(message));
+                error
+            });
+            errors
+        };
+
+        match &batch.vectors {
+            BatchVectorStruct::Single(vectors) => {
+                if batch.ids.len() != vectors.len() {
+                    return Err(create_error(bad_input_description(
+                        batch.ids.len(),
+                        vectors.len(),
+                    )));
+                }
+            }
+            BatchVectorStruct::Multi(named_vectors) => {
+                for vectors in named_vectors.values() {
+                    if batch.ids.len() != vectors.len() {
+                        return Err(create_error(bad_input_description(
+                            batch.ids.len(),
+                            vectors.len(),
+                        )));
+                    }
+                }
+            }
+        }
+        if let Some(payload_vector) = &batch.payloads {
+            if payload_vector.len() != batch.ids.len() {
+                return Err(create_error(format!(
+                    "number of ids and payloads must be equal ({} != {})",
+                    batch.ids.len(),
+                    payload_vector.len(),
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl SplitByShard for PointInsertOperationsInternal {
     fn split_by_shard(self, ring: &HashRing<ShardId>) -> OperationToShard<Self> {
         match self {
-            PointInsertOperations::PointsBatch(batch) => batch
+            PointInsertOperationsInternal::PointsBatch(batch) => batch
                 .split_by_shard(ring)
-                .map(PointInsertOperations::PointsBatch),
-            PointInsertOperations::PointsList(list) => list
+                .map(PointInsertOperationsInternal::PointsBatch),
+            PointInsertOperationsInternal::PointsList(list) => list
                 .split_by_shard(ring)
-                .map(PointInsertOperations::PointsList),
+                .map(PointInsertOperationsInternal::PointsList),
         }
     }
 }
 
 impl From<Batch> for PointInsertOperations {
     fn from(batch: Batch) -> Self {
-        PointInsertOperations::PointsBatch(batch)
+        PointInsertOperations::PointsBatch(PointsBatch {
+            batch,
+            shard_key: None,
+        })
     }
 }
 
 impl From<Vec<PointStruct>> for PointInsertOperations {
     fn from(points: Vec<PointStruct>) -> Self {
-        PointInsertOperations::PointsList(points)
+        PointInsertOperations::PointsList(PointsList {
+            points,
+            shard_key: None,
+        })
+    }
+}
+
+impl From<Batch> for PointInsertOperationsInternal {
+    fn from(batch: Batch) -> Self {
+        PointInsertOperationsInternal::PointsBatch(batch)
+    }
+}
+
+impl From<Vec<PointStruct>> for PointInsertOperationsInternal {
+    fn from(points: Vec<PointStruct>) -> Self {
+        PointInsertOperationsInternal::PointsList(points)
     }
 }
 
@@ -297,7 +316,7 @@ impl From<Vec<PointStruct>> for PointInsertOperations {
 #[serde(rename_all = "snake_case")]
 pub enum PointOperations {
     /// Insert or update points
-    UpsertPoints(PointInsertOperations),
+    UpsertPoints(PointInsertOperationsInternal),
     /// Delete point if exists
     DeletePoints { ids: Vec<PointIdType> },
     /// Delete points by given filter criteria
@@ -449,13 +468,13 @@ impl SplitByShard for PointOperations {
 
 impl From<Batch> for PointOperations {
     fn from(batch: Batch) -> Self {
-        PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(batch))
+        PointOperations::UpsertPoints(batch.into())
     }
 }
 
 impl From<Vec<PointStruct>> for PointOperations {
     fn from(points: Vec<PointStruct>) -> Self {
-        PointOperations::UpsertPoints(PointInsertOperations::PointsList(points))
+        PointOperations::UpsertPoints(points.into())
     }
 }
 
@@ -474,25 +493,28 @@ mod tests {
 
     #[test]
     fn validate_batch() {
-        let batch = PointInsertOperations::PointsBatch(Batch {
+        let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
             vectors: vec![].into(),
             payloads: None,
-        });
+        }
+        .into();
         assert!(batch.validate().is_err());
 
-        let batch = PointInsertOperations::PointsBatch(Batch {
+        let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
             vectors: vec![vec![0.1]].into(),
             payloads: None,
-        });
+        }
+        .into();
         assert!(batch.validate().is_ok());
 
-        let batch = PointInsertOperations::PointsBatch(Batch {
+        let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
             vectors: vec![vec![0.1]].into(),
             payloads: Some(vec![]),
-        });
+        }
+        .into();
         assert!(batch.validate().is_err());
     }
 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -99,8 +99,7 @@ impl Batch {
 #[serde(rename_all = "snake_case")]
 pub struct PointIdsList {
     pub points: Vec<PointIdType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 
@@ -117,14 +116,12 @@ impl From<Vec<PointIdType>> for PointIdsList {
 #[serde(rename_all = "snake_case")]
 pub struct FilterSelector {
     pub filter: Filter,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PointsSelector {
     /// Select points by list of IDs
     PointIdsSelector(PointIdsList),
@@ -159,16 +156,14 @@ pub struct PointSyncOperation {
 #[derive(Debug, Deserialize, Serialize, Clone, Validate, JsonSchema)]
 pub struct PointsBatch {
     pub batch: Batch,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, Validate)]
 pub struct PointsList {
     pub points: Vec<PointStruct>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -138,12 +138,6 @@ impl Validate for PointsSelector {
     }
 }
 
-// Structure used for deriving custom JsonSchema only
-// #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
-// struct PointsList {
-//     points: Vec<PointStruct>,
-// }
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PointSyncOperation {
     /// Minimal id of the sync range

--- a/lib/collection/src/operations/shard_key_selector.rs
+++ b/lib/collection/src/operations/shard_key_selector.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use segment::types::ShardKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[serde(untagged)]
+pub enum ShardKeySelector {
+    ShardKey(ShardKey),
+    ShardKeys(Vec<ShardKey>),
+    // ToDo: select by pattern
+}

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -88,8 +88,7 @@ pub struct Record {
     /// Vector of the point
     pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -22,7 +22,7 @@ use segment::data_types::vectors::{
 };
 use segment::types::{
     Distance, Filter, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig,
-    ScoredPoint, SearchParams, SeqNumberType, WithPayloadInterface, WithVector,
+    ScoredPoint, SearchParams, SeqNumberType, ShardKey, WithPayloadInterface, WithVector,
 };
 use segment::vector_storage::query::context_query::ContextQuery;
 use segment::vector_storage::query::discovery_query::DiscoveryQuery;
@@ -44,7 +44,7 @@ use crate::lookup::types::WithLookupInterface;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;
-use crate::shards::shard::{PeerId, ShardId, ShardKey};
+use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::transfer::shard_transfer::ShardTransferMethod;
 use crate::wal::WalError;
 
@@ -87,6 +87,10 @@ pub struct Record {
     pub payload: Option<Payload>,
     /// Vector of the point
     pub vector: Option<VectorStruct>,
+    /// Shard Key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKey>,
 }
 
 /// Current statistics and configuration of the collection
@@ -769,6 +773,17 @@ impl CollectionError {
         match self {
             Self::ForwardProxyError { peer_id, .. } => Some(*peer_id),
             _ => None,
+        }
+    }
+
+    pub fn shard_key_not_found(shard_key: &Option<ShardKey>) -> CollectionError {
+        match shard_key {
+            Some(shard_key) => CollectionError::NotFound {
+                what: format!("Shard key {} not found", shard_key),
+            },
+            None => CollectionError::NotFound {
+                what: "Shard expected, but not provided".to_string(),
+            },
         }
     }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -778,7 +778,7 @@ impl CollectionError {
     pub fn shard_key_not_found(shard_key: &Option<ShardKey>) -> CollectionError {
         match shard_key {
             Some(shard_key) => CollectionError::NotFound {
-                what: format!("Shard key {} not found", shard_key),
+                what: format!("Shard key {shard_key} not found"),
             },
             None => CollectionError::NotFound {
                 what: "Shard expected, but not provided".to_string(),

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -19,8 +19,7 @@ pub struct UpdateVectors {
     #[validate]
     #[validate(length(min = 1, message = "must specify points to update"))]
     pub points: Vec<PointVectors>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -46,8 +45,7 @@ pub struct DeleteVectors {
     #[serde(alias = "vectors")]
     #[validate(length(min = 1, message = "must specify vector names to delete"))]
     pub vector: HashSet<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKeySelector>,
 }
 

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -1,4 +1,4 @@
-use api::grpc::conversions::payload_to_proto;
+use api::grpc::conversions::{convert_shard_key_from_grpc_opt, payload_to_proto};
 use api::grpc::qdrant::points_selector::PointsSelectorOneOf;
 use api::grpc::qdrant::{
     ClearPayloadPoints, ClearPayloadPointsInternal, CreateFieldIndexCollection,
@@ -390,5 +390,6 @@ pub fn try_scored_point_from_grpc(
         score: point.score,
         payload,
         vector,
+        shard_key: convert_shard_key_from_grpc_opt(point.shard_key),
     })
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -13,10 +13,12 @@ use segment::types::{Filter, PayloadFieldSchema, PayloadSchemaParams, PointIdTyp
 use tonic::Status;
 
 use crate::operations::conversions::write_ordering_to_proto;
-use crate::operations::payload_ops::{DeletePayload, SetPayload};
-use crate::operations::point_ops::{PointInsertOperations, PointSyncOperation, WriteOrdering};
+use crate::operations::payload_ops::{DeletePayloadOp, SetPayloadOp};
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointSyncOperation, WriteOrdering,
+};
 use crate::operations::types::CollectionResult;
-use crate::operations::vector_ops::UpdateVectors;
+use crate::operations::vector_ops::UpdateVectorsOp;
 use crate::operations::CreateIndex;
 use crate::shards::shard::ShardId;
 
@@ -47,7 +49,7 @@ pub fn internal_sync_points(
 pub fn internal_upsert_points(
     shard_id: Option<ShardId>,
     collection_name: String,
-    point_insert_operations: PointInsertOperations,
+    point_insert_operations: PointInsertOperationsInternal,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpsertPointsInternal> {
@@ -57,13 +59,14 @@ pub fn internal_upsert_points(
             collection_name,
             wait: Some(wait),
             points: match point_insert_operations {
-                PointInsertOperations::PointsBatch(batch) => batch.try_into()?,
-                PointInsertOperations::PointsList(list) => list
+                PointInsertOperationsInternal::PointsBatch(batch) => batch.try_into()?,
+                PointInsertOperationsInternal::PointsList(list) => list
                     .into_iter()
                     .map(|id| id.try_into())
                     .collect::<Result<Vec<_>, Status>>()?,
             },
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     })
 }
@@ -86,6 +89,7 @@ pub fn internal_delete_points(
                 })),
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -106,6 +110,7 @@ pub fn internal_delete_points_by_filter(
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -113,7 +118,7 @@ pub fn internal_delete_points_by_filter(
 pub fn internal_update_vectors(
     shard_id: Option<ShardId>,
     collection_name: String,
-    update_vectors: UpdateVectors,
+    update_vectors: UpdateVectorsOp,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> UpdateVectorsInternal {
@@ -131,6 +136,7 @@ pub fn internal_update_vectors(
                 })
                 .collect(),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -157,6 +163,7 @@ pub fn internal_delete_vectors(
                 names: vector_names,
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -181,6 +188,7 @@ pub fn internal_delete_vectors_by_filter(
                 names: vector_names,
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -188,7 +196,7 @@ pub fn internal_delete_vectors_by_filter(
 pub fn internal_set_payload(
     shard_id: Option<ShardId>,
     collection_name: String,
-    set_payload: SetPayload,
+    set_payload: SetPayloadOp,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> SetPayloadPointsInternal {
@@ -212,6 +220,7 @@ pub fn internal_set_payload(
             payload: payload_to_proto(set_payload.payload),
             points_selector,
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -219,7 +228,7 @@ pub fn internal_set_payload(
 pub fn internal_delete_payload(
     shard_id: Option<ShardId>,
     collection_name: String,
-    delete_payload: DeletePayload,
+    delete_payload: DeletePayloadOp,
     wait: bool,
     ordering: Option<WriteOrdering>,
 ) -> DeletePayloadPointsInternal {
@@ -243,6 +252,7 @@ pub fn internal_delete_payload(
             keys: delete_payload.keys,
             points_selector,
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -265,6 +275,7 @@ pub fn internal_clear_payload(
                 })),
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }
@@ -285,6 +296,7 @@ pub fn internal_clear_payload_by_filter(
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
             ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
         }),
     }
 }

--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -251,6 +251,7 @@ mod test {
             score,
             payload: None,
             vector: None,
+            shard_key: None,
         }
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -1,10 +1,6 @@
 use core::marker::{Send, Sync};
-use std::fmt::Display;
 use std::future::{self, Future};
 use std::path::Path;
-
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use super::update_tracker::UpdateTracker;
 use crate::operations::types::CollectionResult;
@@ -31,22 +27,6 @@ pub type ShardReplicasPlacement = Vec<PeerId>;
 ///     [3, 4]
 /// ] - 3 shards, each has 2 replicas
 pub type ShardsPlacement = Vec<ShardReplicasPlacement>;
-
-#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, PartialEq, Eq, Hash)]
-#[serde(untagged)]
-pub enum ShardKey {
-    Keyword(String),
-    Number(u64),
-}
-
-impl Display for ShardKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ShardKey::Keyword(keyword) => write!(f, "\"{}\"", keyword),
-            ShardKey::Number(number) => write!(f, "{}", number),
-        }
-    }
-}
 
 /// Shard
 ///

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -205,8 +205,9 @@ impl ShardHolder {
     pub fn split_by_shard<O: SplitByShard + Clone>(
         &self,
         operation: O,
+        shard_keys_selection: &Option<ShardKey>,
     ) -> Vec<(&ShardReplicaSet, O)> {
-        let Some(hashring) = self.rings.get(&None) else {
+        let Some(hashring) = self.rings.get(shard_keys_selection) else {
             return vec![];
         };
 
@@ -216,10 +217,24 @@ impl ShardHolder {
                 .into_iter()
                 .map(|(shard_id, operation)| (self.shards.get(&shard_id).unwrap(), operation))
                 .collect(),
-            OperationToShard::ToAll(operation) => self
-                .all_shards()
-                .map(|shard| (shard, operation.clone()))
-                .collect(),
+            OperationToShard::ToAll(operation) => {
+                if let Some(shard_key) = shard_keys_selection {
+                    let shard_ids = self
+                        .key_mapping
+                        .read()
+                        .get(shard_key)
+                        .cloned()
+                        .unwrap_or_default();
+                    shard_ids
+                        .into_iter()
+                        .map(|shard_id| (self.shards.get(&shard_id).unwrap(), operation.clone()))
+                        .collect()
+                } else {
+                    self.all_shards()
+                        .map(|shard| (shard, operation.clone()))
+                        .collect()
+                }
+            }
         };
         shard_ops
     }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use itertools::Itertools;
+// TODO rename ReplicaShard to ReplicaSetShard
+use segment::types::ShardKey;
 use tar::Builder as TarBuilder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -20,7 +22,7 @@ use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::replica_set::{ChangePeerState, ReplicaState, ShardReplicaSet}; // TODO rename ReplicaShard to ReplicaSetShard
-use crate::shards::shard::{PeerId, ShardId, ShardKey};
+use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{ShardConfig, ShardType};
 use crate::shards::shard_versioning::latest_shard_paths;
 use crate::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -1,5 +1,5 @@
 use collection::operations::point_ops::{
-    Batch, PointInsertOperations, PointOperations, WriteOrdering,
+    Batch, PointInsertOperationsInternal, PointOperations, WriteOrdering,
 };
 use collection::operations::types::ScrollRequest;
 use collection::operations::CollectionUpdateOperations;
@@ -30,14 +30,14 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
         )
         .await;
         let insert_points = CollectionUpdateOperations::PointOperation(
-            PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
                 vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
                 payloads: None,
             })),
         );
         collection
-            .update_from_client(insert_points, true, WriteOrdering::default())
+            .update_from_client_simple(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
     }
@@ -63,14 +63,14 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
     {
         let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
-            PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
                 vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
                 payloads: serde_json::from_str(r#"[{ "k": "v1" } , { "k": "v2"}]"#).unwrap(),
             })),
         );
         collection
-            .update_from_client(insert_points, true, WriteOrdering::default())
+            .update_from_client_simple(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
     }
@@ -129,7 +129,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
     {
         let collection = simple_collection_fixture(collection_dir.path(), shard_number).await;
         let insert_points = CollectionUpdateOperations::PointOperation(
-            PointOperations::UpsertPoints(PointInsertOperations::PointsBatch(Batch {
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0.into(), 1.into()],
                 vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
                 payloads: serde_json::from_str(
@@ -139,7 +139,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
             })),
         );
         collection
-            .update_from_client(insert_points, true, WriteOrdering::default())
+            .update_from_client_simple(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
     }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fs::File;
 
-use collection::operations::payload_ops::{PayloadOps, SetPayload};
+use collection::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use collection::operations::point_ops::{Batch, PointOperations, PointStruct, WriteOrdering};
 use collection::operations::types::{
     CountRequest, PointRequest, RecommendRequest, ScrollRequest, SearchRequest, UpdateStatus,
@@ -49,7 +49,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
     );
 
     let insert_result = collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await;
 
     match insert_result {
@@ -106,7 +106,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     );
 
     let insert_result = collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await;
 
     match insert_result {
@@ -191,21 +191,21 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
         );
 
         collection
-            .update_from_client(insert_points, true, WriteOrdering::default())
+            .update_from_client_simple(insert_points, true, WriteOrdering::default())
             .await
             .unwrap();
 
         let payload: Payload = serde_json::from_str(r#"{"color":"red"}"#).unwrap();
 
         let assign_payload =
-            CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayload {
+            CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
                 payload,
                 points: Some(vec![2.into(), 3.into()]),
                 filter: None,
             }));
 
         collection
-            .update_from_client(assign_payload, true, WriteOrdering::default())
+            .update_from_client_simple(assign_payload, true, WriteOrdering::default())
             .await
             .unwrap();
     }
@@ -320,7 +320,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
     );
 
     collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
     let result = recommend_by(
@@ -377,7 +377,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
     ));
 
     collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 
@@ -431,7 +431,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
     );
 
     let insert_result = collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await;
 
     match insert_result {
@@ -454,7 +454,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
     );
 
     let delete_result = collection
-        .update_from_client(delete_points, true, WriteOrdering::default())
+        .update_from_client_simple(delete_points, true, WriteOrdering::default())
         .await;
 
     match delete_result {

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -75,7 +75,7 @@ mod group_by {
         );
 
         let insert_result = collection
-            .update_from_client(insert_points, true, WriteOrdering::default())
+            .update_from_client_simple(insert_points, true, WriteOrdering::default())
             .await
             .expect("insert failed");
 
@@ -549,7 +549,7 @@ mod group_by_builder {
             );
 
             let insert_result = collection
-                .update_from_client(insert_points, true, WriteOrdering::default())
+                .update_from_client_simple(insert_points, true, WriteOrdering::default())
                 .await
                 .expect("insert failed");
 
@@ -580,7 +580,7 @@ mod group_by_builder {
                 .into(),
             );
             let insert_result = lookup_collection
-                .update_from_client(insert_points, true, WriteOrdering::default())
+                .update_from_client_simple(insert_points, true, WriteOrdering::default())
                 .await
                 .expect("insert failed");
 

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -64,7 +64,7 @@ async fn setup() -> Resources {
     );
 
     collection
-        .update_from_client(upsert_points, true, WriteOrdering::default())
+        .update_from_client_simple(upsert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::types::{
     CollectionError, PointRequest, RecommendRequest, SearchRequest, VectorParams, VectorsConfig,
@@ -104,10 +104,10 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         });
     }
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperations::PointsList(points),
+        PointInsertOperationsInternal::PointsList(points),
     ));
     collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -1,5 +1,5 @@
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::types::SearchRequest;
 use collection::operations::CollectionUpdateOperations;
@@ -32,10 +32,10 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
         });
     }
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperations::PointsList(points),
+        PointInsertOperationsInternal::PointsList(points),
     ));
     collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use collection::collection::Collection;
 use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::shared_storage_config::SharedStorageConfig;
 use collection::operations::types::{NodeType, SearchRequest, VectorParams, VectorsConfig};
@@ -99,10 +99,10 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         });
     }
     let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperations::PointsList(points),
+        PointInsertOperationsInternal::PointsList(points),
     ));
     collection
-        .update_from_client(insert_points, true, WriteOrdering::default())
+        .update_from_client_simple(insert_points, true, WriteOrdering::default())
         .await
         .unwrap();
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -605,6 +605,7 @@ impl Segment {
                     score: scored_point_offset.score,
                     payload,
                     vector,
+                    shard_key: None,
                 })
             })
             .collect()

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::mem::size_of;
 use std::ops::Deref;
@@ -186,6 +186,10 @@ pub struct ScoredPoint {
     pub payload: Option<Payload>,
     /// Vector of the point
     pub vector: Option<VectorStruct>,
+    /// Shard Key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub shard_key: Option<ShardKey>,
 }
 
 impl Eq for ScoredPoint {}
@@ -3007,3 +3011,19 @@ mod tests {
 }
 
 pub type TheMap<K, V> = BTreeMap<K, V>;
+
+#[derive(Deserialize, Serialize, JsonSchema, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum ShardKey {
+    Keyword(String),
+    Number(u64),
+}
+
+impl Display for ShardKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShardKey::Keyword(keyword) => write!(f, "\"{}\"", keyword),
+            ShardKey::Number(number) => write!(f, "{}", number),
+        }
+    }
+}

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -187,8 +187,7 @@ pub struct ScoredPoint {
     /// Vector of the point
     pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 
@@ -229,8 +228,7 @@ pub enum SegmentType {
 #[serde(rename_all = "snake_case")]
 pub struct PayloadIndexInfo {
     pub data_type: PayloadSchemaType,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<PayloadSchemaParams>,
     /// Number of points indexed with this index
     pub points: usize,
@@ -378,12 +376,10 @@ pub struct HnswConfig {
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
     /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    #[serde(default, skip_serializing_if = "Option::is_none")] // Better backward compatibility
     pub on_disk: Option<bool>,
     /// Custom M param for hnsw graph built for payload index. If not set, default M will be used.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    #[serde(default, skip_serializing_if = "Option::is_none")] // Better backward compatibility
     pub payload_m: Option<usize>,
 }
 
@@ -510,8 +506,7 @@ pub struct BinaryQuantization {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum QuantizationConfig {
     Scalar(ScalarQuantization),
     Product(ProductQuantization),
@@ -586,8 +581,7 @@ impl Default for Indexes {
 
 /// Type of payload index
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type", content = "options")]
+#[serde(tag = "type", content = "options", rename_all = "snake_case")]
 pub enum PayloadIndexType {
     // Do not index anything, just keep of what should be indexed later
     #[default]
@@ -598,8 +592,7 @@ pub enum PayloadIndexType {
 
 /// Type of payload storage
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type", content = "options")]
+#[serde(tag = "type", content = "options", rename_all = "snake_case")]
 pub enum PayloadStorageType {
     // Store payload in memory and use persistence storage only if vectors are changed
     #[default]
@@ -938,8 +931,7 @@ impl<'a> From<&'a Map<String, Value>> for OwnedPayloadRef<'a> {
 /// {..., "payload": {"city": {"type": "keyword", "value": "Moscow" }}},
 /// ```
 #[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadVariant<T> {
     List(Vec<T>),
     Value(T),
@@ -956,8 +948,7 @@ impl<T: Clone> PayloadVariant<T> {
 
 /// Json representation of a payload
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum JsonPayload {
     Keyword(PayloadVariant<String>),
     Integer(PayloadVariant<IntPayloadType>),
@@ -979,15 +970,13 @@ pub enum PayloadSchemaType {
 
 /// Payload type with parameters
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadSchemaParams {
     Text(TextIndexParams),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadFieldSchema {
     FieldType(PayloadSchemaType),
     FieldParams(PayloadSchemaParams),
@@ -1112,8 +1101,7 @@ pub struct MatchExcept {
 
 /// Match filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum MatchInterface {
     Value(MatchValue),
     Text(MatchText),
@@ -1123,8 +1111,7 @@ pub enum MatchInterface {
 
 /// Match filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(from = "MatchInterface")]
-#[serde(untagged)]
+#[serde(untagged, from = "MatchInterface")]
 pub enum Match {
     Value(MatchValue),
     Text(MatchText),
@@ -1347,8 +1334,7 @@ impl PolygonWrapper {
 ///
 /// Matches coordinates inside the polygon, defined by `exterior` and `interiors`
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[serde(try_from = "GeoPolygonShadow")]
-#[serde(rename_all = "snake_case")]
+#[serde(try_from = "GeoPolygonShadow", rename_all = "snake_case")]
 pub struct GeoPolygon {
     /// The exterior line bounds the surface
     /// must consist of a minimum of 4 points, and the first and last points
@@ -1694,8 +1680,7 @@ impl Validate for Condition {
 
 /// Options for specifying which payload to include or not
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum WithPayloadInterface {
     /// If `true` - return all payload,
     /// If `false` - do not return payload
@@ -1714,8 +1699,7 @@ impl From<bool> for WithPayloadInterface {
 
 /// Options for specifying which vector to include
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum WithVector {
     /// If `true` - return all vector,
     /// If `false` - do not return vector
@@ -1783,8 +1767,7 @@ impl From<&WithPayloadInterface> for WithPayload {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct PayloadSelectorInclude {
     /// Only include this payload keys
     pub include: Vec<PayloadKeyType>,
@@ -1797,8 +1780,7 @@ impl PayloadSelectorInclude {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct PayloadSelectorExclude {
     /// Exclude this fields from returning payload
     pub exclude: Vec<PayloadKeyType>,
@@ -1812,8 +1794,7 @@ impl PayloadSelectorExclude {
 
 /// Specifies how to treat payload selector
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[serde(untagged)]
-#[serde(rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadSelector {
     /// Include only this fields into response payload
     Include(PayloadSelectorInclude),
@@ -1868,8 +1849,7 @@ impl PayloadSelector {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct WithPayload {
     /// Enable return payloads or not
     pub enable: bool,
@@ -1878,8 +1858,7 @@ pub struct WithPayload {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct Filter {
     /// At least one of those conditions should match
     #[validate]

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -5,11 +5,11 @@ use collection::operations::config_diff::{
 };
 use collection::operations::types::{VectorsConfig, VectorsConfigDiff};
 use collection::shards::replica_set::ReplicaState;
-use collection::shards::shard::{PeerId, ShardId, ShardKey, ShardsPlacement};
+use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
 use collection::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
 use collection::shards::{replica_set, CollectionId};
 use schemars::JsonSchema;
-use segment::types::QuantizationConfig;
+use segment::types::{QuantizationConfig, ShardKey};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 

--- a/lib/storage/src/content_manager/data_transfer.rs
+++ b/lib/storage/src/content_manager/data_transfer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use collection::collection::Collection;
 use collection::operations::point_ops::{
-    PointInsertOperations, PointOperations, PointStruct, WriteOrdering,
+    PointInsertOperationsInternal, PointOperations, PointStruct, WriteOrdering,
 };
 use collection::operations::types::{CollectionError, CollectionResult, ScrollRequest};
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
@@ -111,14 +111,14 @@ async fn replicate_shard_data(
             .collect();
 
         let upsert_request = CollectionUpdateOperations::PointOperation(
-            PointOperations::UpsertPoints(PointInsertOperations::PointsList(records)),
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(records)),
         );
 
         let target_collection =
             handle_get_collection(collections_read.get(target_collection_name))?;
 
         target_collection
-            .update_from_client(upsert_request, false, WriteOrdering::default())
+            .update_from_client_simple(upsert_request, false, WriteOrdering::default())
             .await?;
 
         if offset.is_none() {
@@ -220,7 +220,7 @@ pub async fn transfer_indexes(
             }),
         );
         target_collection
-            .update_from_client(request, false, WriteOrdering::default())
+            .update_from_client_simple(request, false, WriteOrdering::default())
             .await?;
     }
 

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -13,6 +13,7 @@ pub mod conversions;
 mod data_transfer;
 pub mod errors;
 pub mod shard_distribution;
+pub mod shard_key_selection;
 pub mod snapshots;
 pub mod toc;
 

--- a/lib/storage/src/content_manager/shard_key_selection.rs
+++ b/lib/storage/src/content_manager/shard_key_selection.rs
@@ -1,0 +1,47 @@
+use collection::operations::shard_key_selector::ShardKeySelector;
+use segment::types::ShardKey;
+
+#[derive(Debug, Clone)]
+pub enum ShardKeySelectorInternal {
+    /// No shard key specified
+    Empty,
+    /// All apply to all keys
+    All,
+    /// Select one shard key
+    ShardKey(ShardKey),
+    /// Select multiple shard keys
+    ShardKeys(Vec<ShardKey>),
+}
+
+impl From<Option<ShardKey>> for ShardKeySelectorInternal {
+    fn from(key: Option<ShardKey>) -> Self {
+        match key {
+            None => ShardKeySelectorInternal::Empty,
+            Some(key) => ShardKeySelectorInternal::ShardKey(key),
+        }
+    }
+}
+
+impl From<Vec<ShardKey>> for ShardKeySelectorInternal {
+    fn from(keys: Vec<ShardKey>) -> Self {
+        ShardKeySelectorInternal::ShardKeys(keys)
+    }
+}
+
+impl From<ShardKeySelector> for ShardKeySelectorInternal {
+    fn from(selector: ShardKeySelector) -> Self {
+        match selector {
+            ShardKeySelector::ShardKey(key) => ShardKeySelectorInternal::ShardKey(key),
+            ShardKeySelector::ShardKeys(keys) => ShardKeySelectorInternal::ShardKeys(keys),
+        }
+    }
+}
+
+impl From<Option<ShardKeySelector>> for ShardKeySelectorInternal {
+    fn from(selector: Option<ShardKeySelector>) -> Self {
+        match selector {
+            None => ShardKeySelectorInternal::Empty,
+            Some(selector) => selector.into(),
+        }
+    }
+}

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -83,6 +83,12 @@ impl TableOfContent {
                 }
             }
             ShardingMethod::Custom => {
+                if init_from.is_some() {
+                    return Err(StorageError::bad_input(
+                        "Can't initialize collection from another collection with custom sharding method"
+                            .to_string(),
+                    ));
+                }
                 if let Some(shard_number) = shard_number {
                     shard_number
                 } else {

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -86,7 +86,6 @@ impl TableOfContent {
                 if init_from.is_some() {
                     return Err(StorageError::bad_input(
                         "Can't initialize collection from another collection with custom sharding method"
-                            .to_string(),
                     ));
                 }
                 if let Some(shard_number) = shard_number {

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use collection::collection::Collection;
 use collection::grouping::group_by::GroupRequest;
 use collection::grouping::GroupBy;
 use collection::operations::consistency_params::ReadConsistency;
@@ -8,10 +9,12 @@ use collection::operations::types::*;
 use collection::operations::CollectionUpdateOperations;
 use collection::shards::shard::ShardId;
 use collection::{discovery, recommendations};
-use segment::types::ScoredPoint;
+use futures::future::try_join_all;
+use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
 use crate::content_manager::errors::StorageError;
+use crate::content_manager::shard_key_selection::ShardKeySelectorInternal;
 
 impl TableOfContent {
     /// Recommend points using positive and negative example from the request
@@ -280,6 +283,31 @@ impl TableOfContent {
             .map_err(|err| err.into())
     }
 
+    async fn _update_shard_keys(
+        collection: &Collection,
+        shard_keys: Vec<ShardKey>,
+        operation: CollectionUpdateOperations,
+        wait: bool,
+        ordering: WriteOrdering,
+    ) -> Result<UpdateResult, StorageError> {
+        if shard_keys.is_empty() {
+            return Err(StorageError::bad_input(
+                "Empty shard keys selection".to_string(),
+            ));
+        }
+
+        let updates: Vec<_> = shard_keys
+            .into_iter()
+            .map(|shard_key| {
+                collection.update_from_client(operation.clone(), wait, ordering, Some(shard_key))
+            })
+            .collect();
+
+        let results = try_join_all(updates).await?;
+
+        Ok(results.into_iter().next().unwrap())
+    }
+
     pub async fn update(
         &self,
         collection_name: &str,
@@ -287,6 +315,7 @@ impl TableOfContent {
         shard_selection: Option<ShardId>,
         wait: bool,
         ordering: WriteOrdering,
+        shard_keys_selector: ShardKeySelectorInternal,
     ) -> Result<UpdateResult, StorageError> {
         let collection = self.get_collection(collection_name).await?;
 
@@ -297,16 +326,19 @@ impl TableOfContent {
         // └┬──────────────────┘
         //  │ Shard: None
         //  │ Ordering: Strong
+        //  │ ShardKey: Some("cats")
         // ┌▼──────────────────┐
         // │ First Node        │ <- update_from_client
         // └┬──────────────────┘
         //  │ Shard: Some(N)
         //  │ Ordering: Strong
+        //  │ ShardKey: None
         // ┌▼──────────────────┐
         // │ Leader node       │ <- update_from_peer
         // └┬──────────────────┘
         //  │ Shard: Some(N)
         //  │ Ordering: None(Weak)
+        //  │ ShardKey: None
         // ┌▼──────────────────┐
         // │ Updating node     │ <- update_from_peer
         // └───────────────────┘
@@ -325,9 +357,28 @@ impl TableOfContent {
                 if operation.is_write_operation() {
                     self.check_write_lock()?;
                 }
-                collection
-                    .update_from_client(operation, wait, ordering)
-                    .await
+                let res = match shard_keys_selector {
+                    ShardKeySelectorInternal::Empty => {
+                        collection
+                            .update_from_client(operation, wait, ordering, None)
+                            .await?
+                    }
+                    ShardKeySelectorInternal::All => {
+                        let shard_keys = collection.get_shard_keys().await;
+                        Self::_update_shard_keys(&collection, shard_keys, operation, wait, ordering)
+                            .await?
+                    }
+                    ShardKeySelectorInternal::ShardKey(shard_key) => {
+                        collection
+                            .update_from_client(operation, wait, ordering, Some(shard_key))
+                            .await?
+                    }
+                    ShardKeySelectorInternal::ShardKeys(shard_keys) => {
+                        Self::_update_shard_keys(&collection, shard_keys, operation, wait, ordering)
+                            .await?
+                    }
+                };
+                Ok(res)
             }
         };
         result.map_err(|err| err.into())

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -291,9 +291,7 @@ impl TableOfContent {
         ordering: WriteOrdering,
     ) -> Result<UpdateResult, StorageError> {
         if shard_keys.is_empty() {
-            return Err(StorageError::bad_input(
-                "Empty shard keys selection".to_string(),
-            ));
+            return Err(StorageError::bad_input("Empty shard keys selection"));
         }
 
         let updates: Vec<_> = shard_keys

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -365,8 +365,20 @@ impl TableOfContent {
                     }
                     ShardKeySelectorInternal::All => {
                         let shard_keys = collection.get_shard_keys().await;
-                        Self::_update_shard_keys(&collection, shard_keys, operation, wait, ordering)
+                        if shard_keys.is_empty() {
+                            collection
+                                .update_from_client(operation, wait, ordering, None)
+                                .await?
+                        } else {
+                            Self::_update_shard_keys(
+                                &collection,
+                                shard_keys,
+                                operation,
+                                wait,
+                                ordering,
+                            )
                             .await?
+                        }
                     }
                     ShardKeySelectorInternal::ShardKey(shard_key) => {
                         collection


### PR DESCRIPTION
Tracking: https://github.com/qdrant/qdrant/issues/2807

Implementation of the custom shard routing in point-level APIs:

- [x] Update input and output data structures to support opt shard_key field
- [x] Implement routing of inbound updates
