### PR TITLE
Fix `/readyz` if nodes are unavailable

### DIFF
--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -110,9 +110,9 @@ async fn livez() -> impl Responder {
 }
 
 #[get("/readyz")]
-async fn readyz(ready: web::Data<Option<Arc<health::HealthChecker>>>) -> impl Responder {
-    let is_ready = match ready.as_ref() {
-        Some(ready) => ready.check_ready().await,
+async fn readyz(health_checker: web::Data<Option<Arc<health::HealthChecker>>>) -> impl Responder {
+    let is_ready = match health_checker.as_ref() {
+        Some(health_checker) => health_checker.check_ready().await,
         None => true,
     };
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -49,7 +49,7 @@ pub async fn index() -> impl Responder {
 pub fn init(
     dispatcher: Arc<Dispatcher>,
     telemetry_collector: Arc<tokio::sync::Mutex<TelemetryCollector>>,
-    ready: Option<Arc<health::HealthChecker>>,
+    health_checker: Option<Arc<health::HealthChecker>>,
     settings: Settings,
 ) -> io::Result<()> {
     actix_web::rt::System::new().block_on(async {
@@ -62,7 +62,7 @@ pub fn init(
             .clone();
         let telemetry_collector_data = web::Data::from(telemetry_collector);
         let http_client = web::Data::new(HttpClient::from_settings(&settings)?);
-        let ready = web::Data::new(ready);
+        let health_checker = web::Data::new(health_checker);
         let auth_keys = AuthKeys::try_create(&settings.service);
         let static_folder = settings
             .service
@@ -132,7 +132,7 @@ pub fn init(
                 .app_data(toc_data.clone())
                 .app_data(telemetry_collector_data.clone())
                 .app_data(http_client.clone())
-                .app_data(ready.clone())
+                .app_data(health_checker.clone())
                 .app_data(validate_path_config)
                 .app_data(validate_query_config)
                 .app_data(validate_json_config)

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -183,7 +183,7 @@ impl Task {
                 }
             })
             .collect::<FuturesUnordered<_>>()
-            .inspect_err(|err| log::error!("GetCommitIndex request failed: {err}"))
+            .inspect_err(|err| log::error!("GetConsensusCommit request failed: {err}"))
             .filter_map(|res| future::ready(res.ok()));
 
         // Example:

--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -210,13 +210,17 @@ impl Task {
             commit_indices.push(resp);
         }
 
-        let cluster_commit_index = commit_indices
-            .into_iter()
-            .map(|resp| resp.into_inner().commit)
-            .max()
-            .unwrap_or(0);
+        if commit_indices.len() >= required_commit_indices_count {
+            let cluster_commit_index = commit_indices
+                .into_iter()
+                .map(|resp| resp.into_inner().commit)
+                .max()
+                .unwrap_or(0);
 
-        Some(cluster_commit_index as _)
+            Some(cluster_commit_index as _)
+        } else {
+            Some(0)
+        }
     }
 
     fn commit_index(&self) -> u64 {


### PR DESCRIPTION
This PR removes strict check that node received `cluster_size / 2` successful `GetConsensusCommit` responses during `/readyz` check to allow `/readyz` check to pass, when not enough nodes are available.

Fixes #3193.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
