### PR TITLE
Enable debug info in benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,10 @@ inherits = "release"
 lto = false
 opt-level = 0
 
+# Inherits by default from release
 [profile.bench]
 lto = false
+debug = true
 
 # Profile for performance testing, which is faster to build than release.
 [profile.perf]


### PR DESCRIPTION
This PR enables debug information for cargo benchmarks.

I often end up enabling the debug info when profiling benchmarks in order to get more precise flamegraphs and pprof files.


