### PR TITLE
When bind IP is zero, render it as localhost in greeting

### DIFF
--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -13,6 +13,11 @@ fn paint(text: &str, true_color: bool) -> ColoredString {
     }
 }
 
+/// Check whether the given IP is `0.0.0.0` or the IPv6 equivalent.
+fn is_zero_ip(host: &str) -> bool {
+    host == "0.0.0.0" || host == "::" || host == "0:0:0:0:0:0:0:0"
+}
+
 /// Prints welcome message
 #[rustfmt::skip]
 #[allow(clippy::needless_raw_string_hashes)]
@@ -40,7 +45,11 @@ pub fn welcome(settings: &Settings) {
     let ui_link = format!(
         "http{}://{}:{}/dashboard",
         if settings.service.enable_tls { "s" } else { "" },
-        settings.service.host,
+        if is_zero_ip(&settings.service.host) {
+            "localhost"
+        } else {
+            &settings.service.host
+        },
         settings.service.http_port
     );
 


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/3169> we updated our greeting to render the bind address, rather than localhost.

If the bind address is `0.0.0.0`/`127.0.0.1` or the IPv6 equivalent, render `localhost` instead.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?