### PR TITLE
Remove C# namespace form healthcheck gRPC definition

### DIFF
--- a/lib/api/src/grpc/proto/health_check.proto
+++ b/lib/api/src/grpc/proto/health_check.proto
@@ -2,7 +2,6 @@
 syntax = "proto3";
 
 package grpc.health.v1;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 message HealthCheckRequest {
   string service = 1;


### PR DESCRIPTION
See <https://github.com/qdrant/qdrant-dotnet/pull/36#issuecomment-1845360652>.

We might have to merge this into `master` as well for C#. I'm not sure what implications this might have on our other clients.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?