### PR TITLE
Fix release artifacts for macOS

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -19,6 +19,9 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y gcc-multilib clang cmake protobuf-compiler
+            rustup default stable
+            rustup show
+            cargo -Vv
       - uses: actions/checkout@v4
       - name: Build and publish
         uses: taiki-e/upload-rust-binary-action@v1
@@ -40,7 +43,10 @@ jobs:
       - name: Install dependencies
         run: |
             brew update-reset
-            brew install gcc cmake protobuf-c
+            brew install gcc cmake protobuf-c rustup
+            rustup default stable
+            rustup show
+            cargo -Vv
       - uses: actions/checkout@v4
       - name: Build and publish
         uses: taiki-e/upload-rust-binary-action@v1
@@ -57,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable 
+        uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Install Protoc

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
             brew update-reset
-            brew install gcc cmake protobuf-c rustup
+            brew install gcc cmake protobuf-c
             rustup default stable
             rustup show
             cargo -Vv


### PR DESCRIPTION
This fixes building macOS release artifacts when publishing a new release ([failed run for latest release](https://github.com/qdrant/qdrant/actions/runs/7140593745)).

The Rust compiler shipped on macOS runners was outdated and doesn't match our requirements. This PR ensures that we always install the latest stable version.

Bonus:
- install latest stable on Linux as well
- add `rustup show` and `cargo -Vv` commands to make debugging this easier in the future

The current CI run doesn't test this, as it's for release builds only. But I've tested the changes manually with a dry run here: https://github.com/qdrant/qdrant/actions/runs/7166079287?pr=3194

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?