### PR TITLE
Add possible fallback to plain search for sparse vectors

### DIFF
--- a/lib/segment/src/index/sparse_index/mod.rs
+++ b/lib/segment/src/index/sparse_index/mod.rs
@@ -1,3 +1,4 @@
 #![allow(dead_code)]
+pub mod sparse_index_config;
 pub mod sparse_search_telemetry;
 pub mod sparse_vector_index;

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -1,0 +1,36 @@
+use std::path::{Path, PathBuf};
+
+use io::file_operations::{atomic_save_json, read_json};
+use serde::{Deserialize, Serialize};
+
+use crate::common::operation_error::OperationResult;
+
+pub const SPARSE_INDEX_CONFIG_FILE: &str = "sparse_index_config.json";
+
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
+pub struct SparseIndexConfig {
+    /// We prefer a full scan search upto (excluding) this number of vectors.
+    ///
+    /// Note: this is number of vectors, not KiloBytes.
+    pub full_scan_threshold: usize,
+}
+
+impl SparseIndexConfig {
+    pub fn new(full_scan_threshold: usize) -> Self {
+        SparseIndexConfig {
+            full_scan_threshold,
+        }
+    }
+
+    pub fn get_config_path(path: &Path) -> PathBuf {
+        path.join(SPARSE_INDEX_CONFIG_FILE)
+    }
+
+    pub fn load(path: &Path) -> OperationResult<Self> {
+        Ok(read_json(path)?)
+    }
+
+    pub fn save(&self, path: &Path) -> OperationResult<()> {
+        Ok(atomic_save_json(path, self)?)
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -9,6 +9,7 @@ pub struct SparseSearchesTelemetry {
     pub filtered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
     pub unfiltered_sparse: Arc<Mutex<OperationDurationsAggregator>>,
     pub filtered_plain: Arc<Mutex<OperationDurationsAggregator>>,
+    pub small_cardinality: Arc<Mutex<OperationDurationsAggregator>>,
 }
 
 impl SparseSearchesTelemetry {
@@ -17,6 +18,7 @@ impl SparseSearchesTelemetry {
             filtered_sparse: OperationDurationsAggregator::new(),
             unfiltered_sparse: OperationDurationsAggregator::new(),
             filtered_plain: OperationDurationsAggregator::new(),
+            small_cardinality: OperationDurationsAggregator::new(),
         }
     }
 }
@@ -34,7 +36,7 @@ impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
             unfiltered_plain: Default::default(),
             filtered_plain: value.filtered_plain.lock().get_statistics(),
             unfiltered_hnsw: Default::default(),
-            filtered_small_cardinality: Default::default(),
+            filtered_small_cardinality: value.small_cardinality.lock().get_statistics(),
             filtered_large_cardinality: Default::default(),
             filtered_exact: Default::default(),
             filtered_sparse: value.filtered_sparse.lock().get_statistics(),

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -42,6 +42,21 @@ impl SparseVector {
         }
         score
     }
+
+    /// Check if this vector overlaps with another vector.
+    /// Warning: Expects both vectors to be sorted by indices.
+    pub fn overlaps(&self, other: &SparseVector) -> bool {
+        let mut i = 0;
+        let mut j = 0;
+        while i < self.indices.len() && j < other.indices.len() {
+            match self.indices[i].cmp(&other.indices[j]) {
+                std::cmp::Ordering::Less => i += 1,
+                std::cmp::Ordering::Greater => j += 1,
+                std::cmp::Ordering::Equal => return true,
+            }
+        }
+        false
+    }
 }
 impl TryFrom<Vec<(i32, f64)>> for SparseVector {
     type Error = ValidationErrors;
@@ -136,5 +151,24 @@ mod tests {
 
         let not_unique = SparseVector::new(vec![1, 2, 2], vec![1.0, 2.0, 3.0]);
         assert!(not_unique.is_err());
+    }
+
+    #[test]
+    fn overlaps_test() {
+        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = SparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
+        assert!(v1.overlaps(&v2));
+
+        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = SparseVector::new(vec![4, 5, 6], vec![2.0, 3.0, 4.0]).unwrap();
+        assert!(!v1.overlaps(&v2));
+
+        let v1 = SparseVector::new(vec![2, 3], vec![2.0, 3.0]).unwrap();
+        let v2 = SparseVector::new(vec![3, 4, 5], vec![2.0, 3.0, 4.0]).unwrap();
+        assert!(v1.overlaps(&v2));
+
+        let v1 = SparseVector::new(vec![3, 4, 5], vec![2.0, 3.0, 4.0]).unwrap();
+        let v2 = SparseVector::new(vec![2, 3], vec![2.0, 3.0]).unwrap();
+        assert!(v1.overlaps(&v2));
     }
 }

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -4,8 +4,9 @@ use rand::Rng;
 
 use crate::common::sparse_vector::SparseVector;
 
-const VALUE_RANGE: Range<f64> = -100.0..100.0;
-// Realistic max sizing based on experiences with Splade
+// TODO(sparse) support negative values
+const VALUE_RANGE: Range<f64> = 0.0..100.0;
+// Realistic sizing based on experiences with Splade
 const MAX_VALUES_PER_VECTOR: usize = 300;
 
 /// Generates a non empty sparse vector

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -19,8 +19,8 @@ use crate::index::inverted_index::InvertedIndex;
 use crate::index::posting_list::{PostingElement, PostingListIterator};
 
 const POSTING_HEADER_SIZE: usize = size_of::<PostingListFileHeader>();
-const INDEX_FILE_NAME: &str = "index.data";
-const INDEX_CONFIG_FILE_NAME: &str = "index_config.json";
+const INDEX_FILE_NAME: &str = "inverted_index.data";
+const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {


### PR DESCRIPTION
This PR adds a simple fallback to filtered search based on the cardinality estimated.

The fallback is done using a simplified version of the heuristic done for HNSW.

While writing tests to assert the equivalence of the results between inverted index and plain search, I noticed two issues.

1 - The inverted index does not handle negative weights whereas plain search does.

Negative weights do not interact well with pruning, I will propose a fix in a different PR

2 - The plain search is returning more vector than the inverted index

It happens for the vectors which have no intersections with the query vector in dimension.
The sparse inverted index never returns those, because those posting lists are not explored.
Whereas the plain search returns those and scores them zero.

The proposed solution is to filter out explicitly plain filtered vectors without overlap in dimensions within the `SparseRawScorer.`
