### PR TITLE
Transform `max_ack_version` from mutex into atomic

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -362,8 +362,9 @@ impl Inner {
     /// Providing `None` will release this limitation.
     async fn set_max_ack_version(&self, max_version: Option<u64>) {
         let update_handler = self.wrapped_shard.update_handler.lock().await;
-        let mut max_ack_version = update_handler.max_ack_version.lock().await;
-        *max_ack_version = max_version;
+        update_handler
+            .max_ack_version
+            .store(max_version.unwrap_or(u64::MAX), Ordering::Relaxed);
     }
 }
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -169,7 +169,7 @@ impl ShardReplicaSet {
                     Err((err, queue_proxy)) => {
                         log::error!("Failed to un-proxify local shard because transferring remaining queue items to remote failed: {err}");
                         let (wrapped_shard, _remote_shard) =
-                            queue_proxy.forget_updates_and_finalize().await;
+                            queue_proxy.forget_updates_and_finalize();
                         (Err(err), wrapped_shard)
                     }
                 };
@@ -206,7 +206,7 @@ impl ShardReplicaSet {
         };
 
         log::debug!("Forgetting queue proxy updates and reverting to local shard");
-        let (local_shard, _) = queue_proxy.forget_updates_and_finalize().await;
+        let (local_shard, _) = queue_proxy.forget_updates_and_finalize();
         let _ = local_write.insert(Shard::Local(local_shard));
     }
 


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

This transforms the `max_ack_version` parameter in the update handler from a shared mutex into a shared atomic.

It is required for safe shard snapshot transfer cancellation. For safety, it cannot rely on `async`/`await` which was used for locking, and a synchronous lock would block the runtime. An atomic parameter solves the issue.

As a bonus this removes some locking steps across our code base, and removes the `async` marker from some methods.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
