### PR TITLE
Accept empty sparse vectors

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6142,7 +6142,7 @@
         ]
       },
       "SparseVector": {
-        "description": "Sparse vector structure\n\nexpects: - indices to be unique - indices and values to be the same length - indices and values to be non-empty",
+        "description": "Sparse vector structure\n\nexpects: - indices to be unique - indices and values to be the same length",
         "type": "object",
         "required": [
           "indices",

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -261,7 +261,10 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
     fn update_vector(&mut self, id: PointOffsetType) -> OperationResult<()> {
         let vector_storage = self.vector_storage.borrow();
         let vector: &SparseVector = vector_storage.get_vector(id).try_into()?;
-        self.inverted_index.upsert(id, vector.clone());
+        // do not upsert empty vectors into the index
+        if !vector.is_empty() {
+            self.inverted_index.upsert(id, vector.clone());
+        }
         Ok(())
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -227,6 +227,10 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         for id in borrowed_id_tracker.iter_ids_excluding(deleted_bitslice) {
             check_process_stopped(stopped)?;
             let vector: &SparseVector = borrowed_vector_storage.get_vector(id).try_into()?;
+            // do not index empty vectors
+            if vector.is_empty() {
+                continue;
+            }
             ram_index.upsert(id, vector.to_owned());
             index_point_count += 1;
         }

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -69,13 +69,7 @@ impl InvertedIndexRam {
     }
 
     /// Upsert a vector into the inverted index.
-    ///
-    /// Empty vectors are ignored.
     pub fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {
-        // do not upsert empty vectors
-        if vector.is_empty() {
-            return;
-        }
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             match self.postings.get_mut(dim_id) {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -69,7 +69,13 @@ impl InvertedIndexRam {
     }
 
     /// Upsert a vector into the inverted index.
+    ///
+    /// Empty vectors are ignored.
     pub fn upsert(&mut self, id: PointOffsetType, vector: SparseVector) {
+        // do not upsert empty vectors
+        if vector.is_empty() {
+            return;
+        }
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             match self.postings.get_mut(dim_id) {


### PR DESCRIPTION
This PR removes the validation that a sparse vector must be non-empty.

The rational is that it is overly restrictive given that:
- embeddings might generate such vectors
- users might want to only attach payload to a sparse vector

Instead of forcing more work onto the user, we decided to loosen up that constraint.

Empty sparse vectors cannot be indexed but can be found in storage through the scrolling API.