### PR TITLE
fix awaiting of the consensus thread to actually await entry to be ap…

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -112,6 +112,7 @@ impl Collection {
                 channel_service.clone(),
                 update_runtime.clone().unwrap_or_else(Handle::current),
                 search_runtime.clone().unwrap_or_else(Handle::current),
+                None,
             )
             .await?;
 

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -6,7 +6,7 @@ use crate::collection::Collection;
 use crate::config::ShardingMethod;
 use crate::operations::types::CollectionError;
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
-use crate::shards::replica_set::ShardReplicaSet;
+use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::shard::{PeerId, ShardId, ShardsPlacement};
 
 impl Collection {
@@ -37,6 +37,7 @@ impl Collection {
             self.channel_service.clone(),
             self.update_runtime.clone(),
             self.search_runtime.clone(),
+            Some(ReplicaState::Active),
         )
         .await
     }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -437,6 +437,7 @@ mod tests {
             Default::default(),
             update_runtime,
             search_runtime,
+            None,
         )
         .await
         .unwrap()

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -587,7 +587,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         }
     }
 
-    /// Wait and block until consensus reaches a `commit` and `term`
+    /// Wait and block until consensus reaches a `term` and actually applies the `commit`.
     ///
     /// # Errors
     ///
@@ -605,8 +605,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         while start.elapsed() < timeout {
             let state = &self.hard_state();
 
+            let unapplied_commit = self.persistent.read().current_unapplied_entry();
+
+            let applied_commit = unapplied_commit
+                .map(|commit_id| commit_id.saturating_sub(1))
+                .unwrap_or(state.commit);
+
             // Okay if on the same term and have at least the specified commit
-            let is_ok = state.term == term && state.commit >= commit;
+            let is_ok = state.term == term && applied_commit >= commit;
             if is_ok {
                 return Ok(());
             }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -605,14 +605,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         while start.elapsed() < timeout {
             let state = &self.hard_state();
 
-            let unapplied_commit = self.persistent.read().current_unapplied_entry();
+            let last_applied_commit = self.persistent.read().last_applied_entry();
 
-            let applied_commit = unapplied_commit
-                .map(|commit_id| commit_id.saturating_sub(1))
-                .unwrap_or(state.commit);
+            let is_commit_ok = last_applied_commit
+                .map(|applied| applied >= commit)
+                .unwrap_or(false);
 
             // Okay if on the same term and have at least the specified commit
-            let is_ok = state.term == term && applied_commit >= commit;
+            let is_ok = state.term == term && is_commit_ok;
             if is_ok {
                 return Ok(());
             }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -163,6 +163,12 @@ impl Dispatcher {
                 .await_commit_on_all_peers(this_peer_id, commit, term, timeout)
                 .await?;
 
+            log::debug!(
+                "Consensus is synchronized with term: {}, commit: {}",
+                term,
+                commit
+            );
+
             Ok(())
         } else {
             Ok(())

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -1,0 +1,115 @@
+import pathlib
+
+from .fixtures import upsert_random_points, create_collection
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 3
+N_REPLICAS = 1
+
+COLLECTION_NAME = "test_collection"
+
+
+def create_collection_with_custom_sharding(
+        peer_url,
+        collection=COLLECTION_NAME,
+        shard_number=1,
+        replication_factor=1,
+        write_consistency_factor=1,
+        timeout=10
+):
+    # Create collection in peer_url
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}?timeout={timeout}", json={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot"
+            },
+            "shard_number": shard_number,
+            "replication_factor": replication_factor,
+            "write_consistency_factor": write_consistency_factor,
+            "sharding_method": "custom",
+        })
+    assert_http_ok(r_batch)
+
+
+def create_shard(
+        peer_url,
+        collection,
+        shard_key,
+        shard_number=1,
+        replication_factor=1,
+        placement=None,
+        timeout=10
+):
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}/shards?timeout={timeout}", json={
+            "shard_key": shard_key,
+            "shards_number": shard_number,
+            "replication_factor": replication_factor,
+            "placement": placement,
+        })
+    assert_http_ok(r_batch)
+
+
+def test_shard_consistency(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection_with_custom_sharding(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+    wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris)
+
+    # Create shards
+    create_shard(
+        peer_api_uris[0],
+        COLLECTION_NAME,
+        shard_key="cats",
+        shard_number=1,
+        replication_factor=1
+    )
+
+    create_shard(
+        peer_api_uris[0],
+        COLLECTION_NAME,
+        shard_key="dogs",
+        shard_number=1,
+        replication_factor=1
+    )
+
+    # Insert data
+
+    # Create points in first peer's collection
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points?wait=true", json={
+            "shard_key": "cats",
+            "points": [
+                {"id": 1, "vector": [0.29, 0.81, 0.75, 0.11], "payload": {"name": "Barsik"}},
+                {"id": 2, "vector": [0.19, 0.11, 0.15, 0.21], "payload": {"name": "Murzik"}},
+                {"id": 3, "vector": [0.99, 0.81, 0.75, 0.31], "payload": {"name": "Vaska"}},
+                {"id": 4, "vector": [0.29, 0.01, 0.05, 0.91], "payload": {"name": "Chubais"}},
+            ]
+        })
+    assert_http_ok(r)
+
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points?wait=true", json={
+            "shard_key": "dogs",
+            "points": [
+                {"id": 5, "vector": [0.29, 0.81, 0.75, 0.11], "payload": {"name": "Sharik"}},
+                {"id": 6, "vector": [0.19, 0.11, 0.15, 0.21], "payload": {"name": "Tuzik"}},
+                {"id": 7, "vector": [0.99, 0.81, 0.75, 0.31], "payload": {"name": "Bobik"}},
+                {"id": 8, "vector": [0.29, 0.01, 0.05, 0.91], "payload": {"name": "Muhtar"}},
+            ]
+        })
+    assert_http_ok(r)
+
+    # Check total number of points
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/count",
+        json={
+            "exact": True,
+        }
+    )
+    assert_http_ok(r)
+    assert r.json()["result"]["count"] == 8


### PR DESCRIPTION
Introduces test for working with custom shards.
Fixes awaiting for the consensus on all nodes:

- Instead await simply for commit, we await for the commit to be applied
- Disable usage of `Initialized` state for custom shards