### PR TITLE
Remove `csharp_namespace` from "internal" proto files

### DIFF
--- a/lib/api/src/grpc/proto/collections_internal_service.proto
+++ b/lib/api/src/grpc/proto/collections_internal_service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 import "collections.proto";
 
 package qdrant;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 service CollectionsInternal {
   /*

--- a/lib/api/src/grpc/proto/health_check.proto
+++ b/lib/api/src/grpc/proto/health_check.proto
@@ -2,7 +2,6 @@
 syntax = "proto3";
 
 package grpc.health.v1;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 message HealthCheckRequest {
   string service = 1;

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 import "points.proto";
 
 package qdrant;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 service PointsInternal {
   rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package qdrant;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 service QdrantInternal {
   /*

--- a/lib/api/src/grpc/proto/raft_service.proto
+++ b/lib/api/src/grpc/proto/raft_service.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package qdrant;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "google/protobuf/empty.proto";
 

--- a/lib/api/src/grpc/proto/shard_snapshots_service.proto
+++ b/lib/api/src/grpc/proto/shard_snapshots_service.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package qdrant;
-option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "snapshots_service.proto";
 


### PR DESCRIPTION
Supersedes <https://github.com/qdrant/qdrant/pull/3180>.

(I'll add proper description later, once we're done with Qdrant 1.7.0 release. This is just a minor cleanup.)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
	* there's, actually, #3180 🙈

### New Feature Submissions:

1. [ ] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
