### PR TITLE
Remove one usage of `async-trait`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4841,7 +4841,6 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",
- "async-trait",
  "atomicwrites",
  "cancel",
  "chrono",

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"] }
 itertools = "0.12"
-async-trait = "0.1.75"
 log = "0.4"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 http = "0.2"

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use collection::collection::Collection;
 use collection::shards::CollectionId;
 
@@ -8,7 +7,6 @@ use crate::content_manager::errors::StorageError;
 
 pub type Collections = HashMap<CollectionId, Collection>;
 
-#[async_trait]
 pub trait Checker {
     fn is_collection_exists(&self, collection_name: &str) -> bool;
 


### PR DESCRIPTION
Since Rust 1.75 we can remove this usage of [`async-trait`](https://docs.rs/async-trait/latest/async_trait/).

We still have some other usages left but we cannot remove those due to other constraints and due to code generation including them.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?