### PR TITLE
Benchmark sparse filter plain search

### DIFF
--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -3,44 +3,128 @@ mod prof;
 
 use std::sync::atomic::AtomicBool;
 
+use common::types::PointOffsetType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram;
-use segment::index::VectorIndex;
+use segment::index::{PayloadIndex, VectorIndex};
+use segment::types::PayloadSchemaType::Keyword;
+use segment::types::{Condition, FieldCondition, Filter, Payload};
+use serde_json::json;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use tempfile::Builder;
 
-const NUM_VECTORS: usize = 10000;
-const MAX_SPARSE_DIM: usize = 512;
+const NUM_VECTORS: usize = 50_000;
+const MAX_SPARSE_DIM: usize = 30_000;
+const TOP: usize = 10;
 
 fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse-vector-search-group");
 
     let stopped = AtomicBool::new(false);
     let mut rnd = StdRng::seed_from_u64(42);
-    let sparse_vector_index =
-        fixture_sparse_index_ram(&mut rnd, NUM_VECTORS, MAX_SPARSE_DIM, &stopped);
 
-    let mut result_size = 0;
-    let mut query_count = 0;
+    let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let index_dir = Builder::new().prefix("index_dir").tempdir().unwrap();
 
-    group.bench_function("sparse-index-search", |b| {
+    let sparse_vector_index = fixture_sparse_index_ram(
+        &mut rnd,
+        NUM_VECTORS,
+        MAX_SPARSE_DIM,
+        payload_dir.path(),
+        storage_dir.path(),
+        index_dir.path(),
+        &stopped,
+    );
+
+    // adding payload on field
+    let field_name = "field";
+    let field_value = "important value";
+    let payload: Payload = json!({
+        field_name: field_value,
+    })
+    .into();
+
+    // all points have the same payload
+    let mut payload_index = sparse_vector_index.payload_index.borrow_mut();
+    for idx in 0..NUM_VECTORS {
+        payload_index
+            .assign(idx as PointOffsetType, &payload)
+            .unwrap();
+    }
+    drop(payload_index);
+
+    // shared query vector
+    let sparse_vector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+    eprintln!("sparse_vector size = {:#?}", sparse_vector.values.len());
+    let query_vector = sparse_vector.into();
+
+    group.bench_function("inverted-index", |b| {
         b.iter(|| {
-            let sparse_vector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
-            let query_vector = sparse_vector.into();
-            result_size += sparse_vector_index
-                .search(&[&query_vector], None, 1, None, &stopped)
-                .unwrap()
-                .len();
+            let results = sparse_vector_index
+                .search(&[&query_vector], None, TOP, None, &stopped)
+                .unwrap();
 
-            query_count += 1;
+            assert_eq!(results[0].len(), TOP);
         })
     });
 
-    eprintln!(
-        "result_size / query_count = {:#?}",
-        result_size / query_count
-    );
+    // filter by field
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        field_name,
+        field_value.to_owned().into(),
+    )));
+
+    group.bench_function("inverted-index-filtered-plain", |b| {
+        b.iter(|| {
+            let results = sparse_vector_index
+                .search(&[&query_vector], Some(&filter), TOP, None, &stopped)
+                .unwrap();
+
+            assert_eq!(results[0].len(), TOP);
+        })
+    });
+
+    group.bench_function("plain-storage", |b| {
+        b.iter(|| {
+            let results = sparse_vector_index
+                .search_plain(&[&query_vector], &filter, TOP, &stopped)
+                .unwrap();
+
+            assert_eq!(results[0].len(), TOP);
+        })
+    });
+
+    let mut payload_index = sparse_vector_index.payload_index.borrow_mut();
+
+    // create payload field index
+    payload_index
+        .set_indexed(field_name, Keyword.into())
+        .unwrap();
+
+    drop(payload_index);
+
+    group.bench_function("inverted-index-filtered-payload-index", |b| {
+        b.iter(|| {
+            let results = sparse_vector_index
+                .search(&[&query_vector], Some(&filter), TOP, None, &stopped)
+                .unwrap();
+
+            assert_eq!(results[0].len(), TOP);
+        })
+    });
+
+    group.bench_function("payload-index", |b| {
+        b.iter(|| {
+            let results = sparse_vector_index
+                .search_plain(&[&query_vector], &filter, TOP, &stopped)
+                .unwrap();
+
+            assert_eq!(results[0].len(), TOP);
+        })
+    });
 
     group.finish();
 }

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -8,7 +8,6 @@ use rand::Rng;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
-use tempfile::Builder;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
@@ -24,12 +23,10 @@ use crate::vector_storage::VectorStorage;
 /// Helper to open a test sparse vector index
 pub fn fixture_open_sparse_index<I: InvertedIndex>(
     index_dir: &Path,
+    payload_dir: &Path,
+    storage_dir: &Path,
     num_vectors: usize, // used to size the id tracker
 ) -> OperationResult<SparseVectorIndex<I>> {
-    // temp dirs
-    let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
-    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
-
     // setup
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num_vectors)));
     let payload_storage = InMemoryPayloadStorage::default();
@@ -37,12 +34,12 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
     let payload_index = StructPayloadIndex::open(
         wrapped_payload_storage,
         id_tracker.clone(),
-        payload_dir.path(),
+        payload_dir,
         true,
     )?;
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
 
-    let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let db = open_db(storage_dir, &[DB_VECTOR_CF]).unwrap();
     let vector_storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot)?;
 
     let sparse_vector_index: SparseVectorIndex<I> = SparseVectorIndex::open(
@@ -60,10 +57,13 @@ pub fn fixture_sparse_index_ram<R: Rng + ?Sized>(
     rnd: &mut R,
     num_vectors: usize,
     max_dim: usize,
+    payload_dir: &Path,
+    storage_dir: &Path,
+    index_dir: &Path,
     stopped: &AtomicBool,
 ) -> SparseVectorIndex<InvertedIndexRam> {
-    let index_dir = Builder::new().prefix("index_dir").tempdir().unwrap();
-    let mut sparse_vector_index = fixture_open_sparse_index(index_dir.path(), num_vectors).unwrap();
+    let mut sparse_vector_index =
+        fixture_open_sparse_index(index_dir, payload_dir, storage_dir, num_vectors).unwrap();
     let mut borrowed_storage = sparse_vector_index.vector_storage.borrow_mut();
 
     // add points to storage

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -8,6 +8,7 @@ use crate::telemetry::VectorIndexSearchesTelemetry;
 pub struct SparseSearchesTelemetry {
     pub filtered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
     pub unfiltered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
+    pub filtered_plain: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
 impl SparseSearchesTelemetry {
@@ -15,6 +16,7 @@ impl SparseSearchesTelemetry {
         SparseSearchesTelemetry {
             filtered_sparse: OperationDurationsAggregator::new(),
             unfiltered_sparse: OperationDurationsAggregator::new(),
+            filtered_plain: OperationDurationsAggregator::new(),
         }
     }
 }
@@ -30,7 +32,7 @@ impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
         VectorIndexSearchesTelemetry {
             index_name: None,
             unfiltered_plain: Default::default(),
-            filtered_plain: Default::default(),
+            filtered_plain: value.filtered_plain.lock().get_statistics(),
             unfiltered_hnsw: Default::default(),
             filtered_small_cardinality: Default::default(),
             filtered_large_cardinality: Default::default(),

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -21,7 +21,7 @@ use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 use crate::vector_storage::sparse_raw_scorer::sparse_check_vector;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum};
 
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     pub id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
@@ -69,7 +69,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         with_filter: bool,
         condition: impl Fn(PointOffsetType) -> bool,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let mut result = vec![];
+        let mut result = Vec::with_capacity(vectors.len());
 
         for vector in vectors {
             check_process_stopped(is_stopped)?;
@@ -119,6 +119,35 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             }
         }
         unique_record_ids.len()
+    }
+
+    /// Plain search not using the inverted index.
+    pub fn search_plain(
+        &self,
+        vectors: &[&QueryVector],
+        filter: &Filter,
+        top: usize,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let mut results = Vec::with_capacity(vectors.len());
+        let id_tracker = self.id_tracker.borrow();
+        let payload_index = self.payload_index.borrow();
+        let vector_storage: &VectorStorageEnum = &self.vector_storage.borrow();
+        for &vector in vectors {
+            check_process_stopped(is_stopped)?;
+            let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_sparse);
+            let raw_scorer = new_stoppable_raw_scorer(
+                vector.clone(),
+                vector_storage,
+                id_tracker.deleted_point_bitslice(),
+                is_stopped,
+            )?;
+            let filtered_points = payload_index.query_points(filter);
+            let search_results =
+                raw_scorer.peek_top_iter(&mut filtered_points.iter().copied(), top);
+            results.push(search_results);
+        }
+        Ok(results)
     }
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -132,7 +132,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let mut results = Vec::with_capacity(vectors.len());
         let id_tracker = self.id_tracker.borrow();
         let payload_index = self.payload_index.borrow();
-        let vector_storage: &VectorStorageEnum = &self.vector_storage.borrow();
+        let vector_storage = &self.vector_storage.borrow();
         for &vector in vectors {
             check_process_stopped(is_stopped)?;
             let _timer = ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_sparse);

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -1,9 +1,10 @@
+use std::ops::Range;
+
 use rand::Rng;
 
 use crate::common::sparse_vector::SparseVector;
 
-const MIN_WEIGHT: f64 = -100.0;
-const MAX_WEIGHT: f64 = 100.0;
+const VALUE_RANGE: Range<f64> = -100.0..100.0;
 // Realistic max sizing based on experiences with Splade
 const MAX_VALUES_PER_VECTOR: usize = 300;
 
@@ -20,7 +21,7 @@ pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_dim_size: usiz
         // high probability of skipping a dimension to make the vectors more sparse
         let no_skip = rnd_gen.gen_bool(0.01);
         if no_skip {
-            tuples.push((i as i32, rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT)));
+            tuples.push((i as i32, rnd_gen.gen_range(VALUE_RANGE)));
         }
     }
 
@@ -28,7 +29,7 @@ pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_dim_size: usiz
     if tuples.is_empty() {
         tuples.push((
             rnd_gen.gen_range(1..max_dim_size) as i32,
-            rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT),
+            rnd_gen.gen_range(VALUE_RANGE),
         ));
     }
 
@@ -43,7 +44,7 @@ pub fn random_full_sparse_vector<R: Rng + ?Sized>(
     let mut tuples: Vec<(i32, f64)> = vec![];
 
     for i in 1..=max_size {
-        tuples.push((i as i32, rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT)));
+        tuples.push((i as i32, rnd_gen.gen_range(VALUE_RANGE)));
     }
 
     SparseVector::from(tuples)

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -2,23 +2,33 @@ use rand::Rng;
 
 use crate::common::sparse_vector::SparseVector;
 
+const MIN_WEIGHT: f64 = -100.0;
+const MAX_WEIGHT: f64 = 100.0;
+// Realistic max sizing based on experiences with Splade
+const MAX_VALUES_PER_VECTOR: usize = 300;
+
 /// Generates a non empty sparse vector
-pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_size: usize) -> SparseVector {
-    let size = rnd_gen.gen_range(1..max_size);
+pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_dim_size: usize) -> SparseVector {
+    let size = rnd_gen.gen_range(1..max_dim_size);
     let mut tuples: Vec<(i32, f64)> = vec![];
 
     for i in 1..=size {
-        let no_skip = rnd_gen.gen_bool(0.5);
+        // make sure the vector is not too large (for performance reasons)
+        if tuples.len() == MAX_VALUES_PER_VECTOR {
+            break;
+        }
+        // high probability of skipping a dimension to make the vectors more sparse
+        let no_skip = rnd_gen.gen_bool(0.01);
         if no_skip {
-            tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+            tuples.push((i as i32, rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT)));
         }
     }
 
     // make sure we have at least one vector
     if tuples.is_empty() {
         tuples.push((
-            rnd_gen.gen_range(1..max_size) as i32,
-            rnd_gen.gen_range(0.0..100.0),
+            rnd_gen.gen_range(1..max_dim_size) as i32,
+            rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT),
         ));
     }
 
@@ -33,7 +43,7 @@ pub fn random_full_sparse_vector<R: Rng + ?Sized>(
     let mut tuples: Vec<(i32, f64)> = vec![];
 
     for i in 1..=max_size {
-        tuples.push((i as i32, rnd_gen.gen_range(0.0..100.0)));
+        tuples.push((i as i32, rnd_gen.gen_range(MIN_WEIGHT..MAX_WEIGHT)));
     }
 
     SparseVector::from(tuples)

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -215,6 +215,7 @@ impl<'a> PostingListIterator<'a> {
     /// If the iterator skipped to the end, None is returned and current index is set to the length of the list.
     /// Uses binary search.
     pub fn skip_to(&mut self, id: PointOffsetType) -> Option<&PostingElement> {
+        // Check if we are already at the end
         if self.current_index >= self.elements.len() {
             return None;
         }


### PR DESCRIPTION
This PR introduces benchmarks for various access pattern on the sparse index vector.

The idea is to gather data to find the sweet spot for a potential fallback to plain & payload search.

## Benchmarks

Run it yourself with:

`cargo bench -p segment --bench sparse_index_search`

The current parameters are:

- 50k points
- sparse vector query with 200 values
- top 10
- with and without filter
- with and without payload index

![sparse-plain](https://github.com/qdrant/qdrant/assets/606963/563d345f-f490-4aaa-88a1-50da107cc6d0)

- `inverted-index`: sparse search without filter
- `inverted-index-filtered-payload-index`: sparse search with filter on indexed payload key
- `inverted-index-filtered-payload-plain`: sparse search with filter on non-indexed payload key
- `payload-index`: plain search using filter on indexed payload key
- `plain-storage`: plain search using filter on non-indexed payload key

## Insights

While playing with the size of the sparse vector query, I noticed it has a large impact on the inverted index performance (smaller better).
  - less than 100 is fast
  - less than 300 is Ok. 

## Future Work

Wire the `search_plain` method behind a heuristic for fallback.

Something like:
- if small query vector then use sparse index
- if low cardinality use plain search

