### PR TITLE
Regenerate storage compatibility data with new sparse index_tracker

### DIFF
--- a/tests/storage-compat/full-snapshot.snapshot.gz
+++ b/tests/storage-compat/full-snapshot.snapshot.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e472b2c6edcab2ce035fbd27b18dcc19c8a228460446a2495b4c41ccf1dfd62a
-size 19526384
+oid sha256:01938a15b397c96f9f71f0bde647c070d0f797a3f11ddf24c4cd235591e1b5f7
+size 18722078

--- a/tests/storage-compat/storage.tar.bz2
+++ b/tests/storage-compat/storage.tar.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:019eb2b7fe9ae960385c7ba06bb0c08246853e439d17c088c256ee6f5b2b32a4
-size 21106710
+oid sha256:c3eeef55309d1cfac24a819682560a202668247987bdb442a1eda260a95f94ab
+size 18724352


### PR DESCRIPTION
This PR regenerates the data for the storage compatibility tests.

The rational is to capture the latest `indices_tracker.json` file introduced in https://github.com/qdrant/qdrant/pull/3230

e.g.

```
./storage/collections/test_collection_product_x64/0/segments/d40060bb-3737-4ff6-9b84-faba16f51e6b/vector_index-text/
./storage/collections/test_collection_product_x64/0/segments/d40060bb-3737-4ff6-9b84-faba16f51e6b/vector_index-text/inverted_index.data
./storage/collections/test_collection_product_x64/0/segments/d40060bb-3737-4ff6-9b84-faba16f51e6b/vector_index-text/inverted_index_config.json
./storage/collections/test_collection_product_x64/0/segments/d40060bb-3737-4ff6-9b84-faba16f51e6b/vector_index-text/indices_tracker.json
./storage/collections/test_collection_product_x64/0/segments/d40060bb-3737-4ff6-9b84-faba16f51e6b/vector_index-text/sparse_index_config.json

``` 