### PR TITLE
Add csharp_namespace option to protos

### DIFF
--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 message VectorParams {
   uint64 size = 1; // Size of the vectors

--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "collections.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service CollectionsInternal {
   /*

--- a/lib/api/src/grpc/proto/collections_service.proto
+++ b/lib/api/src/grpc/proto/collections_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "collections.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service Collections {
   /*

--- a/lib/api/src/grpc/proto/health_check.proto
+++ b/lib/api/src/grpc/proto/health_check.proto
@@ -2,6 +2,7 @@
 syntax = "proto3";
 
 package grpc.health.v1;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 message HealthCheckRequest {
   string service = 1;

--- a/lib/api/src/grpc/proto/json_with_int.proto
+++ b/lib/api/src/grpc/proto/json_with_int.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 // `Struct` represents a structured data value, consisting of fields
 // which map to dynamically typed values. In some languages, `Struct`

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "json_with_int.proto";
 import "collections.proto";

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "points.proto";
 
 package qdrant;
-
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service PointsInternal {
   rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "points.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 
 service Points {

--- a/lib/api/src/grpc/proto/qdrant.proto
+++ b/lib/api/src/grpc/proto/qdrant.proto
@@ -11,6 +11,7 @@ import "shard_snapshots_service.proto";
 import "snapshots_service.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service Qdrant {
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckReply) {}

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service QdrantInternal {
   /*

--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "google/protobuf/empty.proto";
 

--- a/lib/api/src/grpc/proto/shard_snapshots_service.proto
+++ b/lib/api/src/grpc/proto/shard_snapshots_service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "snapshots_service.proto";
 

--- a/lib/api/src/grpc/proto/snapshots_service.proto
+++ b/lib/api/src/grpc/proto/snapshots_service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "google/protobuf/timestamp.proto";
 


### PR DESCRIPTION
This commit adds the csharp_namespace option to proto files, allowing the C# gRPC client generated from the protos to be generated with the namespace used in the official .NET client, without needing to patch the values in.

Closes qdrant/qdrant-dotnet#3

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
