### PR TITLE
Some micro optimizations in reserve/resize usage

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -91,14 +91,14 @@ impl InvertedIndex {
         self.points_count += 1;
         if self.point_to_docs.len() <= idx as usize {
             self.point_to_docs
-                .resize(idx as usize + 1, Default::default());
+                .resize_with(idx as usize + 1, Default::default);
         }
 
         for token_idx in document.tokens() {
             let token_idx_usize = *token_idx as usize;
             if self.postings.len() <= token_idx_usize {
                 self.postings
-                    .resize(token_idx_usize + 1, Default::default());
+                    .resize_with(token_idx_usize + 1, Default::default);
             }
             let posting = self
                 .postings

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -116,7 +116,7 @@ impl MutableGeoMapIndex {
             let geo_point = GeoMapIndex::decode_db_value(value)?;
 
             if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize(idx as usize + 1, Vec::new())
+                self.point_to_values.resize_with(idx as usize + 1, Vec::new);
             }
 
             if self.point_to_values[idx as usize].is_empty() {
@@ -203,7 +203,7 @@ impl MutableGeoMapIndex {
 
         if self.point_to_values.len() <= idx as usize {
             // That's a smart reallocation
-            self.point_to_values.resize(idx as usize + 1, vec![]);
+            self.point_to_values.resize_with(idx as usize + 1, Vec::new);
         }
 
         self.point_to_values[idx as usize] = values.to_vec();

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -49,7 +49,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MutableMapIndex<N> {
 
         self.values_count += values.len();
         if self.point_to_values.len() <= idx as usize {
-            self.point_to_values.resize(idx as usize + 1, Vec::new())
+            self.point_to_values.resize_with(idx as usize + 1, Vec::new)
         }
 
         self.point_to_values[idx as usize] = Vec::with_capacity(values.len());
@@ -102,7 +102,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MutableMapIndex<N> {
             })?;
             let (value, idx) = MapIndex::decode_db_record(record)?;
             if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize(idx as usize + 1, Vec::new())
+                self.point_to_values.resize_with(idx as usize + 1, Vec::new)
             }
             if self.point_to_values[idx as usize].is_empty() {
                 self.indexed_points += 1;

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -68,7 +68,7 @@ impl<T: Encodable + Numericable> MutableNumericIndex<T> {
         values: impl IntoIterator<Item = T>,
     ) -> OperationResult<()> {
         if self.point_to_values.len() <= idx as usize {
-            self.point_to_values.resize(idx as usize + 1, Vec::new())
+            self.point_to_values.resize_with(idx as usize + 1, Vec::new)
         }
         let values: Vec<T> = values.into_iter().collect();
         for value in &values {
@@ -96,7 +96,7 @@ impl<T: Encodable + Numericable> MutableNumericIndex<T> {
             }
 
             if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize(idx as usize + 1, Vec::new())
+                self.point_to_values.resize_with(idx as usize + 1, Vec::new)
             }
 
             self.point_to_values[idx as usize].push(value);

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -110,15 +110,15 @@ impl GraphLayersBuilder {
         use_heuristic: bool,
         reserve: bool,
     ) -> Self {
-        let mut links_layers: Vec<LockedLayersContainer> = vec![];
-
-        for _i in 0..num_vectors {
-            let mut links = Vec::new();
-            if reserve {
-                links.reserve(m0);
-            }
-            links_layers.push(vec![RwLock::new(links)]);
-        }
+        let links_layers = std::iter::repeat_with(|| {
+            vec![RwLock::new(if reserve {
+                Vec::with_capacity(m0)
+            } else {
+                vec![]
+            })]
+        })
+        .take(num_vectors)
+        .collect();
 
         let ready_list = RwLock::new(BitVec::repeat(false, num_vectors));
 

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -61,10 +61,10 @@ impl<'a> FilteredScorer<'a> {
         };
         if limit == 0 {
             self.points_buffer
-                .resize(filtered_point_ids.len(), ScoredPointOffset::default());
+                .resize_with(filtered_point_ids.len(), ScoredPointOffset::default);
         } else {
             self.points_buffer
-                .resize(limit, ScoredPointOffset::default());
+                .resize_with(limit, ScoredPointOffset::default);
         }
         let count = self
             .raw_scorer

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -69,7 +69,7 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
         let key = key as usize;
         self.len = max(self.len, key + 1);
         self.chunks
-            .resize(div_ceil(self.len, self.chunk_capacity), vec![]);
+            .resize_with(div_ceil(self.len, self.chunk_capacity), Vec::new);
 
         let chunk_idx = key / self.chunk_capacity;
         let chunk_data = &mut self.chunks[chunk_idx];
@@ -158,7 +158,7 @@ impl<T: Clone> TrySetCapacityExact for ChunkedVectors<T> {
         let num_chunks = div_ceil(capacity, self.chunk_capacity);
         let last_chunk_idx = capacity / self.chunk_capacity;
         self.chunks.try_set_capacity_exact(num_chunks)?;
-        self.chunks.resize(num_chunks, vec![]);
+        self.chunks.resize_with(num_chunks, Vec::new);
         for chunk_idx in 0..num_chunks {
             if chunk_idx == last_chunk_idx {
                 let desired_capacity = (capacity % self.chunk_capacity) * self.dim;

--- a/lib/segment/src/vector_storage/chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors.rs
@@ -91,7 +91,7 @@ impl<T: Copy + Clone + Default> ChunkedVectors<T> {
                 let desired_capacity = self.chunk_capacity * self.dim;
                 chunk_data.try_set_capacity_exact(desired_capacity)?;
             }
-            chunk_data.resize(idx + self.dim, T::default());
+            chunk_data.resize_with(idx + self.dim, T::default);
         }
 
         let data = &mut chunk_data[idx..idx + self.dim];

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -69,7 +69,7 @@ impl InvertedIndexRam {
                 }
                 None => {
                     // resize postings vector
-                    self.postings.resize(dim_id + 1, PostingList::default());
+                    self.postings.resize_with(dim_id + 1, PostingList::default);
                     // initialize new posting for dimension
                     self.postings[dim_id] = PostingList::new_one(id, weight);
                 }
@@ -108,7 +108,7 @@ impl InvertedIndexBuilder {
         let last_key = *keys.last().unwrap_or(&0);
         // Allocate postings of max key size
         let mut postings = Vec::new();
-        postings.resize(last_key as usize + 1, PostingList::default());
+        postings.resize_with(last_key as usize + 1, PostingList::default);
 
         // Move postings from hashmap to postings vector
         for key in keys {


### PR DESCRIPTION
I looked into the way we use `reserve{,_exact}` in our code base in <https://github.com/qdrant/qdrant/pull/2960>. This are some other changes with micro optimizations I made next to that. Nothing super significant, but I guess nice to haves.

All business logic is unchanged.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
