### PR TITLE
add support for f16 in lib/segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -1376,6 +1376,12 @@ checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -2086,6 +2092,20 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+]
 
 [[package]]
 name = "hash32"
@@ -4506,6 +4526,7 @@ dependencies = [
  "futures",
  "geo",
  "geohash",
+ "half 2.3.1",
  "io",
  "io-uring",
  "itertools 0.12.0",
@@ -4579,7 +4600,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.2",
  "serde",
 ]
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -9,9 +9,11 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
+default = ["use_f32"]
 multiling-chinese = ["charabia/chinese"]
 multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
+use_f32 = []
 
 [dev-dependencies]
 criterion = "0.5"
@@ -72,6 +74,7 @@ memory = { path = "../common/memory" }
 sparse = { path = "../sparse" }
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
+half = { version = "2.3.1", features = ["num-traits", "rand_distr", "serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -21,7 +21,8 @@ use crate::vector_storage::{
 };
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
-    (0..size).map(|_| rnd_gen.gen_range(-1.0..1.0)).collect()
+    let one = num_traits::identities::one::<VectorElementType>();
+    (0..size).map(|_| rnd_gen.gen_range(-one..one)).collect()
 }
 
 pub struct FakeFilterContext {}

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -415,6 +415,7 @@ mod tests {
         assert_eq!(res1, res2)
     }
 
+    #[cfg_attr(not(feature = "use_f32"), ignore)] // FIXME: disabled due to rounding errors
     #[test]
     fn test_add_points() {
         let num_vectors = 1000;

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -86,6 +86,7 @@ mod tests {
     use crate::common::operation_error::OperationError;
     use crate::data_types::vectors::only_default_vector;
     use crate::entry::entry_point::SegmentEntry;
+    use crate::segment::vector;
 
     #[test]
     fn test_create_simple_segment() {
@@ -99,13 +100,13 @@ mod tests {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
 
-        let wrong_vec = vec![1.0, 1.0, 1.0];
+        let wrong_vec = vector![1.0, 1.0, 1.0];
 
-        let vec1 = vec![1.0, 0.0, 1.0, 1.0];
-        let vec2 = vec![1.0, 0.0, 1.0, 0.0];
-        let vec3 = vec![1.0, 1.0, 1.0, 1.0];
-        let vec4 = vec![1.0, 1.0, 0.0, 1.0];
-        let vec5 = vec![1.0, 0.0, 0.0, 0.0];
+        let vec1 = vector![1.0, 0.0, 1.0, 1.0];
+        let vec2 = vector![1.0, 0.0, 1.0, 0.0];
+        let vec3 = vector![1.0, 1.0, 1.0, 1.0];
+        let vec4 = vector![1.0, 1.0, 0.0, 1.0];
+        let vec5 = vector![1.0, 0.0, 0.0, 0.0];
 
         match segment.upsert_point(1, 120.into(), only_default_vector(&wrong_vec)) {
             Err(OperationError::WrongVector { .. }) => (),

--- a/lib/segment/src/spaces/mod.rs
+++ b/lib/segment/src/spaces/mod.rs
@@ -2,11 +2,11 @@ pub mod metric;
 pub mod simple;
 pub mod tools;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
 pub mod simple_sse;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
 pub mod simple_avx;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
 pub mod simple_neon;

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -1,22 +1,27 @@
 use common::types::ScoreType;
+#[cfg(not(feature = "use_f32"))]
+use num_traits::Float as _;
 
 use super::metric::Metric;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
 use super::simple_avx::*;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
 use super::simple_neon::*;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
 use super::simple_sse::*;
 use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
 const MIN_DIM_SIZE_AVX: usize = 32;
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", target_feature = "neon")
+#[cfg(all(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    ),
+    feature = "use_f32",
 ))]
 const MIN_DIM_SIZE_SIMD: usize = 16;
 
@@ -38,7 +43,7 @@ impl Metric for EuclidMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
@@ -48,14 +53,14 @@ impl Metric for EuclidMetric {
             }
         }
 
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
         {
             if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { euclid_similarity_sse(v1, v2) };
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { euclid_similarity_neon(v1, v2) };
@@ -80,7 +85,7 @@ impl Metric for ManhattanMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
@@ -90,14 +95,14 @@ impl Metric for ManhattanMetric {
             }
         }
 
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
         {
             if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { manhattan_similarity_sse(v1, v2) };
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { manhattan_similarity_neon(v1, v2) };
@@ -122,7 +127,7 @@ impl Metric for DotProductMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
@@ -132,14 +137,14 @@ impl Metric for DotProductMetric {
             }
         }
 
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
         {
             if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_sse(v1, v2) };
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_neon(v1, v2) };
@@ -164,7 +169,7 @@ impl Metric for CosineMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
@@ -174,14 +179,14 @@ impl Metric for CosineMetric {
             }
         }
 
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
         {
             if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_sse(v1, v2) };
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { dot_similarity_neon(v1, v2) };
@@ -192,7 +197,7 @@ impl Metric for CosineMetric {
     }
 
     fn preprocess(vector: DenseVector) -> DenseVector {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "use_f32"))]
         {
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
@@ -202,14 +207,14 @@ impl Metric for CosineMetric {
             }
         }
 
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "use_f32"))]
         {
             if is_x86_feature_detected!("sse") && vector.len() >= MIN_DIM_SIZE_SIMD {
                 return unsafe { cosine_preprocess_sse(vector) };
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", feature = "use_f32"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= MIN_DIM_SIZE_SIMD
             {
@@ -228,20 +233,20 @@ impl Metric for CosineMetric {
 pub fn euclid_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
     -v1.iter()
         .zip(v2)
-        .map(|(a, b)| (a - b).powi(2))
+        .map(|(a, b)| ScoreType::from((a - b).powi(2)))
         .sum::<ScoreType>()
 }
 
 pub fn manhattan_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
     -v1.iter()
         .zip(v2)
-        .map(|(a, b)| (a - b).abs())
+        .map(|(a, b)| ScoreType::from((a - b).abs()))
         .sum::<ScoreType>()
 }
 
 pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
-    let mut length: f32 = vector.iter().map(|x| x * x).sum();
-    if length < f32::EPSILON {
+    let mut length: VectorElementType = vector.iter().map(|x| x * x).sum();
+    if length < VectorElementType::EPSILON {
         return vector;
     }
     length = length.sqrt();
@@ -249,16 +254,17 @@ pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
 }
 
 pub fn dot_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-    v1.iter().zip(v2).map(|(a, b)| a * b).sum()
+    v1.iter().zip(v2).map(|(a, b)| ScoreType::from(a * b)).sum()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::segment::vector;
 
     #[test]
     fn test_cosine_preprocessing() {
-        let res = CosineMetric::preprocess(vec![0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(res, vec![0.0, 0.0, 0.0, 0.0]);
+        let res = CosineMetric::preprocess(vector![0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(res, vector![0.0, 0.0, 0.0, 0.0]);
     }
 }

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -220,10 +220,12 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
+    use crate::array;
     use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
     use crate::data_types::vectors::QueryVector;
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::IdTracker;
+    use crate::segment::vector;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
     use crate::vector_storage::new_raw_scorer;
     use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -234,11 +236,11 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let points = vec![
-            vec![1.0, 0.0, 1.0, 1.0],
-            vec![1.0, 0.0, 1.0, 0.0],
-            vec![1.0, 1.0, 1.0, 1.0],
-            vec![1.0, 1.0, 0.0, 1.0],
-            vec![1.0, 0.0, 0.0, 0.0],
+            vector![1.0, 0.0, 1.0, 1.0],
+            vector![1.0, 0.0, 1.0, 0.0],
+            vector![1.0, 1.0, 1.0, 1.0],
+            vector![1.0, 1.0, 0.0, 1.0],
+            vector![1.0, 0.0, 0.0, 0.0],
         ];
         let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
         let storage = open_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
@@ -331,11 +333,11 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let points = vec![
-            vec![1.0, 0.0, 1.0, 1.0],
-            vec![1.0, 0.0, 1.0, 0.0],
-            vec![1.0, 1.0, 1.0, 1.0],
-            vec![1.0, 1.0, 0.0, 1.0],
-            vec![1.0, 0.0, 0.0, 0.0],
+            vector![1.0, 0.0, 1.0, 1.0],
+            vector![1.0, 0.0, 1.0, 0.0],
+            vector![1.0, 1.0, 1.0, 1.0],
+            vector![1.0, 1.0, 0.0, 1.0],
+            vector![1.0, 0.0, 0.0, 0.0],
         ];
         let delete_mask = [false, false, true, true, false];
         let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
@@ -383,7 +385,7 @@ mod tests {
             "2 vectors must be deleted"
         );
 
-        let vector = vec![0.0, 1.0, 1.1, 1.0];
+        let vector = vector![0.0, 1.0, 1.1, 1.0];
         let query = vector.as_slice().into();
         let closest = new_raw_scorer(
             query,
@@ -410,7 +412,7 @@ mod tests {
             "3 vectors must be deleted"
         );
 
-        let vector = vec![1.0, 0.0, 0.0, 0.0];
+        let vector = vector![1.0, 0.0, 0.0, 0.0];
         let query = vector.as_slice().into();
 
         let closest = new_raw_scorer(
@@ -437,7 +439,7 @@ mod tests {
             "all vectors must be deleted"
         );
 
-        let vector = vec![1.0, 0.0, 0.0, 0.0];
+        let vector = vector![1.0, 0.0, 0.0, 0.0];
         let query = vector.as_slice().into();
         let closest = new_raw_scorer(
             query,
@@ -455,11 +457,11 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let points = vec![
-            vec![1.0, 0.0, 1.0, 1.0],
-            vec![1.0, 0.0, 1.0, 0.0],
-            vec![1.0, 1.0, 1.0, 1.0],
-            vec![1.0, 1.0, 0.0, 1.0],
-            vec![1.0, 0.0, 0.0, 0.0],
+            vector![1.0, 0.0, 1.0, 1.0],
+            vector![1.0, 0.0, 1.0, 0.0],
+            vector![1.0, 1.0, 1.0, 1.0],
+            vector![1.0, 1.0, 0.0, 1.0],
+            vector![1.0, 0.0, 0.0, 0.0],
         ];
         let delete_mask = [false, false, true, true, false];
         let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
@@ -499,7 +501,7 @@ mod tests {
             "2 vectors must be deleted from other storage"
         );
 
-        let vector = vec![0.0, 1.0, 1.1, 1.0];
+        let vector = vector![0.0, 1.0, 1.1, 1.0];
         let query = vector.as_slice().into();
         let closest = new_raw_scorer(
             query,
@@ -535,11 +537,11 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let points = vec![
-            vec![1.0, 0.0, 1.0, 1.0],
-            vec![1.0, 0.0, 1.0, 0.0],
-            vec![1.0, 1.0, 1.0, 1.0],
-            vec![1.0, 1.0, 0.0, 1.0],
-            vec![1.0, 0.0, 0.0, 0.0],
+            vector![1.0, 0.0, 1.0, 1.0],
+            vector![1.0, 0.0, 1.0, 0.0],
+            vector![1.0, 1.0, 1.0, 1.0],
+            vector![1.0, 1.0, 0.0, 1.0],
+            vector![1.0, 0.0, 0.0, 0.0],
         ];
         let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
         let storage = open_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
@@ -567,7 +569,7 @@ mod tests {
                 .unwrap();
         }
 
-        let vector = vec![-1.0, -1.0, -1.0, -1.0];
+        let vector = vector![-1.0, -1.0, -1.0, -1.0];
         let query = vector.as_slice().into();
         let query_points: Vec<PointOffsetType> = vec![0, 2, 4];
 
@@ -592,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_casts() {
-        let data: Vec<VectorElementType> = vec![0.42, 0.069, 333.1, 100500.];
+        let data: Vec<VectorElementType> = vector![0.42, 0.069, 333.1, 100500.];
 
         let raw_data = transmute_to_u8_slice(&data);
 
@@ -614,11 +616,11 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
         let points = vec![
-            vec![1.0, 0.0, 1.0, 1.0],
-            vec![1.0, 0.0, 1.0, 0.0],
-            vec![1.0, 1.0, 1.0, 1.0],
-            vec![1.0, 1.0, 0.0, 1.0],
-            vec![1.0, 0.0, 0.0, 0.0],
+            vector![1.0, 0.0, 1.0, 1.0],
+            vector![1.0, 0.0, 1.0, 0.0],
+            vector![1.0, 1.0, 1.0, 1.0],
+            vector![1.0, 1.0, 0.0, 1.0],
+            vector![1.0, 0.0, 0.0, 0.0],
         ];
         let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
         let storage = open_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
@@ -657,7 +659,7 @@ mod tests {
         let quantized_vectors =
             QuantizedVectors::create(&borrowed_storage, &config, dir.path(), 1, &stopped).unwrap();
 
-        let query: QueryVector = [0.5, 0.5, 0.5, 0.5].into();
+        let query: QueryVector = array![0.5, 0.5, 0.5, 0.5].into();
 
         let scorer_quant = quantized_vectors
             .raw_scorer(

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -44,7 +44,12 @@ where
             .unwrap();
         let query = original_query
             .clone()
-            .transform(|v: DenseVector| Ok(quantized_storage.encode_query(&v)))
+            .transform(|v: DenseVector| {
+                // TODO: Remove this once `quantization` supports f16.
+                #[cfg(not(feature = "use_f32"))]
+                let v = v.iter().map(|&x| x.to_f32()).collect::<Vec<f32>>();
+                Ok(quantized_storage.encode_query(&v))
+            })
             .unwrap();
 
         Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -24,6 +24,15 @@ where
         distance: Distance,
     ) -> Self {
         let original_query = distance.preprocess_vector(raw_query);
+        // TODO: Remove this once `quantization` supports f16.
+        #[cfg(not(feature = "use_f32"))]
+        let query = quantized_data.encode_query(
+            &original_query
+                .iter()
+                .map(|&x| x.to_f32())
+                .collect::<Vec<f32>>(),
+        );
+        #[cfg(feature = "use_f32")]
         let query = quantized_data.encode_query(&original_query);
 
         Self {

--- a/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
@@ -80,7 +80,7 @@ pub fn open_simple_vector_storage(
             db_wrapper,
             update_buffer: StoredRecord {
                 deleted: false,
-                vector: vec![0.; dim],
+                vector: vec![num_traits::identities::zero(); dim],
             },
             deleted,
             deleted_count,

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -48,7 +48,7 @@ type WithQuantization = (
 fn random_query<R: Rng + ?Sized>(
     query_variant: &QueryVariant,
     rnd: &mut R,
-    sampler: &mut impl Iterator<Item = f32>,
+    sampler: &mut impl Iterator<Item = VectorElementType>,
 ) -> QueryVector {
     match query_variant {
         QueryVariant::Recommend => random_reco_query(rnd, sampler),
@@ -59,7 +59,7 @@ fn random_query<R: Rng + ?Sized>(
 
 fn random_reco_query<R: Rng + ?Sized>(
     rnd: &mut R,
-    sampler: &mut impl Iterator<Item = f32>,
+    sampler: &mut impl Iterator<Item = VectorElementType>,
 ) -> QueryVector {
     let num_positives: usize = rnd.gen_range(0..MAX_EXAMPLES);
     let num_negatives: usize = rnd.gen_range(1..MAX_EXAMPLES);
@@ -77,7 +77,7 @@ fn random_reco_query<R: Rng + ?Sized>(
 
 fn random_discovery_query<R: Rng + ?Sized>(
     rnd: &mut R,
-    sampler: &mut impl Iterator<Item = f32>,
+    sampler: &mut impl Iterator<Item = VectorElementType>,
 ) -> QueryVector {
     let num_pairs: usize = rnd.gen_range(0..MAX_EXAMPLES);
 
@@ -96,7 +96,7 @@ fn random_discovery_query<R: Rng + ?Sized>(
 
 fn random_context_query<R: Rng + ?Sized>(
     rnd: &mut R,
-    sampler: &mut impl Iterator<Item = f32>,
+    sampler: &mut impl Iterator<Item = VectorElementType>,
 ) -> QueryVector {
     let num_pairs: usize = rnd.gen_range(0..MAX_EXAMPLES);
 
@@ -139,7 +139,15 @@ fn scalar_u8() -> Option<WithQuantization> {
 
     let sampler = {
         let rng = StdRng::seed_from_u64(SEED);
-        Box::new(rng.sample_iter(rand_distr::Normal::new(0.0, 8.0).unwrap()))
+        Box::new(
+            rng.sample_iter(
+                rand_distr::Normal::new(
+                    num_traits::NumCast::from(0.0).unwrap(),
+                    num_traits::NumCast::from(8.0).unwrap(),
+                )
+                .unwrap(),
+            ),
+        )
     };
 
     Some((config, sampler))
@@ -170,7 +178,7 @@ fn binary() -> Option<WithQuantization> {
         let rng = StdRng::seed_from_u64(SEED);
         Box::new(
             rng.sample_iter(rand::distributions::Uniform::new_inclusive(-1.0, 1.0))
-                .map(|x| x as u8 as f32),
+                .map(|x| num_traits::NumCast::from(x as u8).unwrap()),
         )
     };
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_vector_storage.rs
@@ -10,6 +10,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
+use crate::vector;
 use crate::vector_storage::appendable_mmap_vector_storage::open_appendable_memmap_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
@@ -17,11 +18,11 @@ use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 
 fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points = vec![
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![1.0, 0.0, 0.0, 0.0],
+        vector![1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 0.0],
+        vector![1.0, 1.0, 1.0, 1.0],
+        vector![1.0, 1.0, 0.0, 1.0],
+        vector![1.0, 0.0, 0.0, 0.0],
     ];
     let delete_mask = [false, false, true, true, false];
     let id_tracker: Arc<AtomicRefCell<IdTrackerSS>> =
@@ -52,7 +53,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         "2 vectors must be deleted"
     );
 
-    let vector = vec![0.0, 1.0, 1.1, 1.0];
+    let vector = vector![0.0, 1.0, 1.1, 1.0];
     let query = vector.as_slice().into();
     let closest = new_raw_scorer(
         query,
@@ -79,7 +80,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         "3 vectors must be deleted"
     );
 
-    let vector = vec![1.0, 0.0, 0.0, 0.0];
+    let vector = vector![1.0, 0.0, 0.0, 0.0];
     let query = vector.as_slice().into();
     let closest = new_raw_scorer(
         query,
@@ -105,7 +106,7 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
         "all vectors must be deleted"
     );
 
-    let vector = vec![1.0, 0.0, 0.0, 0.0];
+    let vector = vector![1.0, 0.0, 0.0, 0.0];
     let query = vector.as_slice().into();
     let closest = new_raw_scorer(
         query,
@@ -119,11 +120,11 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
 fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points = vec![
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![1.0, 0.0, 0.0, 0.0],
+        vector![1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 0.0],
+        vector![1.0, 1.0, 1.0, 1.0],
+        vector![1.0, 1.0, 0.0, 1.0],
+        vector![1.0, 0.0, 0.0, 0.0],
     ];
     let delete_mask = [false, false, true, true, false];
     let id_tracker: Arc<AtomicRefCell<IdTrackerSS>> =
@@ -163,7 +164,7 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
         "2 vectors must be deleted from other storage"
     );
 
-    let vector = vec![0.0, 1.0, 1.1, 1.0];
+    let vector = vector![0.0, 1.0, 1.1, 1.0];
     let query = vector.as_slice().into();
 
     let closest = new_raw_scorer(
@@ -197,11 +198,11 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
 
 fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points = vec![
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![1.0, 0.0, 0.0, 0.0],
+        vector![1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 0.0],
+        vector![1.0, 1.0, 1.0, 1.0],
+        vector![1.0, 1.0, 0.0, 1.0],
+        vector![1.0, 0.0, 0.0, 0.0],
     ];
     let id_tracker: Arc<AtomicRefCell<IdTrackerSS>> =
         Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
@@ -214,7 +215,7 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
             .unwrap();
     }
 
-    let query: QueryVector = [0.0, 1.0, 1.1, 1.0].into();
+    let query: QueryVector = vector![0.0, 1.0, 1.1, 1.0].into();
 
     let closest = new_raw_scorer(
         query.clone(),
@@ -274,11 +275,11 @@ fn do_test_score_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
 
 fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points = vec![
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![1.0, 0.0, 0.0, 0.0],
+        vector![1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 0.0],
+        vector![1.0, 1.0, 1.0, 1.0],
+        vector![1.0, 1.0, 0.0, 1.0],
+        vector![1.0, 0.0, 0.0, 0.0],
     ];
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(points.len())));
     let mut borrowed_storage = storage.borrow_mut();
@@ -306,7 +307,7 @@ fn test_score_quantized_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let quantized_vectors =
         QuantizedVectors::create(&borrowed_storage, &config, dir.path(), 1, &stopped).unwrap();
 
-    let query: QueryVector = vec![0.5, 0.5, 0.5, 0.5].into();
+    let query: QueryVector = vector![0.5, 0.5, 0.5, 0.5].into();
 
     let scorer_quant = quantized_vectors
         .raw_scorer(

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -5,12 +5,13 @@ use rand::seq::IteratorRandom;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::id_tracker::IdTracker;
+use crate::vector;
 use crate::vector_storage::{RawScorer, VectorStorage};
 
 pub type Result<T, E = Error> = result::Result<T, E>;
 pub type Error = Box<dyn error::Error>;
 
-pub fn sampler(rng: impl rand::Rng) -> impl Iterator<Item = f32> {
+pub fn sampler(rng: impl rand::Rng) -> impl Iterator<Item = VectorElementType> {
     rng.sample_iter(rand::distributions::Standard)
 }
 
@@ -22,7 +23,7 @@ pub fn insert_distributed_vectors(
     let start = storage.total_vector_count() as u32;
     let end = start + vectors as u32;
 
-    let mut vector = vec![0.; storage.vector_dim()];
+    let mut vector = vector![0.; storage.vector_dim()];
 
     for offset in start..end {
         for (item, value) in vector.iter_mut().zip(&mut *sampler) {

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -9,6 +9,7 @@ use segment::segment::Segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_multivec_segment;
 use segment::types::Distance;
+use segment::vector;
 use segment::vector_storage::VectorStorage;
 use tempfile::Builder;
 
@@ -28,8 +29,8 @@ fn test_rebuild_with_removed_vectors() {
                 1,
                 i.into(),
                 NamedVectors::from([
-                    ("vector1".to_string(), vec![i as f32, 0., 0., 0.]),
-                    ("vector2".to_string(), vec![0., i as f32, 0., 0., 0., 0.]),
+                    ("vector1".to_string(), vector![i as f32, 0., 0., 0.]),
+                    ("vector2".to_string(), vector![0., i as f32, 0., 0., 0., 0.]),
                 ]),
             )
             .unwrap();
@@ -37,11 +38,11 @@ fn test_rebuild_with_removed_vectors() {
 
     for i in 0..NUM_VECTORS_2 {
         let vectors = if i % 5 == 0 {
-            NamedVectors::from([("vector1".to_string(), vec![0., 0., i as f32, 0.])])
+            NamedVectors::from([("vector1".to_string(), vector![0., 0., i as f32, 0.])])
         } else {
             NamedVectors::from([
-                ("vector1".to_string(), vec![0., 0., i as f32, 0.]),
-                ("vector2".to_string(), vec![0., 0., 0., i as f32, 0., 0.]),
+                ("vector1".to_string(), vector![0., 0., i as f32, 0.]),
+                ("vector2".to_string(), vector![0., 0., 0., i as f32, 0., 0.]),
             ])
         };
 

--- a/lib/segment/tests/integration/fail_recovery_test.rs
+++ b/lib/segment/tests/integration/fail_recovery_test.rs
@@ -1,6 +1,7 @@
 use segment::common::operation_error::{OperationError, SegmentFailedState};
 use segment::data_types::vectors::only_default_vector;
 use segment::entry::entry_point::SegmentEntry;
+use segment::vector;
 use serde_json::json;
 use tempfile::Builder;
 
@@ -10,7 +11,7 @@ use crate::fixtures::segment::empty_segment;
 fn test_insert_fail_recovery() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let vec1 = vec![1.0, 0.0, 1.0, 1.0];
+    let vec1 = vector![1.0, 0.0, 1.0, 1.0];
 
     let mut segment = empty_segment(dir.path());
 

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -92,7 +92,10 @@ fn _test_filterable_hnsw(
     let num_vectors: u64 = 5_000;
     let ef_construct = 16;
     let distance = Distance::Cosine;
+    #[cfg(feature = "use_f32")]
     let full_scan_threshold = 16; // KB
+    #[cfg(not(feature = "use_f32"))]
+    let full_scan_threshold = 8; // KB
     let indexing_threshold = 500; // num vectors
     let num_payload_values = 2;
 

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{only_default_vector, VectorElementType};
 use segment::entry::entry_point::SegmentEntry;
-use segment::segment::Segment;
+use segment::segment::{vector, Segment};
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::{Distance, Indexes, SegmentConfig, VectorDataConfig, VectorStorageType};
@@ -18,11 +18,11 @@ pub fn empty_segment(path: &Path) -> Segment {
 pub fn build_segment_1(path: &Path) -> Segment {
     let mut segment1 = empty_segment(path);
 
-    let vec1 = vec![1.0, 0.0, 1.0, 1.0];
-    let vec2 = vec![1.0, 0.0, 1.0, 0.0];
-    let vec3 = vec![1.0, 1.0, 1.0, 1.0];
-    let vec4 = vec![1.0, 1.0, 0.0, 1.0];
-    let vec5 = vec![1.0, 0.0, 0.0, 0.0];
+    let vec1 = vector![1.0, 0.0, 1.0, 1.0];
+    let vec2 = vector![1.0, 0.0, 1.0, 0.0];
+    let vec3 = vector![1.0, 1.0, 1.0, 1.0];
+    let vec4 = vector![1.0, 1.0, 0.0, 1.0];
+    let vec5 = vector![1.0, 0.0, 0.0, 0.0];
 
     segment1
         .upsert_point(1, 1.into(), only_default_vector(&vec1))
@@ -59,11 +59,11 @@ pub fn build_segment_1(path: &Path) -> Segment {
 pub fn build_segment_2(path: &Path) -> Segment {
     let mut segment2 = empty_segment(path);
 
-    let vec1 = vec![-1.0, 0.0, 1.0, 1.0];
-    let vec2 = vec![-1.0, 0.0, 1.0, 0.0];
-    let vec3 = vec![-1.0, 1.0, 1.0, 1.0];
-    let vec4 = vec![-1.0, 1.0, 0.0, 1.0];
-    let vec5 = vec![-1.0, 0.0, 0.0, 0.0];
+    let vec1 = vector![-1.0, 0.0, 1.0, 1.0];
+    let vec2 = vector![-1.0, 0.0, 1.0, 0.0];
+    let vec3 = vector![-1.0, 1.0, 1.0, 1.0];
+    let vec4 = vector![-1.0, 1.0, 0.0, 1.0];
+    let vec5 = vector![-1.0, 0.0, 0.0, 0.0];
 
     segment2
         .upsert_point(11, 11.into(), only_default_vector(&vec1))
@@ -159,29 +159,29 @@ pub fn build_segment_3(path: &Path) -> Segment {
     };
 
     let vec1 = [
-        vec![1.0, 0.0, 1.0, 1.0],
-        vec![0.0],
-        vec![-1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 1.0],
+        vector![0.0],
+        vector![-1.0, 0.0, 1.0, 1.0],
     ];
     let vec2 = [
-        vec![1.0, 0.0, 1.0, 0.0],
-        vec![1.0],
-        vec![-1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 1.0, 0.0],
+        vector![1.0],
+        vector![-1.0, 0.0, 1.0, 1.0],
     ];
     let vec3 = [
-        vec![1.0, 1.0, 1.0, 1.0],
-        vec![2.0],
-        vec![-1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 1.0, 1.0, 1.0],
+        vector![2.0],
+        vector![-1.0, 0.0, 1.0, 1.0],
     ];
     let vec4 = [
-        vec![1.0, 1.0, 0.0, 1.0],
-        vec![3.0],
-        vec![-1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 1.0, 0.0, 1.0],
+        vector![3.0],
+        vector![-1.0, 0.0, 1.0, 1.0],
     ];
     let vec5 = [
-        vec![1.0, 0.0, 0.0, 0.0],
-        vec![4.0],
-        vec![-1.0, 0.0, 1.0, 1.0],
+        vector![1.0, 0.0, 0.0, 0.0],
+        vector![4.0],
+        vector![-1.0, 0.0, 1.0, 1.0],
     ];
 
     segment3

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -22,6 +22,7 @@ use segment::types::{
     ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
     ScalarQuantizationConfig, SearchParams, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
+use segment::vector;
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use serde_json::json;
 use tempfile::Builder;
@@ -164,7 +165,7 @@ fn hnsw_quantized_search_test(
 
     // check that rescoring is working
     // to check it, set all vectors to zero and expect zero scores
-    let zero_vector = vec![0.0; dim];
+    let zero_vector = vector![0.0; dim];
     for n in 0..num_vectors {
         let idx = n.into();
         segment

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use itertools::Itertools;
+use segment::array;
 use segment::common::operation_error::OperationError;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
@@ -29,7 +30,7 @@ fn test_building_new_segment() {
 
     // Include overlapping with segment1 to check the
     segment2
-        .upsert_point(100, 3.into(), only_default_vector(&[0., 0., 0., 0.]))
+        .upsert_point(100, 3.into(), only_default_vector(&array![0., 0., 0., 0.]))
         .unwrap();
 
     builder.update_from(&segment1, &stopped).unwrap();
@@ -139,18 +140,18 @@ fn test_building_cancellation() {
 
     for idx in 0..2000 {
         baseline_segment
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(1, idx.into(), only_default_vector(&array![0., 0., 0., 0.]))
             .unwrap();
         segment
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(1, idx.into(), only_default_vector(&array![0., 0., 0., 0.]))
             .unwrap();
         segment_2
-            .upsert_point(1, idx.into(), only_default_vector(&[0., 0., 0., 0.]))
+            .upsert_point(1, idx.into(), only_default_vector(&array![0., 0., 0., 0.]))
             .unwrap();
     }
 
     // Get normal build time
-    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 20000);
+    let (time_baseline, was_cancelled_baseline) = estimate_build_time(&baseline_segment, 40000);
     assert!(!was_cancelled_baseline);
     eprintln!("baseline time: {}", time_baseline);
 

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -29,7 +29,9 @@ fn convert_to_sparse_vector(vector: &[VectorElementType]) -> SparseVector {
     let mut sparse_vector = SparseVector::default();
     for (idx, value) in vector.iter().enumerate() {
         sparse_vector.indices.push(idx as u32);
-        sparse_vector.values.push(*value);
+        sparse_vector
+            .values
+            .push(num_traits::NumCast::from(*value).unwrap());
     }
     sparse_vector
 }


### PR DESCRIPTION
Issue #3333.

This PR  adds the feature `use_f32` to crate `segment`, enabled by default. If disabled, `half::f16` is used instead of `f32`.

It seems, that just changing the type alias would require a big amount of changes across all of the code base. Particularly, a lot of tests will need to be fixed because `0.0` is not a valid `half::f16` literal, and we should use `f16::from_f32(0.0)` instead. I've started it by migrating the `segment` crate first (this PR). I think, [`quantization`](https://github.com/qdrant/quantization) should be the next.

To test, run this command: `cd lib/segment && cargo test --no-default-features`.

Adding the `use_f32` feature rather than `use_f16` is a less disruptive change because checking commands like `cargo clippy --workspace --all-features` would still work. This is not ideal (and neither adding `use_f16` is) because cargo features are supposed to be additive. However, a proper solution would require too much effort, as stated in the original issue description.

### Further work

A few tests fail due to rounding errors. I'll investigate it later.  For now, they're disabled for `f16` but still enabled for `f32`. For reference, there is a result of a failing test:
```
---- index::hnsw_index::graph_layers_builder::tests::test_parallel_graph_build stdout ----
total_links_0 = 16000
num_vectors = 1000
thread 'index::hnsw_index::graph_layers_builder::tests::test_parallel_graph_build' panicked at lib/segment/src/index/hnsw_index/graph_layers_builder.rs:658:9:
assertion `left == right` failed
  left: [ScoredPointOffset { idx: 794, score: 0.9126377 }, ScoredPointOffset { idx: 86, score: 0.9084263 }, ScoredPointOffset { idx: 387, score: 0.8991871 }, ScoredPointOffset { idx: 597, score: 0.8913193 }, ScoredPointOffset { idx: 285, score: 0.8529053 }]
 right: [ScoredPointOffset { idx: 794, score: 0.9134178 }, ScoredPointOffset { idx: 86, score: 0.90905 }, ScoredPointOffset { idx: 387, score: 0.8995018 }, ScoredPointOffset { idx: 597, score: 0.89193726 }, ScoredPointOffset { idx: 285, score: 0.85342026 }]
```
It seems to be almost right (`idx` is right, and `score` is just a bit off). It must be a rounding error somewhere.


---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
  * No new tests, but fixed existing ones to be compatible both for `f32` and `f16`. 
* [x] Have you successfully ran tests with your changes locally?
