### PR TITLE
Fix type for SparseVector converter

### DIFF
--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -86,15 +86,15 @@ impl SparseVector {
         }
     }
 }
-impl TryFrom<Vec<(i32, f64)>> for SparseVector {
+impl TryFrom<Vec<(u32, f32)>> for SparseVector {
     type Error = ValidationErrors;
 
-    fn try_from(tuples: Vec<(i32, f64)>) -> Result<Self, Self::Error> {
+    fn try_from(tuples: Vec<(u32, f32)>) -> Result<Self, Self::Error> {
         let mut indices = Vec::with_capacity(tuples.len());
         let mut values = Vec::with_capacity(tuples.len());
         for (i, w) in tuples {
-            indices.push(i as u32);
-            values.push(w as f32);
+            indices.push(i);
+            values.push(w);
         }
         SparseVector::new(indices, values)
     }

--- a/lib/sparse/src/common/sparse_vector_fixture.rs
+++ b/lib/sparse/src/common/sparse_vector_fixture.rs
@@ -11,7 +11,7 @@ const MAX_VALUES_PER_VECTOR: usize = 300;
 /// Generates a non empty sparse vector
 pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_dim_size: usize) -> SparseVector {
     let size = rnd_gen.gen_range(1..max_dim_size);
-    let mut tuples: Vec<(i32, f64)> = vec![];
+    let mut tuples: Vec<(u32, f32)> = vec![];
 
     for i in 1..=size {
         // make sure the vector is not too large (for performance reasons)
@@ -21,15 +21,15 @@ pub fn random_sparse_vector<R: Rng + ?Sized>(rnd_gen: &mut R, max_dim_size: usiz
         // high probability of skipping a dimension to make the vectors more sparse
         let no_skip = rnd_gen.gen_bool(0.01);
         if no_skip {
-            tuples.push((i as i32, rnd_gen.gen_range(VALUE_RANGE)));
+            tuples.push((i as u32, rnd_gen.gen_range(VALUE_RANGE) as f32));
         }
     }
 
     // make sure we have at least one vector
     if tuples.is_empty() {
         tuples.push((
-            rnd_gen.gen_range(1..max_dim_size) as i32,
-            rnd_gen.gen_range(VALUE_RANGE),
+            rnd_gen.gen_range(1..max_dim_size) as u32,
+            rnd_gen.gen_range(VALUE_RANGE) as f32,
         ));
     }
 
@@ -41,10 +41,10 @@ pub fn random_full_sparse_vector<R: Rng + ?Sized>(
     rnd_gen: &mut R,
     max_size: usize,
 ) -> SparseVector {
-    let mut tuples: Vec<(i32, f64)> = vec![];
+    let mut tuples: Vec<(u32, f32)> = Vec::with_capacity(max_size);
 
     for i in 1..=max_size {
-        tuples.push((i as i32, rnd_gen.gen_range(VALUE_RANGE)));
+        tuples.push((i as u32, rnd_gen.gen_range(VALUE_RANGE) as f32));
     }
 
     SparseVector::try_from(tuples).unwrap()


### PR DESCRIPTION
This PR fixes the `TryFrom` impl. for sparse vectors to use the correct types.

Found while porting the conversion to the Rust client.