### PR TITLE
Fix docker on windows snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,7 +5653,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?branch=copy-wal-files-using-memcpy#0dd89b794f462baa616fb8c0685348f43ae6f3a0"
+source = "git+https://github.com/qdrant/wal.git?branch=copy-wal-files-using-memcpy#4cae86c8baa0042452e57e693664c4671f296465"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,7 +5653,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=fad0e7c48be58d8e7db4cc739acd9b1cf6735de0#fad0e7c48be58d8e7db4cc739acd9b1cf6735de0"
+source = "git+https://github.com/qdrant/wal.git?branch=copy-wal-files-using-memcpy#0dd89b794f462baa616fb8c0685348f43ae6f3a0"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,7 +5653,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?branch=copy-wal-files-using-memcpy#4cae86c8baa0042452e57e693664c4671f296465"
+source = "git+https://github.com/qdrant/wal.git?rev=3f69dff6f32809e804293aa202f82f04323649ab#3f69dff6f32809e804293aa202f82f04323649ab"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ clap = { version = "4.4.14", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 uuid = { version = "1.6", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "3f69dff6f32809e804293aa202f82f04323649ab" }
 
 config = "~0.13.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ clap = { version = "4.4.14", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 uuid = { version = "1.6", features = ["v4", "serde"] }
 sys-info = "0.9.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
 
 config = "~0.13.4"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "3f69dff6f32809e804293aa202f82f04323649ab" }
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "~1.0", features = ["std"] }
 serde_cbor = "0.11.2"
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0"}
+wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -685,7 +685,7 @@ impl LocalShard {
         let wal_path = LocalShard::wal_path(snapshot_shard_path);
         fs_extra::dir::create(&wal_path, true).map_err(|err| {
             CollectionError::service_error(format!(
-                "Error while creating directory for WAL shapshot {wal_path:?} {err}"
+                "Error while creating directory for WAL snapshot {wal_path:?} {err}"
             ))
         })?;
 

--- a/lib/collection/src/shards/local_shard.rs
+++ b/lib/collection/src/shards/local_shard.rs
@@ -685,13 +685,7 @@ impl LocalShard {
         // lock wal during snapshot
         let mut wal_guard = wal.lock();
         wal_guard.flush()?;
-        let source_wal_path = wal_guard.path();
-        let options = fs_extra::dir::CopyOptions::new();
-        fs_extra::dir::copy(source_wal_path, snapshot_shard_path, &options).map_err(|err| {
-            CollectionError::service_error(format!(
-                "Error while copy WAL {snapshot_shard_path:?} {err}"
-            ))
-        })?;
+        wal_guard.save_to_path(snapshot_shard_path)?;
         Ok(())
     }
 

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -229,12 +229,12 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         self.options.segment_capacity
     }
 
-    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    pub fn copy_to_path<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
         self.wal
-            .save_to_path(path)
+            .copy_to_path(path)
             .map_err(|err| WalError::WriteWalError(format!("failed to save WAL to path: {err:?}")))
     }
 }

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -228,6 +228,15 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     pub fn segment_capacity(&self) -> usize {
         self.options.segment_capacity
     }
+
+    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.wal
+            .save_to_path(path)
+            .map_err(|err| WalError::WriteWalError(format!("failed to save WAL to path: {err:?}")))
+    }
 }
 
 #[cfg(test)]

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.10.1"
 num_cpus = "1.16"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "3f69dff6f32809e804293aa202f82f04323649ab" }
 tokio = { version = "~1.35", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.10.1"
 num_cpus = "1.16"
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
+wal = { git = "https://github.com/qdrant/wal.git", branch = "copy-wal-files-using-memcpy" }
 tokio = { version = "~1.35", features = ["rt-multi-thread"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"


### PR DESCRIPTION
Fix of https://github.com/qdrant/qdrant/issues/2620

To reproduce this bug, qdrant must be started on docker on windows with mounted ntfs filesystem. Taking snapshots does not work because wal mmapped files are locked. To fix it, it was added new copy function into WAL:
https://github.com/qdrant/wal/pull/68

Taking snapshot is covered by unit tests so there are no new unit tests. Tested that this PR fixes a bug locally.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
