### PR TITLE
Avoid logging `/metrics` and `/telemetry` in access log

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -124,7 +124,13 @@ pub fn init(
                     ApiKey::new(auth_keys.clone(), api_key_whitelist.clone()),
                 ))
                 .wrap(Condition::new(settings.service.enable_cors, cors))
-                .wrap(Logger::default().exclude("/")) // Avoid logging healthcheck requests
+                // Set up logger, but avoid logging health checks, metrics and telemetry
+                .wrap(
+                    Logger::default()
+                        .exclude("/")
+                        .exclude("/metrics")
+                        .exclude("/telemetry"),
+                )
                 .wrap(actix_telemetry::ActixTelemetryTransform::new(
                     actix_telemetry_collector.clone(),
                 ))

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -124,8 +124,8 @@ pub fn init(
                     ApiKey::new(auth_keys.clone(), api_key_whitelist.clone()),
                 ))
                 .wrap(Condition::new(settings.service.enable_cors, cors))
-                // Set up logger, but avoid logging health checks, metrics and telemetry
                 .wrap(
+                    // Set up logger, but avoid logging health checks, metrics and telemetry
                     Logger::default()
                         .exclude("/")
                         .exclude("/metrics")


### PR DESCRIPTION
Avoid logging `/metrics` and `/telemetry` in access logs because it can be quite noisy.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?