### PR TITLE
Faster inverted index with minheap traversal

### DIFF
--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -111,7 +111,16 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
                 .filter(|s| s.score != 0.0)
                 .zip(no_filter_result.iter().filter(|s| s.score != 0.0))
             {
-                assert_eq!(filter_result, no_filter_result);
+                assert_eq!(filter_result.idx, no_filter_result.idx);
+                // the scores between search and plain search can be slightly different due to different order in which points are processed
+                let score_error = (filter_result.score - no_filter_result.score).abs();
+                assert!(
+                    score_error < 0.01,
+                    "query = {:#?}, filter_result = {:#?} no_filter_result = {:#?}",
+                    query,
+                    filter_result,
+                    no_filter_result,
+                );
             }
         }
     }

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -196,6 +196,11 @@ impl<'a> PostingListIterator<'a> {
         self.elements.get(self.current_index)
     }
 
+    /// Returns the next element *without* bounds checking.
+    pub fn get_unchecked(&self) -> &PostingElement {
+        unsafe { self.elements.get_unchecked(self.current_index) }
+    }
+
     /// Returns the number of elements from the current position to the end of the list.
     pub fn len_to_end(&self) -> usize {
         self.elements.len() - self.current_index

--- a/tests/consensus_tests/test_sparse_points_search.py
+++ b/tests/consensus_tests/test_sparse_points_search.py
@@ -6,7 +6,8 @@ from .assertions import assert_http_ok
 
 N_PEERS = 5
 N_SHARDS = 4
-N_REPLICA = 2
+N_REPLICA = 1  # replicas introduces non-determinism in sparse scores
+
 
 def test_sparse_points_search(tmp_path: pathlib.Path):
     assert_project_root()


### PR DESCRIPTION
This PR builds on top of https://github.com/qdrant/qdrant/pull/3347 to go even faster.

The key insight is that it is unnecessary to constantly probe all posting list for finding the ones that should be explored.

By leveraging the previously introduced min-heap to drive the search, we can access directly the right positing lists.

### Performance

This brings a a large performance improvement to the criterion benchmarks.
Those are using 50k indexed sparse vectors with around 300 dimensions with a max dimension of 30k.

```
sparse-vector-search-group/mmap-inverted-index-search
                        time:   [8.7720 ms 8.7792 ms 8.7891 ms]
                        change: [-72.942% -72.337% -71.780%] (p = 0.00 < 0.05)
                        Performance has improved.

sparse-vector-search-group/inverted-index-search
                        time:   [10.112 ms 10.142 ms 10.174 ms]
                        change: [-66.641% -66.489% -66.342%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### Notes

1. Given that the posting list cannot be re-ordered anymore, the logic to decide which posting to prune has been changed to target any postings which has the lowest unique min record id. But the pruning logic as not changed.

2. The score seems to not be completely equivalent due to the change of order for float multiplication.

3. I have verified that the python client congruence tests are still green with this change.