### PR TITLE
Optimize sparse vector for real life distribution

### DIFF
--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -70,16 +70,6 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     pub fn is_empty(&self) -> bool {
         self.heap.is_empty()
     }
-
-    /// Returns the smallest element in the queue
-    pub fn peek(&self) -> Option<&T> {
-        self.heap.peek().map(|x| &x.0)
-    }
-
-    /// Removes the smallest element in the queue
-    pub fn pop(&mut self) -> Option<T> {
-        self.heap.pop().map(|Reverse(x)| x)
-    }
 }
 
 pub struct Iter<'a, T> {


### PR DESCRIPTION
This PR optimizes the sparse vector search for real life data.

# Context

The work done in https://github.com/qdrant/qdrant/pull/3347 & https://github.com/qdrant/qdrant/pull/3359 has yielded great gains on synthetic random data.

However, a more end to end test with a real SPLADE embeddings for MSMARCO revealed that the performance actually worsened compared to 1.7.3.

Using a min-heap to track the minimum record ids works well when posting lists have more or less the same size but **not** when the distribution is highly skewed. The cost of repeatedly pushing new values onto the heap starts to dominate.

Here is an example of real distribution where most posting lists are very short except a few which contains a large amount of data.

![neurIPS_posting_len_example](https://github.com/qdrant/qdrant/assets/606963/ae67c292-007c-415c-863b-2df8cd4eb628)
 
# Optimization

In order to fix this issue it is necessary to rollback the min-heap approach to restore the performance of 1.7.3 and then try to get more performance on top.

This PR proposes a new approach to avoid both tracking the min record id explicitly and constantly computing it.

By relying on the fact that internal ids have no gaps and that the posting lists are sorted, we can optimistically increment the id manually and fallback to a search if it does not work.

This approach works well when the ids have no holes:
- with a low amount of segment to maximize contiguous ids
- with a low amount of deleted points

In the worst case, it performs an additional scan to find the minimum id like in 1.7.3

# Results

Using the [new sparse vector test bed](https://github.com/qdrant/sparse-vectors-benchmark) on the 100k dataset,

```
DEV:
Latency distribution:
50p: 61.06 millis
95p: 103.23 millis
99p: 123.85 millis
999p: 157.92 millis
max: 182.39 millis

v1.7.3
Latency distribution:
50p: 60.8 millis
95p: 104.22 millis
99p: 126.7 millis
999p: 151.25 millis
max: 179.12 millis

PR:
Latency distribution:
50p: 54.86 millis
95p: 85.31 millis
99p: 100.23 millis
999p: 115.24 millis
max: 126.31 millis
```

- dev

![neurIPS_bench_small_dev_dim_count](https://github.com/qdrant/qdrant/assets/606963/3c018d36-2cd9-429e-a12f-58717322ccfa)

- 1.7.3

![neurIPS_bench_small_1 7 3_dim_count](https://github.com/qdrant/qdrant/assets/606963/b815b8ca-9a82-4468-bb41-8e5760e5e218)

- PR

![neurIPS_bench_small_NEW_dim_count](https://github.com/qdrant/qdrant/assets/606963/4b00d26c-3922-4292-b055-0307d3bc9080)
