### PR TITLE
Better heuristic for sparse vector pruning

### DIFF
--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -12,7 +12,7 @@ use segment::index::{PayloadIndex, VectorIndex};
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{Condition, FieldCondition, Filter, Payload};
 use serde_json::json;
-use sparse::common::sparse_vector_fixture::random_sparse_vector;
+use sparse::common::sparse_vector_fixture::random_positive_sparse_vector;
 use tempfile::Builder;
 
 const NUM_VECTORS: usize = 50_000;
@@ -53,8 +53,8 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     }
     drop(payload_index);
 
-    // shared query vector
-    let sparse_vector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
+    // shared query vector (positive values to test pruning)
+    let sparse_vector = random_positive_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
     eprintln!("sparse_vector size = {:#?}", sparse_vector.values.len());
     let query_vector = sparse_vector.into();
 

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -49,3 +49,15 @@ pub fn random_full_sparse_vector<R: Rng + ?Sized>(
 
     SparseVector::try_from(tuples).unwrap()
 }
+
+/// Generates a sparse vector with only positive values
+pub fn random_positive_sparse_vector<R: Rng + ?Sized>(
+    rnd_gen: &mut R,
+    max_dim_size: usize,
+) -> SparseVector {
+    let mut vec = random_sparse_vector(rnd_gen, max_dim_size);
+    for value in vec.values.iter_mut() {
+        *value = value.abs();
+    }
+    vec
+}


### PR DESCRIPTION
This PR introduces a simple heuristic to drastically decrease the number of pruning operations during sparse vector search.

Instead of trying to prune on all search candidates, we only try to prune when the worst best score changes.
This is a good signal that we should try pruning again as the eviction threshold increased.

This increases performance significantly on our synthetic benchmark.

```
sparse_vector size = 196
sparse-vector-search-group/inverted-index
                        time:   [15.326 ms 15.374 ms 15.422 ms]
                        change: [-42.208% -41.984% -41.762%] (p = 0.00 < 0.05)
                        Performance has improved.
``` 