### PR TITLE
Fix release artifacts for macOS, explicitly update

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -20,6 +20,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y gcc-multilib clang cmake protobuf-compiler
             rustup default stable
+            rustup update
             rustup show
             cargo -Vv
       - uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
             brew update-reset
             brew install gcc cmake protobuf-c
             rustup default stable
+            rustup update
             rustup show
             cargo -Vv
       - uses: actions/checkout@v4


### PR DESCRIPTION
Follow up after <https://github.com/qdrant/qdrant/pull/3194>.

It appears those changes weren't good enough. We need to run `rustup update` explicitly.

Somehow this wasn't needed in my testing on CI. Maybe we're getting different macOS machines assigned on CI having a different image.

Test run: https://github.com/qdrant/qdrant/actions/runs/7179454708/job/19549668581?pr=3214
- 'install dependencies' now really shows installing the latest Rust version

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?