### PR TITLE
Validate sparse indices in grpc search

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -164,7 +164,6 @@ fn configure_validation(builder: Builder) -> Builder {
             ("CreateFieldIndexCollection.field_name", "length(min = 1)"),
             ("DeleteFieldIndexCollection.collection_name", "length(min = 1, max = 255)"),
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
-            // TODO(sparse) validate sparse vector for `SearchPoints`
             ("SearchPoints.collection_name", "length(min = 1, max = 255)"),
             ("SearchPoints.filter", ""),
             ("SearchPoints.limit", "range(min = 1)"),
@@ -173,7 +172,6 @@ fn configure_validation(builder: Builder) -> Builder {
             ("SearchBatchPoints.collection_name", "length(min = 1, max = 255)"),
             ("SearchBatchPoints.search_points", ""),
             ("SearchBatchPoints.timeout", "custom = \"crate::grpc::validate::validate_u64_range_min_1\""),
-            // TODO(sparse) validate sparse vector for `SearchPointGroups`
             ("SearchPointGroups.collection_name", "length(min = 1, max = 255)"),
             ("SearchPointGroups.group_by", "length(min = 1)"),
             ("SearchPointGroups.filter", ""),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1237,10 +1237,9 @@ pub fn into_named_vector_struct(
         Some(indices) => NamedVectorStruct::Sparse(NamedSparseVector {
             name: vector_name
                 .ok_or_else(|| Status::invalid_argument("Sparse vector must have a name"))?,
-            vector: SparseVector {
-                values: vector,
-                indices: indices.data,
-            },
+            vector: SparseVector::new(indices.data, vector).map_err(|_| {
+                Status::invalid_argument("Sparse indices does not match sparse vector conditions")
+            })?,
         }),
         None => {
             if let Some(vector_name) = vector_name {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -915,7 +915,7 @@ impl TryFrom<api::grpc::qdrant::SearchPoints> for CoreSearchRequest {
 
         if let Some(sparse_indices) = &sparse_indices {
             validate_sparse_vector_impl(&sparse_indices.data, &vector).map_err(|_| {
-                Status::invalid_argument("Sparse_indices does not match sparse vector conditions")
+                Status::invalid_argument("Sparse indices does not match sparse vector conditions")
             })?;
         }
 
@@ -1226,7 +1226,7 @@ impl TryFrom<api::grpc::qdrant::SearchPointGroups> for SearchGroupsRequestIntern
             validate_sparse_vector_impl(&sparse_indices.data, &search_points.vector).map_err(
                 |_| {
                     Status::invalid_argument(
-                        "Sparse_indices does not match sparse vector conditions",
+                        "Sparse indices does not match sparse vector conditions",
                     )
                 },
             )?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1049,7 +1049,10 @@ pub async fn recommend(
         .into_iter()
         .map(TryInto::try_into)
         .collect::<Result<Vec<RecommendExample>, Status>>()?;
-    let positive_vectors = positive_vectors.into_iter().map(Into::into).collect();
+    let positive_vectors = positive_vectors
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect::<Result<_, _>>()?;
     let positive = [positive_ids, positive_vectors].concat();
 
     let negative_ids = negative

--- a/tests/basic_sparse_grpc_test.sh
+++ b/tests/basic_sparse_grpc_test.sh
@@ -173,4 +173,28 @@ if [[ $response != *"Sparse indices does not match sparse vector conditions"* ]]
     echo Unexpected response, expected validation error: $response
     exit 1
 fi
+
+response=$(
+  $docker_grpcurl -d '{
+    "collection_name": "test_sparse_collection",
+    "wait": true,
+    "ordering": null,
+    "points": [
+      {
+        "id": { "uuid": "f0e09527-b096-42a8-94e9-ea94d342b885" },
+        "vectors": {
+          "vectors": {
+            "vectors": {
+              "test": {"data": [0.35, 0.08], "indices": { "data": [0,1,2,3] }}
+            }
+          }
+        }
+      }
+    ]
+  }' $QDRANT_HOST qdrant.Points/Upsert 2>&1
+)
+if [[ $response != *"Sparse indices does not match sparse vector conditions"* ]]; then
+    echo Unexpected response, expected validation error: $response
+    exit 1
+fi
 set -e

--- a/tests/basic_sparse_grpc_test.sh
+++ b/tests/basic_sparse_grpc_test.sh
@@ -157,3 +157,20 @@ $docker_grpcurl -d '{
   "with_vectors": {"enable": true},
   "ids": [{ "num": 2 }, { "num": 3 }, { "num": 4 }]
 }' $QDRANT_HOST qdrant.Points/Get
+
+# validate search request when vector and indices have different sizes
+set +e
+response=$(
+  $docker_grpcurl -d '{
+    "collection_name": "test_sparse_collection",
+    "vector": [0.2,0.1],
+    "sparse_indices": { "data": [0,1,2,3] },
+    "vector_name": "test",
+    "limit": 3
+  }' $QDRANT_HOST qdrant.Points/Search 2>&1
+)
+if [[ $response != *"Sparse indices does not match sparse vector conditions"* ]]; then
+    echo Unexpected response, expected validation error: $response
+    exit 1
+fi
+set -e


### PR DESCRIPTION
Add custom validation step in grpc while conversion. We cannot use default field-based validation because sparse requests require checking 2 separate fields. I find the custom implementation of struct validation bad because It affects another validated field.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
