### PR TITLE
Set MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.75"
 default-run = "qdrant"
 
 [features]


### PR DESCRIPTION
This [sets](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) our MSRV to 1.75 in `Cargo.toml`, which is now our minimum version since merging <https://github.com/qdrant/qdrant/pull/3314>.

It will inform users with an outdated toolchain when trying to compile:

```bash
$ cargo +1.74.0 build
error: package `qdrant v0.11.1 (/home/timvisee/git/qdrant)` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.0
```

We could also list the MSRV as requirement in our README, but I think it's easy to miss if we change it again. The above is probably good enough to prevent users being confused about it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?