### PR TITLE
Filter points by empty vectors

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -845,6 +845,7 @@ impl From<segment::types::Condition> for Condition {
             segment::types::Condition::Nested(nested) => {
                 ConditionOneOf::Nested(nested.nested.into())
             }
+            segment::types::Condition::DoesNotHaveVector(does_not_have_vector) => todo!(),
         };
 
         Self {

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -113,6 +113,13 @@ pub trait SegmentEntry {
     /// Iterator over all points in segment in ascending order.
     fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_>;
 
+    /// Validate `vector_name` and extend the output collections with points in segment that don't have vector with the provided name.
+    fn try_extend_points_with_empty_vector(
+        &self,
+        vector_name: &str,
+        out: &mut impl Extend<PointIdType>,
+    ) -> OperationResult<()>;
+
     /// Paginate over points which satisfies filtering condition starting with `offset` id including.
     fn read_filtered<'a>(
         &'a self,

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -121,6 +121,7 @@ pub fn condition_converter<'a>(
             })
         }
         Condition::Filter(_) => unreachable!(),
+        Condition::DoesNotHaveVector(_) => todo!(),
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -310,6 +310,7 @@ impl StructPayloadIndex {
             Condition::Field(field_condition) => self
                 .estimate_field_condition(field_condition, nested_path)
                 .unwrap_or_else(|| CardinalityEstimation::unknown(self.available_point_count())),
+            Condition::DoesNotHaveVector(_) => todo!(),
         }
     }
 

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -125,6 +125,7 @@ where
                 })
         }
         Condition::Filter(_) => unreachable!(),
+        Condition::DoesNotHaveVector(_) => todo!(),
     };
 
     check_filter(&checker, query)

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1020,6 +1020,57 @@ impl SegmentEntry for Segment {
         unsafe { self.id_tracker.as_ptr().as_ref().unwrap().iter_external() }
     }
 
+    fn try_extend_points_with_empty_vector(
+        &self,
+        vector_name: &str,
+        out: &mut impl Extend<PointIdType>,
+    ) -> OperationResult<()> {
+        check_vector_name(vector_name, &self.segment_config)?;
+
+        let vector_data = self.vector_data.get(vector_name).ok_or_else(|| {
+            OperationError::VectorNameNotExists {
+                received_name: vector_name.to_string(),
+            }
+        })?;
+        let segment_path = self.current_path.as_path();
+        let vector_storage = vector_data.vector_storage.borrow();
+        let id_tracker = self.id_tracker.borrow();
+        let deleted_points = id_tracker.deleted_point_bitslice();
+
+        let points_with_empty_vector_iter = vector_storage.deleted_vector_bitslice()
+            .iter_ones()
+            .filter_map(|point_offset| {
+                let point_deleted = if let Some(point_deleted_ref) =
+                    deleted_points.get(point_offset)
+                {
+                    *point_deleted_ref
+                } else {
+                    // point is not deleted
+                    false
+                };
+
+                if !point_deleted {
+                    // point has empty vector
+                    let poffset = PointOffsetType::try_from(point_offset).expect("point offsets are in range");
+
+                    if let Some(point_id) = id_tracker.external_id(poffset) {
+                        Some(point_id)
+                    } else {
+                        log::error!(
+                            "Skipping point: failed to get external point id for point offset {}. Segment path {}",
+                            point_offset,
+                            segment_path.display()
+                        );
+                        None
+                    }
+                } else {
+                    None
+                }
+            });
+        out.extend(points_with_empty_vector_iter);
+        Ok(())
+    }
+
     fn read_filtered<'a>(
         &'a self,
         offset: Option<PointIdType>,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1462,7 +1462,7 @@ impl GeoPolygon {
                 || (first.lon - last.lon).abs() > f64::EPSILON
             {
                 return Err(OperationError::ValidationError {
-                    description: String::from("polygon invalid, the first and the last points should be the same to form a closed line") 
+                    description: String::from("polygon invalid, the first and the last points should be the same to form a closed line")
                 });
             }
         }
@@ -1668,6 +1668,11 @@ pub struct IsEmptyCondition {
 pub struct IsNullCondition {
     pub is_null: PayloadField,
 }
+/// Check if a point doesn't have vector with the provided name
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+pub struct DoesNotHaveVectorCondition {
+    pub vector_name: String,
+}
 
 impl From<String> for IsNullCondition {
     fn from(key: String) -> Self {
@@ -1753,6 +1758,8 @@ pub enum Condition {
     Nested(NestedCondition),
     /// Nested filter
     Filter(Filter),
+    /// Check if a point doesn't have vector with the provided name
+    DoesNotHaveVector(DoesNotHaveVectorCondition),
 }
 
 impl Condition {
@@ -1770,7 +1777,10 @@ impl Condition {
 impl Validate for Condition {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
-            Condition::HasId(_) | Condition::IsEmpty(_) | Condition::IsNull(_) => Ok(()),
+            Condition::HasId(_)
+            | Condition::IsEmpty(_)
+            | Condition::IsNull(_)
+            | Condition::DoesNotHaveVector(_) => Ok(()),
             Condition::Field(field_condition) => field_condition.validate(),
             Condition::Nested(nested_condition) => nested_condition.validate(),
             Condition::Filter(filter) => filter.validate(),
@@ -2013,6 +2023,15 @@ impl Filter {
             must: merge_component(self.must.clone(), other.must.clone()),
             must_not: merge_component(self.must_not.clone(), other.must_not.clone()),
         }
+    }
+
+    pub fn first_condition(&self) -> Option<&Condition> {
+        self.must
+            .as_ref()
+            .map(|c| c.first())
+            .flatten()
+            .or_else(|| self.must_not.as_ref().map(|c| c.first()).flatten())
+            .or_else(|| self.should.as_ref().map(|c| c.first()).flatten())
     }
 }
 
@@ -2294,7 +2313,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.first() {
+        let c = match should.get(0) {
             Some(Condition::Field(c)) => c,
             _ => panic!("Condition::Field expected"),
         };
@@ -2399,7 +2418,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.first() {
+        let c = match should.get(0) {
             Some(Condition::IsEmpty(c)) => c,
             _ => panic!("Condition::IsEmpty expected"),
         };
@@ -2425,7 +2444,7 @@ mod tests {
         let should = filter.should.unwrap();
 
         assert_eq!(should.len(), 1);
-        let c = match should.first() {
+        let c = match should.get(0) {
             Some(Condition::IsNull(c)) => c,
             _ => panic!("Condition::IsNull expected"),
         };
@@ -2465,13 +2484,13 @@ mod tests {
         let filter: Filter = serde_json::from_str(query).unwrap();
         let musts = filter.must.unwrap();
         assert_eq!(musts.len(), 1);
-        match musts.first() {
+        match musts.get(0) {
             Some(Condition::Nested(nested_condition)) => {
                 assert_eq!(nested_condition.raw_key(), "country.cities");
                 assert_eq!(nested_condition.array_key(), "country.cities[]");
                 let nested_musts = nested_condition.filter().must.as_ref().unwrap();
                 assert_eq!(nested_musts.len(), 2);
-                let first_must = nested_musts.first().unwrap();
+                let first_must = nested_musts.get(0).unwrap();
                 match first_must {
                     Condition::Field(c) => {
                         assert_eq!(c.key, "population");


### PR DESCRIPTION
* Initial code that intersects deleted vectors and deleted points bitsets.
Intersection logic is `deleted_vectors && !deleted_points`.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
