### PR TITLE
Add plain_search_limit search parameter

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3008,6 +3008,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | exact | [bool](#bool) | optional | Search without approximation. If set to true, search may run long but with exact results. |
 | quantization | [QuantizationSearchParams](#qdrant-QuantizationSearchParams) | optional | If set to true, search will ignore quantized vector data |
 | indexed_only | [bool](#bool) | optional | If enabled, the engine will only perform search among indexed or small segments. Using this option prevents slow searches in case of delayed index, but does not guarantee that all uploaded vectors will be included in search results |
+| plain_search_limit | [uint64](#uint64) | optional | If set, the engine will perform truncated searches up to this limit when scanning plain segments. Using this option allows an upper bound to be set on the cost of searching plain segments exhaustively when indexing throughput cannot keep up with ingest throughput, but does not guarantee that all uploaded vectors will be included in search results |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6672,6 +6672,13 @@
             "description": "If enabled, the engine will only perform search among indexed or small segments. Using this option prevents slow searches in case of delayed index, but does not guarantee that all uploaded vectors will be included in search results",
             "default": false,
             "type": "boolean"
+          },
+          "plain_search_limit": {
+            "description": "If set, the engine will perform truncated searches up to this limit when scanning plain segments. Using this option allows an upper bound to be set on the cost of searching plain segments exhaustively when indexing throughput cannot keep up with ingest throughput, but does not guarantee that all uploaded vectors will be included in search results",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -404,6 +404,7 @@ impl From<SearchParams> for segment::types::SearchParams {
             exact: params.exact.unwrap_or(false),
             quantization: params.quantization.map(|q| q.into()),
             indexed_only: params.indexed_only.unwrap_or(false),
+            plain_search_limit: params.plain_search_limit.map(|x| x as usize),
         }
     }
 }
@@ -415,6 +416,7 @@ impl From<segment::types::SearchParams> for SearchParams {
             exact: Some(params.exact),
             quantization: params.quantization.map(|q| q.into()),
             indexed_only: Some(params.indexed_only),
+            plain_search_limit: params.plain_search_limit.map(|x| x as u64),
         }
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -246,6 +246,14 @@ message SearchParams {
   guarantee that all uploaded vectors will be included in search results
    */
   optional bool indexed_only = 4;
+
+  /*
+  If set, the engine will perform truncated searches up to this limit when scanning plain segments.
+  Using this option allows an upper bound to be set on the cost of searching plain segments
+  exhaustively when indexing throughput cannot keep up with ingest throughput, but does not
+  guarantee that all uploaded vectors will be included in search results
+  */
+  optional uint64 plain_search_limit = 5;
 }
 
 message SearchPoints {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3598,6 +3598,13 @@ pub struct SearchParams {
     /// guarantee that all uploaded vectors will be included in search results
     #[prost(bool, optional, tag = "4")]
     pub indexed_only: ::core::option::Option<bool>,
+    ///
+    /// If set, the engine will perform truncated searches up to this limit when scanning plain segments.
+    /// Using this option allows an upper bound to be set on the cost of searching plain segments
+    /// exhaustively when indexing throughput cannot keep up with ingest throughput, but does not
+    /// guarantee that all uploaded vectors will be included in search results
+    #[prost(uint64, optional, tag = "5")]
+    pub plain_search_limit: ::core::option::Option<u64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -69,7 +69,7 @@ fn benchmark_naive(c: &mut Criterion) {
                 borrowed_id_tracker.deleted_point_bitslice(),
             )
             .unwrap()
-            .peek_top_all(10)
+            .peek_top_all(10, None)
         })
     });
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -331,8 +331,11 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         )?;
         let oversampled_top = Self::get_oversampled_top(quantized_vectors.as_deref(), params, top);
 
-        let search_result =
-            raw_scorer.peek_top_iter(&mut filtered_points.iter().copied(), oversampled_top);
+        let search_result = raw_scorer.peek_top_iter(
+            &mut filtered_points.iter().copied(),
+            oversampled_top,
+            params.and_then(|p| p.plain_search_limit)
+        );
 
         self.postprocess_search_result(search_result, vector, params, top, is_stopped)
     }
@@ -536,7 +539,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                                 id_tracker.deleted_point_bitslice(),
                                 is_stopped,
                             )
-                            .map(|scorer| scorer.peek_top_all(top))
+                            .map(|scorer| scorer.peek_top_all(top, params.and_then(|p| p.plain_search_limit)))
                         })
                         .collect()
                 } else {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -334,7 +334,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
         let search_result = raw_scorer.peek_top_iter(
             &mut filtered_points.iter().copied(),
             oversampled_top,
-            params.and_then(|p| p.plain_search_limit)
+            params.and_then(|p| p.plain_search_limit),
         );
 
         self.postprocess_search_result(search_result, vector, params, top, is_stopped)
@@ -539,7 +539,9 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                                 id_tracker.deleted_point_bitslice(),
                                 is_stopped,
                             )
-                            .map(|scorer| scorer.peek_top_all(top, params.and_then(|p| p.plain_search_limit)))
+                            .map(|scorer| {
+                                scorer.peek_top_all(top, params.and_then(|p| p.plain_search_limit))
+                            })
                         })
                         .collect()
                 } else {

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -249,7 +249,11 @@ impl VectorIndex for PlainIndex {
                             is_stopped,
                         )
                         .map(|scorer| {
-                            scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top, maybe_limit)
+                            scorer.peek_top_iter(
+                                &mut filtered_ids_vec.iter().copied(),
+                                top,
+                                maybe_limit,
+                            )
                         })
                     })
                     .collect()

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -227,9 +227,11 @@ impl VectorIndex for PlainIndex {
         vectors: &[&QueryVector],
         filter: Option<&Filter>,
         top: usize,
-        _params: Option<&SearchParams>,
+        params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let maybe_limit = params.and_then(|p| p.plain_search_limit);
+
         match filter {
             Some(filter) => {
                 let _timer = ScopeDurationMeasurer::new(&self.filtered_searches_telemetry);
@@ -247,7 +249,7 @@ impl VectorIndex for PlainIndex {
                             is_stopped,
                         )
                         .map(|scorer| {
-                            scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top)
+                            scorer.peek_top_iter(&mut filtered_ids_vec.iter().copied(), top, maybe_limit)
                         })
                     })
                     .collect()
@@ -265,7 +267,7 @@ impl VectorIndex for PlainIndex {
                             id_tracker.deleted_point_bitslice(),
                             is_stopped,
                         )
-                        .map(|scorer| scorer.peek_top_all(top))
+                        .map(|scorer| scorer.peek_top_all(top, maybe_limit))
                     })
                     .collect()
             }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -188,9 +188,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                         prefiltered_points.as_ref().unwrap().iter().copied()
                     }
                 };
-                Ok(raw_scorer.peek_top_iter(&mut filtered_points, top))
+                Ok(raw_scorer.peek_top_iter(&mut filtered_points, top, None))
             }
-            None => Ok(raw_scorer.peek_top_all(top)),
+            None => Ok(raw_scorer.peek_top_all(top, None)),
         }
     }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -345,7 +345,7 @@ pub struct SearchParams {
     /// Using this option allows an upper bound to be set on the cost of searching plain segments
     /// exhaustively when indexing throughput cannot keep up with ingest throughput, but does not
     /// guarantee that all uploaded vectors will be included in search results
-    pub plain_search_limit: Option<usize>
+    pub plain_search_limit: Option<usize>,
 }
 
 /// Vector index configuration

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -340,6 +340,12 @@ pub struct SearchParams {
     /// guarantee that all uploaded vectors will be included in search results
     #[serde(default)]
     pub indexed_only: bool,
+
+    /// If set, the engine will perform truncated searches up to this limit when scanning plain segments.
+    /// Using this option allows an upper bound to be set on the cost of searching plain segments
+    /// exhaustively when indexing throughput cannot keep up with ingest throughput, but does not
+    /// guarantee that all uploaded vectors will be included in search results
+    pub plain_search_limit: Option<usize>
 }
 
 /// Vector index configuration

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -151,6 +151,7 @@ where
         &self,
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
+        limit: Option<usize>,
     ) -> Vec<ScoredPointOffset> {
         if top == 0 {
             return vec![];
@@ -159,6 +160,7 @@ where
         let mut pq = FixedLengthPriorityQueue::new(top);
         let points_stream = points
             .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
+            .take(limit.unwrap_or(usize::MAX))
             .filter(|point_id| self.check_vector(*point_id));
 
         self.storage
@@ -178,13 +180,14 @@ where
         pq.into_vec()
     }
 
-    fn peek_top_all(&self, top: usize) -> Vec<ScoredPointOffset> {
+    fn peek_top_all(&self, top: usize, limit: Option<usize>) -> Vec<ScoredPointOffset> {
         if top == 0 {
             return vec![];
         }
 
         let points_stream = (0..self.points_count)
             .take_while(|_| !self.is_stopped.load(Ordering::Relaxed))
+            .take(limit.unwrap_or(usize::MAX))
             .filter(|point_id| self.check_vector(*point_id));
 
         let mut pq = FixedLengthPriorityQueue::new(top);

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -314,13 +314,13 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap();
-        let res = raw_scorer.peek_top_all(2);
+        let res = raw_scorer.peek_top_all(2, None);
 
         assert_eq!(res.len(), 2);
 
         assert_ne!(res[0].idx, 2);
 
-        let res = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+        let res = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, None);
 
         assert_eq!(res.len(), 2);
         assert_ne!(res[0].idx, 2);
@@ -391,7 +391,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
         assert_eq!(closest[1].idx, 1);
@@ -419,7 +419,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
         assert_eq!(closest[0].idx, 4);
         assert_eq!(closest[1].idx, 0);
@@ -445,7 +445,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap()
-        .peek_top_all(5);
+        .peek_top_all(5, None);
         assert!(closest.is_empty(), "must have no results, all deleted");
     }
 
@@ -507,7 +507,7 @@ mod tests {
             borrowed_id_tracker.deleted_point_bitslice(),
         )
         .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
         assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
         assert_eq!(closest[0].idx, 0);
         assert_eq!(closest[1].idx, 1);

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -77,7 +77,7 @@ pub trait RawScorer {
         &self,
         points: &mut dyn Iterator<Item = PointOffsetType>,
         top: usize,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Vec<ScoredPointOffset>;
 
     fn peek_top_all(&self, top: usize, limit: Option<usize>) -> Vec<ScoredPointOffset>;

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -80,7 +80,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
@@ -181,7 +181,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -60,7 +60,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
@@ -87,7 +87,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
     assert_eq!(closest[0].idx, 4);
     assert_eq!(closest[1].idx, 0);
@@ -113,7 +113,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_all(5);
+    .peek_top_all(5, None);
     assert!(closest.is_empty(), "must have no results, all deleted");
 }
 
@@ -172,7 +172,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 5, None);
     assert_eq!(closest.len(), 3, "must have 3 vectors, 2 are deleted");
     assert_eq!(closest[0].idx, 0);
     assert_eq!(closest[1].idx, 1);
@@ -221,8 +221,21 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
+        .unwrap()
+        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, Some(2));
+
+    match closest.get(0) {
+        Some(scored_point) => assert_eq!(scored_point.idx, 0),
+        None => panic!("No close vector found!"),
+    };
+
+    let closest = new_raw_scorer(
+        query.clone(),
+        &borrowed_storage,
+        borrowed_id_tracker.deleted_point_bitslice(),
+    )
     .unwrap()
-    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, None);
 
     let top_idx = match closest.get(0) {
         Some(scored_point) => {
@@ -242,7 +255,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         borrowed_id_tracker.deleted_point_bitslice(),
     )
     .unwrap();
-    let closest = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
+    let closest = raw_scorer.peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, None);
 
     let query_points = vec![0, 1, 2, 3, 4];
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -221,8 +221,8 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         &borrowed_storage,
         borrowed_id_tracker.deleted_point_bitslice(),
     )
-        .unwrap()
-        .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, Some(2));
+    .unwrap()
+    .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2, Some(2));
 
     match closest.get(0) {
         Some(scored_point) => assert_eq!(scored_point.idx, 0),

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -266,7 +266,7 @@ fn test_update_named_vector() {
         exact: true,
         quantization: None,
         indexed_only: false,
-        plain_search_limit: None
+        plain_search_limit: None,
     };
     let nearest_upsert = segment
         .search(

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -266,6 +266,7 @@ fn test_update_named_vector() {
         exact: true,
         quantization: None,
         indexed_only: false,
+        plain_search_limit: None
     };
     let nearest_upsert = segment
         .search(

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -6,8 +6,8 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-# QDRANT_HOST='localhost:6334'
-QDRANT_HOST='host.docker.internal:6334'
+QDRANT_HOST='localhost:6334'
+
 docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
 
 $docker_grpcurl -d '{

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -6,8 +6,8 @@ set -ex
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_HOST='localhost:6334'
-
+# QDRANT_HOST='localhost:6334'
+QDRANT_HOST='host.docker.internal:6334'
 docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
 
 $docker_grpcurl -d '{


### PR DESCRIPTION
We observe a ~20% drop in recall when using `indexed_only: true` in our searches in a collection with `default_segment_number: 5`.
I believe what is happening is:
1. An indexed segment gets selected for another round of optimization
2. A proxy segment is created where the original indexed segment is `wrapped` and a new temporary plain segment is `write`
3. The `write` segment accrues new vectors
4. The `is_search_optimized` function is eventually `false` for the entire ProxySegment because `num_vectors` of `VectorDataInfo` is summed across both `write` and `wrapped` segments but `num_indexed_vectors` only includes the value from the optimized `wrapped` segment.

In the above case, really only the plain `write` segment of the proxy segment should be excluded from searches, not the optimized `wrapped` segment. 

This PR is a proposal to introduce a new `plain_search_limit` search parameter which is applied at a lower level. It:
1. Sets a limit on the number of vectors that will be scanned when performing a plain index search.
2. Pushes the logic down into the vector index, allowing ProxySegment to propagate reads to its underlying segments properly.
3. Decouples index creation-time `indexing_threshold` and `full_scan_threshold` parameters with search-time parameters to allow for better control and fine-tuning

I did not make any changes to `indexed_only` logic. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
5. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
6. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
