### PR TITLE
Sparse vectors sanity integration checks

### DIFF
--- a/openapi/tests/openapi_integration/helpers/collection_setup.py
+++ b/openapi/tests/openapi_integration/helpers/collection_setup.py
@@ -10,6 +10,7 @@ def drop_collection(collection_name='test_collection'):
     )
     assert response.ok
 
+
 def geo_collection_setup(
         collection_name='test_collection',
         on_disk_payload=False,
@@ -132,6 +133,9 @@ def basic_collection_setup(
                 "distance": "Dot",
                 "on_disk": on_disk_vectors,
             },
+            "sparse_vectors": {
+                "sparse-text": {},
+            },
             "on_disk_payload": on_disk_payload
         }
     )
@@ -190,6 +194,25 @@ def basic_collection_setup(
                     "vector": [0.79, 0.53, 0.72, 0.15],
                     "payload": {"city": []}
                 },
+                {
+                    "id": 9,
+                    "vector": {
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [0.5, 0.5]
+                        }
+                    }
+                },
+                {
+                    "id": 10,
+                    "vector": {
+                        "sparse-text": {
+                            "indices": [1, 2, 3],
+                            "values": [0.1, 0.2, 0.3]
+                        }
+                    },
+                    "payload": {"city": []}
+                }
             ]
         }
     )
@@ -225,6 +248,10 @@ def multivec_collection_setup(
                     "distance": distance or "Cosine",
                     "on_disk": on_disk_vectors,
                 },
+            },
+            "sparse_vectors": {
+                "sparse-image": {},
+                "sparse-text": {},
             },
             "on_disk_payload": on_disk_payload,
         }
@@ -291,6 +318,33 @@ def multivec_collection_setup(
                         "image": [0.35, 0.08, 0.11, 0.44],
                         "text": [0.35, 0.08, 0.11, 0.44, 0.35, 0.08, 0.11, 0.44],
                     }
+                },
+                {
+                    "id": 7,
+                    "vector": {
+                        "sparse-image": {
+                            "indices": [1, 2, 4, 8],
+                            "values": [1.5, 1.5, 1.5, 1.5]
+                        },
+                        "sparse-text": {
+                            "indices": [66, 12],
+                            "values": [0.5, 0.5]
+                        }
+                    }
+                },
+                {
+                    "id": 8,
+                    "vector": {
+                        "sparse-image": {
+                            "indices": [2, 8],
+                            "values": [2.5, 2.5]
+                        },
+                        "sparse-text": {
+                            "indices": [1, 2, 3],
+                            "values": [0.1, 0.2, 0.3]
+                        }
+                    },
+                    "payload": {"count": 0}
                 }
             ]
         }

--- a/openapi/tests/openapi_integration/test_basic_retrieve_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_api.py
@@ -38,7 +38,7 @@ def test_points_retrieve():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['vectors_count'] == 8
+    assert response.json()['result']['vectors_count'] == 10
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
@@ -210,6 +210,7 @@ def test_is_null_condition():
 
     must_not_is_null("city")
     must_not_is_null("city[]")
+
 
 def test_recommendation():
     response = request_with_validation(

--- a/openapi/tests/openapi_integration/test_basic_retrieve_multivec_api.py
+++ b/openapi/tests/openapi_integration/test_basic_retrieve_multivec_api.py
@@ -38,7 +38,7 @@ def test_points_retrieve():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['vectors_count'] == 12
+    assert response.json()['result']['vectors_count'] == 16
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
@@ -51,6 +51,24 @@ def test_points_retrieve():
     )
     assert response.ok
     assert len(response.json()['result']) == 3
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": {
+                "name": "sparse-image",
+                "vector": {
+                    "indices": [2, 8],
+                    "values": [0.2, 0.3]
+                }
+            },
+            "limit": 2
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 2
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',
@@ -89,6 +107,19 @@ def test_points_retrieve():
         assert point['vector'] is not None
         assert len(point['vector']['text']) == 8
         assert len(point['vector']['image']) == 4
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={"offset": 7, "limit": 2, "with_vector": True}
+    )
+    assert response.ok
+    assert len(response.json()['result']['points']) == 2
+    for point in response.json()['result']['points']:
+        assert point['vector'] is not None
+        assert len(point['vector']['sparse-text']) == 2
+        assert len(point['vector']['sparse-image']) == 2
 
 
 def test_retrieve_invalid_vector():

--- a/openapi/tests/openapi_integration/test_batch_update.py
+++ b/openapi/tests/openapi_integration/test_batch_update.py
@@ -79,6 +79,23 @@ def test_batch_update():
                         ]
                     }
                 },
+                {
+                    "upsert": {
+                        "points": [
+                            {
+                                "id": 9,
+                                "vector": {
+                                    "sparse-text": {
+                                        "indices": [123, 321],
+                                        "values": [5.5, 5.5]
+                                    }
+                                },
+                                "payload": {},
+                            },
+                        ]
+                    }
+                },
+                {"delete": {"points": [10]}},
             ]
         },
         query_params={"wait": "true"},
@@ -94,6 +111,23 @@ def test_batch_update():
             }
         ],
         nonexisting_ids=[8],
+        with_vectors=True,
+    )
+
+    assert_points(
+        [
+            {
+                "id": 9,
+                "vector":  {
+                    "sparse-text": {
+                        "indices": [123, 321],
+                        "values": [5.5, 5.5]
+                    },
+                },
+                "payload": {},
+            }
+        ],
+        nonexisting_ids=[10],
         with_vectors=True,
     )
 

--- a/openapi/tests/openapi_integration/test_collection_update.py
+++ b/openapi/tests/openapi_integration/test_collection_update.py
@@ -34,6 +34,13 @@ def test_collection_update():
                     },
                 },
             },
+            "sparse_vectors": {
+                "sparse-text": {
+                    "index": {
+                        "on_disk": True,
+                    }
+                },
+            },
             "optimizers_config": {
                 "default_segment_number": 6,
                 "indexing_threshold": 10000,

--- a/openapi/tests/openapi_integration/test_count.py
+++ b/openapi/tests/openapi_integration/test_count.py
@@ -67,5 +67,5 @@ def test_approx_count_search():
         }
     )
     assert response.ok
-    assert response.json()['result']['count'] < 8
+    assert response.json()['result']['count'] < 10
     assert response.json()['result']['count'] > 0

--- a/openapi/tests/openapi_integration/test_delete_points.py
+++ b/openapi/tests/openapi_integration/test_delete_points.py
@@ -37,8 +37,8 @@ def test_delete_points():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['points_count'] == 7
-    assert response.json()['result']['vectors_count'] == 8 # We don't propagate deletes to vectors at this time
+    assert response.json()['result']['points_count'] == 9
+    assert response.json()['result']['vectors_count'] == 10  # We don't propagate deletes to vectors at this time
 
     response = request_with_validation(
         api='/collections/{collection_name}/points/delete',
@@ -58,5 +58,5 @@ def test_delete_points():
         path_params={'collection_name': collection_name},
     )
     assert response.ok
-    assert response.json()['result']['points_count'] == 3
-    assert response.json()['result']['vectors_count'] == 8
+    assert response.json()['result']['points_count'] == 5
+    assert response.json()['result']['vectors_count'] == 10

--- a/openapi/tests/openapi_integration/test_filter.py
+++ b/openapi/tests/openapi_integration/test_filter.py
@@ -65,6 +65,5 @@ def test_just_key():
     assert not response.ok
     assert response.status_code == 422
     error = response.json()["status"]["error"]
-    print(error)
     assert "Validation error in JSON body" in error
     assert "At least one field condition must be specified" in error

--- a/openapi/tests/openapi_integration/test_mix_batch_update.py
+++ b/openapi/tests/openapi_integration/test_mix_batch_update.py
@@ -58,19 +58,19 @@ def mix_collection_setup(
         body={
             "points": [
                 {
-                    "id": 1, "vector": { "image": [1, 2], "text": { "indices": [100, 500, 10], "values": [0.9, 0.8, 0.5] }}
+                    "id": 1, "vector": {"image": [1, 2], "text": {"indices": [100, 500, 10], "values": [0.9, 0.8, 0.5]}}
                 },
                 {
-                    "id": 2, "vector": { "image": [1, 3], "text": { "indices": [10], "values": [0.1] }}
+                    "id": 2, "vector": {"image": [1, 3], "text": {"indices": [10], "values": [0.1]}}
                 },
                 {
-                    "id": 3, "vector": { "image": [2, 0], "text": { "indices": [55, 20, 101], "values": [0.4, 0.6, 0.1] }}
+                    "id": 3, "vector": {"image": [2, 0], "text": {"indices": [55, 20, 101], "values": [0.4, 0.6, 0.1]}}
                 },
                 {
-                    "id": 4, "vector": { "image": [1, 1], "text": { "indices": [66, 12], "values": [0.5, 0.5] }}
+                    "id": 4, "vector": {"image": [1, 1], "text": {"indices": [66, 12], "values": [0.5, 0.5]}}
                 },
                 {
-                    "id": 5, "vector": { "image": [0, 0], "text": { "indices": [1, 2, 3], "values": [0.1, 0.2, 0.3] }}
+                    "id": 5, "vector": {"image": [0, 0], "text": {"indices": [1, 2, 3], "values": [0.1, 0.2, 0.3]}}
                 }
             ]
         }
@@ -87,19 +87,19 @@ def test_collection_mix_batch_update():
         body={
             "points": [
                 {
-                    "id": 1, "vector": { "image": [1, 1], "text": { "indices": [100, 500, 10], "values": [0.9, 0.8, 0.5] }}
+                    "id": 1, "vector": {"image": [1, 1], "text": {"indices": [100, 500, 10], "values": [0.9, 0.8, 0.5]}}
                 },
                 {
-                    "id": 2, "vector": { "image": [2, 2], "text": { "indices": [10, 100, 500], "values": [0.1, 0, 0] }}
+                    "id": 2, "vector": {"image": [2, 2], "text": {"indices": [10, 100, 500], "values": [0.1, 0, 0]}}
                 },
                 {
-                    "id": 3, "vector": { "image": [3, 3], "text": { "indices": [55, 20, 101], "values": [0.4, 0.6, 0.1] }}
+                    "id": 3, "vector": {"image": [3, 3], "text": {"indices": [55, 20, 101], "values": [0.4, 0.6, 0.1]}}
                 },
                 {
-                    "id": 4, "vector": { "image": [4, 4], "text": { "indices": [66, 12], "values": [0.5, 0.5] }}
+                    "id": 4, "vector": {"image": [4, 4], "text": {"indices": [66, 12], "values": [0.5, 0.5]}}
                 },
                 {
-                    "id": 5, "vector": { "image": [5, 5], "text": { "indices": [1, 2, 3], "values": [0.1, 0.2, 0.3] }}
+                    "id": 5, "vector": {"image": [5, 5], "text": {"indices": [1, 2, 3], "values": [0.1, 0.2, 0.3]}}
                 }
             ]
         }


### PR DESCRIPTION
This PR introduces basic sanity checks for the sparse vector integration.

The main goal is to increase the confidence in the integration of sparse vectors.

I usually prefer writing completely new tests to validate features but as sparse vectors interact potentially with all other existing features I decided to change the existing infrastructure.

I want to make sure that:
- all existing  tests are not broken by the presence of sparse vectors
- new future feature will have to consider sparse vectors

To that end, this PR adds sparse vectors to our default test fixtures:
- `basic_collection_setup` (24 usages)
- `multivec_collection_setup` (5 usages)

I have performed mechanical changes in changed assertions and added a few more tests specific to sparse vectors.
