### PR TITLE
Add backoff when syncing locally disabled peers state to consensus

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -457,7 +457,7 @@ impl Collection {
         };
 
         for replica_set in shard_holder.all_shards() {
-            replica_set.sync_local_state(get_shard_transfers).await?;
+            replica_set.sync_local_state(get_shard_transfers)?;
         }
 
         // Check for un-reported finished transfers

--- a/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
+++ b/lib/collection/src/shards/replica_set/locally_disabled_peers.rs
@@ -1,0 +1,96 @@
+use std::cmp;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::shards::shard::PeerId;
+
+#[derive(Clone, Debug, Default)]
+pub struct Registry {
+    locally_disabled_peers: HashMap<PeerId, Backoff>,
+}
+
+impl Registry {
+    pub fn is_disabled(&self, peer_id: PeerId) -> bool {
+        self.locally_disabled_peers.contains_key(&peer_id)
+    }
+
+    pub fn is_all_disabled(&self, peer_ids: impl IntoIterator<Item = PeerId>) -> bool {
+        peer_ids
+            .into_iter()
+            .all(|peer_id| self.is_disabled(peer_id))
+    }
+
+    pub fn disable_peer(&mut self, peer_id: PeerId) {
+        self.locally_disabled_peers.entry(peer_id).or_default();
+    }
+
+    pub fn disable_peer_and_notify_if_elapsed(&mut self, peer_id: PeerId) -> bool {
+        self.locally_disabled_peers
+            .entry(peer_id)
+            .or_default()
+            .retry_if_elapsed()
+    }
+
+    pub fn enable_peer(&mut self, peer_id: PeerId) {
+        let _ = self.locally_disabled_peers.remove(&peer_id);
+    }
+
+    pub fn clear(&mut self) {
+        self.locally_disabled_peers.clear();
+    }
+
+    pub fn notify_elapsed(&mut self) -> impl Iterator<Item = PeerId> + '_ {
+        self.locally_disabled_peers
+            .iter_mut()
+            .filter_map(|(&peer_id, backoff)| {
+                if backoff.retry_if_elapsed() {
+                    Some(peer_id)
+                } else {
+                    None
+                }
+            })
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Backoff {
+    last_attempt: Instant,
+    delay: Duration,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self {
+            last_attempt: Instant::now(),
+            delay: Duration::ZERO,
+        }
+    }
+}
+
+impl Backoff {
+    const MAX_DELAY: Duration = Duration::from_secs(10);
+
+    pub fn retry_if_elapsed(&mut self) -> bool {
+        let is_elapsed = self.is_elapsed();
+
+        if is_elapsed {
+            self.retry();
+        }
+
+        is_elapsed
+    }
+
+    fn is_elapsed(&self) -> bool {
+        self.last_attempt.elapsed() >= self.delay
+    }
+
+    fn retry(&mut self) {
+        self.last_attempt = Instant::now();
+
+        self.delay = if self.delay.is_zero() {
+            Duration::from_secs(1)
+        } else {
+            cmp::min(self.delay * 2, Self::MAX_DELAY)
+        }
+    }
+}

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -136,12 +136,14 @@ impl ShardReplicaSet {
 
                 // ...if this peer is *not* the last active replica
                 if has_other_active_peers {
-                    self.locally_disabled_peers
+                    let notify = self
+                        .locally_disabled_peers
                         .write()
-                        .insert(self.this_peer_id()); // TODO: Blocking `write` call in async context
+                        .disable_peer_and_notify_if_elapsed(self.this_peer_id());
 
-                    // Notify peer failure
-                    self.notify_peer_failure_cb.deref()(self.this_peer_id(), self.shard_id);
+                    if notify {
+                        self.notify_peer_failure_cb.deref()(self.this_peer_id(), self.shard_id);
+                    }
                 }
 
                 // Remove shard directory, so we don't leave empty directory/corrupted data

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -63,8 +63,8 @@ impl ShardReplicaSet {
                         .map_err(|err| {
                             if err.is_transient() {
                                 // Deactivate the peer if forwarding failed with transient error
-                                self.locally_disabled_peers.write().insert(leader_peer);
-                                self.notify_peer_failure(leader_peer);
+                                self.add_locally_disabled(leader_peer);
+
                                 // return service error
                                 CollectionError::service_error(format!(
                                     "Failed to apply update with {ordering:?} ordering via leader peer {leader_peer}: {err}"
@@ -314,8 +314,7 @@ impl ShardReplicaSet {
                 self.shard_id
             );
 
-            self.locally_disabled_peers.write().insert(*peer_id);
-            self.notify_peer_failure(*peer_id);
+            self.add_locally_disabled(*peer_id);
         }
 
         wait_for_deactivation


### PR DESCRIPTION
This PR adds a "backoff" when synchronizing local state to consensus during `sync_local_state`.

This should not be necessary after changes in #3012/#3013/#3026 but still seems "nice to have".

Currently based on #3026, will be rebased on `dev` once it's merged.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
