### PR TITLE
Trigram tokenizer 

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5900,7 +5900,8 @@
           "prefix",
           "whitespace",
           "word",
-          "multilingual"
+          "multilingual",
+          "trigram"
         ]
       },
       "PointRequest": {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -235,9 +235,7 @@ impl TryFrom<TokenizerType> for segment::data_types::text_index::TokenizerType {
                 Ok(segment::data_types::text_index::TokenizerType::Whitespace)
             }
             TokenizerType::Word => Ok(segment::data_types::text_index::TokenizerType::Word),
-            TokenizerType::Trigram => {
-                Ok(segment::data_types::text_index::TokenizerType::Trigram)
-            }
+            TokenizerType::Trigram => Ok(segment::data_types::text_index::TokenizerType::Trigram),
         }
     }
 }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -181,6 +181,7 @@ impl From<segment::data_types::text_index::TokenizerType> for TokenizerType {
                 TokenizerType::Multilingual
             }
             segment::data_types::text_index::TokenizerType::Word => TokenizerType::Word,
+            segment::data_types::text_index::TokenizerType::Trigram => TokenizerType::Trigram,
         }
     }
 }
@@ -234,6 +235,9 @@ impl TryFrom<TokenizerType> for segment::data_types::text_index::TokenizerType {
                 Ok(segment::data_types::text_index::TokenizerType::Whitespace)
             }
             TokenizerType::Word => Ok(segment::data_types::text_index::TokenizerType::Word),
+            TokenizerType::Trigram => {
+                Ok(segment::data_types::text_index::TokenizerType::Trigram)
+            }
         }
     }
 }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -310,6 +310,7 @@ enum TokenizerType {
   Whitespace = 2;
   Word = 3;
   Multilingual = 4;
+  Trigram = 5;
 }
 
 message TextIndexParams {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1172,6 +1172,7 @@ pub enum TokenizerType {
     Whitespace = 2,
     Word = 3,
     Multilingual = 4,
+    Trigram = 5,
 }
 impl TokenizerType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1185,6 +1186,7 @@ impl TokenizerType {
             TokenizerType::Whitespace => "Whitespace",
             TokenizerType::Word => "Word",
             TokenizerType::Multilingual => "Multilingual",
+            TokenizerType::Trigram => "Trigram",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1195,6 +1197,7 @@ impl TokenizerType {
             "Whitespace" => Some(Self::Whitespace),
             "Word" => Some(Self::Word),
             "Multilingual" => Some(Self::Multilingual),
+            "Trigram" => Some(Self::Trigram),
             _ => None,
         }
     }

--- a/lib/segment/src/data_types/text_index.rs
+++ b/lib/segment/src/data_types/text_index.rs
@@ -15,6 +15,7 @@ pub enum TokenizerType {
     #[default]
     Word,
     Multilingual,
+    Trigram,
 }
 
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Hash, Eq)]

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
@@ -7,8 +7,7 @@ struct TrigramTokenizer;
 impl TrigramTokenizer {
     fn tokenize<C: FnMut(&str)>(text: &str, callback: C) {
         text.split_whitespace()
-            .map(|word| generate_trigrams(word))
-            .flatten()
+            .flat_map(|word| generate_trigrams(word))
             .for_each(callback);
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
@@ -6,7 +6,10 @@ struct TrigramTokenizer;
 
 impl TrigramTokenizer {
     fn tokenize<C: FnMut(&str)>(text: &str, callback: C) {
-        text.split_whitespace().map(|word| generate_trigrams(word)).flatten().for_each(callback);
+        text.split_whitespace()
+            .map(|word| generate_trigrams(word))
+            .flatten()
+            .for_each(callback);
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
@@ -2,6 +2,28 @@ use charabia::Tokenize;
 
 use crate::data_types::text_index::{TextIndexParams, TokenizerType};
 
+struct TrigramTokenizer;
+
+impl TrigramTokenizer {
+    fn tokenize<C: FnMut(&str)>(text: &str, callback: C) {
+        text.split_whitespace().map(|word| generate_trigrams(word)).flatten().for_each(callback);
+    }
+}
+
+fn generate_trigrams(word: &str) -> Vec<&str> {
+    if word.len() < 3 {
+        // Return the word itself if it's less than 3 characters
+        return vec![word];
+    }
+
+    let mut trigrams = Vec::new();
+    for i in 0..word.len() - 2 {
+        if let Some(trigram) = word.get(i..i + 3) {
+            trigrams.push(trigram);
+        }
+    }
+    trigrams
+}
 struct WhiteSpaceTokenizer;
 
 impl WhiteSpaceTokenizer {
@@ -108,6 +130,7 @@ impl Tokenizer {
         let token_filter = Self::doc_token_filter(config, &mut callback);
         match config.tokenizer {
             TokenizerType::Whitespace => WhiteSpaceTokenizer::tokenize(text, token_filter),
+            TokenizerType::Trigram => TrigramTokenizer::tokenize(text, token_filter),
             TokenizerType::Word => WordTokenizer::tokenize(text, token_filter),
             TokenizerType::Multilingual => MultilingualTokenizer::tokenize(text, token_filter),
             TokenizerType::Prefix => PrefixTokenizer::tokenize(
@@ -123,6 +146,7 @@ impl Tokenizer {
         let token_filter = Self::doc_token_filter(config, &mut callback);
         match config.tokenizer {
             TokenizerType::Whitespace => WhiteSpaceTokenizer::tokenize(text, token_filter),
+            TokenizerType::Trigram => TrigramTokenizer::tokenize(text, token_filter),
             TokenizerType::Word => WordTokenizer::tokenize(text, token_filter),
             TokenizerType::Multilingual => MultilingualTokenizer::tokenize(text, token_filter),
             TokenizerType::Prefix => PrefixTokenizer::tokenize_query(
@@ -147,6 +171,17 @@ mod tests {
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens.get(0), Some(&"hello".to_owned()));
         assert_eq!(tokens.get(1), Some(&"world".to_owned()));
+    }
+
+    #[test]
+    fn test_trigram_tokenizer() {
+        let text = "hello, world";
+        let mut tokens = Vec::new();
+        TrigramTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
+        assert_eq!(tokens.len(), 7);
+        assert_eq!(tokens.get(0), Some(&"hel".to_owned()));
+        assert_eq!(tokens.get(3), Some(&"lo,".to_owned()));
+        assert_eq!(tokens.get(6), Some(&"rld".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
Adding a new tokenizer for full text search.

For more advanced lexical search, word and whitespace tokenizer might not be enough. For example, if we want to include punctuation or search for substrings. The trigram tokenizer is very popular for those scenarios and many others (see ElasticSearch, Zoekt, Github Blackbird...).

This PR adds this tokenizer.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
