### PR TITLE
Fix vector count in sparse index

### DIFF
--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -84,6 +84,9 @@ pub fn fixture_sparse_index_ram<R: Rng + ?Sized>(
         num_vectors
     );
 
+    // assert no points are indexed following open for RAM index
+    assert_eq!(sparse_vector_index.indexed_vector_count(), 0);
+
     // build index to refresh RAM index
     sparse_vector_index.build_index(stopped).unwrap();
     assert_eq!(sparse_vector_index.indexed_vector_count(), num_vectors);

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -30,7 +30,6 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     path: PathBuf,
     pub inverted_index: TInvertedIndex,
     searches_telemetry: SparseSearchesTelemetry,
-    max_point_id: PointOffsetType, // used to compute the number of indexed vectors
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -45,7 +44,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         create_dir_all(path)?;
 
         let searches_telemetry = SparseSearchesTelemetry::new();
-        let max_point_id = 0;
         let inverted_index = TInvertedIndex::open(path)?;
         let path = path.to_path_buf();
         let index = Self {
@@ -55,7 +53,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             path,
             inverted_index,
             searches_telemetry,
-            max_point_id,
         };
         Ok(index)
     }
@@ -198,7 +195,9 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             ram_index.upsert(id, vector.to_owned());
             index_point_count += 1;
         }
-        self.max_point_id = index_point_count.saturating_sub(1) as PointOffsetType;
+        // the underlying upsert operation does not guarantee that the indexed vector count is correct
+        // so we set the indexed vector count to the number of points we have seen
+        ram_index.indexed_vector_count = index_point_count;
         // TODO(sparse) this operation loads the entire index into memory which can cause OOM on large storage
         self.inverted_index = TInvertedIndex::from_ram_index(ram_index, &self.path)?;
         Ok(())
@@ -214,15 +213,12 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
     }
 
     fn indexed_vector_count(&self) -> usize {
-        // internal ids start at 0
-        self.max_point_id as usize + 1
+        self.inverted_index.indexed_vector_count()
     }
 
     fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()> {
         let vector_storage = self.vector_storage.borrow();
         let vector: &SparseVector = vector_storage.get_vector(id).try_into()?;
-        // there are no holes in the internal ids, so we can just use the id as the count
-        self.max_point_id = self.max_point_id.max(id);
         self.inverted_index.upsert(id, vector.clone());
         Ok(())
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -197,7 +197,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         }
         // the underlying upsert operation does not guarantee that the indexed vector count is correct
         // so we set the indexed vector count to the number of points we have seen
-        ram_index.indexed_vector_count = index_point_count;
+        ram_index.vector_count = index_point_count;
         // TODO(sparse) this operation loads the entire index into memory which can cause OOM on large storage
         self.inverted_index = TInvertedIndex::from_ram_index(ram_index, &self.path)?;
         Ok(())
@@ -213,7 +213,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
     }
 
     fn indexed_vector_count(&self) -> usize {
-        self.inverted_index.indexed_vector_count()
+        self.inverted_index.vector_count()
     }
 
     fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()> {

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -162,6 +162,11 @@ fn sparse_vector_index_consistent_with_storage() {
     )
     .unwrap();
 
+    assert_eq!(
+        sparse_vector_mmap_index.indexed_vector_count(),
+        sparse_vector_ram_index.indexed_vector_count()
+    );
+
     // check consistency with underlying mmap inverted index
     check_index_storage_consistency(&sparse_vector_mmap_index);
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -24,8 +24,8 @@ const INDEX_CONFIG_FILE_NAME: &str = "index_config.json";
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {
-    pub posting_count: usize,    // number oof posting lists
-    indexed_vector_count: usize, // number of unique vectors indexed
+    pub posting_count: usize, // number oof posting lists
+    vector_count: usize,      // number of unique vectors indexed
 }
 
 /// Inverted flatten index from dimension id to posting list
@@ -71,8 +71,8 @@ impl InvertedIndex for InvertedIndexMmap {
         Self::convert_and_save(&ram_index, path)
     }
 
-    fn indexed_vector_count(&self) -> usize {
-        self.file_header.indexed_vector_count
+    fn vector_count(&self) -> usize {
+        self.file_header.vector_count
     }
 }
 
@@ -119,12 +119,12 @@ impl InvertedIndexMmap {
 
         // save header properties
         let posting_count = inverted_index_ram.postings.len();
-        let indexed_vector_count = inverted_index_ram.indexed_vector_count();
+        let indexed_vector_count = inverted_index_ram.vector_count();
 
         // finalize data with index file.
         let file_header = InvertedIndexFileHeader {
             posting_count,
-            indexed_vector_count,
+            vector_count: indexed_vector_count,
         };
         let config_file_path = Self::index_config_file_path(path.as_ref());
         atomic_save_json(&config_file_path, &file_header)?;
@@ -261,7 +261,7 @@ mod tests {
         let inverted_index_mmap = InvertedIndexMmap::load(&tmp_dir_path).unwrap();
         // posting_count: 0th entry is always empty + 1st + 2nd + 3rd + 4th empty + 5th
         assert_eq!(inverted_index_mmap.file_header.posting_count, 6);
-        assert_eq!(inverted_index_mmap.file_header.indexed_vector_count, 9);
+        assert_eq!(inverted_index_mmap.file_header.vector_count, 9);
 
         compare_indexes(&inverted_index_ram, &inverted_index_mmap);
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -24,7 +24,8 @@ const INDEX_CONFIG_FILE_NAME: &str = "index_config.json";
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InvertedIndexFileHeader {
-    pub posting_count: usize,
+    pub posting_count: usize,    // number oof posting lists
+    indexed_vector_count: usize, // number of unique vectors indexed
 }
 
 /// Inverted flatten index from dimension id to posting list
@@ -69,6 +70,10 @@ impl InvertedIndex for InvertedIndexMmap {
     ) -> std::io::Result<Self> {
         Self::convert_and_save(&ram_index, path)
     }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.file_header.indexed_vector_count
+    }
 }
 
 impl InvertedIndexMmap {
@@ -112,10 +117,15 @@ impl InvertedIndexMmap {
         Self::save_posting_headers(&mut mmap, inverted_index_ram, total_posting_headers_size);
         Self::save_posting_elements(&mut mmap, inverted_index_ram, total_posting_headers_size);
 
+        // save header properties
         let posting_count = inverted_index_ram.postings.len();
+        let indexed_vector_count = inverted_index_ram.indexed_vector_count();
 
         // finalize data with index file.
-        let file_header = InvertedIndexFileHeader { posting_count };
+        let file_header = InvertedIndexFileHeader {
+            posting_count,
+            indexed_vector_count,
+        };
         let config_file_path = Self::index_config_file_path(path.as_ref());
         atomic_save_json(&config_file_path, &file_header)?;
 
@@ -249,6 +259,9 @@ mod tests {
             compare_indexes(&inverted_index_ram, &inverted_index_mmap);
         }
         let inverted_index_mmap = InvertedIndexMmap::load(&tmp_dir_path).unwrap();
+        // posting_count: 0th entry is always empty + 1st + 2nd + 3rd + 4th empty + 5th
+        assert_eq!(inverted_index_mmap.file_header.posting_count, 6);
+        assert_eq!(inverted_index_mmap.file_header.indexed_vector_count, 9);
 
         compare_indexes(&inverted_index_ram, &inverted_index_mmap);
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -85,12 +86,9 @@ impl InvertedIndexRam {
                 }
             }
         }
-        // update indexed vector count by guessing whether we already have seen this point id
         // given that there are no holes in the internal ids and that we are not deleting from the index
         // we can just use the id as a proxy the count
-        if self.vector_count() < id as usize {
-            self.vector_count += 1;
-        }
+        self.vector_count = max(self.vector_count, id as usize);
     }
 }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
@@ -11,7 +11,12 @@ use crate::index::posting_list::{PostingElement, PostingList, PostingListIterato
 /// Inverted flatten index from dimension id to posting list
 #[derive(Debug, Clone, PartialEq)]
 pub struct InvertedIndexRam {
+    /// Posting lists for each dimension flattened (dimension id -> posting list)
+    /// Gaps are filled with empty posting lists
     pub postings: Vec<PostingList>,
+    /// Number of unique indexed vectors
+    /// pre-computed on build and upsert to avoid having to traverse the posting lists.
+    pub indexed_vector_count: usize,
 }
 
 impl InvertedIndex for InvertedIndexRam {
@@ -42,6 +47,10 @@ impl InvertedIndex for InvertedIndexRam {
     ) -> std::io::Result<Self> {
         Ok(ram_index)
     }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.indexed_vector_count
+    }
 }
 
 impl InvertedIndexRam {
@@ -49,6 +58,7 @@ impl InvertedIndexRam {
     pub fn empty() -> InvertedIndexRam {
         InvertedIndexRam {
             postings: Vec::new(),
+            indexed_vector_count: 0,
         }
     }
 
@@ -68,16 +78,23 @@ impl InvertedIndexRam {
                     posting.upsert(posting_element);
                 }
                 None => {
-                    // resize postings vector
+                    // resize postings vector (fill gaps with empty posting lists)
                     self.postings.resize_with(dim_id + 1, PostingList::default);
                     // initialize new posting for dimension
                     self.postings[dim_id] = PostingList::new_one(id, weight);
                 }
             }
         }
+        // update indexed vector count by guessing whether we already have seen this point id
+        // given that there are no holes in the internal ids and that we are not deleting from the index
+        // we can just use the id as a proxy the count
+        if self.indexed_vector_count() < id as usize {
+            self.indexed_vector_count += 1;
+        }
     }
 }
 
+/// Builder used in tests to validate `upsert` implementation
 pub struct InvertedIndexBuilder {
     postings: HashMap<DimId, PostingList>,
 }
@@ -114,7 +131,19 @@ impl InvertedIndexBuilder {
         for key in keys {
             postings[key as usize] = self.postings.remove(&key).unwrap();
         }
-        InvertedIndexRam { postings }
+
+        // Count unique ids
+        let unique_ids: HashSet<PointOffsetType> = postings
+            .iter()
+            .flat_map(|posting_list| posting_list.elements.iter())
+            .map(|posting| posting.record_id)
+            .collect();
+        let indexed_vector_count = unique_ids.len();
+
+        InvertedIndexRam {
+            postings,
+            indexed_vector_count,
+        }
     }
 }
 
@@ -129,6 +158,7 @@ mod tests {
             .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
+        assert_eq!(inverted_index_ram.indexed_vector_count, 3);
 
         inverted_index_ram.upsert(
             4,
@@ -152,6 +182,8 @@ mod tests {
             .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
+
+        assert_eq!(inverted_index_ram.indexed_vector_count, 3);
 
         // 4 postings, 0th empty
         assert_eq!(inverted_index_ram.postings.len(), 4);
@@ -191,6 +223,8 @@ mod tests {
             .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
             .build();
+
+        assert_eq!(inverted_index_ram_built.indexed_vector_count, 3);
 
         let mut inverted_index_ram_upserted = InvertedIndexRam::empty();
         inverted_index_ram_upserted.upsert(

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -34,5 +34,5 @@ pub trait InvertedIndex {
         Self: Sized;
 
     /// Number of indexed vectors
-    fn indexed_vector_count(&self) -> usize;
+    fn vector_count(&self) -> usize;
 }

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -32,4 +32,7 @@ pub trait InvertedIndex {
     ) -> std::io::Result<Self>
     where
         Self: Sized;
+
+    /// Number of indexed vectors
+    fn indexed_vector_count(&self) -> usize;
 }


### PR DESCRIPTION
This PR fixes the indexed vector count for the sparse vector index.

The are two bugs:
- empty sparse RAM index would report a size of 1 instead of 0
- loading a non empty memmap index would report a size of zero

The logic for keeping track of the number of indexed points has been pushed lower into the `InvertedIndex` trait to enable different implementations.
