### PR TITLE
Increased maximum visited-list pool size to 128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
  "io",
  "io-uring",
  "itertools 0.11.0",
+ "lazy_static",
  "log",
  "memmap2 0.7.1",
  "memory",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -61,6 +61,7 @@ quantization = { git = "https://github.com/qdrant/quantization.git" }
 validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.31", features = ["serde"] }
 smol_str = "0.2.0"
+lazy_static = "1.4"
 
 sysinfo = "0.29"
 futures = "0.3.28"

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -1,13 +1,18 @@
 //! Structures for fast and tread-safe way to check if some points were visited or not
 
 use common::types::PointOffsetType;
+use lazy_static::lazy_static;
 use parking_lot::RwLock;
 
-/// Max number of visited lists to preserve in memory
-/// If more than this number of concurrent requests occurred - new list will be created dynamically,
-/// but will be deleted right after query finishes.
-/// Implemented in order to limit memory leak
-const POOL_KEEP_LIMIT: usize = 128;
+lazy_static! {
+    /// Max number of visited lists to preserve in memory
+    ///
+    /// If there are more concurrent requests, a new temporary list is created dynamically.
+    /// This limit is implemented to prevent memory leakage.
+    /// It matches the number of logical CPU cores, to best represent the expected number of
+    /// concurrent requests. Clamped between 16 and 128 to prevent extreme values.
+    static ref POOL_KEEP_LIMIT: usize = num_cpus::get().clamp(16, 128);
+}
 
 /// Visited list handle is an owner of the `VisitedList`, which is returned by `VisitedPool` and returned back to it
 #[derive(Debug)]
@@ -126,7 +131,7 @@ impl VisitedPool {
 
     fn return_back(&self, data: VisitedList) {
         let mut pool = self.pool.write();
-        if pool.len() < POOL_KEEP_LIMIT {
+        if pool.len() < *POOL_KEEP_LIMIT {
             pool.push(data);
         }
     }

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -113,7 +113,7 @@ pub struct VisitedPool {
 impl VisitedPool {
     pub fn new() -> Self {
         VisitedPool {
-            pool: RwLock::new(vec![]),
+            pool: RwLock::new(Vec::with_capacity(*POOL_KEEP_LIMIT)),
         }
     }
 

--- a/lib/segment/src/index/visited_pool.rs
+++ b/lib/segment/src/index/visited_pool.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 /// If more than this number of concurrent requests occurred - new list will be created dynamically,
 /// but will be deleted right after query finishes.
 /// Implemented in order to limit memory leak
-const POOL_KEEP_LIMIT: usize = 16;
+const POOL_KEEP_LIMIT: usize = 128;
 
 /// Visited list handle is an owner of the `VisitedList`, which is returned by `VisitedPool` and returned back to it
 #[derive(Debug)]


### PR DESCRIPTION
We observe a significant degradation in tail latencies when there are more than 16 concurrent searches. Profiling reveals that the culprit is the visited list allocation under the exclusive lock. This PR is a proposal to increase the maximum visited-list pool size from 16 to 128. This is a reasonable maximum based on logical core count available on modern server processors suitable for the most extreme cases when a single segment is being searched by all hardware threads.

We have benchmarked this change and observe an ~80-90% reduction in 99th, 99.9th, and 99.99th percentile latencies under 27 concurrent searches. The benchmarked collection consists of 5 indexed segments of 2M points each.
Prior to the change:
```
p50: 19ms
p90: 23ms
p99: 221ms
p999: 295ms
p9999: 330ms
```
After:
```
p50: 22ms
p90: 25ms
p99: 29ms
p999: 32ms
p9999: 35ms
```
The slight increase in p50 and p90 latencies is expected as we have more concurrent segment search tasks than available cores (27 * 5 = 135 tasks vs 128 cores) which are no longer bottlenecked by visited-list allocation. If the concurrency is decreased to 24, ~3ms is shaved off of all percentiles and p50 and p90 latencies return to the original values of 19ms & 23ms.

A future improvement may be deriving the maximum pool size from the configured search thread count or using a lock-free cache which can grow to satisfy bursts in traffic and later shrink to bound auxiliary memory use.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
