### PR TITLE
fix `test_discover_same_target`

### DIFF
--- a/openapi/tests/openapi_integration/test_discovery.py
+++ b/openapi/tests/openapi_integration/test_discovery.py
@@ -218,8 +218,6 @@ def test_discover_same_target():
 
     # We keep same target, so context part of the score (integer part) can be different,
     # while target part of the score (decimal part) should be the same
-    assert scored_points1 != scored_points2
-
     scored_points2_map = {point["id"]: point for point in scored_points2}
 
     for point1 in scored_points1:


### PR DESCRIPTION
Since context part of discover search moves in integer steps, it is not a guarantee that same order (and scores) will be the result of using two different contexts and same target. 

So, this assertion shouldn't be here.