### PR TITLE
Deactivate sparse index pruning for negative query vectors

### DIFF
--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::sync::atomic::AtomicBool;
 
 use common::types::PointOffsetType;
@@ -61,9 +62,9 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
     // compares results with and without filters
     // expects the filter to have no effect on the results because the filter matches everything
     for query in query_vectors.into_iter() {
-        // top to get all results
-        let top = sparse_vector_index.max_result_count(&query);
-        assert!(top > 0);
+        let maximum_number_of_results = sparse_vector_index.max_result_count(&query);
+        // get all results minus 10 to force a bit of pruning
+        let top = max(1, maximum_number_of_results.saturating_sub(10));
         let query_vector: QueryVector = query.into();
         // with filter
         let index_results_filter = sparse_vector_index

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -4,8 +4,7 @@ use rand::Rng;
 
 use crate::common::sparse_vector::SparseVector;
 
-// TODO(sparse) support negative values
-const VALUE_RANGE: Range<f64> = 0.0..100.0;
+const VALUE_RANGE: Range<f64> = -100.0..100.0;
 // Realistic sizing based on experiences with Splade
 const MAX_VALUES_PER_VECTOR: usize = 300;
 


### PR DESCRIPTION
This PR deactivates at runtime the pruning of the sparse index for queries containing negative values.

A small reminder, the pruning is an optimization that should not affect correctness.

This is necessary because the pruning mechanism is designed to track the max value in each posting list in order find a cutoff points.

However, the multiplication of two negative numbers can create large positive values that the max value tracked did not account for.

For this reason, having the pruning enabled for negative query values generates bad pruning choices.

I tried tracking instead the max absolute value but it causes more problems during scoring.

The bottom line is that:
- we support negative and positive values in index and queries
- queries with negative values might be slower on indexes with hot keys
