### PR TITLE
Fix optimizer change sparse index on disk

### DIFF
--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -53,6 +53,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let config = if config_path.exists() {
             SparseIndexConfig::load(&config_path)?
         } else {
+            // create new files if they do not exist
+            TInvertedIndex::from_ram_index(InvertedIndexRam::empty(), path)?;
             // use provided config if no config file exists
             config
         };

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -652,6 +652,7 @@ impl SegmentConfig {
         }
     }
 
+    /// Check if any vector storages are indexed
     pub fn is_any_vector_indexed(&self) -> bool {
         self.vector_data
             .values()
@@ -662,6 +663,7 @@ impl SegmentConfig {
                 .any(|config| config.is_indexed())
     }
 
+    /// Check if all vector storages are indexed
     pub fn are_all_vectors_indexed(&self) -> bool {
         self.vector_data
             .values()
@@ -677,7 +679,10 @@ impl SegmentConfig {
         self.vector_data
             .values()
             .any(|config| config.storage_type.is_on_disk())
-            || !self.sparse_vector_data.is_empty()
+            || self
+                .sparse_vector_data
+                .values()
+                .any(|config| config.is_index_on_disk())
     }
 }
 
@@ -754,11 +759,17 @@ pub struct SparseVectorDataConfig {
 
 impl SparseVectorDataConfig {
     pub fn is_appendable(&self) -> bool {
-        true
+        !self.is_index_on_disk()
     }
 
     pub fn is_indexed(&self) -> bool {
         true
+    }
+
+    pub fn is_index_on_disk(&self) -> bool {
+        self.index
+            .and_then(|config| config.on_disk)
+            .unwrap_or(false)
     }
 }
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -172,13 +172,32 @@ fn sparse_vector_index_consistent_with_storage() {
     check_index_storage_consistency(&sparse_vector_ram_index);
 
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
-    // copy index mmap and save to disk
-    let mmap_inverted_index = InvertedIndexMmap::convert_and_save(
-        &sparse_vector_ram_index.inverted_index,
-        &mmap_index_dir,
-    )
-    .unwrap();
-    drop(mmap_inverted_index);
+
+    // create mmap sparse vector index
+    let sparse_index_config = sparse_vector_ram_index.config;
+    let mut sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexMmap> =
+        SparseVectorIndex::open(
+            sparse_index_config,
+            sparse_vector_ram_index.id_tracker.clone(),
+            sparse_vector_ram_index.vector_storage.clone(),
+            sparse_vector_ram_index.payload_index.clone(),
+            mmap_index_dir.path(),
+        )
+        .unwrap();
+
+    // build index
+    sparse_vector_mmap_index.build_index(&stopped).unwrap();
+
+    assert_eq!(
+        sparse_vector_mmap_index.indexed_vector_count(),
+        sparse_vector_ram_index.indexed_vector_count()
+    );
+
+    // check consistency with underlying mmap inverted index
+    check_index_storage_consistency(&sparse_vector_mmap_index);
+
+    // drop and reload index
+    drop(sparse_vector_mmap_index);
 
     // load index from memmap file
     let sparse_index_config = sparse_vector_ram_index.config;

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -205,8 +205,9 @@ fn sparse_vector_index_load_missing_mmap() {
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     let sparse_vector_index: OperationResult<SparseVectorIndex<InvertedIndexMmap>> =
         fixture_open_sparse_index(data_dir.path(), 0, 10_000);
-    // fails to open index if mmap file is missing
-    assert!(sparse_vector_index.is_err())
+    // absent configuration file for mmap are ignored
+    // a new index is created
+    assert!(sparse_vector_index.is_ok())
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes the optimizer to apply the `on_disk` parameter to a sparse vector index once the memap threshold is reached.
