### PR TITLE
Fix flaky snapshot recovery test

### DIFF
--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -179,17 +179,17 @@ async fn _do_recover_from_snapshot(
     for (shard_id, shard_info) in &state.shards {
         let shards = latest_shard_paths(tmp_collection_dir.path(), *shard_id).await?;
 
-        let snapshot_shard_path = shards
-            .into_iter()
-            .filter_map(
-                |(snapshot_shard_path, _version, shard_type)| match shard_type {
-                    ShardType::Local => Some(snapshot_shard_path),
-                    ShardType::ReplicaSet => Some(snapshot_shard_path),
-                    ShardType::Remote { .. } => None,
-                    ShardType::Temporary => None,
-                },
-            )
-            .next();
+        let snapshot_shard_path =
+            shards
+                .into_iter()
+                .find_map(
+                    |(snapshot_shard_path, _version, shard_type)| match shard_type {
+                        ShardType::Local => Some(snapshot_shard_path),
+                        ShardType::ReplicaSet => Some(snapshot_shard_path),
+                        ShardType::Remote { .. } => None,
+                        ShardType::Temporary => None,
+                    },
+                );
 
         if let Some(snapshot_shard_path) = snapshot_shard_path {
             log::debug!(

--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -141,6 +141,16 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
 
     assert len(new_search_result) == len(search_result)
     for i in range(len(new_search_result)):
+        # Allow point versions to be off by 1
+        # A possible difference of 1 is a side effect of having two operations
+        # for creating payload indexes as introduced in <https://github.com/qdrant/qdrant/pull/2938>.
+        # That is to migrate from segment level to collection level payload
+        # schemas. If we eventually remove the segment level payload schema, we
+        # can do exact version matches here again.
+        assert abs(search_result[i]["version"] - new_search_result[i]["version"]) <= 1
+        search_result[i].pop("version")
+        new_search_result[i].pop("version")
+
         assert new_search_result[i] == search_result[i]
 
     new_collection_info = get_collection_info(new_url, COLLECTION_NAME)


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/3005>.

Our snapshot recovery test recently became flaky and started failing most of the time. This was due to search results having different point versions after a snapshot was recovered, while before the version was always the same.

I bisected <https://github.com/qdrant/qdrant/pull/2938> to have introduced this problem. More specifically in [3b5920b^...243da10](https://github.com/qdrant/qdrant/compare/3b5920b07b27412e45739d04af1b7d1394c69046%5E...243da10fc1c36aecef8fdf3cd669f6f5ff0d78bb).

In <https://github.com/qdrant/qdrant/pull/2938> we've restructured the payload schema definition to be part of both segments and the collection. For example, to create a new payload index, we now internally use two operations to update the schema on both levels. It causes the point version number to be one higher.

I've updated the test to support this; version numbers may now be off by one.

If we eventually remove payload schema definitions from the segment level and go back to a single operation, we can go back to doing exact version matches again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?