### PR TITLE
Raw scorer for sparse vectors

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -81,6 +81,17 @@ impl From<Vector> for VectorType {
     }
 }
 
+impl TryFrom<Vector> for SparseVector {
+    type Error = OperationError;
+
+    fn try_from(value: Vector) -> Result<Self, Self::Error> {
+        match value {
+            Vector::Dense(_) => Err(OperationError::WrongSparse),
+            Vector::Sparse(v) => Ok(v),
+        }
+    }
+}
+
 impl<'a> From<&'a [VectorElementType]> for VectorRef<'a> {
     fn from(val: &'a [VectorElementType]) -> Self {
         VectorRef::Dense(val)
@@ -370,5 +381,11 @@ impl<const N: usize> From<[VectorElementType; N]> for QueryVector {
 impl<'a> From<VectorRef<'a>> for QueryVector {
     fn from(vec: VectorRef<'a>) -> Self {
         Self::Nearest(vec.to_vec())
+    }
+}
+
+impl From<SparseVector> for QueryVector {
+    fn from(vec: SparseVector) -> Self {
+        Self::Nearest(Vector::Sparse(vec))
     }
 }

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -23,6 +23,7 @@ pub mod common;
 pub mod query;
 mod query_scorer;
 mod simple_sparse_vector_storage;
+mod sparse_raw_scorer;
 
 pub use raw_scorer::*;
 pub use vector_storage_base::*;

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -9,7 +9,7 @@ use super::query::discovery_query::DiscoveryQuery;
 use super::query::reco_query::RecoQuery;
 use super::query::TransformInto;
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
-use super::{DenseVectorStorage, VectorStorageEnum};
+use super::{DenseVectorStorage, SparseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::{QueryVector, VectorType};
 use crate::spaces::metric::Metric;
@@ -19,7 +19,6 @@ use crate::types::Distance;
 use crate::vector_storage::query_scorer::metric_query_scorer::MetricQueryScorer;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::sparse_raw_scorer::SparseRawScorer;
-use crate::vector_storage::VectorStorage;
 
 /// RawScorer            QueryScorer        Metric
 /// ┌────────────────┐   ┌──────────────┐   ┌───────────────────┐
@@ -127,7 +126,7 @@ pub fn new_stoppable_raw_scorer<'a>(
 
 pub static DEFAULT_STOPPED: AtomicBool = AtomicBool::new(false);
 
-pub fn raw_sparse_scorer_impl<'a, TVectorStorage: VectorStorage>(
+pub fn raw_sparse_scorer_impl<'a, TVectorStorage: SparseVectorStorage>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,
@@ -241,7 +240,7 @@ pub fn raw_scorer_from_query_scorer<'a, TQueryScorer: QueryScorer + 'a>(
     }))
 }
 
-pub fn raw_sparse_scorer_from_query_scorer<'a, TVectorStorage: VectorStorage>(
+pub fn raw_sparse_scorer_from_query_scorer<'a, TVectorStorage: SparseVectorStorage>(
     vector: SparseVector,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -10,6 +10,7 @@ use rocksdb::DB;
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
 
+use super::SparseVectorStorage;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
@@ -123,6 +124,12 @@ impl SimpleSparseVectorStorage {
     }
 }
 
+impl SparseVectorStorage for SimpleSparseVectorStorage {
+    fn get_sparse(&self, key: PointOffsetType) -> &SparseVector {
+        self.vectors.get(key as usize).expect("Invalid point id")
+    }
+}
+
 impl VectorStorage for SimpleSparseVectorStorage {
     fn vector_dim(&self) -> usize {
         0 // not applicable
@@ -141,10 +148,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> VectorRef {
-        self.vectors
-            .get(key as usize)
-            .expect("Invalid point id")
-            .into()
+        self.get_sparse(key).into()
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {

--- a/lib/segment/src/vector_storage/sparse_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/sparse_raw_scorer.rs
@@ -4,10 +4,10 @@ use bitvec::slice::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use sparse::common::sparse_vector::SparseVector;
 
-use super::{RawScorer, VectorStorage};
+use super::{RawScorer, SparseVectorStorage};
 use crate::spaces::tools::peek_top_largest_iterable;
 
-pub struct SparseRawScorer<'a, TVectorStorage: VectorStorage> {
+pub struct SparseRawScorer<'a, TVectorStorage: SparseVectorStorage> {
     query: SparseVector,
     vector_storage: &'a TVectorStorage,
     point_deleted: &'a BitSlice,
@@ -15,7 +15,7 @@ pub struct SparseRawScorer<'a, TVectorStorage: VectorStorage> {
     is_stopped: &'a AtomicBool,
 }
 
-impl<'a, TVectorStorage: VectorStorage> SparseRawScorer<'a, TVectorStorage> {
+impl<'a, TVectorStorage: SparseVectorStorage> SparseRawScorer<'a, TVectorStorage> {
     pub fn new(
         query: SparseVector,
         vector_storage: &'a TVectorStorage,
@@ -33,7 +33,7 @@ impl<'a, TVectorStorage: VectorStorage> SparseRawScorer<'a, TVectorStorage> {
     }
 }
 
-impl<'a, TVectorStorage: VectorStorage> RawScorer for SparseRawScorer<'a, TVectorStorage> {
+impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, TVectorStorage> {
     fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
         if self.is_stopped.load(Ordering::Relaxed) {
             return 0;

--- a/lib/segment/src/vector_storage/sparse_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/sparse_raw_scorer.rs
@@ -43,8 +43,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             if !self.check_vector(point_id) {
                 continue;
             }
-            let vector: &SparseVector =
-                self.vector_storage.get_vector(point_id).try_into().unwrap();
+            let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
             scores[size] = ScoredPointOffset {
                 idx: point_id,
                 score: vector.score(&self.query),
@@ -67,8 +66,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
         }
         let mut scores = vec![];
         for point_id in points {
-            let vector: &SparseVector =
-                self.vector_storage.get_vector(point_id).try_into().unwrap();
+            let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
             scores.push(ScoredPointOffset {
                 idx: point_id,
                 score: vector.score(&self.query),
@@ -95,13 +93,13 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
-        let vector: &SparseVector = self.vector_storage.get_vector(point).try_into().unwrap();
+        let vector: &SparseVector = self.vector_storage.get_sparse(point);
         vector.score(&self.query)
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        let vector_a: &SparseVector = self.vector_storage.get_vector(point_a).try_into().unwrap();
-        let vector_b: &SparseVector = self.vector_storage.get_vector(point_b).try_into().unwrap();
+        let vector_a: &SparseVector = self.vector_storage.get_sparse(point_a);
+        let vector_b: &SparseVector = self.vector_storage.get_sparse(point_b);
         vector_a.score(vector_b)
     }
 
@@ -114,8 +112,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
             .filter(|point_id| self.check_vector(*point_id))
             .map(|point_id| {
-                let vector: &SparseVector =
-                    self.vector_storage.get_vector(point_id).try_into().unwrap();
+                let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
                 ScoredPointOffset {
                     idx: point_id,
                     score: vector.score(&self.query),
@@ -130,8 +127,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             .filter(|point_id| self.check_vector(*point_id))
             .map(|point_id| {
                 let point_id = point_id as PointOffsetType;
-                let vector: &SparseVector =
-                    self.vector_storage.get_vector(point_id).try_into().unwrap();
+                let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
                 ScoredPointOffset {
                     idx: point_id,
                     score: vector.score(&self.query),

--- a/lib/segment/src/vector_storage/sparse_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/sparse_raw_scorer.rs
@@ -1,0 +1,142 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use bitvec::slice::BitSlice;
+use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use sparse::common::sparse_vector::SparseVector;
+
+use super::{RawScorer, VectorStorage};
+use crate::spaces::tools::peek_top_largest_iterable;
+
+pub struct SparseRawScorer<'a, TVectorStorage: VectorStorage> {
+    query: SparseVector,
+    vector_storage: &'a TVectorStorage,
+    point_deleted: &'a BitSlice,
+    vec_deleted: &'a BitSlice,
+    is_stopped: &'a AtomicBool,
+}
+
+impl<'a, TVectorStorage: VectorStorage> SparseRawScorer<'a, TVectorStorage> {
+    pub fn new(
+        query: SparseVector,
+        vector_storage: &'a TVectorStorage,
+        point_deleted: &'a BitSlice,
+        vec_deleted: &'a BitSlice,
+        is_stopped: &'a AtomicBool,
+    ) -> Self {
+        Self {
+            query,
+            vector_storage,
+            point_deleted,
+            vec_deleted,
+            is_stopped,
+        }
+    }
+}
+
+impl<'a, TVectorStorage: VectorStorage> RawScorer for SparseRawScorer<'a, TVectorStorage> {
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoredPointOffset]) -> usize {
+        if self.is_stopped.load(Ordering::Relaxed) {
+            return 0;
+        }
+        let mut size: usize = 0;
+        for point_id in points.iter().copied() {
+            if !self.check_vector(point_id) {
+                continue;
+            }
+            let vector: &SparseVector =
+                self.vector_storage.get_vector(point_id).try_into().unwrap();
+            scores[size] = ScoredPointOffset {
+                idx: point_id,
+                score: vector.score(&self.query),
+            };
+
+            size += 1;
+            if size == scores.len() {
+                return size;
+            }
+        }
+        size
+    }
+
+    fn score_points_unfiltered(
+        &self,
+        points: &mut dyn Iterator<Item = PointOffsetType>,
+    ) -> Vec<ScoredPointOffset> {
+        if self.is_stopped.load(Ordering::Relaxed) {
+            return vec![];
+        }
+        let mut scores = vec![];
+        for point_id in points {
+            let vector: &SparseVector =
+                self.vector_storage.get_vector(point_id).try_into().unwrap();
+            scores.push(ScoredPointOffset {
+                idx: point_id,
+                score: vector.score(&self.query),
+            });
+        }
+        scores
+    }
+
+    fn check_vector(&self, point: PointOffsetType) -> bool {
+        // Deleted points propagate to vectors; check vector deletion for possible early return
+        !self
+            .vec_deleted
+            .get(point as usize)
+            .map(|x| *x)
+            // Default to not deleted if our deleted flags failed grow
+            .unwrap_or(false)
+            // Additionally check point deletion for integrity if delete propagation to vector failed
+            && !self
+            .point_deleted
+            .get(point as usize)
+            .map(|x| *x)
+            // Default to deleted if the point mapping was removed from the ID tracker
+            .unwrap_or(true)
+    }
+
+    fn score_point(&self, point: PointOffsetType) -> ScoreType {
+        let vector: &SparseVector = self.vector_storage.get_vector(point).try_into().unwrap();
+        vector.score(&self.query)
+    }
+
+    fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
+        let vector_a: &SparseVector = self.vector_storage.get_vector(point_a).try_into().unwrap();
+        let vector_b: &SparseVector = self.vector_storage.get_vector(point_b).try_into().unwrap();
+        vector_a.score(vector_b)
+    }
+
+    fn peek_top_iter(
+        &self,
+        points: &mut dyn Iterator<Item = PointOffsetType>,
+        top: usize,
+    ) -> Vec<ScoredPointOffset> {
+        let scores = points
+            .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
+            .filter(|point_id| self.check_vector(*point_id))
+            .map(|point_id| {
+                let vector: &SparseVector =
+                    self.vector_storage.get_vector(point_id).try_into().unwrap();
+                ScoredPointOffset {
+                    idx: point_id,
+                    score: vector.score(&self.query),
+                }
+            });
+        peek_top_largest_iterable(scores, top)
+    }
+
+    fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
+        let scores = (0..self.point_deleted.len() as PointOffsetType)
+            .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
+            .filter(|point_id| self.check_vector(*point_id))
+            .map(|point_id| {
+                let point_id = point_id as PointOffsetType;
+                let vector: &SparseVector =
+                    self.vector_storage.get_vector(point_id).try_into().unwrap();
+                ScoredPointOffset {
+                    idx: point_id,
+                    score: vector.score(&self.query),
+                }
+            });
+        peek_top_largest_iterable(scores, top)
+    }
+}

--- a/lib/segment/src/vector_storage/sparse_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/sparse_raw_scorer.rs
@@ -43,7 +43,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             if !self.check_vector(point_id) {
                 continue;
             }
-            let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
+            let vector = self.vector_storage.get_sparse(point_id);
             scores[size] = ScoredPointOffset {
                 idx: point_id,
                 score: vector.score(&self.query),
@@ -66,7 +66,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
         }
         let mut scores = vec![];
         for point_id in points {
-            let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
+            let vector = self.vector_storage.get_sparse(point_id);
             scores.push(ScoredPointOffset {
                 idx: point_id,
                 score: vector.score(&self.query),
@@ -93,13 +93,13 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
     }
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
-        let vector: &SparseVector = self.vector_storage.get_sparse(point);
+        let vector = self.vector_storage.get_sparse(point);
         vector.score(&self.query)
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
-        let vector_a: &SparseVector = self.vector_storage.get_sparse(point_a);
-        let vector_b: &SparseVector = self.vector_storage.get_sparse(point_b);
+        let vector_a = self.vector_storage.get_sparse(point_a);
+        let vector_b = self.vector_storage.get_sparse(point_b);
         vector_a.score(vector_b)
     }
 
@@ -112,7 +112,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
             .filter(|point_id| self.check_vector(*point_id))
             .map(|point_id| {
-                let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
+                let vector = self.vector_storage.get_sparse(point_id);
                 ScoredPointOffset {
                     idx: point_id,
                     score: vector.score(&self.query),
@@ -127,7 +127,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             .filter(|point_id| self.check_vector(*point_id))
             .map(|point_id| {
                 let point_id = point_id as PointOffsetType;
-                let vector: &SparseVector = self.vector_storage.get_sparse(point_id);
+                let vector = self.vector_storage.get_sparse(point_id);
                 ScoredPointOffset {
                     idx: point_id,
                     score: vector.score(&self.query),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::BitSlice;
 use common::types::PointOffsetType;
+use sparse::common::sparse_vector::SparseVector;
 
 use super::memmap_vector_storage::MemmapVectorStorage;
 use super::simple_vector_storage::SimpleVectorStorage;
@@ -90,6 +91,10 @@ pub trait VectorStorage {
 
 pub trait DenseVectorStorage: VectorStorage {
     fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType];
+}
+
+pub trait SparseVectorStorage: VectorStorage {
+    fn get_sparse(&self, key: PointOffsetType) -> &SparseVector;
 }
 
 pub enum VectorStorageEnum {

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -12,6 +12,25 @@ impl SparseVector {
     pub fn new(indices: Vec<DimId>, values: Vec<DimWeight>) -> SparseVector {
         SparseVector { indices, values }
     }
+
+    /// Score this vector against another vector using dot product.
+    pub fn score(&self, other: &SparseVector) -> f32 {
+        let mut score = 0.0;
+        let mut i = 0;
+        let mut j = 0;
+        while i < self.indices.len() && j < other.indices.len() {
+            match self.indices[i].cmp(&other.indices[j]) {
+                std::cmp::Ordering::Less => i += 1,
+                std::cmp::Ordering::Greater => j += 1,
+                std::cmp::Ordering::Equal => {
+                    score += self.values[i] * other.values[j];
+                    i += 1;
+                    j += 1;
+                }
+            }
+        }
+        score
+    }
 }
 impl From<Vec<(i32, f64)>> for SparseVector {
     fn from(v: Vec<(i32, f64)>) -> Self {


### PR DESCRIPTION
This PR introduces a `RawScorer` for sparse vector so that we can fallback to payload index scan in case of low filter cardinality estimation.