### PR TITLE
Dynamic CPU saturation integration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,8 +41,15 @@ storage:
     max_search_threads: 0
 
     # Max number of threads (jobs) for running optimizations across all collections, each thread runs one job.
+    # If 0 - have no limit and choose dynamically to saturate CPU.
     # Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
-    max_optimization_threads: 1
+    max_optimization_threads: 0
+
+    # CPU budget, how many CPUs (threads) to allocate for an optimization job.
+    # If 0 - auto selection, keep 1 or more CPUs unallocated depending on CPU size
+    # If negative - subtract this number of CPUs from the available CPUs.
+    # If positive - use this exact number of CPUs.
+    optimizer_cpu_budget: 0
 
     # Prevent DDoS of too many concurrent updates in distributed mode.
     # One external update usually triggers multiple internal updates, which breaks internal
@@ -109,8 +116,9 @@ storage:
 
     # Max number of threads (jobs) for running optimizations per shard.
     # Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    # If null - have no limit and choose dynamically to saturate CPU.
     # If 0 - no optimization threads, optimizations will be disabled.
-    max_optimization_threads: 1
+    max_optimization_threads: null
 
   # Default parameters of HNSW Index. Could be overridden for each collection or named vector individually
   hnsw_index:

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -746,7 +746,7 @@
 | m | [uint64](#uint64) | optional | Number of edges per node in the index graph. Larger the value - more accurate the search, more space required. |
 | ef_construct | [uint64](#uint64) | optional | Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index. |
 | full_scan_threshold | [uint64](#uint64) | optional | Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If the payload chunk is smaller than `full_scan_threshold` additional indexing won&#39;t be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1 Kb = 1 vector of size 256 |
-| max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - auto selection. |
+| max_indexing_threads | [uint64](#uint64) | optional | Number of parallel threads used for background index building. If 0 - automatically select from 8 to 16. Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs. On small CPUs, less threads are used. |
 | on_disk | [bool](#bool) | optional | Store HNSW index on disk. If set to false, the index will be stored in RAM. |
 | payload_m | [uint64](#uint64) | optional | Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used. |
 
@@ -923,7 +923,7 @@ To disable vector indexing, set to `0`.
 
 Note: 1kB = 1 vector of size 256. |
 | flush_interval_sec | [uint64](#uint64) | optional | Interval between forced flushes. |
-| max_optimization_threads | [uint64](#uint64) | optional | Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used |
+| max_optimization_threads | [uint64](#uint64) | optional | Max number of threads (jobs) for running optimizations per shard. Note: each optimization job will also use `max_indexing_threads` threads by itself for index building. If null - have no limit and choose dynamically to saturate CPU. If 0 - no optimization threads, optimizations will be disabled. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5526,7 +5526,7 @@
             "nullable": true
           },
           "max_indexing_threads": {
-            "description": "Number of parallel threads used for background index building. If 0 - auto selection.",
+            "description": "Number of parallel threads used for background index building. If 0 - automatically select from 8 to 16. Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs. On small CPUs, less threads are used.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
@@ -5726,7 +5726,7 @@
             "minimum": 0
           },
           "max_indexing_threads": {
-            "description": "Number of parallel threads used for background index building. If 0 - auto selection.",
+            "description": "Number of parallel threads used for background index building. If 0 - automatically select from 8 to 16. Best to keep between 8 and 16 to prevent likelihood of slow building or broken/inefficient HNSW graphs. On small CPUs, less threads are used.",
             "default": 0,
             "type": "integer",
             "format": "uint",
@@ -5752,7 +5752,6 @@
           "default_segment_number",
           "deleted_threshold",
           "flush_interval_sec",
-          "max_optimization_threads",
           "vacuum_min_vector_number"
         ],
         "properties": {
@@ -5806,10 +5805,12 @@
             "minimum": 0
           },
           "max_optimization_threads": {
-            "description": "Maximum available threads for optimization workers",
+            "description": "Max number of threads (jobs) for running optimizations per shard. Note: each optimization job will also use `max_indexing_threads` threads by itself for index building. If null - have no limit and choose dynamically to saturate CPU. If 0 - no optimization threads, optimizations will be disabled.",
+            "default": null,
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 0,
+            "nullable": true
           }
         }
       },
@@ -7484,7 +7485,7 @@
             "nullable": true
           },
           "max_optimization_threads": {
-            "description": "Maximum available threads for optimization workers",
+            "description": "Max number of threads (jobs) for running optimizations per shard. Note: each optimization job will also use `max_indexing_threads` threads by itself for index building. If null - have no limit and choose dynamically to saturate CPU. If 0 - no optimization threads, optimizations will be disabled.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -141,7 +141,10 @@ message HnswConfigDiff {
   */
   optional uint64 full_scan_threshold = 3;
   /*
-  Number of parallel threads used for background index building. If 0 - auto selection.
+  Number of parallel threads used for background index building.
+  If 0 - automatically select from 8 to 16.
+  Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+  On small CPUs, less threads are used.
   */
   optional uint64 max_indexing_threads = 4;
   /*
@@ -228,7 +231,10 @@ message OptimizersConfigDiff {
   */
   optional uint64 flush_interval_sec = 7;
   /*
-  Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
+  Max number of threads (jobs) for running optimizations per shard.
+  Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+  If null - have no limit and choose dynamically to saturate CPU.
+  If 0 - no optimization threads, optimizations will be disabled.
   */
   optional uint64 max_optimization_threads = 8;
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -220,7 +220,10 @@ pub struct HnswConfigDiff {
     #[prost(uint64, optional, tag = "3")]
     pub full_scan_threshold: ::core::option::Option<u64>,
     ///
-    /// Number of parallel threads used for background index building. If 0 - auto selection.
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16.
+    /// Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+    /// On small CPUs, less threads are used.
     #[prost(uint64, optional, tag = "4")]
     pub max_indexing_threads: ::core::option::Option<u64>,
     ///
@@ -322,7 +325,10 @@ pub struct OptimizersConfigDiff {
     #[prost(uint64, optional, tag = "7")]
     pub flush_interval_sec: ::core::option::Option<u64>,
     ///
-    /// Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
+    /// Max number of threads (jobs) for running optimizations per shard.
+    /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    /// If null - have no limit and choose dynamically to saturate CPU.
+    /// If 0 - no optimization threads, optimizations will be disabled.
     #[prost(uint64, optional, tag = "8")]
     pub max_optimization_threads: ::core::option::Option<u64>,
 }

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -81,7 +81,7 @@ fn batch_search_bench(c: &mut Criterion) {
             memmap_threshold: Some(100_000),
             indexing_threshold: Some(50_000),
             flush_interval_sec: 30,
-            max_optimization_threads: 2,
+            max_optimization_threads: Some(2),
         },
         wal_config,
         hnsw_config: Default::default(),

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -71,7 +71,10 @@ pub struct HnswConfigDiff {
     )]
     #[validate(range(min = 10))]
     pub full_scan_threshold: Option<usize>,
-    /// Number of parallel threads used for background index building. If 0 - auto selection.
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16.
+    /// Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+    /// On small CPUs, less threads are used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_indexing_threads: Option<usize>,
     /// Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false
@@ -154,7 +157,10 @@ pub struct OptimizersConfigDiff {
     pub indexing_threshold: Option<usize>,
     /// Minimum interval between forced flushes.
     pub flush_interval_sec: Option<u64>,
-    /// Maximum available threads for optimization workers
+    /// Max number of threads (jobs) for running optimizations per shard.
+    /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    /// If null - have no limit and choose dynamically to saturate CPU.
+    /// If 0 - no optimization threads, optimizations will be disabled.
     pub max_optimization_threads: Option<usize>,
 }
 
@@ -376,7 +382,7 @@ mod tests {
             memmap_threshold: None,
             indexing_threshold: Some(50_000),
             flush_interval_sec: 30,
-            max_optimization_threads: 1,
+            max_optimization_threads: Some(1),
         };
         let update: OptimizersConfigDiff =
             serde_json::from_str(r#"{ "indexing_threshold": 10000 }"#).unwrap();

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -412,9 +412,10 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                         .indexing_threshold
                         .map(|x| x as u64),
                     flush_interval_sec: Some(config.optimizer_config.flush_interval_sec),
-                    max_optimization_threads: Some(
-                        config.optimizer_config.max_optimization_threads as u64,
-                    ),
+                    max_optimization_threads: config
+                        .optimizer_config
+                        .max_optimization_threads
+                        .map(|n| n as u64),
                 }),
                 wal_config: Some(api::grpc::qdrant::WalConfigDiff {
                     wal_capacity_mb: Some(config.wal_config.wal_capacity_mb as u64),
@@ -469,8 +470,9 @@ impl From<api::grpc::qdrant::OptimizersConfigDiff> for OptimizersConfig {
             memmap_threshold: optimizer_config.memmap_threshold.map(|x| x as usize),
             indexing_threshold: optimizer_config.indexing_threshold.map(|x| x as usize),
             flush_interval_sec: optimizer_config.flush_interval_sec.unwrap_or_default(),
-            max_optimization_threads: optimizer_config.max_optimization_threads.unwrap_or(1)
-                as usize,
+            max_optimization_threads: optimizer_config
+                .max_optimization_threads
+                .map(|n| n as usize),
         }
     }
 }

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -70,8 +70,12 @@ pub struct OptimizersConfig {
     pub indexing_threshold: Option<usize>,
     /// Minimum interval between forced flushes.
     pub flush_interval_sec: u64,
-    /// Maximum available threads for optimization workers
-    pub max_optimization_threads: usize,
+    /// Max number of threads (jobs) for running optimizations per shard.
+    /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    /// If null - have no limit and choose dynamically to saturate CPU.
+    /// If 0 - no optimization threads, optimizations will be disabled.
+    #[serde(default)]
+    pub max_optimization_threads: Option<usize>,
 }
 
 impl OptimizersConfig {
@@ -85,7 +89,7 @@ impl OptimizersConfig {
             memmap_threshold: None,
             indexing_threshold: Some(100_000),
             flush_interval_sec: 60,
-            max_optimization_threads: 0,
+            max_optimization_threads: Some(0),
         }
     }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -136,7 +136,7 @@ impl LocalShard {
             segment_holder.clone(),
             locked_wal.clone(),
             config.optimizer_config.flush_interval_sec,
-            Some(config.optimizer_config.max_optimization_threads),
+            config.optimizer_config.max_optimization_threads,
         );
 
         let (update_sender, update_receiver) =

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -424,7 +424,7 @@ mod tests {
         memmap_threshold: None,
         indexing_threshold: Some(50_000),
         flush_interval_sec: 30,
-        max_optimization_threads: 2,
+        max_optimization_threads: Some(2),
     };
 
     async fn new_shard_replica_set(collection_dir: &TempDir) -> ShardReplicaSet {

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -23,7 +23,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     memmap_threshold: None,
     indexing_threshold: Some(50_000),
     flush_interval_sec: 30,
-    max_optimization_threads: 2,
+    max_optimization_threads: Some(2),
 };
 
 pub fn dummy_on_replica_failure() -> ChangePeerState {

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -31,7 +31,7 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
     memmap_threshold: None,
     indexing_threshold: Some(50_000),
     flush_interval_sec: 30,
-    max_optimization_threads: 2,
+    max_optimization_threads: Some(2),
 };
 
 #[cfg(test)]

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -42,9 +42,12 @@ pub fn get_cpu_budget(cpu_budget_param: isize) -> usize {
             .saturating_sub(-cpu_budget_param as usize)
             .max(1),
         // If zero, use automatic selection
-        Ordering::Equal => get_num_cpus()
-            .saturating_sub(-default_cpu_budget_unallocated(get_num_cpus()) as usize)
-            .max(1),
+        Ordering::Equal => {
+            let num_cpus = get_num_cpus();
+            num_cpus
+                .saturating_sub(-default_cpu_budget_unallocated(num_cpus) as usize)
+                .max(1)
+        }
         // If greater than zero, use exact number
         Ordering::Greater => cpu_budget_param as usize,
     }

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -31,13 +31,9 @@ pub fn default_cpu_budget_unallocated(num_cpu: usize) -> isize {
 /// Will be less if currently available CPU budget is lower.
 #[inline(always)]
 pub fn thread_count_for_hnsw(num_cpu: usize) -> usize {
-    // TODO(1.8.0): temporarily imitate behavior in 1.7.0 of always preferring 16 HNSW threads.
-    // TODO(1.8.0): before the next minor release, remove this and switch to the heuristic below.
-    16.min(num_cpu).max(1)
-
-    // match num_cpu {
-    //     0..=48 => 8.min(num_cpu).max(1),
-    //     49..=64 => 12,
-    //     65.. => 16,
-    // }
+    match num_cpu {
+        0..=48 => 8.min(num_cpu).max(1),
+        49..=64 => 12,
+        65.. => 16,
+    }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -387,7 +387,10 @@ pub struct HnswConfig {
     /// Note: 1Kb = 1 vector of size 256
     #[serde(alias = "full_scan_threshold_kb")]
     pub full_scan_threshold: usize,
-    /// Number of parallel threads used for background index building. If 0 - auto selection.
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16.
+    /// Best to keep between 8 and 16 to prevent likelihood of slow building or broken/inefficient HNSW graphs.
+    /// On small CPUs, less threads are used.
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
     /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -40,7 +40,7 @@ fn test_alias_operation() {
             memmap_threshold: Some(100),
             indexing_threshold: Some(100),
             flush_interval_sec: 2,
-            max_optimization_threads: 2,
+            max_optimization_threads: Some(2),
         },
         wal: Default::default(),
         performance: PerformanceConfig {


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/3364> we made the groundwork for dynamically saturating CPU usage while optimizing.

This PR integrates the feature with additionally required public API/configuration changes. Instead of having fixed optimization limits in the configuration, everything now defaults to being dynamic (automatic).

Configuration changes are mostly described in review comments below. I've also added a `cpu_budget` property to configure what number of CPUs to saturate for optimization tasks.

The idea is to merge this as part of Qdrant 1.8.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?