### PR TITLE
Add "clock_tag" field to update operations in the WAL and to the internal gRPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "ordered-float 4.2.0",
  "parking_lot",
  "pprof",
+ "proptest",
  "rand 0.8.5",
  "rmp-serde",
  "rstest",
@@ -3607,6 +3608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4873,6 +4885,8 @@ dependencies = [
  "memmap2 0.9.4",
  "memory",
  "ordered-float 4.2.0",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "schemars",
  "serde",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -26,10 +26,11 @@ use crate::grpc::qdrant::{
     HasIdCondition, HealthCheckReply, HnswConfigDiff, IntegerIndexParams, IsEmptyCondition,
     IsNullCondition, ListCollectionsResponse, ListValue, Match, NamedVectors, NestedCondition,
     PayloadExcludeSelector, PayloadIncludeSelector, PayloadIndexParams, PayloadSchemaInfo,
-    PayloadSchemaType, PointId, ProductQuantization, QuantizationConfig, QuantizationSearchParams,
-    QuantizationType, Range, RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint,
-    SearchParams, ShardKey, Struct, TextIndexParams, TokenizerType, Value, ValuesCount, Vector,
-    Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
+    PayloadSchemaType, PointId, PointsOperationResponse, PointsOperationResponseInternal,
+    ProductQuantization, QuantizationConfig, QuantizationSearchParams, QuantizationType, Range,
+    RepeatedIntegers, RepeatedStrings, ScalarQuantization, ScoredPoint, SearchParams, ShardKey,
+    Struct, TextIndexParams, TokenizerType, UpdateResult, UpdateResultInternal, Value, ValuesCount,
+    Vector, Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector,
 };
 
 pub fn payload_to_proto(payload: segment::types::Payload) -> HashMap<String, Value> {
@@ -1315,4 +1316,43 @@ pub fn into_named_vector_struct(
             }
         }
     })
+}
+
+impl From<PointsOperationResponseInternal> for PointsOperationResponse {
+    fn from(resp: PointsOperationResponseInternal) -> Self {
+        Self {
+            result: resp.result.map(Into::into),
+            time: resp.time,
+        }
+    }
+}
+
+// TODO: Make it explicit `from_operations_response` method instead of `impl From<PointsOperationResponse>`?
+impl From<PointsOperationResponse> for PointsOperationResponseInternal {
+    fn from(resp: PointsOperationResponse) -> Self {
+        Self {
+            result: resp.result.map(Into::into),
+            time: resp.time,
+        }
+    }
+}
+
+impl From<UpdateResultInternal> for UpdateResult {
+    fn from(res: UpdateResultInternal) -> Self {
+        Self {
+            operation_id: res.operation_id,
+            status: res.status,
+        }
+    }
+}
+
+// TODO: Make it explicit `from_update_result` method instead of `impl From<UpdateResult>`?
+impl From<UpdateResult> for UpdateResultInternal {
+    fn from(res: UpdateResult) -> Self {
+        Self {
+            operation_id: res.operation_id,
+            status: res.status,
+            clock_tag: None,
+        }
+    }
 }

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -6,17 +6,17 @@ package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
 
 service PointsInternal {
-  rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponse) {}
-  rpc Sync (SyncPointsInternal) returns (PointsOperationResponse) {}
-  rpc Delete (DeletePointsInternal) returns (PointsOperationResponse) {}
-  rpc UpdateVectors (UpdateVectorsInternal) returns (PointsOperationResponse) {}
-  rpc DeleteVectors (DeleteVectorsInternal) returns (PointsOperationResponse) {}
-  rpc SetPayload (SetPayloadPointsInternal) returns (PointsOperationResponse) {}
-  rpc OverwritePayload (SetPayloadPointsInternal) returns (PointsOperationResponse) {}
-  rpc DeletePayload (DeletePayloadPointsInternal) returns (PointsOperationResponse) {}
-  rpc ClearPayload (ClearPayloadPointsInternal) returns (PointsOperationResponse) {}
-  rpc CreateFieldIndex (CreateFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
-  rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponse) {}
+  rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc Sync (SyncPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc Delete (DeletePointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc UpdateVectors (UpdateVectorsInternal) returns (PointsOperationResponseInternal) {}
+  rpc DeleteVectors (DeleteVectorsInternal) returns (PointsOperationResponseInternal) {}
+  rpc SetPayload (SetPayloadPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc OverwritePayload (SetPayloadPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc DeletePayload (DeletePayloadPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc ClearPayload (ClearPayloadPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc CreateFieldIndex (CreateFieldIndexCollectionInternal) returns (PointsOperationResponseInternal) {}
+  rpc DeleteFieldIndex (DeleteFieldIndexCollectionInternal) returns (PointsOperationResponseInternal) {}
   rpc Search (SearchPointsInternal) returns (SearchResponse) {}
   rpc SearchBatch (SearchBatchPointsInternal) returns (SearchBatchResponse) {}
   rpc CoreSearchBatch (CoreSearchBatchPointsInternal) returns (SearchBatchResponse) {}
@@ -39,51 +39,80 @@ message SyncPoints {
 message SyncPointsInternal {
   SyncPoints sync_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message UpsertPointsInternal {
   UpsertPoints upsert_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message DeletePointsInternal {
   DeletePoints delete_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message UpdateVectorsInternal {
   UpdatePointVectors update_vectors = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message DeleteVectorsInternal {
   DeletePointVectors delete_vectors = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message SetPayloadPointsInternal {
   SetPayloadPoints set_payload_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message DeletePayloadPointsInternal {
   DeletePayloadPoints delete_payload_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message ClearPayloadPointsInternal {
   ClearPayloadPoints clear_payload_points = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message CreateFieldIndexCollectionInternal {
   CreateFieldIndexCollection create_field_index_collection = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
 }
 
 message DeleteFieldIndexCollectionInternal {
   DeleteFieldIndexCollection delete_field_index_collection = 1;
   optional uint32 shard_id = 2;
+  optional ClockTag clock_tag = 3;
+}
+
+// Has to be backward compatible with `PointsOperationResponse`!
+message PointsOperationResponseInternal {
+  UpdateResultInternal result = 1;
+  double time = 2; // Time spent to process
+}
+
+// Has to be backward compatible with `UpdateResult`!
+message UpdateResultInternal {
+  optional uint64 operation_id = 1; // Number of operation
+  UpdateStatus status = 2; // Operation status
+  optional ClockTag clock_tag = 3;
+}
+
+message ClockTag {
+  uint64 peer_id = 1;
+  uint32 clock_id = 2;
+  uint64 clock_tick = 3;
 }
 
 message SearchPointsInternal {
@@ -113,8 +142,8 @@ message DiscoveryQuery {
   repeated ContextPair context = 2;
 }
 
-message ContextQuery { 
-  repeated ContextPair context = 1; 
+message ContextQuery {
+  repeated ContextPair context = 1;
 }
 
 message QueryEnum {
@@ -131,14 +160,14 @@ message CoreSearchPoints {
   string collection_name = 1;
   QueryEnum query = 2;
   Filter filter = 3;
-  uint64 limit = 4; 
+  uint64 limit = 4;
   WithPayloadSelector with_payload = 5;
   SearchParams params = 6;
   optional float score_threshold = 7;
   optional uint64 offset = 8;
-  optional string vector_name = 9; 
-  optional WithVectorsSelector with_vectors = 10; 
-  optional ReadConsistency read_consistency = 11; 
+  optional string vector_name = 9;
+  optional WithVectorsSelector with_vectors = 10;
+  optional ReadConsistency read_consistency = 11;
 }
 
 message CoreSearchBatchPointsInternal {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7076,6 +7076,8 @@ pub struct SyncPointsInternal {
     pub sync_points: ::core::option::Option<SyncPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7087,6 +7089,8 @@ pub struct UpsertPointsInternal {
     pub upsert_points: ::core::option::Option<UpsertPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7098,6 +7102,8 @@ pub struct DeletePointsInternal {
     pub delete_points: ::core::option::Option<DeletePoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7109,6 +7115,8 @@ pub struct UpdateVectorsInternal {
     pub update_vectors: ::core::option::Option<UpdatePointVectors>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7120,6 +7128,8 @@ pub struct DeleteVectorsInternal {
     pub delete_vectors: ::core::option::Option<DeletePointVectors>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7131,6 +7141,8 @@ pub struct SetPayloadPointsInternal {
     pub set_payload_points: ::core::option::Option<SetPayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7142,6 +7154,8 @@ pub struct DeletePayloadPointsInternal {
     pub delete_payload_points: ::core::option::Option<DeletePayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7153,6 +7167,8 @@ pub struct ClearPayloadPointsInternal {
     pub clear_payload_points: ::core::option::Option<ClearPayloadPoints>,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7166,6 +7182,8 @@ pub struct CreateFieldIndexCollectionInternal {
     >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7179,6 +7197,44 @@ pub struct DeleteFieldIndexCollectionInternal {
     >,
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
+}
+/// Has to be backward compatible with `PointsOperationResponse`!
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointsOperationResponseInternal {
+    #[prost(message, optional, tag = "1")]
+    pub result: ::core::option::Option<UpdateResultInternal>,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
+}
+/// Has to be backward compatible with `UpdateResult`!
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateResultInternal {
+    /// Number of operation
+    #[prost(uint64, optional, tag = "1")]
+    pub operation_id: ::core::option::Option<u64>,
+    /// Operation status
+    #[prost(enumeration = "UpdateStatus", tag = "2")]
+    pub status: i32,
+    #[prost(message, optional, tag = "3")]
+    pub clock_tag: ::core::option::Option<ClockTag>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClockTag {
+    #[prost(uint64, tag = "1")]
+    pub peer_id: u64,
+    #[prost(uint32, tag = "2")]
+    pub clock_id: u32,
+    #[prost(uint64, tag = "3")]
+    pub clock_tick: u64,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -7461,7 +7517,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7486,7 +7542,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7511,7 +7567,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7536,7 +7592,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateVectorsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7561,7 +7617,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteVectorsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7586,7 +7642,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7611,7 +7667,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SetPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7636,7 +7692,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeletePayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7661,7 +7717,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ClearPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7686,7 +7742,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateFieldIndexCollectionInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7711,7 +7767,7 @@ pub mod points_internal_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFieldIndexCollectionInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         > {
             self.inner
@@ -7907,77 +7963,77 @@ pub mod points_internal_server {
             &self,
             request: tonic::Request<super::UpsertPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn sync(
             &self,
             request: tonic::Request<super::SyncPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn delete(
             &self,
             request: tonic::Request<super::DeletePointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn update_vectors(
             &self,
             request: tonic::Request<super::UpdateVectorsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn delete_vectors(
             &self,
             request: tonic::Request<super::DeleteVectorsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn set_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn overwrite_payload(
             &self,
             request: tonic::Request<super::SetPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn delete_payload(
             &self,
             request: tonic::Request<super::DeletePayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn clear_payload(
             &self,
             request: tonic::Request<super::ClearPayloadPointsInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn create_field_index(
             &self,
             request: tonic::Request<super::CreateFieldIndexCollectionInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn delete_field_index(
             &self,
             request: tonic::Request<super::DeleteFieldIndexCollectionInternal>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponse>,
+            tonic::Response<super::PointsOperationResponseInternal>,
             tonic::Status,
         >;
         async fn search(
@@ -8104,7 +8160,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::UpsertPointsInternal>
                     for UpsertSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8150,7 +8206,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::SyncPointsInternal>
                     for SyncSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8196,7 +8252,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::DeletePointsInternal>
                     for DeleteSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8242,7 +8298,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::UpdateVectorsInternal>
                     for UpdateVectorsSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8288,7 +8344,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::DeleteVectorsInternal>
                     for DeleteVectorsSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8334,7 +8390,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::SetPayloadPointsInternal>
                     for SetPayloadSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8380,7 +8436,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::SetPayloadPointsInternal>
                     for OverwritePayloadSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8427,7 +8483,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::DeletePayloadPointsInternal>
                     for DeletePayloadSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8473,7 +8529,7 @@ pub mod points_internal_server {
                         T: PointsInternal,
                     > tonic::server::UnaryService<super::ClearPayloadPointsInternal>
                     for ClearPayloadSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8520,7 +8576,7 @@ pub mod points_internal_server {
                     > tonic::server::UnaryService<
                         super::CreateFieldIndexCollectionInternal,
                     > for CreateFieldIndexSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -8570,7 +8626,7 @@ pub mod points_internal_server {
                     > tonic::server::UnaryService<
                         super::DeleteFieldIndexCollectionInternal,
                     > for DeleteFieldIndexSvc<T> {
-                        type Response = super::PointsOperationResponse;
+                        type Response = super::PointsOperationResponseInternal;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -14,6 +14,7 @@ tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 [dev-dependencies]
 criterion = "0.5"
 rstest = "0.18.2"
+proptest = "1.4.0"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -104,7 +104,9 @@ fn batch_search_bench(c: &mut Criterion) {
 
     let rnd_batch = create_rnd_batch();
 
-    handle.block_on(shard.update(rnd_batch, true)).unwrap();
+    handle
+        .block_on(shard.update(rnd_batch.into(), true))
+        .unwrap();
 
     let mut group = c.benchmark_group("batch-search-bench");
 

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -51,11 +51,9 @@ impl Collection {
             }),
         );
 
-        // This function is called from consensus, so we can't afford to wait for the result
-        // as indexation may take a long time
-        let wait = false;
-
-        let result = self.update_all_local(create_index_operation, wait).await?;
+        // This function is called from consensus, so we use `wait = false`, because we can't afford
+        // to wait for the result as indexation may take a long time
+        let result = self.update_all_local(create_index_operation, false).await?;
 
         Ok(result)
     }

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -11,7 +11,7 @@ use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::*;
-use crate::operations::CollectionUpdateOperations;
+use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use crate::shards::shard::ShardId;
 
 impl Collection {
@@ -41,7 +41,13 @@ impl Collection {
 
             let local_updates: FuturesUnordered<_> = shard_holder
                 .all_shards()
-                .map(|shard| shard.update_local(operation.clone(), wait))
+                .map(|shard| {
+                    // The operation *can't* have a clock tag!
+                    //
+                    // We update *all* shards with a single operation, but each shard has it's own clock,
+                    // so it's *impossible* to assign any single clock tag to this operation.
+                    shard.update_local(OperationWithClockTag::from(operation.clone()), wait)
+                })
                 .collect();
 
             let results: Vec<_> = local_updates.collect().await;
@@ -72,7 +78,7 @@ impl Collection {
     /// This method is cancel safe.
     pub async fn update_from_peer(
         &self,
-        operation: CollectionUpdateOperations,
+        operation: OperationWithClockTag,
         shard_selection: ShardId,
         wait: bool,
         ordering: WriteOrdering,
@@ -89,10 +95,16 @@ impl Collection {
 
             match ordering {
                 WriteOrdering::Weak => shard.update_local(operation, wait).await,
-                WriteOrdering::Medium | WriteOrdering::Strong => shard
-                    .update_with_consistency(operation, wait, ordering)
-                    .await
-                    .map(Some),
+                WriteOrdering::Medium | WriteOrdering::Strong => {
+                    if operation.clock_tag.is_some() {
+                        log::error!("TODO"); // TODO!
+                    }
+
+                    shard
+                        .update_with_consistency(operation.operation, wait, ordering)
+                        .await
+                        .map(Some)
+                }
             }
         })
         .await??;

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -96,8 +96,12 @@ impl Collection {
             match ordering {
                 WriteOrdering::Weak => shard.update_local(operation, wait).await,
                 WriteOrdering::Medium | WriteOrdering::Strong => {
-                    if operation.clock_tag.is_some() {
-                        log::error!("TODO"); // TODO!
+                    if let Some(clock_tag) = operation.clock_tag {
+                        log::warn!(
+                            "Received update operation forwarded from another peer with {ordering:?} \
+                             with non-`None` clock tag {clock_tag:?} (operation: {:#?})",
+                             operation.operation,
+                        );
                     }
 
                     shard

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -5,7 +5,9 @@ use segment::types::ShardKey;
 use crate::collection::Collection;
 use crate::config::ShardingMethod;
 use crate::operations::types::CollectionError;
-use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
+use crate::operations::{
+    CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
+};
 use crate::shards::replica_set::{ReplicaState, ShardReplicaSet};
 use crate::shards::shard::{PeerId, ShardId, ShardsPlacement};
 
@@ -109,7 +111,9 @@ impl Collection {
                     }),
                 );
 
-                replica_set.update_local(create_index_op, true).await?;
+                replica_set
+                    .update_local(OperationWithClockTag::from(create_index_op), true) // TODO: Assign clock tag!? 🤔
+                    .await?;
             }
 
             self.shards_holder.write().await.add_shard(

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -903,7 +903,9 @@ impl TryFrom<i32> for UpdateStatus {
             api::grpc::qdrant::UpdateStatus::Completed => Self::Completed,
 
             api::grpc::qdrant::UpdateStatus::UnknownUpdateStatus => {
-                return Err(Status::invalid_argument("TODO")); // TODO!?
+                return Err(Status::invalid_argument(
+                    "Malformed UpdateStatus type: update status is unknown",
+                ));
             }
         };
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -844,34 +844,70 @@ pub fn try_points_selector_from_grpc(
     }
 }
 
-impl From<UpdateResult> for api::grpc::qdrant::UpdateResult {
-    fn from(value: UpdateResult) -> Self {
+impl From<UpdateResult> for api::grpc::qdrant::UpdateResultInternal {
+    fn from(res: UpdateResult) -> Self {
         Self {
-            operation_id: value.operation_id,
-            status: match value.status {
-                UpdateStatus::Acknowledged => api::grpc::qdrant::UpdateStatus::Acknowledged as i32,
-                UpdateStatus::Completed => api::grpc::qdrant::UpdateStatus::Completed as i32,
-            },
+            operation_id: res.operation_id,
+            status: res.status.into(),
+            clock_tag: res.clock_tag.map(Into::into),
         }
+    }
+}
+
+impl From<UpdateResult> for api::grpc::qdrant::UpdateResult {
+    fn from(res: UpdateResult) -> Self {
+        api::grpc::qdrant::UpdateResultInternal::from(res).into()
+    }
+}
+
+impl TryFrom<api::grpc::qdrant::UpdateResultInternal> for UpdateResult {
+    type Error = Status;
+
+    fn try_from(res: api::grpc::qdrant::UpdateResultInternal) -> Result<Self, Self::Error> {
+        let res = Self {
+            operation_id: res.operation_id,
+            status: res.status.try_into()?,
+            clock_tag: res.clock_tag.map(Into::into),
+        };
+
+        Ok(res)
     }
 }
 
 impl TryFrom<api::grpc::qdrant::UpdateResult> for UpdateResult {
     type Error = Status;
 
-    fn try_from(value: api::grpc::qdrant::UpdateResult) -> Result<Self, Self::Error> {
-        Ok(Self {
-            operation_id: value.operation_id,
-            status: match value.status {
-                status if status == api::grpc::qdrant::UpdateStatus::Acknowledged as i32 => {
-                    UpdateStatus::Acknowledged
-                }
-                status if status == api::grpc::qdrant::UpdateStatus::Completed as i32 => {
-                    UpdateStatus::Completed
-                }
-                _ => return Err(Status::invalid_argument("Malformed UpdateStatus type")),
-            },
-        })
+    fn try_from(res: api::grpc::qdrant::UpdateResult) -> Result<Self, Self::Error> {
+        api::grpc::qdrant::UpdateResultInternal::from(res).try_into()
+    }
+}
+
+impl From<UpdateStatus> for i32 {
+    fn from(status: UpdateStatus) -> Self {
+        match status {
+            UpdateStatus::Acknowledged => api::grpc::qdrant::UpdateStatus::Acknowledged as i32,
+            UpdateStatus::Completed => api::grpc::qdrant::UpdateStatus::Completed as i32,
+        }
+    }
+}
+
+impl TryFrom<i32> for UpdateStatus {
+    type Error = Status;
+
+    fn try_from(status: i32) -> Result<Self, Self::Error> {
+        let status = api::grpc::qdrant::UpdateStatus::from_i32(status)
+            .ok_or_else(|| Status::invalid_argument("Malformed UpdateStatus type"))?;
+
+        let status = match status {
+            api::grpc::qdrant::UpdateStatus::Acknowledged => Self::Acknowledged,
+            api::grpc::qdrant::UpdateStatus::Completed => Self::Completed,
+
+            api::grpc::qdrant::UpdateStatus::UnknownUpdateStatus => {
+                return Err(Status::invalid_argument("TODO")); // TODO!?
+            }
+        };
+
+        Ok(status)
     }
 }
 

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -20,16 +20,16 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::hash_ring::HashRing;
-use crate::shards::shard::ShardId;
+use crate::shards::shard::{PeerId, ShardId};
 
-#[derive(Debug, Deserialize, Serialize, Validate, Default, Clone)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateIndex {
     pub field_name: String,
     pub field_schema: Option<PayloadFieldSchema>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FieldIndexOperations {
     /// Create index for payload field
@@ -38,9 +38,68 @@ pub enum FieldIndexOperations {
     DeleteIndex(String),
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct OperationWithClockTag {
+    #[serde(flatten)]
+    pub operation: CollectionUpdateOperations,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clock_tag: Option<ClockTag>,
+}
+
+impl OperationWithClockTag {
+    pub fn new(
+        operation: impl Into<CollectionUpdateOperations>,
+        clock_tag: Option<ClockTag>,
+    ) -> Self {
+        Self {
+            operation: operation.into(),
+            clock_tag,
+        }
+    }
+}
+
+impl From<CollectionUpdateOperations> for OperationWithClockTag {
+    fn from(operation: CollectionUpdateOperations) -> Self {
+        Self::new(operation, None)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ClockTag {
+    peer_id: PeerId,
+    clock_id: u32,
+    clock_tick: u64,
+}
+
+impl ClockTag {
+    pub fn new(peer_id: PeerId, clock_id: u32, clock_tick: u64) -> Self {
+        Self {
+            peer_id,
+            clock_id,
+            clock_tick,
+        }
+    }
+}
+
+impl From<api::grpc::qdrant::ClockTag> for ClockTag {
+    fn from(meta: api::grpc::qdrant::ClockTag) -> Self {
+        Self::new(meta.peer_id, meta.clock_id, meta.clock_tick)
+    }
+}
+
+impl From<ClockTag> for api::grpc::qdrant::ClockTag {
+    fn from(meta: ClockTag) -> Self {
+        Self {
+            peer_id: meta.peer_id,
+            clock_id: meta.clock_id,
+            clock_tick: meta.clock_tick,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum CollectionUpdateOperations {
     PointOperation(point_ops::PointOperations),
     VectorOperation(vector_ops::VectorOperations),
@@ -179,18 +238,201 @@ impl CollectionUpdateOperations {
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use proptest::prelude::*;
+    use segment::types::*;
 
+    use super::payload_ops::*;
+    use super::point_ops::*;
+    use super::vector_ops::*;
     use super::*;
 
-    #[test]
-    fn test_deserialize() {
-        let op =
-            CollectionUpdateOperations::PayloadOperation(payload_ops::PayloadOps::ClearPayload {
-                points: vec![1.into(), 2.into(), 3.into()],
+    proptest::proptest! {
+        #[test]
+        fn operation_with_clock_tag_json(operation in any::<OperationWithClockTag>()) {
+            // Assert that `OperationWithClockTag` can be serialized
+            let input = serde_json::to_string(&operation).unwrap();
+            let output: OperationWithClockTag = serde_json::from_str(&input).unwrap();
+            assert_eq!(operation, output);
+
+            // Assert that `OperationWithClockTag` can be deserialized from `CollectionUpdateOperation`
+            let input = serde_json::to_string(&operation.operation).unwrap();
+            let output: OperationWithClockTag = serde_json::from_str(&input).unwrap();
+            assert_eq!(operation.operation, output.operation);
+
+            // Assert that `CollectionUpdateOperation` serializes into JSON object with a single key
+            // (e.g., `{ "upsert_points": <upsert points object> }`)
+            match serde_json::to_value(&operation.operation).unwrap() {
+                serde_json::Value::Object(map) if map.len() == 1 => (),
+                _ => panic!("TODO"),
+            };
+        }
+
+        #[test]
+        fn operation_with_clock_tag_cbor(operation in any::<OperationWithClockTag>()) {
+            // Assert that `OperationWithClockTag` can be serialized
+            let input = serde_cbor::to_vec(&operation).unwrap();
+            let output: OperationWithClockTag = serde_cbor::from_slice(&input).unwrap();
+            assert_eq!(operation, output);
+
+            // Assert that `OperationWithClockTag` can be deserialized from `CollectionUpdateOperation`
+            let input = serde_cbor::to_vec(&operation.operation).unwrap();
+            let output: OperationWithClockTag = serde_cbor::from_slice(&input).unwrap();
+            assert_eq!(operation.operation, output.operation);
+        }
+    }
+
+    impl Arbitrary for OperationWithClockTag {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            any::<(CollectionUpdateOperations, Option<ClockTag>)>()
+                .prop_map(|(operation, clock_tag)| Self::new(operation, clock_tag))
+                .boxed()
+        }
+    }
+
+    impl Arbitrary for ClockTag {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            any::<(PeerId, u32, u64)>()
+                .prop_map(|(peer_id, clock_id, clock_tick)| {
+                    Self::new(peer_id, clock_id, clock_tick)
+                })
+                .boxed()
+        }
+    }
+
+    impl Arbitrary for CollectionUpdateOperations {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            prop_oneof![
+                any::<point_ops::PointOperations>().prop_map(Self::PointOperation),
+                any::<vector_ops::VectorOperations>().prop_map(Self::VectorOperation),
+                any::<payload_ops::PayloadOps>().prop_map(Self::PayloadOperation),
+                any::<FieldIndexOperations>().prop_map(Self::FieldIndexOperation),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for point_ops::PointOperations {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            let upsert = Self::UpsertPoints(PointInsertOperationsInternal::PointsList(Vec::new()));
+            let delete = Self::DeletePoints { ids: Vec::new() };
+
+            let delete_by_filter = Self::DeletePointsByFilter(Filter {
+                should: None,
+                must: None,
+                must_not: None,
             });
 
-        let json = serde_json::to_string_pretty(&op).unwrap();
-        println!("{json}")
+            let sync = Self::SyncPoints(PointSyncOperation {
+                from_id: None,
+                to_id: None,
+                points: Vec::new(),
+            });
+
+            prop_oneof![
+                Just(upsert),
+                Just(delete),
+                Just(delete_by_filter),
+                Just(sync),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for vector_ops::VectorOperations {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            let update = Self::UpdateVectors(UpdateVectorsOp { points: Vec::new() });
+
+            let delete = Self::DeleteVectors(
+                PointIdsList {
+                    points: Vec::new(),
+                    shard_key: None,
+                },
+                Vec::new(),
+            );
+
+            let delete_by_filter = Self::DeleteVectorsByFilter(
+                Filter {
+                    should: None,
+                    must: None,
+                    must_not: None,
+                },
+                Vec::new(),
+            );
+
+            prop_oneof![Just(update), Just(delete), Just(delete_by_filter),].boxed()
+        }
+    }
+
+    impl Arbitrary for payload_ops::PayloadOps {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            let set = Self::SetPayload(SetPayloadOp {
+                payload: Payload(Default::default()),
+                points: None,
+                filter: None,
+            });
+
+            let overwrite = Self::OverwritePayload(SetPayloadOp {
+                payload: Payload(Default::default()),
+                points: None,
+                filter: None,
+            });
+
+            let delete = Self::DeletePayload(DeletePayloadOp {
+                keys: Vec::new(),
+                points: None,
+                filter: None,
+            });
+
+            let clear = Self::ClearPayload { points: Vec::new() };
+
+            let clear_by_filter = Self::ClearPayloadByFilter(Filter {
+                should: None,
+                must: None,
+                must_not: None,
+            });
+
+            prop_oneof![
+                Just(set),
+                Just(overwrite),
+                Just(delete),
+                Just(clear),
+                Just(clear_by_filter),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for FieldIndexOperations {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            let create = Self::CreateIndex(CreateIndex {
+                field_name: String::new(),
+                field_schema: None,
+            });
+
+            let delete = Self::DeleteIndex(String::new());
+
+            prop_oneof![Just(create), Just(delete),].boxed()
+        }
     }
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -83,17 +83,17 @@ impl ClockTag {
 }
 
 impl From<api::grpc::qdrant::ClockTag> for ClockTag {
-    fn from(meta: api::grpc::qdrant::ClockTag) -> Self {
-        Self::new(meta.peer_id, meta.clock_id, meta.clock_tick)
+    fn from(tag: api::grpc::qdrant::ClockTag) -> Self {
+        Self::new(tag.peer_id, tag.clock_id, tag.clock_tick)
     }
 }
 
 impl From<ClockTag> for api::grpc::qdrant::ClockTag {
-    fn from(meta: ClockTag) -> Self {
+    fn from(tag: ClockTag) -> Self {
         Self {
-            peer_id: meta.peer_id,
-            clock_id: meta.clock_id,
-            clock_tick: meta.clock_tick,
+            peer_id: tag.peer_id,
+            clock_id: tag.clock_id,
+            clock_tick: tag.clock_tick,
         }
     }
 }

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -27,7 +27,7 @@ pub struct SetPayload {
 ///
 /// Unlike `SetPayload` it does not contain `shard_key` field
 /// as individual shard does not need to know about shard key
-#[derive(Debug, Deserialize, Serialize, Validate, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Validate)]
 pub struct SetPayloadOp {
     pub payload: Payload,
     /// Assigns payload to each point in this list
@@ -91,7 +91,7 @@ pub struct DeletePayload {
 ///
 /// Unlike `DeletePayload` it does not contain `shard_key` field
 /// as individual shard does not need to know about shard key
-#[derive(Debug, Deserialize, Serialize, Validate, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Validate)]
 pub struct DeletePayloadOp {
     /// List of payload keys to remove from payload
     pub keys: Vec<PayloadKeyType>,
@@ -127,7 +127,7 @@ impl TryFrom<DeletePayloadShadow> for DeletePayload {
 }
 
 /// Define operations description for point payloads manipulation
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PayloadOps {
     /// Set payload value, overrides if it is already exists

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -33,7 +33,7 @@ pub enum WriteOrdering {
     Strong,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Validate)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct PointStruct {
     /// Point id
@@ -70,7 +70,7 @@ impl TryFrom<Record> for PointStruct {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Batch {
     pub ids: Vec<PointIdType>,
@@ -96,7 +96,7 @@ impl Batch {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct PointIdsList {
     pub points: Vec<PointIdType>,
@@ -139,7 +139,7 @@ impl Validate for PointsSelector {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct PointSyncOperation {
     /// Minimal id of the sync range
     pub from_id: Option<PointIdType>,
@@ -191,7 +191,7 @@ impl PointInsertOperations {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PointInsertOperationsInternal {
     /// Inset points from a batch.
@@ -305,7 +305,7 @@ impl From<Vec<PointStruct>> for PointInsertOperationsInternal {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PointOperations {
     /// Insert or update points

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -38,6 +38,7 @@ use tonic::codegen::http::uri::InvalidUri;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::config_diff::{self};
+use super::ClockTag;
 use crate::config::{CollectionConfig, CollectionParams};
 use crate::lookup::types::WithLookupInterface;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
@@ -256,8 +257,14 @@ pub struct UpdateResult {
     /// Sequential number of the operation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_id: Option<SeqNumberType>,
+
     /// Update status
     pub status: UpdateStatus,
+
+    /// Updated value for the external clock tick
+    /// Provided if incoming update request also specify clock tick
+    #[serde(skip)]
+    pub clock_tag: Option<ClockTag>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -23,7 +23,7 @@ pub struct UpdateVectors {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct PointVectors {
     /// Point id
     pub id: PointIdType,
@@ -61,7 +61,7 @@ pub struct DeleteVectors {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Validate, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Validate)]
 pub struct UpdateVectorsOp {
     /// Points with named vectors
     #[validate]
@@ -69,7 +69,7 @@ pub struct UpdateVectorsOp {
     pub points: Vec<PointVectors>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VectorOperations {
     /// Update vectors

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -19,11 +19,12 @@ use crate::operations::point_ops::{
 };
 use crate::operations::types::CollectionResult;
 use crate::operations::vector_ops::UpdateVectorsOp;
-use crate::operations::CreateIndex;
+use crate::operations::{ClockTag, CreateIndex};
 use crate::shards::shard::ShardId;
 
 pub fn internal_sync_points(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     points_sync_operation: PointSyncOperation,
     wait: bool,
@@ -31,6 +32,7 @@ pub fn internal_sync_points(
 ) -> CollectionResult<SyncPointsInternal> {
     Ok(SyncPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         sync_points: Some(SyncPoints {
             collection_name,
             wait: Some(wait),
@@ -48,6 +50,7 @@ pub fn internal_sync_points(
 
 pub fn internal_upsert_points(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     point_insert_operations: PointInsertOperationsInternal,
     wait: bool,
@@ -55,6 +58,7 @@ pub fn internal_upsert_points(
 ) -> CollectionResult<UpsertPointsInternal> {
     Ok(UpsertPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         upsert_points: Some(UpsertPoints {
             collection_name,
             wait: Some(wait),
@@ -73,6 +77,7 @@ pub fn internal_upsert_points(
 
 pub fn internal_delete_points(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     ids: Vec<PointIdType>,
     wait: bool,
@@ -80,6 +85,7 @@ pub fn internal_delete_points(
 ) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_points: Some(DeletePoints {
             collection_name,
             wait: Some(wait),
@@ -96,6 +102,7 @@ pub fn internal_delete_points(
 
 pub fn internal_delete_points_by_filter(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
     wait: bool,
@@ -103,6 +110,7 @@ pub fn internal_delete_points_by_filter(
 ) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_points: Some(DeletePoints {
             collection_name,
             wait: Some(wait),
@@ -117,6 +125,7 @@ pub fn internal_delete_points_by_filter(
 
 pub fn internal_update_vectors(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     update_vectors: UpdateVectorsOp,
     wait: bool,
@@ -124,6 +133,7 @@ pub fn internal_update_vectors(
 ) -> UpdateVectorsInternal {
     UpdateVectorsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         update_vectors: Some(UpdatePointVectors {
             collection_name,
             wait: Some(wait),
@@ -143,6 +153,7 @@ pub fn internal_update_vectors(
 
 pub fn internal_delete_vectors(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     ids: Vec<PointIdType>,
     vector_names: Vec<String>,
@@ -151,6 +162,7 @@ pub fn internal_delete_vectors(
 ) -> DeleteVectorsInternal {
     DeleteVectorsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_vectors: Some(DeletePointVectors {
             collection_name,
             wait: Some(wait),
@@ -170,6 +182,7 @@ pub fn internal_delete_vectors(
 
 pub fn internal_delete_vectors_by_filter(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
     vector_names: Vec<String>,
@@ -178,6 +191,7 @@ pub fn internal_delete_vectors_by_filter(
 ) -> DeleteVectorsInternal {
     DeleteVectorsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_vectors: Some(DeletePointVectors {
             collection_name,
             wait: Some(wait),
@@ -195,6 +209,7 @@ pub fn internal_delete_vectors_by_filter(
 
 pub fn internal_set_payload(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     set_payload: SetPayloadOp,
     wait: bool,
@@ -214,6 +229,7 @@ pub fn internal_set_payload(
 
     SetPayloadPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         set_payload_points: Some(SetPayloadPoints {
             collection_name,
             wait: Some(wait),
@@ -227,6 +243,7 @@ pub fn internal_set_payload(
 
 pub fn internal_delete_payload(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     delete_payload: DeletePayloadOp,
     wait: bool,
@@ -246,6 +263,7 @@ pub fn internal_delete_payload(
 
     DeletePayloadPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_payload_points: Some(DeletePayloadPoints {
             collection_name,
             wait: Some(wait),
@@ -259,6 +277,7 @@ pub fn internal_delete_payload(
 
 pub fn internal_clear_payload(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     points: Vec<PointIdType>,
     wait: bool,
@@ -266,6 +285,7 @@ pub fn internal_clear_payload(
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name,
             wait: Some(wait),
@@ -282,6 +302,7 @@ pub fn internal_clear_payload(
 
 pub fn internal_clear_payload_by_filter(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
     wait: bool,
@@ -289,6 +310,7 @@ pub fn internal_clear_payload_by_filter(
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name,
             wait: Some(wait),
@@ -303,6 +325,7 @@ pub fn internal_clear_payload_by_filter(
 
 pub fn internal_create_index(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     create_index: CreateIndex,
     wait: bool,
@@ -353,6 +376,7 @@ pub fn internal_create_index(
 
     CreateFieldIndexCollectionInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         create_field_index_collection: Some(CreateFieldIndexCollection {
             collection_name,
             wait: Some(wait),
@@ -366,6 +390,7 @@ pub fn internal_create_index(
 
 pub fn internal_delete_index(
     shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
     collection_name: String,
     delete_index: String,
     wait: bool,
@@ -373,6 +398,7 @@ pub fn internal_delete_index(
 ) -> DeleteFieldIndexCollectionInternal {
     DeleteFieldIndexCollectionInternal {
         shard_id,
+        clock_tag: clock_tag.map(Into::into),
         delete_field_index_collection: Some(DeleteFieldIndexCollection {
             collection_name,
             wait: Some(wait),

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -12,7 +12,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::CollectionUpdateOperations;
+use crate::operations::OperationWithClockTag;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
 
@@ -56,11 +56,7 @@ impl DummyShard {
 
 #[async_trait]
 impl ShardOperation for DummyShard {
-    async fn update(
-        &self,
-        _: CollectionUpdateOperations,
-        _: bool,
-    ) -> CollectionResult<UpdateResult> {
+    async fn update(&self, _: OperationWithClockTag, _: bool) -> CollectionResult<UpdateResult> {
         self.dummy()
     }
 

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -21,7 +21,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::CollectionUpdateOperations;
+use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -135,14 +135,14 @@ impl ShardOperation for ProxyShard {
     /// This method is *not* cancel safe.
     async fn update(
         &self,
-        operation: CollectionUpdateOperations,
+        operation: OperationWithClockTag,
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
         // If we modify `self.changed_points`, we *have to* (?) execute `local_shard` update
         // to completion, so this method is not cancel safe.
 
         let local_shard = &self.wrapped_shard;
-        let estimate_effect = operation.estimate_effect_area();
+        let estimate_effect = operation.operation.estimate_effect_area();
         let points_operation_effect: PointsOperationEffect = match estimate_effect {
             OperationEffectArea::Empty => PointsOperationEffect::Empty,
             OperationEffectArea::Points(points) => PointsOperationEffect::Some(points),

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -18,7 +18,7 @@ use crate::operations::types::{
     CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequestInternal, CountResult,
     PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::CollectionUpdateOperations;
+use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -158,7 +158,7 @@ impl ShardOperation for QueueProxyShard {
     /// This method is cancel safe.
     async fn update(
         &self,
-        operation: CollectionUpdateOperations,
+        operation: OperationWithClockTag,
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
         // `Inner::update` is cancel safe, so this is also cancel safe.
@@ -392,7 +392,7 @@ impl ShardOperation for Inner {
     /// This method is cancel safe.
     async fn update(
         &self,
-        operation: CollectionUpdateOperations,
+        operation: OperationWithClockTag,
         wait: bool,
     ) -> CollectionResult<UpdateResult> {
         // `LocalShard::update` is cancel safe, so this is also cancel safe.
@@ -475,7 +475,7 @@ impl ShardOperation for Inner {
 ///
 /// If cancelled - none, some or all operations of the batch may be transmitted to the remote.
 async fn transfer_operations_batch(
-    batch: &[(u64, CollectionUpdateOperations)],
+    batch: &[(u64, OperationWithClockTag)],
     remote_shard: &RemoteShard,
 ) -> CollectionResult<()> {
     // TODO: naive transfer approach, transfer batch of points instead

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -229,7 +229,7 @@ impl RemoteShard {
         &self,
         shard_id: Option<ShardId>,
         collection_name: String,
-        with_meta: OperationWithClockTag,
+        operation: OperationWithClockTag,
         wait: bool,
         ordering: Option<WriteOrdering>,
     ) -> CollectionResult<UpdateResult> {
@@ -239,12 +239,12 @@ impl RemoteShard {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_update_durations);
         timer.set_success(false);
 
-        let point_operation_response = match with_meta.operation {
+        let point_operation_response = match operation.operation {
             CollectionUpdateOperations::PointOperation(point_ops) => match point_ops {
                 PointOperations::UpsertPoints(point_insert_operations) => {
                     let request = &internal_upsert_points(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         point_insert_operations,
                         wait,
@@ -259,7 +259,7 @@ impl RemoteShard {
                 PointOperations::DeletePoints { ids } => {
                     let request = &internal_delete_points(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         ids,
                         wait,
@@ -274,7 +274,7 @@ impl RemoteShard {
                 PointOperations::DeletePointsByFilter(filter) => {
                     let request = &internal_delete_points_by_filter(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         filter,
                         wait,
@@ -289,7 +289,7 @@ impl RemoteShard {
                 PointOperations::SyncPoints(operation) => {
                     let request = &internal_sync_points(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         operation,
                         wait,
@@ -306,7 +306,7 @@ impl RemoteShard {
                 VectorOperations::UpdateVectors(update_operation) => {
                     let request = &internal_update_vectors(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         update_operation,
                         wait,
@@ -323,7 +323,7 @@ impl RemoteShard {
                 VectorOperations::DeleteVectors(ids, vector_names) => {
                     let request = &internal_delete_vectors(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         ids.points,
                         vector_names.clone(),
@@ -341,7 +341,7 @@ impl RemoteShard {
                 VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
                     let request = &internal_delete_vectors_by_filter(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         filter,
                         vector_names.clone(),
@@ -361,7 +361,7 @@ impl RemoteShard {
                 PayloadOps::SetPayload(set_payload) => {
                     let request = &internal_set_payload(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         set_payload,
                         wait,
@@ -378,7 +378,7 @@ impl RemoteShard {
                 PayloadOps::DeletePayload(delete_payload) => {
                     let request = &internal_delete_payload(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         delete_payload,
                         wait,
@@ -395,7 +395,7 @@ impl RemoteShard {
                 PayloadOps::ClearPayload { points } => {
                     let request = &internal_clear_payload(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         points,
                         wait,
@@ -412,7 +412,7 @@ impl RemoteShard {
                 PayloadOps::ClearPayloadByFilter(filter) => {
                     let request = &internal_clear_payload_by_filter(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         filter,
                         wait,
@@ -429,7 +429,7 @@ impl RemoteShard {
                 PayloadOps::OverwritePayload(set_payload) => {
                     let request = &internal_set_payload(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         set_payload,
                         wait,
@@ -449,7 +449,7 @@ impl RemoteShard {
                 FieldIndexOperations::CreateIndex(create_index) => {
                     let request = &internal_create_index(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         create_index,
                         wait,
@@ -466,7 +466,7 @@ impl RemoteShard {
                 FieldIndexOperations::DeleteIndex(delete_index) => {
                     let request = &internal_delete_index(
                         shard_id,
-                        with_meta.clock_tag,
+                        operation.clock_tag,
                         collection_name,
                         delete_index,
                         wait,

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -289,7 +289,7 @@ impl RemoteShard {
                 PointOperations::SyncPoints(operation) => {
                     let request = &internal_sync_points(
                         shard_id,
-                        operation.clock_tag,
+                        None, // TODO!?
                         collection_name,
                         operation,
                         wait,

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -2,22 +2,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
-};
+use segment::types::*;
 use tokio::runtime::Handle;
 
-use crate::operations::types::{
-    CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequestInternal, CountResult,
-    PointRequestInternal, Record, UpdateResult,
-};
-use crate::operations::CollectionUpdateOperations;
+use crate::operations::types::*;
+use crate::operations::OperationWithClockTag;
 
 #[async_trait]
 pub trait ShardOperation {
     async fn update(
         &self,
-        operation: CollectionUpdateOperations,
+        operation: OperationWithClockTag,
         wait: bool,
     ) -> CollectionResult<UpdateResult>;
 

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -129,14 +129,14 @@ async fn test_delete_from_indexed_payload() {
 
     let upsert_ops = upsert_operation();
 
-    shard.update(upsert_ops, true).await.unwrap();
+    shard.update(upsert_ops.into(), true).await.unwrap();
 
     let index_op = create_payload_index_operation();
 
-    shard.update(index_op, true).await.unwrap();
+    shard.update(index_op.into(), true).await.unwrap();
 
     let delete_point_op = delete_point_operation(4);
-    shard.update(delete_point_op, true).await.unwrap();
+    shard.update(delete_point_op.into(), true).await.unwrap();
 
     let info = shard.info().await.unwrap();
     eprintln!("info = {:#?}", info.payload_schema);
@@ -160,7 +160,7 @@ async fn test_delete_from_indexed_payload() {
 
     eprintln!("dropping point 5");
     let delete_point_op = delete_point_operation(5);
-    shard.update(delete_point_op, true).await.unwrap();
+    shard.update(delete_point_op.into(), true).await.unwrap();
 
     drop(shard);
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -217,7 +217,7 @@ impl UpdateHandler {
             Some(first_failed_op) => {
                 let wal_lock = wal.lock();
                 for (op_num, operation) in wal_lock.read(first_failed_op) {
-                    CollectionUpdater::update(&segments, op_num, operation)?;
+                    CollectionUpdater::update(&segments, op_num, operation.operation)?;
                 }
             }
         };

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -413,9 +413,8 @@ impl Validate for NamedVectorStruct {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum BatchVectorStruct {
     Single(Vec<DenseVector>),
     Multi(HashMap<String, Vec<Vector>>),

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -8,6 +8,8 @@ authors = [
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+proptest = ["dep:proptest", "dep:proptest-derive"]
 
 [dependencies]
 common = { path = "../common/common" }
@@ -21,3 +23,6 @@ ordered-float = "4.2"
 rand = "0.8.5"
 validator = "0.16"
 itertools = "0.12.1"
+
+proptest = { version = "1.4", optional = true }
+proptest-derive = { version = "0.4", optional = true }

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -388,6 +388,7 @@ impl TableOfContent {
                     .await?
             }
         };
+
         Ok(res)
     }
 }

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -346,6 +346,7 @@ impl TableOfContent {
                     .update_from_client(operation.operation, wait, ordering, None)
                     .await?
             }
+
             ShardSelectorInternal::All => {
                 let shard_keys = collection.get_shard_keys().await;
                 if shard_keys.is_empty() {
@@ -363,11 +364,13 @@ impl TableOfContent {
                     .await?
                 }
             }
+
             ShardSelectorInternal::ShardKey(shard_key) => {
                 collection
                     .update_from_client(operation.operation, wait, ordering, Some(shard_key))
                     .await?
             }
+
             ShardSelectorInternal::ShardKeys(shard_keys) => {
                 Self::_update_shard_keys(
                     &collection,
@@ -378,6 +381,7 @@ impl TableOfContent {
                 )
                 .await?
             }
+
             ShardSelectorInternal::ShardId(shard_selection) => {
                 collection
                     .update_from_peer(operation, shard_selection, wait, ordering)

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -48,6 +48,7 @@ async fn upsert_points(
         collection.into_inner().name,
         operation,
         None,
+        None,
         wait,
         ordering,
     )
@@ -71,6 +72,7 @@ async fn delete_points(
         toc.into_inner(),
         collection.into_inner().name,
         operation,
+        None,
         None,
         wait,
         ordering,
@@ -96,6 +98,7 @@ async fn update_vectors(
         collection.into_inner().name,
         operation,
         None,
+        None,
         wait,
         ordering,
     )
@@ -119,6 +122,7 @@ async fn delete_vectors(
         toc.into_inner(),
         collection.into_inner().name,
         operation,
+        None,
         None,
         wait,
         ordering,
@@ -144,6 +148,7 @@ async fn set_payload(
         collection.into_inner().name,
         operation,
         None,
+        None,
         wait,
         ordering,
     )
@@ -167,6 +172,7 @@ async fn overwrite_payload(
         toc.into_inner(),
         collection.into_inner().name,
         operation,
+        None,
         None,
         wait,
         ordering,
@@ -192,6 +198,7 @@ async fn delete_payload(
         collection.into_inner().name,
         operation,
         None,
+        None,
         wait,
         ordering,
     )
@@ -215,6 +222,7 @@ async fn clear_payload(
         toc.into_inner(),
         collection.into_inner().name,
         operation,
+        None,
         None,
         wait,
         ordering,
@@ -240,6 +248,7 @@ async fn update_batch(
         collection.into_inner().name,
         operations.operations,
         None,
+        None,
         wait,
         ordering,
     )
@@ -263,6 +272,7 @@ async fn create_field_index(
         collection.into_inner().name,
         operation,
         None,
+        None,
         wait,
         ordering,
     )
@@ -285,6 +295,7 @@ async fn delete_field_index(
         dispatcher.into_inner(),
         collection.into_inner().name,
         field.name.clone(),
+        None,
         None,
         wait,
         ordering,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -257,10 +257,9 @@ pub async fn do_delete_vectors(
     } = operation;
 
     let vector_names: Vec<_> = vector.into_iter().collect();
+    let shard_selector = get_shard_selector_for_update(shard_selection, shard_key);
 
     let mut result = None;
-
-    let shard_selector = get_shard_selector_for_update(shard_selection, shard_key);
 
     if let Some(filter) = filter {
         let vectors_operation =

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -21,7 +21,9 @@ use collection::operations::types::{
 use collection::operations::vector_ops::{
     DeleteVectors, UpdateVectors, UpdateVectorsOp, VectorOperations,
 };
-use collection::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
+use collection::operations::{
+    ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
+};
 use collection::shards::shard::ShardId;
 use schemars::JsonSchema;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint};
@@ -158,6 +160,7 @@ pub async fn do_upsert_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: PointInsertOperations,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -170,7 +173,7 @@ pub async fn do_upsert_points(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -182,6 +185,7 @@ pub async fn do_delete_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
     points: PointsSelector,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -199,7 +203,7 @@ pub async fn do_delete_points(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -211,6 +215,7 @@ pub async fn do_update_vectors(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: UpdateVectors,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -225,7 +230,7 @@ pub async fn do_update_vectors(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -237,12 +242,11 @@ pub async fn do_delete_vectors(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: DeleteVectors,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
-    // TODO: Is this cancel safe!?
-
     let DeleteVectors {
         vector,
         filter,
@@ -252,20 +256,18 @@ pub async fn do_delete_vectors(
 
     let vector_names: Vec<_> = vector.into_iter().collect();
 
-    let shard_selector = get_shard_selector_for_update(shard_selection, shard_key);
-
     let mut result = None;
+
+    let shard_selector = get_shard_selector_for_update(shard_selection, shard_key);
 
     if let Some(filter) = filter {
         let vectors_operation =
             VectorOperations::DeleteVectorsByFilter(filter, vector_names.clone());
-
         let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
-
         result = Some(
             toc.update(
                 &collection_name,
-                collection_operation,
+                OperationWithClockTag::new(collection_operation, clock_tag),
                 wait,
                 ordering,
                 shard_selector.clone(),
@@ -276,13 +278,11 @@ pub async fn do_delete_vectors(
 
     if let Some(points) = points {
         let vectors_operation = VectorOperations::DeleteVectors(points.into(), vector_names);
-
         let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
-
         result = Some(
             toc.update(
                 &collection_name,
-                collection_operation,
+                OperationWithClockTag::new(collection_operation, clock_tag),
                 wait,
                 ordering,
                 shard_selector,
@@ -298,6 +298,7 @@ pub async fn do_set_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: SetPayload,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -320,7 +321,7 @@ pub async fn do_set_payload(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -332,6 +333,7 @@ pub async fn do_overwrite_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: SetPayload,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -354,7 +356,7 @@ pub async fn do_overwrite_payload(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -366,6 +368,7 @@ pub async fn do_delete_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operation: DeletePayload,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -388,7 +391,7 @@ pub async fn do_delete_payload(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -400,6 +403,7 @@ pub async fn do_clear_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
     points: PointsSelector,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -419,7 +423,7 @@ pub async fn do_clear_payload(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -431,6 +435,7 @@ pub async fn do_batch_update_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
     operations: Vec<UpdateOperation>,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -443,6 +448,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.upsert,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -454,6 +460,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.delete,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -465,6 +472,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.set_payload,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -476,6 +484,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.overwrite_payload,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -487,6 +496,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.delete_payload,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -498,6 +508,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.clear_payload,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -509,6 +520,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.update_vectors,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -520,6 +532,7 @@ pub async fn do_batch_update_points(
                     toc.clone(),
                     collection_name.clone(),
                     operation.delete_vectors,
+                    clock_tag,
                     shard_selection,
                     wait,
                     ordering,
@@ -532,11 +545,13 @@ pub async fn do_batch_update_points(
     Ok(results)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_create_index_internal(
     toc: Arc<TableOfContent>,
     collection_name: String,
     field_name: PayloadKeyType,
     field_schema: Option<PayloadFieldSchema>,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -556,7 +571,7 @@ pub async fn do_create_index_internal(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -568,6 +583,7 @@ pub async fn do_create_index(
     dispatcher: Arc<Dispatcher>,
     collection_name: String,
     operation: CreateFieldIndex,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -603,6 +619,7 @@ pub async fn do_create_index(
         collection_name,
         operation.field_name,
         Some(field_schema),
+        clock_tag,
         shard_selection,
         wait,
         ordering,
@@ -614,6 +631,7 @@ pub async fn do_delete_index_internal(
     toc: Arc<TableOfContent>,
     collection_name: String,
     index_name: String,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -630,7 +648,7 @@ pub async fn do_delete_index_internal(
 
     toc.update(
         &collection_name,
-        collection_operation,
+        OperationWithClockTag::new(collection_operation, clock_tag),
         wait,
         ordering,
         shard_selector,
@@ -642,6 +660,7 @@ pub async fn do_delete_index(
     dispatcher: Arc<Dispatcher>,
     collection_name: String,
     index_name: String,
+    clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
@@ -665,6 +684,7 @@ pub async fn do_delete_index(
         dispatcher.toc().clone(),
         collection_name,
         index_name,
+        clock_tag,
         shard_selection,
         wait,
         ordering,

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -247,6 +247,8 @@ pub async fn do_delete_vectors(
     wait: bool,
     ordering: WriteOrdering,
 ) -> Result<UpdateResult, StorageError> {
+    // TODO: Is this cancel safe!?
+
     let DeleteVectors {
         vector,
         filter,
@@ -263,7 +265,9 @@ pub async fn do_delete_vectors(
     if let Some(filter) = filter {
         let vectors_operation =
             VectorOperations::DeleteVectorsByFilter(filter, vector_names.clone());
+
         let collection_operation = CollectionUpdateOperations::VectorOperation(vectors_operation);
+
         result = Some(
             toc.update(
                 &collection_name,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -44,7 +44,14 @@ impl Points for PointsService {
         request: Request<UpsertPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        upsert(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        upsert(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn delete(
@@ -52,7 +59,14 @@ impl Points for PointsService {
         request: Request<DeletePoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        delete(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn get(&self, request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
@@ -65,7 +79,14 @@ impl Points for PointsService {
         request: Request<UpdatePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        update_vectors(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        update_vectors(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn delete_vectors(
@@ -73,7 +94,14 @@ impl Points for PointsService {
         request: Request<DeletePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_vectors(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        delete_vectors(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn set_payload(
@@ -81,7 +109,14 @@ impl Points for PointsService {
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        set_payload(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        set_payload(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn overwrite_payload(
@@ -89,7 +124,14 @@ impl Points for PointsService {
         request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        overwrite_payload(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        overwrite_payload(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn delete_payload(
@@ -97,7 +139,14 @@ impl Points for PointsService {
         request: Request<DeletePayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_payload(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        delete_payload(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn clear_payload(
@@ -105,7 +154,14 @@ impl Points for PointsService {
         request: Request<ClearPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        clear_payload(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        clear_payload(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn update_batch(
@@ -113,7 +169,13 @@ impl Points for PointsService {
         request: Request<UpdateBatchPoints>,
     ) -> Result<Response<UpdateBatchResponse>, Status> {
         validate(request.get_ref())?;
-        update_batch(self.dispatcher.toc().clone(), request.into_inner(), None).await
+        update_batch(
+            self.dispatcher.toc().clone(),
+            request.into_inner(),
+            None,
+            None,
+        )
+        .await
     }
 
     async fn create_field_index(
@@ -121,7 +183,9 @@ impl Points for PointsService {
         request: Request<CreateFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        create_field_index(self.dispatcher.clone(), request.into_inner(), None).await
+        create_field_index(self.dispatcher.clone(), request.into_inner(), None, None)
+            .await
+            .map(|resp| resp.map(Into::into))
     }
 
     async fn delete_field_index(
@@ -129,7 +193,9 @@ impl Points for PointsService {
         request: Request<DeleteFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_field_index(self.dispatcher.clone(), request.into_inner(), None).await
+        delete_field_index(self.dispatcher.clone(), request.into_inner(), None, None)
+            .await
+            .map(|resp| resp.map(Into::into))
     }
 
     async fn search(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -6,7 +6,7 @@ use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, GetPointsInternal,
-    GetResponse, PointsOperationResponse, RecommendPointsInternal, RecommendResponse,
+    GetResponse, PointsOperationResponseInternal, RecommendPointsInternal, RecommendResponse,
     ScrollPointsInternal, ScrollResponse, SearchBatchPointsInternal, SearchBatchResponse,
     SearchPointsInternal, SearchResponse, SetPayloadPointsInternal, SyncPointsInternal,
     UpdateVectorsInternal, UpsertPointsInternal,
@@ -38,159 +38,231 @@ impl PointsInternal for PointsInternalService {
     async fn upsert(
         &self,
         request: Request<UpsertPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let UpsertPointsInternal {
             upsert_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let upsert_points =
             upsert_points.ok_or_else(|| Status::invalid_argument("UpsertPoints is missing"))?;
 
-        upsert(self.toc.clone(), upsert_points, shard_id).await
+        upsert(
+            self.toc.clone(),
+            upsert_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn delete(
         &self,
         request: Request<DeletePointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let DeletePointsInternal {
             delete_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let delete_points =
             delete_points.ok_or_else(|| Status::invalid_argument("DeletePoints is missing"))?;
 
-        delete(self.toc.clone(), delete_points, shard_id).await
+        delete(
+            self.toc.clone(),
+            delete_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn update_vectors(
         &self,
         request: Request<UpdateVectorsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let request = request.into_inner();
-        let shard_id = request.shard_id;
-        let update_point_vectors = request.update_vectors;
 
-        let update_point_vectors = update_point_vectors
+        let shard_id = request.shard_id;
+        let clock_tag = request.clock_tag;
+
+        let update_point_vectors = request
+            .update_vectors
             .ok_or_else(|| Status::invalid_argument("UpdateVectors is missing"))?;
 
-        update_vectors(self.toc.clone(), update_point_vectors, shard_id).await
+        update_vectors(
+            self.toc.clone(),
+            update_point_vectors,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn delete_vectors(
         &self,
         request: Request<DeleteVectorsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let request = request.into_inner();
-        let shard_id = request.shard_id;
-        let delete_point_vectors = request.delete_vectors;
 
-        let delete_point_vectors = delete_point_vectors
+        let shard_id = request.shard_id;
+        let clock_tag = request.clock_tag;
+
+        let delete_point_vectors = request
+            .delete_vectors
             .ok_or_else(|| Status::invalid_argument("DeleteVectors is missing"))?;
 
-        delete_vectors(self.toc.clone(), delete_point_vectors, shard_id).await
+        delete_vectors(
+            self.toc.clone(),
+            delete_point_vectors,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn set_payload(
         &self,
         request: Request<SetPayloadPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let set_payload_points = set_payload_points
             .ok_or_else(|| Status::invalid_argument("SetPayloadPoints is missing"))?;
 
-        set_payload(self.toc.clone(), set_payload_points, shard_id).await
+        set_payload(
+            self.toc.clone(),
+            set_payload_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn overwrite_payload(
         &self,
         request: Request<SetPayloadPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let set_payload_points = set_payload_points
             .ok_or_else(|| Status::invalid_argument("SetPayloadPoints is missing"))?;
 
-        overwrite_payload(self.toc.clone(), set_payload_points, shard_id).await
+        overwrite_payload(
+            self.toc.clone(),
+            set_payload_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn delete_payload(
         &self,
         request: Request<DeletePayloadPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let DeletePayloadPointsInternal {
             delete_payload_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let delete_payload_points = delete_payload_points
             .ok_or_else(|| Status::invalid_argument("DeletePayloadPoints is missing"))?;
 
-        delete_payload(self.toc.clone(), delete_payload_points, shard_id).await
+        delete_payload(
+            self.toc.clone(),
+            delete_payload_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn clear_payload(
         &self,
         request: Request<ClearPayloadPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let ClearPayloadPointsInternal {
             clear_payload_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let clear_payload_points = clear_payload_points
             .ok_or_else(|| Status::invalid_argument("ClearPayloadPoints is missing"))?;
 
-        clear_payload(self.toc.clone(), clear_payload_points, shard_id).await
+        clear_payload(
+            self.toc.clone(),
+            clear_payload_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn create_field_index(
         &self,
         request: Request<CreateFieldIndexCollectionInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let CreateFieldIndexCollectionInternal {
             create_field_index_collection,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let create_field_index_collection = create_field_index_collection
             .ok_or_else(|| Status::invalid_argument("CreateFieldIndexCollection is missing"))?;
 
-        create_field_index_internal(self.toc.clone(), create_field_index_collection, shard_id).await
+        create_field_index_internal(
+            self.toc.clone(),
+            create_field_index_collection,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn delete_field_index(
         &self,
         request: Request<DeleteFieldIndexCollectionInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let DeleteFieldIndexCollectionInternal {
             delete_field_index_collection,
             shard_id,
+            clock_tag,
         } = request.into_inner();
 
         let delete_field_index_collection = delete_field_index_collection
             .ok_or_else(|| Status::invalid_argument("DeleteFieldIndexCollection is missing"))?;
 
-        delete_field_index_internal(self.toc.clone(), delete_field_index_collection, shard_id).await
+        delete_field_index_internal(
+            self.toc.clone(),
+            delete_field_index_collection,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 
     async fn search(
@@ -317,14 +389,22 @@ impl PointsInternal for PointsInternalService {
     async fn sync(
         &self,
         request: Request<SyncPointsInternal>,
-    ) -> Result<Response<PointsOperationResponse>, Status> {
+    ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
         let SyncPointsInternal {
             sync_points,
             shard_id,
+            clock_tag,
         } = request.into_inner();
+
         let sync_points =
             sync_points.ok_or_else(|| Status::invalid_argument("SyncPoints is missing"))?;
-        sync(self.toc.clone(), sync_points, shard_id).await
+        sync(
+            self.toc.clone(),
+            sync_points,
+            clock_tag.map(Into::into),
+            shard_id,
+        )
+        .await
     }
 }


### PR DESCRIPTION
This PR adds a `clock_tag` field to update operations stored in WAL and to the internal gRPC API.

This field will be used (in follow-up PRs) to optimize shard transfer: e.g., search relevant position in WAL on a "good" node and only transfer part of WAL that is missing on "dead" node.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
