### PR TITLE
Sparse vector index build handles missing points in storage

### DIFF
--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -113,7 +113,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             // - the sparse index is built *before* recovering the WAL when loading a segment
             match borrowed_vector_storage.get_vector_opt(id) {
                 None => {
-                    // the vector was lost in a crash but will be recored by the WAL
+                    // the vector was lost in a crash but will be recovered by the WAL
                     log::debug!("Sparse vector with id {} is not found", id)
                 }
                 Some(vector) => {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -110,11 +110,11 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             // It is possible that the vector is not present in the storage in case of crash.
             // Because:
             // - the `id_tracker` is flushed before the `vector_storage`
-            // - the sparse index *before* recovering the WAL when loading a segment
+            // - the sparse index is built *before* recovering the WAL when loading a segment
             match borrowed_vector_storage.get_vector_opt(id) {
                 None => {
-                    // this means the vector was lost in a crash
-                    log::warn!("Sparse vector with id {} is not found", id)
+                    // the vector was lost in a crash but will be recored by the WAL
+                    log::debug!("Sparse vector with id {} is not found", id)
                 }
                 Some(vector) => {
                     let vector: &SparseVector = vector.as_vec_ref().try_into()?;

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -39,7 +39,10 @@ impl<'a, TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> Query
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        let stored = self.vector_storage.get_sparse(idx);
+        let stored = self
+            .vector_storage
+            .get_sparse(idx)
+            .expect("Failed to get sparse vector");
         self.query
             .score_by(|example| stored.score(example).unwrap_or(0.0))
     }

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -144,12 +144,13 @@ impl SimpleSparseVectorStorage {
 }
 
 impl SparseVectorStorage for SimpleSparseVectorStorage {
-    fn get_sparse(&self, key: PointOffsetType) -> SparseVector {
-        let data = self.db_wrapper.get(bincode::serialize(&key).unwrap());
-        let record: StoredRecord = bincode::deserialize(&data.unwrap())
-            .map_err(|_| OperationError::service_error("Cannot deserialize vector from db"))
-            .unwrap();
-        record.vector
+    fn get_sparse(&self, key: PointOffsetType) -> OperationResult<SparseVector> {
+        let bin_key = bincode::serialize(&key)
+            .map_err(|_| OperationError::service_error("Cannot serialize sparse vector key"))?;
+        let data = self.db_wrapper.get(bin_key)?;
+        let record: StoredRecord = bincode::deserialize(&data)
+            .map_err(|_| OperationError::service_error("Cannot deserialize vector from db"))?;
+        Ok(record.vector)
     }
 }
 
@@ -172,7 +173,12 @@ impl VectorStorage for SimpleSparseVectorStorage {
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        self.get_sparse(key).into()
+        self.get_vector_opt(key).expect("Vector must exist")
+    }
+
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        // ignore any error
+        self.get_sparse(key).ok().map(CowVector::from)
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -148,8 +148,9 @@ impl SparseVectorStorage for SimpleSparseVectorStorage {
         let bin_key = bincode::serialize(&key)
             .map_err(|_| OperationError::service_error("Cannot serialize sparse vector key"))?;
         let data = self.db_wrapper.get(bin_key)?;
-        let record: StoredRecord = bincode::deserialize(&data)
-            .map_err(|_| OperationError::service_error("Cannot deserialize vector from db"))?;
+        let record: StoredRecord = bincode::deserialize(&data).map_err(|_| {
+            OperationError::service_error("Cannot deserialize sparse vector from db")
+        })?;
         Ok(record.vector)
     }
 }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -46,6 +46,12 @@ pub trait VectorStorage {
     /// Get the vector by the given key
     fn get_vector(&self, key: PointOffsetType) -> CowVector;
 
+    /// Get the vector by the given key if it exists
+    /// Blanket implementation - override if necessary
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        Some(self.get_vector(key))
+    }
+
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
 
     fn update_from(
@@ -95,7 +101,7 @@ pub trait DenseVectorStorage: VectorStorage {
 }
 
 pub trait SparseVectorStorage: VectorStorage {
-    fn get_sparse(&self, key: PointOffsetType) -> SparseVector;
+    fn get_sparse(&self, key: PointOffsetType) -> OperationResult<SparseVector>;
 }
 
 pub enum VectorStorageEnum {
@@ -148,6 +154,15 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::Memmap(v) => v.get_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.get_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
+        }
+    }
+
+    fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
+        match self {
+            VectorStorageEnum::Simple(v) => v.get_vector_opt(key),
+            VectorStorageEnum::Memmap(v) => v.get_vector_opt(key),
+            VectorStorageEnum::AppendableMemmap(v) => v.get_vector_opt(key),
+            VectorStorageEnum::SparseSimple(v) => v.get_vector_opt(key),
         }
     }
 


### PR DESCRIPTION
This PR protects the sparse vector index build from crashing over an inconsistent storage.

This situation can be created using [crasher](https://github.com/qdrant/crasher) with the experimental [sparse vector branch](https://github.com/qdrant/crasher/tree/sparse-vectors).

Running with `cargo run -- --working-dir "/home/agourlay/Workspace/qdrant/" --exec-path "target/release/qdrant"`

Yields after a few minutes:

```
2023-12-07T10:10:23.044680Z DEBUG segment::segment_constructor::segment_constructor_base: Mismatch of point and vector counts (3100 != 0, storage: ./storage/collections/workload-crasher/0/segments/c3f149e2-3182-4643-b1e4-162d61a7dd17/vector_storage-sparse-name)    
2023-12-07T10:10:23.230269Z ERROR qdrant::startup: Panic backtrace: 
   0: qdrant::startup::setup_panic_hook::{{closure}}
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2021:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:735:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:609:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys_common/backtrace.rs:170:18
   5: rust_begin_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:597:5
   6: core::panicking::panic_fmt
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/panicking.rs:72:14
   7: core::result::unwrap_failed
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/result.rs:1652:5
   8: <segment::vector_storage::simple_sparse_vector_storage::SimpleSparseVectorStorage as segment::vector_storage::vector_storage_base::SparseVectorStorage>::get_sparse
   9: segment::index::sparse_index::sparse_vector_index::SparseVectorIndex<TInvertedIndex>::build_inverted_index
  10: segment::segment_constructor::segment_constructor_base::create_segment
  11: segment::segment_constructor::segment_constructor_base::load_segment
  12: std::sys_common::backtrace::__rust_begin_short_backtrace
  13: core::ops::function::FnOnce::call_once{{vtable.shim}}
  14: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9
  15: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9
  16: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys/unix/thread.rs:108:17
  17: start_thread
             at ./nptl/pthread_create.c:444:8
  18: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
    
2023-12-07T10:10:23.230317Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/vector_storage/simple_sparse_vector_storage.rs at line 149: called `Result::unwrap()` on an `Err` value: ServiceError { description: "RocksDB get_cf error: key not found", backtrace: Some("   0: segment::common::operation_error::OperationError::service_error\n   1: <segment::vector_storage::simple_sparse_vector_storage::SimpleSparseVectorStorage as segment::vector_storage::vector_storage_base::SparseVectorStorage>::get_sparse\n   2: segment::index::sparse_index::sparse_vector_index::SparseVectorIndex<TInvertedIndex>::build_inverted_index\n   3: segment::segment_constructor::segment_constructor_base::create_segment\n   4: segment::segment_constructor::segment_constructor_base::load_segment\n   5: std::sys_common::backtrace::__rust_begin_short_backtrace\n   6: core::ops::function::FnOnce::call_once{{vtable.shim}}\n   7: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once\n             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9\n   8: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once\n             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007:9\n   9: std::sys::unix::thread::Thread::new::thread_start\n             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sys/unix/thread.rs:108:17\n  10: start_thread\n             at ./nptl/pthread_create.c:444:8\n  11: __GI___clone3\n             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78\n") }  
```

This happens because the `id_tracker` is flushed before the `vector_storage`. 
The inconsistencies are usually corrected with the WAL replay after the segment is loaded.

However the segments with sparse vectors are building their in-memory inverted index at loading time.

The proposed solution is to introduce a new function to detect missing key in the storage.

When testing locally with a broken storage, I witness the absence of crash.

```
2023-12-07T11:20:35.905104Z  INFO storage::content_manager::toc: Loading collection: workload-crasher    
2023-12-07T11:20:36.153934Z DEBUG segment::segment_constructor::segment_constructor_base: Mismatch of point and vector counts (3100 != 0, storage: ./storage/collections/workload-crasher/0/segments/c3f149e2-3182-4643-b1e4-162d61a7dd17/vector_storage-sparse-name)    
2023-12-07T11:20:36.526074Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 0 is not found    
2023-12-07T11:20:36.526352Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 1 is not found    
2023-12-07T11:20:36.526528Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 2 is not found    
2023-12-07T11:20:36.526691Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 3 is not found    
2023-12-07T11:20:36.526849Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 4 is not found    
...
2023-12-07T11:20:37.033591Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 3096 is not found    
2023-12-07T11:20:37.033783Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 3097 is not found    
2023-12-07T11:20:37.033972Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 3098 is not found    
2023-12-07T11:20:37.034162Z  WARN segment::index::sparse_index::sparse_vector_index: Sparse vector with id 3099 is not found    
2023-12-07T11:20:37.362721Z DEBUG collection::shards::local_shard: Deduplicated 3100 points    
2023-12-07T11:20:37.362772Z DEBUG collection::optimizers_builder: Removing temp_segments directory: "./storage/collections/workload-crasher/0/temp_segments"    
Recovering collection workload-crasher [00:00:02] ███████
2023-12-07T11:20:40.330959Z DEBUG qdrant: Loaded collection: workload-crasher    
```