### PR TITLE
Rename IntegerParams to IntegerIndexParams to be consistent with text

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -31,7 +31,7 @@
     - [GetCollectionInfoRequest](#qdrant-GetCollectionInfoRequest)
     - [GetCollectionInfoResponse](#qdrant-GetCollectionInfoResponse)
     - [HnswConfigDiff](#qdrant-HnswConfigDiff)
-    - [IntegerParams](#qdrant-IntegerParams)
+    - [IntegerIndexParams](#qdrant-IntegerIndexParams)
     - [ListAliasesRequest](#qdrant-ListAliasesRequest)
     - [ListAliasesResponse](#qdrant-ListAliasesResponse)
     - [ListCollectionAliasesRequest](#qdrant-ListCollectionAliasesRequest)
@@ -705,9 +705,9 @@
 
 
 
-<a name="qdrant-IntegerParams"></a>
+<a name="qdrant-IntegerIndexParams"></a>
 
-### IntegerParams
+### IntegerIndexParams
 
 
 
@@ -889,7 +889,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | text_index_params | [TextIndexParams](#qdrant-TextIndexParams) |  | Parameters for text index |
-| integer_params | [IntegerParams](#qdrant-IntegerParams) |  | Parameters for integer index |
+| integer_index_params | [IntegerIndexParams](#qdrant-IntegerIndexParams) |  | Parameters for integer index |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5780,7 +5780,7 @@
             "$ref": "#/components/schemas/TextIndexParams"
           },
           {
-            "$ref": "#/components/schemas/IntegerParams"
+            "$ref": "#/components/schemas/IntegerIndexParams"
           }
         ]
       },
@@ -5830,7 +5830,7 @@
           "multilingual"
         ]
       },
-      "IntegerParams": {
+      "IntegerIndexParams": {
         "type": "object",
         "required": [
           "lookup",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -21,7 +21,7 @@ use crate::grpc::qdrant::with_payload_selector::SelectorOptions;
 use crate::grpc::qdrant::{
     shard_key, with_vectors_selector, CollectionDescription, CollectionOperationResponse,
     Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius,
-    HasIdCondition, HealthCheckReply, HnswConfigDiff, IntegerParams, IsEmptyCondition,
+    HasIdCondition, HealthCheckReply, HnswConfigDiff, IntegerIndexParams, IsEmptyCondition,
     IsNullCondition, ListCollectionsResponse, ListValue, Match, NamedVectors, NestedCondition,
     PayloadExcludeSelector, PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo,
     PayloadSchemaType, PointId, ProductQuantization, QuantizationConfig, QuantizationSearchParams,
@@ -201,10 +201,10 @@ impl From<segment::data_types::text_index::TextIndexParams> for PayloadIndexPara
     }
 }
 
-impl From<segment::data_types::integer_index::IntegerParams> for PayloadIndexParams {
-    fn from(params: segment::data_types::integer_index::IntegerParams) -> Self {
+impl From<segment::data_types::integer_index::IntegerIndexParams> for PayloadIndexParams {
+    fn from(params: segment::data_types::integer_index::IntegerIndexParams) -> Self {
         PayloadIndexParams {
-            index_params: Some(IndexParams::IntegerParams(IntegerParams {
+            index_params: Some(IndexParams::IntegerIndexParams(IntegerIndexParams {
                 lookup: params.lookup,
                 range: params.range,
             })),
@@ -269,10 +269,10 @@ impl TryFrom<TextIndexParams> for segment::data_types::text_index::TextIndexPara
     }
 }
 
-impl TryFrom<IntegerParams> for segment::data_types::integer_index::IntegerParams {
+impl TryFrom<IntegerIndexParams> for segment::data_types::integer_index::IntegerIndexParams {
     type Error = Status;
-    fn try_from(params: IntegerParams) -> Result<Self, Self::Error> {
-        Ok(segment::data_types::integer_index::IntegerParams {
+    fn try_from(params: IntegerIndexParams) -> Result<Self, Self::Error> {
+        Ok(segment::data_types::integer_index::IntegerIndexParams {
             r#type: IntegerIndexType::Integer,
             lookup: params.lookup,
             range: params.range,
@@ -288,7 +288,7 @@ impl TryFrom<IndexParams> for segment::types::PayloadSchemaParams {
             IndexParams::TextIndexParams(text_index_params) => Ok(
                 segment::types::PayloadSchemaParams::Text(text_index_params.try_into()?),
             ),
-            IndexParams::IntegerParams(integer_params) => Ok(
+            IndexParams::IntegerIndexParams(integer_params) => Ok(
                 segment::types::PayloadSchemaParams::Integer(integer_params.try_into()?),
             ),
         }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -343,7 +343,7 @@ message TextIndexParams {
   optional uint64 max_token_len = 4; // Maximal token length
 }
 
-message IntegerParams {
+message IntegerIndexParams {
   bool lookup = 1; // If true - support direct lookups.
   bool range = 2; // If true - support ranges filters.
 }
@@ -351,7 +351,7 @@ message IntegerParams {
 message PayloadIndexParams {
   oneof index_params {
     TextIndexParams text_index_params = 1; // Parameters for text index
-    IntegerParams integer_params = 2; // Parameters for integer index
+    IntegerIndexParams integer_index_params = 2; // Parameters for integer index
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -602,7 +602,7 @@ pub struct TextIndexParams {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IntegerParams {
+pub struct IntegerIndexParams {
     /// If true - support direct lookups.
     #[prost(bool, tag = "1")]
     pub lookup: bool,
@@ -628,7 +628,7 @@ pub mod payload_index_params {
         TextIndexParams(super::TextIndexParams),
         /// Parameters for integer index
         #[prost(message, tag = "2")]
-        IntegerParams(super::IntegerParams),
+        IntegerIndexParams(super::IntegerIndexParams),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/segment/src/data_types/integer_index.rs
+++ b/lib/segment/src/data_types/integer_index.rs
@@ -10,7 +10,7 @@ pub enum IntegerIndexType {
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
-pub struct IntegerParams {
+pub struct IntegerIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
     pub r#type: IntegerIndexType,
     /// If true - support direct lookups.

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -25,7 +25,7 @@ use crate::common::utils::{
     check_exclude_pattern, check_include_pattern, filter_json_values, get_value_from_json_map,
     get_value_from_json_map_opt, MultiValue,
 };
-use crate::data_types::integer_index::IntegerParams;
+use crate::data_types::integer_index::IntegerIndexParams;
 use crate::data_types::text_index::TextIndexParams;
 use crate::data_types::vectors::{DenseVector, VectorElementType, VectorStruct};
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -1072,7 +1072,7 @@ pub enum PayloadSchemaType {
 #[serde(untagged, rename_all = "snake_case")]
 pub enum PayloadSchemaParams {
     Text(TextIndexParams),
-    Integer(IntegerParams),
+    Integer(IntegerIndexParams),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Hash, Eq)]

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use segment::data_types::integer_index::{IntegerIndexType, IntegerParams};
+use segment::data_types::integer_index::{IntegerIndexParams, IntegerIndexType};
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
@@ -101,22 +101,26 @@ fn build_test_segments(path_struct: &Path, path_plain: &Path) -> (Segment, Segme
         .create_field_index(
             opnum,
             INT_KEY_2,
-            Some(&FieldParams(PayloadSchemaParams::Integer(IntegerParams {
-                r#type: IntegerIndexType::Integer,
-                lookup: true,
-                range: false,
-            }))),
+            Some(&FieldParams(PayloadSchemaParams::Integer(
+                IntegerIndexParams {
+                    r#type: IntegerIndexType::Integer,
+                    lookup: true,
+                    range: false,
+                },
+            ))),
         )
         .unwrap();
     struct_segment
         .create_field_index(
             opnum,
             INT_KEY_3,
-            Some(&FieldParams(PayloadSchemaParams::Integer(IntegerParams {
-                r#type: IntegerIndexType::Integer,
-                lookup: false,
-                range: true,
-            }))),
+            Some(&FieldParams(PayloadSchemaParams::Integer(
+                IntegerIndexParams {
+                    r#type: IntegerIndexType::Integer,
+                    lookup: false,
+                    range: true,
+                },
+            ))),
         )
         .unwrap();
     struct_segment

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -686,7 +686,7 @@ fn convert_field_type(
         (
             Some(FieldType::Integer),
             Some(PayloadIndexParams {
-                index_params: Some(IndexParams::IntegerParams(integer_params)),
+                index_params: Some(IndexParams::IntegerIndexParams(integer_params)),
             }),
         ) => Some(PayloadFieldSchema::FieldParams(
             PayloadSchemaParams::Integer(integer_params.try_into()?),


### PR DESCRIPTION
Fixes naming inconsistency in <https://github.com/qdrant/qdrant/pull/3380>.

We had `IntegerParams`, but on second thought, I changed it to `IntegerIndexParams` in this PR. It makes it consistent with `TextIndexParams` and may prevent naming conflicts in the future.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?