### PR TITLE
Remove unnecessary validations for QueryEnum

### DIFF
--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -6,7 +6,7 @@ use validator::Validate;
 
 use crate::operations::point_ops::{Batch, PointStruct, PointsBatch, PointsList};
 use crate::operations::types::{
-    BaseGroupRequest, ContextExamplePair, DiscoverRequestInternal, QueryEnum, RecommendExample,
+    BaseGroupRequest, ContextExamplePair, DiscoverRequestInternal, RecommendExample,
     RecommendRequestInternal, SearchGroupsRequestInternal, SearchRequestInternal,
 };
 use crate::operations::vector_ops::PointVectors;
@@ -86,11 +86,6 @@ fn validate_error_sparse_vector_search_request_internal() {
         with_vector: None,
         score_threshold: None,
     });
-}
-
-#[test]
-fn validate_error_sparse_vector_query_enum() {
-    check_validation_error(QueryEnum::Nearest(wrong_named_vector_struct()));
 }
 
 #[test]

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -14,18 +14,6 @@ pub fn validate_iter<T: Validate>(iter: impl Iterator<Item = T>) -> Result<(), V
     errors.errors().is_empty().then_some(()).ok_or(errors)
 }
 
-#[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
-pub fn merge_validation_results(
-    results: &[Result<(), ValidationErrors>],
-) -> Result<(), ValidationErrors> {
-    results
-        .iter()
-        .filter_map(|result| result.clone().err())
-        .fold(Err(ValidationErrors::new()), |bag, err| {
-            ValidationErrors::merge(bag, "?", Err(err))
-        })
-}
-
 /// Validate the value is in `[min, max]`
 #[inline]
 pub fn validate_range_generic<N>(

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -419,10 +419,7 @@ impl Validate for BatchVectorStruct {
         match self {
             BatchVectorStruct::Single(_) => Ok(()),
             BatchVectorStruct::Multi(v) => {
-                for batch in v.values() {
-                    common::validation::validate_iter(batch.iter())?;
-                }
-                Ok(())
+                common::validation::validate_iter(v.values().flat_map(|batch| batch.iter()))
             }
         }
     }
@@ -452,17 +449,6 @@ pub enum QueryVector {
     Recommend(RecoQuery<Vector>),
     Discovery(DiscoveryQuery<Vector>),
     Context(ContextQuery<Vector>),
-}
-
-impl Validate for QueryVector {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            QueryVector::Nearest(v) => v.validate(),
-            QueryVector::Recommend(v) => v.validate(),
-            QueryVector::Discovery(v) => v.validate(),
-            QueryVector::Context(v) => v.validate(),
-        }
-    }
 }
 
 impl From<VectorType> for QueryVector {

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -2,7 +2,6 @@ use std::iter;
 
 use common::types::ScoreType;
 use itertools::Itertools;
-use validator::Validate;
 
 use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
@@ -102,21 +101,6 @@ impl<T> Query<T> for ContextQuery<T> {
             .iter()
             .map(|pair| pair.loss_by(&similarity))
             .sum()
-    }
-}
-
-impl<T: Validate> Validate for ContextPair<T> {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        common::validation::merge_validation_results(&[
-            self.positive.validate(),
-            self.negative.validate(),
-        ])
-    }
-}
-
-impl<T: Validate> Validate for ContextQuery<T> {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        common::validation::validate_iter(self.pairs.iter())
     }
 }
 

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -3,7 +3,6 @@ use std::iter;
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 use itertools::Itertools;
-use validator::Validate;
 
 use super::context_query::ContextPair;
 use super::{Query, TransformInto};
@@ -72,15 +71,6 @@ impl<T> Query<T> for DiscoveryQuery<T> {
         let sigmoid_similarity = scaled_fast_sigmoid(target_similarity);
 
         rank as ScoreType + sigmoid_similarity
-    }
-}
-
-impl<T: Validate> Validate for DiscoveryQuery<T> {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        common::validation::merge_validation_results(&[
-            self.target.validate(),
-            common::validation::validate_iter(self.pairs.iter()),
-        ])
     }
 }
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -1,7 +1,6 @@
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 use itertools::Itertools;
-use validator::Validate;
 
 use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
@@ -47,15 +46,6 @@ impl<T> Query<T> for RecoQuery<T> {
         let negative_similarities = self.negatives.iter().map(&similarity);
 
         merge_similarities(positive_similarities, negative_similarities)
-    }
-}
-
-impl<T: Validate> Validate for RecoQuery<T> {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        common::validation::merge_validation_results(&[
-            common::validation::validate_iter(self.positives.iter()),
-            common::validation::validate_iter(self.negatives.iter()),
-        ])
     }
 }
 


### PR DESCRIPTION
I have added unnecessary validations in this PR: https://github.com/qdrant/qdrant/pull/3111 
Rollback validation for QueryEnum (and their fields down to discovery, ect) because it's not a part of REST API. It also simplifies some other validations.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
