### PR TITLE
Add a health check before starting shard transfer during `sync_local_state` (#2977)

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -701,6 +701,20 @@ impl ShardReplicaSet {
         }
     }
 
+    pub(crate) async fn health_check(&self, peer_id: PeerId) -> CollectionResult<()> {
+        let remotes = self.remotes.read().await;
+
+        let Some(remote) = remotes.iter().find(|remote| remote.peer_id == peer_id) else {
+            return Err(CollectionError::NotFound {
+                what: format!("{}/{}:{} shard", peer_id, self.collection_id, self.shard_id),
+            });
+        };
+
+        remote.health_check().await?;
+
+        Ok(())
+    }
+
     fn init_remote_shards(
         shard_id: ShardId,
         collection_id: CollectionId,


### PR DESCRIPTION
This PR adds explicit "health check" before requesting shard transfer, to see if the other node is _available_. 

It is possible for the cluster to be in a state, when the last `Active` node is offline/unavailable, and without this check `Dead` node may request shard transfer (and switch into `Partial`) a bit too soon, which may then enable a bunch of other issues (e.g., #2975/#3012 and #2976/#3013).

Resolves #2977. Currently based on #3013, will be rebased on `dev` once it's merged.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
