### PR TITLE
Demote column family not found during flush

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -168,14 +168,17 @@ impl DatabaseColumnWrapper {
         let column_name = self.column_name.clone();
         Box::new(move || {
             let db = database.read();
-            let column_family = db.cf_handle(&column_name).ok_or_else(|| {
+            let Some(column_family) = db.cf_handle(&column_name) else {
                 // It is possible, that the index was removed during the flush by user or another thread.
                 // In this case, non-existing column family is not an error, but an expected behavior.
 
                 // Still we want to log this event, for potential debugging.
-                log::warn!("Flush: RocksDB cf_handle error: Cannot find column family {}. Ignoring", &column_name);
+                log::warn!(
+                    "Flush: RocksDB cf_handle error: Cannot find column family {}. Ignoring",
+                    &column_name
+                );
                 return Ok(()); // ignore error
-            })?;
+            };
 
             db.flush_cf(column_family).map_err(|err| {
                 OperationError::service_error(format!("RocksDB flush_cf error: {err}"))


### PR DESCRIPTION
During investigating this error:

![image](https://github.com/qdrant/qdrant/assets/1935623/8a876fc5-761c-4770-8a56-f248f762c09b)

Found a possible scenario of how to break flush thread and reproduce this error.

Intro:

We have an async segment flushing operation. This async operation captures references to the DB object and the name of the column family it should use for the index. 

see https://github.com/qdrant/qdrant/blob/591a7e7c7f6b3427603a2a87f517e1452a7d9c44/lib/segment/src/common/rocksdb_wrapper.rs#L166

If user or some other operation removes the index after flusher closure is created, but before it executed, it is possible that during the flusher execution it will try to flush non-existing CF.

This PR:

demotes error of not-found-cf into warning, cause it looks like a valid situation to have.

Addressed Concerns:

- Demoting the error should not create unpredictable behavior, as if, assuming, that column family was wrongly removed, there are other places to catch this problem.
- We still have a warning on the spot, to potentially simplify further debugging, if it would be required



