### PR TITLE
Fix sparse vector search with_vector

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -435,9 +435,8 @@ impl Segment {
                 .is_deleted_vector(point_offset);
             if !is_vector_deleted {
                 let vector_storage = vector_data.vector_storage.borrow();
-                // TODO(sparse) remove unwrap after NamedVectors changes
-                let vector: &[_] = vector_storage.get_vector(point_offset).try_into().unwrap();
-                vectors.insert(vector_name.clone(), vector.to_vec().into());
+                let vector = vector_storage.get_vector(point_offset).to_vec();
+                vectors.insert(vector_name.clone(), vector);
             }
         }
         Ok(vectors)


### PR DESCRIPTION
Fixing bug found while testing sparse vector search using `with_vector`.

```
2023-11-29T13:42:02.017828Z  INFO actix_web::middleware::logger: 127.0.0.1 "PUT /collections/congruence_test_collection/points?wait=true HTTP/1.1" 200 91 "-" "python-httpx/0.16.1" 0.006373    
2023-11-29T13:42:02.325569Z ERROR qdrant::startup: Panic backtrace: 
   0: qdrant::startup::setup_panic_hook::{{closure}}
             at ./src/startup.rs:19:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2021:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:735:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:609:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys_common/backtrace.rs:170:18
   5: rust_begin_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:597:5
   6: core::panicking::panic_fmt
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/panicking.rs:72:14
   7: core::result::unwrap_failed
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1652:5
   8: core::result::Result<T,E>::unwrap
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1077:23
   9: segment::segment::Segment::all_vectors_by_offset
             at ./lib/segment/src/segment.rs:439:36
  10: segment::segment::Segment::process_search_result::{{closure}}
             at ./lib/segment/src/segment.rs:592:30
  11: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/map.rs:91:28
  12: core::iter::adapters::filter_map::filter_map_try_fold::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/filter_map.rs:48:20
  13: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2461:21
  14: <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/filter_map.rs:137:9
  15: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/map.rs:117:9
  16: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:199:9
  17: core::iter::traits::iterator::Iterator::try_for_each
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2523:9
  18: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:182:14
  19: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/spec_from_iter_nested.rs:26:32
  20: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/spec_from_iter.rs:33:9
  21: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/mod.rs:2749:9
  22: core::iter::traits::iterator::Iterator::collect
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2053:9
  23: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1933:51
  24: core::iter::adapters::try_process
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:168:17
  25: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1933:9
  26: core::iter::traits::iterator::Iterator::collect
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2053:9
  27: segment::segment::Segment::process_search_result
             at ./lib/segment/src/segment.rs:555:9
  28: <segment::segment::Segment as segment::entry::entry_point::SegmentEntry>::search_batch::{{closure}}
             at ./lib/segment/src/segment.rs:801:17
  29: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/map.rs:91:28
  30: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2461:21
  31: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/map.rs:117:9
  32: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:199:9
  33: core::iter::traits::iterator::Iterator::try_for_each
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2523:9
  34: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:182:14
  35: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/spec_from_iter_nested.rs:26:32
  36: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/spec_from_iter.rs:33:9
  37: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/vec/mod.rs:2749:9
  38: core::iter::traits::iterator::Iterator::collect
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2053:9
  39: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1933:51
  40: core::iter::adapters::try_process
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/adapters/mod.rs:168:17
  41: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1933:9
  42: core::iter::traits::iterator::Iterator::collect
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/iter/traits/iterator.rs:2053:9
  43: <segment::segment::Segment as segment::entry::entry_point::SegmentEntry>::search_batch
             at ./lib/segment/src/segment.rs:798:19
  44: collection::collection_manager::segments_searcher::execute_batch_search
             at ./lib/collection/src/collection_manager/segments_searcher.rs:536:15
  45: collection::collection_manager::segments_searcher::search_in_segment
             at ./lib/collection/src/collection_manager/segments_searcher.rs:480:38
  46: collection::collection_manager::segments_searcher::SegmentsSearcher::search::{{closure}}::{{closure}}::{{closure}}
             at ./lib/collection/src/collection_manager/segments_searcher.rs:208:29
  47: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/task.rs:42:21
  48: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/core.rs:328:17
  49: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/loom/std/unsafe_cell.rs:16:9
  50: tokio::runtime::task::core::Core<T,S>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/core.rs:317:13
  51: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:485:19
  52: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/panic/unwind_safe.rs:271:9
  53: std::panicking::try::do_call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:504:40
  54: __rust_try
  55: std::panicking::try
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:468:19
  56: std::panic::catch_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panic.rs:142:14
  57: tokio::runtime::task::harness::poll_future
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:473:18
  58: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:208:27
  59: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:153:15
  60: tokio::runtime::task::raw::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/raw.rs:271:5
  61: tokio::runtime::task::raw::RawTask::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/raw.rs:201:18
  62: tokio::runtime::task::UnownedTask<S>::run
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/mod.rs:445:9
  63: tokio::runtime::blocking::pool::Task::run
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:159:9
  64: tokio::runtime::blocking::pool::Inner::run
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:513:17
  65: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:471:13
  66: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys_common/backtrace.rs:154:18
  67: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/mod.rs:529:17
  68: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/panic/unwind_safe.rs:271:9
  69: std::panicking::try::do_call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:504:40
  70: __rust_try
  71: std::panicking::try
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:468:19
  72: std::panic::catch_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panic.rs:142:14
  73: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/mod.rs:528:30
  74: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:250:5
  75: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9
  76: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9
  77: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys/unix/thread.rs:108:17
  78: start_thread
             at ./nptl/pthread_create.c:444:8
  79: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
    
2023-11-29T13:42:02.325656Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/segment.rs at line 439: called `Result::unwrap()` on an `Err` value: WrongSparse    
2023-11-29T13:42:02.379451Z DEBUG collection::shards::replica_set::execute_read_operation: Read operation failed: Service internal error: task 13157 panicked    
2023-11-29T13:42:02.380427Z  WARN qdrant::actix::helpers: error processing request: 1 of 1 read operations failed:
  Service internal error: task 13157 panicked    
```