### PR TITLE
Delete RocksDB files more aggressively

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -12,7 +12,7 @@ use crate::common::Flusher;
 const DB_CACHE_SIZE: usize = 10 * 1024 * 1024; // 10 mb
 const DB_MAX_LOG_SIZE: usize = 1024 * 1024; // 1 mb
 const DB_MAX_OPEN_FILES: usize = 256;
-const DB_DELETE_OBSOLETE_FILES_PERIOD: u64 = 30 * 60 * 1_000_000; // 30 minutes in microseconds
+const DB_DELETE_OBSOLETE_FILES_PERIOD: u64 = 3 * 60 * 1_000_000; // 3 minutes in microseconds
 
 pub const DB_VECTOR_CF: &str = "vector";
 pub const DB_PAYLOAD_CF: &str = "payload";
@@ -41,7 +41,8 @@ pub fn db_options() -> Options {
     options.set_write_buffer_size(DB_CACHE_SIZE);
     options.create_if_missing(true);
     options.set_log_level(LogLevel::Error);
-    options.set_recycle_log_file_num(2);
+    options.set_recycle_log_file_num(1);
+    options.set_keep_log_file_num(1); // must be greater than zero
     options.set_max_log_file_size(DB_MAX_LOG_SIZE);
     options.set_delete_obsolete_files_period_micros(DB_DELETE_OBSOLETE_FILES_PERIOD);
     options.create_missing_column_families(true);


### PR DESCRIPTION
context: deployments with large number of collections are full of log files

This PR configures RocksDB to remove more aggressively its log files.

The changes are:

- limit the number log files kept to 1
- instruct RocksDB to reuse the log file by overwriting it
- increase the cleanup frequency of all RocksDB related files