### PR TITLE
Optimize inverted index search by tracking min record ids

### DIFF
--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -70,6 +70,16 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     pub fn is_empty(&self) -> bool {
         self.heap.is_empty()
     }
+
+    /// Returns the smallest element in the queue
+    pub fn peek(&self) -> Option<&T> {
+        self.heap.peek().map(|x| &x.0)
+    }
+
+    /// Removes the smallest element in the queue
+    pub fn pop(&mut self) -> Option<T> {
+        self.heap.pop().map(|Reverse(x)| x)
+    }
 }
 
 pub struct Iter<'a, T> {


### PR DESCRIPTION
This PR optimizes the sparse vector search.

One short-coming of the current implementation is that it recomputes continuously the min record ids across posting lists to know how to advance the cursors.

This PR proposes to track the min records ids across all posting lists in a min-heap to avoid performing extra work.

It yields a 20% performance improvement.

```
sparse-vector-search-group/inverted-index-search
                        time:   [23.966 ms 24.069 ms 24.180 ms]
                        change: [-21.418% -20.990% -20.558%] (p = 0.00 < 0.05)
                        Performance has improved.
```
