### PR TITLE
spare one extra worker by replacing spawn with block_on

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         if !collections_to_recover_in_consensus.is_empty() {
-            runtime_handle.spawn(handle_existing_collections(
+            runtime_handle.block_on(handle_existing_collections(
                 toc_arc.clone(),
                 consensus_state.clone(),
                 dispatcher_arc.clone(),


### PR DESCRIPTION
When migrating from local -> distributed,
qdrant should explicitly fill consensus WAL with missing operations, so they could be replicated to other collection.

It appears, that in current implementation the migration requires one extra parallel thread of execution.

If we try to run migration of low CPU machine (<=2 CPU), the allocated thread pool doesn't have enough processes to execute the operation, which results in stuck consensus:

```
"raft_info": {
      "term": 0,
      "commit": 0,
      "pending_operations": 0,
      "leader": null,
      "role": null,
      "is_voter": true
    }
```

This PR changes `spawn` into `block_on` for migration process, which should prevent over-usage of threads.

An alternative could be to allocate +1 thread minimum by default or use different runtime.
But the current option looks the simplest.

Workaround for previous versions:
Run qdrant with `QDRANT_NUM_CPUS=3`