### PR TITLE
Rename SimpleDenseVectorStorage

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -11,7 +11,7 @@ use segment::data_types::vectors::{Vector, VectorElementType};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
-use segment::vector_storage::simple_vector_storage::open_simple_vector_storage;
+use segment::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use segment::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 use tempfile::Builder;
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -208,7 +208,7 @@ impl Segment {
                 None => {
                     let dim = vector_storage.vector_dim();
                     let vector: Vector = match *vector_storage {
-                        VectorStorageEnum::Simple(_)
+                        VectorStorageEnum::DenseSimple(_)
                         | VectorStorageEnum::Memmap(_)
                         | VectorStorageEnum::AppendableMemmap(_) => vec![1.0; dim].into(),
                         VectorStorageEnum::SparseSimple(_) => SparseVector::default().into(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -34,8 +34,8 @@ use crate::types::{
 use crate::vector_storage::appendable_mmap_vector_storage::open_appendable_memmap_vector_storage;
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::VectorStorage;
 
 pub const PAYLOAD_INDEX_PATH: &str = "payload_index";

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -227,7 +227,7 @@ mod tests {
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
     use crate::vector_storage::new_raw_scorer;
     use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-    use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
+    use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 
     #[test]
     fn test_basic_persistence() {

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -9,7 +9,7 @@ pub mod memmap_vector_storage;
 mod mmap_vectors;
 pub mod quantized;
 pub mod raw_scorer;
-pub mod simple_vector_storage;
+pub mod simple_dense_vector_storage;
 mod vector_storage_base;
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -109,7 +109,7 @@ impl QuantizedVectors {
         stopped: &AtomicBool,
     ) -> OperationResult<Arc<AtomicRefCell<Self>>> {
         match vector_storage {
-            VectorStorageEnum::Simple(v) => {
+            VectorStorageEnum::DenseSimple(v) => {
                 Self::create_impl(v, quantization_config, path, max_threads, stopped)
             }
             VectorStorageEnum::Memmap(v) => {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -108,7 +108,7 @@ pub fn new_stoppable_raw_scorer<'a>(
     is_stopped: &'a AtomicBool,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match vector_storage {
-        VectorStorageEnum::Simple(vs) => raw_scorer_impl(query, vs, point_deleted, is_stopped),
+        VectorStorageEnum::DenseSimple(vs) => raw_scorer_impl(query, vs, point_deleted, is_stopped),
 
         VectorStorageEnum::Memmap(vs) => {
             if vs.has_async_reader() {

--- a/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
@@ -23,7 +23,7 @@ use crate::types::Distance;
 use crate::vector_storage::bitvec::bitvec_set_deleted;
 
 /// In-memory vector storage with on-update persistence using `store`
-pub struct SimpleVectorStorage {
+pub struct SimpleDenseVectorStorage {
     dim: usize,
     distance: Distance,
     vectors: ChunkedVectors<VectorElementType>,
@@ -72,8 +72,8 @@ pub fn open_simple_vector_storage(
         vectors.len() * dim * size_of::<VectorElementType>() / 1024 / 1024
     );
 
-    Ok(Arc::new(AtomicRefCell::new(VectorStorageEnum::Simple(
-        SimpleVectorStorage {
+    Ok(Arc::new(AtomicRefCell::new(
+        VectorStorageEnum::DenseSimple(SimpleDenseVectorStorage {
             dim,
             distance,
             vectors,
@@ -84,11 +84,11 @@ pub fn open_simple_vector_storage(
             },
             deleted,
             deleted_count,
-        },
-    ))))
+        }),
+    )))
 }
 
-impl SimpleVectorStorage {
+impl SimpleDenseVectorStorage {
     /// Set deleted flag for given key. Returns previous deleted state.
     #[inline]
     fn set_deleted(&mut self, key: PointOffsetType, deleted: bool) -> bool {
@@ -129,13 +129,13 @@ impl SimpleVectorStorage {
     }
 }
 
-impl DenseVectorStorage for SimpleVectorStorage {
+impl DenseVectorStorage for SimpleDenseVectorStorage {
     fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
         self.vectors.get(key)
     }
 }
 
-impl VectorStorage for SimpleVectorStorage {
+impl VectorStorage for SimpleDenseVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
     }

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -12,7 +12,7 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTracker;
 use crate::types::Distance;
 use crate::vector_storage::memmap_vector_storage::open_memmap_vector_storage_with_async_io;
-use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::vector_storage_base::VectorStorage;
 use crate::vector_storage::{async_raw_scorer, new_raw_scorer, VectorStorageEnum};
 

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -26,7 +26,7 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::context_query::{ContextPair, ContextQuery};
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query::reco_query::RecoQuery;
-use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::tests::utils::score;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -12,7 +12,7 @@ use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::appendable_mmap_vector_storage::open_appendable_memmap_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::simple_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 
 fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::memmap_vector_storage::MemmapVectorStorage;
-use super::simple_vector_storage::SimpleVectorStorage;
+use super::simple_dense_vector_storage::SimpleDenseVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
@@ -105,7 +105,7 @@ pub trait SparseVectorStorage: VectorStorage {
 }
 
 pub enum VectorStorageEnum {
-    Simple(SimpleVectorStorage),
+    DenseSimple(SimpleDenseVectorStorage),
     Memmap(Box<MemmapVectorStorage>),
     AppendableMemmap(Box<AppendableMmapVectorStorage>),
     SparseSimple(SimpleSparseVectorStorage),
@@ -114,7 +114,7 @@ pub enum VectorStorageEnum {
 impl VectorStorage for VectorStorageEnum {
     fn vector_dim(&self) -> usize {
         match self {
-            VectorStorageEnum::Simple(v) => v.vector_dim(),
+            VectorStorageEnum::DenseSimple(v) => v.vector_dim(),
             VectorStorageEnum::Memmap(v) => v.vector_dim(),
             VectorStorageEnum::AppendableMemmap(v) => v.vector_dim(),
             VectorStorageEnum::SparseSimple(v) => v.vector_dim(),
@@ -123,7 +123,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn distance(&self) -> Distance {
         match self {
-            VectorStorageEnum::Simple(v) => v.distance(),
+            VectorStorageEnum::DenseSimple(v) => v.distance(),
             VectorStorageEnum::Memmap(v) => v.distance(),
             VectorStorageEnum::AppendableMemmap(v) => v.distance(),
             VectorStorageEnum::SparseSimple(v) => v.distance(),
@@ -132,7 +132,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn is_on_disk(&self) -> bool {
         match self {
-            VectorStorageEnum::Simple(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseSimple(v) => v.is_on_disk(),
             VectorStorageEnum::Memmap(v) => v.is_on_disk(),
             VectorStorageEnum::AppendableMemmap(v) => v.is_on_disk(),
             VectorStorageEnum::SparseSimple(v) => v.is_on_disk(),
@@ -141,7 +141,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn total_vector_count(&self) -> usize {
         match self {
-            VectorStorageEnum::Simple(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseSimple(v) => v.total_vector_count(),
             VectorStorageEnum::Memmap(v) => v.total_vector_count(),
             VectorStorageEnum::AppendableMemmap(v) => v.total_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.total_vector_count(),
@@ -150,7 +150,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         match self {
-            VectorStorageEnum::Simple(v) => v.get_vector(key),
+            VectorStorageEnum::DenseSimple(v) => v.get_vector(key),
             VectorStorageEnum::Memmap(v) => v.get_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.get_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
@@ -159,7 +159,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn get_vector_opt(&self, key: PointOffsetType) -> Option<CowVector> {
         match self {
-            VectorStorageEnum::Simple(v) => v.get_vector_opt(key),
+            VectorStorageEnum::DenseSimple(v) => v.get_vector_opt(key),
             VectorStorageEnum::Memmap(v) => v.get_vector_opt(key),
             VectorStorageEnum::AppendableMemmap(v) => v.get_vector_opt(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector_opt(key),
@@ -168,7 +168,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
         match self {
-            VectorStorageEnum::Simple(v) => v.insert_vector(key, vector),
+            VectorStorageEnum::DenseSimple(v) => v.insert_vector(key, vector),
             VectorStorageEnum::Memmap(v) => v.insert_vector(key, vector),
             VectorStorageEnum::AppendableMemmap(v) => v.insert_vector(key, vector),
             VectorStorageEnum::SparseSimple(v) => v.insert_vector(key, vector),
@@ -182,7 +182,7 @@ impl VectorStorage for VectorStorageEnum {
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {
-            VectorStorageEnum::Simple(v) => v.update_from(other, other_ids, stopped),
+            VectorStorageEnum::DenseSimple(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::Memmap(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::AppendableMemmap(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::SparseSimple(v) => v.update_from(other, other_ids, stopped),
@@ -191,7 +191,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn flusher(&self) -> Flusher {
         match self {
-            VectorStorageEnum::Simple(v) => v.flusher(),
+            VectorStorageEnum::DenseSimple(v) => v.flusher(),
             VectorStorageEnum::Memmap(v) => v.flusher(),
             VectorStorageEnum::AppendableMemmap(v) => v.flusher(),
             VectorStorageEnum::SparseSimple(v) => v.flusher(),
@@ -200,7 +200,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn files(&self) -> Vec<PathBuf> {
         match self {
-            VectorStorageEnum::Simple(v) => v.files(),
+            VectorStorageEnum::DenseSimple(v) => v.files(),
             VectorStorageEnum::Memmap(v) => v.files(),
             VectorStorageEnum::AppendableMemmap(v) => v.files(),
             VectorStorageEnum::SparseSimple(v) => v.files(),
@@ -209,7 +209,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         match self {
-            VectorStorageEnum::Simple(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseSimple(v) => v.delete_vector(key),
             VectorStorageEnum::Memmap(v) => v.delete_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.delete_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.delete_vector(key),
@@ -218,7 +218,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
         match self {
-            VectorStorageEnum::Simple(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseSimple(v) => v.is_deleted_vector(key),
             VectorStorageEnum::Memmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::AppendableMemmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.is_deleted_vector(key),
@@ -227,7 +227,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_count(&self) -> usize {
         match self {
-            VectorStorageEnum::Simple(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseSimple(v) => v.deleted_vector_count(),
             VectorStorageEnum::Memmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::AppendableMemmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_count(),
@@ -236,7 +236,7 @@ impl VectorStorage for VectorStorageEnum {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         match self {
-            VectorStorageEnum::Simple(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseSimple(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::Memmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::AppendableMemmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_bitslice(),


### PR DESCRIPTION
This is a mechanical change done for the sake of consistency between sparse and dense vector simple storages.