### PR TITLE
fix: Update main dev image tag in ghcr

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -22,7 +22,7 @@ jobs:
             docker login https://ghcr.io -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
 
             # Build regular image for Github Registry
-            GITHUB_TAG="-t ghcr.io/qdrant/qdrant/qdrant:dev-${{ github.sha }}"
+            GITHUB_TAG="-t ghcr.io/qdrant/qdrant/qdrant:dev-${{ github.sha }} -t ghcr.io/qdrant/qdrant/qdrant:dev"
 
             # Pull, retag and push to GitHub packages
             docker buildx build --platform='linux/amd64,linux/arm64' $GITHUB_TAG --push --label "org.opencontainers.image.revision"=${{ github.sha }} .

--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -1,4 +1,4 @@
-name: Docker Build and Push dev branch images
+name: Push dev branch container to ghcr
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This should make it easier to pull the latest dev branch container from Github Container registry in our CI benchmarks

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you followed the guidelines in our Contributing document?

