### PR TITLE
If we cannot render a progress bar, fall back to text

### DIFF
--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use common::panic;
@@ -47,6 +48,9 @@ use crate::update_handler::{Optimizer, UpdateHandler, UpdateSignal};
 use crate::wal::SerdeWal;
 
 pub type LockedWal = Arc<ParkingMutex<SerdeWal<CollectionUpdateOperations>>>;
+
+/// If rendering WAL load progression in basic text form, report progression every 60 seconds.
+const WAL_LOAD_REPORT_EVERY: Duration = Duration::from_secs(60);
 
 /// LocalShard
 ///
@@ -454,6 +458,7 @@ impl LocalShard {
 
         // Fall back to basic text output if the progress bar is hidden (e.g. not a tty)
         let show_progress_bar = !bar.is_hidden();
+        let mut last_progress_report = Instant::now();
         if !show_progress_bar {
             log::info!(
                 "Recovering collection {collection_id}: 0/{} (0%)",
@@ -502,16 +507,17 @@ impl LocalShard {
                 Ok(_) => (),
             }
 
-            // Update progress bar or show text progress every 100 operations
+            // Update progress bar or show text progress every WAL_LOAD_REPORT_EVERY
             let progress = i as u64 + 1;
             bar.set_position(progress);
-            if !show_progress_bar && progress % 100 == 0 {
+            if !show_progress_bar && last_progress_report.elapsed() >= WAL_LOAD_REPORT_EVERY {
                 log::info!(
                     "{}/{} ({}%)",
                     progress,
                     wal.len(),
                     (progress as f32 / wal.len() as f32 * 100.0) as usize,
                 );
+                last_progress_report = Instant::now();
             }
         }
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -455,7 +455,7 @@ impl LocalShard {
         // Fall back to basic text output if the progress bar is hidden (e.g. not a tty)
         let show_progress_bar = !bar.is_hidden();
         if !show_progress_bar {
-            eprintln!(
+            log::info!(
                 "Recovering collection {collection_id}: 0/{} (0%)",
                 wal.len(),
             );
@@ -506,7 +506,7 @@ impl LocalShard {
             let progress = i as u64 + 1;
             bar.set_position(progress);
             if !show_progress_bar && progress % 100 == 0 {
-                eprintln!(
+                log::info!(
                     "{}/{} ({}%)",
                     progress,
                     wal.len(),
@@ -519,7 +519,7 @@ impl LocalShard {
 
         bar.finish();
         if !show_progress_bar {
-            eprintln!(
+            log::info!(
                 "Recovered collection {collection_id}: {0}/{0} (100%)",
                 wal.len(),
             );

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -479,7 +479,7 @@ impl LocalShard {
         // (`SerdeWal::read_all` may even start reading WAL from some already truncated
         // index *occasionally*), but the storage can handle it.
 
-        for (i, (op_num, update)) in wal.read_all().enumerate() {
+        for (op_num, update) in wal.read_all() {
             // Propagate `CollectionError::ServiceError`, but skip other error types.
             match &CollectionUpdater::update(segments, op_num, update) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {
@@ -508,12 +508,11 @@ impl LocalShard {
             }
 
             // Update progress bar or show text progress every WAL_LOAD_REPORT_EVERY
-            let progress = i as u64 + 1;
-            bar.set_position(progress);
+            bar.inc(1);
             if !show_progress_bar && last_progress_report.elapsed() >= WAL_LOAD_REPORT_EVERY {
+                let progress = bar.position();
                 log::info!(
-                    "{}/{} ({}%)",
-                    progress,
+                    "{progress}/{} ({}%)",
                     wal.len(),
                     (progress as f32 / wal.len() as f32 * 100.0) as usize,
                 );


### PR DESCRIPTION
During collection recovery, we normally show a progress bar as part of recovering the WAL. This is useful information because this step can take a very long time if it contains expensive operations.

The progress bar is not rendered if the output is non-interactive, making it hidden. This is what happens on our cloud, making it very hard to determine whether a long recovery is going on or not.

This PR adds a fall back to render the current progression in text:

```
2024-01-02T16:35:25.606991Z  INFO collection::shards::local_shard: Recovering collection benchmark: 0/749 (0%)
2024-01-02T16:35:25.824195Z  INFO collection::shards::local_shard: 100/749 (13%)
2024-01-02T16:35:26.048062Z  INFO collection::shards::local_shard: 200/749 (26%)
2024-01-02T16:35:26.273770Z  INFO collection::shards::local_shard: 300/749 (40%)
2024-01-02T16:35:26.492999Z  INFO collection::shards::local_shard: 400/749 (53%)
2024-01-02T16:35:27.647663Z  INFO collection::shards::local_shard: 500/749 (66%)
2024-01-02T16:35:28.996474Z  INFO collection::shards::local_shard: 600/749 (80%)
2024-01-02T16:35:30.356724Z  INFO collection::shards::local_shard: 700/749 (93%)
2024-01-02T16:35:31.400845Z  INFO collection::shards::local_shard: Recovered collection benchmark: 749/749 (100%)
```

This prints the progression through `log::info!()`. Alternatively we could use `eprintln!();` but info logging may be nicer as it also includes timestamps.

Since this is the only one place we use a progress bar I kept the implementation simple and skipped the idea of building a fancy wrapper for it.

I've tested this by running Qdrant through `ssh -T localhost "./qdrant"`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?