### PR TITLE
Fix `/readyz` when upgrading cluster from 1.6 to 1.7

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -181,6 +181,7 @@ impl Task {
 
         let peer_address_by_id = self.consensus_state.peer_address_by_id();
 
+        // Endpoint we check is not available before Qdrant 1.7.0, allow checks on nodes with earlier versions to fail by counting them here
         let mut unimplemented_errors_count = 0;
 
         let mut requests = peer_address_by_id


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/3193>.

When doing rolling upgrade from Qdrant v1.6.* to v1.7.*, the `/readyz` check would fail _indefinitely_, practically preventing graceful rolling upgrades in Kubernetes. 🤦‍♀️

The issue is that v1.6.* (and earlier) versions simply don't have gRPC APIs required for the `/readyz` check in v1.7.*, and "unimplemented" errors aren't handled properly.

This PR implements "unimplemented" errors handling during `/readyz`, allowing upgrade to v1.7.*.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
