### PR TITLE
Synchronize nodes after collection creation

### DIFF
--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -126,7 +126,7 @@ impl Dispatcher {
                         AliasOperations::DeleteAlias(_) => false,
                     })
                 }
-                // Do not sync nodes for other operations
+                // No need to sync nodes for other operations
                 CollectionMetaOperations::UpdateCollection(_)
                 | CollectionMetaOperations::DeleteCollection(_)
                 | CollectionMetaOperations::TransferShard(_, _)
@@ -155,7 +155,7 @@ impl Dispatcher {
                 }
             }
 
-            // On create operations, synchronize all nodes to ensure all are ready for point operations
+            // On some operations, synchronize all nodes to ensure all are ready for point operations
             if do_sync_nodes {
                 let remaining_timeout =
                     wait_timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -132,7 +132,7 @@ impl Dispatcher {
                 }
             }
 
-            // Synchronize all nodes, so that all are ready for follow-up operations
+            // Synchronize all nodes, so that all are ready for point operations on this collection
             let remaining_timeout =
                 wait_timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));
             if let Err(err) = self.await_consensus_sync(remaining_timeout).await {

--- a/src/actix/api/shards_api.rs
+++ b/src/actix/api/shards_api.rs
@@ -39,15 +39,6 @@ async fn create_shard_key(
     )
     .await;
 
-    let response = if response.is_ok() {
-        match dispatcher.await_consensus_sync(wait_timeout).await {
-            Ok(_) => response,
-            Err(x) => Err(x),
-        }
-    } else {
-        response
-    };
-
     process_response(response, timing)
 }
 

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -243,11 +243,6 @@ impl Collections for CollectionsService {
         .await
         .map_err(error_to_status)?;
 
-        self.dispatcher
-            .await_consensus_sync(timeout)
-            .await
-            .map_err(error_to_status)?;
-
         Ok(Response::new(CreateShardKeyResponse { result }))
     }
 

--- a/tests/consensus_tests/test_collection_creation_after_dropping.py
+++ b/tests/consensus_tests/test_collection_creation_after_dropping.py
@@ -46,6 +46,9 @@ def test_collection_creation_after_dropping(tmp_path: pathlib.Path):
     r = requests.put(
         f"{peer_api_uris[randrange(N_PEERS)]}/collections/test_collection",
         json=COLLECTION_CONFIG,
+        # Collection creation is expensive, give very busy CI machines 20 extra
+        # seconds for creating them in cluster mode to prevent flakiness
+        params={"timeout": 30},
     )
     assert_http_ok(r)
 
@@ -60,6 +63,10 @@ def test_collection_creation_after_dropping(tmp_path: pathlib.Path):
         r = requests.put(
             f"{peer_api_uris[randrange(N_PEERS)]}/collections/test_collection",
             json=COLLECTION_CONFIG,
+            # Collection creation is expensive, give very busy CI machines 20
+            # extra seconds for creating them in cluster mode to prevent
+            # flakiness
+            params={"timeout": 30},
         )
         assert_http_ok(r)
 


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/2616>, <https://github.com/qdrant/qdrant/issues/3254>.

After creating a collection in distributed mode, synchronize all nodes. This ensures the collection is ready on all nodes for follow-up operations such as upsertions.

If we don't do this, upserting into the collection on another node can fail as it may still be setting things up.

When synchronization fails a warning is reported and the collection creation call returns as if it was successful. This can happen if a node is unreachable during that time. This is better than failing, because this will eventually resolve itself and firing the same call another time will result in a 'already exists' error.

We don't have to do this for collection deletion, as it is unlikely that we expect follow-up operations on a collection right after deleting it as it should be gone. If we do, they'll fail eventually.

This change also fixes the above linked flaky test. I've extensively tested this locally with all scenarios I can think of to confirm this. Running the test 1000 times locally didn't trigger the error anymore.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?