### PR TITLE
fix missing indexing values on set-payload operation

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -203,10 +203,7 @@ pub fn get_value_from_json_map_opt<'a>(
                     // no array notation
                     match json_map.get(element) {
                         Some(Value::Object(map)) => get_value_from_json_map_opt(rest_path, map),
-                        Some(value) => match rest_path.is_empty() {
-                            true => Some(MultiValue::one(value)),
-                            false => None,
-                        },
+                        Some(value) => rest_path.is_empty().then_some(MultiValue::one(value)),
                         None => None,
                     }
                 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -475,9 +475,11 @@ impl PayloadIndex for StructPayloadIndex {
 
     fn assign(&mut self, point_id: PointOffsetType, payload: &Payload) -> OperationResult<()> {
         for (field, field_index) in &mut self.field_indexes {
-            let field_value = &payload.get_value(field);
-            for index in field_index {
-                index.add_point(point_id, field_value)?;
+            let field_value_opt = &payload.get_value_opt(field);
+            if let Some(field_value) = field_value_opt {
+                for index in field_index {
+                    index.add_point(point_id, field_value)?;
+                }
             }
         }
         self.payload.borrow_mut().assign(point_id, payload)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -855,13 +855,17 @@ pub trait PayloadContainer {
     /// Return value from payload by path if it is present in the payload.
     /// If value is not present in the payload, returns `None`.
     ///
-    /// WARN: Absence of value and value `null` is NOT the same in this function.
+    /// # Warning
+    ///
+    /// Absence of value and value `null` is NOT the same in this function.
     fn get_value_opt(&self, path: &str) -> Option<MultiValue<&Value>>;
 
     /// Return value from payload by path.
     /// If value is not present in the payload, returns empty value.
     ///
-    /// WARN: Absence of value and value `null` is considered same in this function.
+    /// # Warning
+    ///
+    /// Absence of value and value `null` is considered same in this function.
     fn get_value(&self, path: &str) -> MultiValue<&Value>;
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -23,7 +23,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils;
 use crate::common::utils::{
     check_exclude_pattern, check_include_pattern, filter_json_values, get_value_from_json_map,
-    MultiValue,
+    get_value_from_json_map_opt, MultiValue,
 };
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{DenseVector, VectorElementType, VectorStruct};
@@ -852,6 +852,16 @@ impl TryFrom<GeoPointShadow> for GeoPoint {
 }
 
 pub trait PayloadContainer {
+    /// Return value from payload by path if it is present in the payload.
+    /// If value is not present in the payload, returns `None`.
+    ///
+    /// WARN: Absence of value and value `null` is NOT the same in this function.
+    fn get_value_opt(&self, path: &str) -> Option<MultiValue<&Value>>;
+
+    /// Return value from payload by path.
+    /// If value is not present in the payload, returns empty value.
+    ///
+    /// WARN: Absence of value and value `null` is considered same in this function.
     fn get_value(&self, path: &str) -> MultiValue<&Value>;
 }
 
@@ -890,18 +900,30 @@ impl Payload {
 }
 
 impl PayloadContainer for Map<String, Value> {
+    fn get_value_opt(&self, path: &str) -> Option<MultiValue<&Value>> {
+        get_value_from_json_map_opt(path, self)
+    }
+
     fn get_value(&self, path: &str) -> MultiValue<&Value> {
         get_value_from_json_map(path, self)
     }
 }
 
 impl PayloadContainer for Payload {
+    fn get_value_opt(&self, path: &str) -> Option<MultiValue<&Value>> {
+        get_value_from_json_map_opt(path, &self.0)
+    }
+
     fn get_value(&self, path: &str) -> MultiValue<&Value> {
         get_value_from_json_map(path, &self.0)
     }
 }
 
 impl<'a> PayloadContainer for OwnedPayloadRef<'a> {
+    fn get_value_opt(&self, path: &str) -> Option<MultiValue<&Value>> {
+        get_value_from_json_map_opt(path, self.as_ref())
+    }
+
     fn get_value(&self, path: &str) -> MultiValue<&Value> {
         get_value_from_json_map(path, self.deref())
     }


### PR DESCRIPTION
What happened:

- Payload `assign` operation was trying to upgrade index no matter is the value was actually present in the index or not. It was considering the non-present value as `None` (which is incorrect)

Why it broke only in 1.7.x?

- The change introduced in https://github.com/qdrant/qdrant/commit/8b05c4a388504ab3473db70a61702b9a8e8642b5 was removing point from index before inserting a new one. It was fixing a different issue. But it was made under the assumption that `assign` will not try to insert non-existing fields.


Current changes are tested manually on the reproducible example, proper integration tests will be introduces in another PR by @KShivendu 


---

Scenario to reproduce:

- Create a collection with vectors and payload
- Create payload index
- Make sure the vectors are indexed as well (non-append-able segments exist)
- Use `set_pyaload` with the field, which is NOT index
- Try to scroll with filter by INDEXED field. The updated point will not be found



