### PR TITLE
Avoid logging `/healthz`, `/readyz`, `/livez` in access logs

### DIFF
--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -125,11 +125,14 @@ pub fn init(
                 ))
                 .wrap(Condition::new(settings.service.enable_cors, cors))
                 .wrap(
-                    // Set up logger, but avoid logging health checks, metrics and telemetry
+                    // Set up logger, but avoid logging hot status endpoints
                     Logger::default()
                         .exclude("/")
                         .exclude("/metrics")
-                        .exclude("/telemetry"),
+                        .exclude("/telemetry")
+                        .exclude("/healthz")
+                        .exclude("/readyz")
+                        .exclude("/livez"),
                 )
                 .wrap(actix_telemetry::ActixTelemetryTransform::new(
                     actix_telemetry_collector.clone(),


### PR DESCRIPTION
Extension to <https://github.com/qdrant/qdrant/pull/3257>.

Avoid logging `/healthz`, `/readyz` and `/livez` in access logs because it can be quite noisy.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?