### PR TITLE
replace enum in status codes with str

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -71,10 +71,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -158,10 +155,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -227,10 +221,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/TelemetryData"
@@ -332,10 +323,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/LocksOption"
@@ -388,10 +376,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/LocksOption"
@@ -524,10 +509,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/ClusterStatus"
@@ -581,10 +563,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -659,10 +638,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -717,10 +693,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CollectionsResponse"
@@ -786,10 +759,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CollectionInfo"
@@ -871,10 +841,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -956,10 +923,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1031,10 +995,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1108,10 +1069,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1205,10 +1163,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -1301,10 +1256,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -1371,10 +1323,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CollectionClusterInfo"
@@ -1456,10 +1405,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1525,10 +1471,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CollectionsAliasesResponse"
@@ -1583,10 +1526,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CollectionsAliasesResponse"
@@ -1687,10 +1627,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1713,10 +1650,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -1799,10 +1733,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -1825,10 +1756,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -1892,10 +1820,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -1972,10 +1897,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/SnapshotDescription"
@@ -1998,10 +1920,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2083,10 +2002,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -2109,10 +2025,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2226,10 +2139,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -2296,10 +2206,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/SnapshotDescription"
@@ -2322,10 +2229,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2397,10 +2301,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -2423,10 +2324,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2585,10 +2483,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -2611,10 +2506,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2706,10 +2598,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -2732,10 +2621,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -2808,10 +2694,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -2897,10 +2780,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/SnapshotDescription"
@@ -2923,10 +2803,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -3017,10 +2894,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "boolean"
@@ -3043,10 +2917,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "accepted"
-                      ]
+                      "type": "string"
                     }
                   }
                 }
@@ -3198,10 +3069,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/Record"
@@ -3286,10 +3154,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -3384,10 +3249,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3481,10 +3343,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3578,10 +3437,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3675,10 +3531,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3772,10 +3625,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3867,10 +3717,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -3964,10 +3811,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -4061,10 +3905,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/UpdateResult"
@@ -4158,10 +3999,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -4249,10 +4087,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/ScrollResult"
@@ -4347,10 +4182,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -4448,10 +4280,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -4552,10 +4381,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/GroupsResult"
@@ -4650,10 +4476,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -4751,10 +4574,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -4855,10 +4675,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/GroupsResult"
@@ -4953,10 +4770,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -5054,10 +4868,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "type": "array",
@@ -5139,10 +4950,7 @@
                       "description": "Time spent to process this request"
                     },
                     "status": {
-                      "type": "string",
-                      "enum": [
-                        "ok"
-                      ]
+                      "type": "string"
                     },
                     "result": {
                       "$ref": "#/components/schemas/CountResult"

--- a/openapi/openapi.lib.yml
+++ b/openapi/openapi.lib.yml
@@ -24,7 +24,6 @@ default:
             description: Time spent to process this request
           status:
             type: string
-            enum: [ "ok" ]
           result: #@ model
 #@ end
 
@@ -54,7 +53,6 @@ default:
             description: Time spent to process this request
           status:
             type: string
-            enum: [ "ok" ]
           result: #@ model
 "202":
   description: operation is accepted
@@ -69,7 +67,6 @@ default:
             description: Time spent to process this request
           status:
             type: string
-            enum: [ "accepted" ]
 #@ end
 
 #@ def reference(model_name):


### PR DESCRIPTION
Current status codes are enums.
Python client generator struggles to work with endpoints which can return several statuses, e.g. "200" and "202".
It simply takes the first response and extract possible field values from it.
E.g. "200" returns "Ok", "202" - "Accept".
Generator produces code which expects field "status" to be only "Ok", and fails on "Accept".
If we don't use enums, but strings, then it won't fail since the value has type which is expected.

https://github.com/qdrant/qdrant-client/issues/254#issuecomment-1739830843

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
