### PR TITLE
Sparse vector search benchmarks

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -14,7 +14,6 @@ multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
 
 [dev-dependencies]
-tempfile = "3.8.0"
 criterion = "0.5"
 rmp-serde = "~1.1"
 rand_distr = "0.4.3"
@@ -27,7 +26,7 @@ pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 
 
 [dependencies]
-
+tempfile = "3.8.0"
 parking_lot = "0.12"
 rayon = "1.7.0"
 num_cpus = "1.16"
@@ -114,3 +113,6 @@ harness = false
 name = "boolean_filtering"
 harness = false
 
+[[bench]]
+name = "sparse_index_search"
+harness = false

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -1,0 +1,62 @@
+#[cfg(not(target_os = "windows"))]
+mod prof;
+
+use std::sync::atomic::AtomicBool;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram;
+use segment::index::VectorIndex;
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
+
+const NUM_VECTORS: usize = 10000;
+const MAX_SPARSE_DIM: usize = 512;
+
+fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse-vector-search-group");
+
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+    let sparse_vector_index =
+        fixture_sparse_index_ram(&mut rnd, NUM_VECTORS, MAX_SPARSE_DIM, &stopped);
+
+    let mut result_size = 0;
+    let mut query_count = 0;
+
+    group.bench_function("sparse-index-search", |b| {
+        b.iter(|| {
+            let sparse_vector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+            let query_vector = sparse_vector.into();
+            result_size += sparse_vector_index
+                .search(&[&query_vector], None, 1, None, &stopped)
+                .unwrap()
+                .len();
+
+            query_count += 1;
+        })
+    });
+
+    eprintln!(
+        "result_size / query_count = {:#?}",
+        result_size / query_count
+    );
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = sparse_vector_index_search_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = sparse_vector_index_search_benchmark,
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/fixtures/mod.rs
+++ b/lib/segment/src/fixtures/mod.rs
@@ -2,3 +2,4 @@ pub mod index_fixtures;
 pub mod payload_context_fixture;
 pub mod payload_fixtures;
 pub mod segment_fixtures;
+pub mod sparse_fixtures;

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::types::PointOffsetType;
+use rand::Rng;
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use sparse::index::inverted_index::InvertedIndex;
+use tempfile::Builder;
+
+use crate::common::operation_error::OperationResult;
+use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use crate::fixtures::payload_context_fixture::FixtureIdTracker;
+use crate::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::VectorIndex;
+use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use crate::types::Distance;
+use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use crate::vector_storage::VectorStorage;
+
+/// Helper to open a test sparse vector index
+pub fn fixture_open_sparse_index<I: InvertedIndex>(
+    index_dir: &Path,
+    num_vectors: usize, // used to size the id tracker
+) -> OperationResult<SparseVectorIndex<I>> {
+    // temp dirs
+    let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+
+    // setup
+    let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num_vectors)));
+    let payload_storage = InMemoryPayloadStorage::default();
+    let wrapped_payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
+    let payload_index = StructPayloadIndex::open(
+        wrapped_payload_storage,
+        id_tracker.clone(),
+        payload_dir.path(),
+        true,
+    )?;
+    let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
+
+    let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let vector_storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot)?;
+
+    let sparse_vector_index: SparseVectorIndex<I> = SparseVectorIndex::open(
+        id_tracker,
+        vector_storage.clone(),
+        wrapped_payload_index,
+        index_dir,
+    )?;
+
+    Ok(sparse_vector_index)
+}
+
+/// Prepares a sparse vector index with random sparse vectors
+pub fn fixture_sparse_index_ram<R: Rng + ?Sized>(
+    rnd: &mut R,
+    num_vectors: usize,
+    max_dim: usize,
+    stopped: &AtomicBool,
+) -> SparseVectorIndex<InvertedIndexRam> {
+    let index_dir = Builder::new().prefix("index_dir").tempdir().unwrap();
+    let mut sparse_vector_index = fixture_open_sparse_index(index_dir.path(), num_vectors).unwrap();
+    let mut borrowed_storage = sparse_vector_index.vector_storage.borrow_mut();
+
+    // add points to storage
+    for idx in 0..num_vectors {
+        let vec = &random_sparse_vector(rnd, max_dim);
+        borrowed_storage
+            .insert_vector(idx as PointOffsetType, vec.into())
+            .unwrap();
+    }
+    drop(borrowed_storage);
+
+    // assert all points are in storage
+    assert_eq!(
+        sparse_vector_index
+            .vector_storage
+            .borrow()
+            .available_vector_count(),
+        num_vectors
+    );
+
+    // build index to refresh RAM index
+    sparse_vector_index.build_index(stopped).unwrap();
+    assert_eq!(sparse_vector_index.indexed_vector_count(), num_vectors);
+    sparse_vector_index
+}


### PR DESCRIPTION
This PR adds the benchmark infrastructure for sparse vector search.

e.g
![search-perf](https://github.com/qdrant/qdrant/assets/606963/7197abbc-1ede-4250-b926-5276b9c77ba8)

This enables to optimize the underlying implementation (e.g https://github.com/qdrant/qdrant/pull/2937) and size properly the filter based search heuristic in the future.

To make this possible, some fixture files were refactored and extracted into the segments crate lib code,