### PR TITLE
Rename `VectorType` to `DenseVector`

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6136,14 +6136,14 @@
             }
           },
           {
-            "$ref": "#/components/schemas/NamedVector"
+            "$ref": "#/components/schemas/NamedDenseVector"
           },
           {
             "$ref": "#/components/schemas/NamedSparseVector"
           }
         ]
       },
-      "NamedVector": {
+      "NamedDenseVector": {
         "description": "Vector data with name",
         "type": "object",
         "required": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6136,14 +6136,14 @@
             }
           },
           {
-            "$ref": "#/components/schemas/NamedDenseVector"
+            "$ref": "#/components/schemas/NamedVector"
           },
           {
             "$ref": "#/components/schemas/NamedSparseVector"
           }
         ]
       },
-      "NamedDenseVector": {
+      "NamedVector": {
         "description": "Vector data with name",
         "type": "object",
         "required": [

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1231,7 +1231,7 @@ pub fn into_named_vector_struct(
     vector: Vec<VectorElementType>,
     indices: Option<SparseIndices>,
 ) -> Result<segment::data_types::vectors::NamedVectorStruct, Status> {
-    use segment::data_types::vectors::{NamedDenseVector, NamedSparseVector, NamedVectorStruct};
+    use segment::data_types::vectors::{NamedSparseVector, NamedVector, NamedVectorStruct};
     use sparse::common::sparse_vector::SparseVector;
     Ok(match indices {
         Some(indices) => NamedVectorStruct::Sparse(NamedSparseVector {
@@ -1244,7 +1244,7 @@ pub fn into_named_vector_struct(
         }),
         None => {
             if let Some(vector_name) = vector_name {
-                NamedVectorStruct::Dense(NamedDenseVector {
+                NamedVectorStruct::Dense(NamedVector {
                     name: vector_name,
                     vector,
                 })

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1231,7 +1231,7 @@ pub fn into_named_vector_struct(
     vector: Vec<VectorElementType>,
     indices: Option<SparseIndices>,
 ) -> Result<segment::data_types::vectors::NamedVectorStruct, Status> {
-    use segment::data_types::vectors::{NamedSparseVector, NamedVector, NamedVectorStruct};
+    use segment::data_types::vectors::{NamedSparseVector, NamedDenseVector, NamedVectorStruct};
     use sparse::common::sparse_vector::SparseVector;
     Ok(match indices {
         Some(indices) => NamedVectorStruct::Sparse(NamedSparseVector {
@@ -1244,7 +1244,7 @@ pub fn into_named_vector_struct(
         }),
         None => {
             if let Some(vector_name) = vector_name {
-                NamedVectorStruct::Named(NamedVector {
+                NamedVectorStruct::Dense(NamedDenseVector {
                     name: vector_name,
                     vector,
                 })

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1231,7 +1231,7 @@ pub fn into_named_vector_struct(
     vector: Vec<VectorElementType>,
     indices: Option<SparseIndices>,
 ) -> Result<segment::data_types::vectors::NamedVectorStruct, Status> {
-    use segment::data_types::vectors::{NamedSparseVector, NamedDenseVector, NamedVectorStruct};
+    use segment::data_types::vectors::{NamedDenseVector, NamedSparseVector, NamedVectorStruct};
     use sparse::common::sparse_vector::SparseVector;
     Ok(match indices {
         Some(indices) => NamedVectorStruct::Sparse(NamedSparseVector {

--- a/lib/collection/src/common/fetch_vectors.rs
+++ b/lib/collection/src/common/fetch_vectors.rs
@@ -233,7 +233,7 @@ pub fn convert_to_vectors_owned(
     examples
         .into_iter()
         .filter_map(|example| match example {
-            RecommendExample::Vector(vector) => Some(vector.into()),
+            RecommendExample::Dense(vector) => Some(vector.into()),
             RecommendExample::Sparse(vector) => Some(vector.into()),
             RecommendExample::PointId(vid) => {
                 let rec = all_vectors_records_map.get(&collection_name, vid).unwrap();
@@ -250,7 +250,7 @@ pub fn convert_to_vectors<'a>(
     collection_name: Option<&'a String>,
 ) -> impl Iterator<Item = VectorRef<'a>> + 'a {
     examples.filter_map(move |example| match example {
-        RecommendExample::Vector(vector) => Some(vector.into()),
+        RecommendExample::Dense(vector) => Some(vector.into()),
         RecommendExample::Sparse(vector) => Some(vector.into()),
         RecommendExample::PointId(vid) => {
             let rec = all_vectors_records_map.get(&collection_name, *vid).unwrap();

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1331,7 +1331,7 @@ impl From<api::grpc::qdrant::Vector> for RecommendExample {
     fn from(value: api::grpc::qdrant::Vector) -> Self {
         let vector: Vector = value.into();
         match vector {
-            Vector::Dense(vector) => Self::Vector(vector),
+            Vector::Dense(vector) => Self::Dense(vector),
             Vector::Sparse(vector) => Self::Sparse(vector),
         }
     }
@@ -1351,7 +1351,7 @@ impl TryFrom<api::grpc::qdrant::VectorExample> for RecommendExample {
                     Ok(Self::PointId(id.try_into()?))
                 }
                 api::grpc::qdrant::vector_example::Example::Vector(vector) => {
-                    Ok(Self::Vector(vector.data))
+                    Ok(Self::Dense(vector.data))
                 }
             })
     }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -16,8 +16,8 @@ use segment::common::anonymize::Anonymize;
 use segment::common::operation_error::OperationError;
 use segment::data_types::groups::GroupId;
 use segment::data_types::vectors::{
-    Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorElementType, VectorRef,
-    VectorStruct, VectorType, DEFAULT_VECTOR_NAME,
+    DenseVector, Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorElementType,
+    VectorRef, VectorStruct, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
     Distance, Filter, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig,
@@ -489,7 +489,7 @@ pub struct PointRequestInternal {
 #[serde(untagged)]
 pub enum RecommendExample {
     PointId(PointIdType),
-    Vector(VectorType),
+    Vector(DenseVector),
     Sparse(SparseVector),
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -489,7 +489,7 @@ pub struct PointRequestInternal {
 #[serde(untagged)]
 pub enum RecommendExample {
     PointId(PointIdType),
-    Vector(DenseVector),
+    Dense(DenseVector),
     Sparse(SparseVector),
 }
 
@@ -506,7 +506,7 @@ impl Validate for RecommendExample {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
             RecommendExample::PointId(_) => Ok(()),
-            RecommendExample::Vector(_) => Ok(()),
+            RecommendExample::Dense(_) => Ok(()),
             RecommendExample::Sparse(sparse) => sparse.validate(),
         }
     }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use segment::data_types::vectors::{
-    NamedQuery, NamedVectorStruct, Vector, VectorElementType, VectorRef, VectorType,
+    DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType, VectorRef,
     DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
@@ -28,7 +28,7 @@ use crate::operations::types::{
 };
 
 fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionResult<Vector> {
-    let mut avg_dense = VectorType::default();
+    let mut avg_dense = DenseVector::default();
     let mut avg_sparse = SparseVector::default();
     let mut dense_count = 0;
     let mut sparse_count = 0;
@@ -79,7 +79,7 @@ fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionRe
 fn merge_positive_and_negative_avg(positive: Vector, negative: Vector) -> CollectionResult<Vector> {
     match (positive, negative) {
         (Vector::Dense(positive), Vector::Dense(negative)) => {
-            let vector: VectorType = positive
+            let vector: DenseVector = positive
                 .iter()
                 .zip(negative.iter())
                 .map(|(pos, neg)| pos + pos - neg)

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -9,13 +9,13 @@ use itertools::Itertools;
 use rand::distributions::Uniform;
 use rand::rngs::ThreadRng;
 use rand::Rng;
-use segment::data_types::vectors::VectorType;
+use segment::data_types::vectors::DenseVector;
 use segment::types::{Filter, Payload, WithPayloadInterface, WithVector};
 use serde_json::json;
 
 use crate::common::simple_collection_fixture;
 
-fn rand_vector(rng: &mut ThreadRng, size: usize) -> VectorType {
+fn rand_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
     rng.sample_iter(Uniform::new(0.4, 0.6)).take(size).collect()
 }
 

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 
 use crate::common::simple_collection_fixture;
 
-fn rand_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
+fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
     rng.sample_iter(Uniform::new(0.4, 0.6)).take(size).collect()
 }
 
@@ -56,7 +56,7 @@ mod group_by {
             Batch {
                 ids: (0..docs * chunks).map(|x| x.into()).collect_vec(),
                 vectors: (0..docs * chunks)
-                    .map(|_| rand_vector(&mut rng, 4))
+                    .map(|_| rand_dense_vector(&mut rng, 4))
                     .collect_vec()
                     .into(),
                 payloads: (0..docs)
@@ -472,7 +472,7 @@ mod group_by_builder {
                 Batch {
                     ids: (0..docs * chunks_per_doc).map(|x| x.into()).collect_vec(),
                     vectors: (0..docs * chunks_per_doc)
-                        .map(|_| rand_vector(&mut rng, 4))
+                        .map(|_| rand_dense_vector(&mut rng, 4))
                         .collect_vec()
                         .into(),
                     payloads: (0..docs)
@@ -503,7 +503,7 @@ mod group_by_builder {
                 Batch {
                     ids: (0..docs).map(|x| x.into()).collect_vec(),
                     vectors: (0..docs)
-                        .map(|_| rand_vector(&mut rng, 4))
+                        .map(|_| rand_dense_vector(&mut rng, 4))
                         .collect_vec()
                         .into(),
                     payloads: (0..docs)

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -15,7 +15,7 @@ use collection::operations::types::{
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::{NamedDenseVector, VectorStruct};
+use segment::data_types::vectors::{NamedVector, VectorStruct};
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
 
@@ -116,7 +116,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     let query_vector = vec![6.0, 0.0, 0.0, 0.0];
 
     let full_search_request = SearchRequestInternal {
-        vector: NamedDenseVector {
+        vector: NamedVector {
             name: VEC_NAME1.to_string(),
             vector: query_vector,
         }
@@ -178,7 +178,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     );
 
     let full_search_request = SearchRequestInternal {
-        vector: NamedDenseVector {
+        vector: NamedVector {
             name: VEC_NAME2.to_string(),
             vector: query_vector,
         }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -15,7 +15,7 @@ use collection::operations::types::{
 use collection::operations::CollectionUpdateOperations;
 use collection::recommendations::recommend_by;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::{NamedVector, VectorStruct};
+use segment::data_types::vectors::{NamedDenseVector, VectorStruct};
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
 
@@ -116,7 +116,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     let query_vector = vec![6.0, 0.0, 0.0, 0.0];
 
     let full_search_request = SearchRequestInternal {
-        vector: NamedVector {
+        vector: NamedDenseVector {
             name: VEC_NAME1.to_string(),
             vector: query_vector,
         }
@@ -178,7 +178,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
     );
 
     let full_search_request = SearchRequestInternal {
-        vector: NamedVector {
+        vector: NamedDenseVector {
             name: VEC_NAME2.to_string(),
             vector: query_vector,
         }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::tiny_map;
-use super::vectors::{Vector, VectorElementType, VectorRef, VectorType};
+use super::vectors::{DenseVector, Vector, VectorElementType, VectorRef};
 use crate::common::operation_error::OperationError;
 use crate::types::Distance;
 
@@ -60,8 +60,8 @@ impl<'a> From<SparseVector> for CowVector<'a> {
     }
 }
 
-impl<'a> From<VectorType> for CowVector<'a> {
-    fn from(v: VectorType) -> Self {
+impl<'a> From<DenseVector> for CowVector<'a> {
+    fn from(v: DenseVector) -> Self {
         CowVector::Dense(Cow::Owned(v))
     }
 }
@@ -89,7 +89,7 @@ impl<'a> TryFrom<CowVector<'a>> for SparseVector {
     }
 }
 
-impl<'a> TryFrom<CowVector<'a>> for VectorType {
+impl<'a> TryFrom<CowVector<'a>> for DenseVector {
     type Error = OperationError;
 
     fn try_from(value: CowVector<'a>) -> Result<Self, Self::Error> {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -276,7 +276,7 @@ impl VectorStruct {
 /// Vector data with name
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
-pub struct NamedDenseVector {
+pub struct NamedVector {
     /// Name of vector data
     pub name: String,
     /// Vector data
@@ -314,7 +314,7 @@ pub struct NamedSparseVector {
 #[serde(untagged)]
 pub enum NamedVectorStruct {
     Default(DenseVector),
-    Dense(NamedDenseVector),
+    Dense(NamedVector),
     Sparse(NamedSparseVector),
 }
 
@@ -324,8 +324,8 @@ impl From<DenseVector> for NamedVectorStruct {
     }
 }
 
-impl From<NamedDenseVector> for NamedVectorStruct {
-    fn from(v: NamedDenseVector) -> Self {
+impl From<NamedVector> for NamedVectorStruct {
+    fn from(v: NamedVector) -> Self {
         NamedVectorStruct::Dense(v)
     }
 }
@@ -353,7 +353,7 @@ impl Named for NamedVectorStruct {
 impl NamedVectorStruct {
     pub fn new_from_vector(vector: Vector, name: String) -> Self {
         match vector {
-            Vector::Dense(vector) => NamedVectorStruct::Dense(NamedDenseVector { name, vector }),
+            Vector::Dense(vector) => NamedVectorStruct::Dense(NamedVector { name, vector }),
             Vector::Sparse(vector) => NamedVectorStruct::Sparse(NamedSparseVector { name, vector }),
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -78,7 +78,7 @@ impl From<NamedVectorStruct> for Vector {
     fn from(value: NamedVectorStruct) -> Self {
         match value {
             NamedVectorStruct::Default(v) => Vector::Dense(v),
-            NamedVectorStruct::Named(v) => Vector::Dense(v.vector),
+            NamedVectorStruct::Dense(v) => Vector::Dense(v.vector),
             NamedVectorStruct::Sparse(v) => Vector::Sparse(v.vector),
         }
     }
@@ -276,7 +276,7 @@ impl VectorStruct {
 /// Vector data with name
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
-pub struct NamedVector {
+pub struct NamedDenseVector {
     /// Name of vector data
     pub name: String,
     /// Vector data
@@ -314,7 +314,7 @@ pub struct NamedSparseVector {
 #[serde(untagged)]
 pub enum NamedVectorStruct {
     Default(DenseVector),
-    Named(NamedVector),
+    Dense(NamedDenseVector),
     Sparse(NamedSparseVector),
 }
 
@@ -324,9 +324,9 @@ impl From<DenseVector> for NamedVectorStruct {
     }
 }
 
-impl From<NamedVector> for NamedVectorStruct {
-    fn from(v: NamedVector) -> Self {
-        NamedVectorStruct::Named(v)
+impl From<NamedDenseVector> for NamedVectorStruct {
+    fn from(v: NamedDenseVector) -> Self {
+        NamedVectorStruct::Dense(v)
     }
 }
 
@@ -344,7 +344,7 @@ impl Named for NamedVectorStruct {
     fn get_name(&self) -> &str {
         match self {
             NamedVectorStruct::Default(_) => DEFAULT_VECTOR_NAME,
-            NamedVectorStruct::Named(v) => &v.name,
+            NamedVectorStruct::Dense(v) => &v.name,
             NamedVectorStruct::Sparse(v) => &v.name,
         }
     }
@@ -353,7 +353,7 @@ impl Named for NamedVectorStruct {
 impl NamedVectorStruct {
     pub fn new_from_vector(vector: Vector, name: String) -> Self {
         match vector {
-            Vector::Dense(vector) => NamedVectorStruct::Named(NamedVector { name, vector }),
+            Vector::Dense(vector) => NamedVectorStruct::Dense(NamedDenseVector { name, vector }),
             Vector::Sparse(vector) => NamedVectorStruct::Sparse(NamedSparseVector { name, vector }),
         }
     }
@@ -361,7 +361,7 @@ impl NamedVectorStruct {
     pub fn get_vector(&self) -> VectorRef {
         match self {
             NamedVectorStruct::Default(v) => v.as_slice().into(),
-            NamedVectorStruct::Named(v) => v.vector.as_slice().into(),
+            NamedVectorStruct::Dense(v) => v.vector.as_slice().into(),
             NamedVectorStruct::Sparse(v) => (&v.vector).into(),
         }
     }
@@ -369,7 +369,7 @@ impl NamedVectorStruct {
     pub fn to_vector(self) -> Vector {
         match self {
             NamedVectorStruct::Default(v) => v.into(),
-            NamedVectorStruct::Named(v) => v.vector.into(),
+            NamedVectorStruct::Dense(v) => v.vector.into(),
             NamedVectorStruct::Sparse(v) => v.vector.into(),
         }
     }
@@ -379,7 +379,7 @@ impl Validate for NamedVectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             NamedVectorStruct::Default(_) => Ok(()),
-            NamedVectorStruct::Named(_) => Ok(()),
+            NamedVectorStruct::Dense(_) => Ok(()),
             NamedVectorStruct::Sparse(v) => v.validate(),
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -15,7 +15,7 @@ use crate::vector_storage::query::reco_query::RecoQuery;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum Vector {
-    Dense(VectorType),
+    Dense(DenseVector),
     Sparse(SparseVector),
 }
 
@@ -84,7 +84,7 @@ impl From<NamedVectorStruct> for Vector {
     }
 }
 
-impl TryFrom<Vector> for VectorType {
+impl TryFrom<Vector> for DenseVector {
     type Error = OperationError;
 
     fn try_from(value: Vector) -> Result<Self, Self::Error> {
@@ -112,8 +112,8 @@ impl<'a> From<&'a [VectorElementType]> for VectorRef<'a> {
     }
 }
 
-impl<'a> From<&'a VectorType> for VectorRef<'a> {
-    fn from(val: &'a VectorType) -> Self {
+impl<'a> From<&'a DenseVector> for VectorRef<'a> {
+    fn from(val: &'a DenseVector) -> Self {
         VectorRef::Dense(val.as_slice())
     }
 }
@@ -124,8 +124,8 @@ impl<'a> From<&'a SparseVector> for VectorRef<'a> {
     }
 }
 
-impl From<VectorType> for Vector {
-    fn from(val: VectorType) -> Self {
+impl From<DenseVector> for Vector {
+    fn from(val: DenseVector) -> Self {
         Vector::Dense(val)
     }
 }
@@ -151,7 +151,7 @@ pub type VectorElementType = f32;
 pub const DEFAULT_VECTOR_NAME: &str = "";
 
 /// Type for dense vector
-pub type VectorType = Vec<VectorElementType>;
+pub type DenseVector = Vec<VectorElementType>;
 
 impl<'a> VectorRef<'a> {
     // Cannot use `ToOwned` trait because of `Borrow` implementation for `Vector`
@@ -208,7 +208,7 @@ pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum VectorStruct {
-    Single(VectorType),
+    Single(DenseVector),
     Multi(HashMap<String, Vector>),
 }
 
@@ -234,8 +234,8 @@ impl Validate for VectorStruct {
     }
 }
 
-impl From<VectorType> for VectorStruct {
-    fn from(v: VectorType) -> Self {
+impl From<DenseVector> for VectorStruct {
+    fn from(v: DenseVector) -> Self {
         VectorStruct::Single(v)
     }
 }
@@ -280,7 +280,7 @@ pub struct NamedVector {
     /// Name of vector data
     pub name: String,
     /// Vector data
-    pub vector: VectorType,
+    pub vector: DenseVector,
 }
 
 /// Sparse vector data with name
@@ -313,13 +313,13 @@ pub struct NamedSparseVector {
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum NamedVectorStruct {
-    Default(VectorType),
+    Default(DenseVector),
     Named(NamedVector),
     Sparse(NamedSparseVector),
 }
 
-impl From<VectorType> for NamedVectorStruct {
-    fn from(v: VectorType) -> Self {
+impl From<DenseVector> for NamedVectorStruct {
+    fn from(v: DenseVector) -> Self {
         NamedVectorStruct::Default(v)
     }
 }
@@ -389,12 +389,12 @@ impl Validate for NamedVectorStruct {
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum BatchVectorStruct {
-    Single(Vec<VectorType>),
+    Single(Vec<DenseVector>),
     Multi(HashMap<String, Vec<Vector>>),
 }
 
-impl From<Vec<VectorType>> for BatchVectorStruct {
-    fn from(v: Vec<VectorType>) -> Self {
+impl From<Vec<DenseVector>> for BatchVectorStruct {
+    fn from(v: Vec<DenseVector>) -> Self {
         BatchVectorStruct::Single(v)
     }
 }
@@ -451,8 +451,8 @@ pub enum QueryVector {
     Context(ContextQuery<Vector>),
 }
 
-impl From<VectorType> for QueryVector {
-    fn from(vec: VectorType) -> Self {
+impl From<DenseVector> for QueryVector {
+    fn from(vec: DenseVector) -> Self {
         Self::Nearest(Vector::Dense(vec))
     }
 }

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
-use crate::data_types::vectors::{VectorElementType, VectorRef, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
 use crate::payload_storage::FilterContext;
 use crate::spaces::metric::Metric;
 use crate::types::Distance;
@@ -127,7 +127,7 @@ where
         }
     }
 
-    pub fn get_raw_scorer(&self, query: VectorType) -> OperationResult<Box<dyn RawScorer + '_>> {
+    pub fn get_raw_scorer(&self, query: DenseVector) -> OperationResult<Box<dyn RawScorer + '_>> {
         let query = TMetric::preprocess(query).into();
         raw_scorer_impl(
             query,

--- a/lib/segment/src/spaces/metric.rs
+++ b/lib/segment/src/spaces/metric.rs
@@ -1,6 +1,6 @@
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 
 /// Defines how to compare vectors
@@ -12,7 +12,7 @@ pub trait Metric {
 
     /// Necessary vector transformations performed before adding it to the collection (like normalization)
     /// If no transformation is needed - returns the same vector
-    fn preprocess(vector: VectorType) -> VectorType;
+    fn preprocess(vector: DenseVector) -> DenseVector;
 
     /// correct metric score for displaying
     fn postprocess(score: ScoreType) -> ScoreType;

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -7,7 +7,7 @@ use super::simple_avx::*;
 use super::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::simple_sse::*;
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 
 #[cfg(target_arch = "x86_64")]
@@ -65,7 +65,7 @@ impl Metric for EuclidMetric {
         euclid_similarity(v1, v2)
     }
 
-    fn preprocess(vector: VectorType) -> VectorType {
+    fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }
 
@@ -107,7 +107,7 @@ impl Metric for ManhattanMetric {
         manhattan_similarity(v1, v2)
     }
 
-    fn preprocess(vector: VectorType) -> VectorType {
+    fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }
 
@@ -149,7 +149,7 @@ impl Metric for DotProductMetric {
         dot_similarity(v1, v2)
     }
 
-    fn preprocess(vector: VectorType) -> VectorType {
+    fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }
 
@@ -191,7 +191,7 @@ impl Metric for CosineMetric {
         dot_similarity(v1, v2)
     }
 
-    fn preprocess(vector: VectorType) -> VectorType {
+    fn preprocess(vector: DenseVector) -> DenseVector {
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx")
@@ -239,7 +239,7 @@ pub fn manhattan_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) 
         .sum::<ScoreType>()
 }
 
-pub fn cosine_preprocess(vector: VectorType) -> VectorType {
+pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
     let mut length: f32 = vector.iter().map(|x| x * x).sum();
     if length < f32::EPSILON {
         return vector;

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -2,7 +2,7 @@ use std::arch::x86_64::*;
 
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
@@ -110,7 +110,7 @@ pub(crate) unsafe fn manhattan_similarity_avx(
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "fma")]
-pub(crate) unsafe fn cosine_preprocess_avx(vector: VectorType) -> VectorType {
+pub(crate) unsafe fn cosine_preprocess_avx(vector: DenseVector) -> DenseVector {
     let n = vector.len();
     let m = n - (n % 32);
     let mut ptr: *const f32 = vector.as_ptr();

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -4,9 +4,9 @@ use std::arch::aarch64::*;
 #[cfg(target_feature = "neon")]
 use common::types::ScoreType;
 
+use crate::data_types::vectors::DenseVector;
 #[cfg(target_feature = "neon")]
 use crate::data_types::vectors::VectorElementType;
-use crate::data_types::vectors::VectorType;
 
 #[cfg(target_feature = "neon")]
 pub(crate) unsafe fn euclid_similarity_neon(
@@ -87,7 +87,7 @@ pub(crate) unsafe fn manhattan_similarity_neon(
 }
 
 #[cfg(target_feature = "neon")]
-pub(crate) unsafe fn cosine_preprocess_neon(vector: VectorType) -> VectorType {
+pub(crate) unsafe fn cosine_preprocess_neon(vector: DenseVector) -> DenseVector {
     let n = vector.len();
     let m = n - (n % 16);
     let mut ptr: *const f32 = vector.as_ptr();

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -5,7 +5,7 @@ use std::arch::x86_64::*;
 
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "sse")]
 unsafe fn hsum128_ps_sse(x: __m128) -> f32 {
@@ -101,7 +101,7 @@ pub(crate) unsafe fn manhattan_similarity_sse(
 }
 
 #[target_feature(enable = "sse")]
-pub(crate) unsafe fn cosine_preprocess_sse(vector: VectorType) -> VectorType {
+pub(crate) unsafe fn cosine_preprocess_sse(vector: DenseVector) -> DenseVector {
     let n = vector.len();
     let m = n - (n % 16);
     let mut ptr: *const f32 = vector.as_ptr();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -26,7 +26,7 @@ use crate::common::utils::{
     MultiValue,
 };
 use crate::data_types::text_index::TextIndexParams;
-use crate::data_types::vectors::{VectorElementType, VectorStruct, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType, VectorStruct};
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
@@ -129,7 +129,7 @@ pub enum Distance {
 }
 
 impl Distance {
-    pub fn preprocess_vector(&self, vector: VectorType) -> VectorType {
+    pub fn preprocess_vector(&self, vector: DenseVector) -> DenseVector {
         match self {
             Distance::Cosine => CosineMetric::preprocess(vector),
             Distance::Euclid => EuclidMetric::preprocess(vector),

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -10,7 +10,7 @@ use super::query::reco_query::RecoQuery;
 use super::query::TransformInto;
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::vectors::{QueryVector, Vector, VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, QueryVector, Vector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::Distance;
@@ -286,7 +286,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 }
             }
             QueryVector::Recommend(reco_query) => {
-                let reco_query: RecoQuery<VectorType> = reco_query.transform_into()?;
+                let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
                 let query_scorer = CustomQueryScorer::<TMetric, _, _>::new(reco_query, storage);
                 Ok(Box::new(AsyncRawScorerImpl::new(
                     points_count,
@@ -298,7 +298,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 )))
             }
             QueryVector::Discovery(discovery_query) => {
-                let discovery_query: DiscoveryQuery<VectorType> =
+                let discovery_query: DiscoveryQuery<DenseVector> =
                     discovery_query.transform_into()?;
                 let query_scorer =
                     CustomQueryScorer::<TMetric, _, _>::new(discovery_query, storage);
@@ -312,7 +312,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                 )))
             }
             QueryVector::Context(context_query) => {
-                let context_query: ContextQuery<VectorType> = context_query.transform_into()?;
+                let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
                 let query_scorer = CustomQueryScorer::<TMetric, _, _>::new(context_query, storage);
                 Ok(Box::new(AsyncRawScorerImpl::new(
                     points_count,

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -14,7 +14,7 @@ use super::{DenseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
-use crate::data_types::vectors::{VectorElementType, VectorRef, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
 use crate::types::Distance;
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::mmap_vectors::MmapVectors;
@@ -139,7 +139,7 @@ impl VectorStorage for MemmapVectorStorage {
         let mut deleted_ids = vec![];
         for id in other_ids {
             check_process_stopped(stopped)?;
-            let vector: VectorType = other.get_vector(id).try_into()?;
+            let vector: DenseVector = other.get_vector(id).try_into()?;
             let raw_bites = mmap_ops::transmute_to_u8_slice(&vector);
             vectors_file.write_all(raw_bites)?;
             end_index += 1;

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -1,6 +1,6 @@
 use common::types::{PointOffsetType, ScoreType};
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -10,7 +10,7 @@ pub struct QuantizedCustomQueryScorer<
     TEncodedQuery,
     TEncodedVectors,
     TQuery: Query<TEncodedQuery>,
-    TOriginalQuery: Query<VectorType>,
+    TOriginalQuery: Query<DenseVector>,
 > where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
@@ -26,10 +26,10 @@ impl<
         TEncodedQuery,
         TEncodedVectors,
         TQuery: Query<TEncodedQuery>,
-        TOriginalQuery: Query<VectorType>
+        TOriginalQuery: Query<DenseVector>
             + Clone
             + TransformInto<TOriginalQuery>
-            + TransformInto<TQuery, VectorType, TEncodedQuery>,
+            + TransformInto<TQuery, DenseVector, TEncodedQuery>,
     > QuantizedCustomQueryScorer<'a, TEncodedQuery, TEncodedVectors, TQuery, TOriginalQuery>
 where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
@@ -44,7 +44,7 @@ where
             .unwrap();
         let query = original_query
             .clone()
-            .transform(|v: VectorType| Ok(quantized_storage.encode_query(&v)))
+            .transform(|v: DenseVector| Ok(quantized_storage.encode_query(&v)))
             .unwrap();
 
         Self {
@@ -60,7 +60,7 @@ where
 impl<
         TEncodedQuery,
         TEncodedVectors,
-        TOriginalQuery: Query<VectorType>,
+        TOriginalQuery: Query<DenseVector>,
         TQuery: Query<TEncodedQuery>,
     > QueryScorer<[VectorElementType]>
     for QuantizedCustomQueryScorer<'_, TEncodedQuery, TEncodedVectors, TQuery, TOriginalQuery>

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -1,6 +1,6 @@
 use common::types::{PointOffsetType, ScoreType};
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -8,7 +8,7 @@ pub struct QuantizedQueryScorer<'a, TEncodedQuery, TEncodedVectors>
 where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
-    original_query: VectorType,
+    original_query: DenseVector,
     query: TEncodedQuery,
     quantized_data: &'a TEncodedVectors,
     distance: Distance,
@@ -19,7 +19,7 @@ where
     TEncodedVectors: quantization::EncodedVectors<TEncodedQuery>,
 {
     pub fn new(
-        raw_query: VectorType,
+        raw_query: DenseVector,
         quantized_data: &'a TEncodedVectors,
         distance: Distance,
     ) -> Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -7,7 +7,7 @@ use super::quantized_custom_query_scorer::QuantizedCustomQueryScorer;
 use super::quantized_query_scorer::QuantizedQueryScorer;
 use super::quantized_vectors::QuantizedVectorStorage;
 use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, VectorType};
+use crate::data_types::vectors::{DenseVector, QueryVector};
 use crate::types::Distance;
 use crate::vector_storage::query::context_query::ContextQuery;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
@@ -75,20 +75,20 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Recommend(reco_query) => {
-                let reco_query: RecoQuery<VectorType> = reco_query.transform_into()?;
+                let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(reco_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Discovery(discovery_query) => {
-                let discovery_query: DiscoveryQuery<VectorType> =
+                let discovery_query: DiscoveryQuery<DenseVector> =
                     discovery_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(discovery_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
             QueryVector::Context(context_query) => {
-                let context_query: ContextQuery<VectorType> = context_query.transform_into()?;
+                let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
                 let query_scorer =
                     QuantizedCustomQueryScorer::new(context_query, quantized_storage, *distance);
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -1,13 +1,13 @@
 use common::types::ScoreType;
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::vectors::VectorType;
+use crate::data_types::vectors::DenseVector;
 
 pub mod context_query;
 pub mod discovery_query;
 pub mod reco_query;
 
-pub trait TransformInto<Output, T = VectorType, U = VectorType> {
+pub trait TransformInto<Output, T = DenseVector, U = DenseVector> {
     /// Change the underlying type of the query, or just process it in some way.
     fn transform<F>(self, f: F) -> OperationResult<Output>
     where

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -12,7 +12,7 @@ pub struct CustomQueryScorer<
     'a,
     TMetric: Metric,
     TVectorStorage: DenseVectorStorage,
-    TQuery: Query<VectorType>,
+    TQuery: Query<DenseVector>,
 > {
     vector_storage: &'a TVectorStorage,
     query: TQuery,
@@ -23,7 +23,7 @@ impl<
         'a,
         TMetric: Metric,
         TVectorStorage: DenseVectorStorage,
-        TQuery: Query<VectorType> + TransformInto<TQuery>,
+        TQuery: Query<DenseVector> + TransformInto<TQuery>,
     > CustomQueryScorer<'a, TMetric, TVectorStorage, TQuery>
 {
     pub fn new(query: TQuery, vector_storage: &'a TVectorStorage) -> Self {
@@ -39,7 +39,7 @@ impl<
     }
 }
 
-impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage, TQuery: Query<VectorType>>
+impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage, TQuery: Query<DenseVector>>
     QueryScorer<[VectorElementType]> for CustomQueryScorer<'a, TMetric, TVectorStorage, TQuery>
 {
     #[inline]

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
-use crate::data_types::vectors::{VectorElementType, VectorType};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::DenseVectorStorage;
@@ -16,7 +16,7 @@ pub struct MetricQueryScorer<'a, TMetric: Metric, TVectorStorage: DenseVectorSto
 impl<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage>
     MetricQueryScorer<'a, TMetric, TVectorStorage>
 {
-    pub fn new(query: VectorType, vector_storage: &'a TVectorStorage) -> Self {
+    pub fn new(query: DenseVector, vector_storage: &'a TVectorStorage) -> Self {
         Self {
             query: TMetric::preprocess(query),
             vector_storage,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -12,7 +12,7 @@ use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;
 use super::{DenseVectorStorage, SparseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::vectors::{QueryVector, VectorType};
+use crate::data_types::vectors::{DenseVector, QueryVector};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::spaces::tools::peek_top_largest_iterable;
@@ -238,7 +238,7 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             is_stopped,
         ),
         QueryVector::Recommend(reco_query) => {
-            let reco_query: RecoQuery<VectorType> = reco_query.transform_into()?;
+            let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(reco_query, vector_storage),
                 point_deleted,
@@ -247,7 +247,7 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             )
         }
         QueryVector::Discovery(discovery_query) => {
-            let discovery_query: DiscoveryQuery<VectorType> = discovery_query.transform_into()?;
+            let discovery_query: DiscoveryQuery<DenseVector> = discovery_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(discovery_query, vector_storage),
                 point_deleted,
@@ -256,7 +256,7 @@ fn new_scorer_with_metric<'a, TMetric: Metric + 'a, TVectorStorage: DenseVectorS
             )
         }
         QueryVector::Context(context_query) => {
-            let context_query: ContextQuery<VectorType> = context_query.transform_into()?;
+            let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 CustomQueryScorer::<TMetric, _, _>::new(context_query, vector_storage),
                 point_deleted,

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1058,7 +1058,7 @@ pub async fn recommend(
         .collect::<Result<Vec<RecommendExample>, Status>>()?;
     let negative_vectors = negative_vectors
         .into_iter()
-        .map(|v| RecommendExample::Vector(v.data))
+        .map(|v| RecommendExample::Dense(v.data))
         .collect();
     let negative = [negative_ids, negative_vectors].concat();
 


### PR DESCRIPTION
`VectorType` is an obsolete name. After sparse vector release it's a dense vector.

Also was renamed:
`NamedVectorStruct::Named` -> `NamedVectorStruct::Dense`
`RecommendExample::Vector` -> `RecommendExample::Dense`

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
