### PR TITLE
Abort shard transfer during `sync_local_state`, if transfer-er node failed (#2975)

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -452,11 +452,6 @@ impl Collection {
         let shard_holder = self.shards_holder.read().await;
         let get_shard_transfer = |key| shard_holder.get_transfer(&key);
         for replica_set in shard_holder.all_shards() {
-            // TODO:
-            //   Aborting shard transfer here doesn't *really* work, if we keep requesting new
-            //   transfer in `Collection::request_shard_transfer` (at the bottom).
-            //
-            //  Shard transfer should be initiated by the *sender*.
             replica_set.sync_local_state(get_shard_transfer).await?;
         }
 
@@ -547,12 +542,6 @@ impl Collection {
                     this_peer_id,
                     replica_id
                 );
-
-                // TODO:
-                //   Aborting shard transfer in `ShardReplicaSet::sync_local_state` (at the top)
-                //   doesn't *really* work, if we keep requesting new transfer here.
-                //
-                //  Shard transfer should be initiated by the *sender*.
                 self.request_shard_transfer(transfer);
                 break;
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -452,6 +452,11 @@ impl Collection {
         let shard_holder = self.shards_holder.read().await;
         let get_shard_transfer = |key| shard_holder.get_transfer(&key);
         for replica_set in shard_holder.all_shards() {
+            // TODO:
+            //   Aborting shard transfer here doesn't *really* work, if we keep requesting new
+            //   transfer in `Collection::request_shard_transfer` (at the bottom).
+            //
+            //  Shard transfer should be initiated by the *sender*.
             replica_set.sync_local_state(get_shard_transfer).await?;
         }
 
@@ -542,6 +547,12 @@ impl Collection {
                     this_peer_id,
                     replica_id
                 );
+
+                // TODO:
+                //   Aborting shard transfer in `ShardReplicaSet::sync_local_state` (at the top)
+                //   doesn't *really* work, if we keep requesting new transfer here.
+                //
+                //  Shard transfer should be initiated by the *sender*.
                 self.request_shard_transfer(transfer);
                 break;
             }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -30,7 +30,6 @@ impl Collection {
             .read()
             .await
             .check_transfer_exists(transfer_key)
-            .await
     }
 
     pub async fn start_shard_transfer<T, F>(
@@ -251,7 +250,7 @@ impl Collection {
                 )));
             };
 
-        let transfer = shard_holder_guard.get_transfer(&transfer_key).await;
+        let transfer = shard_holder_guard.get_transfer(&transfer_key);
 
         if transfer.map(|x| x.sync).unwrap_or(false) {
             replica_set.set_replica_state(&transfer_key.to, ReplicaState::Dead)?;

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -22,7 +22,6 @@ impl Collection {
             .read()
             .await
             .get_outgoing_transfers(current_peer_id)
-            .await
     }
 
     pub async fn check_transfer_exists(&self, transfer_key: &ShardTransferKey) -> bool {

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -30,6 +30,7 @@ impl Collection {
             is_local,
             peers,
             self.notify_peer_failure_cb.clone(),
+            self.abort_shard_transfer_cb.clone(),
             &self.path,
             self.collection_config.clone(),
             self.shared_storage_config.clone(),

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -17,6 +17,7 @@ use tokio::sync::{Mutex, RwLock};
 
 use super::local_shard::LocalShard;
 use super::remote_shard::RemoteShard;
+use super::transfer::shard_transfer::{ShardTransfer, ShardTransferKey};
 use super::CollectionId;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;
@@ -81,6 +82,7 @@ pub struct ShardReplicaSet {
     pub(crate) shard_path: PathBuf,
     pub(crate) shard_id: ShardId,
     notify_peer_failure_cb: ChangePeerState,
+    abort_shard_transfer_cb: AbortShardTransfer,
     channel_service: ChannelService,
     collection_id: CollectionId,
     collection_config: Arc<RwLock<CollectionConfig>>,
@@ -91,6 +93,7 @@ pub struct ShardReplicaSet {
     write_ordering_lock: Mutex<()>,
 }
 
+pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;
 pub type ChangePeerState = Arc<dyn Fn(PeerId, ShardId) + Send + Sync>;
 
 const REPLICA_STATE_FILE: &str = "replica_state.json";
@@ -105,6 +108,7 @@ impl ShardReplicaSet {
         local: bool,
         remotes: HashSet<PeerId>,
         on_peer_failure: ChangePeerState,
+        abort_shard_transfer: AbortShardTransfer,
         collection_path: &Path,
         collection_config: Arc<RwLock<CollectionConfig>>,
         shared_storage_config: Arc<SharedStorageConfig>,
@@ -159,6 +163,7 @@ impl ShardReplicaSet {
             replica_state: replica_state.into(),
             locally_disabled_peers: Default::default(),
             shard_path,
+            abort_shard_transfer_cb: abort_shard_transfer,
             notify_peer_failure_cb: on_peer_failure,
             channel_service,
             collection_id,
@@ -184,6 +189,7 @@ impl ShardReplicaSet {
         shared_storage_config: Arc<SharedStorageConfig>,
         channel_service: ChannelService,
         on_peer_failure: ChangePeerState,
+        abort_shard_transfer: AbortShardTransfer,
         this_peer_id: PeerId,
         update_runtime: Handle,
         search_runtime: Handle,
@@ -265,6 +271,7 @@ impl ShardReplicaSet {
             locally_disabled_peers: Default::default(),
             shard_path: shard_path.to_path_buf(),
             notify_peer_failure_cb: on_peer_failure,
+            abort_shard_transfer_cb: abort_shard_transfer,
             channel_service,
             collection_id,
             collection_config,
@@ -655,9 +662,22 @@ impl ShardReplicaSet {
 
     /// Check if the are any locally disabled peers
     /// And if so, report them to the consensus
-    pub async fn sync_local_state(&self) -> CollectionResult<()> {
-        for failed_peer in self.locally_disabled_peers.read().iter() {
-            self.notify_peer_failure(*failed_peer);
+    pub async fn sync_local_state<F>(&self, get_shard_transfer: F) -> CollectionResult<()>
+    where
+        F: Fn(ShardTransferKey) -> Option<ShardTransfer>,
+    {
+        for &failed_peer in self.locally_disabled_peers.read().iter() {
+            let key = ShardTransferKey {
+                shard_id: self.shard_id,
+                from: failed_peer,
+                to: self.this_peer_id(),
+            };
+
+            if let Some(transfer) = get_shard_transfer(key) {
+                self.abort_shard_transfer(transfer, "TODO"); // TODO!
+            }
+
+            self.notify_peer_failure(failed_peer);
         }
         Ok(())
     }
@@ -736,6 +756,18 @@ impl ShardReplicaSet {
     fn notify_peer_failure(&self, peer_id: PeerId) {
         log::debug!("Notify peer failure: {}", peer_id);
         self.notify_peer_failure_cb.deref()(peer_id, self.shard_id)
+    }
+
+    fn abort_shard_transfer(&self, transfer: ShardTransfer, reason: &str) {
+        log::debug!(
+            "Abort {}:{} / {} -> {} shard transfer",
+            self.collection_id,
+            transfer.shard_id,
+            transfer.from,
+            transfer.to,
+        );
+
+        self.abort_shard_transfer_cb.deref()(transfer, reason)
     }
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -667,6 +667,8 @@ impl ShardReplicaSet {
         F: Fn(ShardTransferKey) -> Option<ShardTransfer>,
     {
         for &failed_peer in self.locally_disabled_peers.read().iter() {
+            self.notify_peer_failure(failed_peer);
+
             let key = ShardTransferKey {
                 shard_id: self.shard_id,
                 from: failed_peer,
@@ -674,10 +676,14 @@ impl ShardReplicaSet {
             };
 
             if let Some(transfer) = get_shard_transfer(key) {
-                self.abort_shard_transfer(transfer, "TODO"); // TODO!
+                self.abort_shard_transfer(
+                    transfer,
+                    &format!(
+                        "{failed_peer}/{}:{} replica failed",
+                        self.collection_id, self.shard_id
+                    ),
+                );
             }
-
-            self.notify_peer_failure(failed_peer);
         }
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -17,7 +17,7 @@ use tokio::sync::{Mutex, RwLock};
 
 use super::local_shard::LocalShard;
 use super::remote_shard::RemoteShard;
-use super::transfer::shard_transfer::ShardTransfer;
+use super::transfer::ShardTransfer;
 use super::CollectionId;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -349,7 +349,7 @@ mod tests {
     use crate::config::*;
     use crate::operations::types::{VectorParams, VectorsConfig};
     use crate::optimizers_builder::OptimizersConfig;
-    use crate::shards::replica_set::ChangePeerState;
+    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
 
     #[tokio::test]
     async fn test_highest_replica_peer_id() {
@@ -420,6 +420,7 @@ mod tests {
             false,
             remotes,
             dummy_on_replica_failure(),
+            dummy_abort_shard_transfer(),
             collection_dir.path(),
             shared_config,
             Default::default(),
@@ -433,5 +434,9 @@ mod tests {
 
     fn dummy_on_replica_failure() -> ChangePeerState {
         Arc::new(move |_peer_id, _shard_id| {})
+    }
+
+    fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+        Arc::new(|_shard_transfer, _reason| {})
     }
 }

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -622,7 +622,7 @@ impl ShardHolder {
             .cloned()
     }
 
-    pub async fn get_transfers<F>(&self, mut predicate: F) -> Vec<ShardTransfer>
+    pub fn get_transfers<F>(&self, mut predicate: F) -> Vec<ShardTransfer>
     where
         F: FnMut(&ShardTransfer) -> bool,
     {
@@ -634,9 +634,8 @@ impl ShardHolder {
             .collect()
     }
 
-    pub async fn get_outgoing_transfers(&self, current_peer_id: &PeerId) -> Vec<ShardTransfer> {
+    pub fn get_outgoing_transfers(&self, current_peer_id: &PeerId) -> Vec<ShardTransfer> {
         self.get_transfers(|transfer| transfer.from == *current_peer_id)
-            .await
     }
 
     /// # Cancel safety

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -9,6 +9,7 @@ use tar::Builder as TarBuilder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
+use super::replica_set::AbortShardTransfer;
 use crate::common::file_utils::move_file;
 use crate::config::{CollectionConfig, ShardingMethod};
 use crate::hash_ring::HashRing;
@@ -403,6 +404,7 @@ impl ShardHolder {
         shared_storage_config: Arc<SharedStorageConfig>,
         channel_service: ChannelService,
         on_peer_failure: ChangePeerState,
+        abort_shard_transfer: AbortShardTransfer,
         this_peer_id: PeerId,
         update_runtime: Handle,
         search_runtime: Handle,
@@ -445,6 +447,7 @@ impl ShardHolder {
                     shared_storage_config.clone(),
                     channel_service.clone(),
                     on_peer_failure.clone(),
+                    abort_shard_transfer.clone(),
                     this_peer_id,
                     update_runtime.clone(),
                     search_runtime.clone(),
@@ -604,14 +607,14 @@ impl ShardHolder {
         })
     }
 
-    pub async fn check_transfer_exists(&self, transfer_key: &ShardTransferKey) -> bool {
+    pub fn check_transfer_exists(&self, transfer_key: &ShardTransferKey) -> bool {
         self.shard_transfers
             .read()
             .iter()
             .any(|transfer| transfer_key.check(transfer))
     }
 
-    pub async fn get_transfer(&self, transfer_key: &ShardTransferKey) -> Option<ShardTransfer> {
+    pub fn get_transfer(&self, transfer_key: &ShardTransferKey) -> Option<ShardTransfer> {
         self.shard_transfers
             .read()
             .iter()

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -12,7 +12,7 @@ use crate::operations::types::{NodeType, VectorParams, VectorsConfig};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-use crate::shards::replica_set::ChangePeerState;
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerState};
 
 pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     deleted_threshold: 0.9,
@@ -31,6 +31,10 @@ pub fn dummy_on_replica_failure() -> ChangePeerState {
 
 pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
     Arc::new(move |_transfer| {})
+}
+
+pub fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_transfer, _reason| {})
 }
 
 fn init_logger() {
@@ -95,6 +99,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )
@@ -134,6 +139,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         ChannelService::default(),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -10,7 +10,7 @@ use collection::operations::types::{CollectionError, VectorParams};
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
-use collection::shards::replica_set::{ChangePeerState, ReplicaState};
+use collection::shards::replica_set::{AbortShardTransfer, ChangePeerState, ReplicaState};
 use collection::shards::CollectionId;
 use segment::types::Distance;
 
@@ -83,6 +83,10 @@ pub fn dummy_request_shard_transfer() -> RequestShardTransfer {
     Arc::new(move |_transfer| {})
 }
 
+pub fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_transfer, _reason| {})
+}
+
 /// Default to a collection with all the shards local
 #[cfg(test)]
 pub async fn new_local_collection(
@@ -102,6 +106,7 @@ pub async fn new_local_collection(
         ChannelService::new(REST_PORT),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )
@@ -134,6 +139,7 @@ pub async fn load_local_collection(
         ChannelService::new(REST_PORT),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -17,7 +17,8 @@ use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
 
 use crate::common::{
-    dummy_on_replica_failure, dummy_request_shard_transfer, REST_PORT, TEST_OPTIMIZERS_CONFIG,
+    dummy_abort_shard_transfer, dummy_on_replica_failure, dummy_request_shard_transfer, REST_PORT,
+    TEST_OPTIMIZERS_CONFIG,
 };
 
 async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
@@ -76,6 +77,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         ChannelService::new(REST_PORT),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )
@@ -132,6 +134,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         ChannelService::new(REST_PORT),
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
         None,
         None,
     )

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -162,6 +162,10 @@ impl TableOfContent {
                             self.consensus_proposal_sender.clone(),
                             id.to_string(),
                         ),
+                        Self::abort_shard_transfer_callback(
+                            self.consensus_proposal_sender.clone(),
+                            id.to_string(),
+                        ),
                         Some(self.search_runtime.handle().clone()),
                         Some(self.update_runtime.handle().clone()),
                     )

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -172,6 +172,10 @@ impl TableOfContent {
                 self.consensus_proposal_sender.clone(),
                 collection_name.to_string(),
             ),
+            Self::abort_shard_transfer_callback(
+                self.consensus_proposal_sender.clone(),
+                collection_name.to_string(),
+            ),
             Some(self.search_runtime.handle().clone()),
             Some(self.update_runtime.handle().clone()),
         )


### PR DESCRIPTION
`sync_local_state` is called on every consensus tick (which is 100 ms by default). Under certain conditions, this may cause a cluster node to spam `SetShardReplicaState(Dead)` consensus proposals (that would ultimately be rejected) every 100 ms.

This PR extends `sync_local_state` to also abort shard transfer (if one exists) along with `SetShardReplicaState(Dead)` notification, which (once propagated through consensus and applied on this node) would partially/temporarily disable `SetShardReplicaState(Dead)` spam. (And further improvements in #3013 and #3026 makes this a complete/permanent fix for `SetShardReplicaState(Dead)` spam.)

Resolves #2975.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
