### PR TITLE
Default `max_values_per_point` to zero, add tests

### DIFF
--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -472,6 +472,11 @@ impl GeoMapIndex {
     }
 
     pub fn match_cardinality(&self, values: &[GeoHash]) -> CardinalityEstimation {
+        let max_values_per_point = self.max_values_per_point();
+        if max_values_per_point == 0 {
+            return CardinalityEstimation::exact(0);
+        }
+
         let common_hash = common_hash_prefix(values);
 
         let total_points = self.get_points_of_hash(&common_hash);

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -1307,4 +1307,81 @@ mod tests {
         assert_eq!(new_index.points_count(), 1);
         assert_eq!(new_index.points_values_count(), 2);
     }
+
+    #[test]
+    fn test_empty_index_cardinality() {
+        let polygon = GeoPolygon {
+            exterior: GeoLineString {
+                points: vec![
+                    GeoPoint {
+                        lon: 19.415558242000287,
+                        lat: 69.18533258102943,
+                    },
+                    GeoPoint {
+                        lon: 2.4664944437317615,
+                        lat: 61.852748225727254,
+                    },
+                    GeoPoint {
+                        lon: 2.713789718828849,
+                        lat: 51.80793869181895,
+                    },
+                    GeoPoint {
+                        lon: 19.415558242000287,
+                        lat: 69.18533258102943,
+                    },
+                ],
+            },
+            interiors: None,
+        };
+        let polygon_with_interior = GeoPolygon {
+            exterior: polygon.exterior.clone(),
+            interiors: Some(vec![GeoLineString {
+                points: vec![
+                    GeoPoint {
+                        lon: 13.2257943327987,
+                        lat: 52.62328249733332,
+                    },
+                    GeoPoint {
+                        lon: 13.11841750240768,
+                        lat: 52.550216162683455,
+                    },
+                    GeoPoint {
+                        lon: 13.11841750240768,
+                        lat: 52.40371784468752,
+                    },
+                    GeoPoint {
+                        lon: 13.2257943327987,
+                        lat: 52.62328249733332,
+                    },
+                ],
+            }]),
+        };
+        let hashes = polygon_hashes(&polygon, GEO_QUERY_MAX_REGION).unwrap();
+        let hashes_with_interior =
+            polygon_hashes(&polygon_with_interior, GEO_QUERY_MAX_REGION).unwrap();
+
+        let field_index = build_random_index(0, 0);
+        assert!(field_index
+            .match_cardinality(&hashes)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+        assert!(field_index
+            .match_cardinality(&hashes_with_interior)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+
+        let field_index = build_random_index(0, 100);
+        assert!(field_index
+            .match_cardinality(&hashes)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+        assert!(field_index
+            .match_cardinality(&hashes_with_interior)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+
+        let field_index = build_random_index(100, 100);
+        assert!(!field_index
+            .match_cardinality(&hashes)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+        assert!(!field_index
+            .match_cardinality(&hashes_with_interior)
+            .equals_min_exp_max(&CardinalityEstimation::exact(0)),);
+    }
 }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -481,7 +481,7 @@ impl GeoMapIndex {
 
         // Assume all selected points have `max_values_per_point` value hits.
         // Therefore number of points can't be less than `total_hits / max_values_per_point`
-        let min_hits_by_value_groups = sum / self.max_values_per_point();
+        let min_hits_by_value_groups = sum.checked_div(max_values_per_point).unwrap_or(0);
 
         // Assume that we have selected all possible duplications of the points
         let point_duplications = total_values - total_points;

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -491,7 +491,8 @@ impl GeoMapIndex {
 
         // Assume all selected points have `max_values_per_point` value hits.
         // Therefore number of points can't be less than `total_hits / max_values_per_point`
-        let min_hits_by_value_groups = sum.checked_div(max_values_per_point).unwrap_or(0);
+        // Note: max_values_per_point is never zero here because we check it above
+        let min_hits_by_value_groups = sum / max_values_per_point;
 
         // Assume that we have selected all possible duplications of the points
         let point_duplications = total_values - total_points;

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -73,7 +73,7 @@ impl MutableGeoMapIndex {
             point_to_values: vec![],
             points_count: 0,
             points_values_count: 0,
-            max_values_per_point: 1,
+            max_values_per_point: 0,
             db_wrapper,
         }
     }
@@ -356,6 +356,11 @@ impl GeoMapIndex {
         }
     }
 
+    /// Maximum number of values per point
+    ///
+    /// # Warning
+    ///
+    /// Zero if the index is empty.
     fn max_values_per_point(&self) -> usize {
         match self {
             GeoMapIndex::Mutable(index) => index.max_values_per_point,

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -73,4 +73,9 @@ impl CardinalityEstimation {
         self.primary_clauses.push(clause);
         self
     }
+
+    #[cfg(test)]
+    pub fn equals_min_exp_max(&self, other: &Self) -> bool {
+        self.min == other.min && self.exp == other.exp && self.max == other.max
+    }
 }

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -49,7 +49,7 @@ pub struct CardinalityEstimation {
 }
 
 impl CardinalityEstimation {
-    pub fn exact(count: usize) -> Self {
+    pub const fn exact(count: usize) -> Self {
         CardinalityEstimation {
             primary_clauses: vec![],
             min: count,
@@ -59,7 +59,7 @@ impl CardinalityEstimation {
     }
 
     /// Generate estimation for unknown filter
-    pub fn unknown(total: usize) -> Self {
+    pub const fn unknown(total: usize) -> Self {
         CardinalityEstimation {
             primary_clauses: vec![],
             min: 0,
@@ -75,7 +75,7 @@ impl CardinalityEstimation {
     }
 
     #[cfg(test)]
-    pub fn equals_min_exp_max(&self, other: &Self) -> bool {
+    pub const fn equals_min_exp_max(&self, other: &Self) -> bool {
         self.min == other.min && self.exp == other.exp && self.max == other.max
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -155,7 +155,12 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         }
     }
 
-    pub fn get_max_values_per_point(&self) -> usize {
+    /// Maximum number of values per point
+    ///
+    /// # Warning
+    ///
+    /// Zero if the index is empty.
+    pub fn max_values_per_point(&self) -> usize {
         match self {
             NumericIndex::Mutable(index) => index.max_values_per_point,
             NumericIndex::Immutable(index) => index.max_values_per_point,
@@ -195,7 +200,7 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         // max = min(1000, 500) = 500
         let expected_min = max(
             min_estimation
-                .checked_div(self.get_max_values_per_point())
+                .checked_div(max_values_per_point)
                 .unwrap_or(0),
             max(
                 min(1, min_estimation),

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(test)]
-mod tests;
-
 mod immutable_numeric_index;
 mod mutable_numeric_index;
+
+#[cfg(test)]
+mod tests;
 
 use std::cmp::{max, min};
 use std::ops::Bound;

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -168,6 +168,11 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
     }
 
     fn range_cardinality(&self, range: &Range) -> CardinalityEstimation {
+        let max_values_per_point = self.max_values_per_point();
+        if max_values_per_point == 0 {
+            return CardinalityEstimation::exact(0);
+        }
+
         let lbound = if let Some(lte) = range.lte {
             Included(T::from_f64(lte))
         } else if let Some(lt) = range.lt {

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -203,10 +203,9 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         // min = max(1, 500 - (1200 - 1000)) = 300
         // exp = 500 / (1200 / 1000) = 416
         // max = min(1000, 500) = 500
+        // Note: max_values_per_point is never zero here because we check it above
         let expected_min = max(
-            min_estimation
-                .checked_div(max_values_per_point)
-                .unwrap_or(0),
+            min_estimation / max_values_per_point,
             max(
                 min(1, min_estimation),
                 min_estimation.saturating_sub(total_values - self.get_points_count()),

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -30,7 +30,7 @@ impl<T: Encodable + Numericable> MutableNumericIndex<T> {
             db_wrapper,
             histogram: Histogram::new(HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION),
             points_count: 0,
-            max_values_per_point: 1,
+            max_values_per_point: 0,
             point_to_values: Default::default(),
         }
     }

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -411,4 +411,15 @@ fn test_empty_cardinality(#[case] immutable: bool) {
             lte: None,
         },
     );
+
+    let (_temp_dir, index) = random_index(0, 0, immutable);
+    cardinality_request(
+        &index,
+        Range {
+            lt: Some(20.0),
+            gt: None,
+            gte: Some(10.0),
+            lte: None,
+        },
+    );
 }


### PR DESCRIPTION
I took a deeper look into the `max_values_per_point` field of index types and what the purpose of it is.

This PR:
- defaults `max_values_per_point` to `0` rather than `1`
- fixes potential divide by zero panic for the geo index if it contained no items
- adds some unit tests to ensure indexes work properly if it doesn't contain points
- shortcuts cardinality estimation if `max_values_per_point` is `0`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?