### PR TITLE
Improve abort/cancellation support for shard transfer

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -231,6 +231,8 @@ impl Collection {
         transfer_key: ShardTransferKey,
         shard_holder_guard: &ShardHolder,
     ) -> CollectionResult<()> {
+        // TODO: Ensure cancel safety!
+
         let _transfer_finished = self
             .transfer_tasks
             .lock()
@@ -272,6 +274,8 @@ impl Collection {
         &self,
         shard_id: ShardId,
     ) -> impl Future<Output = CollectionResult<()>> + 'static {
+        // TODO: Ensure cancel safety!
+
         let shards_holder = self.shards_holder.clone();
 
         async move {

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -49,6 +49,10 @@ impl ChannelService {
     /// - any of the peers is not on the same term
     /// - waiting takes longer than the specified timeout
     /// - any of the peers cannot be reached
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn await_commit_on_all_peers(
         &self,
         this_peer_id: PeerId,
@@ -89,6 +93,10 @@ impl ChannelService {
     /// # Errors
     ///
     /// This errors if the given peer is on a different term. Also errors if the peer cannot be reached.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     async fn await_commit_on_peer(
         &self,
         peer_id: PeerId,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -444,6 +444,10 @@ impl RemoteShard {
     /// # Warning
     ///
     /// This method specifies a timeout of 24 hours.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn recover_shard_snapshot_from_url(
         &self,
         collection_name: &str,

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -1,5 +1,5 @@
-use cancel::future::cancel_on_token;
-use cancel::CancellationToken;
+use std::ops::Deref as _;
+
 use segment::types::PointIdType;
 
 use super::ShardReplicaSet;
@@ -10,18 +10,23 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::Shard;
 
 impl ShardReplicaSet {
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn proxify_local(&self, remote_shard: RemoteShard) -> CollectionResult<()> {
-        let mut local_write = self.local.write().await;
+        let mut local = self.local.write().await;
 
-        match &*local_write {
+        match local.deref() {
             // Expected state, continue
             Some(Shard::Local(_)) => {}
+
             // If a forward proxy to same remote, return early
             Some(Shard::ForwardProxy(proxy))
                 if proxy.remote_shard.peer_id == remote_shard.peer_id =>
             {
                 return Ok(())
             }
+
             // Unexpected states, error
             Some(Shard::ForwardProxy(proxy)) => {
                 return Err(CollectionError::service_error(format!(
@@ -56,23 +61,33 @@ impl ShardReplicaSet {
             }
         };
 
-        if let Some(Shard::Local(local)) = local_write.take() {
-            let proxy_shard = ForwardProxyShard::new(local, remote_shard);
-            let _ = local_write.insert(Shard::ForwardProxy(proxy_shard));
-        }
+        // Explicit `match` instead of `if-let` to catch `unreachable` condition if top `match` is
+        // changed
+        let local_shard = match local.take() {
+            Some(Shard::Local(local_shard)) => local_shard,
+            _ => unreachable!(),
+        };
+
+        let proxy_shard = ForwardProxyShard::new(local_shard, remote_shard);
+        let _ = local.insert(Shard::ForwardProxy(proxy_shard));
 
         Ok(())
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn queue_proxify_local(&self, remote_shard: RemoteShard) -> CollectionResult<()> {
-        let mut local_write = self.local.write().await;
+        let mut local = self.local.write().await;
 
-        match &*local_write {
+        match local.deref() {
             // Expected state, continue
             Some(Shard::Local(_)) => {}
+
             // If a forward proxy to same remote, continue and change into queue proxy
             Some(Shard::ForwardProxy(proxy))
                 if proxy.remote_shard.peer_id == remote_shard.peer_id => {}
+
             // Unexpected states, error
             Some(Shard::QueueProxy(_)) => {
                 return Err(CollectionError::service_error(format!(
@@ -107,17 +122,31 @@ impl ShardReplicaSet {
             }
         };
 
-        match local_write.take() {
-            Some(Shard::Local(local)) => {
-                let proxy_shard = QueueProxyShard::new(local, remote_shard).await;
-                let _ = local_write.insert(Shard::QueueProxy(proxy_shard));
-            }
-            Some(Shard::ForwardProxy(proxy)) => {
-                let proxy_shard = QueueProxyShard::new(proxy.wrapped_shard, remote_shard).await;
-                let _ = local_write.insert(Shard::QueueProxy(proxy_shard));
-            }
+        // Get `max_ack_version` without "taking" local shard (to maintain cancel safety)
+        let local_shard = match local.deref() {
+            Some(Shard::Local(local)) => local,
+            Some(Shard::ForwardProxy(proxy)) => &proxy.wrapped_shard,
             _ => unreachable!(),
-        }
+        };
+
+        let max_ack_version = local_shard
+            .update_handler
+            .lock()
+            .await
+            .max_ack_version
+            .clone();
+
+        // Proxify local shard
+        //
+        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
+        let local_shard = match local.take() {
+            Some(Shard::Local(local)) => local,
+            Some(Shard::ForwardProxy(proxy)) => proxy.wrapped_shard,
+            _ => unreachable!(),
+        };
+
+        let proxy_shard = QueueProxyShard::new(local_shard, remote_shard, max_ack_version);
+        let _ = local.insert(Shard::QueueProxy(proxy_shard));
 
         Ok(())
     }
@@ -126,14 +155,15 @@ impl ShardReplicaSet {
     ///
     /// # Cancel safety
     ///
-    /// This method is *not* cancel safe.
+    /// This method is cancel safe.
     pub async fn un_proxify_local(&self) -> CollectionResult<()> {
-        let mut local_write = self.local.write().await;
+        let mut local = self.local.write().await;
 
-        match &*local_write {
+        match local.deref() {
             // Expected states, continue
-            Some(Shard::ForwardProxy(_) | Shard::QueueProxy(_)) => {}
             Some(Shard::Local(_)) => return Ok(()),
+            Some(Shard::ForwardProxy(_) | Shard::QueueProxy(_)) => {}
+
             // Unexpected states, error
             Some(shard @ (Shard::Proxy(_) | Shard::Dummy(_))) => {
                 return Err(CollectionError::service_error(format!(
@@ -142,6 +172,7 @@ impl ShardReplicaSet {
                     shard.variant_name(),
                 )));
             }
+
             None => {
                 return Err(CollectionError::service_error(format!(
                     "Cannot un-proxify local shard {} on peer {} because it is not active",
@@ -151,39 +182,56 @@ impl ShardReplicaSet {
             }
         };
 
-        // Unproxify local shard of above types
-        match local_write.take() {
-            Some(Shard::ForwardProxy(proxy)) => {
-                let local_shard = proxy.wrapped_shard;
-                let _ = local_write.insert(Shard::Local(local_shard));
-                Ok(())
-            }
+        // Perform async finalization without "taking" local shard (to maintain cancel safety)
+        //
+        // Explicit `match` instead of `if-let` on `Shard::QueueProxy` to catch `unreachable`
+        // condition if top `match` is changed
+        let result = match local.deref() {
+            Some(Shard::ForwardProxy(_)) => Ok(()),
+
             Some(Shard::QueueProxy(proxy)) => {
                 // We should not unproxify a queue proxy shard directly because it can fail if it
                 // fails to send all updates to the remote shard.
                 // Instead we should transform it into a forward proxy shard before unproxify is
                 // called to handle errors at an earlier time.
                 // See `Self::queue_proxy_into_forward_proxy()` for more details.
+
                 log::warn!(
                     "Directly unproxifying queue proxy shard, this should not happen normally"
                 );
 
-                // Finalize, insert local shard back and return finalize result
-                let result = proxy.finalize(CancellationToken::new()).await;
-                let (result, local_shard) = match result {
-                    Ok((local_shard, _)) => (Ok(()), local_shard),
-                    Err((err, queue_proxy)) => {
-                        log::error!("Failed to un-proxify local shard because transferring remaining queue items to remote failed: {err}");
-                        let (wrapped_shard, _remote_shard) =
-                            queue_proxy.forget_updates_and_finalize();
-                        (Err(err), wrapped_shard)
-                    }
-                };
-                let _ = local_write.insert(Shard::Local(local_shard));
+                let result = proxy.transfer_all_missed_updates().await;
+
+                if let Err(err) = &result {
+                    log::error!(
+                        "Failed to un-proxify local shard because transferring remaining queue \
+                         items to remote failed: {err}"
+                    );
+                }
+
                 result
             }
+
             _ => unreachable!(),
-        }
+        };
+
+        // Un-proxify local shard
+        //
+        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
+        let local_shard = match local.take() {
+            Some(Shard::ForwardProxy(proxy)) => proxy.wrapped_shard,
+
+            Some(Shard::QueueProxy(proxy)) => {
+                let (local_shard, _) = proxy.forget_updates_and_finalize();
+                local_shard
+            }
+
+            _ => unreachable!(),
+        };
+
+        let _ = local.insert(Shard::Local(local_shard));
+
+        result
     }
 
     /// Revert usage of a `QueueProxy` shard and forget all updates, then un-proxify to local
@@ -205,57 +253,72 @@ impl ShardReplicaSet {
     ///
     /// This method is cancel safe.
     ///
-    /// If `cancel` is triggered - the queue proxy may not be reverted to a local proxy.
+    /// If cancelled - the queue proxy may not be reverted to a local proxy.
     pub async fn revert_queue_proxy_local(&self) {
-        let mut local_write = self.local.write().await;
+        let mut local = self.local.write().await;
 
         // Take out queue proxy shard or return
-        if !matches!(*local_write, Some(Shard::QueueProxy(_))) {
+        if !matches!(local.deref(), Some(Shard::QueueProxy(_))) {
             return;
-        };
-        let Some(Shard::QueueProxy(queue_proxy)) = local_write.take() else {
-            unreachable!();
         };
 
         log::debug!("Forgetting queue proxy updates and reverting to local shard");
+
+        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
+        let Some(Shard::QueueProxy(queue_proxy)) = local.take() else {
+            unreachable!();
+        };
+
         let (local_shard, _) = queue_proxy.forget_updates_and_finalize();
-        let _ = local_write.insert(Shard::Local(local_shard));
+        let _ = local.insert(Shard::Local(local_shard));
     }
 
     /// Custom operation for transferring data from one shard to another during transfer
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn transfer_batch(
         &self,
         offset: Option<PointIdType>,
         batch_size: usize,
     ) -> CollectionResult<Option<PointIdType>> {
-        let read_local = self.local.read().await;
-        if let Some(Shard::ForwardProxy(proxy)) = &*read_local {
-            proxy
-                .transfer_batch(offset, batch_size, &self.search_runtime)
-                .await
-        } else {
-            Err(CollectionError::service_error(format!(
+        let local = self.local.read().await;
+
+        let Some(Shard::ForwardProxy(proxy)) = local.deref() else {
+            return Err(CollectionError::service_error(format!(
                 "Cannot transfer batch from shard {} because it is not proxified",
                 self.shard_id
-            )))
-        }
+            )));
+        };
+
+        proxy
+            .transfer_batch(offset, batch_size, &self.search_runtime)
+            .await
     }
 
     /// Custom operation for transferring indexes from one shard to another during transfer
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn transfer_indexes(&self) -> CollectionResult<()> {
-        let read_local = self.local.read().await;
-        if let Some(Shard::ForwardProxy(proxy)) = &*read_local {
-            log::trace!(
-                "Transferring indexes to shard {}",
-                proxy.remote_shard.peer_id,
-            );
-            proxy.transfer_indexes().await
-        } else {
-            Err(CollectionError::service_error(format!(
+        let local = self.local.read().await;
+
+        let Some(Shard::ForwardProxy(proxy)) = local.deref() else {
+            return Err(CollectionError::service_error(format!(
                 "Cannot transfer indexes from shard {} because it is not proxified",
                 self.shard_id,
-            )))
-        }
+            )));
+        };
+
+        log::trace!(
+            "Transferring indexes to shard {}",
+            proxy.remote_shard.peer_id,
+        );
+
+        // TODO: Is cancelling `ForwardProxyShard::transfer_indexes` safe for *receiver*?
+        proxy.transfer_indexes().await
     }
 
     /// Send all queue proxy updates to remote and transform into forward proxy
@@ -282,49 +345,43 @@ impl ShardReplicaSet {
     ///
     /// # Cancel safety
     ///
-    /// This method is *not* cancel safe.
+    /// This function is cancel safe.
     ///
-    /// If `cancel` is triggered - transforming the queue proxy into a forward proxy may not
-    /// actually complete in which case an error is returned. None, some or all queued operations
-    /// may be transmitted to the remote.
-    pub async fn queue_proxy_into_forward_proxy(
-        &self,
-        cancel: CancellationToken,
-    ) -> CollectionResult<()> {
-        // First pass: transfer all missed updates with shared read lock, cancellable
+    /// If cancelled - transforming the queue proxy into a forward proxy may not actually complete.
+    /// None, some or all queued operations may be transmitted to the remote.
+    pub async fn queue_proxy_into_forward_proxy(&self) -> CollectionResult<()> {
+        // First pass: transfer all missed updates with shared read lock
         {
-            let local_read = self.local.read().await;
-            let Some(Shard::QueueProxy(proxy)) = &*local_read else {
+            let local = self.local.read().await;
+
+            let Some(Shard::QueueProxy(proxy)) = local.deref() else {
                 return Ok(());
             };
-            cancel_on_token(cancel.clone(), proxy.transfer_all_missed_updates()).await??;
+
+            proxy.transfer_all_missed_updates().await?;
         }
 
-        // Second pass: transfer new updates, safely finalize and transform, not cancellable
-        let mut local_write = self.local.write().await;
-        if !matches!(*local_write, Some(Shard::QueueProxy(_))) {
+        // Second pass: transfer new updates
+        let mut local = self.local.write().await;
+
+        let Some(Shard::QueueProxy(proxy)) = local.deref() else {
             return Ok(());
-        }
-        let Some(Shard::QueueProxy(queue_proxy)) = local_write.take() else {
+        };
+
+        proxy.transfer_all_missed_updates().await?;
+
+        // Transform `QueueProxyShard` into `ForwardProxyShard`
+        log::trace!("Transferred all queue proxy operations, transforming into forward proxy now");
+
+        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
+        let Some(Shard::QueueProxy(queue_proxy)) = local.take() else {
             unreachable!();
         };
-        match queue_proxy.finalize(cancel).await {
-            // When finalization is successful, transform into forward proxy
-            Ok((local_shard, remote_shard)) => {
-                log::trace!(
-                    "Transferred all queue proxy operations, transforming into forward proxy now"
-                );
-                let forward_proxy = ForwardProxyShard::new(local_shard, remote_shard);
-                let _ = local_write.insert(Shard::ForwardProxy(forward_proxy));
-                Ok(())
-            }
-            // When finalization fails, put the queue proxy back
-            Err((err, queue_proxy)) => {
-                let _ = local_write.insert(Shard::QueueProxy(queue_proxy));
-                Err(CollectionError::service_error(format!(
-                    "Failed to finalize queue proxy and transform into forward proxy: {err}"
-                )))
-            }
-        }
+
+        let (local_shard, remote_shard) = queue_proxy.forget_updates_and_finalize();
+        let forward_proxy = ForwardProxyShard::new(local_shard, remote_shard);
+        let _ = local.insert(Shard::ForwardProxy(forward_proxy));
+
+        Ok(())
     }
 }

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -317,7 +317,6 @@ impl ShardReplicaSet {
             proxy.remote_shard.peer_id,
         );
 
-        // TODO: Is cancelling `ForwardProxyShard::transfer_indexes` safe for *receiver*?
         proxy.transfer_indexes().await
     }
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -194,6 +194,8 @@ impl ShardReplicaSet {
                 // fails to send all updates to the remote shard.
                 // Instead we should transform it into a forward proxy shard before unproxify is
                 // called to handle errors at an earlier time.
+                // Also, we're holding a write lock here which could block other accessors for a
+                // long time if transferring updates takes a long time.
                 // See `Self::queue_proxy_into_forward_proxy()` for more details.
 
                 log::warn!(

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -771,6 +771,9 @@ impl ShardHolder {
             .await
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
     pub async fn get_shard_snapshot_path(
         &self,
         snapshots_path: &Path,

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -806,7 +806,7 @@ where
             }
 
             // If `transfer_shard` returned success or task was cancelled...
-            if !matches!(result, Ok(Err(_))) {
+            if matches!(result, Ok(Ok(())) | Err(_)) {
                 break;
             }
         }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -495,6 +495,8 @@ pub async fn handle_transferred_shard_proxy(
     to: PeerId,
     sync: bool,
 ) -> CollectionResult<bool> {
+    // TODO: Ensure cancel safety!
+
     let replica_set = match shard_holder.get_shard(&shard_id) {
         None => return Ok(false),
         Some(replica_set) => replica_set,

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -10,7 +10,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tempfile::TempPath;
 use tokio::time::sleep;
-use tokio_util::sync::CancellationToken;
 
 use super::ShardTransferConsensus;
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
@@ -77,7 +76,7 @@ pub enum ShardTransferMethod {
 
 /// # Cancel safety
 ///
-/// This function is *not* cancel safe.
+/// This function is cancel safe.
 #[allow(clippy::too_many_arguments)]
 pub async fn transfer_shard(
     transfer_config: ShardTransfer,
@@ -88,7 +87,6 @@ pub async fn transfer_shard(
     channel_service: ChannelService,
     snapshots_path: &Path,
     temp_dir: &Path,
-    cancel: CancellationToken,
 ) -> CollectionResult<()> {
     let shard_id = transfer_config.shard_id;
 
@@ -106,8 +104,9 @@ pub async fn transfer_shard(
     match transfer_config.method.unwrap_or_default() {
         // Transfer shard record in batches
         ShardTransferMethod::StreamRecords => {
-            transfer_stream_records(shard_holder.clone(), shard_id, remote_shard, cancel).await
+            transfer_stream_records(shard_holder.clone(), shard_id, remote_shard).await?;
         }
+
         // Transfer shard as snapshot
         ShardTransferMethod::Snapshot => {
             transfer_snapshot(
@@ -120,11 +119,12 @@ pub async fn transfer_shard(
                 snapshots_path,
                 collection_name,
                 temp_dir,
-                cancel,
             )
-            .await
+            .await?;
         }
     }
+
+    Ok(())
 }
 
 /// Orchestrate shard transfer by streaming records
@@ -134,20 +134,24 @@ pub async fn transfer_shard(
 ///
 /// This first transfers configured indices. Then it transfers all point records in batches.
 /// Updates to the local shard are forwarded to the remote concurrently.
+///
+/// # Cancel safety
+///
+/// This function is cancel safe.
 async fn transfer_stream_records(
     shard_holder: Arc<LockedShardHolder>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
-    cancel: CancellationToken,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
+
     log::debug!("Starting shard {shard_id} transfer to peer {remote_peer_id} by streaming records");
 
     // Proxify local shard and create payload indexes on remote shard
     {
-        let shard_holder_guard = shard_holder.read().await;
-        let transferring_shard_opt = shard_holder_guard.get_shard(&shard_id);
-        let Some(replica_set) = transferring_shard_opt else {
+        let shard_holder = shard_holder.read().await;
+
+        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
             return Err(CollectionError::service_error(format!(
                 "Shard {shard_id} cannot be proxied because it does not exist"
             )));
@@ -155,35 +159,33 @@ async fn transfer_stream_records(
 
         replica_set.proxify_local(remote_shard).await?;
 
+        // TODO: Is cancelling `ShardReplicaSet::transfer_indexes` safe for *receiver*?
         replica_set.transfer_indexes().await?;
     }
 
     // Transfer contents batch by batch
     log::trace!("Transferring points to shard {shard_id} by streaming records");
-    let mut offset = None;
-    loop {
-        if cancel.is_cancelled() {
-            return Err(CollectionError::Cancelled {
-                description: "Transfer cancelled".to_string(),
-            });
-        }
-        let shard_holder_guard = shard_holder.read().await;
-        let transferring_shard_opt = shard_holder_guard.get_shard(&shard_id);
 
-        if let Some(replica_set) = transferring_shard_opt {
-            offset = replica_set
-                .transfer_batch(offset, TRANSFER_BATCH_SIZE)
-                .await?;
-            if offset.is_none() {
-                // That was the last batch, all look good
-                break;
-            }
-        } else {
+    let mut offset = None;
+
+    loop {
+        let shard_holder = shard_holder.read().await;
+
+        let Some(replica_set) = shard_holder.get_shard(&shard_id) else {
             // Forward proxy gone?!
             // That would be a programming error.
             return Err(CollectionError::service_error(format!(
                 "Shard {shard_id} is not found"
             )));
+        };
+
+        offset = replica_set
+            .transfer_batch(offset, TRANSFER_BATCH_SIZE)
+            .await?;
+
+        if offset.is_none() {
+            // That was the last batch, all look good
+            break;
         }
     }
 
@@ -249,11 +251,10 @@ async fn transfer_stream_records(
 ///
 /// # Cancel safety
 ///
-/// This method is *not* cancel safe.
+/// This function is cancel safe.
 ///
-/// If `cancel` is triggered - the remote shard may only be partially recovered/transferred and the
-/// local shard may be left in an unexpected state. This must be resolved manually in case of
-/// cancellation.
+/// If cancelled - the remote shard may only be partially recovered/transferred and the local shard
+/// may be left in an unexpected state. This must be resolved manually in case of cancellation.
 #[allow(clippy::too_many_arguments)]
 async fn transfer_snapshot(
     transfer_config: ShardTransfer,
@@ -265,9 +266,9 @@ async fn transfer_snapshot(
     snapshots_path: &Path,
     collection_name: &str,
     temp_dir: &Path,
-    cancel: CancellationToken,
 ) -> CollectionResult<()> {
     let remote_peer_id = remote_shard.peer_id;
+
     log::debug!(
         "Starting shard {shard_id} transfer to peer {remote_peer_id} using snapshot transfer"
     );
@@ -282,18 +283,15 @@ async fn transfer_snapshot(
         )));
     };
 
-    error_if_cancelled(&cancel)?;
-
     // Queue proxy local shard
     replica_set
         .queue_proxify_local(remote_shard.clone())
         .await?;
+
     debug_assert!(
         replica_set.is_queue_proxy().await,
         "Local shard must be a queue proxy"
     );
-
-    error_if_cancelled(&cancel)?;
 
     // Create shard snapshot
     log::trace!("Creating snapshot of shard {shard_id} for shard snapshot transfer");
@@ -301,6 +299,7 @@ async fn transfer_snapshot(
         .create_shard_snapshot(snapshots_path, collection_name, shard_id, temp_dir)
         .await?;
 
+    // TODO: If future is cancelled until `get_shard_snapshot_path` resolves, shard snapshot may not be cleaned up...
     let snapshot_temp_path = shard_holder_read
         .get_shard_snapshot_path(snapshots_path, shard_id, &snapshot_description.name)
         .await
@@ -310,8 +309,6 @@ async fn transfer_snapshot(
                 "Failed to determine snapshot path, cannot continue with shard snapshot recovery: {err}"
             ))
         })?;
-
-    error_if_cancelled(&cancel)?;
 
     // Recover shard snapshot on remote
     let mut shard_download_url = local_rest_address;
@@ -339,8 +336,6 @@ async fn transfer_snapshot(
         log::warn!("Failed to delete shard transfer snapshot after recovery, snapshot file may be left behind: {err}");
     }
 
-    error_if_cancelled(&cancel)?;
-
     // Set shard state to Partial
     log::trace!("Shard {shard_id} snapshot recovered on {remote_peer_id} for snapshot transfer, switching into next stage through consensus");
     consensus
@@ -356,15 +351,9 @@ async fn transfer_snapshot(
             ))
         })?;
 
-    error_if_cancelled(&cancel)?;
-
     // Transfer queued updates to remote, transform into forward proxy
     log::trace!("Transfer all queue proxy updates and transform into forward proxy");
-    replica_set
-        .queue_proxy_into_forward_proxy(cancel.clone())
-        .await?;
-
-    error_if_cancelled(&cancel)?;
+    replica_set.queue_proxy_into_forward_proxy().await?;
 
     // Wait for Partial state in our replica set
     let partial_state = ReplicaState::Partial;
@@ -381,8 +370,6 @@ async fn transfer_snapshot(
                 "Shard being transferred did not reach {partial_state:?} state in time: {err}",
             ))
         })?;
-
-    error_if_cancelled(&cancel)?;
 
     // Synchronize all nodes
     await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
@@ -401,6 +388,10 @@ async fn transfer_snapshot(
 ///
 /// If awaiting on other nodes fails for any reason, this simply continues after the consensus
 /// timeout.
+///
+/// # Cancel safety
+///
+/// This function is cancel safe.
 async fn await_consensus_sync(
     consensus: &dyn ShardTransferConsensus,
     channel_service: &ChannelService,
@@ -428,19 +419,11 @@ async fn await_consensus_sync(
     }
 }
 
-/// Return an error if cancelled.
-#[must_use = "a returned error must be propagated down function calls"]
-fn error_if_cancelled(cancel: &CancellationToken) -> CollectionResult<()> {
-    if cancel.is_cancelled() {
-        Err(CollectionError::Cancelled {
-            description: "Transfer cancelled".to_string(),
-        })
-    } else {
-        Ok(())
-    }
-}
-
 /// Return local shard back from the forward proxy
+///
+/// # Cancel safety
+///
+/// This function is cancel safe.
 pub async fn revert_proxy_shard_to_local(
     shard_holder: &ShardHolder,
     shard_id: ShardId,
@@ -513,6 +496,8 @@ pub async fn handle_transferred_shard_proxy(
     to: PeerId,
     sync: bool,
 ) -> CollectionResult<bool> {
+    // TODO: Ensure cancel safety!
+
     let replica_set = match shard_holder.get_shard(&shard_id) {
         None => return Ok(false),
         Some(replica_set) => replica_set,
@@ -525,6 +510,8 @@ pub async fn handle_transferred_shard_proxy(
         replica_set.un_proxify_local().await?;
     } else {
         // Remove local proxy
+        //
+        // TODO: Ensure cancel safety!
         replica_set.remove_local().await?;
     }
 
@@ -773,67 +760,72 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     spawn_async_cancellable(move |cancel| async move {
-        let mut tries = MAX_RETRY_COUNT;
-        let mut finished = false;
-        while !finished && tries > 0 {
-            let transfer_result = transfer_shard(
-                transfer.clone(),
-                shards_holder.clone(),
-                consensus.as_ref(),
-                collection_id.clone(),
-                &collection_name,
-                channel_service.clone(),
-                &snapshots_path,
-                &temp_dir,
-                cancel.clone(),
-            )
-            .await;
-            finished = match transfer_result {
-                Ok(()) => true,
-                Err(error) => {
-                    // Revert queue proxy if we still have any to clean up or prepare for the next attempt
-                    if let Some(replica_set) =
-                        shards_holder.read().await.get_shard(&transfer.shard_id)
-                    {
-                        replica_set.revert_queue_proxy_local().await;
-                    }
+        let mut result = Err(CollectionError::Cancelled {
+            description:
+                "shard transfer task exit without attempting any work, this is a programming error"
+                    .into(),
+        });
 
-                    if matches!(error, CollectionError::Cancelled { .. }) {
-                        return false;
-                    }
+        for attempt in 0..MAX_RETRY_COUNT {
+            let future = async {
+                if attempt > 0 {
+                    sleep(RETRY_DELAY * attempt as u32).await;
+
+                    log::warn!(
+                        "Retrying shard transfer {} -> {} (retry {attempt})",
+                        transfer.shard_id,
+                        transfer.to,
+                    );
+                }
+
+                transfer_shard(
+                    transfer.clone(),
+                    shards_holder.clone(),
+                    consensus.as_ref(),
+                    collection_id.clone(),
+                    &collection_name,
+                    channel_service.clone(),
+                    &snapshots_path,
+                    &temp_dir,
+                )
+                .await
+            };
+
+            result = cancel::future::cancel_on_token(cancel.clone(), future)
+                .await
+                .map_err(Into::into)
+                .and_then(|res| res);
+
+            match &result {
+                Ok(()) => break,
+
+                // TODO: Should we break early if shard transfer is cancelled, or should we handle it as regular error?
+                Err(CollectionError::Cancelled { .. }) => break,
+
+                Err(err) => {
                     log::error!(
-                        "Failed to transfer shard {} -> {}: {error}",
+                        "Failed to transfer shard {} -> {}: {err}",
                         transfer.shard_id,
                         transfer.to,
                     );
 
-                    false
+                    // Revert queue proxy if we still have any to prepare for the next attempt
+                    if let Some(shard) = shards_holder.read().await.get_shard(&transfer.shard_id) {
+                        shard.revert_queue_proxy_local().await;
+                    }
                 }
-            };
-            if cancel.is_cancelled() {
-                return false;
-            }
-            if !finished {
-                tries -= 1;
-                log::warn!(
-                    "Retrying shard transfer {} -> {} (retry {})",
-                    transfer.shard_id,
-                    transfer.to,
-                    MAX_RETRY_COUNT - tries
-                );
-                let exp_timeout = RETRY_DELAY * (MAX_RETRY_COUNT - tries) as u32;
-                sleep(exp_timeout).await;
             }
         }
 
-        if finished {
-            // On the end of transfer, the new shard is active but most likely is under the optimization
-            // process. Requests to this node might be slow, but we rely on the assumption that
-            // there should be at least one other replica that is not under optimization.
-            on_finish.await;
-        } else {
-            on_error.await;
+        match &result {
+            Ok(()) => on_finish.await,
+
+            // TODO: Should we ignore `on_error` if shard transfer is cancelled, or should we handle it as regular error?
+            Err(CollectionError::Cancelled { .. }) => (),
+
+            Err(_) => on_error.await,
         }
-        finished
+
+        result.is_ok()
     })
 }

--- a/lib/collection/src/shards/transfer/shard_transfer.rs
+++ b/lib/collection/src/shards/transfer/shard_transfer.rs
@@ -159,7 +159,6 @@ async fn transfer_stream_records(
 
         replica_set.proxify_local(remote_shard).await?;
 
-        // TODO: Is cancelling `ShardReplicaSet::transfer_indexes` safe for *receiver*?
         replica_set.transfer_indexes().await?;
     }
 
@@ -496,8 +495,6 @@ pub async fn handle_transferred_shard_proxy(
     to: PeerId,
     sync: bool,
 ) -> CollectionResult<bool> {
-    // TODO: Ensure cancel safety!
-
     let replica_set = match shard_holder.get_shard(&shard_id) {
         None => return Ok(false),
         Some(replica_set) => replica_set,

--- a/lib/common/cancel/src/blocking.rs
+++ b/lib/common/cancel/src/blocking.rs
@@ -4,8 +4,7 @@ use super::*;
 ///
 /// This function is cancel safe.
 ///
-/// If cancelled, the provided closure will still run to completion. It may return early by using
-/// the `CancellationToken`.
+/// If cancelled, the cancellation token provided to the `task` will be triggered automatically.
 pub async fn spawn_cancel_on_drop<Out, Task>(task: Task) -> Result<Out, Error>
 where
     Task: FnOnce(CancellationToken) -> Out + Send + 'static,
@@ -29,8 +28,10 @@ where
 ///
 /// This function is cancel safe.
 ///
-/// If cancelled, the provided closure will still run to completion. It may return early by using
-/// the `CancellationToken`.
+/// If cancelled without triggering the cancellation token, the `task` will still run to completion.
+///
+/// This function *will* return early, and the `task` *may* return early by triggering the
+/// cancellation token.
 pub async fn spawn_cancel_on_token<Out, Task>(
     cancel: CancellationToken,
     task: Task,

--- a/lib/common/cancel/src/future.rs
+++ b/lib/common/cancel/src/future.rs
@@ -6,8 +6,7 @@ use super::*;
 ///
 /// This function is cancel safe.
 ///
-/// If cancelled, the provided future will still run to completion. It may return early by using
-/// the `CancellationToken`.
+/// If cancelled, the cancellation token provided to the `task` will be triggered automatically.
 pub async fn spawn_cancel_on_drop<Task, Fut>(task: Task) -> Result<Fut::Output, Error>
 where
     Task: FnOnce(CancellationToken) -> Fut,

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -344,11 +344,15 @@ impl TableOfContent {
         collection_name: String,
         shard_id: ShardId,
     ) -> Result<(), StorageError> {
+        // TODO: Ensure cancel safety!
+
         log::info!(
             "Initiating receiving shard {}:{}",
             collection_name,
             shard_id
         );
+
+        // TODO: Ensure cancel safety!
         let initiate_shard_transfer_future = self
             .get_collection(&collection_name)
             .await?

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -50,6 +50,8 @@ impl CollectionsInternal for CollectionsInternalService {
         &self,
         request: Request<InitiateShardTransferRequest>,
     ) -> Result<Response<CollectionOperationResponse>, Status> {
+        // TODO: Ensure cancel safety!
+
         validate_and_log(request.get_ref());
         let timing = Instant::now();
         let InitiateShardTransferRequest {
@@ -57,6 +59,7 @@ impl CollectionsInternal for CollectionsInternalService {
             shard_id,
         } = request.into_inner();
 
+        // TODO: Ensure cancel safety!
         self.toc
             .initiate_receiving_shard(collection_name, shard_id)
             .await


### PR DESCRIPTION
Tracked in #2432.

This PR continues the work in #2918 and makes most of the shard transfer methods and functions cancel safe.

There are a bunch of `TODO`s added by this PR, but I think they should be left as-is for now, and can be worked on in the following PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
