### PR TITLE
Bump Rust to v1.74.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} tonistiigi/xx AS xx
 # Utilizing Docker layer caching with `cargo-chef`.
 #
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.72.1 AS chef
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.74.0 AS chef
 
 
 FROM chef AS planner


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2819>.

Rust [v1.74.0 ](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html) was released today.

This bumps our project to use it, which also unblocks other pending changes.

We [skipped](https://github.com/qdrant/qdrant/pull/2794) version 1.73.x as it caused a segfault during compilation (<https://github.com/rust-lang/rust/issues/116668>). This has been tackled in v1.74.0 by updating the LLVM backend to v17.0.4 <https://github.com/rust-lang/rust/pull/117436>. I've confirmed that this Rust release includes the updated LLVM update:

```bash
$ rustc --version --verbose
rustc 1.74.0 (79e9716c9 2023-11-13)
# -- snip --
LLVM version: 17.0.4
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?