### PR TITLE
Bump WAL for security issue in outdated rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,13 +1805,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
+checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "libc",
- "rustix 0.35.13",
- "winapi",
+ "rustix 0.38.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2925,6 +2924,15 @@ name = "memmap2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
@@ -5594,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=a32f6a38acf7ffd761df83b0790eaefeb107cd60#a32f6a38acf7ffd761df83b0790eaefeb107cd60"
+source = "git+https://github.com/qdrant/wal.git?rev=f62d2844ba0bb2b1f1aeb9a4766cdbd46f29d594#f62d2844ba0bb2b1f1aeb9a4766cdbd46f29d594"
 dependencies = [
  "byteorder",
  "crc",
@@ -5603,10 +5611,10 @@ dependencies = [
  "env_logger",
  "fs4",
  "log",
- "memmap2 0.7.1",
+ "memmap2 0.9.0",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.38.3",
+ "rustix 0.35.13",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ clap = { version = "4.4.4", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 uuid = { version = "1.4", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a32f6a38acf7ffd761df83b0790eaefeb107cd60" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "f62d2844ba0bb2b1f1aeb9a4766cdbd46f29d594" }
 
 config = "~0.13.3"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a32f6a38acf7ffd761df83b0790eaefeb107cd60"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "f62d2844ba0bb2b1f1aeb9a4766cdbd46f29d594"}
 ordered-float = "4.1"
 hashring = "0.3.2"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.10.0"
 num_cpus = "1.16"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "a32f6a38acf7ffd761df83b0790eaefeb107cd60" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "f62d2844ba0bb2b1f1aeb9a4766cdbd46f29d594" }
 tokio = { version = "~1.32", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
This PR bumps our WAL dependency to its latest version.

The motivation is to tackle this security alert https://github.com/qdrant/qdrant/security/dependabot/56

It happens because the current WAL pulls an outdated `rustix` version via `fs4` 0.6.

The latest WAL version already contains an update to `fs4` 0.7. 