### PR TITLE
Check cancellation after filtering condition to speedup filtered sparse search

### DIFF
--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -208,13 +208,13 @@ impl<'a> SearchContext<'a> {
         }
         let mut best_min_score = f32::MIN;
         while let Some(candidate) = self.advance() {
-            // check for cancellation
-            if self.is_stopped.load(Relaxed) {
-                break;
-            }
             // check filter condition
             if !filter_condition(candidate.idx) {
                 continue;
+            }
+            // check for cancellation
+            if self.is_stopped.load(Relaxed) {
+                break;
             }
             // push candidate to result queue
             self.result_queue.push(candidate);


### PR DESCRIPTION
This PR is a low hanging fruit for filtered search on sparse vector search.

For the case where no index is present for the payload, a high number of candidate will be discarded by the filtering condition.

Given that the request cancellation shows up in profiling, it makes sense to perform the filtering check first in order to shortcut the iteration.

This yields a 2% performance improvement almost for free.

```
sparse-vector-search-group/inverted-index-filtered-plain
                        time:   [277.97 ms 278.39 ms 278.79 ms]
                        change: [-2.4829% -2.2152% -1.9612%] (p = 0.00 < 0.05)
                        Performance has improved.
```