### PR TITLE
Fix potential context search edge case

### DIFF
--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -130,7 +130,6 @@ mod test {
         *x as ScoreType
     }
 
-
     /// Possible similarities
     fn sim() -> impl Strategy<Value = f32> {
         (-100.0..=100.0).prop_map(|x| x as f32)
@@ -142,7 +141,7 @@ mod test {
         /// Checks that the loss is between 0 and -1
         #[test]
         fn loss_is_not_more_than_1_per_pair((p, n) in (sim(), sim())) {
-            let query= ContextQuery::new(vec![ContextPair::from((p, n))]);
+            let query = ContextQuery::new(vec![ContextPair::from((p, n))]);
 
             let score = query.score_by(dummy_similarity);
             assert!(score <= 0.0, "similarity: {}", score);

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use common::math::fast_sigmoid;
 use common::types::ScoreType;
 use itertools::Itertools;
 
@@ -44,6 +45,8 @@ impl<T> ContextPair<T> {
     ///  -0.4        -0.1 │   +0
     ///                   │
     ///
+    /// Simple 2D model:
+    /// https://www.desmos.com/calculator/vlmskkagg2
     pub fn loss_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         const MARGIN: ScoreType = ScoreType::EPSILON;
 
@@ -52,7 +55,7 @@ impl<T> ContextPair<T> {
 
         let difference = positive - negative - MARGIN;
 
-        ScoreType::min(difference, 0.0)
+        fast_sigmoid(ScoreType::min(difference, 0.0))
     }
 }
 
@@ -118,40 +121,32 @@ impl From<ContextQuery<Vector>> for QueryVector {
 
 #[cfg(test)]
 mod test {
-
     use common::types::ScoreType;
-    use rstest::rstest;
+    use proptest::prelude::*;
 
     use super::*;
 
-    fn dummy_similarity(x: &i32) -> ScoreType {
+    fn dummy_similarity(x: &f32) -> ScoreType {
         *x as ScoreType
     }
 
-    /// Test that the score is calculated correctly
-    ///
-    /// for reference:
-    #[rstest]
-    #[case::no_pairs(vec![], 0.0)] // having no input always scores 0
-    #[case::on_negative(vec![(0, 1)], -1.0)]
-    #[case::on_positive(vec![(1, 0)], 0.0)]
-    #[case::on_both(vec![(1, 0), (0, 1)], -1.0)]
-    #[case::positive_positive_negative(vec![(1,0),(1,0),(0,1)], -1.0)]
-    #[case::positive_negative_negative(vec![(1,0),(0,1),(0,1)], -2.0)]
-    #[case::only_positives(vec![(2,-1),(-1,-3),(4,0)], 0.0)]
-    #[case::only_negatives(vec![(-5,-4),(-1,3),(0,2)], -7.0)]
-    fn scoring(#[case] pairs: Vec<(i32, i32)>, #[case] expected: f32) {
-        let pairs = pairs.into_iter().map(ContextPair::from).collect();
 
-        let query = ContextQuery::new(pairs);
+    /// Possible similarities
+    fn sim() -> impl Strategy<Value = f32> {
+        (-100.0..=100.0).prop_map(|x| x as f32)
+    }
 
-        let score = query.score_by(dummy_similarity);
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1000))]
 
-        assert!(
-            score > expected - 0.00001 && score < expected + 0.00001,
-            "score: {}, expected: {}",
-            score,
-            expected
-        );
+        /// Checks that the loss is between 0 and -1
+        #[test]
+        fn loss_is_not_more_than_1_per_pair((p, n) in (sim(), sim())) {
+            let query= ContextQuery::new(vec![ContextPair::from((p, n))]);
+
+            let score = query.score_by(dummy_similarity);
+            assert!(score <= 0.0, "similarity: {}", score);
+            assert!(score > -1.0, "similarity: {}", score);
+        }
     }
 }

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -46,7 +46,7 @@ impl<T> ContextPair<T> {
     ///                   │
     ///
     /// Simple 2D model:
-    /// https://www.desmos.com/calculator/vlmskkagg2
+    /// https://www.desmos.com/calculator/lbxycyh2hs
     pub fn loss_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         const MARGIN: ScoreType = ScoreType::EPSILON;
 


### PR DESCRIPTION
Context search combines the "loss"es of multiple positive-negative pairs, right now the formula is 

$L(x)=min(s(a,p)-s(a,n), 0)$
where $s(v_1, v_2)$: similarity between two vectors, $a$: vector we are evaluating, $p$: positive vector, $n$: negative vector

This function creates a __linear__ loss once a point $a$ is closer to the negative vector. However, it may be problematic, as pointed out by @generall, when a pair of examples is at the periphery of the embedding space, and the negative vector points towards the rest of the points, relative to the positive vector.

This makes the combination with other pairs hard, because the loss of single pair can eclipse the loss of other pairs. There is no lower limit to how much loss is assigned to a pair.

By plugging in our current loss function into a sigmoid(-ish) function, we get a non-linear loss which is always in the range of (-1, 0], for instance: $sig(L(x))$

Graphical modeling on a 2-D scale of the loss profile: https://www.desmos.com/calculator/lbxycyh2hs
<img width="770" alt="imagen" src="https://github.com/qdrant/qdrant/assets/62079184/08b55a55-e7d2-474f-933a-e2bba49a7236">

Black line: sample anchor point. Red continuous line: new loss. Purple line: current loss

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
