### PR TITLE
chore: bump to tonic 0.10.2 and prost to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ dependencies = [
  "env_logger",
  "log",
  "parking_lot",
- "prost 0.11.9",
+ "prost 0.12.2",
  "prost-build 0.11.9",
- "prost-types 0.11.9",
+ "prost-types 0.12.2",
  "rand 0.8.5",
  "schemars",
  "segment",
@@ -490,7 +490,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tower",
  "tracing",
@@ -1089,7 +1089,7 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tracing",
  "url",
@@ -1165,7 +1165,7 @@ checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost 0.11.9",
  "prost-types 0.11.9",
- "tonic",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
@@ -1188,7 +1188,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -3559,12 +3559,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8473a65b88506c106c28ae905ca4a2b83a2993640467a41bb3080627ddfd2c"
+checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
 dependencies = [
  "bytes",
- "prost-derive 0.12.0",
+ "prost-derive 0.12.2",
 ]
 
 [[package]]
@@ -3605,8 +3605,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease 0.2.4",
- "prost 0.12.0",
- "prost-types 0.12.0",
+ "prost 0.12.2",
+ "prost-types 0.12.2",
  "regex",
  "syn 2.0.28",
  "tempfile",
@@ -3628,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56075c27b20ae524d00f247b8a4dc333e5784f889fe63099f8e626bc8d73486c"
+checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3650,11 +3650,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebe0a918c97f86c217b0f76fd754e966f8b9f41595095cf7d74cb4e59d730f6"
+checksum = "8339f32236f590281e2f6368276441394fcd1b2133b549cc895d0ae80f2f9a52"
 dependencies = [
- "prost 0.12.0",
+ "prost 0.12.2",
 ]
 
 [[package]]
@@ -3752,7 +3752,7 @@ dependencies = [
  "thiserror",
  "tikv-jemallocator",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-reflection",
  "tower",
  "tower-layer",
@@ -4823,7 +4823,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "url",
  "uuid",
@@ -5176,14 +5176,13 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.9.2"
-source = "git+https://github.com/qdrant/tonic?branch=v0.9.2-patched#060ab88c87955adc59d46a44b4e3b72cb4cc1522"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.0",
  "bytes",
- "flate2",
  "futures-core",
  "futures-util",
  "h2",
@@ -5194,6 +5193,35 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.2",
+ "rustls",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
@@ -5219,15 +5247,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0543d7092032041fbeac1f2c84304537553421a11a623c2301b12ef0264862c7"
+checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
 dependencies = [
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "prost 0.12.2",
+ "prost-types 0.12.2",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -5577,7 +5605,7 @@ dependencies = [
  "memmap2 0.9.0",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.36.13",
+ "rustix 0.38.21",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ actix-web = { version = "4.3.1", optional = true, features = ["rustls-0_21", "ac
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
 actix-web-httpauth = "0.8.1"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
-tonic-reflection = "0.9.2"
+tonic = { version = "0.10.2", features = ["gzip", "tls"] }
+tonic-reflection = "0.10.2"
 tower = "0.4.13"
 tower-layer = "0.3.2"
 num-traits = "0.2.16"
@@ -157,7 +157,3 @@ lto = false
 inherits = "release"
 lto = false
 opt-level = 3
-
-[patch.crates-io]
-# Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
-tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -14,9 +14,9 @@ tracing = ["dep:tracing", "segment/tracing"]
 [dependencies]
 log = "0.4"
 env_logger = "0.10.0"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
-prost = "0.11.9"
-prost-types = "0.11.9"
+tonic = { version = "0.10.2", features = ["gzip", "tls"] }
+prost = "0.12.2"
+prost-types = "0.12.2"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 schemars = { version = "0.8.15", features = ["uuid1", "preserve_order", "chrono"] }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -243,9 +243,9 @@ impl TryFrom<TextIndexParams> for segment::data_types::text_index::TextIndexPara
     fn try_from(params: TextIndexParams) -> Result<Self, Self::Error> {
         Ok(segment::data_types::text_index::TextIndexParams {
             r#type: TextIndexType::Text,
-            tokenizer: TokenizerType::from_i32(params.tokenizer)
+            tokenizer: TokenizerType::try_from(params.tokenizer)
                 .map(|x| x.try_into())
-                .unwrap_or_else(|| Err(Status::invalid_argument("unknown tokenizer type")))?,
+                .unwrap_or_else(|_| Err(Status::invalid_argument("unknown tokenizer type")))?,
             lowercase: params.lowercase,
             min_token_len: params.min_token_len.map(|x| x as usize),
             max_token_len: params.max_token_len.map(|x| x as usize),
@@ -281,13 +281,13 @@ impl TryFrom<PayloadSchemaInfo> for segment::types::PayloadIndexInfo {
     type Error = Status;
 
     fn try_from(schema: PayloadSchemaInfo) -> Result<Self, Self::Error> {
-        let data_type = match PayloadSchemaType::from_i32(schema.data_type) {
-            None => {
+        let data_type = match PayloadSchemaType::try_from(schema.data_type) {
+            Err(_) => {
                 return Err(Status::invalid_argument(
                     "Malformed payload schema".to_string(),
                 ))
             }
-            Some(data_type) => match data_type {
+            Ok(data_type) => match data_type {
                 PayloadSchemaType::Keyword => segment::types::PayloadSchemaType::Keyword,
                 PayloadSchemaType::Integer => segment::types::PayloadSchemaType::Integer,
                 PayloadSchemaType::Float => segment::types::PayloadSchemaType::Float,
@@ -584,9 +584,9 @@ impl TryFrom<ScalarQuantization> for segment::types::ScalarQuantization {
     fn try_from(value: ScalarQuantization) -> Result<Self, Self::Error> {
         Ok(segment::types::ScalarQuantization {
             scalar: segment::types::ScalarQuantizationConfig {
-                r#type: match QuantizationType::from_i32(value.r#type) {
-                    Some(QuantizationType::Int8) => segment::types::ScalarType::Int8,
-                    Some(QuantizationType::UnknownQuantization) | None => {
+                r#type: match QuantizationType::try_from(value.r#type) {
+                    Ok(QuantizationType::Int8) => segment::types::ScalarType::Int8,
+                    Ok(QuantizationType::UnknownQuantization) | Err(_) => {
                         return Err(Status::invalid_argument("Unknown quantization type"))
                     }
                 },
@@ -619,17 +619,17 @@ impl TryFrom<ProductQuantization> for segment::types::ProductQuantization {
     fn try_from(value: ProductQuantization) -> Result<Self, Self::Error> {
         Ok(segment::types::ProductQuantization {
             product: segment::types::ProductQuantizationConfig {
-                compression: match CompressionRatio::from_i32(value.compression) {
-                    None => {
+                compression: match CompressionRatio::try_from(value.compression) {
+                    Err(_) => {
                         return Err(Status::invalid_argument(
                             "Unknown compression ratio".to_string(),
                         ))
                     }
-                    Some(CompressionRatio::X4) => segment::types::CompressionRatio::X4,
-                    Some(CompressionRatio::X8) => segment::types::CompressionRatio::X8,
-                    Some(CompressionRatio::X16) => segment::types::CompressionRatio::X16,
-                    Some(CompressionRatio::X32) => segment::types::CompressionRatio::X32,
-                    Some(CompressionRatio::X64) => segment::types::CompressionRatio::X64,
+                    Ok(CompressionRatio::X4) => segment::types::CompressionRatio::X4,
+                    Ok(CompressionRatio::X8) => segment::types::CompressionRatio::X8,
+                    Ok(CompressionRatio::X16) => segment::types::CompressionRatio::X16,
+                    Ok(CompressionRatio::X32) => segment::types::CompressionRatio::X32,
+                    Ok(CompressionRatio::X64) => segment::types::CompressionRatio::X64,
                 },
                 always_ram: value.always_ram,
             },
@@ -1183,10 +1183,10 @@ impl TryFrom<Distance> for segment::types::Distance {
 }
 
 pub fn from_grpc_dist(dist: i32) -> Result<segment::types::Distance, Status> {
-    match Distance::from_i32(dist) {
-        None => Err(Status::invalid_argument(format!(
+    match Distance::try_from(dist) {
+        Err(_) => Err(Status::invalid_argument(format!(
             "Malformed distance parameter, unexpected value: {dist}"
         ))),
-        Some(grpc_distance) => Ok(grpc_distance.try_into()?),
+        Ok(grpc_distance) => Ok(grpc_distance.try_into()?),
     }
 }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -42,7 +42,7 @@ env_logger = "0.10.0"
 merge = "0.1.0"
 async-trait = "0.1.73"
 arc-swap = "1.6.0"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
+tonic = { version = "0.10.2", features = ["gzip", "tls"] }
 tower = "0.4.13"
 uuid = { version = "1.5", features = ["v4", "serde"] }
 url = { version = "2", features = ["serde"] }

--- a/lib/collection/src/operations/consistency_params.rs
+++ b/lib/collection/src/operations/consistency_params.rs
@@ -160,7 +160,7 @@ impl TryFrom<i32> for ReadConsistencyType {
     type Error = tonic::Status;
 
     fn try_from(consistency: i32) -> Result<Self, Self::Error> {
-        let consistency = ReadConsistencyTypeGrpc::from_i32(consistency).ok_or_else(|| {
+        let consistency = ReadConsistencyTypeGrpc::try_from(consistency).map_err(|_| {
             tonic::Status::invalid_argument(format!(
                 "invalid read consistency type value {consistency}",
             ))

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -94,14 +94,14 @@ pub fn write_ordering_from_proto(
     let ordering_parsed = match ordering {
         None => api::grpc::qdrant::WriteOrderingType::Weak,
         Some(write_ordering) => {
-            match api::grpc::qdrant::WriteOrderingType::from_i32(write_ordering.r#type) {
-                None => {
+            match api::grpc::qdrant::WriteOrderingType::try_from(write_ordering.r#type) {
+                Err(_) => {
                     return Err(Status::invalid_argument(format!(
                         "cannot convert ordering: {}",
                         write_ordering.r#type
                     )))
                 }
-                Some(res) => res,
+                Ok(res) => res,
             }
         }
     };
@@ -1264,8 +1264,8 @@ impl TryFrom<i32> for ReplicaState {
     type Error = Status;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        let replica_state = api::grpc::qdrant::ReplicaState::from_i32(value)
-            .ok_or_else(|| Status::invalid_argument(format!("Unknown replica state: {}", value)))?;
+        let replica_state = api::grpc::qdrant::ReplicaState::try_from(value)
+            .map_err(|_| Status::invalid_argument(format!("Unknown replica state: {}", value)))?;
         Ok(replica_state.into())
     }
 }
@@ -1300,7 +1300,7 @@ impl TryFrom<i32> for RecommendStrategy {
     type Error = Status;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        let strategy = api::grpc::qdrant::RecommendStrategy::from_i32(value).ok_or_else(|| {
+        let strategy = api::grpc::qdrant::RecommendStrategy::try_from(value).map_err(|_| {
             Status::invalid_argument(format!("Unknown recommend strategy: {}", value))
         })?;
         Ok(strategy.into())
@@ -1555,9 +1555,9 @@ impl TryFrom<i32> for ShardTransferMethod {
     type Error = Status;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        api::grpc::qdrant::ShardTransferMethod::from_i32(value)
+        api::grpc::qdrant::ShardTransferMethod::try_from(value)
             .map(Into::into)
-            .ok_or_else(|| {
+            .map_err(|_| {
                 Status::invalid_argument(format!("Unknown shard transfer method: {value}"))
             })
     }

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -30,9 +30,9 @@ impl TryFrom<i32> for SnapshotPriority {
     type Error = tonic::Status;
 
     fn try_from(snapshot_priority: i32) -> Result<Self, Self::Error> {
-        api::grpc::qdrant::ShardSnapshotPriority::from_i32(snapshot_priority)
+        api::grpc::qdrant::ShardSnapshotPriority::try_from(snapshot_priority)
             .map(Into::into)
-            .ok_or_else(|| tonic::Status::invalid_argument("Malformed shard snapshot priority"))
+            .map_err(|_| tonic::Status::invalid_argument("Malformed shard snapshot priority"))
     }
 }
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -28,7 +28,7 @@ schemars = { version = "0.8.15", features = ["uuid1", "preserve_order", "chrono"
 itertools = "0.11"
 async-trait = "0.1.73"
 log = "0.4"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
+tonic = { version = "0.10.2", features = ["gzip", "tls"] }
 http = "0.2"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 tar = "0.4.40"


### PR DESCRIPTION
- https://github.com/hyperium/tonic/pull/1401 has been merged, so we should be able to bump tonic and prost versions now. 

- `from_32` was deprecated in favor of `TryFrom::try_from`, so that's the other source of changes here.