### PR TITLE
Precreate and chown `snapshots` and `storage` dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,7 @@ ARG USER_ID=0
 RUN if [ "$USER_ID" != 0 ]; then \
         groupadd --gid "$USER_ID" qdrant; \
         useradd --uid "$USER_ID" --gid "$USER_ID" -m qdrant; \
+        mkdir -p snapshots storage; \
         chown -R "$USER_ID:$USER_ID" "$APP"; \
     fi
 


### PR DESCRIPTION
... in unprivileged mode to avoid Docker named volumes being owned by the root user.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Currently, with this `docker-compose.yaml` file:
``` yaml
---
version: "3.8"

name: test

services:
  qdrant:
    image: qdrant/qdrant:v1.6.1-unprivileged
    volumes:
      - qdrant:/qdrant/storage/

volumes:
  qdrant:
```
`docker compose up` fails:
```
...
test-qdrant-1  | 2023-11-02T20:24:57.189168Z  INFO storage::content_manager::consensus::persistent: Initializing new raft state at ./storage/raft_state.json
test-qdrant-1  | Error: Service internal error: Failed to write file: Permission denied (os error 13) at path "/qdrant/./storage/.atomicwriteZEuaWn"
test-qdrant-1 exited with code 1
```
If we change the container command to `ls -al` we see that the target of the Docker named volume is owned by the root user:
```
Attaching to test-qdrant-1
test-qdrant-1  | total 57248
test-qdrant-1  | drwxr-xr-x 1 qdrant qdrant     4096 Nov  2 20:26 .
test-qdrant-1  | drwxr-xr-x 1 root   root       4096 Nov  2 20:26 ..
test-qdrant-1  | drwxr-xr-x 1 qdrant qdrant     4096 Oct  9 09:45 config
test-qdrant-1  | -rwxrwxr-x 1 qdrant qdrant     1840 Sep  6 22:21 entrypoint.sh
test-qdrant-1  | -rwxr-xr-x 1 qdrant qdrant 58590208 Oct 11 15:39 qdrant
test-qdrant-1  | drwxr-xr-x 1 qdrant qdrant     4096 Oct 11 15:39 static
test-qdrant-1  | drwxr-xr-x 2 root   root       4096 Nov  2 20:24 storage
test-qdrant-1 exited with code 0
```
A similar error is received when the volume targets `snapshots` directory instead.
 
After some research, it seems the only way to fix this is to run `chown` inside the container. It works even if we run `chown` before the volume is mounted. Currently `chown` is already run in here:
https://github.com/qdrant/qdrant/blob/50f3ef175772ce4aba77fd259a2d850183cfdcf5/Dockerfile#L127
But since `snapshots` and `storage` directories don't exist at that point, they are not currently affected by it. The solution is to precreate those directories before that line, and this PR does that.