### PR TITLE
Discovery API: Rename `context_pairs` -> `context` in grpc

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -170,6 +170,7 @@
     - [SetPayloadPoints](#qdrant-SetPayloadPoints)
     - [SetPayloadPoints.PayloadEntry](#qdrant-SetPayloadPoints-PayloadEntry)
     - [ShardKeySelector](#qdrant-ShardKeySelector)
+    - [TargetVector](#qdrant-TargetVector)
     - [UpdateBatchPoints](#qdrant-UpdateBatchPoints)
     - [UpdateBatchResponse](#qdrant-UpdateBatchResponse)
     - [UpdatePointVectors](#qdrant-UpdatePointVectors)
@@ -1773,8 +1774,8 @@ The JSON representation for `Value` is a JSON value.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | collection_name | [string](#string) |  | name of the collection |
-| target | [VectorExample](#qdrant-VectorExample) |  | Use this as the primary search objective |
-| context_pairs | [ContextExamplePair](#qdrant-ContextExamplePair) | repeated | Search will be constrained by these pairs of examples |
+| target | [TargetVector](#qdrant-TargetVector) |  | Use this as the primary search objective |
+| context | [ContextExamplePair](#qdrant-ContextExamplePair) | repeated | Search will be constrained by these pairs of examples |
 | filter | [Filter](#qdrant-Filter) |  | Filter conditions - return only those points that satisfy the specified conditions |
 | limit | [uint64](#uint64) |  | Max number of result |
 | with_payload | [WithPayloadSelector](#qdrant-WithPayloadSelector) |  | Options for specifying which payload to include or not |
@@ -2952,6 +2953,21 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | shard_keys | [ShardKey](#qdrant-ShardKey) | repeated | List of shard keys which should be used in the request |
+
+
+
+
+
+
+<a name="qdrant-TargetVector"></a>
+
+### TargetVector
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| single | [VectorExample](#qdrant-VectorExample) |  |  |
 
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -374,6 +374,14 @@ message RecommendPointGroups {
   optional ShardKeySelector shard_key_selector = 21; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
+message TargetVector {
+  oneof target {
+    VectorExample single = 1;
+    
+    // leaving extensibility for possibly adding multi-target
+  }
+}
+
 message VectorExample {
   oneof example {
     PointId id = 1;
@@ -388,8 +396,8 @@ message ContextExamplePair {
 
 message DiscoverPoints {
   string collection_name = 1; // name of the collection
-  VectorExample target = 2; // Use this as the primary search objective
-  repeated ContextExamplePair context_pairs = 3; // Search will be constrained by these pairs of examples
+  TargetVector target = 2; // Use this as the primary search objective
+  repeated ContextExamplePair context = 3; // Search will be constrained by these pairs of examples
   Filter filter = 4; // Filter conditions - return only those points that satisfy the specified conditions
   uint64 limit = 5; // Max number of result
   WithPayloadSelector with_payload = 6; // Options for specifying which payload to include or not

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -110,11 +110,11 @@ message ContextPair {
 
 message DiscoveryQuery {
   Vector target = 1;
-  repeated ContextPair context_pairs = 2;
+  repeated ContextPair context = 2;
 }
 
 message ContextQuery { 
-  repeated ContextPair context_pairs = 1; 
+  repeated ContextPair context = 1; 
 }
 
 message QueryEnum {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3656,6 +3656,23 @@ pub struct RecommendPointGroups {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TargetVector {
+    #[prost(oneof = "target_vector::Target", tags = "1")]
+    pub target: ::core::option::Option<target_vector::Target>,
+}
+/// Nested message and enum types in `TargetVector`.
+pub mod target_vector {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Target {
+        #[prost(message, tag = "1")]
+        Single(super::VectorExample),
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VectorExample {
     #[prost(oneof = "vector_example::Example", tags = "1, 2")]
     pub example: ::core::option::Option<vector_example::Example>,
@@ -3692,10 +3709,10 @@ pub struct DiscoverPoints {
     pub collection_name: ::prost::alloc::string::String,
     /// Use this as the primary search objective
     #[prost(message, optional, tag = "2")]
-    pub target: ::core::option::Option<VectorExample>,
+    pub target: ::core::option::Option<TargetVector>,
     /// Search will be constrained by these pairs of examples
     #[prost(message, repeated, tag = "3")]
-    pub context_pairs: ::prost::alloc::vec::Vec<ContextExamplePair>,
+    pub context: ::prost::alloc::vec::Vec<ContextExamplePair>,
     /// Filter conditions - return only those points that satisfy the specified conditions
     #[prost(message, optional, tag = "4")]
     #[validate]
@@ -6768,14 +6785,14 @@ pub struct DiscoveryQuery {
     #[prost(message, optional, tag = "1")]
     pub target: ::core::option::Option<Vector>,
     #[prost(message, repeated, tag = "2")]
-    pub context_pairs: ::prost::alloc::vec::Vec<ContextPair>,
+    pub context: ::prost::alloc::vec::Vec<ContextPair>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContextQuery {
     #[prost(message, repeated, tag = "1")]
-    pub context_pairs: ::prost::alloc::vec::Vec<ContextPair>,
+    pub context: ::prost::alloc::vec::Vec<ContextPair>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
- Renames `context_pairs` to `context` in grpc to match the rest counterpart
- Also adds `TargetVector` with a  `oneof` to future-proof target in grpc