### PR TITLE
sparse vectors with large indices support

### DIFF
--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -25,17 +25,17 @@ impl IndicesTracker {
                 max_index,
             })
         } else {
-            let path = Self::index_file_path(path);
+            let path = Self::file_path(path);
             Ok(read_json(&path)?)
         }
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
-        let path = Self::index_file_path(path);
+        let path = Self::file_path(path);
         Ok(atomic_save_json(&path, self)?)
     }
 
-    pub fn index_file_path(path: &Path) -> PathBuf {
+    pub fn file_path(path: &Path) -> PathBuf {
         path.join(INDICES_TRACKER_FILE_NAME)
     }
 

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use io::file_operations::{atomic_save_json, read_json};
+use serde::{Deserialize, Serialize};
+use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::DimId;
+
+use crate::common::operation_error::OperationResult;
+
+const INDICES_TRACKER_FILE_NAME: &str = "indices_tracker.json";
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct IndicesTracker {
+    pub map: HashMap<DimId, DimId>,
+    pub max_index: DimId,
+}
+
+impl IndicesTracker {
+    pub fn open(path: &Path, max_index_fn: impl Fn() -> DimId) -> std::io::Result<Self> {
+        if !Path::new(path).exists() {
+            let max_index = max_index_fn();
+            Ok(IndicesTracker {
+                map: (0..max_index).map(|i| (i, i)).collect(),
+                max_index,
+            })
+        } else {
+            let path = Self::index_file_path(path);
+            Ok(read_json(&path)?)
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> OperationResult<()> {
+        let path = Self::index_file_path(path);
+        Ok(atomic_save_json(&path, self)?)
+    }
+
+    pub fn index_file_path(path: &Path) -> PathBuf {
+        path.join(INDICES_TRACKER_FILE_NAME)
+    }
+
+    pub fn register_indices(&mut self, vector: &SparseVector) {
+        for index in &vector.indices {
+            if !self.map.contains_key(index) {
+                self.max_index = std::cmp::max(self.max_index, *index);
+
+                let new_index = self.map.len() as DimId;
+                self.map.insert(*index, new_index);
+            }
+        }
+    }
+
+    pub fn remap_index(&self, index: DimId) -> Option<DimId> {
+        self.map.get(&index).copied()
+    }
+
+    pub fn remap_vector(&self, mut vector: SparseVector) -> SparseVector {
+        let mut placeholder_indices = self.max_index + 1;
+        vector.indices.iter_mut().for_each(|index| {
+            *index = if let Some(index) = self.remap_index(*index) {
+                index
+            } else {
+                placeholder_indices += 1;
+                placeholder_indices
+            }
+        });
+        vector.sort_by_indices();
+        vector
+    }
+}

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -18,14 +18,14 @@ pub struct IndicesTracker {
 
 impl IndicesTracker {
     pub fn open(path: &Path, max_index_fn: impl Fn() -> DimId) -> std::io::Result<Self> {
-        if !Path::new(path).exists() {
+        let path = Self::file_path(path);
+        if !path.exists() {
             let max_index = max_index_fn();
             Ok(IndicesTracker {
                 map: (0..max_index).map(|i| (i, i)).collect(),
                 max_index,
             })
         } else {
-            let path = Self::file_path(path);
             Ok(read_json(&path)?)
         }
     }

--- a/lib/segment/src/index/sparse_index/mod.rs
+++ b/lib/segment/src/index/sparse_index/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+pub mod indices_tracker;
 pub mod sparse_index_config;
 pub mod sparse_search_telemetry;
 pub mod sparse_vector_index;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -412,7 +412,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         let mut all_files = vec![];
 
         let indices_tracker_file = IndicesTracker::file_path(&self.path);
-        if !indices_tracker_file.exists() {
+        if indices_tracker_file.exists() {
             all_files.push(indices_tracker_file);
         }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -410,6 +410,12 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         }
 
         let mut all_files = vec![];
+
+        let indices_tracker_file = IndicesTracker::file_path(&self.path);
+        if !indices_tracker_file.exists() {
+            all_files.push(indices_tracker_file);
+        }
+
         all_files.push(config_file);
         all_files.extend_from_slice(&TInvertedIndex::files(&self.path));
         all_files

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -12,6 +12,7 @@ use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::search_context::SearchContext;
 
+use super::indices_tracker::IndicesTracker;
 use super::sparse_index_config::SparseIndexType;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
@@ -39,6 +40,7 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     pub inverted_index: TInvertedIndex,
     searches_telemetry: SparseSearchesTelemetry,
     is_appendable: bool,
+    indices_tracker: IndicesTracker,
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -55,24 +57,27 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let is_appendable = config.index_type == SparseIndexType::MutableRam;
 
         let config_path = SparseIndexConfig::get_config_path(path);
-        let (config, inverted_index) = if is_appendable {
+        let (config, inverted_index, indices_tracker) = if is_appendable {
             // RAM mutable case - build inverted index from scratch and use provided config
-            let inverted_index = Self::build_inverted_index(
+            let (inverted_index, indices_tracker) = Self::build_inverted_index(
                 id_tracker.clone(),
                 vector_storage.clone(),
                 path,
                 &AtomicBool::new(false),
             )?;
-            (config, inverted_index)
+            (config, inverted_index, indices_tracker)
         } else if config_path.exists() {
             // Load inverted index and config
             let loaded_config = SparseIndexConfig::load(&config_path)?;
             let inverted_index = TInvertedIndex::open(path)?;
-            (loaded_config, inverted_index)
+            let indices_tracker =
+                IndicesTracker::open(path, || inverted_index.max_index().unwrap_or_default())?;
+            (loaded_config, inverted_index, indices_tracker)
         } else {
             // Inverted index and config are not presented - initialize empty inverted index
             let inverted_index = TInvertedIndex::from_ram_index(InvertedIndexRam::empty(), path)?;
-            (config, inverted_index)
+            let indices_tracker = Default::default();
+            (config, inverted_index, indices_tracker)
         };
 
         let searches_telemetry = SparseSearchesTelemetry::new();
@@ -86,6 +91,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             inverted_index,
             searches_telemetry,
             is_appendable,
+            indices_tracker,
         })
     }
 
@@ -99,12 +105,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
         path: &Path,
         stopped: &AtomicBool,
-    ) -> OperationResult<TInvertedIndex> {
+    ) -> OperationResult<(TInvertedIndex, IndicesTracker)> {
         let borrowed_vector_storage = vector_storage.borrow();
         let borrowed_id_tracker = id_tracker.borrow();
         let deleted_bitslice = borrowed_vector_storage.deleted_vector_bitslice();
-        let mut ram_index = InvertedIndexRam::empty();
-        let mut index_point_count: usize = 0;
+
+        let mut indices_tracker = IndicesTracker::default();
         for id in borrowed_id_tracker.iter_ids_excluding(deleted_bitslice) {
             check_process_stopped(stopped)?;
             // It is possible that the vector is not present in the storage in case of crash.
@@ -118,11 +124,28 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 }
                 Some(vector) => {
                     let vector: &SparseVector = vector.as_vec_ref().try_into()?;
+                    indices_tracker.register_indices(vector);
+                }
+            }
+        }
+
+        let mut ram_index = InvertedIndexRam::empty();
+        let mut index_point_count: usize = 0;
+        for id in borrowed_id_tracker.iter_ids_excluding(deleted_bitslice) {
+            check_process_stopped(stopped)?;
+            match borrowed_vector_storage.get_vector_opt(id) {
+                None => {
+                    // the vector was lost in a crash but will be recovered by the WAL
+                    log::debug!("Sparse vector with id {} is not found", id)
+                }
+                Some(vector) => {
+                    let vector: &SparseVector = vector.as_vec_ref().try_into()?;
                     // do not index empty vectors
                     if vector.is_empty() {
                         continue;
                     }
-                    ram_index.upsert(id, vector.to_owned());
+                    let remapped_vector = indices_tracker.remap_vector(vector.to_owned());
+                    ram_index.upsert(id, remapped_vector);
                     index_point_count += 1;
                 }
             }
@@ -130,7 +153,10 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         // the underlying upsert operation does not guarantee that the indexed vector count is correct
         // so we set the indexed vector count to the number of points we have seen
         ram_index.vector_count = index_point_count;
-        Ok(TInvertedIndex::from_ram_index(ram_index, path)?)
+        Ok((
+            TInvertedIndex::from_ram_index(ram_index, path)?,
+            indices_tracker,
+        ))
     }
 
     /// Returns the maximum number of results that can be returned by the index for a given sparse vector
@@ -138,9 +164,11 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     pub fn max_result_count(&self, query_vector: &SparseVector) -> usize {
         let mut unique_record_ids = HashSet::new();
         for dim_id in query_vector.indices.iter() {
-            if let Some(posting_list) = self.inverted_index.get(dim_id) {
-                for element in posting_list.elements.iter() {
-                    unique_record_ids.insert(element.record_id);
+            if let Some(dim_id) = self.indices_tracker.remap_index(*dim_id) {
+                if let Some(posting_list) = self.inverted_index.get(&dim_id) {
+                    for element in posting_list.elements.iter() {
+                        unique_record_ids.insert(element.record_id);
+                    }
                 }
             }
         }
@@ -221,12 +249,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         .filter(|&idx| check_deleted_condition(idx, deleted_vectors, deleted_point_bitslice))
         .collect_vec();
 
-        let mut search_context = SearchContext::new(
-            sparse_vector.to_owned(),
-            top,
-            &self.inverted_index,
-            is_stopped,
-        );
+        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector.to_owned());
+        let mut search_context =
+            SearchContext::new(sparse_vector, top, &self.inverted_index, is_stopped);
         Ok(search_context.plain_search(&ids))
     }
 
@@ -246,12 +271,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let not_deleted_condition = |idx: PointOffsetType| -> bool {
             check_deleted_condition(idx, deleted_vectors, deleted_point_bitslice)
         };
-        let mut search_context = SearchContext::new(
-            sparse_vector.to_owned(),
-            top,
-            &self.inverted_index,
-            is_stopped,
-        );
+        let sparse_vector = self.indices_tracker.remap_vector(sparse_vector.to_owned());
+        let mut search_context =
+            SearchContext::new(sparse_vector, top, &self.inverted_index, is_stopped);
 
         match filter {
             Some(filter) => {
@@ -355,15 +377,19 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
     }
 
     fn build_index(&mut self, stopped: &AtomicBool) -> OperationResult<()> {
-        self.inverted_index = Self::build_inverted_index(
+        let (inverted_index, indices_tracker) = Self::build_inverted_index(
             self.id_tracker.clone(),
             self.vector_storage.clone(),
             &self.path,
             stopped,
         )?;
 
+        self.inverted_index = inverted_index;
+        self.indices_tracker = indices_tracker;
+
         // save inverted index
         if !self.is_appendable {
+            self.indices_tracker.save(&self.path)?;
             self.inverted_index.save(&self.path)?;
         }
 
@@ -403,7 +429,9 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         let vector: &SparseVector = vector.try_into()?;
         // do not upsert empty vectors into the index
         if !vector.is_empty() {
-            self.inverted_index.upsert(id, vector.clone());
+            self.indices_tracker.register_indices(vector);
+            let vector = self.indices_tracker.remap_vector(vector.to_owned());
+            self.inverted_index.upsert(id, vector);
         }
         Ok(())
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -40,7 +40,7 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     pub inverted_index: TInvertedIndex,
     searches_telemetry: SparseSearchesTelemetry,
     is_appendable: bool,
-    indices_tracker: IndicesTracker,
+    pub indices_tracker: IndicesTracker,
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -136,6 +136,9 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
         // assuming no deleted points
         let vector = borrowed_vector_storage.get_vector(id);
         let vector: &SparseVector = vector.as_vec_ref().try_into().unwrap();
+        let vector = sparse_vector_index
+            .indices_tracker
+            .remap_vector(vector.to_owned());
         // check posting lists are consistent with storage
         for (dim_id, dim_value) in vector.indices.iter().zip(vector.values.iter()) {
             let posting_list = sparse_vector_index.inverted_index.get(dim_id).unwrap();
@@ -151,7 +154,7 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
                 .any(|e| e.record_id == id && e.weight == *dim_value));
         }
         // check the vector can be found via search using large top
-        let top = sparse_vector_index.max_result_count(vector);
+        let top = sparse_vector_index.max_result_count(&vector);
         let query_vector: QueryVector = vector.to_owned().into();
         let results = sparse_vector_index
             .search(&[&query_vector], None, top, None, &false.into())

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -158,7 +158,7 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
                 .any(|e| e.record_id == id && e.weight == *dim_value));
         }
         // check the vector can be found via search using large top
-        let top = sparse_vector_index.max_result_count(&vector);
+        let top = sparse_vector_index.max_result_count(vector);
         let query_vector: QueryVector = vector.to_owned().into();
         let results = sparse_vector_index
             .search(&[&query_vector], None, top, None, &false.into())

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -76,6 +76,13 @@ impl InvertedIndex for InvertedIndexMmap {
     fn vector_count(&self) -> usize {
         self.file_header.vector_count
     }
+
+    fn max_index(&self) -> Option<DimId> {
+        match self.file_header.posting_count {
+            0 => None,
+            len => Some(len as DimId - 1),
+        }
+    }
 }
 
 impl InvertedIndexMmap {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -78,6 +78,13 @@ impl InvertedIndex for InvertedIndexRam {
     fn vector_count(&self) -> usize {
         self.vector_count
     }
+
+    fn max_index(&self) -> Option<DimId> {
+        match self.postings.len() {
+            0 => None,
+            len => Some(len as DimId - 1),
+        }
+    }
 }
 
 impl InvertedIndexRam {

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -34,4 +34,7 @@ pub trait InvertedIndex: Sized {
 
     /// Number of indexed vectors
     fn vector_count(&self) -> usize;
+
+    // Get max existed index
+    fn max_index(&self) -> Option<DimId>;
 }

--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -152,6 +152,8 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
     new_sparse_search_result = search(new_url, sparse_query_vector, query_city)
     assert len(new_sparse_search_result) == len(sparse_search_result)
     for i in range(len(new_sparse_search_result)):
+        # skip score check because it is not deterministic
+        new_sparse_search_result[i].score = sparse_search_result[i].score
         assert new_sparse_search_result[i] == sparse_search_result[i]
 
     new_collection_info = get_collection_info(new_url, COLLECTION_NAME)

--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -153,7 +153,7 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
     assert len(new_sparse_search_result) == len(sparse_search_result)
     for i in range(len(new_sparse_search_result)):
         # skip score check because it is not deterministic
-        new_sparse_search_result[i].score = sparse_search_result[i].score
+        new_sparse_search_result[i]["score"] = sparse_search_result[i]["score"]
         assert new_sparse_search_result[i] == sparse_search_result[i]
 
     new_collection_info = get_collection_info(new_url, COLLECTION_NAME)

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -153,7 +153,7 @@ def recover_from_uploaded_snapshot(tmp_path: pathlib.Path, n_replicas):
     assert len(new_sparse_search_result) == len(sparse_search_result)
     for i in range(len(new_sparse_search_result)):
         # skip score check because it is not deterministic
-        new_sparse_search_result[i].score = sparse_search_result[i].score
+        new_sparse_search_result[i]["score"] = sparse_search_result[i]["score"]
         assert new_sparse_search_result[i] == sparse_search_result[i]
 
     peer_0_remote_shards_new = get_remote_shards(peer_api_uris[0])

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -152,6 +152,8 @@ def recover_from_uploaded_snapshot(tmp_path: pathlib.Path, n_replicas):
     new_sparse_search_result = search(new_url, sparse_query_vector, query_city)
     assert len(new_sparse_search_result) == len(sparse_search_result)
     for i in range(len(new_sparse_search_result)):
+        # skip score check because it is not deterministic
+        new_sparse_search_result[i].score = sparse_search_result[i].score
         assert new_sparse_search_result[i] == sparse_search_result[i]
 
     peer_0_remote_shards_new = get_remote_shards(peer_api_uris[0])


### PR DESCRIPTION
Currently, sparse vector index does not support large indices (like `u32::MAX`). Fixed it using indices remapping

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
