### PR TITLE
Fix clippy 1.75

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -224,7 +224,7 @@ mod tests {
 
         assert_eq!(res.len(), 3);
 
-        match res.get(0) {
+        match res.first() {
             None => panic!(),
             Some(r) => match &r.payload {
                 None => panic!("No payload assigned"),

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -305,8 +305,8 @@ mod tests {
         // Collection configuration
         let (point_count, dim) = (1000, 10);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: std::usize::MAX,
-            memmap_threshold: std::usize::MAX,
+            max_segment_size: usize::MAX,
+            memmap_threshold: usize::MAX,
             indexing_threshold: 10,
         };
         let collection_params = CollectionParams {
@@ -428,8 +428,8 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: std::usize::MAX,
-            memmap_threshold: std::usize::MAX,
+            max_segment_size: usize::MAX,
+            memmap_threshold: usize::MAX,
             indexing_threshold: 10,
         };
         let hnsw_config_vector1 = HnswConfigDiff {
@@ -591,8 +591,8 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: std::usize::MAX,
-            memmap_threshold: std::usize::MAX,
+            max_segment_size: usize::MAX,
+            memmap_threshold: usize::MAX,
             indexing_threshold: 10,
         };
         let quantization_config_vector1 =

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -709,9 +709,9 @@ mod tests {
         // Collection configuration
         let (point_count, dim) = (1000, 10);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: std::usize::MAX,
+            max_segment_size: usize::MAX,
             memmap_threshold: 10,
-            indexing_threshold: std::usize::MAX,
+            indexing_threshold: usize::MAX,
         };
         let mut collection_params = CollectionParams {
             vectors: VectorsConfig::Single(VectorParams {

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -386,8 +386,8 @@ mod tests {
         // Collection configuration
         let (point_count, vector1_dim, vector2_dim) = (1000, 10, 20);
         let thresholds_config = OptimizerThresholds {
-            max_segment_size: std::usize::MAX,
-            memmap_threshold: std::usize::MAX,
+            max_segment_size: usize::MAX,
+            memmap_threshold: usize::MAX,
             indexing_threshold: 10,
         };
         let collection_params = CollectionParams {

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -556,10 +556,10 @@ mod tests {
 
         // assert
         assert_eq!(groups.len(), 2);
-        assert_eq!(groups.get(0).unwrap().hits.len(), 2);
+        assert_eq!(groups.first().unwrap().hits.len(), 2);
         assert_eq!(groups.get(1).unwrap().hits.len(), 2);
 
-        let a = groups.get(0).unwrap();
+        let a = groups.first().unwrap();
         let b = groups.get(1).unwrap();
 
         assert!(a

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -221,15 +221,15 @@ impl ShardHolder {
         shard_keys_selection: &Option<ShardKey>,
     ) -> CollectionResult<Vec<(&ShardReplicaSet, O)>> {
         let Some(hashring) = self.rings.get(shard_keys_selection) else {
-            if let Some(shard_key) = shard_keys_selection {
-                return Err(CollectionError::bad_input(format!(
+            return if let Some(shard_key) = shard_keys_selection {
+                Err(CollectionError::bad_input(format!(
                     "Shard key {shard_key} not found"
-                )));
+                )))
             } else {
-                return Err(CollectionError::bad_input(
+                Err(CollectionError::bad_input(
                     "Shard key not specified".to_string(),
-                ));
-            }
+                ))
+            };
         };
 
         if hashring.is_empty() {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -505,7 +505,7 @@ impl UpdateHandler {
                     debug!("Stopping flush worker.");
                     return;
                 }
-            };
+            }
 
             trace!("Attempting flushing");
             let wal_flash_job = wal.lock().flush_async();

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -502,7 +502,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
 
     // check if we only have 3 out of 5 points left and that the point id were really deleted
     assert_eq!(result.points.len(), 3);
-    assert_eq!(result.points.get(0).unwrap().id, 1.into());
+    assert_eq!(result.points.first().unwrap().id, 1.into());
     assert_eq!(result.points.get(1).unwrap().id, 2.into());
     assert_eq!(result.points.get(2).unwrap().id, 4.into());
 }

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -7,6 +7,8 @@ use crate::data_types::vectors::Vector;
 use crate::index::field_index::FieldIndex;
 use crate::types::PayloadKeyType;
 
+pub type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;
+
 /// Avoids allocating Vec with a single element
 #[derive(Debug)]
 pub enum MultiValue<T> {
@@ -779,5 +781,3 @@ mod tests {
         );
     }
 }
-
-pub type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers.rs
@@ -145,7 +145,7 @@ mod tests {
         let mut tokens = Vec::new();
         WhiteSpaceTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.get(0), Some(&"hello".to_owned()));
+        assert_eq!(tokens.first(), Some(&"hello".to_owned()));
         assert_eq!(tokens.get(1), Some(&"world".to_owned()));
     }
 
@@ -155,7 +155,7 @@ mod tests {
         let mut tokens = Vec::new();
         WordTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.get(0), Some(&"hello".to_owned()));
+        assert_eq!(tokens.first(), Some(&"hello".to_owned()));
         assert_eq!(tokens.get(1), Some(&"world".to_owned()));
         assert_eq!(tokens.get(2), Some(&"Привет".to_owned()));
         assert_eq!(tokens.get(3), Some(&"мир".to_owned()));
@@ -168,7 +168,7 @@ mod tests {
         PrefixTokenizer::tokenize(text, 1, 4, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
-        assert_eq!(tokens.get(0), Some(&"h".to_owned()));
+        assert_eq!(tokens.first(), Some(&"h".to_owned()));
         assert_eq!(tokens.get(1), Some(&"he".to_owned()));
         assert_eq!(tokens.get(2), Some(&"hel".to_owned()));
         assert_eq!(tokens.get(3), Some(&"hell".to_owned()));
@@ -184,7 +184,7 @@ mod tests {
         PrefixTokenizer::tokenize_query(text, 4, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens.get(0), Some(&"hell".to_owned()));
+        assert_eq!(tokens.first(), Some(&"hell".to_owned()));
         assert_eq!(tokens.get(1), Some(&"мир".to_owned()));
     }
 
@@ -196,7 +196,7 @@ mod tests {
         MultilingualTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.get(0), Some(&"本日".to_owned()));
+        assert_eq!(tokens.first(), Some(&"本日".to_owned()));
         assert_eq!(tokens.get(1), Some(&"の".to_owned()));
         assert_eq!(tokens.get(2), Some(&"日付".to_owned()));
         assert_eq!(tokens.get(3), Some(&"は".to_owned()));
@@ -210,7 +210,7 @@ mod tests {
         MultilingualTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens.get(0), Some(&"jīntiān".to_owned()));
+        assert_eq!(tokens.first(), Some(&"jīntiān".to_owned()));
         assert_eq!(tokens.get(1), Some(&"shì".to_owned()));
         assert_eq!(tokens.get(2), Some(&"xīngqīyī".to_owned()));
     }
@@ -222,7 +222,7 @@ mod tests {
         MultilingualTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens.get(0), Some(&"มา".to_owned()));
+        assert_eq!(tokens.first(), Some(&"มา".to_owned()));
         assert_eq!(tokens.get(1), Some(&"ทางาน".to_owned()));
         assert_eq!(tokens.get(2), Some(&"กน".to_owned()));
         assert_eq!(tokens.get(3), Some(&"เถอะ".to_owned()));
@@ -235,7 +235,7 @@ mod tests {
         MultilingualTokenizer::tokenize(text, |token| tokens.push(token.to_owned()));
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 5);
-        assert_eq!(tokens.get(0), Some(&"what".to_owned()));
+        assert_eq!(tokens.first(), Some(&"what".to_owned()));
         assert_eq!(tokens.get(1), Some(&"are".to_owned()));
         assert_eq!(tokens.get(2), Some(&"you".to_owned()));
         assert_eq!(tokens.get(3), Some(&"waiting".to_owned()));
@@ -259,7 +259,7 @@ mod tests {
         );
         eprintln!("tokens = {tokens:#?}");
         assert_eq!(tokens.len(), 7);
-        assert_eq!(tokens.get(0), Some(&"h".to_owned()));
+        assert_eq!(tokens.first(), Some(&"h".to_owned()));
         assert_eq!(tokens.get(1), Some(&"he".to_owned()));
         assert_eq!(tokens.get(2), Some(&"hel".to_owned()));
         assert_eq!(tokens.get(3), Some(&"hell".to_owned()));

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -378,10 +378,10 @@ fn minimum_bounding_rectangle_for_circle(circle: &GeoRadius) -> GeoBoundingBox {
 }
 
 fn minimum_bounding_rectangle_for_boundary(boundary: &LineString) -> GeoBoundingBox {
-    let mut min_lon = std::f64::MAX;
-    let mut max_lon = std::f64::MIN;
-    let mut min_lat = std::f64::MAX;
-    let mut max_lat = std::f64::MIN;
+    let mut min_lon = f64::MAX;
+    let mut max_lon = f64::MIN;
+    let mut min_lat = f64::MAX;
+    let mut max_lat = f64::MIN;
 
     for point in boundary.coords() {
         if point.x < min_lon {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2287,7 +2287,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.get(0) {
+        let c = match should.first() {
             Some(Condition::Field(c)) => c,
             _ => panic!("Condition::Field expected"),
         };
@@ -2392,7 +2392,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.get(0) {
+        let c = match should.first() {
             Some(Condition::IsEmpty(c)) => c,
             _ => panic!("Condition::IsEmpty expected"),
         };
@@ -2418,7 +2418,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.get(0) {
+        let c = match should.first() {
             Some(Condition::IsNull(c)) => c,
             _ => panic!("Condition::IsNull expected"),
         };
@@ -2458,13 +2458,13 @@ mod tests {
         let filter: Filter = serde_json::from_str(query).unwrap();
         let musts = filter.must.unwrap();
         assert_eq!(musts.len(), 1);
-        match musts.get(0) {
+        match musts.first() {
             Some(Condition::Nested(nested_condition)) => {
                 assert_eq!(nested_condition.raw_key(), "country.cities");
                 assert_eq!(nested_condition.array_key(), "country.cities[]");
                 let nested_musts = nested_condition.filter().must.as_ref().unwrap();
                 assert_eq!(nested_musts.len(), 2);
-                let first_must = nested_musts.get(0).unwrap();
+                let first_must = nested_musts.first().unwrap();
                 match first_must {
                     Condition::Field(c) => {
                         assert_eq!(c.key, "population");

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -191,7 +191,7 @@ mod test {
             let context_part1 = score1.floor();
             let context_part2 = score2.floor();
 
-            assert!(context_part1 == context_part2, "Context part of score isn't equal, score1: {score1}, score2: {score2}");
+            assert_eq!(context_part1, context_part2,"Context part of score isn't equal, score1: {score1}, score2: {score2}");
         }
     }
 }

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -224,7 +224,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     .unwrap()
     .peek_top_iter(&mut [0, 1, 2, 3, 4].iter().cloned(), 2);
 
-    let top_idx = match closest.get(0) {
+    let top_idx = match closest.first() {
         Some(scored_point) => {
             assert_eq!(scored_point.idx, 2);
             scored_point.idx
@@ -256,7 +256,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
     assert_eq!(raw_res1, raw_res2);
 
-    match closest.get(0) {
+    match closest.first() {
         Some(scored_point) => {
             assert_ne!(scored_point.idx, 2);
             assert_eq!(&raw_res1[scored_point.idx as usize], scored_point);

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -823,7 +823,7 @@ fn test_any_matcher_cardinality_estimation() {
         .estimate_cardinality(&filter);
 
     assert_eq!(estimation.primary_clauses.len(), 1);
-    for (_, clause) in estimation.primary_clauses.iter().enumerate() {
+    for clause in estimation.primary_clauses.iter() {
         let expected_primary_clause = any_match.clone();
 
         match clause {

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -39,7 +39,7 @@ fn test_point_exclusion() {
         )
         .unwrap();
 
-    let best_match = res.get(0).expect("Non-empty result");
+    let best_match = res.first().expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
 
     let ids: HashSet<_> = HashSet::from_iter([3.into()]);
@@ -63,7 +63,7 @@ fn test_point_exclusion() {
         )
         .unwrap();
 
-    let best_match = res.get(0).expect("Non-empty result");
+    let best_match = res.first().expect("Non-empty result");
     assert_ne!(best_match.id, 3.into());
 
     let point_ids1: Vec<_> = segment.iter_points().collect();
@@ -98,7 +98,7 @@ fn test_named_vector_search() {
         )
         .unwrap();
 
-    let best_match = res.get(0).expect("Non-empty result");
+    let best_match = res.first().expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
 
     let ids: HashSet<_> = HashSet::from_iter([3.into()]);
@@ -122,7 +122,7 @@ fn test_named_vector_search() {
         )
         .unwrap();
 
-    let best_match = res.get(0).expect("Non-empty result");
+    let best_match = res.first().expect("Non-empty result");
     assert_ne!(best_match.id, 3.into());
 
     let point_ids1: Vec<_> = segment.iter_points().collect();
@@ -181,7 +181,7 @@ fn test_vector_name_not_exists() {
     );
 
     if let Err(OperationError::VectorNameNotExists { received_name }) = result {
-        assert!(received_name == "vector4");
+        assert_eq!(received_name, "vector4");
     } else {
         panic!("wrong upsert result")
     }
@@ -214,7 +214,7 @@ fn ordered_deletion_test() {
             &false.into(),
         )
         .unwrap();
-    let best_match = res.get(0).expect("Non-empty result");
+    let best_match = res.first().expect("Non-empty result");
     assert_eq!(best_match.id, 3.into());
 }
 
@@ -279,7 +279,7 @@ fn test_update_named_vector() {
             &false.into(),
         )
         .unwrap();
-    let nearest_upsert = nearest_upsert.get(0).unwrap();
+    let nearest_upsert = nearest_upsert.first().unwrap();
 
     let sqrt_distance = |v: &[f32]| -> f32 { v.iter().map(|x| x * x).sum::<f32>().sqrt() };
 
@@ -317,7 +317,7 @@ fn test_update_named_vector() {
             &false.into(),
         )
         .unwrap();
-    let nearest_update = nearest_update.get(0).unwrap();
+    let nearest_update = nearest_update.first().unwrap();
 
     // check that nearest_upsert is normalized
     match &nearest_update.vector {

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -201,7 +201,7 @@ mod tests {
             let posting_list = inverted_index_ram.get(&i).unwrap();
             let posting_list = posting_list.elements.as_slice();
             assert_eq!(posting_list.len(), 4);
-            assert_eq!(posting_list.get(0).unwrap().weight, 10.0);
+            assert_eq!(posting_list.first().unwrap().weight, 10.0);
             assert_eq!(posting_list.get(1).unwrap().weight, 20.0);
             assert_eq!(posting_list.get(2).unwrap().weight, 30.0);
             assert_eq!(posting_list.get(3).unwrap().weight, 40.0);
@@ -234,7 +234,7 @@ mod tests {
             let posting_list = inverted_index_ram.get(&i).unwrap();
             let posting_list = posting_list.elements.as_slice();
             assert_eq!(posting_list.len(), 4);
-            assert_eq!(posting_list.get(0).unwrap().weight, 10.0);
+            assert_eq!(posting_list.first().unwrap().weight, 10.0);
             assert_eq!(posting_list.get(1).unwrap().weight, 20.0);
             assert_eq!(posting_list.get(2).unwrap().weight, 30.0);
             assert_eq!(posting_list.get(3).unwrap().weight, 40.0);
@@ -244,7 +244,7 @@ mod tests {
         let postings = inverted_index_ram.get(&30).unwrap();
         let postings = postings.elements.as_slice();
         assert_eq!(postings.len(), 1);
-        let posting = postings.get(0).unwrap();
+        let posting = postings.first().unwrap();
         assert_eq!(posting.record_id, 4);
         assert_eq!(posting.weight, 40.0);
     }


### PR DESCRIPTION
Rust 1.75 is landing on [December 28th](https://blog.rust-lang.org/inside-rust/2023/12/21/1.75.0-prerelease.html) so now is a good time to make sure our CI won't fail on that day.

This PR fixes new clippy lints issues and a bunch of minor reports from RustRover.

The main source of noise is the [get_first lint](https://rust-lang.github.io/rust-clippy/master/index.html#/get_first).