### PR TITLE
Fix consensus operations not proposed if already listening to result

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -556,7 +556,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             match on_apply_lock.get(&operation) {
                 Some(listener) => {
                     // subscribe to existing sender for faster feedback
-                    receiver = listener.on_apply.subscribe()
+                    receiver = listener.on_apply.subscribe();
                 }
                 None => {
                     // insert new listener
@@ -675,7 +675,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                     }
 
                     // subscribe to existing sender for faster feedback
-                    receiver = listener.on_apply.subscribe()
+                    receiver = listener.on_apply.subscribe();
                 }
                 None => {
                     // propose operation to consensus thread
@@ -686,8 +686,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             };
         }
 
-        let res = Self::await_receiver(receiver, wait_timeout).await?;
-        Ok(res)
+        Self::await_receiver(receiver, wait_timeout).await
     }
 
     pub fn peer_address_by_id(&self) -> PeerAddressById {


### PR DESCRIPTION
We have two important consensus methods:
1. `propose_consensus_op_with_await()`: propose new operation and listen for operation result
2. `await_for_multiple_operations()`: listen for operation result (without proposing)

With our current implementation, just listening <sup>(2)</sup> for an operation result prevents it from being proposed <sup>(1)</sup> after. That is because creating the notification channel for just listening makes the proposal method assume that the operation has already been proposed.

In code, if we are already listening for an operation result, we cannot propose the operation here because we subscribe on an _existing sender_: https://github.com/qdrant/qdrant/blob/c6a351c82d57eb786b75dac785de7b085c6f80ff/lib/storage/src/content_manager/consensus_manager.rs#L667-L681

This PR fixes this problem. We track the 'proposed' status in a boolean. If we didn't propose yet while trying to do so, we propose and flip the boolean.

I did not find immediate problems caused by this in our current code base, though I'm unsure about edge cases. It appears that we sometimes do listen without proposing first, but for these all seems to work fine according to our tests. I did hit this bug with some testing code though, causing waiting forever. I decided to make this patch in an attempt to prevent issues with it in the future, these are painful to debug.

An alternative is to add a strong warning `await_for_multiple_operations()` mentioning that awaiting can break further proposals.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?