### PR TITLE
Faster sparse vectors plain search

### DIFF
--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -57,6 +57,10 @@ impl<'a> SearchContext<'a> {
 
     /// Plain search against the given ids without any pruning
     pub fn plain_search(&mut self, ids: &[PointOffsetType]) -> Vec<ScoredPointOffset> {
+        // sort ids to fully leverage posting list iterator traversal
+        let mut sorted_ids = ids.to_vec();
+        sorted_ids.sort_unstable();
+
         for id in ids {
             // check for cancellation
             if self.is_stopped.load(Relaxed) {
@@ -66,18 +70,12 @@ impl<'a> SearchContext<'a> {
             let mut indices = Vec::with_capacity(self.query.indices.len());
             let mut values = Vec::with_capacity(self.query.values.len());
             // collect indices and values for the current record id from the query's posting lists *only*
-            for posting_iterator in &self.postings_iterators {
-                // rely on binary search as the posting lists are sorted by record id
-                match posting_iterator
-                    .posting_list_iterator
-                    .elements
-                    .binary_search_by(|element| element.record_id.cmp(id))
-                {
-                    Err(_missing) => {} // no match for posting list
-                    Ok(element_index) => {
+            for posting_iterator in self.postings_iterators.iter_mut() {
+                // rely on underlying binary search as the posting lists are sorted by record id
+                match posting_iterator.posting_list_iterator.skip_to(*id) {
+                    None => {} // no match for posting list
+                    Some(element) => {
                         // match for posting list
-                        let element =
-                            &posting_iterator.posting_list_iterator.elements[element_index];
                         indices.push(self.query.indices[posting_iterator.query_weight_offset]);
                         values.push(element.weight);
                     }


### PR DESCRIPTION
This PR optimizes the plain search through the inverted index for sparse vectors.

```
sparse-vector-search-group/inverted-index-filtered-plain
                        time:   [134.17 ms 134.44 ms 134.70 ms]
                        change: [-34.599% -34.462% -34.317%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
...
sparse-vector-search-group/plain-filtered-payload-index
                        time:   [128.26 ms 128.41 ms 128.56 ms]
                        change: [-35.495% -35.337% -35.185%] (p = 0.00 < 0.05)
                        Performance has improved.


```

The insight is that by sorting the input ids, we can actually fully leverage the posting list iterator by performing binary search on a shrinking space.