### PR TITLE
Add web UI sync script to DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,6 +80,12 @@ To run Qdrant on local development environment you need to install below:
 
     ./target/release/qdrant
     ```
+- Use the web UI
+  
+    Web UI repo is [in a separate repo](https://github.com/qdrant/qdrant-web-ui), but there's a utility script to sync it to the `static` folder:
+    ```shell
+    ./tools/sync-web-ui.sh
+    ```
 
 ## Profiling
 


### PR DESCRIPTION
Just for completeness, we should mention that `sync-web-ui.sh` is needed to be run at least once for the web ui to show when developing/building