### PR TITLE
fix: ghcr image name should be just qdrant

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -22,7 +22,7 @@ jobs:
             docker login https://ghcr.io -u qdrant --password ${{ secrets.GITHUB_TOKEN }}
 
             # Build regular image for Github Registry
-            GITHUB_TAG="-t ghcr.io/qdrant/qdrant/qdrant:dev-${{ github.sha }} -t ghcr.io/qdrant/qdrant/qdrant:dev"
+            GITHUB_TAG="-t ghcr.io/qdrant/qdrant:dev-${{ github.sha }} -t ghcr.io/qdrant/qdrant:dev"
 
             # Pull, retag and push to GitHub packages
             docker buildx build --platform='linux/amd64,linux/arm64' $GITHUB_TAG --push --label "org.opencontainers.image.revision"=${{ github.sha }} .


### PR DESCRIPTION
All of our containers were getting pushed as `ghcr.io/qdrant/qdrant/qdrant:dev` instead of `ghcr.io/qdrant/qdrant:dev`

See [this](https://github.com/qdrant/qdrant/pkgs/container/qdrant%2Fqdrant)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

