### PR TITLE
Integrate vector into NamedVectors struct

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -74,8 +74,8 @@ pub fn random_multi_vec_segment(
         let random_vector1: Vec<_> = (0..dim1).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let random_vector2: Vec<_> = (0..dim2).map(|_| rnd.gen_range(0.0..1.0)).collect();
         let mut vectors = NamedVectors::default();
-        vectors.insert("vector1".to_owned(), random_vector1);
-        vectors.insert("vector2".to_owned(), random_vector2);
+        vectors.insert("vector1".to_owned(), random_vector1.into());
+        vectors.insert("vector2".to_owned(), random_vector2.into());
 
         let point_id: PointIdType = id_gen.unique();
         let payload_value = rnd.gen_range(1..1_000);

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -440,7 +440,7 @@ impl SegmentEntry for ProxySegment {
             .keys()
         {
             if let Some(vector) = self.vector(vector_name, point_id)? {
-                result.insert(vector_name.clone(), vector);
+                result.insert(vector_name.clone(), vector.into());
             }
         }
         Ok(result)

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -325,7 +325,7 @@ impl SegmentsSearcher {
                                 let mut selected_vectors = NamedVectors::default();
                                 for vector_name in vector_names {
                                     if let Some(vector) = segment.vector(vector_name, id)? {
-                                        selected_vectors.insert(vector_name.into(), vector);
+                                        selected_vectors.insert(vector_name.into(), vector.into());
                                     }
                                 }
                                 Some(selected_vectors.into())

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -7,7 +7,9 @@ use schemars::schema::{ObjectValidation, Schema, SchemaObject, SubschemaValidati
 use schemars::JsonSchema;
 use segment::common::utils::transpose_map_into_named_vector;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::{only_default_vector, BatchVectorStruct, VectorStruct};
+use segment::data_types::vectors::{
+    only_default_vector, BatchVectorStruct, Vector, VectorStruct, VectorType,
+};
 use segment::types::{Filter, Payload, PointIdType};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -369,7 +371,9 @@ impl SplitByShard for Batch {
                         let batch_vectors = batch.vectors.multi();
                         for (name, vector) in named_vector {
                             let name = name.into_owned();
-                            let vector = vector.into_owned();
+                            let vector: Vector = vector.to_owned();
+                            // TODO(sparse) remove this unwrap after sparse vectors are supported in `Batch`
+                            let vector: VectorType = vector.try_into().unwrap();
                             batch_vectors.entry(name).or_default().push(vector);
                         }
                         batch.payloads.as_mut().unwrap().push(payload);
@@ -407,7 +411,9 @@ impl SplitByShard for Batch {
                         let batch_vectors = batch.vectors.multi();
                         for (name, vector) in named_vector {
                             let name = name.into_owned();
-                            let vector = vector.into_owned();
+                            let vector: Vector = vector.to_owned();
+                            // TODO(sparse) remove this unwrap after sparse vectors are supported in `Batch`
+                            let vector: VectorType = vector.try_into().unwrap();
                             batch_vectors.entry(name).or_default().push(vector);
                         }
                     }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -94,8 +94,8 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     let mut points = Vec::new();
     for i in 0..1000 {
         let mut vectors = NamedVectors::default();
-        vectors.insert(VEC_NAME1.to_string(), vec![i as f32, 0.0, 0.0, 0.0]);
-        vectors.insert(VEC_NAME2.to_string(), vec![0.0, i as f32, 0.0, 0.0]);
+        vectors.insert(VEC_NAME1.to_string(), vec![i as f32, 0.0, 0.0, 0.0].into());
+        vectors.insert(VEC_NAME2.to_string(), vec![0.0, i as f32, 0.0, 0.0].into());
 
         points.push(PointStruct {
             id: i.into(),

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -91,7 +91,7 @@ pub fn check_named_vectors(
     segment_config: &SegmentConfig,
 ) -> OperationResult<()> {
     for (vector_name, vector_data) in vectors.iter() {
-        check_vector(vector_name, &vector_data.to_vec().into(), segment_config)?;
+        check_vector(vector_name, &vector_data.into(), segment_config)?;
     }
     Ok(())
 }

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -432,7 +432,7 @@ pub fn transpose_map_into_named_vector(
     for (key, values) in map {
         result.resize_with(values.len(), NamedVectors::default);
         for (i, value) in values.into_iter().enumerate() {
-            result[i].insert(key.clone(), value);
+            result[i].insert(key.clone(), value.into());
         }
     }
     result

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -165,10 +165,11 @@ impl<'a> NamedVectors<'a> {
         self.map.iter().map(|(k, _)| k.as_ref())
     }
 
-    pub fn into_default_vector(mut self) -> Option<Vector> {
+    // TODO(sparse) remove this function. There is only one usage and this fn is logically strange
+    pub fn into_default_vector(mut self) -> Option<Vec<VectorElementType>> {
         self.map.get_mut(DEFAULT_VECTOR_NAME).map(|src| match src {
-            CowValue::Dense(src) => Vector::Dense(std::mem::take(src).into_owned()),
-            CowValue::Sparse(src) => Vector::Sparse(std::mem::take(src).into_owned()),
+            CowValue::Dense(v) => std::mem::take(v).into_owned(),
+            CowValue::Sparse(_v) => unreachable!(),
         })
     }
 

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -137,17 +137,16 @@ impl<'a> NamedVectors<'a> {
 
     pub fn preprocess<F>(&mut self, distance_map: F)
     where
-        F: Fn(&str) -> Option<Distance>,
+        F: Fn(&str) -> Distance,
     {
         for (name, vector) in self.map.iter_mut() {
-            if let Some(distance) = distance_map(name) {
-                match vector {
-                    CowValue::Dense(v) => {
-                        let preprocessed_vector = distance.preprocess_vector(v.to_vec());
-                        *vector = CowValue::Dense(Cow::Owned(preprocessed_vector))
-                    }
-                    CowValue::Sparse(_) => {}
+            let distance = distance_map(name);
+            match vector {
+                CowValue::Dense(v) => {
+                    let preprocessed_vector = distance.preprocess_vector(v.to_vec());
+                    *vector = CowValue::Dense(Cow::Owned(preprocessed_vector))
                 }
+                CowValue::Sparse(_) => {}
             }
         }
     }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -35,6 +35,13 @@ impl<'a> CowValue<'a> {
             CowValue::Sparse(v) => Vector::Sparse(v.into_owned()),
         }
     }
+
+    pub fn as_vec_ref(&self) -> VectorRef {
+        match self {
+            CowValue::Dense(v) => VectorRef::Dense(v.as_ref()),
+            CowValue::Sparse(v) => VectorRef::Sparse(v.as_ref()),
+        }
+    }
 }
 
 impl<'a> NamedVectors<'a> {
@@ -121,23 +128,11 @@ impl<'a> NamedVectors<'a> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&str, VectorRef<'_>)> {
-        self.map.iter().map(|(k, v)| {
-            (
-                k.as_ref(),
-                match v {
-                    CowValue::Dense(v) => VectorRef::Dense(v.as_ref()),
-                    CowValue::Sparse(v) => VectorRef::Sparse(v.as_ref()),
-                },
-            )
-        })
+        self.map.iter().map(|(k, v)| (k.as_ref(), v.as_vec_ref()))
     }
 
     pub fn get(&self, key: &str) -> Option<VectorRef<'_>> {
-        match self.map.get(key) {
-            Some(CowValue::Dense(v)) => Some(VectorRef::Dense(v.as_ref())),
-            Some(CowValue::Sparse(v)) => Some(VectorRef::Sparse(v.as_ref())),
-            None => None,
-        }
+        self.map.get(key).map(|v| v.as_vec_ref())
     }
 
     pub fn preprocess<F>(&mut self, distance_map: F)

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -116,15 +116,7 @@ impl<'a> NamedVectors<'a> {
     pub fn into_owned_map(self) -> HashMap<String, Vector> {
         self.map
             .into_iter()
-            .map(|(k, v)| {
-                (
-                    k.into_owned(),
-                    match v {
-                        CowValue::Dense(src) => Vector::Dense(src.into_owned()),
-                        CowValue::Sparse(src) => Vector::Sparse(src.into_owned()),
-                    },
-                )
-            })
+            .map(|(k, v)| (k.into_owned(), v.to_owned()))
             .collect()
     }
 

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -68,32 +68,6 @@ impl<'a> NamedVectors<'a> {
         }
     }
 
-    pub fn from_sparse_map(map: HashMap<String, SparseVector>) -> Self {
-        Self {
-            map: map
-                .into_iter()
-                .map(|(k, v)| (CowKey::from(k), CowValue::Sparse(Cow::Owned(v))))
-                .collect(),
-        }
-    }
-
-    pub fn from_mixed_map(map: HashMap<String, Vector>) -> Self {
-        Self {
-            map: map
-                .into_iter()
-                .map(|(k, v)| {
-                    (
-                        CowKey::from(k),
-                        match v {
-                            Vector::Dense(v) => CowValue::Dense(Cow::Owned(v)),
-                            Vector::Sparse(v) => CowValue::Sparse(Cow::Owned(v)),
-                        },
-                    )
-                })
-                .collect(),
-        }
-    }
-
     pub fn from_map_ref(map: &'a HashMap<String, Vec<VectorElementType>>) -> Self {
         Self {
             map: map

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::tiny_map;
-use super::vectors::{Vector, VectorElementType, VectorRef, DEFAULT_VECTOR_NAME};
+use super::vectors::{Vector, VectorElementType, VectorRef};
 use crate::types::Distance;
 
 type CowKey<'a> = Cow<'a, str>;
@@ -111,14 +111,6 @@ impl<'a> NamedVectors<'a> {
 
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.map.iter().map(|(k, _)| k.as_ref())
-    }
-
-    // TODO(sparse) remove this function. There is only one usage and this fn is logically strange
-    pub fn into_default_vector(mut self) -> Option<Vec<VectorElementType>> {
-        self.map.get_mut(DEFAULT_VECTOR_NAME).map(|src| match src {
-            CowValue::Dense(v) => std::mem::take(v).into_owned(),
-            CowValue::Sparse(_v) => unreachable!(),
-        })
     }
 
     pub fn into_owned_map(self) -> HashMap<String, Vector> {

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -103,32 +103,6 @@ impl<'a> NamedVectors<'a> {
         }
     }
 
-    pub fn from_sparse_map_ref(map: &'a HashMap<String, SparseVector>) -> Self {
-        Self {
-            map: map
-                .iter()
-                .map(|(k, v)| (CowKey::from(k), CowValue::Sparse(Cow::Borrowed(v))))
-                .collect(),
-        }
-    }
-
-    pub fn from_mixed_map_ref(map: &'a HashMap<String, Vector>) -> Self {
-        Self {
-            map: map
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        CowKey::from(k),
-                        match v {
-                            Vector::Dense(v) => CowValue::Dense(Cow::Borrowed(v)),
-                            Vector::Sparse(v) => CowValue::Sparse(Cow::Borrowed(v)),
-                        },
-                    )
-                })
-                .collect(),
-        }
-    }
-
     pub fn insert(&mut self, name: String, vector: Vector) {
         self.map.insert(
             CowKey::Owned(name),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -192,10 +192,9 @@ impl From<&[VectorElementType]> for VectorStruct {
 }
 
 impl<'a> From<NamedVectors<'a>> for VectorStruct {
-    // TODO(sparse): this is temporary conversion while `VectorStruct` does not support sparse vectors
     fn from(v: NamedVectors) -> Self {
         if v.len() == 1 && v.contains_key(DEFAULT_VECTOR_NAME) {
-            VectorStruct::Single(v.into_default_vector().unwrap().try_into().unwrap())
+            VectorStruct::Single(v.into_default_vector().unwrap())
         } else {
             VectorStruct::Multi(
                 v.into_owned_map()

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -143,21 +143,7 @@ pub fn default_vector(vec: Vec<VectorElementType>) -> NamedVectors<'static> {
     NamedVectors::from([(DEFAULT_VECTOR_NAME.to_owned(), vec)])
 }
 
-pub fn default_sparse_vector(vec: SparseVector) -> NamedVectors<'static> {
-    let mut result = NamedVectors::default();
-    result.insert(DEFAULT_VECTOR_NAME.to_owned(), vec.into());
-    result
-}
-
 pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
-    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vec.into())
-}
-
-pub fn only_default_sparse_vector(vec: &SparseVector) -> NamedVectors {
-    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vec.into())
-}
-
-pub fn only_default_mixed_vector(vec: &Vector) -> NamedVectors {
     NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vec.into())
 }
 

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -194,7 +194,8 @@ impl From<&[VectorElementType]> for VectorStruct {
 impl<'a> From<NamedVectors<'a>> for VectorStruct {
     fn from(v: NamedVectors) -> Self {
         if v.len() == 1 && v.contains_key(DEFAULT_VECTOR_NAME) {
-            VectorStruct::Single(v.into_default_vector().unwrap())
+            let vector: &[_] = v.get(DEFAULT_VECTOR_NAME).unwrap().try_into().unwrap();
+            VectorStruct::Single(vector.to_owned())
         } else {
             VectorStruct::Multi(
                 v.into_owned_map()

--- a/lib/segment/src/fixtures/segment_fixtures.rs
+++ b/lib/segment/src/fixtures/segment_fixtures.rs
@@ -25,7 +25,7 @@ pub fn random_segment(path: &Path, num_points: usize) -> Segment {
             .upsert_point(
                 100,
                 (point_id as u64).into(),
-                NamedVectors::from_ref(DEFAULT_VECTOR_NAME, &vector),
+                NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vector.as_slice().into()),
             )
             .unwrap();
         segment

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -23,8 +23,8 @@ use crate::common::version::{StorageVersion, VERSION_FILE};
 use crate::common::{
     check_named_vectors, check_query_vectors, check_stopped, check_vector, check_vector_name,
 };
-use crate::data_types::named_vectors::{CowValue, NamedVectors};
-use crate::data_types::vectors::{QueryVector, VectorElementType, VectorRef};
+use crate::data_types::named_vectors::NamedVectors;
+use crate::data_types::vectors::{QueryVector, VectorElementType};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
@@ -173,10 +173,7 @@ impl Segment {
         check_named_vectors(&vectors, &self.segment_config)?;
         for (vector_name, new_vector) in vectors {
             let vector_data = &self.vector_data[vector_name.as_ref()];
-            let new_vector = match &new_vector {
-                CowValue::Dense(vec) => VectorRef::Dense(vec),
-                CowValue::Sparse(sparse) => VectorRef::Sparse(sparse),
-            };
+            let new_vector = new_vector.as_vec_ref();
             vector_data
                 .vector_storage
                 .borrow_mut()

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -23,8 +23,8 @@ use crate::common::version::{StorageVersion, VERSION_FILE};
 use crate::common::{
     check_named_vectors, check_query_vectors, check_stopped, check_vector, check_vector_name,
 };
-use crate::data_types::named_vectors::NamedVectors;
-use crate::data_types::vectors::{QueryVector, VectorElementType};
+use crate::data_types::named_vectors::{CowValue, NamedVectors};
+use crate::data_types::vectors::{QueryVector, VectorElementType, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
@@ -137,7 +137,7 @@ impl Segment {
             match vector {
                 Some(vector) => {
                     let mut vector_storage = vector_data.vector_storage.borrow_mut();
-                    vector_storage.insert_vector(internal_id, vector.into())?;
+                    vector_storage.insert_vector(internal_id, vector)?;
                     let mut vector_index = vector_data.vector_index.borrow_mut();
                     vector_index.update_vector(internal_id)?;
                 }
@@ -173,10 +173,14 @@ impl Segment {
         check_named_vectors(&vectors, &self.segment_config)?;
         for (vector_name, new_vector) in vectors {
             let vector_data = &self.vector_data[vector_name.as_ref()];
+            let new_vector = match &new_vector {
+                CowValue::Dense(vec) => VectorRef::Dense(vec),
+                CowValue::Sparse(sparse) => VectorRef::Sparse(sparse),
+            };
             vector_data
                 .vector_storage
                 .borrow_mut()
-                .insert_vector(internal_id, new_vector.as_ref().into())?;
+                .insert_vector(internal_id, new_vector)?;
             vector_data
                 .vector_index
                 .borrow_mut()
@@ -211,7 +215,7 @@ impl Segment {
                     vector_index.update_vector(new_index)?;
                 }
                 Some(vec) => {
-                    vector_storage.insert_vector(new_index, vec.into())?;
+                    vector_storage.insert_vector(new_index, vec)?;
                     vector_index.update_vector(new_index)?;
                 }
             }
@@ -432,7 +436,7 @@ impl Segment {
                 let vector_storage = vector_data.vector_storage.borrow();
                 // TODO(sparse) remove unwrap after NamedVectors changes
                 let vector: &[_] = vector_storage.get_vector(point_offset).try_into().unwrap();
-                vectors.insert(vector_name.clone(), vector.to_vec());
+                vectors.insert(vector_name.clone(), vector.to_vec().into());
             }
         }
         Ok(vectors)
@@ -592,7 +596,7 @@ impl Segment {
                             if let Some(vector) =
                                 self.vector_by_offset(vector_name, point_offset)?
                             {
-                                result.insert(vector_name.clone(), vector);
+                                result.insert(vector_name.clone(), vector.into());
                             }
                         }
                         Some(result.into())
@@ -807,7 +811,7 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<bool> {
         debug_assert!(self.is_appendable());
         check_named_vectors(&vectors, &self.segment_config)?;
-        vectors.preprocess(|name| self.segment_config.vector_data[name].distance);
+        vectors.preprocess(|name| Some(self.segment_config.vector_data[name].distance));
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
         self.handle_version_and_failure(op_num, stored_internal_point, |segment| {
             if let Some(existing_internal_id) = stored_internal_point {
@@ -860,7 +864,7 @@ impl SegmentEntry for Segment {
         mut vectors: NamedVectors,
     ) -> OperationResult<bool> {
         check_named_vectors(&vectors, &self.segment_config)?;
-        vectors.preprocess(|name| self.segment_config.vector_data[name].distance);
+        vectors.preprocess(|name| Some(self.segment_config.vector_data[name].distance));
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
             None => Err(OperationError::PointIdError {
@@ -997,7 +1001,7 @@ impl SegmentEntry for Segment {
         let mut result = NamedVectors::default();
         for vector_name in self.vector_data.keys() {
             if let Some(vec) = self.vector(vector_name, point_id)? {
-                result.insert(vector_name.clone(), vec);
+                result.insert(vector_name.clone(), vec.into());
             }
         }
         Ok(result)
@@ -2189,12 +2193,12 @@ mod tests {
         ];
         let wrong_vectors_multi = vec![
             // Incorrect dimensionality
-            NamedVectors::from_ref("a", &[]),
-            NamedVectors::from_ref("a", &[0.0, 1.0, 0.0]),
-            NamedVectors::from_ref("a", &[0.0, 1.0, 0.0, 1.0, 0.0]),
-            NamedVectors::from_ref("b", &[]),
-            NamedVectors::from_ref("b", &[0.5]),
-            NamedVectors::from_ref("b", &[0.0, 0.1, 0.2, 0.3]),
+            NamedVectors::from_ref("a", [].as_slice().into()),
+            NamedVectors::from_ref("a", [0.0, 1.0, 0.0].as_slice().into()),
+            NamedVectors::from_ref("a", [0.0, 1.0, 0.0, 1.0, 0.0].as_slice().into()),
+            NamedVectors::from_ref("b", [].as_slice().into()),
+            NamedVectors::from_ref("b", [0.5].as_slice().into()),
+            NamedVectors::from_ref("b", [0.0, 0.1, 0.2, 0.3].as_slice().into()),
             NamedVectors::from([
                 ("a".into(), vec![0.1, 0.2, 0.3]),
                 ("b".into(), vec![1.0, 0.9]),
@@ -2204,8 +2208,8 @@ mod tests {
                 ("b".into(), vec![1.0, 0.9, 0.0]),
             ]),
             // Incorrect names
-            NamedVectors::from_ref("aa", &[0.0, 0.1, 0.2, 0.3]),
-            NamedVectors::from_ref("bb", &[0.0, 0.1]),
+            NamedVectors::from_ref("aa", [0.0, 0.1, 0.2, 0.3].as_slice().into()),
+            NamedVectors::from_ref("bb", [0.0, 0.1].as_slice().into()),
             NamedVectors::from([
                 ("aa".into(), vec![0.1, 0.2, 0.3, 0.4]),
                 ("b".into(), vec![1.0, 0.9]),

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -808,7 +808,7 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<bool> {
         debug_assert!(self.is_appendable());
         check_named_vectors(&vectors, &self.segment_config)?;
-        vectors.preprocess(|name| Some(self.segment_config.vector_data[name].distance));
+        vectors.preprocess(|name| self.segment_config.vector_data[name].distance);
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
         self.handle_version_and_failure(op_num, stored_internal_point, |segment| {
             if let Some(existing_internal_id) = stored_internal_point {
@@ -861,7 +861,7 @@ impl SegmentEntry for Segment {
         mut vectors: NamedVectors,
     ) -> OperationResult<bool> {
         check_named_vectors(&vectors, &self.segment_config)?;
-        vectors.preprocess(|name| Some(self.segment_config.vector_data[name].distance));
+        vectors.preprocess(|name| self.segment_config.vector_data[name].distance);
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
         match internal_id {
             None => Err(OperationError::PointIdError {


### PR DESCRIPTION
Sparse vector index integration step. Propagate `Vector` type with sparse vector into `NamedVectors` struct.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
