### PR TITLE
Remove distance from sparse storage

### DIFF
--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -16,7 +16,6 @@ use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::VectorIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
-use segment::types::Distance;
 use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use segment::vector_storage::VectorStorage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
@@ -52,8 +51,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
 
     let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let vector_storage =
-        open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+    let vector_storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
     let mut borrowed_storage = vector_storage.borrow_mut();
 
     // add points to storage only once

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -17,7 +17,6 @@ use crate::index::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
-use crate::types::Distance;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::VectorStorage;
 
@@ -45,7 +44,7 @@ pub fn fixture_open_sparse_index<I: InvertedIndex>(
     let wrapped_payload_index = Arc::new(AtomicRefCell::new(payload_index));
 
     let db = open_db(storage_dir, &[DB_VECTOR_CF]).unwrap();
-    let vector_storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot)?;
+    let vector_storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF)?;
 
     let sparse_index_config = SparseIndexConfig::new(full_scan_threshold, None);
     let sparse_vector_index: SparseVectorIndex<I> = SparseVectorIndex::open(

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -21,7 +21,6 @@ use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
 /// In-memory vector storage with on-update persistence using `store`
 pub struct SimpleSparseVectorStorage {
-    distance: Distance,
     vectors: Vec<SparseVector>,
     db_wrapper: DatabaseColumnWrapper,
     update_buffer: StoredRecord,
@@ -41,7 +40,6 @@ struct StoredRecord {
 pub fn open_simple_sparse_vector_storage(
     database: Arc<RwLock<DB>>,
     database_column_name: &str,
-    distance: Distance,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
     let (mut deleted, mut deleted_count) = (BitVec::new(), 0);
     let mut vectors = Vec::new();
@@ -70,7 +68,6 @@ pub fn open_simple_sparse_vector_storage(
 
     Ok(Arc::new(AtomicRefCell::new(
         VectorStorageEnum::SparseSimple(SimpleSparseVectorStorage {
-            distance,
             vectors,
             db_wrapper,
             update_buffer: StoredRecord {
@@ -136,7 +133,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
     }
 
     fn distance(&self) -> Distance {
-        self.distance
+        Distance::Dot
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -9,7 +9,6 @@ use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
-use crate::types::Distance;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 
@@ -128,7 +127,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
     {
         let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
         let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage2 = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        let storage2 = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
         {
             let mut borrowed_storage2 = storage2.borrow_mut();
             points.iter().enumerate().for_each(|(i, vec)| {
@@ -197,12 +196,12 @@ fn test_delete_points_in_simple_sparse_vector_storage() {
 
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
         do_test_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
 }
 
 #[test]
@@ -210,11 +209,11 @@ fn test_update_from_delete_points_simple_sparse_vector_storage() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+        let storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
         do_test_update_from_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF, Distance::Dot).unwrap();
+    let _storage = open_simple_sparse_vector_storage(db, DB_VECTOR_CF).unwrap();
 }


### PR DESCRIPTION
Sparse vectors are hardcoded to work with dot product for the moment. 

We can cleanup the simple sparse storage implementation to not care about it.