### PR TITLE
Only use ANSI in logging if we should colorize

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as _;
 use std::str::FromStr as _;
 
+use colored::control::ShouldColorize;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter, fmt};
 
@@ -34,7 +35,8 @@ pub fn setup(user_filters: &str) -> anyhow::Result<()> {
 
     let reg = tracing_subscriber::registry().with(
         fmt::layer()
-            .with_ansi(true)
+            // Only use ANSI if we should colorize
+            .with_ansi(ShouldColorize::from_env().should_colorize())
             .with_span_events(fmt::format::FmtSpan::NEW)
             .with_filter(
                 filter::EnvFilter::builder()


### PR DESCRIPTION
Fix `NO_COLOR` (and others) not disabling colored log levels in stdout.

Before:

![image](https://github.com/qdrant/qdrant/assets/856222/7a5643f8-5b49-488f-9332-d63d97a1ec7c)

After:

![image](https://github.com/qdrant/qdrant/assets/856222/10b1a355-e2db-4991-a792-d3f13cea3de2)

Report: https://discord.com/channels/907569970500743200/1175945733787107489/1176513151387320392

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?