### PR TITLE
Datetime payload index

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -108,6 +108,7 @@
     - [CountResponse](#qdrant-CountResponse)
     - [CountResult](#qdrant-CountResult)
     - [CreateFieldIndexCollection](#qdrant-CreateFieldIndexCollection)
+    - [DatetimeRange](#qdrant-DatetimeRange)
     - [DeleteFieldIndexCollection](#qdrant-DeleteFieldIndexCollection)
     - [DeletePayloadPoints](#qdrant-DeletePayloadPoints)
     - [DeletePointVectors](#qdrant-DeletePointVectors)
@@ -1410,6 +1411,7 @@ Note: 1kB = 1 vector of size 256. |
 | Geo | 4 |  |
 | Text | 5 |  |
 | Bool | 6 |  |
+| Datetime | 7 |  |
 
 
 
@@ -1852,6 +1854,24 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-DatetimeRange"></a>
+
+### DatetimeRange
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| lt | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional |  |
+| gt | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional |  |
+| gte | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional |  |
+| lte | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional |  |
+
+
+
+
+
+
 <a name="qdrant-DeleteFieldIndexCollection"></a>
 
 ### DeleteFieldIndexCollection
@@ -2022,6 +2042,7 @@ The JSON representation for `Value` is a JSON value.
 | geo_radius | [GeoRadius](#qdrant-GeoRadius) |  | Check if geo point is within a given radius |
 | values_count | [ValuesCount](#qdrant-ValuesCount) |  | Check number of values for a specific field |
 | geo_polygon | [GeoPolygon](#qdrant-GeoPolygon) |  | Check if geo point is within a given polygon |
+| datetime_range | [DatetimeRange](#qdrant-DatetimeRange) |  | Check if datetime is within a given range |
 
 
 
@@ -3438,6 +3459,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | FieldTypeGeo | 3 |  |
 | FieldTypeText | 4 |  |
 | FieldTypeBool | 5 |  |
+| FieldTypeDatetime | 6 |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5770,7 +5770,8 @@
           "float",
           "geo",
           "text",
-          "bool"
+          "bool",
+          "datetime"
         ]
       },
       "PayloadSchemaParams": {
@@ -6345,7 +6346,18 @@
             "description": "Check if points value lies in a given range",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Range"
+                "$ref": "#/components/schemas/Range_for_double"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "datetime_range": {
+            "description": "Check if datetime is within a given range",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Range_for_DateTime"
               },
               {
                 "nullable": true
@@ -6494,7 +6506,7 @@
           }
         }
       },
-      "Range": {
+      "Range_for_double": {
         "description": "Range filter request",
         "type": "object",
         "properties": {
@@ -6520,6 +6532,36 @@
             "description": "point.key <= range.lte",
             "type": "number",
             "format": "double",
+            "nullable": true
+          }
+        }
+      },
+      "Range_for_DateTime": {
+        "description": "Range filter request",
+        "type": "object",
+        "properties": {
+          "lt": {
+            "description": "point.key < range.lt",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gt": {
+            "description": "point.key > range.gt",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gte": {
+            "description": "point.key >= range.gte",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lte": {
+            "description": "point.key <= range.lte",
+            "type": "string",
+            "format": "date-time",
             "nullable": true
           }
         }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -241,6 +241,10 @@ fn configure_validation(builder: Builder) -> Builder {
             ("DiscoveryQuery.context", ""),
             ("ContextQuery.context", ""),
         ], &[])
+        .field_attribute("DatetimeRange.lt", "#[serde(skip)]")
+        .field_attribute("DatetimeRange.gt", "#[serde(skip)]")
+        .field_attribute("DatetimeRange.lte", "#[serde(skip)]")
+        .field_attribute("DatetimeRange.gte", "#[serde(skip)]")
         .type_attribute(".", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1,15 +1,17 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
-use chrono::{NaiveDateTime, Timelike};
+use chrono::{NaiveDateTime, TimeZone as _, Timelike};
 use segment::data_types::integer_index::IntegerIndexType;
 use segment::data_types::text_index::TextIndexType;
 use segment::data_types::vectors::VectorElementType;
-use segment::types::default_quantization_ignore_value;
+use segment::types::{default_quantization_ignore_value, DateTimePayloadType, FloatPayloadType};
 use tonic::Status;
 use uuid::Uuid;
 
-use super::qdrant::{BinaryQuantization, CompressionRatio, GeoLineString, GroupId, SparseIndices};
+use super::qdrant::{
+    BinaryQuantization, CompressionRatio, DatetimeRange, GeoLineString, GroupId, SparseIndices,
+};
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
 use crate::grpc::qdrant::payload_index_params::IndexParams;
@@ -222,6 +224,7 @@ impl From<segment::types::PayloadIndexInfo> for PayloadSchemaInfo {
                 segment::types::PayloadSchemaType::Geo => PayloadSchemaType::Geo,
                 segment::types::PayloadSchemaType::Text => PayloadSchemaType::Text,
                 segment::types::PayloadSchemaType::Bool => PayloadSchemaType::Bool,
+                segment::types::PayloadSchemaType::Datetime => PayloadSchemaType::Datetime,
             }
             .into(),
             params: schema.params.map(|params| match params {
@@ -312,6 +315,7 @@ impl TryFrom<PayloadSchemaInfo> for segment::types::PayloadIndexInfo {
                 PayloadSchemaType::Geo => segment::types::PayloadSchemaType::Geo,
                 PayloadSchemaType::Text => segment::types::PayloadSchemaType::Text,
                 PayloadSchemaType::Bool => segment::types::PayloadSchemaType::Bool,
+                PayloadSchemaType::Datetime => segment::types::PayloadSchemaType::Datetime,
                 PayloadSchemaType::UnknownType => {
                     return Err(Status::invalid_argument(
                         "Malformed payload schema".to_string(),
@@ -942,6 +946,7 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
             geo_radius,
             values_count,
             geo_polygon,
+            datetime_range,
         } = value;
 
         let geo_bounding_box =
@@ -952,6 +957,7 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
             key,
             r#match: r#match.map_or_else(|| Ok(None), |m| m.try_into().map(Some))?,
             range: range.map(Into::into),
+            datetime_range: datetime_range.map(Into::into),
             geo_bounding_box,
             geo_radius,
             geo_polygon,
@@ -966,23 +972,22 @@ impl From<segment::types::FieldCondition> for FieldCondition {
             key,
             r#match,
             range,
+            datetime_range,
             geo_bounding_box,
             geo_radius,
             geo_polygon,
             values_count,
         } = value;
 
-        let geo_bounding_box = geo_bounding_box.map(Into::into);
-        let geo_radius = geo_radius.map(Into::into);
-        let geo_polygon = geo_polygon.map(Into::into);
         Self {
             key,
             r#match: r#match.map(Into::into),
             range: range.map(Into::into),
-            geo_bounding_box,
-            geo_radius,
-            geo_polygon,
+            geo_bounding_box: geo_bounding_box.map(Into::into),
+            geo_radius: geo_radius.map(Into::into),
+            geo_polygon: geo_polygon.map(Into::into),
             values_count: values_count.map(Into::into),
+            datetime_range: datetime_range.map(Into::into),
         }
     }
 }
@@ -1095,7 +1100,7 @@ impl From<segment::types::GeoLineString> for GeoLineString {
     }
 }
 
-impl From<Range> for segment::types::Range {
+impl From<Range> for segment::types::Range<FloatPayloadType> {
     fn from(value: Range) -> Self {
         Self {
             lt: value.lt,
@@ -1106,13 +1111,35 @@ impl From<Range> for segment::types::Range {
     }
 }
 
-impl From<segment::types::Range> for Range {
-    fn from(value: segment::types::Range) -> Self {
+impl From<segment::types::Range<FloatPayloadType>> for Range {
+    fn from(value: segment::types::Range<FloatPayloadType>) -> Self {
         Self {
             lt: value.lt,
             gt: value.gt,
             gte: value.gte,
             lte: value.lte,
+        }
+    }
+}
+
+impl From<DatetimeRange> for segment::types::Range<DateTimePayloadType> {
+    fn from(value: DatetimeRange) -> Self {
+        Self {
+            lt: value.lt.map(date_time_from_proto),
+            gt: value.gt.map(date_time_from_proto),
+            gte: value.gte.map(date_time_from_proto),
+            lte: value.lte.map(date_time_from_proto),
+        }
+    }
+}
+
+impl From<segment::types::Range<DateTimePayloadType>> for DatetimeRange {
+    fn from(value: segment::types::Range<DateTimePayloadType>) -> Self {
+        Self {
+            lt: value.lt.map(date_time_to_proto),
+            gt: value.gt.map(date_time_to_proto),
+            gte: value.gte.map(date_time_to_proto),
+            lte: value.lte.map(date_time_to_proto),
         }
     }
 }
@@ -1210,11 +1237,28 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
     }
 }
 
-pub fn date_time_to_proto(date_time: NaiveDateTime) -> prost_types::Timestamp {
+pub fn naive_date_time_to_proto(date_time: NaiveDateTime) -> prost_types::Timestamp {
     prost_types::Timestamp {
         seconds: date_time.timestamp(), // number of non-leap seconds since the midnight on January 1, 1970.
         nanos: date_time.nanosecond() as i32,
     }
+}
+
+pub fn date_time_to_proto(date_time: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
+    naive_date_time_to_proto(date_time.naive_utc())
+}
+
+pub fn date_time_from_proto(date_time: prost_types::Timestamp) -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc.from_utc_datetime(
+        &chrono::NaiveDateTime::from_timestamp_opt(
+            date_time.seconds,
+            date_time.nanos.try_into().unwrap_or(0),
+        )
+        .unwrap_or_else(|| {
+            log::warn!("Failed to decode {date_time}, fallback to UNIX_EPOCH");
+            NaiveDateTime::UNIX_EPOCH
+        }),
+    )
 }
 
 impl TryFrom<Distance> for segment::types::Distance {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -90,6 +90,7 @@ enum PayloadSchemaType {
   Geo = 4;
   Text = 5;
   Bool = 6;
+  Datetime = 7;
 }
 
 enum QuantizationType {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -3,8 +3,9 @@ syntax = "proto3";
 package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
 
-import "json_with_int.proto";
 import "collections.proto";
+import "google/protobuf/timestamp.proto";
+import "json_with_int.proto";
 
 
 enum WriteOrderingType {
@@ -145,6 +146,7 @@ enum FieldType {
   FieldTypeGeo = 3;
   FieldTypeText = 4;
   FieldTypeBool = 5;
+  FieldTypeDatetime = 6;
 }
 
 message CreateFieldIndexCollection {
@@ -661,6 +663,7 @@ message FieldCondition {
   GeoRadius geo_radius = 5; // Check if geo point is within a given radius
   ValuesCount values_count = 6; // Check number of values for a specific field
   GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
+  DatetimeRange datetime_range = 8; // Check if datetime is within a given range
 }
 
 message Match {
@@ -689,6 +692,13 @@ message Range {
   optional double gt = 2;
   optional double gte = 3;
   optional double lte = 4;
+}
+
+message DatetimeRange {
+  optional google.protobuf.Timestamp lt = 1;
+  optional google.protobuf.Timestamp gt = 2;
+  optional google.protobuf.Timestamp gte = 3;
+  optional google.protobuf.Timestamp lte = 4;
 }
 
 message GeoBoundingBox {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1098,6 +1098,7 @@ pub enum PayloadSchemaType {
     Geo = 4,
     Text = 5,
     Bool = 6,
+    Datetime = 7,
 }
 impl PayloadSchemaType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1113,6 +1114,7 @@ impl PayloadSchemaType {
             PayloadSchemaType::Geo => "Geo",
             PayloadSchemaType::Text => "Text",
             PayloadSchemaType::Bool => "Bool",
+            PayloadSchemaType::Datetime => "Datetime",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1125,6 +1127,7 @@ impl PayloadSchemaType {
             "Geo" => Some(Self::Geo),
             "Text" => Some(Self::Text),
             "Bool" => Some(Self::Bool),
+            "Datetime" => Some(Self::Datetime),
             _ => None,
         }
     }
@@ -4596,6 +4599,9 @@ pub struct FieldCondition {
     /// Check if geo point is within a given polygon
     #[prost(message, optional, tag = "7")]
     pub geo_polygon: ::core::option::Option<GeoPolygon>,
+    /// Check if datetime is within a given range
+    #[prost(message, optional, tag = "8")]
+    pub datetime_range: ::core::option::Option<DatetimeRange>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4662,6 +4668,23 @@ pub struct Range {
     pub gte: ::core::option::Option<f64>,
     #[prost(double, optional, tag = "4")]
     pub lte: ::core::option::Option<f64>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DatetimeRange {
+    #[prost(message, optional, tag = "1")]
+    #[serde(skip)]
+    pub lt: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, optional, tag = "2")]
+    #[serde(skip)]
+    pub gt: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, optional, tag = "3")]
+    #[serde(skip)]
+    pub gte: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, optional, tag = "4")]
+    #[serde(skip)]
+    pub lte: ::core::option::Option<::prost_types::Timestamp>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4846,6 +4869,7 @@ pub enum FieldType {
     Geo = 3,
     Text = 4,
     Bool = 5,
+    Datetime = 6,
 }
 impl FieldType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4860,6 +4884,7 @@ impl FieldType {
             FieldType::Geo => "FieldTypeGeo",
             FieldType::Text => "FieldTypeText",
             FieldType::Bool => "FieldTypeBool",
+            FieldType::Datetime => "FieldTypeDatetime",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -4871,6 +4896,7 @@ impl FieldType {
             "FieldTypeGeo" => Some(Self::Geo),
             "FieldTypeText" => Some(Self::Text),
             "FieldTypeBool" => Some(Self::Bool),
+            "FieldTypeDatetime" => Some(Self::Datetime),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use api::grpc::conversions::date_time_to_proto;
+use api::grpc::conversions::naive_date_time_to_proto;
 use chrono::NaiveDateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -85,7 +85,7 @@ impl From<SnapshotDescription> for api::grpc::qdrant::SnapshotDescription {
     fn from(value: SnapshotDescription) -> Self {
         Self {
             name: value.name,
-            creation_time: value.creation_time.map(date_time_to_proto),
+            creation_time: value.creation_time.map(naive_date_time_to_proto),
             size: value.size as i64,
             checksum: value.checksum,
         }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -331,6 +331,9 @@ pub fn internal_create_index(
                     segment::types::PayloadSchemaType::Bool => {
                         api::grpc::qdrant::FieldType::Bool as i32
                     }
+                    segment::types::PayloadSchemaType::Datetime => {
+                        api::grpc::qdrant::FieldType::Datetime as i32
+                    }
                 },
                 None,
             ),

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -160,15 +160,9 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     }
 
     let count_request = CountRequestInternal {
-        filter: Some(Filter::new_must(Condition::Field(FieldCondition {
-            key: "k".to_string(),
-            r#match: Some(serde_json::from_str(r#"{ "value": "v2" }"#).unwrap()),
-            range: None,
-            geo_bounding_box: None,
-            geo_radius: None,
-            values_count: None,
-            geo_polygon: None,
-        }))),
+        filter: Some(Filter::new_must(Condition::Field(
+            FieldCondition::new_match("k", serde_json::from_str(r#"{ "value": "v2" }"#).unwrap()),
+        ))),
         exact: true,
     };
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::posting_list::PostingList;
 use super::postings_iterator::intersect_postings_iterator;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
-use crate::types::{FieldCondition, Match, MatchText, PayloadKeyType};
+use crate::types::{FieldCondition, Match, PayloadKeyType};
 
 pub type TokenId = u32;
 
@@ -238,17 +238,7 @@ impl InvertedIndex {
                     )
                 })
                 .map(move |(token, posting)| PayloadBlockCondition {
-                    condition: FieldCondition {
-                        key: key.clone(),
-                        r#match: Some(Match::Text(MatchText {
-                            text: token.clone(),
-                        })),
-                        range: None,
-                        geo_bounding_box: None,
-                        geo_radius: None,
-                        geo_polygon: None,
-                        values_count: None,
-                    },
+                    condition: FieldCondition::new_match(key.clone(), Match::new_text(token)),
                     cardinality: posting.len(),
                 }),
         )

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -244,20 +244,9 @@ mod tests {
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
     use crate::common::utils::MultiValue;
     use crate::data_types::text_index::{TextIndexType, TokenizerType};
-    use crate::types::MatchText;
 
     fn filter_request(text: &str) -> FieldCondition {
-        FieldCondition {
-            key: "text".to_owned(),
-            r#match: Some(Match::Text(MatchText {
-                text: text.to_owned(),
-            })),
-            range: None,
-            geo_bounding_box: None,
-            geo_radius: None,
-            values_count: None,
-            geo_polygon: None,
-        }
+        FieldCondition::new_match("text", Match::new_text(text))
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -49,6 +49,11 @@ pub fn index_selector(
                 field,
             ))],
             PayloadSchemaType::Bool => vec![FieldIndex::BinaryIndex(BinaryIndex::new(db, field))],
+            PayloadSchemaType::Datetime => {
+                vec![FieldIndex::DatetimeIndex(
+                    NumericIndex::<IntPayloadType>::new(db, field, is_appendable),
+                )]
+            }
         },
         PayloadFieldSchema::FieldParams(payload_params) => match payload_params {
             PayloadSchemaParams::Text(text_index_params) => vec![FieldIndex::FullTextIndex(

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -9,6 +9,7 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::sync::Arc;
 
+use chrono::{NaiveDateTime, TimeZone};
 use common::types::PointOffsetType;
 use mutable_numeric_index::MutableNumericIndex;
 use parking_lot::RwLock;
@@ -30,7 +31,9 @@ use crate::index::key_encoding::{
     encode_i64_key_ascending,
 };
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{FieldCondition, FloatPayloadType, IntPayloadType, PayloadKeyType, Range};
+use crate::types::{
+    DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, PayloadKeyType, Range,
+};
 
 const HISTOGRAM_MAX_BUCKET_SIZE: usize = 10_000;
 const HISTOGRAM_PRECISION: f64 = 0.01;
@@ -77,6 +80,32 @@ impl Encodable for FloatPayloadType {
             return std::cmp::Ordering::Greater;
         }
         self.partial_cmp(other).unwrap()
+    }
+}
+
+/// Encodes timestamps as i64 in milliseconds
+impl Encodable for DateTimePayloadType {
+    fn encode_key(&self, id: PointOffsetType) -> Vec<u8> {
+        encode_i64_key_ascending(self.timestamp_millis(), id)
+    }
+
+    fn decode_key(key: &[u8]) -> (PointOffsetType, Self) {
+        let (id, timestamp) = decode_i64_key_ascending(key);
+        let datetime = chrono::Utc.from_utc_datetime(
+            &chrono::NaiveDateTime::from_timestamp_opt(
+                timestamp / 1000,
+                (timestamp % 1000) as u32 * 1_000_000,
+            )
+            .unwrap_or_else(|| {
+                log::warn!("Failed to decode timestamp {timestamp}, fallback to UNIX_EPOCH");
+                NaiveDateTime::UNIX_EPOCH
+            }),
+        );
+        (id, datetime)
+    }
+
+    fn cmp_encoded(&self, other: &Self) -> std::cmp::Ordering {
+        self.timestamp_millis().cmp(&other.timestamp_millis())
     }
 }
 
@@ -167,7 +196,7 @@ impl<T: Encodable + Numericable> NumericIndex<T> {
         }
     }
 
-    fn range_cardinality(&self, range: &Range) -> CardinalityEstimation {
+    fn range_cardinality(&self, range: &Range<FloatPayloadType>) -> CardinalityEstimation {
         let max_values_per_point = self.max_values_per_point();
         if max_values_per_point == 0 {
             return CardinalityEstimation::exact(0);
@@ -429,6 +458,33 @@ impl ValueIndexer<IntPayloadType> for NumericIndex<IntPayloadType> {
             return num.as_i64();
         }
         None
+    }
+
+    fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        NumericIndex::remove_point(self, id)
+    }
+}
+
+impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType> {
+    fn add_many(
+        &mut self,
+        id: PointOffsetType,
+        values: Vec<DateTimePayloadType>,
+    ) -> OperationResult<()> {
+        match self {
+            NumericIndex::Mutable(index) => {
+                index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp_millis()))
+            }
+            NumericIndex::Immutable(_) => Err(OperationError::service_error(
+                "Can't add values to immutable numeric index",
+            )),
+        }
+    }
+
+    fn get_value(&self, value: &Value) -> Option<DateTimePayloadType> {
+        chrono::DateTime::parse_from_rfc3339(value.as_str()?)
+            .ok()
+            .map(|x| x.into())
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -52,7 +52,10 @@ fn random_index(
     }
 }
 
-fn cardinality_request(index: &NumericIndex<f64>, query: Range) -> CardinalityEstimation {
+fn cardinality_request(
+    index: &NumericIndex<f64>,
+    query: Range<FloatPayloadType>,
+) -> CardinalityEstimation {
     let estimation = index.range_cardinality(&query);
 
     let result = index
@@ -378,21 +381,11 @@ fn test_numeric_index(#[case] immutable: bool) {
 
 fn test_cond<T: Encodable + Numericable + PartialOrd + Clone>(
     index: &NumericIndex<T>,
-    rng: Range,
+    rng: Range<FloatPayloadType>,
     result: Vec<u32>,
 ) {
-    let condition = FieldCondition {
-        key: "".to_string(),
-        r#match: None,
-        range: Some(rng),
-        geo_bounding_box: None,
-        geo_radius: None,
-        values_count: None,
-        geo_polygon: None,
-    };
-
+    let condition = FieldCondition::new_range("", rng);
     let offsets = index.filter(&condition).unwrap().collect_vec();
-
     assert_eq!(offsets, result);
 }
 

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -270,6 +270,7 @@ mod tests {
         Condition::Field(FieldCondition {
             key,
             r#match: None,
+            datetime_range: None,
             range: None,
             geo_bounding_box: None,
             geo_radius: None,

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -286,6 +286,7 @@ mod tests {
             "rating": vec![3, 7, 9, 9],
             "color": "red",
             "has_delivery": true,
+            "shipped_at": "2020-02-15T00:00:00Z",
             "parts": [],
             "packaging": null,
             "not_null": [null]
@@ -377,6 +378,40 @@ mod tests {
         let match_blue = Condition::Field(FieldCondition::new_match(
             "color".to_string(),
             "blue".to_owned().into(),
+        ));
+        let shipped_in_february = Condition::Field(FieldCondition::new_datetime_range(
+            "shipped_at".to_string(),
+            Range {
+                lt: Some(
+                    chrono::DateTime::parse_from_rfc3339("2020-03-01T00:00:00Z")
+                        .unwrap()
+                        .into(),
+                ),
+                gt: None,
+                gte: Some(
+                    chrono::DateTime::parse_from_rfc3339("2020-02-01T00:00:00Z")
+                        .unwrap()
+                        .into(),
+                ),
+                lte: None,
+            },
+        ));
+        let shipped_in_march = Condition::Field(FieldCondition::new_datetime_range(
+            "shipped_at".to_string(),
+            Range {
+                lt: Some(
+                    chrono::DateTime::parse_from_rfc3339("2020-04-01T00:00:00Z")
+                        .unwrap()
+                        .into(),
+                ),
+                gt: None,
+                gte: Some(
+                    chrono::DateTime::parse_from_rfc3339("2020-03-01T00:00:00Z")
+                        .unwrap()
+                        .into(),
+                ),
+                lte: None,
+            },
         ));
         let with_delivery = Condition::Field(FieldCondition::new_match(
             "has_delivery".to_string(),
@@ -522,6 +557,19 @@ mod tests {
             must_not: None,
         };
         assert!(payload_checker.check(0, &query));
+
+        let query = Filter {
+            should: None,
+            must: Some(vec![shipped_in_february]),
+            must_not: None,
+        };
+        assert!(payload_checker.check(0, &query));
+        let query = Filter {
+            should: None,
+            must: Some(vec![shipped_in_march]),
+            must_not: None,
+        };
+        assert!(!payload_checker.check(0, &query));
 
         let query = Filter {
             should: None,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -42,6 +42,8 @@ pub type TagType = u64;
 pub type FloatPayloadType = f64;
 /// Type of integer point payload
 pub type IntPayloadType = i64;
+/// Type of datetime point payload
+pub type DateTimePayloadType = chrono::DateTime<chrono::Utc>;
 
 pub const VECTOR_ELEMENT_SIZE: usize = size_of::<VectorElementType>();
 
@@ -1065,6 +1067,7 @@ pub enum PayloadSchemaType {
     Geo,
     Text,
     Bool,
+    Datetime,
 }
 
 /// Payload type with parameters
@@ -1224,8 +1227,7 @@ impl Match {
         Self::Value(MatchValue { value })
     }
 
-    #[cfg(test)]
-    fn new_text(text: &str) -> Self {
+    pub fn new_text(text: &str) -> Self {
         Self::Text(MatchText { text: text.into() })
     }
 
@@ -1324,19 +1326,31 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
 /// Range filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub struct Range {
+pub struct Range<T> {
     /// point.key < range.lt
-    pub lt: Option<FloatPayloadType>,
+    pub lt: Option<T>,
     /// point.key > range.gt
-    pub gt: Option<FloatPayloadType>,
+    pub gt: Option<T>,
     /// point.key >= range.gte
-    pub gte: Option<FloatPayloadType>,
+    pub gte: Option<T>,
     /// point.key <= range.lte
-    pub lte: Option<FloatPayloadType>,
+    pub lte: Option<T>,
 }
 
-impl Range {
-    pub fn check_range(&self, number: FloatPayloadType) -> bool {
+impl<T: Copy> Range<T> {
+    /// Convert range to a range of another type
+    pub fn map<U, F: Fn(T) -> U>(&self, f: F) -> Range<U> {
+        Range {
+            lt: self.lt.map(&f),
+            gt: self.gt.map(&f),
+            gte: self.gte.map(&f),
+            lte: self.lte.map(&f),
+        }
+    }
+}
+
+impl<T: Copy + PartialOrd> Range<T> {
+    pub fn check_range(&self, number: T) -> bool {
         self.lt.map_or(true, |x| number < x)
             && self.gt.map_or(true, |x| number > x)
             && self.lte.map_or(true, |x| number <= x)
@@ -1543,7 +1557,9 @@ pub struct FieldCondition {
     /// Check if point has field with a given value
     pub r#match: Option<Match>,
     /// Check if points value lies in a given range
-    pub range: Option<Range>,
+    pub range: Option<Range<FloatPayloadType>>,
+    /// Check if datetime is within a given range
+    pub datetime_range: Option<Range<DateTimePayloadType>>,
     /// Check if points geo location lies in a given area
     pub geo_bounding_box: Option<GeoBoundingBox>,
     /// Check if geo point is within a given radius
@@ -1560,6 +1576,7 @@ impl FieldCondition {
             key: key.into(),
             r#match: Some(r#match),
             range: None,
+            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1567,11 +1584,28 @@ impl FieldCondition {
         }
     }
 
-    pub fn new_range(key: impl Into<PayloadKeyType>, range: Range) -> Self {
+    pub fn new_range(key: impl Into<PayloadKeyType>, range: Range<FloatPayloadType>) -> Self {
         Self {
             key: key.into(),
             r#match: None,
             range: Some(range),
+            datetime_range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+        }
+    }
+
+    pub fn new_datetime_range(
+        key: impl Into<PayloadKeyType>,
+        datetime_range: Range<DateTimePayloadType>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            r#match: None,
+            range: None,
+            datetime_range: Some(datetime_range),
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1587,6 +1621,7 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
+            datetime_range: None,
             geo_bounding_box: Some(geo_bounding_box),
             geo_radius: None,
             geo_polygon: None,
@@ -1599,6 +1634,7 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
+            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: Some(geo_radius),
             geo_polygon: None,
@@ -1611,6 +1647,7 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
+            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: Some(geo_polygon),
@@ -1623,6 +1660,7 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
+            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1633,6 +1671,7 @@ impl FieldCondition {
     pub fn all_fields_none(&self) -> bool {
         self.r#match.is_none()
             && self.range.is_none()
+            && self.datetime_range.is_none()
             && self.geo_bounding_box.is_none()
             && self.geo_radius.is_none()
             && self.geo_polygon.is_none()

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -699,6 +699,7 @@ fn convert_field_type(
             FieldType::Geo => Some(PayloadSchemaType::Geo.into()),
             FieldType::Text => Some(PayloadSchemaType::Text.into()),
             FieldType::Bool => Some(PayloadSchemaType::Bool.into()),
+            FieldType::Datetime => Some(PayloadSchemaType::Datetime.into()),
         },
         // Parameterized index with mismatching types
         (


### PR DESCRIPTION
This PR adds datetime payload index. /claim #3320

Open for discussion/feedback:
- Internal representation. Current format: milliseconds in `i64`. Possible alternatives: nanoseconds in `u64` or seconds in `f64`.
- Timestamp representation. Current format: RFC3339, e.g., `2019-01-01T00:00:00.000Z`.
- Currently `datetime_range` is a separate key. Need to investigate if this could be merged with the `range` key in a straightforward way.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
