### PR TITLE
Custom thread priorities on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,8 +1128,12 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
+ "num_cpus",
  "ordered-float 4.1.1",
  "serde",
+ "thiserror",
+ "thread-priority",
+ "tokio",
  "validator",
 ]
 
@@ -5071,6 +5075,20 @@ checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
 dependencies = [
  "libc",
  "redox_syscall 0.2.16",
+ "winapi",
+]
+
+[[package]]
+name = "thread-priority"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72cb4958060ee2d9540cef68bb3871fd1e547037772c7fe7650d5d1cbec53b3"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,12 +1128,10 @@ dependencies = [
 name = "common"
 version = "0.0.0"
 dependencies = [
- "num_cpus",
  "ordered-float 4.1.1",
  "serde",
  "thiserror",
  "thread-priority",
- "tokio",
  "validator",
 ]
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -60,7 +60,7 @@ itertools = "0.12"
 indicatif = "0.17.6"
 chrono = { version = "~0.4", features = ["serde"] }
 schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
-num_cpus = "1.16.0"
+num_cpus = "1.16"
 tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.20"

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
+num_cpus = "1.16"
 ordered-float = "4.1"
 serde = { version = "~1.0", features = ["derive"] }
+thiserror = "1.0"
+thread-priority = "0.15"
+tokio = {version = "~1.35", features = ["full"]}
 validator = { version = "0.16", features = ["derive"] }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -10,12 +10,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-num_cpus = "1.16"
 ordered-float = "4.1"
 serde = { version = "~1.0", features = ["derive"] }
-thiserror = "1.0"
-tokio = {version = "~1.35", features = ["full"]}
 validator = { version = "0.16", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+thiserror = "1.0"
 thread-priority = "0.15"

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -14,6 +14,8 @@ num_cpus = "1.16"
 ordered-float = "4.1"
 serde = { version = "~1.0", features = ["derive"] }
 thiserror = "1.0"
-thread-priority = "0.15"
 tokio = {version = "~1.35", features = ["full"]}
 validator = { version = "0.16", features = ["derive"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+thread-priority = "0.15"

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -1,0 +1,71 @@
+use thiserror::Error;
+use thread_priority::{
+    get_current_thread_priority, set_current_thread_priority, ThreadPriority, ThreadPriorityValue,
+};
+
+#[derive(Error, Debug)]
+pub enum ThreadPriorityError {
+    #[error("Failed to get thread priority: {0:?}")]
+    GetThreadPriority(thread_priority::Error),
+    #[error("Failed to set thread priority: {0:?}")]
+    SetThreadPriority(thread_priority::Error),
+    #[error("Got unexpected thread priority type, cannot change: {0:?}")]
+    UnexpectedThreadPriorityType(ThreadPriority),
+    #[error("Thread priority is left unchanged to keep it in bounds")]
+    UnchangedNice,
+    #[error("Failed to parse niceness value: {0}")]
+    ParseNice(&'static str),
+}
+
+/// Make current thread lower priority (renice=+1).
+///
+/// Only has an effect on Unix platforms, ignored on other platforms.
+pub fn current_thread_lower_priority() -> Result<(), ThreadPriorityError> {
+    current_thread_renice(1)
+}
+
+/// Make current thread high priority (renice=-10).
+///
+/// Only has an effect on Unix platforms, ignored on other platforms.
+pub fn current_thread_high_priority() -> Result<(), ThreadPriorityError> {
+    current_thread_renice(-10)
+}
+
+/// Update thread priority and niceness.
+///
+/// Only has an effect on Unix platforms, ignored on other platforms.
+fn current_thread_renice(relative_nice: i8) -> Result<(), ThreadPriorityError> {
+    #[cfg(not(unix))]
+    {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        // Get thread priority value
+        let current =
+            match get_current_thread_priority().map_err(ThreadPriorityError::GetThreadPriority)? {
+                ThreadPriority::Crossplatform(current) => current,
+                thread_priority => {
+                    return Err(ThreadPriorityError::UnexpectedThreadPriorityType(
+                        thread_priority,
+                    ))
+                }
+            };
+
+        // Calculate new niceness, but stay within bounds
+        let old_nice: u8 = current.into();
+        let new_nice = (old_nice as i8).saturating_add(relative_nice).clamp(
+            ThreadPriorityValue::MIN as i8,
+            ThreadPriorityValue::MAX as i8,
+        ) as u8;
+        if old_nice == new_nice {
+            return Err(ThreadPriorityError::UnchangedNice);
+        }
+
+        let new_priority = ThreadPriority::Crossplatform(
+            ThreadPriorityValue::try_from(new_nice).map_err(ThreadPriorityError::ParseNice)?,
+        );
+        set_current_thread_priority(new_priority).map_err(ThreadPriorityError::SetThreadPriority)
+    }
+}

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -20,9 +20,15 @@ pub fn linux_low_thread_priority() -> Result<(), ThreadPriorityError> {
 }
 
 /// On Linux, make current thread high priority (nice: -10).
+///
+/// # Warning
+///
+/// This is very likely to fail because decreasing the nice value requires special privileges. It
+/// is therefore recommended to soft-fail.
+/// See: <https://manned.org/renice.1#head6>
 #[cfg(target_os = "linux")]
 pub fn linux_high_thread_priority() -> Result<(), ThreadPriorityError> {
-    // 75% corresponds to a nice value of 10
+    // 75% corresponds to a nice value of -10
     set_linux_thread_priority(75)
 }
 

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -1,4 +1,6 @@
+#[cfg(target_os = "linux")]
 use thiserror::Error;
+#[cfg(target_os = "linux")]
 use thread_priority::{set_current_thread_priority, ThreadPriority, ThreadPriorityValue};
 
 #[derive(Error, Debug)]

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -16,14 +16,14 @@ pub enum ThreadPriorityError {
 #[cfg(target_os = "linux")]
 pub fn linux_low_thread_priority() -> Result<(), ThreadPriorityError> {
     // 25% corresponds to a nice value of 10
-    current_thread_renice(25)
+    set_linux_thread_priority(25)
 }
 
 /// On Linux, make current thread high priority (nice: -10).
 #[cfg(target_os = "linux")]
 pub fn linux_high_thread_priority() -> Result<(), ThreadPriorityError> {
     // 75% corresponds to a nice value of 10
-    current_thread_renice(75)
+    set_linux_thread_priority(75)
 }
 
 /// On Linux, update priority of current thread.
@@ -33,7 +33,7 @@ pub fn linux_high_thread_priority() -> Result<(), ThreadPriorityError> {
 /// - <https://linux.die.net/man/7/pthreads>
 /// - <https://linux.die.net/man/2/setpriority>
 #[cfg(target_os = "linux")]
-fn current_thread_renice(priority: u8) -> Result<(), ThreadPriorityError> {
+fn set_linux_thread_priority(priority: u8) -> Result<(), ThreadPriorityError> {
     let new_priority = ThreadPriority::Crossplatform(
         ThreadPriorityValue::try_from(priority).map_err(ThreadPriorityError::ParseNice)?,
     );

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cpu;
 pub mod defaults;
 pub mod fixed_length_priority_queue;
 pub mod math;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -12,7 +12,8 @@ use api::grpc::qdrant::{AllPeers, PeerId as GrpcPeerId, RaftMessage as GrpcRaftM
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use collection::shards::channel_service::ChannelService;
 use collection::shards::shard::PeerId;
-use common::cpu::current_thread_high_priority;
+#[cfg(target_os = "linux")]
+use common::cpu::linux_high_thread_priority;
 use common::defaults;
 use prost::Message as _;
 use raft::eraftpb::Message as RaftMessage;
@@ -94,9 +95,13 @@ impl Consensus {
         thread::Builder::new()
             .name("consensus".to_string())
             .spawn(move || {
-                // Use high thread priority because consensus is important
-                if let Err(err) = current_thread_high_priority() {
-                    log::warn!("Failed to increase consensus thread priority, ignoring: {err}");
+                // On Linux, try to use high thread priority because consensus is important
+                // Likely fails as we cannot set a higher priority by default due to permissions
+                #[cfg(target_os = "linux")]
+                if let Err(err) = linux_high_thread_priority() {
+                    log::debug!(
+                        "Failed to set high thread priority for consensus, ignoring: {err}"
+                    );
                 }
 
                 if let Err(err) = consensus.start() {
@@ -112,9 +117,13 @@ impl Consensus {
         thread::Builder::new()
             .name("forward-proposals".to_string())
             .spawn(move || {
-                // Use high thread priority because consensus is important
-                if let Err(err) = current_thread_high_priority() {
-                    log::warn!("Failed to increase consensus thread priority, ignoring: {err}");
+                // On Linux, try to use high thread priority because consensus is important
+                // Likely fails as we cannot set a higher priority by default due to permissions
+                #[cfg(target_os = "linux")]
+                if let Err(err) = linux_high_thread_priority() {
+                    log::debug!(
+                        "Failed to set high thread priority for consensus, ignoring: {err}"
+                    );
                 }
 
                 while let Ok(entry) = propose_receiver.recv() {


### PR DESCRIPTION
Set custom priorities for consensus and HNSW build threads on Linux. This should not affect regular operation but will improve reliability in extreme cases. For example, this can help prevent consensus lagging behind if the machine if very busy building HNSW.

For HNSW build threads the priority is lowered, since these usually fully saturate CPU cores lowering the priority attempts to make affecting ongoing updates/searches less likely. The consensus threads the priority is raised, to allow handling consensus updates as soon as possible. Raising the thread priority likely fails because it requires special permissions on most systems, so it soft-fails with a debug message.

More specifically, on Linux this tries to set:
- consensus threads: nice=-10
- HNSW build threads: nice=10
- all other threads: nice=0 (unchanged)

This is only implemented for Linux and not other Unix-like platforms. POSIX threads share priority/nice values across all process threads. Linux breaks this behavior and allows setting per-thread priority/nice values[^1][^2]. I'm not sure about Windows.

I've done a basic `bfb` benchmark to see the effect of this.

Search timings during HNSW building without thread priorities:

```bash
$ bfb --skip-create --skip-upload --skip-wait-index --search --p9=4 -n5000
 [00:01:36] ████████████████████ [51.7576/s] 5000/5000 (eta:0s)
--- Server timings ---
Min search time: 0.030139231
Avg search time: 0.037740009691600004
p95 search time: 0.042813196
p99 search time: 0.043735879
p999 search time: 0.045643002
p9999 search time: 0.050678771
Max search time: 0.050678771
```

Search timings during HNSW building with thread priorities:

```bash
$ bfb --skip-create --skip-upload --skip-wait-index --search --p9=4 -n5000
 [00:01:31] ████████████████████ [54.4541/s] 5000/5000 (eta:0s)
--- Server timings ---
Min search time: 0.031290399
Avg search time: 0.03583264708799998
p95 search time: 0.042004593
p99 search time: 0.042975104
p999 search time: 0.043672693
p9999 search time: 0.043811394
Max search time: 0.043811394
```

[^1]: https://linux.die.net/man/7/pthreads
[^2]: https://linux.die.net/man/2/setpriority


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
4. [x] Have you successfully ran tests with your changes locally?