### PR TITLE
add optional checksum to snapshot recovery request

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9738,6 +9738,12 @@
                 "nullable": true
               }
             ]
+          },
+          "checksum": {
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "default": null,
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -10409,6 +10415,12 @@
                 "nullable": true
               }
             ]
+          },
+          "checksum": {
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "default": null,
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1630,6 +1630,15 @@
             "schema": {
               "$ref": "#/components/schemas/SnapshotPriority"
             }
+          },
+          {
+            "name": "checksum",
+            "in": "query",
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -1741,6 +1750,15 @@
             "required": false,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "name": "checksum",
+            "in": "query",
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -2486,6 +2504,15 @@
             "schema": {
               "$ref": "#/components/schemas/SnapshotPriority"
             }
+          },
+          {
+            "name": "checksum",
+            "in": "query",
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -2606,6 +2633,15 @@
             "required": false,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "name": "checksum",
+            "in": "query",
+            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -287,6 +287,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("DeleteShardSnapshotRequest.snapshot_name", "length(min = 1)"),
             ("RecoverShardSnapshotRequest.collection_name", "length(min = 1, max = 255)"),
             ("RecoverShardSnapshotRequest.snapshot_name", "length(min = 1)"),
+            ("RecoverShardSnapshotRequest.checksum", "custom = \"common::validation::validate_sha256_hash_option\""),
         ], &[
             "CreateFullSnapshotRequest",
             "ListFullSnapshotsRequest",

--- a/lib/api/src/grpc/proto/shard_snapshots_service.proto
+++ b/lib/api/src/grpc/proto/shard_snapshots_service.proto
@@ -45,6 +45,7 @@ message RecoverShardSnapshotRequest {
   uint32 shard_id = 2; // Id of the shard
   ShardSnapshotLocation snapshot_location = 3; // Location of the shard snapshot
   ShardSnapshotPriority snapshot_priority = 4; // Priority of the shard snapshot
+  optional string checksum = 5; // SHA256 checksum for verifying snapshot integrity
 }
 
 message ShardSnapshotLocation {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -10688,6 +10688,10 @@ pub struct RecoverShardSnapshotRequest {
     /// Priority of the shard snapshot
     #[prost(enumeration = "ShardSnapshotPriority", tag = "4")]
     pub snapshot_priority: i32,
+    /// SHA256 checksum for verifying snapshot integrity
+    #[prost(string, optional, tag = "5")]
+    #[validate(custom = "common::validation::validate_sha256_hash_option")]
+    pub checksum: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -24,3 +24,28 @@ pub async fn hash_file(file_path: &Path) -> io::Result<String> {
     let hash = sha.finalize();
     Ok(format!("{hash:x}"))
 }
+
+/// Compare two hashes, ignoring whitespace and case
+pub fn hashes_equal(a: &str, b: &str) -> bool {
+    Iterator::eq(
+        a.chars()
+            .filter(|c| !c.is_whitespace())
+            .map(|c| c.to_ascii_lowercase()),
+        b.chars()
+            .filter(|c| !c.is_whitespace())
+            .map(|c| c.to_ascii_lowercase()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_hash() {
+        assert!(hashes_equal("0123abc", "0123abc"));
+        assert!(hashes_equal("0123abc", "0123ABC"));
+        assert!(hashes_equal("0123abc", "0123abc "));
+        assert!(!hashes_equal("0123abc", "0123abd"));
+    }
+}

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -70,6 +70,11 @@ pub struct SnapshotRecover {
     /// If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.
     #[serde(default)]
     pub priority: Option<SnapshotPriority>,
+
+    /// Optional SHA256 checksum to verify snapshot integrity before recovery.
+    #[serde(default)]
+    #[validate(custom = "common::validation::validate_sha256_hash")]
+    pub checksum: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -148,6 +153,11 @@ pub struct ShardSnapshotRecover {
 
     #[serde(default)]
     pub priority: Option<SnapshotPriority>,
+
+    /// Optional SHA256 checksum to verify snapshot integrity before recovery.
+    #[validate(custom = "common::validation::validate_sha256_hash")]
+    #[serde(default)]
+    pub checksum: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -484,6 +484,7 @@ impl RemoteShard {
                             snapshot_priority: api::grpc::qdrant::ShardSnapshotPriority::from(
                                 snapshot_priority,
                             ) as i32,
+                            checksum: None,
                         })
                         .await
                 },

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -19,6 +19,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
         StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
         StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
+        StorageError::ChecksumMismatch { .. } => tonic::Code::DataLoss,
     };
     tonic::Status::new(error_code, format!("{error}"))
 }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -26,6 +26,8 @@ pub enum StorageError {
     Locked { description: String },
     #[error("Timeout: {description}")]
     Timeout { description: String },
+    #[error("Checksum mismatch: expected {expected}, actual {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
 }
 
 impl StorageError {
@@ -51,6 +53,13 @@ impl StorageError {
     pub fn already_exists(description: impl Into<String>) -> StorageError {
         StorageError::AlreadyExists {
             description: description.into(),
+        }
+    }
+
+    pub fn checksum_mismatch(expected: impl Into<String>, actual: impl Into<String>) -> Self {
+        StorageError::ChecksumMismatch {
+            expected: expected.into(),
+            actual: actual.into(),
         }
     }
 

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,4 +1,5 @@
 use collection::collection::Collection;
+use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::config::CollectionConfig;
 use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};
 use collection::shards::replica_set::ReplicaState;
@@ -70,7 +71,11 @@ async fn _do_recover_from_snapshot(
     source: SnapshotRecover,
     client: &reqwest::Client,
 ) -> Result<bool, StorageError> {
-    let SnapshotRecover { location, priority } = source;
+    let SnapshotRecover {
+        location,
+        priority,
+        checksum,
+    } = source;
     let toc = dispatcher.toc();
 
     let this_peer_id = toc.this_peer_id;
@@ -86,6 +91,15 @@ async fn _do_recover_from_snapshot(
 
     let (snapshot_path, snapshot_temp_path) =
         download_snapshot(client, location, download_dir.path()).await?;
+
+    if let Some(checksum) = checksum {
+        let snapshot_checksum = hash_file(&snapshot_path).await?;
+        if !hashes_equal(&snapshot_checksum, &checksum) {
+            return Err(StorageError::bad_input(format!(
+                "Snapshot checksum mismatch: expected {checksum}, got {snapshot_checksum}"
+            )));
+        }
+    }
 
     log::debug!("Snapshot downloaded to {}", snapshot_path.display());
 

--- a/openapi/openapi-shard-snapshots.ytt.yaml
+++ b/openapi/openapi-shard-snapshots.ytt.yaml
@@ -34,6 +34,12 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/SnapshotPriority"
+        - name: checksum
+          in: query
+          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
+          required: false
+          schema:
+            type: string
       requestBody:
         description: Snapshot to recover from
         content:
@@ -72,6 +78,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: checksum
+          in: query
+          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
+          required: false
+          schema:
+            type: string
       requestBody:
         description: Snapshot to recover from
         content:

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -28,6 +28,12 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/SnapshotPriority"
+        - name: checksum
+          in: query
+          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
+          required: false
+          schema:
+            type: string
       requestBody:
         description: Snapshot to recover from
         content:
@@ -60,6 +66,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: checksum
+          in: query
+          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
+          required: false
+          schema:
+            type: string
       requestBody:
         description: Snapshot to recover from
         content:

--- a/openapi/tests/openapi_integration/conftest.py
+++ b/openapi/tests/openapi_integration/conftest.py
@@ -1,4 +1,7 @@
+import http.server
 import pytest
+import socketserver
+import threading
 
 
 @pytest.fixture(params=[False, True], scope="module")
@@ -9,3 +12,32 @@ def on_disk_vectors(request):
 @pytest.fixture(params=[False, True], scope="module")
 def on_disk_payload(request):
     return request.param
+
+
+@pytest.fixture
+def http_server(tmpdir):
+    """
+    Starts a HTTP server serving files from a temporary directory.
+    Yields a tuple (tmpdir, url).
+    """
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            # Serve files from the temporary directory
+            super().__init__(*args, directory=str(tmpdir), **kwargs)
+
+        def log_request(self, *args, **kwargs):
+            # Silence logging
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+        httpd.allow_reuse_address = True
+        thread = threading.Thread(
+            target=httpd.serve_forever,
+            # Lower the shutdown poll interval to speed up tests
+            kwargs={"poll_interval": 0.1},
+        )
+        thread.start()
+        yield (tmpdir, f"http://127.0.0.1:{httpd.server_address[1]}")
+        httpd.shutdown()
+        thread.join()

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -364,7 +364,7 @@ async fn recover_shard_snapshot(
         )
         .await?;
 
-        Ok(())
+        Ok(true)
     };
 
     helpers::time_or_accept(future, query.wait.unwrap_or(true)).await

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -5,6 +5,7 @@ use actix_web::rt::time::Instant;
 use actix_web::{delete, get, post, put, web, Responder, Result};
 use actix_web_validator as valid;
 use collection::common::file_utils::move_file;
+use collection::common::sha_256::{hash_file, hashes_equal};
 use collection::operations::snapshot_ops::{
     ShardSnapshotRecover, SnapshotPriority, SnapshotRecover,
 };
@@ -44,6 +45,11 @@ struct SnapshotPath {
 pub struct SnapshotUploadingParam {
     pub wait: Option<bool>,
     pub priority: Option<SnapshotPriority>,
+
+    /// Optional SHA256 checksum to verify snapshot integrity before recovery.
+    #[serde(default)]
+    #[validate(custom = "::common::validation::validate_sha256_hash")]
+    pub checksum: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, JsonSchema, Validate)]
@@ -156,6 +162,19 @@ async fn upload_snapshot(
     let snapshot = form.snapshot;
     let wait = params.wait.unwrap_or(true);
 
+    if let Some(checksum) = &params.checksum {
+        let snapshot_checksum = match hash_file(snapshot.file.path()).await {
+            Ok(checksum) => checksum,
+            Err(err) => return process_response::<()>(Err(err.into()), timing),
+        };
+        if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+            return process_response::<()>(
+                Err(StorageError::checksum_mismatch(snapshot_checksum, checksum)),
+                timing,
+            );
+        }
+    }
+
     let snapshot_location =
         match do_save_uploaded_snapshot(dispatcher.get_ref(), &collection.name, snapshot).await {
             Ok(location) => location,
@@ -170,6 +189,7 @@ async fn upload_snapshot(
     let snapshot_recover = SnapshotRecover {
         location: snapshot_location,
         priority: params.priority,
+        checksum: None,
     };
 
     let response = do_recover_from_snapshot(
@@ -339,6 +359,7 @@ async fn recover_shard_snapshot(
             shard,
             request.location,
             request.priority.unwrap_or_default(),
+            request.checksum,
             http_client.as_ref().clone(),
         )
         .await?;
@@ -358,12 +379,24 @@ async fn upload_shard_snapshot(
     MultipartForm(form): MultipartForm<SnapshottingForm>,
 ) -> impl Responder {
     let (collection, shard) = path.into_inner();
-    let SnapshotUploadingParam { wait, priority } = query.into_inner();
+    let SnapshotUploadingParam {
+        wait,
+        priority,
+        checksum,
+    } = query.into_inner();
 
     // - `recover_shard_snapshot_impl` is *not* cancel safe
     //   - but the task is *spawned* on the runtime and won't be cancelled, if request is cancelled
 
     let future = cancel::future::spawn_cancel_on_drop(move |cancel| async move {
+        if let Some(checksum) = checksum {
+            let snapshot_checksum = hash_file(form.snapshot.file.path()).await?;
+            if !hashes_equal(snapshot_checksum.as_str(), checksum.as_str()) {
+                let err = StorageError::checksum_mismatch(snapshot_checksum, checksum);
+                return Result::<_, helpers::HttpError>::Err(err.into());
+            }
+        }
+
         let future = async {
             let collection = toc.get_collection(&collection).await?;
             collection.assert_shard_exists(shard).await?;

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -25,6 +25,7 @@ pub fn storage_into_actix_error(err: StorageError) -> Error {
         StorageError::Locked { .. } => error::ErrorForbidden(format!("{err}")),
         StorageError::Timeout { .. } => error::ErrorRequestTimeout(format!("{err}")),
         StorageError::AlreadyExists { .. } => error::ErrorConflict(format!("{err}")),
+        StorageError::ChecksumMismatch { .. } => error::ErrorBadRequest(format!("{err}")),
     }
 }
 
@@ -66,6 +67,7 @@ where
                 StorageError::Locked { .. } => HttpResponse::Forbidden(),
                 StorageError::Timeout { .. } => HttpResponse::RequestTimeout(),
                 StorageError::AlreadyExists { .. } => HttpResponse::Conflict(),
+                StorageError::ChecksumMismatch { .. } => HttpResponse::BadRequest(),
             };
 
             resp.json(ApiResponse::<()> {
@@ -194,6 +196,9 @@ impl From<StorageError> for HttpError {
             }
             StorageError::AlreadyExists { description } => {
                 (http::StatusCode::CONFLICT, description)
+            }
+            StorageError::ChecksumMismatch { .. } => {
+                (http::StatusCode::BAD_REQUEST, err.to_string())
             }
         };
 

--- a/src/tonic/api/snapshots_api.rs
+++ b/src/tonic/api/snapshots_api.rs
@@ -232,6 +232,7 @@ impl ShardSnapshots for ShardSnapshotsService {
             request.shard_id,
             request.snapshot_location.try_into()?,
             request.snapshot_priority.try_into()?,
+            request.checksum,
             self.http_client.clone(),
         )
         .await


### PR DESCRIPTION
Add `checksum` option to `RecoverShardSnapshotRequest` (GRPC), `/collections/{collection_name}/snapshots/recover`, `/collections/{collection}/shards/{shard}/snapshots/recover`, and (REST).
Closes #3371.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
