### PR TITLE
Remove quantization update from hnsw index

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -56,7 +56,7 @@ const SINGLE_THREADED_HNSW_BUILD_THRESHOLD: usize = 256;
 pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     config: HnswGraphConfig,
     path: PathBuf,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -56,7 +56,7 @@ const SINGLE_THREADED_HNSW_BUILD_THRESHOLD: usize = 256;
 pub struct HNSWIndex<TGraphLinks: GraphLinks> {
     id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     config: HnswGraphConfig,
     path: PathBuf,
@@ -132,6 +132,10 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
     #[cfg(test)]
     pub(super) fn graph(&self) -> Option<&GraphLayers<TGraphLinks>> {
         self.graph.as_ref()
+    }
+
+    pub fn get_quantized_vectors(&self) -> Arc<AtomicRefCell<Option<QuantizedVectors>>> {
+        self.quantized_vectors.clone()
     }
 
     fn save_config(&self) -> OperationResult<()> {

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -75,7 +75,7 @@ fn test_graph_connectivity() {
         segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_storage
             .clone(),
-        None,
+        Default::default(),
         payload_index_ptr.clone(),
         hnsw_config,
     )

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -27,7 +27,6 @@ use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PayloadSchemaType,
     SearchParams,
 };
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{new_stoppable_raw_scorer, VectorStorageEnum};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
@@ -301,13 +300,6 @@ impl VectorIndex for PlainIndex {
 
     fn update_vector(&mut self, _id: PointOffsetType, _vector: VectorRef) -> OperationResult<()> {
         Ok(())
-    }
-
-    fn set_quantized_vectors(
-        &mut self,
-        _quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
-    ) {
-        // ToDo: maybe use quantized vectors for plain index as well?
     }
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -25,7 +25,6 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
 };
@@ -406,15 +405,5 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             self.inverted_index.upsert(id, vector.clone());
         }
         Ok(())
-    }
-
-    fn set_quantized_vectors(
-        &mut self,
-        quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
-    ) {
-        debug_assert!(
-            quantized_vectors.is_none(),
-            "Sparse index does not support quantization"
-        );
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use common::types::{PointOffsetType, ScoredPointOffset};
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -15,7 +13,6 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
 /// Trait for vector searching
 pub trait VectorIndex {
@@ -41,11 +38,6 @@ pub trait VectorIndex {
 
     /// Update index for a single vector
     fn update_vector(&mut self, id: PointOffsetType, vector: VectorRef) -> OperationResult<()>;
-
-    fn set_quantized_vectors(
-        &mut self,
-        quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
-    );
 }
 
 pub enum VectorIndexEnum {
@@ -141,19 +133,6 @@ impl VectorIndex for VectorIndexEnum {
             Self::HnswMmap(index) => index.update_vector(id, vector),
             Self::SparseRam(index) => index.update_vector(id, vector),
             Self::SparseMmap(index) => index.update_vector(id, vector),
-        }
-    }
-
-    fn set_quantized_vectors(
-        &mut self,
-        quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
-    ) {
-        match self {
-            Self::Plain(index) => index.set_quantized_vectors(quantized_vectors),
-            Self::HnswRam(index) => index.set_quantized_vectors(quantized_vectors),
-            Self::HnswMmap(index) => index.set_quantized_vectors(quantized_vectors),
-            Self::SparseRam(index) => index.set_quantized_vectors(quantized_vectors),
-            Self::SparseMmap(index) => index.set_quantized_vectors(quantized_vectors),
         }
     }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -93,7 +93,7 @@ pub struct Segment {
 pub struct VectorData {
     pub vector_index: Arc<AtomicRefCell<VectorIndexEnum>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    pub quantized_vectors: Option<Arc<AtomicRefCell<QuantizedVectors>>>,
+    pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
 }
 
 impl VectorData {
@@ -1492,8 +1492,8 @@ impl SegmentEntry for Segment {
                 )?;
             }
 
-            if let Some(quantized_vectors) = &vector_data.quantized_vectors {
-                for file in quantized_vectors.borrow().files() {
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow().as_ref() {
+                for file in quantized_vectors.files() {
                     utils::tar::append_file_relative_to_base(
                         &mut builder,
                         &self.current_path,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -238,7 +238,7 @@ impl SegmentBuilder {
 
                 let vector_storage = vector_data.vector_storage.borrow();
 
-                let quantized_vectors_arc = QuantizedVectors::create(
+                let quantized_vectors = QuantizedVectors::create(
                     &vector_storage,
                     quantization,
                     &vector_storage_path,
@@ -246,11 +246,7 @@ impl SegmentBuilder {
                     stopped,
                 )?;
 
-                vector_data.quantized_vectors = Some(quantized_vectors_arc.clone());
-                vector_data
-                    .vector_index
-                    .borrow_mut()
-                    .set_quantized_vectors(Some(quantized_vectors_arc));
+                *vector_data.quantized_vectors.borrow_mut() = Some(quantized_vectors);
             }
         }
         Ok(())

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -152,7 +152,7 @@ fn create_segment(
             );
         }
 
-        let quantized_vectors = if config.quantization_config(vector_name).is_some() {
+        let quantized_vectors = sp(if config.quantization_config(vector_name).is_some() {
             let quantized_data_path = vector_storage_path;
             if QuantizedVectors::config_exists(&quantized_data_path) {
                 let quantized_vectors =
@@ -163,7 +163,7 @@ fn create_segment(
             }
         } else {
             None
-        };
+        });
 
         let vector_index: Arc<AtomicRefCell<VectorIndexEnum>> = match &vector_config.index {
             Indexes::Plain {} => sp(VectorIndexEnum::Plain(PlainIndex::new(
@@ -243,7 +243,7 @@ fn create_segment(
             VectorData {
                 vector_storage,
                 vector_index,
-                quantized_vectors: None,
+                quantized_vectors: sp(None),
             },
         );
     }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -659,42 +659,38 @@ mod tests {
 
         let query: QueryVector = [0.5, 0.5, 0.5, 0.5].into();
 
-        {
-            let borrowed_quantized_vectors = quantized_vectors.borrow();
-            let scorer_quant = borrowed_quantized_vectors
-                .raw_scorer(
-                    query.clone(),
-                    borrowed_id_tracker.deleted_point_bitslice(),
-                    borrowed_storage.deleted_vector_bitslice(),
-                    &stopped,
-                )
-                .unwrap();
-            let scorer_orig = new_raw_scorer(
+        let scorer_quant = quantized_vectors
+            .raw_scorer(
                 query.clone(),
-                &borrowed_storage,
                 borrowed_id_tracker.deleted_point_bitslice(),
+                borrowed_storage.deleted_vector_bitslice(),
+                &stopped,
             )
             .unwrap();
-            for i in 0..5 {
-                let quant = scorer_quant.score_point(i);
-                let orig = scorer_orig.score_point(i);
-                assert!((orig - quant).abs() < 0.15);
+        let scorer_orig = new_raw_scorer(
+            query.clone(),
+            &borrowed_storage,
+            borrowed_id_tracker.deleted_point_bitslice(),
+        )
+        .unwrap();
+        for i in 0..5 {
+            let quant = scorer_quant.score_point(i);
+            let orig = scorer_orig.score_point(i);
+            assert!((orig - quant).abs() < 0.15);
 
-                let quant = scorer_quant.score_internal(0, i);
-                let orig = scorer_orig.score_internal(0, i);
-                assert!((orig - quant).abs() < 0.15);
-            }
+            let quant = scorer_quant.score_internal(0, i);
+            let orig = scorer_orig.score_internal(0, i);
+            assert!((orig - quant).abs() < 0.15);
         }
         let files = borrowed_storage.files();
-        let quantization_files = quantized_vectors.borrow().files();
+        let quantization_files = quantized_vectors.files();
 
         // test save-load
         let quantized_vectors = QuantizedVectors::load(&borrowed_storage, dir.path()).unwrap();
         assert_eq!(files, borrowed_storage.files());
-        assert_eq!(quantization_files, quantized_vectors.borrow().files());
+        assert_eq!(quantization_files, quantized_vectors.files());
 
-        let borrowed_quantized_vectors = quantized_vectors.borrow();
-        let scorer_quant = borrowed_quantized_vectors
+        let scorer_quant = quantized_vectors
             .raw_scorer(
                 query.clone(),
                 borrowed_id_tracker.deleted_point_bitslice(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -1,8 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use bitvec::slice::BitSlice;
 use common::types::PointOffsetType;
 use io::file_operations::{atomic_save_json, read_json};
@@ -107,7 +105,7 @@ impl QuantizedVectors {
         path: &Path,
         max_threads: usize,
         stopped: &AtomicBool,
-    ) -> OperationResult<Arc<AtomicRefCell<Self>>> {
+    ) -> OperationResult<Self> {
         match vector_storage {
             VectorStorageEnum::Simple(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
@@ -128,7 +126,7 @@ impl QuantizedVectors {
         path: &Path,
         max_threads: usize,
         stopped: &AtomicBool,
-    ) -> OperationResult<Arc<AtomicRefCell<Self>>> {
+    ) -> OperationResult<Self> {
         let count = vector_storage.total_vector_count();
         let vectors = (0..count as PointOffsetType).map(|i| vector_storage.get_dense(i));
         let on_disk_vector_storage = vector_storage.is_on_disk();
@@ -185,17 +183,14 @@ impl QuantizedVectors {
 
         quantized_vectors.save_to(path)?;
         atomic_save_json(&path.join(QUANTIZED_CONFIG_PATH), &quantized_vectors.config)?;
-        Ok(Arc::new(AtomicRefCell::new(quantized_vectors)))
+        Ok(quantized_vectors)
     }
 
     pub fn config_exists(path: &Path) -> bool {
         path.join(QUANTIZED_CONFIG_PATH).exists()
     }
 
-    pub fn load(
-        vector_storage: &VectorStorageEnum,
-        path: &Path,
-    ) -> OperationResult<Arc<AtomicRefCell<Self>>> {
+    pub fn load(vector_storage: &VectorStorageEnum, path: &Path) -> OperationResult<Self> {
         let on_disk_vector_storage = vector_storage.is_on_disk();
         let distance = vector_storage.distance();
 
@@ -257,12 +252,12 @@ impl QuantizedVectors {
             }
         };
 
-        Ok(Arc::new(AtomicRefCell::new(QuantizedVectors {
+        Ok(QuantizedVectors {
             storage_impl: quantized_store,
             config,
             path: path.to_path_buf(),
             distance,
-        })))
+        })
     }
 
     fn create_scalar<'a>(

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -233,7 +233,6 @@ fn scoring_equivalency(
     } else {
         None
     };
-    let quantized_vectors = quantized_vectors.as_ref().map(|q| q.borrow());
 
     let attempts = 50;
     for i in 0..attempts {

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -308,42 +308,39 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     let query: QueryVector = vec![0.5, 0.5, 0.5, 0.5].into();
 
-    {
-        let borrowed_quantized_vectors = quantized_vectors.borrow();
-        let scorer_quant = borrowed_quantized_vectors
-            .raw_scorer(
-                query.clone(),
-                borrowed_id_tracker.deleted_point_bitslice(),
-                borrowed_storage.deleted_vector_bitslice(),
-                &stopped,
-            )
-            .unwrap();
-        let scorer_orig = new_raw_scorer(
+    let scorer_quant = quantized_vectors
+        .raw_scorer(
             query.clone(),
-            &borrowed_storage,
             borrowed_id_tracker.deleted_point_bitslice(),
+            borrowed_storage.deleted_vector_bitslice(),
+            &stopped,
         )
         .unwrap();
-        for i in 0..5 {
-            let quant = scorer_quant.score_point(i);
-            let orig = scorer_orig.score_point(i);
-            assert!((orig - quant).abs() < 0.15);
+    let scorer_orig = new_raw_scorer(
+        query.clone(),
+        &borrowed_storage,
+        borrowed_id_tracker.deleted_point_bitslice(),
+    )
+    .unwrap();
+    for i in 0..5 {
+        let quant = scorer_quant.score_point(i);
+        let orig = scorer_orig.score_point(i);
+        assert!((orig - quant).abs() < 0.15);
 
-            let quant = scorer_quant.score_internal(0, i);
-            let orig = scorer_orig.score_internal(0, i);
-            assert!((orig - quant).abs() < 0.15);
-        }
+        let quant = scorer_quant.score_internal(0, i);
+        let orig = scorer_orig.score_internal(0, i);
+        assert!((orig - quant).abs() < 0.15);
     }
+
     let files = borrowed_storage.files();
-    let quantization_files = quantized_vectors.borrow().files();
+    let quantization_files = quantized_vectors.files();
 
     // test save-load
     let quantized_vectors = QuantizedVectors::load(&borrowed_storage, dir.path()).unwrap();
     assert_eq!(files, borrowed_storage.files());
-    assert_eq!(quantization_files, quantized_vectors.borrow().files());
+    assert_eq!(quantization_files, quantized_vectors.files());
 
-    let borrowed_quantized_vectors = quantized_vectors.borrow();
-    let scorer_quant = borrowed_quantized_vectors
+    let scorer_quant = quantized_vectors
         .raw_scorer(
             query.clone(),
             borrowed_id_tracker.deleted_point_bitslice(),

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use common::types::{ScoreType, ScoredPointOffset};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -103,7 +105,7 @@ fn hnsw_quantized_search_test(
             &stopped,
         )
         .unwrap();
-        vector_storage.quantized_vectors = Some(quantized_vectors);
+        vector_storage.quantized_vectors = Arc::new(AtomicRefCell::new(Some(quantized_vectors)));
     });
 
     let hnsw_config = HnswConfig {

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -430,7 +430,7 @@ fn test_build_hnsw_using_quantization() {
         .borrow();
     match borrowed_index.deref() {
         VectorIndexEnum::HnswRam(hnsw_index) => {
-            assert!(hnsw_index.quantized_vectors.borrow().is_some())
+            assert!(hnsw_index.get_quantized_vectors().borrow().is_some())
         }
         _ => panic!("unexpected vector index type"),
     }

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
+use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -11,9 +12,10 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_vector, STR_KEY};
 use segment::index::hnsw_index::graph_links::GraphLinksRam;
 use segment::index::hnsw_index::hnsw::HNSWIndex;
-use segment::index::VectorIndex;
+use segment::index::{VectorIndex, VectorIndexEnum};
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
+use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload,
@@ -23,6 +25,8 @@ use segment::types::{
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use serde_json::json;
 use tempfile::Builder;
+
+use crate::fixtures::segment::build_segment_1;
 
 fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> usize {
     a[0].iter()
@@ -381,4 +385,53 @@ fn hnsw_product_quantization_manhattan_test() {
         }
         .into(),
     );
+}
+
+#[test]
+fn test_build_hnsw_using_quantization() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+
+    let segment1 = build_segment_1(dir.path());
+    let mut config = segment1.segment_config.clone();
+    let vector_data_config = config.vector_data.get_mut(DEFAULT_VECTOR_NAME).unwrap();
+    vector_data_config.quantization_config = Some(
+        ScalarQuantizationConfig {
+            r#type: Default::default(),
+            quantile: None,
+            always_ram: None,
+        }
+        .into(),
+    );
+    vector_data_config.index = Indexes::Hnsw(HnswConfig {
+        m: 16,
+        ef_construct: 64,
+        full_scan_threshold: 16,
+        max_indexing_threads: 2,
+        on_disk: Some(false),
+        payload_m: None,
+    });
+
+    let mut builder = SegmentBuilder::new(dir.path(), temp_dir.path(), &config).unwrap();
+
+    builder.update_from(&segment1, &stopped).unwrap();
+
+    let builded_segment: Segment = builder.build(&stopped).unwrap();
+
+    // check if builded segment has quantization and index
+    assert!(builded_segment.vector_data[DEFAULT_VECTOR_NAME]
+        .quantized_vectors
+        .borrow()
+        .is_some());
+    let borrowed_index = builded_segment.vector_data[DEFAULT_VECTOR_NAME]
+        .vector_index
+        .borrow();
+    match borrowed_index.deref() {
+        VectorIndexEnum::HnswRam(hnsw_index) => {
+            assert!(hnsw_index.quantized_vectors.borrow().is_some())
+        }
+        _ => panic!("unexpected vector index type"),
+    }
 }

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -418,14 +418,14 @@ fn test_build_hnsw_using_quantization() {
 
     builder.update_from(&segment1, &stopped).unwrap();
 
-    let builded_segment: Segment = builder.build(&stopped).unwrap();
+    let built_segment: Segment = builder.build(&stopped).unwrap();
 
-    // check if builded segment has quantization and index
-    assert!(builded_segment.vector_data[DEFAULT_VECTOR_NAME]
+    // check if built segment has quantization and index
+    assert!(built_segment.vector_data[DEFAULT_VECTOR_NAME]
         .quantized_vectors
         .borrow()
         .is_some());
-    let borrowed_index = builded_segment.vector_data[DEFAULT_VECTOR_NAME]
+    let borrowed_index = built_segment.vector_data[DEFAULT_VECTOR_NAME]
         .vector_index
         .borrow();
     match borrowed_index.deref() {


### PR DESCRIPTION
Fix for https://github.com/qdrant/qdrant/issues/3137

Here is a test for quantization existing during HNSW building.

Also a refactoring. All segment entities (and connections between them!!!) are defined during construction. Fix this concept for quantization.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
