### PR TITLE
Filed index point-to-values as separate struct

### DIFF
--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -1,0 +1,56 @@
+use std::ops::Range;
+
+use common::types::PointOffsetType;
+
+// Flatten points-to-values map
+#[derive(Debug, Clone, Default)]
+pub struct ImmutablePointToValues<N: Default> {
+    point_to_values: Vec<Range<u32>>,
+    point_to_values_container: Vec<N>,
+}
+
+impl<N: Default> ImmutablePointToValues<N> {
+    pub fn new(src: Vec<Vec<N>>) -> Self {
+        let mut point_to_values: Vec<_> = Default::default();
+        let mut point_to_values_container: Vec<_> = Default::default();
+        for values in src {
+            let values = values.into_iter().collect::<Vec<_>>();
+            let container_len = point_to_values_container.len() as u32;
+            let range = container_len..container_len + values.len() as u32;
+            point_to_values.push(range.clone());
+            point_to_values_container.extend(values);
+        }
+        Self {
+            point_to_values,
+            point_to_values_container,
+        }
+    }
+
+    pub fn get_values(&self, idx: PointOffsetType) -> Option<&[N]> {
+        let range = self.point_to_values.get(idx as usize)?.clone();
+        let range = range.start as usize..range.end as usize;
+        Some(&self.point_to_values_container[range])
+    }
+
+    pub fn remove_point(&mut self, idx: PointOffsetType) -> usize {
+        if self.point_to_values.len() <= idx as usize {
+            return 0;
+        }
+
+        // Point removing has to remove `idx` from both maps: points-to-values and values-to-points.
+        // The first one is easy: we just remove the entry from the map.
+        // The second one is more complicated: we have to remove all mentions of `idx` in values-to-points map.
+        // To deal with it, take old values from points-to-values map, witch contains all values with `idx` in values-to-points map.
+
+        let removed_values_range = self.point_to_values[idx as usize].clone();
+        let removed_values_count = removed_values_range.len();
+        self.point_to_values[idx as usize] = Default::default();
+
+        // Iterate over all values which were removed from points-to-values map
+        for value_index in removed_values_range {
+            self.point_to_values_container[value_index as usize] = Default::default();
+        }
+
+        removed_values_count
+    }
+}

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -5,7 +5,7 @@ use common::types::PointOffsetType;
 // Flatten points-to-values map
 // It's an analogue of `Vec<Vec<N>>` but more RAM efficient because it stores values in a single Vec.
 // This structure doesn't support adding new values, only removing.
-// It's used in immutable field indices like ImmutableMapIndex, ImmutableNumericIndex, ect to store points-to-values map.
+// It's used in immutable field indices like ImmutableMapIndex, ImmutableNumericIndex, etc to store points-to-values map.
 #[derive(Debug, Clone, Default)]
 pub struct ImmutablePointToValues<N: Default> {
     // ranges in `point_to_values_container` which contains values for each point

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -32,25 +32,25 @@ impl<N: Default> ImmutablePointToValues<N> {
         Some(&self.point_to_values_container[range])
     }
 
-    pub fn remove_point(&mut self, idx: PointOffsetType) -> usize {
+    pub fn remove_point(&mut self, idx: PointOffsetType) -> Vec<N> {
         if self.point_to_values.len() <= idx as usize {
-            return 0;
+            return Default::default();
         }
 
         // Point removing has to remove `idx` from both maps: points-to-values and values-to-points.
         // The first one is easy: we just remove the entry from the map.
         // The second one is more complicated: we have to remove all mentions of `idx` in values-to-points map.
         // To deal with it, take old values from points-to-values map, witch contains all values with `idx` in values-to-points map.
-
         let removed_values_range = self.point_to_values[idx as usize].clone();
-        let removed_values_count = removed_values_range.len();
         self.point_to_values[idx as usize] = Default::default();
 
         // Iterate over all values which were removed from points-to-values map
+        let mut result = Vec::with_capacity(removed_values_range.len());
         for value_index in removed_values_range {
-            self.point_to_values_container[value_index as usize] = Default::default();
+            let value = std::mem::take(&mut self.point_to_values_container[value_index as usize]);
+            result.push(value);
         }
 
-        removed_values_count
+        result
     }
 }

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -5,7 +5,7 @@ use common::types::PointOffsetType;
 // Flatten points-to-values map
 // It's an analogue of `Vec<Vec<N>>` but more RAM efficient because it stores values in a single Vec.
 // This structure doesn't support adding new values, only removing.
-// It's used in immutable field indices like ImmutableMapIndex, ImmutableNumericIndex, etc to store points-to-values map.
+// It's used in immutable field indices like `ImmutableMapIndex`, `ImmutableNumericIndex`, etc to store points-to-values map.
 #[derive(Debug, Clone, Default)]
 pub struct ImmutablePointToValues<N: Default> {
     // ranges in `point_to_values_container` which contains values for each point
@@ -55,5 +55,47 @@ impl<N: Default> ImmutablePointToValues<N> {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_immutable_point_to_values_remove() {
+        let mut values = vec![
+            vec![0, 1, 2, 3, 4],
+            vec![5, 6, 7, 8, 9],
+            vec![0, 1, 2, 3, 4],
+            vec![5, 6, 7, 8, 9],
+            vec![10, 11, 12],
+            vec![],
+            vec![13],
+            vec![14, 15],
+        ];
+
+        let mut point_to_values = ImmutablePointToValues::new(values.clone());
+
+        let check = |point_to_values: &ImmutablePointToValues<_>, values: &[Vec<_>]| {
+            for (idx, values) in values.iter().enumerate() {
+                assert_eq!(
+                    point_to_values.get_values(idx as PointOffsetType),
+                    Some(values.as_slice()),
+                );
+            }
+        };
+
+        check(&point_to_values, &values);
+
+        point_to_values.remove_point(0);
+        values[0].clear();
+
+        check(&point_to_values, &values);
+
+        point_to_values.remove_point(3);
+        values[3].clear();
+
+        check(&point_to_values, &values);
     }
 }

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -18,10 +18,10 @@ pub struct ImmutablePointToValues<N: Default> {
 
 impl<N: Default> ImmutablePointToValues<N> {
     pub fn new(src: Vec<Vec<N>>) -> Self {
-        let mut point_to_values: Vec<_> = Default::default();
-        let mut point_to_values_container: Vec<_> = Default::default();
+        let mut point_to_values = Vec::with_capacity(src.len());
+        let all_values_count = src.iter().fold(0, |acc, values| acc + values.len());
+        let mut point_to_values_container = Vec::with_capacity(all_values_count);
         for values in src {
-            let values = values.into_iter().collect::<Vec<_>>();
             let container_len = point_to_values_container.len() as u32;
             let range = container_len..container_len + values.len() as u32;
             point_to_values.push(range.clone());

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -122,6 +122,11 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
+            if !removed_values.is_empty() {
+                self.indexed_points -= 1;
+            }
+            self.values_count -= removed_values.len();
+
             for value in removed_values {
                 Self::remove_idx_from_value_list(
                     &mut self.value_to_points,

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -43,7 +43,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
     /// Return mutable slice of a container which holds point_ids for given value.
     fn get_mut_point_ids_slice<'a>(
         value_to_points: &mut HashMap<N, Range<u32>>,
-        value_to_points_container: &'a mut Vec<PointOffsetType>,
+        value_to_points_container: &'a mut [PointOffsetType],
         value: &N,
     ) -> Option<&'a mut [PointOffsetType]> {
         match value_to_points.get(value) {
@@ -95,7 +95,7 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> ImmutableMapIndex<N> {
     /// value_to_points_container -> [0, 1, 2, 4, (3), 5, 6, 7, 8, 9]
     fn remove_idx_from_value_list(
         value_to_points: &mut HashMap<N, Range<u32>>,
-        value_to_points_container: &mut Vec<PointOffsetType>,
+        value_to_points_container: &mut [PointOffsetType],
         value: &N,
         idx: PointOffsetType,
     ) {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -29,7 +29,7 @@ use crate::types::{
     PayloadKeyType, ValueVariants,
 };
 
-pub enum MapIndex<N: Hash + Eq + Clone + Display + FromStr> {
+pub enum MapIndex<N: Hash + Eq + Clone + Display + FromStr + Default> {
     Mutable(MutableMapIndex<N>),
     Immutable(ImmutableMapIndex<N>),
 }

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -9,6 +9,7 @@ pub mod full_text_index;
 pub mod geo_hash;
 pub mod geo_index;
 mod histogram;
+mod immutable_point_to_values;
 pub mod index_selector;
 pub mod map_index;
 pub mod numeric_index;

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -263,6 +263,10 @@ impl<T: Encodable + Numericable + Default> ImmutableNumericIndex<T> {
 
     pub(super) fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
+            if !removed_values.is_empty() {
+                self.points_count -= 1;
+            }
+
             for value in removed_values {
                 let key = NumericIndexKey::new(*value, idx);
                 Self::remove_from_map(&mut self.map, &mut self.histogram, key);

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -80,12 +80,12 @@ impl Encodable for FloatPayloadType {
     }
 }
 
-pub enum NumericIndex<T: Encodable + Numericable> {
+pub enum NumericIndex<T: Encodable + Numericable + Default> {
     Mutable(MutableNumericIndex<T>),
     Immutable(ImmutableNumericIndex<T>),
 }
 
-impl<T: Encodable + Numericable> NumericIndex<T> {
+impl<T: Encodable + Numericable + Default> NumericIndex<T> {
     pub fn new(db: Arc<RwLock<DB>>, field: &str, is_appendable: bool) -> Self {
         if is_appendable {
             NumericIndex::Mutable(MutableNumericIndex::new(db, field))
@@ -248,7 +248,7 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
     }
 }
 
-impl<T: Encodable + Numericable> PayloadFieldIndex for NumericIndex<T> {
+impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T> {
     fn count_indexed_points(&self) -> usize {
         self.get_points_count()
     }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -21,7 +21,7 @@ pub struct MutableNumericIndex<T: Encodable + Numericable> {
     pub(super) point_to_values: Vec<Vec<T>>,
 }
 
-impl<T: Encodable + Numericable> MutableNumericIndex<T> {
+impl<T: Encodable + Numericable + Default> MutableNumericIndex<T> {
     pub fn new(db: Arc<RwLock<DB>>, field: &str) -> Self {
         let store_cf_name = NumericIndex::<T>::storage_cf_name(field);
         let db_wrapper = DatabaseColumnWrapper::new(db, &store_cf_name);

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -376,7 +376,7 @@ fn test_numeric_index(#[case] immutable: bool) {
     );
 }
 
-fn test_cond<T: Encodable + Numericable + PartialOrd + Clone>(
+fn test_cond<T: Encodable + Numericable + PartialOrd + Clone + Default>(
     index: &NumericIndex<T>,
     rng: Range,
     result: Vec<u32>,


### PR DESCRIPTION
`ImmutableMapIndex` and `ImmutableNumericIndex` have a similar pattern for mapping from point id to values. This pattern is a flattened `Vec<Vec<_>>` structure.

Because geo index will use the same pattern too, I find it important to separate this pattern to avoid logic copying.

`ImmutablePointToValues` is a flattened representation of `Vec<Vec<_>>` with deletion.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
