### PR TITLE
Benchmark sparse index build

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -116,3 +116,7 @@ harness = false
 [[bench]]
 name = "sparse_index_search"
 harness = false
+
+[[bench]]
+name = "sparse_index_build"
+harness = false

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -1,0 +1,122 @@
+#[cfg(not(target_os = "windows"))]
+mod prof;
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::types::PointOffsetType;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use segment::fixtures::payload_context_fixture::FixtureIdTracker;
+use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
+use segment::index::struct_payload_index::StructPayloadIndex;
+use segment::index::VectorIndex;
+use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use segment::types::Distance;
+use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::VectorStorage;
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use tempfile::Builder;
+
+const NUM_VECTORS: usize = 100_000;
+const MAX_SPARSE_DIM: usize = 30_000;
+
+fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse-vector-build-group");
+
+    let stopped = AtomicBool::new(false);
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let index_dir = Builder::new().prefix("index_dir").tempdir().unwrap();
+
+    // setup
+    let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(NUM_VECTORS)));
+    let payload_storage = InMemoryPayloadStorage::default();
+    let wrapped_payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
+    let payload_index = StructPayloadIndex::open(
+        wrapped_payload_storage,
+        id_tracker.clone(),
+        payload_dir.path(),
+        true,
+    )
+    .unwrap();
+    let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
+
+    let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
+    let vector_storage =
+        open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+    let mut borrowed_storage = vector_storage.borrow_mut();
+
+    // add points to storage only once
+    for idx in 0..NUM_VECTORS {
+        let vec = &random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+        borrowed_storage
+            .insert_vector(idx as PointOffsetType, vec.into())
+            .unwrap();
+    }
+    drop(borrowed_storage);
+
+    // intent: measure in-memory build time from storage
+    group.bench_function("build-ram-index", |b| {
+        b.iter(|| {
+            let mut sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
+                SparseVectorIndex::open(
+                    id_tracker.clone(),
+                    vector_storage.clone(),
+                    wrapped_payload_index.clone(),
+                    index_dir.path(),
+                )
+                .unwrap();
+            sparse_vector_index.build_index(&stopped).unwrap();
+            assert_eq!(sparse_vector_index.indexed_vector_count(), NUM_VECTORS);
+        })
+    });
+
+    // build once to reuse in mmap conversion benchmark
+    let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = SparseVectorIndex::open(
+        id_tracker,
+        vector_storage.clone(),
+        wrapped_payload_index,
+        index_dir.path(),
+    )
+    .unwrap();
+
+    // intent: measure mmap conversion time
+    group.bench_function("convert-mmap-index", |b| {
+        b.iter(|| {
+            let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
+
+            let _mmap_inverted_index = InvertedIndexMmap::convert_and_save(
+                &sparse_vector_index.inverted_index,
+                &mmap_index_dir,
+            )
+            .unwrap();
+            // TODO(sparse) assert indexed vector count
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(prof::FlamegraphProfiler::new(100));
+    targets = sparse_vector_index_build_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = sparse_vector_index_build_benchmark,
+}
+
+criterion_main!(benches);

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -119,12 +119,12 @@ impl InvertedIndexMmap {
 
         // save header properties
         let posting_count = inverted_index_ram.postings.len();
-        let indexed_vector_count = inverted_index_ram.vector_count();
+        let vector_count = inverted_index_ram.vector_count();
 
         // finalize data with index file.
         let file_header = InvertedIndexFileHeader {
             posting_count,
-            vector_count: indexed_vector_count,
+            vector_count,
         };
         let config_file_path = Self::index_config_file_path(path.as_ref());
         atomic_save_json(&config_file_path, &file_header)?;

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -57,7 +57,7 @@ impl PostingList {
     /// Worst case is adding a new element at the end of the list with a very large weight.
     /// This forces to propagate it as potential max_next_weight to all the previous elements.
     pub fn upsert(&mut self, posting_element: PostingElement) {
-        // find insertion point in sorted posting list
+        // find insertion point in sorted posting list (most expensive operation for large posting list)
         let index = self
             .elements
             .binary_search_by_key(&posting_element.record_id, |e| e.record_id);


### PR DESCRIPTION
This PR adds benchmark for building the sparse index vector.

![sparse-build](https://github.com/qdrant/qdrant/assets/606963/0016925f-283e-494b-913b-fbca16e5207d)

The takeaway is that:
- building the inverted index via repeated upsert operations is very fast 
- the binary search is the most expensive operation (annotated in source code)
- converting to mmap is very fast
- found a bug in computing vector count for mmap which I will fix in a next PR