### PR TITLE
Fix potential data race when confirming consensus operation

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -531,14 +531,13 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .map_err(|_: Elapsed| {
                 StorageError::service_error(format!(
                     "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
-                    wait_timeout.as_secs_f64()
+                    wait_timeout.as_secs_f64(),
                 ))
             })?;
         // 2 possible errors to forward: channel sender dropped OR operation failed
         timeout_res.map_err(|err| {
             StorageError::service_error(format!(
-                "Error occurred while waiting for consensus operation. Channel sender dropped ({})",
-                err
+                "Error occurred while waiting for consensus operation. Channel sender dropped ({err})",
             ))
         })?
     }
@@ -636,7 +635,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     ///
     /// * `operation` - operation to propose
     /// * `wait_timeout` - How long do we need to wait for the confirmation
-    ///
     pub async fn propose_consensus_op_with_await(
         &self,
         operation: ConsensusOperations,
@@ -657,7 +655,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         if !is_leader_established {
             return Err(StorageError::service_error(format!(
                 "Failed to propose operation: leader is not established within {} secs",
-                wait_timeout.as_secs()
+                wait_timeout.as_secs(),
             )));
         }
 

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -175,10 +175,10 @@ impl From<tokio::sync::oneshot::error::RecvError> for StorageError {
     }
 }
 
-impl From<tokio::sync::broadcast::error::RecvError> for StorageError {
-    fn from(err: tokio::sync::broadcast::error::RecvError) -> Self {
+impl From<tokio::sync::watch::error::RecvError> for StorageError {
+    fn from(err: tokio::sync::watch::error::RecvError) -> Self {
         StorageError::ServiceError {
-            description: format!("Broadcast channel sender dropped: {err}"),
+            description: format!("Watch channel sender dropped: {err}"),
             backtrace: Some(Backtrace::force_capture().to_string()),
         }
     }


### PR DESCRIPTION
I found a potential data race in our logic for waiting on consensus operations.

We used a [broadcast](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html) channel to notify waiters with consensus operations results once they resolve. The problem is that these waiters are not notified if it resolves before subscribing.

If we resubmit an operation we subscribed to the existing broadcast channel. It is easily possible for it to be resolved already, in which case we never get notified.

This PR changes the logic to use a [watch](https://docs.rs/tokio/latest/tokio/sync/watch/index.html) instead. It allows reusing the result value even if we await (subscribe) to it later. In other words, when subscribing we check if we already resolved to a value and start waiting if we have not resolved yet. Because the watch channel needs to hold some value at all times, it uses an `Option`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?