### PR TITLE
Put checksum computation debug message in a central place

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -137,7 +137,6 @@ impl Collection {
 
         // compute and store the file's checksum before the final snapshot file is saved
         // to avoid making snapshot available without checksum
-        log::debug!("Computing checksum for snapshot: {snapshot_path_tmp_move:?}");
         let checksum_path = snapshot_ops::get_checksum_path(&snapshot_path);
         let checksum = hash_file(&snapshot_path_tmp_move).await?;
         let checksum_file = tempfile::TempPath::from_path(&checksum_path);

--- a/lib/collection/src/common/sha_256.rs
+++ b/lib/collection/src/common/sha_256.rs
@@ -6,6 +6,8 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 
 pub async fn hash_file(file_path: &Path) -> io::Result<String> {
+    log::debug!("Computing checksum for file: {file_path:?}");
+
     const ONE_MB: usize = 1024 * 1024;
     let input_file = tokio::fs::File::open(file_path).await?;
     let mut reader = tokio::io::BufReader::new(input_file);

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -222,7 +222,6 @@ async fn _do_create_full_snapshot(
     archiving.await??;
 
     // Compute and store the file's checksum
-    log::debug!("Computing checksum for snapshot: {full_snapshot_path:?}");
     let checksum_path = get_checksum_path(&full_snapshot_path);
     let checksum = hash_file(full_snapshot_path.as_path()).await?;
     let checksum_file = tempfile::TempPath::from_path(&checksum_path);


### PR DESCRIPTION
Very small change. This puts the debug message for computing a file checksum in a central place.

Hashing can be quite expensive on large files, so it's useful to print a debug line to sense what might be going on.

I decided to put it here because we'll be using the file hashing function in a lot more places, in <https://github.com/qdrant/qdrant/pull/3381> for example.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?