### PR TITLE
doc: update `RawScorer` composition diagram

### DIFF
--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -18,17 +18,26 @@ use crate::types::Distance;
 use crate::vector_storage::query_scorer::metric_query_scorer::MetricQueryScorer;
 use crate::vector_storage::query_scorer::QueryScorer;
 
-/// RawScorer            QueryScorer        Metric
-/// ┌────────────────┐   ┌──────────────┐   ┌───────────────────┐
-/// │                │   │              │   │  - Cosine         │
-/// │       ┌─────┐  │   │     ┌─────┐  │   │  - Dot            │
-/// │       │     │◄─┼───┤     │     │◄─┼───┤  - Euclidean      │
-/// │       └─────┘  │   │     └─────┘  │   │                   │
-/// │                │   │              │   │                   │
-/// └────────────────┘   └──────────────┘   └───────────────────┘
-/// - Deletions          - Scoring logic    - Vector Distance
-/// - Stopping           - Query holding
-/// - Access patterns    - Complex Queries
+/// RawScorer composition:
+///                                              Metric
+///                                             ┌───────────────────┐
+///                                             │  - Cosine         │
+///   RawScorer            QueryScorer          │  - Dot            │
+///  ┌────────────────┐   ┌──────────────┐  ┌───┤  - Euclidean      │
+///  │                │   │              │  │   │                   │
+///  │       ┌─────┐  │   │    ┌─────┐   │  │   └───────────────────┘
+///  │       │     │◄─┼───┤    │     │◄──┼──┘   - Vector Distance
+///  │       └─────┘  │   │    └─────┘   │
+///  │                │   │              │
+///  └────────────────┘   │    ┌─────┐   │        Query
+///  - Deletions          │    │     │◄──┼───┐   ┌───────────────────┐
+///  - Stopping           │    └─────┘   │   │   │  - RecoQuery      │
+///  - Access patterns    │              │   │   │  - DiscoveryQuery │
+///                       └──────────────┘   └───┤  - ContextQuery   │
+///                       - Query holding        │                   │
+///                       - Vector storage       └───────────────────┘
+///                                              - Scoring logic
+///                                              - Complex queries
 ///
 /// Optimized scorer for multiple scoring requests comparing with a single query
 /// Holds current query and params, receives only subset of points to score


### PR DESCRIPTION
Only a documentation PR, updates the `RawScorer` composition diagram for taking into account the recently added `Query` trait