### PR TITLE
Estimate sparse vector dimension for optimizer

### DIFF
--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -127,6 +127,11 @@ impl SimpleSparseVectorStorage {
         Ok(())
     }
 
+    /// Estimate average vector size based on total number of non-zero elements in all vectors.
+    ///
+    /// This is needed because the optimizer relies on the vector dimension * size_of_f32 * point_count to
+    /// trigger reindexing and on_disk data move.
+    /// TODO(sparse) get a separate function to get the vector storage instead for the optimizer
     pub fn get_average_dimension(&self) -> usize {
         if self.total_vector_count == 0 {
             // default dimension to play nice with optimizers

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -31,6 +31,8 @@ pub struct SimpleSparseVectorStorage {
     /// Current number of deleted vectors.
     deleted_count: usize,
     total_vector_count: usize,
+    /// Total number of non-zero elements in all vectors. Used to estimate average vector size.
+    total_sparse_size: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -48,6 +50,7 @@ pub fn open_simple_sparse_vector_storage(
     let db_wrapper = DatabaseColumnWrapper::new(database, database_column_name);
 
     let mut total_vector_count = 0;
+    let mut total_sparse_size = 0;
     db_wrapper.lock_db().iter()?;
     for (key, value) in db_wrapper.lock_db().iter()? {
         let point_id: PointOffsetType = bincode::deserialize(&key)
@@ -61,6 +64,7 @@ pub fn open_simple_sparse_vector_storage(
             deleted_count += 1;
         }
         total_vector_count = std::cmp::max(total_vector_count, point_id as usize + 1);
+        total_sparse_size += stored_record.vector.values.len();
     }
 
     Ok(Arc::new(AtomicRefCell::new(
@@ -73,6 +77,7 @@ pub fn open_simple_sparse_vector_storage(
             deleted,
             deleted_count,
             total_vector_count,
+            total_sparse_size,
         }),
     )))
 }
@@ -89,7 +94,7 @@ impl SimpleSparseVectorStorage {
             if !was_deleted {
                 self.deleted_count += 1;
             } else {
-                self.deleted_count -= 1;
+                self.deleted_count = self.deleted_count.saturating_sub(1);
             }
         }
         was_deleted
@@ -105,6 +110,11 @@ impl SimpleSparseVectorStorage {
         let record = &mut self.update_buffer;
         record.deleted = deleted;
         if let Some(vector) = vector {
+            if deleted {
+                self.total_sparse_size = self.total_sparse_size.saturating_sub(vector.values.len());
+            } else {
+                self.total_sparse_size += vector.values.len();
+            }
             record.vector = vector.clone();
         }
 
@@ -115,6 +125,16 @@ impl SimpleSparseVectorStorage {
         )?;
 
         Ok(())
+    }
+
+    pub fn get_average_dimension(&self) -> usize {
+        if self.total_vector_count == 0 {
+            // default dimension to play nice with optimizers
+            1
+        } else {
+            // multiply by 2 to account for indices & values
+            (self.total_sparse_size / self.total_vector_count) * 2
+        }
     }
 }
 
@@ -130,7 +150,8 @@ impl SparseVectorStorage for SimpleSparseVectorStorage {
 
 impl VectorStorage for SimpleSparseVectorStorage {
     fn vector_dim(&self) -> usize {
-        0 // not applicable
+        // estimate average vector size
+        self.get_average_dimension()
     }
 
     fn distance(&self) -> Distance {


### PR DESCRIPTION
The indexer optimizer decides if a segment should be rebuilt based on the vector sizes in bytes computed from the vector dimension.

The current implementation for sparse vectors returns zero which prevents the optimizer from running.

This PR proposes a simple scheme to compute an estimation based on the average size of sparse vectors.

## Topics for further discussion:

- a segment rebuild all its indices regardless of the named vector triggering the rebuild 
  - a.k.a rebuild HNSW because of sparse changes
- the current size estimations in the optimizer are not counting number of of actual vectors per named vectors
  - mix setup dense & sparse will not trigger rebuild with high precision  
