### PR TITLE
Better shard transfer init

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -327,12 +327,7 @@ impl Collection {
                         |state| {
                             state
                                 .get_peer_state(&this_peer_id)
-                                .map_or(false, |peer_state| {
-                                    matches!(
-                                        peer_state,
-                                        ReplicaState::Partial | ReplicaState::PartialSnapshot
-                                    )
-                                })
+                                .map_or(false, |peer_state| peer_state.is_partial_like())
                         },
                         defaults::CONSENSUS_META_OP_WAIT,
                     )

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -307,13 +307,33 @@ impl Collection {
             let this_peer_id = replica_set.this_peer_id();
 
             let shard_transfer_requested = tokio::task::spawn_blocking(move || {
-                shards_holder.shard_transfers.wait_for(
+                // We can guarantee that replica_set is not None, cause we checked it before
+                // and `shards_holder` is holding the lock.
+                // This is a workaround for lifetime checker.
+                let replica_set = shards_holder.get_shard(&shard_id).unwrap();
+                let shard_transfer_registered = shards_holder.shard_transfers.wait_for(
                     |shard_transfers| {
                         shard_transfers.iter().any(|shard_transfer| {
                             shard_transfer.shard_id == shard_id && shard_transfer.to == this_peer_id
                         })
                     },
                     Duration::from_secs(60),
+                );
+
+                // It is not enough to check for shard_transfer_registered,
+                // because it is registered before the state of the shard is changed.
+                shard_transfer_registered && replica_set.wait_for_state_condition_sync(
+                    |state| {
+                        state
+                            .get_peer_state(&this_peer_id)
+                            .map_or(false, |peer_state| {
+                                matches!(
+                                    peer_state,
+                                    ReplicaState::Partial | ReplicaState::PartialSnapshot
+                                )
+                            })
+                    },
+                    defaults::CONSENSUS_META_OP_WAIT,
                 )
             });
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -322,19 +322,20 @@ impl Collection {
 
                 // It is not enough to check for shard_transfer_registered,
                 // because it is registered before the state of the shard is changed.
-                shard_transfer_registered && replica_set.wait_for_state_condition_sync(
-                    |state| {
-                        state
-                            .get_peer_state(&this_peer_id)
-                            .map_or(false, |peer_state| {
-                                matches!(
-                                    peer_state,
-                                    ReplicaState::Partial | ReplicaState::PartialSnapshot
-                                )
-                            })
-                    },
-                    defaults::CONSENSUS_META_OP_WAIT,
-                )
+                shard_transfer_registered
+                    && replica_set.wait_for_state_condition_sync(
+                        |state| {
+                            state
+                                .get_peer_state(&this_peer_id)
+                                .map_or(false, |peer_state| {
+                                    matches!(
+                                        peer_state,
+                                        ReplicaState::Partial | ReplicaState::PartialSnapshot
+                                    )
+                                })
+                        },
+                        defaults::CONSENSUS_META_OP_WAIT,
+                    )
             });
 
             match shard_transfer_requested.await {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -344,6 +344,14 @@ impl ShardReplicaSet {
             .await
     }
 
+    pub fn wait_for_state_condition_sync<F>(&self, check: F, timeout: Duration) -> bool
+    where
+        F: Fn(&ReplicaSetState) -> bool,
+    {
+        let replica_state = self.replica_state.clone();
+        replica_state.wait_for(check, timeout)
+    }
+
     /// Wait for a local shard to get into `state`
     ///
     /// Uses a blocking thread internally.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -879,6 +879,19 @@ pub enum ReplicaState {
     PartialSnapshot,
 }
 
+impl ReplicaState {
+    /// Check whether the replica state is partial or partial-like.
+    pub fn is_partial_like(self) -> bool {
+        match self {
+            ReplicaState::Partial | ReplicaState::PartialSnapshot => true,
+            ReplicaState::Active
+            | ReplicaState::Dead
+            | ReplicaState::Initializing
+            | ReplicaState::Listener => false,
+        }
+    }
+}
+
 /// Represents a change in replica set, due to scaling of `replication_factor`
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 pub enum Change {


### PR DESCRIPTION
Prevents

```
2023-12-04T21:07:20.019429Z ERROR qdrant::tonic::logging: gRPC /qdrant.PointsInternal/Sync unexpectedly failed with Internal error "Service internal error: No target shard 1 found for update" 0.253019    
```

on shard reocvery.