### PR TITLE
Merge scoring and overlap check for sparse vector

### DIFF
--- a/lib/segment/src/vector_storage/sparse_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/sparse_raw_scorer.rs
@@ -42,14 +42,10 @@ impl<'a, TVectorStorage: SparseVectorStorage> SparseRawScorer<'a, TVectorStorage
     pub fn score_overlapping_point(&self, point_id: PointOffsetType) -> Option<ScoredPointOffset> {
         let point_id = point_id as PointOffsetType;
         let vector = self.vector_storage.get_sparse(point_id);
-        if self.query.overlaps(vector) {
-            Some(ScoredPointOffset {
-                idx: point_id,
-                score: vector.score(&self.query),
-            })
-        } else {
-            None
-        }
+        vector.score(&self.query).map(|score| ScoredPointOffset {
+            idx: point_id,
+            score,
+        })
     }
 }
 
@@ -67,7 +63,7 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
             // do not check overlap here as we want to score all points
             scores[size] = ScoredPointOffset {
                 idx: point_id,
-                score: vector.score(&self.query),
+                score: vector.score(&self.query).unwrap_or_default(),
             };
 
             size += 1;
@@ -94,13 +90,13 @@ impl<'a, TVectorStorage: SparseVectorStorage> RawScorer for SparseRawScorer<'a, 
 
     fn score_point(&self, point: PointOffsetType) -> ScoreType {
         let vector = self.vector_storage.get_sparse(point);
-        vector.score(&self.query)
+        vector.score(&self.query).unwrap_or_default()
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         let vector_a = self.vector_storage.get_sparse(point_a);
         let vector_b = self.vector_storage.get_sparse(point_b);
-        vector_a.score(vector_b)
+        vector_a.score(vector_b).unwrap_or_default()
     }
 
     fn peek_top_iter(


### PR DESCRIPTION
This PR merges the overlapping check with the scoring for sparse vector.

The overlap check was introduced to make sure the plain search and the index search are returning the same elements.

However this check adds a non negligible overhead and looks a lot like scoring.

This PR merges the function to restore previous performance and to keep the code less duplicated.

```
sparse-vector-search-group/plain-storage
                        time:   [101.01 ms 101.22 ms 101.41 ms]
                        change: [-9.5036% -9.2767% -9.0607%] (p = 0.00 < 0.05)
                        Performance has improved.

```