### PR TITLE
Mmap InvertedIndex uses Sequential madvice

### DIFF
--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -8,11 +8,14 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram;
+use segment::index::sparse_index::sparse_index_config::SparseIndexConfig;
+use segment::index::sparse_index::sparse_vector_index::SparseVectorIndex;
 use segment::index::{PayloadIndex, VectorIndex};
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{Condition, FieldCondition, Filter, Payload};
 use serde_json::json;
 use sparse::common::sparse_vector_fixture::random_positive_sparse_vector;
+use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use tempfile::Builder;
 
 const NUM_VECTORS: usize = 50_000;
@@ -57,6 +60,33 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     let sparse_vector = random_positive_sparse_vector(&mut rnd, MAX_SPARSE_DIM);
     eprintln!("sparse_vector size = {:#?}", sparse_vector.values.len());
     let query_vector = sparse_vector.into();
+
+    // mmap inverted index
+    let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
+    let _mmap_inverted_index =
+        InvertedIndexMmap::convert_and_save(&sparse_vector_index.inverted_index, &mmap_index_dir)
+            .unwrap();
+    drop(_mmap_inverted_index);
+    let sparse_index_config = SparseIndexConfig::new(FULL_SCAN_THRESHOLD, None);
+    let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> = SparseVectorIndex::open(
+        sparse_index_config,
+        sparse_vector_index.id_tracker.clone(),
+        sparse_vector_index.vector_storage.clone(),
+        sparse_vector_index.payload_index.clone(),
+        mmap_index_dir.path(),
+    )
+    .unwrap();
+
+    // intent: bench `search` without filter on mmap inverted index
+    group.bench_function("mmap-inverted-index", |b| {
+        b.iter(|| {
+            let results = sparse_vector_index_mmap
+                .search(&[&query_vector], None, TOP, None, &stopped)
+                .unwrap();
+
+            assert_eq!(results[0].len(), TOP);
+        })
+    });
 
     // intent: bench `search` without filter
     group.bench_function("inverted-index", |b| {

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -111,7 +111,8 @@ impl InvertedIndexMmap {
         create_and_ensure_length(file_path.as_ref(), file_length)?;
 
         let mut mmap = open_write_mmap(file_path.as_ref())?;
-        madvise::madvise(&mmap, madvise::get_global())?;
+        // posting lists are traversed sequentially
+        madvise::madvise(&mmap, madvise::Advice::Sequential)?;
 
         // file index data
         Self::save_posting_headers(&mut mmap, inverted_index_ram, total_posting_headers_size);
@@ -144,7 +145,8 @@ impl InvertedIndexMmap {
         // read index data into mmap
         let file_path = Self::index_file_path(path.as_ref());
         let mmap = open_read_mmap(file_path.as_ref())?;
-        madvise::madvise(&mmap, madvise::get_global())?;
+        // posting lists are traversed sequentially
+        madvise::madvise(&mmap, madvise::Advice::Sequential)?;
         Ok(Self {
             path: path.as_ref().to_owned(),
             mmap: Arc::new(mmap),


### PR DESCRIPTION
This PR changes the madvice for the mmap inverted index to be sequential instead of random.

The rational is that posting lists are traversed sequentially during search so it should match the access pattern.

I was not able to validate a performance improvement on the included benchmark because:
- everything fits in memory nicely.
- the query vector does not change.

I still think it is a good change based on the design of the search algorithm.
