### PR TITLE
Randomize peer order for shard placements

### DIFF
--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -50,11 +50,10 @@ impl ShardDistributionProposal {
         known_peers: &[PeerId],
     ) -> Self {
         // min number of shard_count on top to make this a min-heap
-        let mut min_heap: BinaryHeap<Reverse<PeerShardCount>> =
-            BinaryHeap::with_capacity(known_peers.len());
-        for peer in known_peers {
-            min_heap.push(Reverse(PeerShardCount::new(*peer)));
-        }
+        let mut min_heap: BinaryHeap<Reverse<PeerShardCount>> = known_peers
+            .iter()
+            .map(|peer| Reverse(PeerShardCount::new(*peer)))
+            .collect();
 
         let mut distribution = Vec::with_capacity(shard_number.get() as usize);
         // There should not be more than 1 replica per peer

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -78,7 +78,7 @@ impl ShardDistributionProposal {
         known_peers: &[PeerId],
     ) -> Self {
         // Min-heap: peer with lowest number of shards is on top
-        let mut min_heap: BinaryHeap<Reverse<PeerShardCount>> = known_peers
+        let mut min_heap: BinaryHeap<_> = known_peers
             .iter()
             .map(|peer| Reverse(PeerShardCount::new(*peer)))
             .collect();

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct PeerShardCount {
     shard_count: usize, // self.shard_count and other.shard_count are compared first to determine eq & ord
+    /// Randomized bias value, to prevent having a consistent order of peers across multiple
+    /// generated distributions. This rougly balances nodes across all nodes, if the number of
+    /// shards is less than the number of nodes.
+    bias: usize,
     peer_id: PeerId,
 }
 
@@ -18,6 +22,7 @@ impl PeerShardCount {
     fn new(peer_id: PeerId) -> Self {
         Self {
             shard_count: 0,
+            bias: rand::random(),
             peer_id,
         }
     }

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -77,21 +77,21 @@ impl ShardDistributionProposal {
         replication_factor: NonZeroU32,
         known_peers: &[PeerId],
     ) -> Self {
-        // min number of shard_count on top to make this a min-heap
+        // Min-heap: peer with lowest number of shards is on top
         let mut min_heap: BinaryHeap<Reverse<PeerShardCount>> = known_peers
             .iter()
             .map(|peer| Reverse(PeerShardCount::new(*peer)))
             .collect();
 
         // There should not be more than 1 replica per peer
-        let n_replicas = cmp::min(replication_factor.get() as usize, known_peers.len());
+        let replica_number = cmp::min(replication_factor.get() as usize, known_peers.len());
 
         // Get fair distribution of shards on peers
         let distribution = (0..shard_number.get())
             .map(|shard_id| {
                 let replicas =
                     repeat_with(|| min_heap.peek_mut().unwrap().0.get_and_inc_shard_count())
-                        .take(n_replicas)
+                        .take(replica_number)
                         .collect();
                 (shard_id, replicas)
             })

--- a/lib/storage/src/content_manager/shard_distribution.rs
+++ b/lib/storage/src/content_manager/shard_distribution.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 struct PeerShardCount {
     shard_count: usize,
     /// Randomized bias value, to prevent having a consistent order of peers across multiple
-    /// generated distributions. This rougly balances nodes across all nodes, if the number of
+    /// generated distributions. This roughly balances nodes across all nodes, if the number of
     /// shards is less than the number of nodes.
     bias: usize,
     peer_id: PeerId,


### PR DESCRIPTION
Currently, the order of peers is always consistent when generating shard distributions.

If the number of shards is a multiple of the number of peers, this is fine. But for example, if you have less shards than the number of peers things get problematic. In that case, all shards (across different collections) always end up on the  same nodes, leaving other nodes uninhabited.

For example, if you have 3 nodes (peer 111, 222, 333) and you create 4 collections on it all with two shards, the shard distributions will end up being:
- 1: 111, 222
- 2: 111, 222
- 3: 111, 222
- 4: 111, 222

That is because the second level of ordering for placement is based on the peer ID, always preferring lower peer IDs. In the above case, peer 333 will remain uninhabited.

To fix this I've added a randomized `bias` to each peer on each distribution generation. The bias will replace the second level of ordering, guaranteeing a shuffled order each time. This should roughly spread shards across nodes, such as:

- 1: 333, 111
- 2: 333, 222
- 3: 222, 111
- 4: 111, 333

I've also:
- used iterator for distributing logic so that we allocate collections with the correct capacity right away
- simplified our distributing loop a bit
- implemented ordering explicitly so we don't depend on the order of fields and prevent future mistakes
- added a test ensuring all nodes are inhabited with 100 distributions for various configurations

I've also manually tested the behavior.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
