### PR TITLE
Cancel shard snapshot transfer test right away

### DIFF
--- a/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_cancel.py
@@ -162,11 +162,6 @@ def test_shard_snapshot_transfer_cancel_during_updates(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # With unthrottled updates the transfer should never complete in 0.2 seconds
-    # because the queue proxy cannot keep up with transferring all of these to
-    # the remote
-    sleep(0.2)
-
     upload_process_1.kill()
     upload_process_2.kill()
     upload_process_3.kill()


### PR DESCRIPTION
Right after merging <https://github.com/qdrant/qdrant/pull/3009>, it [failed](https://github.com/qdrant/qdrant/actions/runs/6875240092/job/18698432683) again.

This removes the timeout of 0.2 seconds and cancels right away.

If this still ends up being problematic I'll remove the test.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?