### PR TITLE
Disable large limit optimization for plain indices

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -388,7 +388,11 @@ fn sampling_limit(
     let poisson_sampling =
         find_search_sampling_over_point_distribution(limit as f64, segment_probability)
             .unwrap_or(limit);
-    let effective = effective_limit(limit, ef_limit.unwrap_or(0), poisson_sampling);
+
+    // if no ef_limit was found, it is a plain index => sampling optimization is not needed.
+    let effective = ef_limit.map_or(limit, |ef_limit| {
+        effective_limit(limit, ef_limit, poisson_sampling)
+    });
     log::trace!("sampling: {effective}, poisson: {poisson_sampling} segment_probability: {segment_probability}, segment_points: {segment_points}, total_points: {total_points}");
     effective
 }
@@ -799,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_sampling_limit() {
-        assert_eq!(sampling_limit(1000, None, 464530, 35103551), 30);
+        assert_eq!(sampling_limit(1000, None, 464530, 35103551), 1000);
     }
 
     #[test]


### PR DESCRIPTION
Interesting side-effect of Context Search made this shine: many (or all) results can have score of `0.0`, which triggers search re-runs. 

The main reason of this optimization is that using large search `ef` values is expensive, but currently it is also being used for non-indexed segments (where there is no `ef` value). This causes that even for small limits, there is sampling happening.

This fix disables the sampling optimization for when a plain index is being used.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
