### PR TITLE
Faster search in sparse inverted index with unstable sort

### DIFF
--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -127,7 +127,7 @@ impl<'a> SearchContext<'a> {
     /// Make sure the longest posting list is at the head of the posting list iterators
     fn sort_posting_lists_by_len(&mut self) {
         // decreasing order
-        self.postings_iterators.sort_by(|a, b| {
+        self.postings_iterators.sort_unstable_by(|a, b| {
             b.posting_list_iterator
                 .len_to_end()
                 .cmp(&a.posting_list_iterator.len_to_end())


### PR DESCRIPTION
I found a low hanging fruit while benching the sparse index search.

Using an unstable sort for the posting list yields large improvements on my local benchmarks.

e.g. rolling back to stable sort

```
sparse-vector-search-group/sparse-index-search
                        time:   [2.1994 ms 2.2515 ms 2.3023 ms]
                        change: [+29.512% +34.146% +39.613%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
