### PR TITLE
Bump rustix 0.37.x to 0.37.27 to fix vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1163d9d7c51de51a2b79d6df5e8888d11e9df17c752ce4a285fb6ca1580734e"
 dependencies = [
- "rustix 0.37.19",
+ "rustix 0.37.27",
  "tempfile",
  "windows-sys 0.48.0",
 ]
@@ -2435,7 +2435,7 @@ checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.3",
  "io-lifetimes",
- "rustix 0.37.19",
+ "rustix 0.37.27",
  "windows-sys 0.45.0",
 ]
 
@@ -4254,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/2988>.

Covers security alerts:
- https://github.com/qdrant/qdrant/security/dependabot/53
- https://github.com/qdrant/qdrant/security/dependabot/54
- https://github.com/qdrant/qdrant/security/dependabot/55
- https://github.com/qdrant/qdrant/security/dependabot/56

We still have `rustix >= 0.37.0, < 0.37.25` usages in our `dev` branch which is marked as vulnerable. This bumps them to 0.37.27 to fix it, making the above PR obsolete once we cherry-pick into `master`.

We had:

```bash
$ cargo tree | grep rustix
│   │   └── rustix v0.38.21
│   │   │   └── rustix v0.37.19
│   │   │   ├── rustix v0.37.19 (*)
│   │   │   └── rustix v0.36.13
│       │   └── rustix v0.38.21 (*)
│       ├── rustix v0.38.21 (*)
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?