### PR TITLE
Fix divide by zero panic, fall back to 0

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -194,7 +194,9 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         // exp = 500 / (1200 / 1000) = 416
         // max = min(1000, 500) = 500
         let expected_min = max(
-            min_estimation / self.get_max_values_per_point(),
+            min_estimation
+                .checked_div(self.get_max_values_per_point())
+                .unwrap_or(0),
             max(
                 min(1, min_estimation),
                 min_estimation.saturating_sub(total_values - self.get_points_count()),

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -395,3 +395,20 @@ fn test_cond<T: Encodable + Numericable + PartialOrd + Clone>(
 
     assert_eq!(offsets, result);
 }
+
+// Check we don't panic on an empty index. See <https://github.com/qdrant/qdrant/pull/2933>.
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn test_empty_cardinality(#[case] immutable: bool) {
+    let (_temp_dir, index) = random_index(0, 1, immutable);
+    cardinality_request(
+        &index,
+        Range {
+            lt: Some(20.0),
+            gt: None,
+            gte: Some(10.0),
+            lte: None,
+        },
+    );
+}


### PR DESCRIPTION
Prevent a divide by zero panic in production if `self.get_max_values_per_point()` ends up being zero.

I'm unsure if the above function is ever expected to return zero, but I'll ask @IvanPleshkov to investigate that as he has a better understanding of these internals. Even if it should never return zero, I suggest to merge this first anyway because it's a good way to prevent a panic if something similar happens in the future.

Fixes the following panic:

```rust
2023-11-04T01:45:17.548852Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/index/field_index/numeric_index/mod.rs at line 197: attempt to divide by zero    
2023-11-04T01:45:17.549736Z ERROR qdrant::startup: Panic backtrace: 
   0: qdrant::startup::setup_panic_hook::{{closure}}
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/alloc/src/boxed.rs:2007:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/panicking.rs:709:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/panicking.rs:595:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/sys_common/backtrace.rs:151:18
   5: rust_begin_unwind
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/panicking.rs:593:5
   6: core::panicking::panic_fmt
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/panicking.rs:67:14
   7: core::panicking::panic
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/panicking.rs:117:5
   8: segment::index::field_index::numeric_index::NumericIndex<T>::range_cardinality
   9: <segment::index::field_index::numeric_index::NumericIndex<T> as segment::index::field_index::field_index_base::PayloadFieldIndex>::estimate_cardinality
  10: segment::index::struct_payload_index::StructPayloadIndex::condition_cardinality
  11: segment::index::query_estimator::estimate_filter
  12: <segment::index::struct_payload_index::StructPayloadIndex as segment::index::payload_index_base::PayloadIndex>::estimate_cardinality
  13: <segment::index::struct_payload_index::StructPayloadIndex as segment::index::payload_index_base::PayloadIndex>::query_points
  14: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
  15: <segment::index::hnsw_index::hnsw::HNSWIndex<TGraphLinks> as segment::index::vector_index_base::VectorIndex>::search
  16: <segment::segment::Segment as segment::entry::entry_point::SegmentEntry>::search_batch
  17: collection::collection_manager::segments_searcher::execute_batch_search
  18: collection::collection_manager::segments_searcher::search_in_segment
  19: tokio::runtime::task::raw::poll
  20: std::sys_common::backtrace::__rust_begin_short_backtrace
  21: core::ops::function::FnOnce::call_once{{vtable.shim}}
  22: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/alloc/src/boxed.rs:1993:9
  23: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/alloc/src/boxed.rs:1993:9
  24: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/sys/unix/thread.rs:108:17
  25: <unknown>
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?