### PR TITLE
Support cancellation in queue proxy to forward proxy method

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -133,7 +133,7 @@ impl QueueProxyShard {
     ///
     /// # Cancel safety
     ///
-    /// This method is *not* cancel safe.
+    /// This method is *not* cancel safe, it consumes `self`.
     ///
     /// If `cancel` is triggered - finalization may not actually complete in which case an error is
     /// returned. None, some or all operations may be transmitted to the remote.

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -74,6 +74,15 @@ impl QueueProxyShard {
     }
 
     /// Transfer all updates that the remote missed from WAL
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    ///
+    /// If cancelled - none, some or all operations of that batch may be transmitted to the remote.
+    ///
+    /// The maximum acknowledged WAL version likely won't be updated. In the worst case this might
+    /// cause double sending operations. This should be fine as operations are idempotent.
     pub async fn transfer_all_missed_updates(&self) -> CollectionResult<()> {
         self.inner
             .as_ref()
@@ -121,6 +130,10 @@ impl QueueProxyShard {
     ///
     /// Because we have ownership (`self`) we have exclusive access to the internals. It guarantees
     /// that we will not process new operations on the shard while finalization is happening.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is *not* cancel safe.
     pub async fn finalize(self) -> Result<(LocalShard, RemoteShard), (CollectionError, Self)> {
         // Transfer all updates, do not unwrap on failure but return error with self
         match self.transfer_all_missed_updates().await {
@@ -302,6 +315,15 @@ impl Inner {
     }
 
     /// Transfer all updates that the remote missed from WAL
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    ///
+    /// If cancelled - none, some or all operations of that batch may be transmitted to the remote.
+    ///
+    /// The maximum acknowledged WAL version likely won't be updated. In the worst case this might
+    /// cause double sending operations. This should be fine as operations are idempotent.
     pub async fn transfer_all_missed_updates(&self) -> CollectionResult<()> {
         while !self.transfer_wal_batch().await? {}
 
@@ -316,6 +338,16 @@ impl Inner {
     ///
     /// Returns `true` if this was the last batch and we're now done. `false` if more batches must
     /// be sent.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    ///
+    /// If cancelled - none, some or all operations of that batch may be transmitted to the remote.
+    ///
+    /// The internal field keeping track of the last transfer likely won't be updated. In the worst
+    /// case this might cause double sending operations. This should be fine as operations are
+    /// idempotent.
     async fn transfer_wal_batch(&self) -> CollectionResult<bool> {
         let mut update_lock = Some(self.update_lock.lock().await);
         let start_index = self.last_update_idx.load(Ordering::Relaxed) + 1;
@@ -346,7 +378,7 @@ impl Inner {
         let last_idx = batch.last().map(|(idx, _)| *idx);
         for attempts in (0..BATCH_RETRIES).rev() {
             match transfer_operations_batch(&batch, &self.remote_shard).await {
-                Ok(()) => break,
+                Ok(()) => {}
                 Err(err) if attempts > 0 => {
                     log::error!(
                         "Failed to transfer batch of updates to peer {}, retrying: {err}",
@@ -356,9 +388,10 @@ impl Inner {
                 }
                 Err(err) => return Err(err),
             }
-        }
-        if let Some(idx) = last_idx {
-            self.last_update_idx.store(idx, Ordering::Relaxed);
+
+            if let Some(idx) = last_idx {
+                self.last_update_idx.store(idx, Ordering::Relaxed);
+            }
         }
 
         Ok(last_batch)
@@ -471,6 +504,12 @@ impl ShardOperation for Inner {
 }
 
 /// Transfer batch of operations without retries
+///
+/// # Cancel safety
+///
+/// This method is cancel safe.
+///
+/// If cancelled - none, some or all operations of the batch may be transmitted to the remote.
 async fn transfer_operations_batch(
     batch: &[(u64, CollectionUpdateOperations)],
     remote_shard: &RemoteShard,

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -203,7 +203,9 @@ impl ShardReplicaSet {
     ///
     /// # Cancel safety
     ///
-    /// This method is *not* cancel safe.
+    /// This method is cancel safe.
+    ///
+    /// If `cancel` is triggered - the queue proxy may not be reverted to a local proxy.
     pub async fn revert_queue_proxy_local(&self) {
         let mut local_write = self.local.write().await;
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -267,6 +267,10 @@ impl ShardReplicaSet {
     /// # Errors
     ///
     /// Returns an error if transferring all updates to the remote failed.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is *not* cancel safe.
     pub async fn queue_proxy_into_forward_proxy(&self) -> CollectionResult<()> {
         // First pass: transfer all missed updates with shared read lock
         {

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -200,6 +200,10 @@ impl ShardReplicaSet {
     /// This intentionally forgets and drops updates pending to be transferred to the remote shard.
     /// The remote shard may therefore therefore be left in an inconsistent state, which should be
     /// resolved separately.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is *not* cancel safe.
     pub async fn revert_queue_proxy_local(&self) {
         let mut local_write = self.local.write().await;
 

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -246,6 +246,14 @@ async fn transfer_stream_records(
 /// - The local shard is un-proxified
 /// - The shard transfer is finished
 /// - The remote shard state is set to `Active` through consensus
+///
+/// # Cancel safety
+///
+/// This method is *not* cancel safe.
+///
+/// If `cancel` is triggered - the remote shard may only be partially recovered/transferred and the
+/// local shard may be left in an unexpected state. This must be resolved manually in case of
+/// cancellation.
 #[allow(clippy::too_many_arguments)]
 async fn transfer_snapshot(
     transfer_config: ShardTransfer,

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -349,7 +349,9 @@ async fn transfer_snapshot(
 
     // Transfer queued updates to remote, transform into forward proxy
     log::trace!("Transfer all queue proxy updates and transform into forward proxy");
-    replica_set.queue_proxy_into_forward_proxy().await?;
+    replica_set
+        .queue_proxy_into_forward_proxy(cancel.clone())
+        .await?;
 
     error_if_cancelled(&cancel)?;
 

--- a/lib/common/cancel/src/blocking.rs
+++ b/lib/common/cancel/src/blocking.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// # Cancel safety
+///
+/// This function is cancel safe.
+///
+/// If cancelled, the provided closure will still run to completion. It may return early by using
+/// the `CancellationToken`.
 pub async fn spawn_cancel_on_drop<Out, Task>(task: Task) -> Result<Out, Error>
 where
     Task: FnOnce(CancellationToken) -> Out + Send + 'static,
@@ -19,6 +25,12 @@ where
     Ok(output)
 }
 
+/// # Cancel safety
+///
+/// This function is cancel safe.
+///
+/// If cancelled, the provided closure will still run to completion. It may return early by using
+/// the `CancellationToken`.
 pub async fn spawn_cancel_on_token<Out, Task>(
     cancel: CancellationToken,
     task: Task,

--- a/lib/common/cancel/src/future.rs
+++ b/lib/common/cancel/src/future.rs
@@ -2,6 +2,12 @@ use std::future::Future;
 
 use super::*;
 
+/// # Cancel safety
+///
+/// This function is cancel safe.
+///
+/// If cancelled, the provided future will still run to completion. It may return early by using
+/// the `CancellationToken`.
 pub async fn spawn_cancel_on_drop<Task, Fut>(task: Task) -> Result<Fut::Output, Error>
 where
     Task: FnOnce(CancellationToken) -> Fut,
@@ -21,7 +27,9 @@ where
 
 /// # Cancel safety
 ///
-/// Future must be cancel safe.
+/// This function is cancel safe.
+///
+/// The provided future must be cancel safe.
 pub async fn cancel_on_token<Fut>(
     cancel: CancellationToken,
     future: Fut,


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

Depends on <https://github.com/qdrant/qdrant/pull/2907>.

In the shard snapshot transfer logic we use `queue_proxy_into_forward_proxy()` method to safely transform one shard type into the other. This method could have a long runtime, for example, when a lot of updates have to be transferred to a remote.

This PR adds support for cancelling this process early through a `CancellationToken`. Not removing the queue proxy here on cancellation is fine because our shard transfer retry logic does this for us on (cancellation) failure.

This also defines cancellation safety in some function comments.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?