### PR TITLE
Make shard snapshot transfer recovery cancellable

### DIFF
--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -444,6 +444,10 @@ impl RemoteShard {
     /// # Warning
     ///
     /// This method specifies a timeout of 24 hours.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Recovery may be aborted on the remote.
     pub async fn recover_shard_snapshot_from_url(
         &self,
         collection_name: &str,


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

This allows cancelling the 'transfer and recover on remote' step of shard snapshot transfer.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?