### PR TITLE
Attempt to fix flaky shard snapshot transfer tests

### DIFF
--- a/tests/consensus_tests/test_shard_snapshot_transfer.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer.py
@@ -20,7 +20,7 @@ def update_points_in_loop(peer_url, collection_name, offset=0, throttle=False, d
         offset += limit
 
         if throttle:
-            sleep(0.01)
+            sleep(0.1)
         if duration is not None and (time.time() - start) > duration:
             break
 
@@ -50,7 +50,7 @@ def test_shard_snapshot_transfer_throttled_updates(tmp_path: pathlib.Path):
     )
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], 10000)
 
     # Start pushing points to the cluster
     upload_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=100, throttle=True)
@@ -123,7 +123,7 @@ def test_shard_snapshot_transfer_fast_burst(tmp_path: pathlib.Path):
     )
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], 10000)
 
     # Start pushing points to the cluster
     upload_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=100, duration=5)

--- a/tests/consensus_tests/test_shard_snapshot_transfer.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer.py
@@ -148,6 +148,7 @@ def test_shard_snapshot_transfer_throttled_updates(tmp_path: pathlib.Path):
     upload_process_1.kill()
     upload_process_2.kill()
     upload_process_3.kill()
+    sleep(1)
 
     receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
     number_local_shards = len(receiver_collection_cluster_info['local_shards'])
@@ -221,6 +222,7 @@ def test_shard_snapshot_transfer_fast_burst(tmp_path: pathlib.Path):
     upload_process_1.kill()
     upload_process_2.kill()
     upload_process_3.kill()
+    sleep(1)
 
     receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
     number_local_shards = len(receiver_collection_cluster_info['local_shards'])

--- a/tests/consensus_tests/test_shard_snapshot_transfer.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer.py
@@ -31,6 +31,69 @@ def run_update_points_in_background(peer_url, collection_name, init_offset=0, th
     return p
 
 
+# Transfer shards from one node to another
+#
+# Simply does the most basic transfer: no concurrent updates during the
+# transfer.
+#
+# Test that data on the both sides is consistent
+def test_shard_snapshot_transfer(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, 20000)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    # Insert some initial number of points
+    upsert_random_points(peer_api_uris[0], 100)
+
+    transfer_collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+
+    from_peer_id = transfer_collection_cluster_info['peer_id']
+    to_peer_id = receiver_collection_cluster_info['peer_id']
+
+    shard_id = transfer_collection_cluster_info['local_shards'][0]['shard_id']
+
+    # Transfer shard from one node to another
+
+    # Move shard `shard_id` to peer `target_peer_id`
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": from_peer_id,
+                "to_peer_id": to_peer_id,
+                "method": "snapshot"
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+    number_local_shards = len(receiver_collection_cluster_info['local_shards'])
+    assert number_local_shards == 2
+
+    # Point counts must be consistent across nodes
+    counts = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
+                "exact": True
+            }
+        )
+        assert_http_ok(r)
+        counts.append(r.json()["result"]['count'])
+    assert counts[0] == counts[1] == counts[2]
+
+
 # Transfer shards from one node to another while applying throttled updates in parallel
 #
 # Updates are throttled to prevent sending updates faster than the queue proxy

--- a/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
@@ -20,7 +20,7 @@ def update_points_in_loop(peer_url, collection_name, offset=0, throttle=False, d
         offset += limit
 
         if throttle:
-            sleep(0.01)
+            sleep(0.1)
         if duration is not None and (time.time() - start) > duration:
             break
 

--- a/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
@@ -133,7 +133,7 @@ def test_shard_snapshot_transfer_cancel_during_updates(tmp_path: pathlib.Path):
     )
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], 10000)
 
     # Start pushing points to the cluster
     upload_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=100)
@@ -162,10 +162,10 @@ def test_shard_snapshot_transfer_cancel_during_updates(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # With unthrottled updates the transfer will never complete in 5 seconds
+    # With unthrottled updates the transfer will never complete in 1 seconds
     # because the queue proxy cannot keep up with transferring all of these to
     # the remote
-    sleep(5)
+    sleep(1)
 
     upload_process_1.kill()
     upload_process_2.kill()

--- a/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
@@ -162,10 +162,10 @@ def test_shard_snapshot_transfer_cancel_during_updates(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # With unthrottled updates the transfer will never complete in 1 seconds
+    # With unthrottled updates the transfer should never complete in 0.2 seconds
     # because the queue proxy cannot keep up with transferring all of these to
     # the remote
-    sleep(1)
+    sleep(0.2)
 
     upload_process_1.kill()
     upload_process_2.kill()


### PR DESCRIPTION
Tracked in <https://github.com/qdrant/qdrant/issues/2432>.

- Fixes <https://github.com/qdrant/qdrant/issues/3006>:
  Have bigger dataset and shorter cancel time to make it less likely for the transfer to complete before it is being cancelled.
- Fixes <https://github.com/qdrant/qdrant/issues/3007>:
  Throttle updates 10 times harder, may still have been too much on a slow CI server.
- Fixes <https://github.com/qdrant/qdrant/issues/3008>:
  I suspect that some points still had to propagate through the cluster, it now sleeps 1 second to give it some time.

This attempts to fix the above three tests. They were already working fine in previous runs for me. We'll have to see how these function on CI and potentially improve them further if issues still arise.

As a bonus I've added an additional test for the most simple shard snapshot transfer, a transfer with 100 points and no concurrent updates.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?