### PR TITLE
Add `error_if_cancelled` to `CancellationToken` for easy early returns

### DIFF
--- a/lib/common/cancel/src/lib.rs
+++ b/lib/common/cancel/src/lib.rs
@@ -11,3 +11,19 @@ pub enum Error {
     #[error("task was cancelled")]
     Cancelled,
 }
+
+pub trait CancelError {
+    /// Return an error if cancelled.
+    #[must_use = "a returned error must be propagated down function calls"]
+    fn error_if_cancelled(&self) -> Result<(), Error>;
+}
+
+impl CancelError for CancellationToken {
+    fn error_if_cancelled(&self) -> Result<(), Error> {
+        if self.is_cancelled() {
+            Err(Error::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Merges into <https://github.com/qdrant/qdrant/pull/2918>.

This adds `error_if_cancelled()` to the `CancellationToken` to easily return early with a cancellation error if triggered.

```rust
let cancel = CancellationToken::new();

cancel.error_if_cancelled()?;
```

@ffuugoo What do you think? Maybe you have a better idea of doing this, or maybe it conflicts with your current work on this branch.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?