### PR TITLE
integrate sparse vectors into queries

### DIFF
--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -50,7 +50,7 @@ fn discovery_into_core_search(
         lookup_collection_name,
     )
     .next()
-    .cloned();
+    .map(|v| v.to_owned());
 
     let context_pairs = request
         .context
@@ -63,7 +63,7 @@ fn discovery_into_core_search(
                 &lookup_vector_name,
                 lookup_collection_name,
             )
-            .cloned();
+            .map(|v| v.to_owned());
 
             ContextPair {
                 // SAFETY: we know there are two elements in the iterator

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -39,10 +39,13 @@ where
         quantized_storage: &'a TEncodedVectors,
         distance: Distance,
     ) -> Self {
-        let original_query = raw_query.transform(|v| distance.preprocess_vector(v));
+        let original_query = raw_query
+            .transform(|v| Ok(distance.preprocess_vector(v)))
+            .unwrap();
         let query = original_query
             .clone()
-            .transform(|v: VectorType| quantized_storage.encode_query(&v));
+            .transform(|v: VectorType| Ok(quantized_storage.encode_query(&v)))
+            .unwrap();
 
         Self {
             original_query,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -71,23 +71,24 @@ impl<'a> QuantizedScorerBuilder<'a> {
         match query {
             QueryVector::Nearest(vector) => {
                 let query_scorer =
-                    QuantizedQueryScorer::new(vector.into(), quantized_storage, *distance);
+                    QuantizedQueryScorer::new(vector.try_into()?, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Recommend(reco_query) => {
-                let reco_query: RecoQuery<VectorType> = reco_query.transform_into();
+                let reco_query: RecoQuery<VectorType> = reco_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(reco_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Discovery(discovery_query) => {
-                let discovery_query: DiscoveryQuery<VectorType> = discovery_query.transform_into();
+                let discovery_query: DiscoveryQuery<VectorType> =
+                    discovery_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(discovery_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Context(context_query) => {
-                let context_query: ContextQuery<VectorType> = context_query.transform_into();
+                let context_query: ContextQuery<VectorType> = context_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(context_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -2,9 +2,11 @@ use std::iter;
 
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
+use itertools::Itertools;
 
 use super::context_query::ContextPair;
 use super::{Query, TransformInto};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
 
 type RankType = i32;
@@ -47,17 +49,17 @@ impl<T> DiscoveryQuery<T> {
 }
 
 impl<T, U> TransformInto<DiscoveryQuery<U>, T, U> for DiscoveryQuery<T> {
-    fn transform<F>(self, mut f: F) -> DiscoveryQuery<U>
+    fn transform<F>(self, mut f: F) -> OperationResult<DiscoveryQuery<U>>
     where
-        F: FnMut(T) -> U,
+        F: FnMut(T) -> OperationResult<U>,
     {
-        DiscoveryQuery::new(
-            f(self.target),
+        Ok(DiscoveryQuery::new(
+            f(self.target)?,
             self.pairs
                 .into_iter()
                 .map(|pair| pair.transform(&mut f))
-                .collect(),
-        )
+                .try_collect()?,
+        ))
     }
 }
 

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -1,5 +1,6 @@
 use common::types::ScoreType;
 
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::VectorType;
 
 pub mod context_query;
@@ -8,16 +9,16 @@ pub mod reco_query;
 
 pub trait TransformInto<Output, T = VectorType, U = VectorType> {
     /// Change the underlying type of the query, or just process it in some way.
-    fn transform<F>(self, f: F) -> Output
+    fn transform<F>(self, f: F) -> OperationResult<Output>
     where
-        F: FnMut(T) -> U;
+        F: FnMut(T) -> OperationResult<U>;
 
-    fn transform_into(self) -> Output
+    fn transform_into(self) -> OperationResult<Output>
     where
         Self: Sized,
-        T: Into<U>,
+        T: TryInto<U, Error = OperationError>,
     {
-        self.transform(|v| v.into())
+        self.transform(|v| v.try_into())
     }
 }
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -1,7 +1,9 @@
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
+use itertools::Itertools;
 
 use super::{Query, TransformInto};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
 
 #[derive(Debug, Clone)]
@@ -24,14 +26,14 @@ impl<T> RecoQuery<T> {
 }
 
 impl<T, U> TransformInto<RecoQuery<U>, T, U> for RecoQuery<T> {
-    fn transform<F>(self, mut f: F) -> RecoQuery<U>
+    fn transform<F>(self, mut f: F) -> OperationResult<RecoQuery<U>>
     where
-        F: FnMut(T) -> U,
+        F: FnMut(T) -> OperationResult<U>,
     {
-        RecoQuery::new(
-            self.positives.into_iter().map(&mut f).collect(),
-            self.negatives.into_iter().map(&mut f).collect(),
-        )
+        Ok(RecoQuery::new(
+            self.positives.into_iter().map(&mut f).try_collect()?,
+            self.negatives.into_iter().map(&mut f).try_collect()?,
+        ))
     }
 }
 

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -27,7 +27,9 @@ impl<
     > CustomQueryScorer<'a, TMetric, TVectorStorage, TQuery>
 {
     pub fn new(query: TQuery, vector_storage: &'a TVectorStorage) -> Self {
-        let query = query.transform(|vector| TMetric::preprocess(vector));
+        let query = query
+            .transform(|vector| Ok(TMetric::preprocess(vector)))
+            .unwrap();
 
         Self {
             query,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -200,13 +200,13 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
     let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
         QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MetricQueryScorer::<TMetric, _>::new(vector.into(), vector_storage),
+            MetricQueryScorer::<TMetric, _>::new(vector.try_into()?, vector_storage),
             point_deleted,
             vec_deleted,
             is_stopped,
         ),
         QueryVector::Recommend(reco_query) => {
-            let reco_query: RecoQuery<VectorType> = reco_query.transform_into();
+            let reco_query: RecoQuery<VectorType> = reco_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(reco_query, vector_storage),
                 point_deleted,
@@ -215,7 +215,7 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             )
         }
         QueryVector::Discovery(discovery_query) => {
-            let discovery_query: DiscoveryQuery<VectorType> = discovery_query.transform_into();
+            let discovery_query: DiscoveryQuery<VectorType> = discovery_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(discovery_query, vector_storage),
                 point_deleted,
@@ -224,7 +224,7 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             )
         }
         QueryVector::Context(context_query) => {
-            let context_query: ContextQuery<VectorType> = context_query.transform_into();
+            let context_query: ContextQuery<VectorType> = context_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(context_query, vector_storage),
                 point_deleted,


### PR DESCRIPTION
Next cherry-pick from the magic branch with sparse vector experiments https://github.com/qdrant/qdrant/pull/2802

In this PR introduces `Vector` type in query types (context, discovery, ect). Also it removes temporary conversion from `Vector` into `Vec<f32>`.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
