### PR TITLE
Handle empty sparse vector search

### DIFF
--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -282,6 +282,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         is_stopped: &AtomicBool,
         prefiltered_points: &mut Option<Vec<PointOffsetType>>,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
+        if vector.is_empty() {
+            return Ok(vec![]);
+        }
         let mut vector = vector.clone();
         vector.sort_by_indices();
 


### PR DESCRIPTION
With https://github.com/qdrant/qdrant/pull/3347 we introduced a new min-heap to track the min record id.

This min-heap expects to be sized with a non-zero capacity otherwise it panics.

This PR makes sure that this situation cannot occur by:
- protecting the search context at construction time
- filtering empty search query vectors at the sparse vector index level 