### PR TITLE
Remove deprecated search methods

### DIFF
--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -8,7 +8,7 @@ use collection::config::{CollectionConfig, CollectionParams, WalConfig};
 use collection::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStruct,
 };
-use collection::operations::types::{SearchRequest, SearchRequestBatch, VectorParams};
+use collection::operations::types::{CoreSearchRequestBatch, SearchRequest, VectorParams};
 use collection::operations::CollectionUpdateOperations;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::local_shard::LocalShard;
@@ -144,9 +144,9 @@ fn batch_search_bench(c: &mut Criterion) {
                             score_threshold: None,
                         };
                         let result = shard
-                            .search(
-                                Arc::new(SearchRequestBatch {
-                                    searches: vec![search_query],
+                            .core_search(
+                                Arc::new(CoreSearchRequestBatch {
+                                    searches: vec![search_query.into()],
                                 }),
                                 search_runtime_handle,
                                 None,
@@ -176,12 +176,12 @@ fn batch_search_bench(c: &mut Criterion) {
                             with_vector: None,
                             score_threshold: None,
                         };
-                        searches.push(search_query);
+                        searches.push(search_query.into());
                     }
 
-                    let search_query = SearchRequestBatch { searches };
+                    let search_query = CoreSearchRequestBatch { searches };
                     let result = shard
-                        .search(Arc::new(search_query), search_runtime_handle, None)
+                        .core_search(Arc::new(search_query), search_runtime_handle, None)
                         .await
                         .unwrap();
                     assert!(!result.is_empty());

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -14,7 +14,7 @@ use crate::shards::shard::ShardId;
 impl Collection {
     pub async fn search(
         &self,
-        request: SearchRequest,
+        request: CoreSearchRequest,
         read_consistency: Option<ReadConsistency>,
         shard_selection: Option<ShardId>,
         timeout: Option<Duration>,
@@ -23,104 +23,15 @@ impl Collection {
             return Ok(vec![]);
         }
         // search is a special case of search_batch with a single batch
-        let request_batch = SearchRequestBatch {
+        let request_batch = CoreSearchRequestBatch {
             searches: vec![request],
         };
         let results = self
-            .do_search_batch(request_batch, read_consistency, shard_selection, timeout)
+            .do_core_search_batch(request_batch, read_consistency, shard_selection, timeout)
             .await?;
         Ok(results.into_iter().next().unwrap())
     }
 
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    pub async fn search_batch(
-        &self,
-        request: SearchRequestBatch,
-        read_consistency: Option<ReadConsistency>,
-        shard_selection: Option<ShardId>,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        // shortcuts batch if all requests with limit=0
-        if request.searches.iter().all(|s| s.limit == 0) {
-            return Ok(vec![]);
-        }
-        // A factor which determines if we need to use the 2-step search or not
-        // Should be adjusted based on usage statistics.
-        const PAYLOAD_TRANSFERS_FACTOR_THRESHOLD: usize = 10;
-
-        let is_payload_required = request.searches.iter().all(|s| {
-            s.with_payload
-                .clone()
-                .map(|p| p.is_required())
-                .unwrap_or_default()
-        });
-        let with_vectors = request.searches.iter().all(|s| {
-            s.with_vector
-                .as_ref()
-                .map(|wv| wv.is_some())
-                .unwrap_or(false)
-        });
-
-        let metadata_required = is_payload_required || with_vectors;
-
-        let sum_limits: usize = request.searches.iter().map(|s| s.limit).sum();
-        let sum_offsets: usize = request.searches.iter().map(|s| s.offset).sum();
-
-        // Number of records we need to retrieve to fill the search result.
-        let require_transfers = self.shards_holder.read().await.len() * (sum_limits + sum_offsets);
-        // Actually used number of records.
-        let used_transfers = sum_limits;
-
-        let is_required_transfer_large_enough =
-            require_transfers > used_transfers * PAYLOAD_TRANSFERS_FACTOR_THRESHOLD;
-
-        if metadata_required && is_required_transfer_large_enough {
-            // If there is a significant offset, we need to retrieve the whole result
-            // set without payload first and then retrieve the payload.
-            // It is required to do this because the payload might be too large to send over the
-            // network.
-            let mut without_payload_requests = Vec::with_capacity(request.searches.len());
-            for search in &request.searches {
-                let mut without_payload_request = search.clone();
-                without_payload_request.with_payload = None;
-                without_payload_request.with_vector = None;
-                without_payload_requests.push(without_payload_request);
-            }
-            let without_payload_batch = SearchRequestBatch {
-                searches: without_payload_requests,
-            };
-            let without_payload_results = self
-                .do_search_batch(
-                    without_payload_batch,
-                    read_consistency,
-                    shard_selection,
-                    timeout,
-                )
-                .await?;
-            let filled_results = without_payload_results
-                .into_iter()
-                .zip(request.clone().searches.into_iter())
-                .map(|(without_payload_result, req)| {
-                    self.fill_search_result_with_payload(
-                        without_payload_result,
-                        req.with_payload.clone(),
-                        req.with_vector.unwrap_or_default(),
-                        read_consistency,
-                        shard_selection,
-                    )
-                });
-            future::try_join_all(filled_results).await
-        } else {
-            let result = self
-                .do_search_batch(request, read_consistency, shard_selection, timeout)
-                .await?;
-            Ok(result)
-        }
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     pub async fn core_search_batch(
         &self,
         request: CoreSearchRequestBatch,
@@ -206,42 +117,6 @@ impl Collection {
         }
     }
 
-    // ! COPY-PASTE: `do_core_search_batch` is a copy-paste of `do_search_batch` with different request type
-    // ! please replicate any changes to both methods
-    async fn do_search_batch(
-        &self,
-        request: SearchRequestBatch,
-        read_consistency: Option<ReadConsistency>,
-        shard_selection: Option<ShardId>,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let request = Arc::new(request);
-
-        // query all shards concurrently
-        let all_searches_res = {
-            let shard_holder = self.shards_holder.read().await;
-            let target_shards = shard_holder.target_shard(shard_selection)?;
-            let all_searches = target_shards.iter().map(|shard| {
-                shard.search(
-                    request.clone(),
-                    read_consistency,
-                    shard_selection.is_some(),
-                    timeout,
-                )
-            });
-            future::try_join_all(all_searches).await?
-        };
-
-        let request = Arc::into_inner(request)
-            .expect("We have already dropped all of the Arc clones at this point")
-            .into();
-
-        self.merge_from_shards(all_searches_res, request, shard_selection)
-            .await
-    }
-
-    // ! COPY-PASTE: `do_core_search_batch` is a copy-paste of `do_search_batch` with different request type
-    // ! please replicate any changes to both methods
     async fn do_core_search_batch(
         &self,
         request: CoreSearchRequestBatch,

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -16,8 +16,8 @@ use crate::collection::Collection;
 use crate::lookup::WithLookup;
 use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::types::{
-    BaseGroupRequest, CollectionError, CollectionResult, CoreSearchRequest, PointGroup, QueryEnum,
-    RecommendGroupsRequest, RecommendRequest, SearchGroupsRequest, UsingVector,
+    BaseGroupRequest, CollectionError, CollectionResult, PointGroup, RecommendGroupsRequest,
+    RecommendRequest, SearchGroupsRequest, SearchRequest, UsingVector,
 };
 use crate::recommendations::recommend_by;
 use crate::shards::shard::ShardId;
@@ -27,19 +27,14 @@ const MAX_GROUP_FILLING_REQUESTS: usize = 5;
 
 #[derive(Clone, Debug)]
 pub enum SourceRequest {
-    Search(CoreSearchRequest),
+    Search(SearchRequest),
     Recommend(RecommendRequest),
 }
 
 impl SourceRequest {
     fn vector_field_name(&self) -> &str {
         match self {
-            SourceRequest::Search(request) => match &request.query {
-                QueryEnum::Nearest(x) => x.get_name(),
-                QueryEnum::RecommendBestScore(x) => x.get_name(),
-                QueryEnum::Discover(x) => x.get_name(),
-                QueryEnum::Context(x) => x.get_name(),
-            },
+            SourceRequest::Search(request) => request.vector.get_name(),
             SourceRequest::Recommend(request) => {
                 if let Some(UsingVector::Name(name)) = &request.using {
                     name
@@ -161,7 +156,7 @@ impl GroupRequest {
                 request.with_vector = None;
 
                 collection
-                    .search(request, read_consistency, shard_selection, timeout)
+                    .search(request.into(), read_consistency, shard_selection, timeout)
                     .await
             }
             SourceRequest::Recommend(mut request) => {
@@ -204,8 +199,8 @@ impl From<SearchGroupsRequest> for GroupRequest {
                 },
         } = request;
 
-        let search = CoreSearchRequest {
-            query: QueryEnum::Nearest(vector),
+        let search = SearchRequest {
+            vector,
             filter,
             params,
             limit: 0,

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -171,9 +171,7 @@ where
     //
     // In the future we'll fix this by unify them into CoreSearchRequests and make a single batch
     for (strategy, run) in batch_by_strategy(&request_batch.searches) {
-        let mut core_searches = Vec::new();
-
-        core_searches.reserve_exact(run.len());
+        let mut core_searches = Vec::with_capacity(run.len());
 
         for request in run {
             let vector_name = match &request.using {

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -204,27 +204,23 @@ where
             lookup_collection_name,
         );
 
-        match request.strategy {
-            None | Some(RecommendStrategy::AverageVector) => {
-                let search = recommend_by_avg_vector(
-                    request.clone(),
-                    positive_vectors,
-                    negative_vectors,
-                    vector_name,
-                    reference_vectors_ids,
-                );
-                core_searches.push(search);
-            }
-            Some(RecommendStrategy::BestScore) => {
-                let core_search = recommend_by_best_score(
-                    request,
-                    positive_vectors,
-                    negative_vectors,
-                    reference_vectors_ids,
-                );
-                core_searches.push(core_search);
-            }
+        let search = match request.strategy.unwrap_or_default() {
+            RecommendStrategy::AverageVector => recommend_by_avg_vector(
+                request.clone(),
+                positive_vectors,
+                negative_vectors,
+                vector_name,
+                reference_vectors_ids,
+            ),
+            RecommendStrategy::BestScore => recommend_by_best_score(
+                request,
+                positive_vectors,
+                negative_vectors,
+                reference_vectors_ids,
+            ),
         };
+
+        core_searches.push(search);
     }
 
     let core_search_batch_request = CoreSearchRequestBatch {

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Handle;
 
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
-    CountResult, PointRequest, Record, SearchRequestBatch, UpdateResult,
+    CountResult, PointRequest, Record, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::shard_trait::ShardOperation;
@@ -81,19 +81,6 @@ impl ShardOperation for DummyShard {
         self.dummy()
     }
 
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        _: Arc<SearchRequestBatch>,
-        _: &Handle,
-        _: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.dummy()
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         _: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -14,7 +14,7 @@ use super::update_tracker::UpdateTracker;
 use crate::operations::point_ops::{PointOperations, PointStruct, PointSyncOperation};
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
-    CountResult, PointRequest, Record, SearchRequestBatch, UpdateResult,
+    CountResult, PointRequest, Record, UpdateResult,
 };
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::shards::local_shard::LocalShard;
@@ -206,23 +206,6 @@ impl ShardOperation for ForwardProxyShard {
         let local_shard = &self.wrapped_shard;
         local_shard.info().await
     }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let local_shard = &self.wrapped_shard;
-        local_shard
-            .search(request, search_runtime_handle, timeout)
-            .await
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -14,7 +14,7 @@ use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
-    CountResult, PointRequest, QueryEnum, Record, SearchRequestBatch, UpdateResult, UpdateStatus,
+    CountResult, PointRequest, QueryEnum, Record, UpdateResult, UpdateStatus,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
@@ -197,24 +197,6 @@ impl ShardOperation for LocalShard {
         Ok(self.local_shard_info().await)
     }
 
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.do_search(
-            Arc::new(request.as_ref().clone().into()),
-            search_runtime_handle,
-            timeout,
-        )
-        .await
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/local_shard_operations.rs
+++ b/lib/collection/src/shards/local_shard_operations.rs
@@ -48,8 +48,8 @@ impl LocalShard {
         let is_stopped = StoppingGuard::new();
 
         let search_request = SegmentsSearcher::search(
-            self.segments.clone(),
-            core_request.clone(),
+            Arc::clone(&self.segments),
+            Arc::clone(&core_request),
             search_runtime_handle,
             true,
             is_stopped.get_is_stopped(),

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -19,7 +19,7 @@ use crate::operations::operation_effect::{
 };
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest,
-    CountResult, PointRequest, Record, SearchRequestBatch, UpdateResult,
+    CountResult, PointRequest, Record, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::LocalShard;
@@ -202,22 +202,6 @@ impl ShardOperation for ProxyShard {
     }
 
     /// Forward read-only `search` to `wrapped_shard`
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let local_shard = &self.wrapped_shard;
-        local_shard
-            .search(request, search_runtime_handle, timeout)
-            .await
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -16,7 +16,7 @@ use super::update_tracker::UpdateTracker;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest, CountResult,
-    PointRequest, Record, SearchRequestBatch, UpdateResult,
+    PointRequest, Record, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::LocalShard;
@@ -196,21 +196,6 @@ impl ShardOperation for QueueProxyShard {
             .info()
             .await
     }
-
-    /// Forward read-only `search` to `wrapped_shard`
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.inner
-            .as_ref()
-            .expect("Queue proxy has been finalized")
-            .search(request, search_runtime_handle, timeout)
-            .await
-    }
-
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,
@@ -438,22 +423,6 @@ impl ShardOperation for Inner {
     }
 
     /// Forward read-only `search` to `wrapped_shard`
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        let local_shard = &self.wrapped_shard;
-        local_shard
-            .search(request, search_runtime_handle, timeout)
-            .await
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -50,31 +50,6 @@ impl ShardReplicaSet {
         )
         .await
     }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    pub async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        read_consistency: Option<ReadConsistency>,
-        local_only: bool,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-        self.execute_and_resolve_read_operation(
-            |shard| {
-                let request = request.clone();
-                let search_runtime = self.search_runtime.clone();
-
-                async move { shard.search(request, &search_runtime, timeout).await }.boxed()
-            },
-            read_consistency,
-            local_only,
-        )
-        .await
-    }
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     pub async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/src/shards/replica_set/read_ops.rs
+++ b/lib/collection/src/shards/replica_set/read_ops.rs
@@ -59,7 +59,7 @@ impl ShardReplicaSet {
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.execute_and_resolve_read_operation(
             |shard| {
-                let request = request.clone();
+                let request = Arc::clone(&request);
                 let search_runtime = self.search_runtime.clone();
 
                 async move { shard.core_search(request, &search_runtime, timeout).await }.boxed()

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -9,7 +9,7 @@ use tokio::runtime::Handle;
 
 use crate::operations::types::{
     CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequest, CountResult,
-    PointRequest, Record, SearchRequestBatch, UpdateResult,
+    PointRequest, Record, UpdateResult,
 };
 use crate::operations::CollectionUpdateOperations;
 
@@ -34,17 +34,6 @@ pub trait ShardOperation {
 
     async fn info(&self) -> CollectionResult<CollectionInfo>;
 
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
-    async fn search(
-        &self,
-        request: Arc<SearchRequestBatch>,
-        search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<Vec<ScoredPoint>>>;
-
-    // ! COPY-PASTE: `core_search` is a copy-paste of `search` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search(
         &self,
         request: Arc<CoreSearchRequestBatch>,

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -70,7 +70,9 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
         score_threshold: None,
     };
 
-    let search_res = collection.search(search_request, None, None, None).await;
+    let search_res = collection
+        .search(search_request.into(), None, None, None)
+        .await;
 
     match search_res {
         Ok(res) => {
@@ -127,7 +129,9 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
         score_threshold: None,
     };
 
-    let search_res = collection.search(search_request, None, None, None).await;
+    let search_res = collection
+        .search(search_request.into(), None, None, None)
+        .await;
 
     match search_res {
         Ok(res) => {

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -33,16 +33,19 @@ mod group_by {
     async fn setup(docs: u64, chunks: u64) -> Resources {
         let mut rng = rand::thread_rng();
 
-        let source = SourceRequest::Search(SearchRequest {
-            vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-            filter: None,
-            params: None,
-            limit: 4,
-            offset: 0,
-            with_payload: None,
-            with_vector: None,
-            score_threshold: None,
-        });
+        let source = SourceRequest::Search(
+            SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }
+            .into(),
+        );
 
         let request = GroupRequest::with_limit_from_request(source, "docId".to_string(), 3);
 
@@ -199,16 +202,19 @@ mod group_by {
         .unwrap();
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: Some(filter.clone()),
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: Some(filter.clone()),
+                    params: None,
+                    limit: 4,
+                    offset: 0,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             3,
         );
@@ -235,16 +241,19 @@ mod group_by {
         let resources = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: Some(WithPayloadInterface::Bool(true)),
-                with_vector: Some(WithVector::Bool(true)),
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 4,
+                    offset: 0,
+                    with_payload: Some(WithPayloadInterface::Bool(true)),
+                    with_vector: Some(WithVector::Bool(true)),
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             3,
         );
@@ -282,16 +291,19 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: Some(WithPayloadInterface::Bool(true)),
-                with_vector: Some(WithVector::Bool(true)),
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 4,
+                    offset: 0,
+                    with_payload: Some(WithPayloadInterface::Bool(true)),
+                    with_vector: Some(WithVector::Bool(true)),
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "other_stuff".to_string(),
             3,
         );
@@ -327,16 +339,19 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 4,
+                    offset: 0,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             0,
         );
@@ -368,16 +383,19 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 0,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 0,
+                    offset: 0,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             3,
         );
@@ -409,16 +427,19 @@ mod group_by {
         } = setup(1000, 5).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 500,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 500,
+                    offset: 0,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             3,
         );
@@ -454,16 +475,19 @@ mod group_by {
         } = setup(10, 500).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 3,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }),
+            SourceRequest::Search(
+                SearchRequest {
+                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                    filter: None,
+                    params: None,
+                    limit: 3,
+                    offset: 0,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                }
+                .into(),
+            ),
             "docId".to_string(),
             400,
         );
@@ -512,16 +536,19 @@ mod group_by_builder {
     async fn setup(docs: u64, chunks_per_doc: u64) -> Resources {
         let mut rng = rand::thread_rng();
 
-        let source_request = SourceRequest::Search(SearchRequest {
-            vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-            filter: None,
-            params: None,
-            limit: 4,
-            offset: 0,
-            with_payload: None,
-            with_vector: None,
-            score_threshold: None,
-        });
+        let source_request = SourceRequest::Search(
+            SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }
+            .into(),
+        );
 
         let request = GroupRequest::with_limit_from_request(source_request, "docId".to_string(), 3);
 

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -33,19 +33,16 @@ mod group_by {
     async fn setup(docs: u64, chunks: u64) -> Resources {
         let mut rng = rand::thread_rng();
 
-        let source = SourceRequest::Search(
-            SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }
-            .into(),
-        );
+        let source = SourceRequest::Search(SearchRequest {
+            vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+            filter: None,
+            params: None,
+            limit: 4,
+            offset: 0,
+            with_payload: None,
+            with_vector: None,
+            score_threshold: None,
+        });
 
         let request = GroupRequest::with_limit_from_request(source, "docId".to_string(), 3);
 
@@ -202,19 +199,16 @@ mod group_by {
         .unwrap();
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: Some(filter.clone()),
-                    params: None,
-                    limit: 4,
-                    offset: 0,
-                    with_payload: None,
-                    with_vector: None,
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: Some(filter.clone()),
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }),
             "docId".to_string(),
             3,
         );
@@ -241,19 +235,16 @@ mod group_by {
         let resources = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 4,
-                    offset: 0,
-                    with_payload: Some(WithPayloadInterface::Bool(true)),
-                    with_vector: Some(WithVector::Bool(true)),
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vector: Some(WithVector::Bool(true)),
+                score_threshold: None,
+            }),
             "docId".to_string(),
             3,
         );
@@ -291,19 +282,16 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 4,
-                    offset: 0,
-                    with_payload: Some(WithPayloadInterface::Bool(true)),
-                    with_vector: Some(WithVector::Bool(true)),
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vector: Some(WithVector::Bool(true)),
+                score_threshold: None,
+            }),
             "other_stuff".to_string(),
             3,
         );
@@ -339,19 +327,16 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 4,
-                    offset: 0,
-                    with_payload: None,
-                    with_vector: None,
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 4,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }),
             "docId".to_string(),
             0,
         );
@@ -383,19 +368,16 @@ mod group_by {
         } = setup(16, 8).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 0,
-                    offset: 0,
-                    with_payload: None,
-                    with_vector: None,
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 0,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }),
             "docId".to_string(),
             3,
         );
@@ -427,19 +409,16 @@ mod group_by {
         } = setup(1000, 5).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 500,
-                    offset: 0,
-                    with_payload: None,
-                    with_vector: None,
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 500,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }),
             "docId".to_string(),
             3,
         );
@@ -475,19 +454,16 @@ mod group_by {
         } = setup(10, 500).await;
 
         let group_by_request = GroupRequest::with_limit_from_request(
-            SourceRequest::Search(
-                SearchRequest {
-                    vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                    filter: None,
-                    params: None,
-                    limit: 3,
-                    offset: 0,
-                    with_payload: None,
-                    with_vector: None,
-                    score_threshold: None,
-                }
-                .into(),
-            ),
+            SourceRequest::Search(SearchRequest {
+                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+                filter: None,
+                params: None,
+                limit: 3,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            }),
             "docId".to_string(),
             400,
         );
@@ -536,19 +512,16 @@ mod group_by_builder {
     async fn setup(docs: u64, chunks_per_doc: u64) -> Resources {
         let mut rng = rand::thread_rng();
 
-        let source_request = SourceRequest::Search(
-            SearchRequest {
-                vector: vec![0.5, 0.5, 0.5, 0.5].into(),
-                filter: None,
-                params: None,
-                limit: 4,
-                offset: 0,
-                with_payload: None,
-                with_vector: None,
-                score_threshold: None,
-            }
-            .into(),
-        );
+        let source_request = SourceRequest::Search(SearchRequest {
+            vector: vec![0.5, 0.5, 0.5, 0.5].into(),
+            filter: None,
+            params: None,
+            limit: 4,
+            offset: 0,
+            with_payload: None,
+            with_vector: None,
+            score_threshold: None,
+        });
 
         let request = GroupRequest::with_limit_from_request(source_request, "docId".to_string(), 3);
 

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -129,7 +129,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     };
 
     let result = collection
-        .search(full_search_request, None, None, None)
+        .search(full_search_request.into(), None, None, None)
         .await
         .unwrap();
 
@@ -157,7 +157,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     };
 
     let result = collection
-        .search(failed_search_request, None, None, None)
+        .search(failed_search_request.into(), None, None, None)
         .await;
 
     assert!(
@@ -181,7 +181,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     };
 
     let result = collection
-        .search(full_search_request, None, None, None)
+        .search(full_search_request.into(), None, None, None)
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -53,7 +53,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     };
 
     let reference_result = collection
-        .search(full_search_request, None, None, None)
+        .search(full_search_request.into(), None, None, None)
         .await
         .unwrap();
 
@@ -74,7 +74,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     };
 
     let page_1_result = collection
-        .search(page_1_request, None, None, None)
+        .search(page_1_request.into(), None, None, None)
         .await
         .unwrap();
 
@@ -96,7 +96,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     };
 
     let page_9_result = collection
-        .search(page_9_request, None, None, None)
+        .search(page_9_request.into(), None, None, None)
         .await
         .unwrap();
 

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -150,12 +150,12 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
     };
 
     let reference_result = collection
-        .search(full_search_request.clone(), None, None, None)
+        .search(full_search_request.clone().into(), None, None, None)
         .await
         .unwrap();
 
     let recovered_result = recovered_collection
-        .search(full_search_request, None, None, None)
+        .search(full_search_request.into(), None, None, None)
         .await
         .unwrap();
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -75,62 +75,20 @@ impl TableOfContent {
         .map_err(|err| err.into())
     }
 
-    /// Search for the closest points using vector similarity with given restrictions defined
-    /// in the request
-    ///
-    /// # Arguments
-    ///
-    /// * `collection_name` - in what collection do we search
-    /// * `request` - [`SearchRequest`]
-    /// * `shard_selection` - which local shard to use
-    /// # Result
-    ///
-    /// Points with search score
-    pub async fn search(
-        &self,
-        collection_name: &str,
-        request: SearchRequest,
-        read_consistency: Option<ReadConsistency>,
-        shard_selection: Option<ShardId>,
-        timeout: Option<Duration>,
-    ) -> Result<Vec<ScoredPoint>, StorageError> {
-        let collection = self.get_collection(collection_name).await?;
-        collection
-            .search(request, read_consistency, shard_selection, timeout)
-            .await
-            .map_err(|err| err.into())
-    }
-
     /// Search in a batching fashion for the closest points using vector similarity with given restrictions defined
     /// in the request
     ///
     /// # Arguments
     ///
     /// * `collection_name` - in what collection do we search
-    /// * `request` - [`SearchRequestBatch`]
+    /// * `request` - [`CoreSearchRequestBatch`]
     /// * `shard_selection` - which local shard to use
+    /// * `timeout` - how long to wait for the response
+    /// * `read_consistency` - consistency level
+    ///
     /// # Result
     ///
     /// Points with search score
-    // ! COPY-PASTE: `core_search_batch` is a copy-paste of `search_batch` with different request type
-    // ! please replicate any changes to both methods
-    pub async fn search_batch(
-        &self,
-        collection_name: &str,
-        request: SearchRequestBatch,
-        read_consistency: Option<ReadConsistency>,
-        shard_selection: Option<ShardId>,
-        timeout: Option<Duration>,
-    ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        let collection = self.get_collection(collection_name).await?;
-        collection
-            .search_batch(request, read_consistency, shard_selection, timeout)
-            .await
-            .map_err(|err| err.into())
-    }
-
-    // ! COPY-PASTE: `core_search_batch` is a copy-paste of `search_batch` with different request type
-    // ! please replicate any changes to both methods
     pub async fn core_search_batch(
         &self,
         collection_name: &str,

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -7,7 +7,9 @@ use storage::content_manager::toc::TableOfContent;
 use super::read_params::ReadParams;
 use super::CollectionPath;
 use crate::actix::helpers::process_response;
-use crate::common::points::{do_search_batch_points, do_search_point_groups, do_search_points};
+use crate::common::points::{
+    do_core_search_batch_points, do_core_search_points, do_search_point_groups,
+};
 
 #[post("/collections/{name}/points/search")]
 async fn search_points(
@@ -18,10 +20,10 @@ async fn search_points(
 ) -> impl Responder {
     let timing = Instant::now();
 
-    let response = do_search_points(
+    let response = do_core_search_points(
         toc.get_ref(),
         &collection.name,
-        request.into_inner(),
+        request.into_inner().into(),
         params.consistency,
         None,
         params.timeout(),
@@ -40,10 +42,12 @@ async fn batch_search_points(
 ) -> impl Responder {
     let timing = Instant::now();
 
-    let response = do_search_batch_points(
+    let request = request.into_inner();
+
+    let response = do_core_search_batch_points(
         toc.get_ref(),
         &collection.name,
-        request.into_inner(),
+        request.into(),
         params.consistency,
         None,
         params.timeout(),

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -14,12 +14,12 @@ use api::grpc::qdrant::{
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
-use super::points_common::core_search_batch;
+use super::points_common::core_search_list;
 use super::validate_and_log;
 use crate::tonic::api::points_common::{
     clear_payload, count, create_field_index_internal, delete, delete_field_index_internal,
-    delete_payload, delete_vectors, get, overwrite_payload, recommend, scroll, search,
-    search_batch, set_payload, sync, update_vectors, upsert,
+    delete_payload, delete_vectors, get, overwrite_payload, recommend, scroll, set_payload, sync,
+    update_vectors, upsert,
 };
 
 /// This API is intended for P2P communication within a distributed deployment.
@@ -181,55 +181,24 @@ impl PointsInternal for PointsInternalService {
 
     async fn search(
         &self,
-        request: Request<SearchPointsInternal>,
+        _request: Request<SearchPointsInternal>,
     ) -> Result<Response<SearchResponse>, Status> {
-        validate_and_log(request.get_ref());
-        let SearchPointsInternal {
-            search_points,
-            shard_id,
-        } = request.into_inner();
-
-        let mut search_points =
-            search_points.ok_or_else(|| Status::invalid_argument("SearchPoints is missing"))?;
-
-        search_points.read_consistency = None; // *Have* to be `None`!
-
-        search(self.toc.as_ref(), search_points, shard_id).await
+        return Err(Status::unimplemented(
+            "search API was deprecated and removed, use core_search_batch instead. \
+        Please make sure versions of your cluster is consistent",
+        ));
     }
 
-    // ! COPY-PASTE: `core_search_batch` is a copy-paste of `search_batch` with different request type
-    // ! please replicate any changes to both methods
     async fn search_batch(
         &self,
-        request: Request<SearchBatchPointsInternal>,
+        _request: Request<SearchBatchPointsInternal>,
     ) -> Result<Response<SearchBatchResponse>, Status> {
-        validate_and_log(request.get_ref());
-        let SearchBatchPointsInternal {
-            collection_name,
-            search_points,
-            shard_id,
-            timeout,
-        } = request.into_inner();
-
-        // Individual `read_consistency` values are ignored by `search_batch`...
-        //
-        // search_points
-        //     .iter_mut()
-        //     .for_each(|search_points| search_points.read_consistency = None);
-
-        search_batch(
-            self.toc.as_ref(),
-            collection_name,
-            search_points,
-            None, // *Has* to be `None`!
-            shard_id,
-            timeout.map(Duration::from_secs),
-        )
-        .await
+        return Err(Status::unimplemented(
+            "search_batch API was deprecated and removed, use core_search_batch instead. \
+        Please make sure versions of your cluster is consistent",
+        ));
     }
 
-    // ! COPY-PASTE: `core_search_batch` is a copy-paste of `search_batch` with different request type
-    // ! please replicate any changes to both methods
     async fn core_search_batch(
         &self,
         request: Request<CoreSearchBatchPointsInternal>,
@@ -250,7 +219,7 @@ impl PointsInternal for PointsInternalService {
         //     .iter_mut()
         //     .for_each(|search_points| search_points.read_consistency = None);
 
-        core_search_batch(
+        core_search_list(
             self.toc.as_ref(),
             collection_name,
             search_points,


### PR DESCRIPTION
Last version introduced duplicated search methods for the purposes of the migration to a unified internal API for extendable modes of the search.
This PR removed duplication and completely switches search into the new version of internal API.

This change is required, as custom sharding requires a significant change in those search methods and duplication expected changes seemed unpractical.

Compatibility notes: this change makes migration from versions <=1.5 directly to >=1.7   (skipping 1.6.x) potentially error-prone. In particular: search requests between two nodes with too different versions in cluster mode will fail. This, however, doesn't violate the contract of supporting backward compatibility & migration compatibility for one minor version. 
