### PR TITLE
fix: Prune containers and volumes in self-hosted gh runner

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -27,4 +27,6 @@ jobs:
             # Pull, retag and push to GitHub packages
             docker buildx build --platform='linux/amd64,linux/arm64' $GITHUB_TAG --push --label "org.opencontainers.image.revision"=${{ github.sha }} .
             
-            docker buildx prune -a -f --filter until=12h
+            docker container rm -f $(docker container ls -qf "name=buildx_buildkit")
+            docker volume rm $(docker volume ls -qf "name=buildx_buildkit")
+


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This should fix the bloating of disk in our self hosted GH runner