### PR TITLE
Shard key index consistency

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3009,7 +3009,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| operation_id | [uint64](#uint64) |  | Number of operation |
+| operation_id | [uint64](#uint64) | optional | Number of operation |
 | status | [UpdateStatus](#qdrant-UpdateStatus) |  | Operation status |
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6626,7 +6626,6 @@
       "UpdateResult": {
         "type": "object",
         "required": [
-          "operation_id",
           "status"
         ],
         "properties": {
@@ -6634,7 +6633,8 @@
             "description": "Sequential number of the operation",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           },
           "status": {
             "$ref": "#/components/schemas/UpdateStatus"

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -472,7 +472,7 @@ message PointsOperationResponse {
 }
 
 message UpdateResult {
-  uint64 operation_id = 1; // Number of operation
+  optional uint64 operation_id = 1; // Number of operation
   UpdateStatus status = 2; // Operation status
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3906,8 +3906,8 @@ pub struct PointsOperationResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateResult {
     /// Number of operation
-    #[prost(uint64, tag = "1")]
-    pub operation_id: u64,
+    #[prost(uint64, optional, tag = "1")]
+    pub operation_id: ::core::option::Option<u64>,
     /// Operation status
     #[prost(enumeration = "UpdateStatus", tag = "2")]
     pub status: i32,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -5,6 +5,7 @@ mod shard_transfer;
 mod sharding_keys;
 mod snapshots;
 mod state_management;
+mod payload_index_schema;
 
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -17,12 +18,14 @@ use segment::types::ShardKey;
 use semver::Version;
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 
 use crate::collection_state::{ShardInfo, State};
 use crate::common::is_ready::IsReady;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult, NodeType};
+use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::replica_set::ReplicaState::{Active, Dead, Initializing, Listener};
@@ -40,6 +43,7 @@ pub struct Collection {
     pub(crate) shards_holder: Arc<LockedShardHolder>,
     pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
+    pub(crate) payload_index_schema: SaveOnDisk<PayloadIndexSchema>,
     this_peer_id: PeerId,
     path: PathBuf,
     snapshots_path: PathBuf,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1,5 +1,5 @@
 mod collection_ops;
-mod payload_index_schema;
+pub mod payload_index_schema;
 mod point_ops;
 mod search;
 mod shard_transfer;
@@ -420,6 +420,7 @@ impl Collection {
                 .collect(),
             transfers,
             shards_key_mapping: shards_holder.get_shard_key_to_ids_mapping(),
+            payload_index_schema: self.payload_index_schema.read().clone(),
         }
     }
 

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use serde::{Deserialize, Serialize};
+use segment::types::{PayloadFieldSchema, PayloadKeyType};
+use crate::collection::Collection;
+use crate::save_on_disk::SaveOnDisk;
+
+pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "payload_index.json";
+
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct PayloadIndexSchema {
+    schema: HashMap<PayloadKeyType, PayloadFieldSchema>
+}
+
+impl Collection {
+    fn payload_index_file(collection_path: &Path) -> PathBuf {
+        collection_path.join(PAYLOAD_INDEX_CONFIG_FILE)
+    }
+
+    fn load_payload_index_schema(collection_path: &Path) -> SaveOnDisk<PayloadIndexSchema> {
+        let payload_index_file = Self::payload_index_file(collection_path);
+
+        let schema: SaveOnDisk<PayloadIndexSchema> = SaveOnDisk::load_or_init(payload_index_file).unwrap();
+
+
+
+    }
+
+}

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -17,7 +17,7 @@ pub struct PayloadIndexSchema {
 }
 
 impl Collection {
-    fn payload_index_file(collection_path: &Path) -> PathBuf {
+    pub(crate) fn payload_index_file(collection_path: &Path) -> PathBuf {
         collection_path.join(PAYLOAD_INDEX_CONFIG_FILE)
     }
 

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -11,7 +11,7 @@ use crate::save_on_disk::SaveOnDisk;
 
 pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "payload_index.json";
 
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct PayloadIndexSchema {
     pub schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
 }

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -13,7 +13,7 @@ pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "payload_index.json";
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PayloadIndexSchema {
-    schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
+    pub schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
 }
 
 impl Collection {

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -1,16 +1,19 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use serde::{Deserialize, Serialize};
+
 use segment::types::{PayloadFieldSchema, PayloadKeyType};
+use serde::{Deserialize, Serialize};
+
 use crate::collection::Collection;
+use crate::operations::types::{CollectionResult, UpdateResult};
+use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::save_on_disk::SaveOnDisk;
 
 pub const PAYLOAD_INDEX_CONFIG_FILE: &str = "payload_index.json";
 
-
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PayloadIndexSchema {
-    schema: HashMap<PayloadKeyType, PayloadFieldSchema>
+    schema: HashMap<PayloadKeyType, PayloadFieldSchema>,
 }
 
 impl Collection {
@@ -18,13 +21,59 @@ impl Collection {
         collection_path.join(PAYLOAD_INDEX_CONFIG_FILE)
     }
 
-    fn load_payload_index_schema(collection_path: &Path) -> SaveOnDisk<PayloadIndexSchema> {
+    pub(crate) fn load_payload_index_schema(
+        collection_path: &Path,
+    ) -> CollectionResult<SaveOnDisk<PayloadIndexSchema>> {
         let payload_index_file = Self::payload_index_file(collection_path);
-
-        let schema: SaveOnDisk<PayloadIndexSchema> = SaveOnDisk::load_or_init(payload_index_file).unwrap();
-
-
-
+        let schema: SaveOnDisk<PayloadIndexSchema> = SaveOnDisk::load_or_init(payload_index_file)?;
+        Ok(schema)
     }
 
+    pub async fn create_payload_index(
+        &self,
+        field_name: String,
+        field_schema: PayloadFieldSchema,
+    ) -> CollectionResult<Option<UpdateResult>> {
+        self.payload_index_schema.write(|schema| {
+            schema
+                .schema
+                .insert(field_name.clone(), field_schema.clone());
+        })?;
+
+        // This operation might be redundant, if we also create index as a regular collection op,
+        // but it looks better in long term to also have it here, so
+        // the creation of payload index may be eventually completely converted
+        // into the consensus operation
+        let create_index_operation = CollectionUpdateOperations::FieldIndexOperation(
+            FieldIndexOperations::CreateIndex(CreateIndex {
+                field_name,
+                field_schema: Some(field_schema),
+            }),
+        );
+
+        // This function is called from consensus, so we can't afford to wait for the result
+        // as indexation may take a long time
+        let wait = false;
+
+        let result = self.update_all_local(create_index_operation, wait).await?;
+
+        Ok(result)
+    }
+
+    pub async fn drop_payload_index(
+        &self,
+        field_name: String,
+    ) -> CollectionResult<Option<UpdateResult>> {
+        self.payload_index_schema.write(|schema| {
+            schema.schema.remove(&field_name);
+        })?;
+
+        let delete_index_operation = CollectionUpdateOperations::FieldIndexOperation(
+            FieldIndexOperations::DeleteIndex(field_name),
+        );
+
+        let result = self.update_all_local(delete_index_operation, false).await?;
+
+        Ok(result)
+    }
 }

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -5,6 +5,7 @@ use segment::types::ShardKey;
 use crate::collection::Collection;
 use crate::config::ShardingMethod;
 use crate::operations::types::CollectionError;
+use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId, ShardsPlacement};
 
@@ -91,6 +92,8 @@ impl Collection {
             .copied()
             .unwrap_or(0);
 
+        let payload_schema = self.payload_index_schema.read().schema.clone();
+
         for (idx, shard_replicas_placement) in placement.iter().enumerate() {
             let shard_id = max_shard_id + idx as ShardId + 1;
 
@@ -98,7 +101,16 @@ impl Collection {
                 .create_replica_set(shard_id, shard_replicas_placement)
                 .await?;
 
-            // ToDo: initialize payload index
+            for (field_name, field_schema) in payload_schema.iter() {
+                let create_index_op = CollectionUpdateOperations::FieldIndexOperation(
+                    FieldIndexOperations::CreateIndex(CreateIndex {
+                        field_name: field_name.clone(),
+                        field_schema: Some(field_schema.clone()),
+                    }),
+                );
+
+                replica_set.update_local(create_index_op, true).await?;
+            }
 
             self.shards_holder.write().await.add_shard(
                 shard_id,

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -98,6 +98,8 @@ impl Collection {
                 .create_replica_set(shard_id, shard_replicas_placement)
                 .await?;
 
+            // ToDo: initialize payload index
+
             self.shards_holder.write().await.add_shard(
                 shard_id,
                 replica_set,

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -101,6 +101,11 @@ impl Collection {
             .await
             .save_key_mapping_to_dir(&snapshot_temp_target_dir_path)?;
 
+        let payload_index_schema_tmp_path =
+            Self::payload_index_file(&snapshot_temp_target_dir_path);
+        self.payload_index_schema
+            .save_to(&payload_index_schema_tmp_path)?;
+
         // Dedicated temporary file for archiving this snapshot (deleted on drop)
         let mut snapshot_temp_arc_file = tempfile::Builder::new()
             .prefix(&format!("{snapshot_name}-arc-"))

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -112,6 +112,14 @@ impl Collection {
         &self,
         payload_index_schema: PayloadIndexSchema,
     ) -> CollectionResult<()> {
+        let state = self.state().await;
+
+        for field_name in state.payload_index_schema.schema.keys() {
+            if !payload_index_schema.schema.contains_key(field_name) {
+                self.drop_payload_index(field_name.clone()).await?;
+            }
+        }
+
         for (field_name, field_schema) in payload_index_schema.schema {
             self.create_payload_index(field_name, field_schema).await?;
         }

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection::Collection;
 use crate::collection_state::{ShardInfo, State};
 use crate::config::CollectionConfig;
@@ -20,6 +21,8 @@ impl Collection {
         self.apply_shard_transfers(state.transfers, this_peer_id, abort_transfer)
             .await?;
         self.apply_shard_info(state.shards, state.shards_key_mapping)
+            .await?;
+        self.apply_payload_index_schema(state.payload_index_schema)
             .await?;
         Ok(())
     }
@@ -103,5 +106,15 @@ impl Collection {
             .await
             .apply_shards_state(shard_ids, shards_key_mapping, extra_shards)
             .await
+    }
+
+    async fn apply_payload_index_schema(
+        &self,
+        payload_index_schema: PayloadIndexSchema,
+    ) -> CollectionResult<()> {
+        for (field_name, field_schema) in payload_index_schema.schema {
+            self.create_payload_index(field_name, field_schema).await?;
+        }
+        Ok(())
     }
 }

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::config::CollectionConfig;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -23,4 +24,6 @@ pub struct State {
     pub transfers: HashSet<ShardTransfer>,
     #[serde(default)]
     pub shards_key_mapping: ShardKeyMapping,
+    #[serde(default)]
+    pub payload_index_schema: PayloadIndexSchema,
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -204,7 +204,8 @@ pub enum UpdateStatus {
 #[serde(rename_all = "snake_case")]
 pub struct UpdateResult {
     /// Sequential number of the operation
-    pub operation_id: SeqNumberType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<SeqNumberType>,
     /// Update status
     pub status: UpdateStatus,
 }

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -136,12 +136,12 @@ impl ShardOperation for LocalShard {
         if let Some(receiver) = callback_receiver {
             let _res = receiver.await??;
             Ok(UpdateResult {
-                operation_id,
+                operation_id: Some(operation_id),
                 status: UpdateStatus::Completed,
             })
         } else {
             Ok(UpdateResult {
-                operation_id,
+                operation_id: Some(operation_id),
                 status: UpdateStatus::Acknowledged,
             })
         }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -9,7 +9,7 @@ use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
 use collection::shards::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
 use collection::shards::{replica_set, CollectionId};
 use schemars::JsonSchema;
-use segment::types::{QuantizationConfig, ShardKey};
+use segment::types::{PayloadFieldSchema, PayloadKeyType, QuantizationConfig, ShardKey};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -324,6 +324,19 @@ pub struct DropShardKey {
     pub shard_key: ShardKey,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
+pub struct CreatePayloadIndex {
+    pub collection_name: String,
+    pub field_name: PayloadKeyType,
+    pub field_schema: PayloadFieldSchema,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
+pub struct DropPayloadIndex {
+    pub collection_name: String,
+    pub field_name: PayloadKeyType,
+}
+
 /// Enumeration of all possible collection update operations
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -336,6 +349,8 @@ pub enum CollectionMetaOperations {
     SetShardReplicaState(SetShardReplicaState),
     CreateShardKey(CreateShardKey),
     DropShardKey(DropShardKey),
+    CreatePayloadIndex(CreatePayloadIndex),
+    DropPayloadIndex(DropPayloadIndex),
     Nop { token: usize }, // Empty operation
 }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -630,9 +630,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     ///
     /// * `operation` - operation to propose
     /// * `wait_timeout` - How long do we need to wait for the confirmation
-    /// * `with_confirmation` - If `true` - additional empty operation will be sent to the consensus thread.
-    ///   This is needed to ensure that the operation is committed and applied on majority of the nodes.
-    ///   We can not wait for all nodes confirmation, because it is not guaranteed that all nodes will be online.
     ///
     pub async fn propose_consensus_op_with_await(
         &self,

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -85,6 +85,18 @@ impl TableOfContent {
                 log::debug!("Drop shard key {:?}", drop_shard_key);
                 self.drop_shard_key(drop_shard_key).await.map(|()| true)
             }
+            CollectionMetaOperations::CreatePayloadIndex(create_payload_index) => {
+                log::debug!("Create payload index {:?}", create_payload_index);
+                self.create_payload_index(create_payload_index)
+                    .await
+                    .map(|()| true)
+            }
+            CollectionMetaOperations::DropPayloadIndex(drop_payload_index) => {
+                log::debug!("Drop payload index {:?}", drop_payload_index);
+                self.drop_payload_index(drop_payload_index)
+                    .await
+                    .map(|()| true)
+            }
         }
     }
 
@@ -388,6 +400,25 @@ impl TableOfContent {
         self.get_collection(&operation.collection_name)
             .await?
             .drop_shard_key(operation.shard_key)
+            .await?;
+        Ok(())
+    }
+
+    async fn create_payload_index(
+        &self,
+        operation: CreatePayloadIndex,
+    ) -> Result<(), StorageError> {
+        self.get_collection(&operation.collection_name)
+            .await?
+            .create_payload_index(operation.field_name, operation.field_schema)
+            .await?;
+        Ok(())
+    }
+
+    async fn drop_payload_index(&self, operation: DropPayloadIndex) -> Result<(), StorageError> {
+        self.get_collection(&operation.collection_name)
+            .await?
+            .drop_payload_index(operation.field_name)
             .await?;
         Ok(())
     }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -257,6 +257,7 @@ impl TableOfContent {
                     shards,
                     transfers,
                     shards_key_mapping: _,
+                    payload_index_schema: _,
                 } = collection.state().await;
                 let all_peers: HashSet<_> = self
                     .channel_service

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -7,6 +7,7 @@ use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
 use validator::Validate;
 
 use super::CollectionPath;
@@ -247,7 +248,7 @@ async fn update_batch(
 }
 #[put("/collections/{name}/index")]
 async fn create_field_index(
-    toc: web::Data<TableOfContent>,
+    dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     operation: Json<CreateFieldIndex>,
     params: Query<UpdateParam>,
@@ -258,7 +259,7 @@ async fn create_field_index(
     let ordering = params.ordering.unwrap_or_default();
 
     let response = do_create_index(
-        toc.get_ref(),
+        dispatcher.get_ref(),
         &collection.name,
         operation,
         None,
@@ -271,7 +272,7 @@ async fn create_field_index(
 
 #[delete("/collections/{name}/index/{field_name}")]
 async fn delete_field_index(
-    toc: web::Data<TableOfContent>,
+    dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     field: Path<FieldPath>,
     params: Query<UpdateParam>,
@@ -281,7 +282,7 @@ async fn delete_field_index(
     let ordering = params.ordering.unwrap_or_default();
 
     let response = do_delete_index(
-        toc.get_ref(),
+        dispatcher.get_ref(),
         &collection.name,
         field.name.clone(),
         None,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -540,6 +540,10 @@ pub async fn do_create_index(
         .submit_collection_meta_op(consensus_op, wait_timeout)
         .await?;
 
+    // This function is required as long as we want to maintain interface compatibility
+    // for `wait` parameter and return type.
+    // The idea is to migrate from the point-like interface to consensus-like interface in the next few versions
+
     do_create_index_internal(
         dispatcher.toc(),
         collection_name,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -19,16 +19,20 @@ use collection::operations::vector_ops::{
 use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use collection::shards::shard::ShardId;
 use schemars::JsonSchema;
-use segment::types::{PayloadFieldSchema, ScoredPoint};
+use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint};
 use serde::{Deserialize, Serialize};
+use storage::content_manager::collection_meta_ops::{
+    CollectionMetaOperations, CreatePayloadIndex, DropPayloadIndex,
+};
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::shard_key_selection::ShardKeySelectorInternal;
 use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
 use validator::Validate;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct CreateFieldIndex {
-    pub field_name: String,
+    pub field_name: PayloadKeyType,
     #[serde(alias = "field_type")]
     pub field_schema: Option<PayloadFieldSchema>,
 }
@@ -482,20 +486,22 @@ pub async fn do_batch_update_points(
     Ok(results)
 }
 
-pub async fn do_create_index(
+pub async fn do_create_index_internal(
     toc: &TableOfContent,
     collection_name: &str,
-    operation: CreateFieldIndex,
+    field_name: PayloadKeyType,
+    field_schema: Option<PayloadFieldSchema>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
-            field_name: operation.field_name,
-            field_schema: operation.field_schema,
+            field_name,
+            field_schema,
         }),
     );
+
     toc.update(
         collection_name,
         collection_operation,
@@ -507,7 +513,46 @@ pub async fn do_create_index(
     .await
 }
 
-pub async fn do_delete_index(
+pub async fn do_create_index(
+    dispatcher: &Dispatcher,
+    collection_name: &str,
+    operation: CreateFieldIndex,
+    shard_selection: Option<ShardId>,
+    wait: bool,
+    ordering: WriteOrdering,
+) -> Result<UpdateResult, StorageError> {
+    let Some(field_schema) = operation.field_schema else {
+        return Err(StorageError::bad_request(
+            "Can't auto-detect field type, please specify `field_schema` in the request",
+        ));
+    };
+
+    let consensus_op = CollectionMetaOperations::CreatePayloadIndex(CreatePayloadIndex {
+        collection_name: collection_name.to_string(),
+        field_name: operation.field_name.clone(),
+        field_schema: field_schema.clone(),
+    });
+
+    // Default consensus timeout will be used
+    let wait_timeout = None; // ToDo: make it configurable
+
+    dispatcher
+        .submit_collection_meta_op(consensus_op, wait_timeout)
+        .await?;
+
+    do_create_index_internal(
+        dispatcher.toc(),
+        collection_name,
+        operation.field_name,
+        Some(field_schema),
+        shard_selection,
+        wait,
+        ordering,
+    )
+    .await
+}
+
+pub async fn do_delete_index_internal(
     toc: &TableOfContent,
     collection_name: &str,
     index_name: String,
@@ -525,6 +570,37 @@ pub async fn do_delete_index(
         wait,
         ordering,
         ShardKeySelectorInternal::All,
+    )
+    .await
+}
+
+pub async fn do_delete_index(
+    dispatcher: &Dispatcher,
+    collection_name: &str,
+    index_name: String,
+    shard_selection: Option<ShardId>,
+    wait: bool,
+    ordering: WriteOrdering,
+) -> Result<UpdateResult, StorageError> {
+    let consensus_op = CollectionMetaOperations::DropPayloadIndex(DropPayloadIndex {
+        collection_name: collection_name.to_string(),
+        field_name: index_name.clone(),
+    });
+
+    // Default consensus timeout will be used
+    let wait_timeout = None; // ToDo: make it configurable
+
+    dispatcher
+        .submit_collection_meta_op(consensus_op, wait_timeout)
+        .await?;
+
+    do_delete_index_internal(
+        dispatcher.toc(),
+        collection_name,
+        index_name,
+        shard_selection,
+        wait,
+        ordering,
     )
     .await
 }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
     SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, UpdateBatchPoints,
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
-use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
 use super::points_common::{
@@ -27,12 +27,12 @@ use crate::tonic::api::points_common::{
 };
 
 pub struct PointsService {
-    toc: Arc<TableOfContent>,
+    dispatcher: Arc<Dispatcher>,
 }
 
 impl PointsService {
-    pub fn new(toc: Arc<TableOfContent>) -> Self {
-        Self { toc }
+    pub fn new(dispatcher: Arc<Dispatcher>) -> Self {
+        Self { dispatcher }
     }
 }
 
@@ -43,7 +43,7 @@ impl Points for PointsService {
         request: Request<UpsertPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        upsert(self.toc.as_ref(), request.into_inner(), None).await
+        upsert(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn delete(
@@ -51,12 +51,12 @@ impl Points for PointsService {
         request: Request<DeletePoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete(self.toc.as_ref(), request.into_inner(), None).await
+        delete(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn get(&self, request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
         validate(request.get_ref())?;
-        get(self.toc.as_ref(), request.into_inner(), None).await
+        get(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn update_vectors(
@@ -64,7 +64,7 @@ impl Points for PointsService {
         request: Request<UpdatePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        update_vectors(self.toc.as_ref(), request.into_inner(), None).await
+        update_vectors(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn delete_vectors(
@@ -72,7 +72,7 @@ impl Points for PointsService {
         request: Request<DeletePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_vectors(self.toc.as_ref(), request.into_inner(), None).await
+        delete_vectors(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn set_payload(
@@ -80,7 +80,7 @@ impl Points for PointsService {
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        set_payload(self.toc.as_ref(), request.into_inner(), None).await
+        set_payload(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn overwrite_payload(
@@ -88,7 +88,7 @@ impl Points for PointsService {
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        overwrite_payload(self.toc.as_ref(), request.into_inner(), None).await
+        overwrite_payload(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn delete_payload(
@@ -96,7 +96,7 @@ impl Points for PointsService {
         request: Request<DeletePayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_payload(self.toc.as_ref(), request.into_inner(), None).await
+        delete_payload(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn clear_payload(
@@ -104,7 +104,7 @@ impl Points for PointsService {
         request: Request<ClearPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        clear_payload(self.toc.as_ref(), request.into_inner(), None).await
+        clear_payload(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn update_batch(
@@ -112,7 +112,7 @@ impl Points for PointsService {
         request: Request<UpdateBatchPoints>,
     ) -> Result<Response<UpdateBatchResponse>, Status> {
         validate(request.get_ref())?;
-        update_batch(self.toc.as_ref(), request.into_inner(), None).await
+        update_batch(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn create_field_index(
@@ -120,7 +120,7 @@ impl Points for PointsService {
         request: Request<CreateFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        create_field_index(self.toc.as_ref(), request.into_inner(), None).await
+        create_field_index(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn delete_field_index(
@@ -128,7 +128,7 @@ impl Points for PointsService {
         request: Request<DeleteFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_field_index(self.toc.as_ref(), request.into_inner(), None).await
+        delete_field_index(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn search(
@@ -136,7 +136,7 @@ impl Points for PointsService {
         request: Request<SearchPoints>,
     ) -> Result<Response<SearchResponse>, Status> {
         validate(request.get_ref())?;
-        search(self.toc.as_ref(), request.into_inner(), None).await
+        search(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn search_batch(
@@ -154,7 +154,7 @@ impl Points for PointsService {
         let timeout = timeout.map(Duration::from_secs);
 
         search_batch(
-            self.toc.as_ref(),
+            self.dispatcher.as_ref(),
             collection_name,
             search_points,
             read_consistency,
@@ -169,7 +169,7 @@ impl Points for PointsService {
         request: Request<SearchPointGroups>,
     ) -> Result<Response<SearchGroupsResponse>, Status> {
         validate(request.get_ref())?;
-        search_groups(self.toc.as_ref(), request.into_inner(), None).await
+        search_groups(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn scroll(
@@ -177,7 +177,7 @@ impl Points for PointsService {
         request: Request<ScrollPoints>,
     ) -> Result<Response<ScrollResponse>, Status> {
         validate(request.get_ref())?;
-        scroll(self.toc.as_ref(), request.into_inner(), None).await
+        scroll(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 
     async fn recommend(
@@ -185,7 +185,7 @@ impl Points for PointsService {
         request: Request<RecommendPoints>,
     ) -> Result<Response<RecommendResponse>, Status> {
         validate(request.get_ref())?;
-        recommend(self.toc.as_ref(), request.into_inner()).await
+        recommend(self.dispatcher.as_ref(), request.into_inner()).await
     }
 
     async fn recommend_batch(
@@ -200,7 +200,7 @@ impl Points for PointsService {
             timeout,
         } = request.into_inner();
         recommend_batch(
-            self.toc.as_ref(),
+            self.dispatcher.as_ref(),
             collection_name,
             recommend_points,
             read_consistency,
@@ -214,7 +214,7 @@ impl Points for PointsService {
         request: Request<RecommendPointGroups>,
     ) -> Result<Response<RecommendGroupsResponse>, Status> {
         validate(request.get_ref())?;
-        recommend_groups(self.toc.as_ref(), request.into_inner()).await
+        recommend_groups(self.dispatcher.as_ref(), request.into_inner()).await
     }
 
     async fn discover(
@@ -222,7 +222,7 @@ impl Points for PointsService {
         request: Request<DiscoverPoints>,
     ) -> Result<Response<DiscoverResponse>, Status> {
         validate(request.get_ref())?;
-        discover(self.toc.as_ref(), request.into_inner()).await
+        discover(self.dispatcher.as_ref(), request.into_inner()).await
     }
 
     async fn discover_batch(
@@ -237,7 +237,7 @@ impl Points for PointsService {
             timeout,
         } = request.into_inner();
         discover_batch(
-            self.toc.as_ref(),
+            self.dispatcher.as_ref(),
             collection_name,
             discover_points,
             read_consistency,
@@ -251,6 +251,6 @@ impl Points for PointsService {
         request: Request<CountPoints>,
     ) -> Result<Response<CountResponse>, Status> {
         validate(request.get_ref())?;
-        count(self.toc.as_ref(), request.into_inner(), None).await
+        count(self.dispatcher.as_ref(), request.into_inner(), None).await
     }
 }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -17,9 +17,9 @@ use tonic::{Request, Response, Status};
 use super::points_common::core_search_batch;
 use super::validate_and_log;
 use crate::tonic::api::points_common::{
-    clear_payload, count, create_field_index, delete, delete_field_index, delete_payload,
-    delete_vectors, get, overwrite_payload, recommend, scroll, search, search_batch, set_payload,
-    sync, update_vectors, upsert,
+    clear_payload, count, create_field_index_internal, delete, delete_field_index_internal,
+    delete_payload, delete_vectors, get, overwrite_payload, recommend, scroll, search,
+    search_batch, set_payload, sync, update_vectors, upsert,
 };
 
 /// This API is intended for P2P communication within a distributed deployment.
@@ -158,7 +158,8 @@ impl PointsInternal for PointsInternalService {
         let create_field_index_collection = create_field_index_collection
             .ok_or_else(|| Status::invalid_argument("CreateFieldIndexCollection is missing"))?;
 
-        create_field_index(self.toc.as_ref(), create_field_index_collection, shard_id).await
+        create_field_index_internal(self.toc.as_ref(), create_field_index_collection, shard_id)
+            .await
     }
 
     async fn delete_field_index(
@@ -174,7 +175,8 @@ impl PointsInternal for PointsInternalService {
         let delete_field_index_collection = delete_field_index_collection
             .ok_or_else(|| Status::invalid_argument("DeleteFieldIndexCollection is missing"))?;
 
-        delete_field_index(self.toc.as_ref(), delete_field_index_collection, shard_id).await
+        delete_field_index_internal(self.toc.as_ref(), delete_field_index_collection, shard_id)
+            .await
     }
 
     async fn search(

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -144,7 +144,7 @@ pub fn init(
         let qdrant_service = QdrantService::default();
         let health_service = HealthService::default();
         let collections_service = CollectionsService::new(dispatcher.clone());
-        let points_service = PointsService::new(dispatcher.toc().clone());
+        let points_service = PointsService::new(dispatcher.clone());
         let snapshot_service = SnapshotsService::new(dispatcher.clone());
 
         // Only advertise the public services. By default, all services in QDRANT_DESCRIPTOR_SET


### PR DESCRIPTION
Tracking: https://github.com/qdrant/qdrant/issues/2807

Creation of new shards requires initializing a proper payload index initialization.
In current storage organization, we don't have centralized storage for payload index information, which makes synchronization of payload index info problematic. 


This PR initiates a transition into the direction of the collection-level payload index storage.

It introduces:

- Storage of payload index info inside Collection structure
- Consensus-level operations to create and delete payload field index
- Migration for the API from collection level to consensus level

There are, however, some compromises, I had to make:

- Collection-level operation is still required to guarantee equivalent behavior with `wait=True` and returned sequence number in the collection update
- Create index operation can't longer auto-detect type of the payload.

Further version of Qdrant should continue unification of API:

- Making `operation_id` optional should allow us to remove it from the further versions along with the collection-level part of the operation
- `wait=True` should be ignored for index creation. It should always be considered async operation.
- Timeout parameter should be introduced to make index creation more uniform with other consensus operations


