### PR TITLE
Fix infinite optimization loop with `on_disk` and `mmap_threshold` fighting

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -148,17 +148,17 @@ pub trait SegmentOptimizer {
         let thresholds = self.threshold_config();
         let collection_params = self.collection_params();
 
-        let is_indexed = maximal_vector_store_size_bytes
+        let threshold_is_indexed = maximal_vector_store_size_bytes
             >= thresholds.indexing_threshold.saturating_mul(BYTES_IN_KB);
 
-        let is_on_disk = maximal_vector_store_size_bytes
+        let threshold_is_on_disk = maximal_vector_store_size_bytes
             >= thresholds.memmap_threshold.saturating_mul(BYTES_IN_KB);
 
         let mut vector_data = collection_params.into_base_vector_data()?;
         let mut sparse_vector_data = collection_params.into_sparse_vector_data()?;
 
         // If indexing, change to HNSW index and quantization
-        if is_indexed {
+        if threshold_is_indexed {
             let collection_hnsw = self.hnsw_config();
             let collection_quantization = self.quantization_config();
             vector_data.iter_mut().for_each(|(vector_name, config)| {
@@ -184,10 +184,25 @@ pub trait SegmentOptimizer {
             });
         }
 
-        // If storing on disk, set storage type
-        if is_on_disk {
-            vector_data.values_mut().for_each(|config| {
-                config.storage_type = VectorStorageType::Mmap;
+        // If storing on disk, set storage type in current segment (not in collection config)
+        if threshold_is_on_disk {
+            vector_data.iter_mut().for_each(|(vector_name, config)| {
+                // Check whether on_disk is explicitly configured, if not, set it to true
+                let has_explicit_on_disk = collection_params
+                    .vectors
+                    .get_params(vector_name)
+                    .and_then(|config| config.on_disk);
+                if has_explicit_on_disk.is_none() {
+                    config.storage_type = VectorStorageType::Mmap;
+                }
+
+                // If we explicitly configure on_disk, but the segment storage type uses something
+                // that doesn't match, warn about it
+                if let Some(config_on_disk) = has_explicit_on_disk {
+                    if config_on_disk != config.storage_type.is_on_disk() {
+                        log::warn!("Collection config for vector {vector_name} has on_disk={config_on_disk:?} configured, but storage type for segment doesn't match it");
+                    }
+                }
             });
 
             sparse_vector_data


### PR DESCRIPTION
It is possible to create an infinite optimization loop when using the `on_disk` and `mmap_threshold` properties together. They'll start fighting which each other and the collection will remain yellow forever.

Setting `on_disk: false` and `mmap_threshold: 1000` will trigger this. The indexing optimizer will put vectors on disk because the threshold is reached. The config mismatch optimizer will try to remove vectors from disk again because `on_disk: false` is configured.

Before this PR, you can create this situation with:

```rust
bfb -n 20000 --dim 2048 --on-disk-vectors false --mmap-threshold 10000 --indexing-threshold 0
```

This PR fixes this issue by preferring `on_disk` over `mmap_threshold`. More specifically, it:
- doesn't put vectors on disk anymore because of the threshold if `on_disk` was explicitly set
- prevents the indexing optimizer triggering due to this threshold if `on_disk` is explicitly set for vectors

I see this is hotfix to get it in for the release. I'd prefer to re-architecture our optimization logic a bit in the near future to prevent situations like this.

I've manually tested this extensively.

I discovered this issue when working on <https://github.com/qdrant/qdrant/pull/3160#pullrequestreview-1765853907>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?