### PR TITLE
remove serde(default)

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8993,7 +8993,6 @@
           },
           "placement": {
             "description": "Placement of shards for this key List of peer ids, that can be used to place shards for this key If not specified, will be randomly placed among all peers",
-            "default": null,
             "type": "array",
             "items": {
               "type": "integer",

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -50,7 +50,6 @@ pub struct CreateShardingKey {
     /// Placement of shards for this key
     /// List of peer ids, that can be used to place shards for this key
     /// If not specified, will be randomly placed among all peers
-    #[serde(default)]
     pub placement: Option<Vec<PeerId>>,
 }
 


### PR DESCRIPTION
It looks like `#[serde(default)]` is not required, and API works without it just fine
