### PR TITLE
feat: debian package build step

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,6 +43,20 @@ jobs:
           bin: qdrant
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Debian Package
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          cargo install cargo-deb
+          cargo deb --no-strip --target ${{ matrix.target }}
+      - name: Upload Debian package
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.target }}/debian/*.deb
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
 
   build-mac-binaries:
     strategy:


### PR DESCRIPTION
This PR adds build step for Debian package.

[Release](https://github.com/neo773/qdrant/releases/tag/v1.7.10)
[CI Run](https://github.com/neo773/qdrant/actions/runs/7434325055/job/20228354047#step:7:146)

<img width="575" alt="image" src="https://github.com/qdrant/qdrant/assets/62795688/df6e65e8-cbeb-463c-be05-22af468fdbe0">

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


/claim #3335