### PR TITLE
Int indexing

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -73,9 +73,9 @@ pub trait ValueIndexer<T> {
         id: PointOffsetType,
         payload: &MultiValue<&Value>,
     ) -> OperationResult<()> {
+        self.remove_point(id)?;
         match payload {
             MultiValue::Multiple(values) => {
-                self.remove_point(id)?;
                 let mut flatten_values: Vec<_> = vec![];
 
                 for value in values {
@@ -93,12 +93,10 @@ pub trait ValueIndexer<T> {
                 self.add_many(id, flatten_values)
             }
             MultiValue::Single(Some(Value::Array(values))) => {
-                self.remove_point(id)?;
                 self.add_many(id, values.iter().flat_map(|x| self.get_value(x)).collect())
             }
             MultiValue::Single(Some(value)) => {
                 if let Some(x) = self.get_value(value) {
-                    self.remove_point(id)?;
                     self.add_many(id, vec![x])
                 } else {
                     Ok(())

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -79,7 +79,9 @@ fn test_set_empty_payload() {
     assert!(!value.is_empty());
 
     let payload = serde_json::json!(null);
-    index.add_point(point_id, &MultiValue::one(&payload)).unwrap();
+    index
+        .add_point(point_id, &MultiValue::one(&payload))
+        .unwrap();
 
     let value = index.get_values(point_id).unwrap();
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,6 +6,7 @@ use tempfile::{Builder, TempDir};
 
 use super::*;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
+use crate::common::utils::MultiValue;
 
 const COLUMN_NAME: &str = "test";
 
@@ -65,6 +66,24 @@ fn cardinality_request(index: &NumericIndex<f64>, query: Range) -> CardinalityEs
     assert!(estimation.min <= result.len());
     assert!(estimation.max >= result.len());
     estimation
+}
+
+#[test]
+fn test_set_empty_payload() {
+    let (_temp_dir, mut index) = random_index(1000, 1, false);
+
+    let point_id = 42;
+
+    let value = index.get_values(point_id).unwrap();
+
+    assert!(!value.is_empty());
+
+    let payload = serde_json::json!(null);
+    index.add_point(point_id, &MultiValue::one(&payload)).unwrap();
+
+    let value = index.get_values(point_id).unwrap();
+
+    assert!(value.is_empty());
 }
 
 #[rstest]


### PR DESCRIPTION
Currently, if we insert new value in payload index with `add_point`, it only clears existing data if the new value is "parsable" (compatible with the index). 
But in reality, it can be any value, e.g. "null". That would mean that old value should still be removed from index even if the new one is not indexable.


Simple way to reproduce problem:

```
POST collections/benchmark/points/payload
{
  "points": [1,2,3],
  "payload": {
    "c": null
  }
}
```

