### PR TITLE
Promote collection create/update/delete debug messages to info

### DIFF
--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -30,7 +30,7 @@ impl TableOfContent {
     ) -> Result<bool, StorageError> {
         match operation {
             CollectionMetaOperations::CreateCollection(mut operation) => {
-                log::debug!("Creating collection {}", operation.collection_name);
+                log::info!("Creating collection {}", operation.collection_name);
                 let distribution = match operation.take_distribution() {
                     None => match operation
                         .create_collection
@@ -53,11 +53,11 @@ impl TableOfContent {
                 .await
             }
             CollectionMetaOperations::UpdateCollection(operation) => {
-                log::debug!("Updating collection {}", operation.collection_name);
+                log::info!("Updating collection {}", operation.collection_name);
                 self.update_collection(operation).await
             }
             CollectionMetaOperations::DeleteCollection(operation) => {
-                log::debug!("Deleting collection {}", operation.0);
+                log::info!("Deleting collection {}", operation.0);
                 self.delete_collection(&operation.0).await
             }
             CollectionMetaOperations::ChangeAliases(operation) => {


### PR DESCRIPTION
We have debug log messages for creating, updating and deleting collections. This promotes them from debug to info.

I think these are important markers, and may function as some form of audit log to discover "hey this collection was indeed deleted". I've seen a few users now where it was unclear to them if a collection had been deleted through Qdrant.

The only concern is that they may introduce some noise if a user is creating/deleting a lot of collections. But we generally recommend against this anyway: https://qdrant.tech/documentation/guides/multiple-partitions/

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?