### PR TITLE
Fix `try_set_capacity` functions

### DIFF
--- a/lib/segment/src/common/vector_utils.rs
+++ b/lib/segment/src/common/vector_utils.rs
@@ -10,16 +10,81 @@ pub trait TrySetCapacityExact {
 
 impl<T> TrySetCapacity for Vec<T> {
     fn try_set_capacity(&mut self, capacity: usize) -> Result<(), TryReserveError> {
-        let current_capacity = self.capacity();
-        let additional_capacity = capacity.saturating_sub(current_capacity);
-        self.try_reserve(additional_capacity)
+        let additional = capacity.saturating_sub(self.len());
+        self.try_reserve(additional)
     }
 }
 
 impl<T> TrySetCapacityExact for Vec<T> {
     fn try_set_capacity_exact(&mut self, capacity: usize) -> Result<(), TryReserveError> {
-        let current_capacity = self.capacity();
-        let additional_capacity = capacity.saturating_sub(current_capacity);
-        self.try_reserve_exact(additional_capacity)
+        let additional = capacity.saturating_sub(self.len());
+        self.try_reserve_exact(additional)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_set_capacity() {
+        // Constructing uses exact capacity
+        let mut v = vec![1, 2, 3];
+        assert_eq!(v.capacity(), 3);
+
+        // Set capacity to 5, but it will double to 6
+        v.try_set_capacity(5).unwrap();
+        assert_eq!(v.capacity(), 6);
+
+        // Setting capacity again does nothing
+        v.try_set_capacity(5).unwrap();
+        assert_eq!(v.capacity(), 6);
+
+        // Fill up to capacity
+        v.extend([4, 5, 6]);
+        assert_eq!(v.capacity(), 6);
+
+        // Push over capacity will double it
+        v.push(7);
+        assert_eq!(v.capacity(), 12);
+
+        // Set capacity to 100
+        v.try_set_capacity(100).unwrap();
+        assert_eq!(v.capacity(), 100);
+
+        // Capacity will never shrink
+        v.try_set_capacity(5).unwrap();
+        assert_eq!(v.capacity(), 100);
+    }
+
+    #[test]
+    fn test_try_set_capacity_exact() {
+        // Constructing uses exact capacity
+        let mut v = vec![1, 2, 3];
+        assert_eq!(v.capacity(), 3);
+
+        // Set capacity to exactly 5
+        v.try_set_capacity_exact(5).unwrap();
+        assert_eq!(v.capacity(), 5);
+
+        // Setting capacity again does nothing
+        v.try_set_capacity_exact(5).unwrap();
+        assert_eq!(v.capacity(), 5);
+
+        // Fill up to capacity
+        v.extend([4, 5]);
+        assert_eq!(v.capacity(), 5);
+
+        // Push over capacity will double it
+        v.push(6);
+        assert_eq!(v.capacity(), 10);
+
+        // Set capacity to exactly 100
+        v.try_set_capacity_exact(100).unwrap();
+        assert_eq!(v.capacity(), 100);
+
+        // Capacity will never shrink
+        v.try_set_capacity_exact(5).unwrap();
+        assert_eq!(v.capacity(), 100);
     }
 }

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -79,7 +79,9 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
                 // Once we have more than one chunk, we don't want to overallocate
                 // and we keep the exact capacity of each chunk.
                 let desired_capacity = self.chunk_capacity * self.dim;
-                chunk_data.try_set_capacity_exact(desired_capacity)?;
+                if chunk_data.capacity() == 0 {
+                    chunk_data.try_set_capacity_exact(desired_capacity)?;
+                }
             }
             chunk_data.resize(idx + self.dim, T::default());
         }

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use common::types::PointOffsetType;
 
 use super::div_ceil;
-use crate::common::vector_utils::{TrySetCapacity, TrySetCapacityExact};
+use crate::common::vector_utils::TrySetCapacityExact;
 
 // chunk size in bytes
 const CHUNK_SIZE: usize = 32 * 1024 * 1024;
@@ -17,9 +17,14 @@ const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 const MIN_CHUNK_CAPACITY: usize = 16;
 
 pub struct ChunkedVectors<T> {
+    /// Vector's dimension.
+    ///
+    /// Each vector will consume `size_of::<T>() * dim` bytes.
     dim: usize,
-    len: usize,            // amount of stored vectors
-    chunk_capacity: usize, // max amount of vectors in each chunk
+    /// Number of stored vectors in all chunks.
+    len: usize,
+    /// Maximum number of vectors in each chunk.
+    chunk_capacity: usize,
     chunks: Vec<Vec<T>>,
 }
 
@@ -69,15 +74,20 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
         let chunk_idx = key / self.chunk_capacity;
         let chunk_data = &mut self.chunks[chunk_idx];
         let idx = (key % self.chunk_capacity) * self.dim;
+
+        // Grow the current chunk if needed to fit the new vector.
+        //
+        // All chunks are dynamically resized to fit their vectors in it.
+        // Chunks have a size of zero by default. It's grown with zeroes to fit new vectors.
+        //
+        // The capacity for the first chunk is allocated normally to keep the memory footprint as
+        // small as possible, see
+        // <https://doc.rust-lang.org/std/vec/struct.Vec.html#capacity-and-reallocation>).
+        // All other chunks allocate their capacity in full on first use to prevent expensive
+        // reallocations when their data grows.
         if chunk_data.len() < idx + self.dim {
-            if chunk_idx == 0 {
-                // Do not overallocate the first chunk, because it is likely to be small
-                // and we don't want to waste memory.
-                let desired_capacity = idx + self.dim;
-                chunk_data.try_set_capacity(desired_capacity)?;
-            } else {
-                // Once we have more than one chunk, we don't want to overallocate
-                // and we keep the exact capacity of each chunk.
+            // If the chunk is not the first one, allocate it fully on first use
+            if chunk_idx != 0 {
                 let desired_capacity = self.chunk_capacity * self.dim;
                 if chunk_data.capacity() == 0 {
                     chunk_data.try_set_capacity_exact(desired_capacity)?;
@@ -85,8 +95,10 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
             }
             chunk_data.resize(idx + self.dim, T::default());
         }
+
         let data = &mut chunk_data[idx..idx + self.dim];
         data.copy_from_slice(vector);
+
         Ok(())
     }
 }

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -89,9 +89,7 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
             // If the chunk is not the first one, allocate it fully on first use
             if chunk_idx != 0 {
                 let desired_capacity = self.chunk_capacity * self.dim;
-                if chunk_data.capacity() == 0 {
-                    chunk_data.try_set_capacity_exact(desired_capacity)?;
-                }
+                chunk_data.try_set_capacity_exact(desired_capacity)?;
             }
             chunk_data.resize(idx + self.dim, T::default());
         }


### PR DESCRIPTION
Fixes the `try_set_capacity{,_exact}` functions. Our logic was wrong.

The [`reserve`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.reserve) function does not reserve additional capacity, but it reserves capacity to fix an additional extra items over `len`.

I've added some unit tests to confirm the change is correct.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
