### PR TITLE
Non-blocking snapshots

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -173,6 +173,7 @@ impl ProxySegment {
         let write_segment = self.write_segment.get();
         let mut write_segment = write_segment.write();
 
+        // TODO: define proper op_num here!
         let op_num = 0;
 
         // Propagate deleted points

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -172,7 +172,7 @@ impl ProxySegment {
     pub(super) fn propagate_to_wrapped(&self) -> OperationResult<()> {
         let wrapped_segment = self.wrapped_segment.get();
         let mut wrapped_segment = wrapped_segment.write();
-        let op_num = wrapped_segment.version() + 1;
+        let op_num = wrapped_segment.version();
 
         // Propagate deleted points
         {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -179,29 +179,29 @@ impl ProxySegment {
 
         // Propagate deleted points
         {
-            let mut deleted_points = self.deleted_points.write();
+            let deleted_points = self.deleted_points.upgradable_read();
             for point_id in deleted_points.iter() {
                 write_segment.delete_point(op_num, *point_id)?;
             }
-            deleted_points.clear();
+            RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
         }
 
         // Propagate deleted indexes
         {
-            let mut deleted_indexes = self.deleted_indexes.write();
+            let deleted_indexes = self.deleted_indexes.upgradable_read();
             for key in deleted_indexes.iter() {
                 write_segment.delete_field_index(op_num, key)?;
             }
-            deleted_indexes.clear();
+            RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
         }
 
         // Propagate created indexes
         {
-            let mut created_indexes = self.created_indexes.write();
+            let created_indexes = self.created_indexes.upgradable_read();
             for (key, field_schema) in created_indexes.iter() {
                 write_segment.create_field_index(op_num, key, Some(field_schema))?;
             }
-            created_indexes.clear();
+            RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
         }
 
         Ok(())

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -179,28 +179,34 @@ impl ProxySegment {
         // Propagate deleted points
         {
             let deleted_points = self.deleted_points.upgradable_read();
-            for point_id in deleted_points.iter() {
-                wrapped_segment.delete_point(op_num, *point_id)?;
+            if !deleted_points.is_empty() {
+                for point_id in deleted_points.iter() {
+                    wrapped_segment.delete_point(op_num, *point_id)?;
+                }
+                RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
             }
-            RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
         }
 
         // Propagate deleted indexes
         {
             let deleted_indexes = self.deleted_indexes.upgradable_read();
-            for key in deleted_indexes.iter() {
-                wrapped_segment.delete_field_index(op_num, key)?;
+            if !deleted_indexes.is_empty() {
+                for key in deleted_indexes.iter() {
+                    wrapped_segment.delete_field_index(op_num, key)?;
+                }
+                RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
             }
-            RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
         }
 
         // Propagate created indexes
         {
             let created_indexes = self.created_indexes.upgradable_read();
-            for (key, field_schema) in created_indexes.iter() {
-                wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
+            if !created_indexes.is_empty() {
+                for (key, field_schema) in created_indexes.iter() {
+                    wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
+                }
+                RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
             }
-            RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
         }
 
         Ok(())

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -172,9 +172,7 @@ impl ProxySegment {
     pub(super) fn propagate_to_wrapped(&self) -> OperationResult<()> {
         let wrapped_segment = self.wrapped_segment.get();
         let mut wrapped_segment = wrapped_segment.write();
-
-        // TODO: define proper op_num here!
-        let op_num = 0;
+        let op_num = wrapped_segment.version() + 1;
 
         // Propagate deleted points
         {

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -170,8 +170,6 @@ impl ProxySegment {
     /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
     /// required.
     pub(super) fn propagate_to_writeable(&self) -> OperationResult<()> {
-        log::trace!("Propagating changes from proxy segment into wrapped segment");
-
         let write_segment = self.write_segment.get();
         let mut write_segment = write_segment.write();
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -169,9 +169,9 @@ impl ProxySegment {
     /// This is required if making both the wrapped segment and the writable segment available in a
     /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
     /// required.
-    pub(super) fn propagate_to_writeable(&self) -> OperationResult<()> {
-        let write_segment = self.write_segment.get();
-        let mut write_segment = write_segment.write();
+    pub(super) fn propagate_to_wrapped(&self) -> OperationResult<()> {
+        let wrapped_segment = self.wrapped_segment.get();
+        let mut wrapped_segment = wrapped_segment.write();
 
         // TODO: define proper op_num here!
         let op_num = 0;
@@ -180,7 +180,7 @@ impl ProxySegment {
         {
             let deleted_points = self.deleted_points.upgradable_read();
             for point_id in deleted_points.iter() {
-                write_segment.delete_point(op_num, *point_id)?;
+                wrapped_segment.delete_point(op_num, *point_id)?;
             }
             RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
         }
@@ -189,7 +189,7 @@ impl ProxySegment {
         {
             let deleted_indexes = self.deleted_indexes.upgradable_read();
             for key in deleted_indexes.iter() {
-                write_segment.delete_field_index(op_num, key)?;
+                wrapped_segment.delete_field_index(op_num, key)?;
             }
             RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
         }
@@ -198,7 +198,7 @@ impl ProxySegment {
         {
             let created_indexes = self.created_indexes.upgradable_read();
             for (key, field_schema) in created_indexes.iter() {
-                write_segment.create_field_index(op_num, key, Some(field_schema))?;
+                wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
             }
             RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
         }

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -158,6 +158,54 @@ impl ProxySegment {
             }
         }
     }
+
+    /// Propagate changes in this proxy to the wrapped segment
+    ///
+    /// This propagates:
+    /// - delete (or moved) points
+    /// - deleted payload indexes
+    /// - created payload indexes
+    ///
+    /// This is required if making both the wrapped segment and the writable segment available in a
+    /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
+    /// required.
+    pub(super) fn propagate_to_writeable(&self) -> OperationResult<()> {
+        log::trace!("Propagating changes from proxy segment into wrapped segment");
+
+        let write_segment = self.write_segment.get();
+        let mut write_segment = write_segment.write();
+
+        let op_num = 0;
+
+        // Propagate deleted points
+        {
+            let mut deleted_points = self.deleted_points.write();
+            for point_id in deleted_points.iter() {
+                write_segment.delete_point(op_num, *point_id)?;
+            }
+            deleted_points.clear();
+        }
+
+        // Propagate deleted indexes
+        {
+            let mut deleted_indexes = self.deleted_indexes.write();
+            for key in deleted_indexes.iter() {
+                write_segment.delete_field_index(op_num, key)?;
+            }
+            deleted_indexes.clear();
+        }
+
+        // Propagate created indexes
+        {
+            let mut created_indexes = self.created_indexes.write();
+            for (key, field_schema) in created_indexes.iter() {
+                write_segment.create_field_index(op_num, key, Some(field_schema))?;
+            }
+            created_indexes.clear();
+        }
+
+        Ok(())
+    }
 }
 
 impl SegmentEntry for ProxySegment {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -750,8 +750,10 @@ impl<'s> SegmentHolder {
 
             let (segment_id, segments) = write_segments.swap(proxy, &[segment_id]);
             debug_assert_eq!(segments.len(), 1);
-            // TODO: do not unwrap here?
-            let locked_proxy_segment = write_segments.get(segment_id).cloned().unwrap();
+            let locked_proxy_segment = write_segments
+                .get(segment_id)
+                .cloned()
+                .expect("failed to get segment from segment holder we just swapped in");
             proxies.push((segment_id, locked_proxy_segment));
         }
         let segments_lock = RwLockWriteGuard::downgrade_to_upgradable(write_segments);

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -236,6 +236,12 @@ impl<'s> SegmentHolder {
         self.segments.get(&id)
     }
 
+    pub fn has_appendable_segment(&self) -> bool {
+        self.segments
+            .iter()
+            .any(|(_idx, seg)| seg.get().read().is_appendable())
+    }
+
     pub fn appendable_segments(&self) -> Vec<SegmentId> {
         self.segments
             .iter()
@@ -807,9 +813,9 @@ impl<'s> SegmentHolder {
 
         // Finalize temporary segment we proxied writes to
         // Append a temp segment to collection if it is not empty or there is no other appendable segment
-        let has_appendable_segments = write_segments.random_appendable_segment().is_some();
         let available_points = tmp_segment.get().read().available_point_count();
-        if available_points > 0 || !has_appendable_segments {
+        let has_appendable_segment = write_segments.has_appendable_segment();
+        if available_points > 0 || !has_appendable_segment {
             log::trace!("Keeping temporary segment with {available_points} points");
             write_segments.add_locked(tmp_segment);
             drop(write_segments);

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -640,7 +640,7 @@ impl<'s> SegmentHolder {
                 }
                 // All segments to snapshot should be proxy, warn if this is not the case
                 LockedSegment::Original(segment) => {
-                    log::warn!("Reached non-proxy segment while applying function to proxies, this should not happen, ignoring");
+                    debug_assert!(false, "Reached non-proxy segment while applying function to proxies, this should not happen, ignoring");
                     segment.clone()
                 }
             };
@@ -740,10 +740,10 @@ impl<'s> SegmentHolder {
         let mut proxies = Vec::with_capacity(new_proxies.len());
         let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
         for (segment_id, mut proxy) in new_proxies {
-            // Replicate field indexes a the second time, because optimized segments could have
+            // Replicate field indexes the second time, because optimized segments could have
             // been changed. The probability is small, though, so we can afford this operation
             // under the full collection write lock
-            let op_num = proxy.version() + 1;
+            let op_num = proxy.version();
             if let Err(err) = proxy.replicate_field_indexes(op_num) {
                 log::error!("Failed to replicate proxy segment field indexes, ignoring: {err}");
             }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -642,8 +642,7 @@ impl<'s> SegmentHolder {
                             .cloned()
                     })
                     .expect("failed to get random appendable segment");
-                let config = appendable_segment.get().read().config().clone();
-                config
+                appendable_segment.get().read().config().clone()
             }
         };
 
@@ -753,8 +752,13 @@ impl<'s> SegmentHolder {
                 };
 
                 match proxy_segment {
+                    // Propagate proxied changes to wrapped segment, take it out and swap with proxy
                     LockedSegment::Proxy(proxy_segment) => {
-                        let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
+                        let wrapped_segment = {
+                            let proxy_segment = proxy_segment.read();
+                            proxy_segment.propagate_to_writeable()?;
+                            proxy_segment.wrapped_segment.clone()
+                        };
                         write_segments.swap(wrapped_segment, &[proxy_id]);
                     }
                     // If already unproxied, do nothing

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -670,8 +670,6 @@ impl<'s> SegmentHolder {
         collection_path: &Path,
         collection_params: Option<&CollectionParams>,
     ) -> OperationResult<(Vec<SegmentId>, LockedSegment)> {
-        let segments_lock = segments.upgradable_read();
-
         // Source config for temporary segment which we target all writes to
         let config = match collection_params {
             // Base config on collection params
@@ -690,7 +688,7 @@ impl<'s> SegmentHolder {
             },
             // Base config on existing appendable or non-appendable segment
             None => {
-                segments_lock
+                segments.read()
                     .random_appendable_segment()
                     .ok_or_else(|| OperationError::service_error("No existing segment to source temporary segment configuration from"))?
                     .get()
@@ -708,6 +706,7 @@ impl<'s> SegmentHolder {
         let proxy_created_indexes = Arc::new(RwLock::default());
 
         // List all segments we want to snapshot
+        let segments_lock = segments.upgradable_read();
         let segment_ids = segments_lock.segments.keys().collect::<Vec<&SegmentId>>();
 
         // Create proxy for all segments

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -773,7 +773,7 @@ impl<'s> SegmentHolder {
                 LockedSegment::Proxy(proxy_segment) => Some((proxy_id, proxy_segment)),
                 LockedSegment::Original(_) => None,
             }).for_each(|(proxy_id, proxy_segment)| {
-                if let Err(err) = proxy_segment.read().propagate_to_writeable() {
+                if let Err(err) = proxy_segment.read().propagate_to_wrapped() {
                     log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}");
                 }
             });
@@ -788,7 +788,7 @@ impl<'s> SegmentHolder {
                     let wrapped_segment = {
                         let proxy_segment = proxy_segment.read();
                         // TODO: can we simply ignore this if failed? what would be better to do?
-                        if let Err(err) = proxy_segment.propagate_to_writeable() {
+                        if let Err(err) = proxy_segment.propagate_to_wrapped() {
                             log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}");
                         }
                         proxy_segment.wrapped_segment.clone()

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -773,8 +773,34 @@ impl<'s> SegmentHolder {
         proxy_ids: Vec<SegmentId>,
         tmp_segment: LockedSegment,
     ) -> OperationResult<()> {
-        let mut write_segments = segments.write();
+        // We must propagate all changes in the proxy into their wrapped segments, as we'll put the
+        // wrapped segments back into the segment holder. This can be an expensive step if we
+        // collected a lot of changes in the proxy, so we do this in two batches. First we
+        // propagate all changes on a shared read lock, not blocking other operations. Second we
+        // propagate any new changes again on an exclusive write lock, blocking other operations.
+        // This second batch should be very fast, as we already propagated all changes in the
+        // first, which is why we can hold a write lock. Once done, we can swap out the proxy for
+        // the wrapped shard.
 
+        // Batch 1: propagate changes to wrapped segment in shared read lock
+        {
+            let read_segments = segments.read();
+            proxy_ids
+                .iter()
+                .flat_map(|proxy_id| read_segments.get(*proxy_id).map(|segment| (proxy_id, segment)))
+                .flat_map(|(proxy_id, proxy_segment)| match proxy_segment {
+                    LockedSegment::Proxy(proxy_segment) => Some((proxy_id, proxy_segment)),
+                    LockedSegment::Original(_) => None,
+                }).for_each(|(proxy_id, proxy_segment)| {
+                    if let Err(err) = proxy_segment.read().propagate_to_writeable() {
+                        log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}");
+                    }
+                });
+        }
+
+        // Batch 2: propagate changes to wrapped segment in exclusive write lock
+        // Swap out each proxy with wrapped segment once changes are propagated
+        let mut write_segments = segments.write();
         for proxy_id in proxy_ids {
             let Some(proxy_segment) = write_segments.get(proxy_id) else {
                 log::error!("Unproxying temporary shard segment proxies, but a proxy segment is missing, cannot unproxy: {proxy_id}");
@@ -795,7 +821,7 @@ impl<'s> SegmentHolder {
                     write_segments.swap(wrapped_segment, &[proxy_id]);
                 }
                 // If already unproxied, do nothing
-                LockedSegment::Original(_) => continue,
+                LockedSegment::Original(_) => {}
             }
         }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -743,7 +743,7 @@ impl<'s> SegmentHolder {
             // Replicate field indexes a the second time, because optimized segments could have
             // been changed. The probability is small, though, so we can afford this operation
             // under the full collection write lock
-            let op_num = 0;
+            let op_num = proxy.version() + 1;
             if let Err(err) = proxy.replicate_field_indexes(op_num) {
                 log::error!("Failed to replicate proxy segment field indexes, ignoring: {err}");
             }

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -600,11 +600,12 @@ impl<'s> SegmentHolder {
     /// significant amount of time.
     ///
     /// This calls function `f` on all segments, but each segment is temporarily proxified while
-    /// the function is called. All segments are also unproxied again when the given function
-    /// returns.
+    /// the function is called. All segments are also unproxied at the end when the given function
+    /// has been executed on all segments.
     ///
     /// A read lock is kept during the whole process to prevent external actors from messing with
-    /// the segment holder while segments are in proxified state.
+    /// the segment holder while segments are in proxified state. That means no other actors can
+    /// take a write lock while this operation is running.
     ///
     /// As part of this process, a new segment is created. All proxies direct their writes to this
     /// segment. The segment is added to the collection if it has any operations, otherwise it is

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -818,10 +818,8 @@ impl<'s> SegmentHolder {
         if available_points > 0 || !has_appendable_segment {
             log::trace!("Keeping temporary segment with {available_points} points");
             write_segments.add_locked(tmp_segment);
-            drop(write_segments);
         } else {
             log::trace!("Dropping temporary segment with no changes");
-            drop(write_segments);
             tmp_segment.drop_data()?;
         }
 

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -616,8 +616,9 @@ impl<'s> SegmentHolder {
     {
         let segments_lock = segments.upgradable_read();
 
+        // Source config for temporary segment which we target all writes to
         let config = match collection_params {
-            // Source temporary segment config from collection parameters
+            // Base config on collection params
             Some(collection_params) => {
                 SegmentConfig {
                     vector_data: collection_params.into_base_vector_data().unwrap(),
@@ -629,7 +630,7 @@ impl<'s> SegmentHolder {
                     },
                 }
             }
-            // Source temporary segment config from random appendable segment
+            // Base config on existing appendable or non-appendable segment
             None => {
                 let appendable_segment = segments_lock
                     .random_appendable_segment()
@@ -665,19 +666,17 @@ impl<'s> SegmentHolder {
             PayloadFieldSchema,
         >::new()));
 
-        let segment_ids = {
-            // let segments_read = segments.read();
-            segments_lock
-                .segments
-                .keys()
-                .cloned()
-                .collect::<Vec<SegmentId>>()
-        };
+        // List all segments we want to snapshot
+        let segment_ids = segments_lock
+            .segments
+            .keys()
+            .cloned()
+            .collect::<Vec<SegmentId>>();
 
+        // Create proxy for all segments
         let mut proxies = Vec::new();
         for segment_id in &segment_ids {
             let segment = segments_lock.segments.get(segment_id).unwrap();
-
             let mut proxy = ProxySegment::new(
                 segment.clone(),
                 tmp_segment.clone(),
@@ -702,6 +701,7 @@ impl<'s> SegmentHolder {
             LockedSegment::Proxy(_) => unreachable!(),
         }
 
+        // Replace all segments with proxies
         let proxy_ids: Vec<_> = {
             // Exclusive lock for the segments operations.
             let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
@@ -722,7 +722,7 @@ impl<'s> SegmentHolder {
             let read_segments = segments.read();
             for proxy_id in &proxy_ids {
                 let Some(proxy_segment) = read_segments.get(*proxy_id) else {
-                    log::warn!("Proxy segment to snapshot is not available anymore, this should not happen, ignoring");
+                    log::error!("Running operation on all proxied shard segments, but a proxy segment is missing: {proxy_id}");
                     continue;
                 };
 
@@ -734,7 +734,7 @@ impl<'s> SegmentHolder {
                     }
                     // All segments to snapshot should be proxy, warn if this is not the case
                     LockedSegment::Original(segment) => {
-                        log::warn!("Reached non-proxy segment while snapshotting, this should not happen, ignoring");
+                        log::warn!("Reached non-proxy segment while applying operation to proxies, this should not happen, ignoring");
                         segment.clone()
                     }
                 };
@@ -748,6 +748,7 @@ impl<'s> SegmentHolder {
             let mut write_segments = segments.write();
             for proxy_id in proxy_ids {
                 let Some(proxy_segment) = write_segments.get(proxy_id) else {
+                    log::error!("Unproxying temporary shard segment proxies, but a proxy segment is missing, cannot unproxy: {proxy_id}");
                     continue;
                 };
 
@@ -792,6 +793,8 @@ impl<'s> SegmentHolder {
         temp_dir: &Path,
         snapshot_dir_path: &Path,
     ) -> OperationResult<()> {
+        // Snapshotting may take long-running read locks on segments blocking incoming writes, do
+        // this through proxied segments to allow writes to continue.
         Self::proxy_all_segments_and_apply(
             segments,
             collection_path,

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -11,11 +11,17 @@ use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWrit
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use segment::common::operation_error::{OperationError, OperationResult};
+use segment::common::version::StorageVersion;
 use segment::entry::entry_point::SegmentEntry;
-use segment::segment::Segment;
-use segment::types::{PointIdType, SeqNumberType};
+use segment::segment::{Segment, SegmentVersion};
+use segment::segment_constructor::build_segment;
+use segment::types::{
+    PayloadFieldSchema, PayloadKeyType, PayloadStorageType, PointIdType, SegmentConfig,
+    SeqNumberType,
+};
 
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
+use crate::config::CollectionParams;
 use crate::operations::types::CollectionError;
 use crate::shards::update_tracker::UpdateTracker;
 
@@ -584,20 +590,218 @@ impl<'s> SegmentHolder {
             .collect()
     }
 
+    /// Temporarily proxify all segments and apply function `f` to it.
+    ///
+    /// Intended to smoothly accept writes while performing long-running read operations on each
+    /// segment, such as during snapshotting.
+    ///
+    /// This calls function `f` on all segments, but each segment is temporarily proxified while
+    /// the function is called. All segments are also unproxied again when the given function
+    /// returns.
+    ///
+    /// As part of this process, a new segment is created. All proxies direct their writes to this
+    /// segment. The segment is added to the collection if it has any operations, otherwise it is
+    /// deleted when all segments are unproxied again.
+    ///
+    /// It is recommended to provide collection parameters. The segment configuration will be
+    /// sourced from it.
+    pub fn proxy_all_segments_and_apply<F>(
+        segments: LockedSegmentHolder,
+        collection_path: &Path,
+        collection_params: Option<&CollectionParams>,
+        f: F,
+    ) -> OperationResult<()>
+    where
+        F: Fn(Arc<RwLock<dyn SegmentEntry>>) -> OperationResult<()>,
+    {
+        let segments_lock = segments.upgradable_read();
+
+        let config = match collection_params {
+            // Source temporary segment config from collection parameters
+            Some(collection_params) => {
+                SegmentConfig {
+                    vector_data: collection_params.into_base_vector_data().unwrap(),
+                    sparse_vector_data: collection_params.into_sparse_vector_data().unwrap(),
+                    payload_storage_type: if collection_params.on_disk_payload {
+                        PayloadStorageType::OnDisk
+                    } else {
+                        PayloadStorageType::InMemory
+                    },
+                }
+            }
+            // Source temporary segment config from random appendable segment
+            None => {
+                let appendable_segment = segments_lock
+                    .random_appendable_segment()
+                    .or_else(|| {
+                        segments_lock
+                            .non_appendable_segments()
+                            .first()
+                            .and_then(|id| segments_lock.get(*id))
+                            .cloned()
+                    })
+                    .expect("failed to get random appendable segment");
+                let config = appendable_segment.get().read().config().clone();
+                config
+            }
+        };
+
+        // Create temporary appendable segment to collect proxy writes
+        let temp_segment = || -> OperationResult<LockedSegment> {
+            let config = config.clone();
+            Ok(LockedSegment::new(build_segment(
+                collection_path,
+                &config,
+                false,
+            )?))
+        };
+
+        let tmp_segment = temp_segment()?;
+
+        let proxy_deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
+        let proxy_deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
+        let proxy_created_indexes = Arc::new(RwLock::new(HashMap::<
+            PayloadKeyType,
+            PayloadFieldSchema,
+        >::new()));
+
+        let segment_ids = {
+            // let segments_read = segments.read();
+            segments_lock
+                .segments
+                .keys()
+                .cloned()
+                .collect::<Vec<SegmentId>>()
+        };
+
+        let mut proxies = Vec::new();
+        for segment_id in &segment_ids {
+            let segment = segments_lock.segments.get(segment_id).unwrap();
+
+            let mut proxy = ProxySegment::new(
+                segment.clone(),
+                tmp_segment.clone(),
+                proxy_deleted_points.clone(),
+                proxy_created_indexes.clone(),
+                proxy_deleted_indexes.clone(),
+            );
+
+            // Wrapped segment is fresh, so it has no operations
+            // Operation with number 0 will be applied
+            proxy.replicate_field_indexes(0)?;
+            proxies.push(proxy);
+        }
+
+        // Save segment version once all payload indices have been converted
+        // If this ends up not being saved due to a crash, the segment will not be used
+        match &tmp_segment {
+            LockedSegment::Original(segment) => {
+                let segment_path = &segment.read().current_path;
+                SegmentVersion::save(segment_path)?;
+            }
+            LockedSegment::Proxy(_) => unreachable!(),
+        }
+
+        let proxy_ids: Vec<_> = {
+            // Exclusive lock for the segments operations.
+            let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
+            let mut proxy_ids = Vec::new();
+            for (mut proxy, idx) in proxies.into_iter().zip(segment_ids) {
+                // replicate_field_indexes for the second time,
+                // because optimized segments could have been changed.
+                // The probability is small, though,
+                // so we can afford this operation under the full collection write lock
+                let op_num = 0;
+                proxy.replicate_field_indexes(op_num)?; // Slow only in case the index is change in the gap between two calls
+                proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
+            }
+            proxy_ids
+        };
+
+        {
+            let read_segments = segments.read();
+            for proxy_id in &proxy_ids {
+                let Some(proxy_segment) = read_segments.get(*proxy_id) else {
+                    log::warn!("Proxy segment to snapshot is not available anymore, this should not happen, ignoring");
+                    continue;
+                };
+
+                // Get segment to snapshot, wrapped proxy segment or regular one
+                let segment = match proxy_segment {
+                    LockedSegment::Proxy(proxy_segment) => {
+                        let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
+                        wrapped_segment.get()
+                    }
+                    // All segments to snapshot should be proxy, warn if this is not the case
+                    LockedSegment::Original(segment) => {
+                        log::warn!("Reached non-proxy segment while snapshotting, this should not happen, ignoring");
+                        segment.clone()
+                    }
+                };
+
+                f(segment)?;
+            }
+        }
+
+        // Unproxy all segments
+        {
+            let mut write_segments = segments.write();
+            for proxy_id in proxy_ids {
+                let Some(proxy_segment) = write_segments.get(proxy_id) else {
+                    continue;
+                };
+
+                match proxy_segment {
+                    LockedSegment::Proxy(proxy_segment) => {
+                        let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
+                        write_segments.swap(wrapped_segment, &[proxy_id]);
+                    }
+                    // If already unproxied, do nothing
+                    LockedSegment::Original(_) => continue,
+                }
+            }
+
+            // Finalize temporary segment we proxied writes to
+            // Append a temp segment to collection if it is not empty or there is no other appendable segment
+            let has_appendable_segments = write_segments.random_appendable_segment().is_some();
+            if tmp_segment.get().read().available_point_count() > 0 || !has_appendable_segments {
+                write_segments.add_locked(tmp_segment);
+
+                // Unlock collection for search and updates
+                drop(write_segments);
+            } else {
+                // Unlock collection for search and updates, then drop empty temporary segment
+                drop(write_segments);
+                tmp_segment.drop_data()?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Take a snapshot of all segments into `snapshot_dir_path`
     ///
-    /// Shortcuts at the first failing segment snapshot
+    /// It is recommended to provide collection parameters. This function internally creates a
+    /// temporary segment, which will source the configuration from it.
+    ///
+    /// Shortcuts at the first failing segment snapshot.
     pub fn snapshot_all_segments(
-        &self,
+        segments: LockedSegmentHolder,
+        collection_path: &Path,
+        collection_params: Option<&CollectionParams>,
         temp_dir: &Path,
         snapshot_dir_path: &Path,
     ) -> OperationResult<()> {
-        for segment in self.segments.values() {
-            let segment_lock = segment.get();
-            let read_segment = segment_lock.read();
-            read_segment.take_snapshot(temp_dir, snapshot_dir_path)?;
-        }
-        Ok(())
+        Self::proxy_all_segments_and_apply(
+            segments,
+            collection_path,
+            collection_params,
+            |segment| {
+                let read_segment = segment.read();
+                read_segment.take_snapshot(temp_dir, snapshot_dir_path)?;
+                Ok(())
+            },
+        )
     }
 
     pub fn report_optimizer_error<E: Into<CollectionError>>(&mut self, error: E) {
@@ -850,11 +1054,19 @@ mod tests {
         let sid2 = holder.add(segment2);
         assert_ne!(sid1, sid2);
 
+        let holder = Arc::new(RwLock::new(holder));
+
+        let collection_dir = Builder::new().prefix("collection_dir").tempdir().unwrap();
         let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
         let snapshot_dir = Builder::new().prefix("snapshot_dir").tempdir().unwrap();
-        holder
-            .snapshot_all_segments(temp_dir.path(), snapshot_dir.path())
-            .unwrap();
+        SegmentHolder::snapshot_all_segments(
+            holder,
+            collection_dir.path(),
+            None,
+            temp_dir.path(),
+            snapshot_dir.path(),
+        )
+        .unwrap();
 
         let archive_count = read_dir(&snapshot_dir).unwrap().count();
         // one archive produced per concrete segment in the SegmentHolder

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -15,10 +15,7 @@ use segment::common::version::StorageVersion;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
-use segment::types::{
-    PayloadFieldSchema, PayloadKeyType, PayloadStorageType, PointIdType, SegmentConfig,
-    SeqNumberType,
-};
+use segment::types::{PayloadStorageType, PointIdType, SegmentConfig, SeqNumberType};
 
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::config::CollectionParams;
@@ -614,25 +611,72 @@ impl<'s> SegmentHolder {
     where
         F: Fn(Arc<RwLock<dyn SegmentEntry>>) -> OperationResult<()>,
     {
+        // Proxy all segments
+        log::trace!("Proxying all shard segments to apply function");
+        let (proxy_ids, tmp_segment) =
+            Self::proxy_all_segments(segments.clone(), collection_path, collection_params)?;
+
+        // Apply provided function
+        log::trace!("Applying function on all proxied shard segments");
+        {
+            let read_segments = segments.read();
+            for proxy_id in &proxy_ids {
+                let Some(proxy_segment) = read_segments.get(*proxy_id) else {
+                    log::error!("Applying function on all proxied shard segments, but a proxy segment is missing: {proxy_id}");
+                    continue;
+                };
+
+                // Get segment to snapshot, wrapped proxy segment or regular one
+                let segment = match proxy_segment {
+                    LockedSegment::Proxy(proxy_segment) => {
+                        let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
+                        wrapped_segment.get()
+                    }
+                    // All segments to snapshot should be proxy, warn if this is not the case
+                    LockedSegment::Original(segment) => {
+                        log::warn!("Reached non-proxy segment while applying function to proxies, this should not happen, ignoring");
+                        segment.clone()
+                    }
+                };
+
+                // Call provided function on segment
+                f(segment)?;
+            }
+        }
+
+        // Unproxy all segments
+        log::trace!("Unproxying all shard segments after function is applied");
+        Self::unproxy_all_segments(segments, proxy_ids, tmp_segment)?;
+
+        Ok(())
+    }
+
+    fn proxy_all_segments(
+        segments: LockedSegmentHolder,
+        collection_path: &Path,
+        collection_params: Option<&CollectionParams>,
+    ) -> OperationResult<(Vec<SegmentId>, LockedSegment)> {
         let segments_lock = segments.upgradable_read();
 
         // Source config for temporary segment which we target all writes to
         let config = match collection_params {
             // Base config on collection params
-            Some(collection_params) => {
-                SegmentConfig {
-                    vector_data: collection_params.into_base_vector_data().unwrap(),
-                    sparse_vector_data: collection_params.into_sparse_vector_data().unwrap(),
-                    payload_storage_type: if collection_params.on_disk_payload {
-                        PayloadStorageType::OnDisk
-                    } else {
-                        PayloadStorageType::InMemory
-                    },
-                }
-            }
+            Some(collection_params) => SegmentConfig {
+                vector_data: collection_params
+                    .into_base_vector_data()
+                    .map_err(|err| OperationError::service_error(format!("Failed to source dense vector configuration from collection parameters: {err:?}")))?,
+                sparse_vector_data: collection_params
+                    .into_sparse_vector_data()
+                    .map_err(|err| OperationError::service_error(format!("Failed to source sparse vector configuration from collection parameters: {err:?}")))?,
+                payload_storage_type: if collection_params.on_disk_payload {
+                    PayloadStorageType::OnDisk
+                } else {
+                    PayloadStorageType::InMemory
+                },
+            },
             // Base config on existing appendable or non-appendable segment
             None => {
-                let appendable_segment = segments_lock
+                segments_lock
                     .random_appendable_segment()
                     .or_else(|| {
                         segments_lock
@@ -641,29 +685,20 @@ impl<'s> SegmentHolder {
                             .and_then(|id| segments_lock.get(*id))
                             .cloned()
                     })
-                    .expect("failed to get random appendable segment");
-                appendable_segment.get().read().config().clone()
+                    .ok_or_else(|| OperationError::service_error("No existing segment to source temporary segment configuration from"))?
+                    .get()
+                    .read()
+                    .config()
+                    .clone()
             }
         };
 
-        // Create temporary appendable segment to collect proxy writes
-        let temp_segment = || -> OperationResult<LockedSegment> {
-            let config = config.clone();
-            Ok(LockedSegment::new(build_segment(
-                collection_path,
-                &config,
-                false,
-            )?))
-        };
+        // Create temporary appendable segment to direct all proxy writes into
+        let tmp_segment = LockedSegment::new(build_segment(collection_path, &config, false)?);
 
-        let tmp_segment = temp_segment()?;
-
-        let proxy_deleted_points = Arc::new(RwLock::new(HashSet::<PointIdType>::new()));
-        let proxy_deleted_indexes = Arc::new(RwLock::new(HashSet::<PayloadKeyType>::new()));
-        let proxy_created_indexes = Arc::new(RwLock::new(HashMap::<
-            PayloadKeyType,
-            PayloadFieldSchema,
-        >::new()));
+        let proxy_deleted_points = Arc::new(RwLock::default());
+        let proxy_deleted_indexes = Arc::new(RwLock::default());
+        let proxy_created_indexes = Arc::new(RwLock::default());
 
         // List all segments we want to snapshot
         let segment_ids = segments_lock
@@ -715,70 +750,51 @@ impl<'s> SegmentHolder {
                 proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
             }
             proxy_ids
+
         };
 
-        {
-            let read_segments = segments.read();
-            for proxy_id in &proxy_ids {
-                let Some(proxy_segment) = read_segments.get(*proxy_id) else {
-                    log::error!("Running operation on all proxied shard segments, but a proxy segment is missing: {proxy_id}");
-                    continue;
-                };
+        Ok((proxy_ids, tmp_segment))
+    }
 
-                // Get segment to snapshot, wrapped proxy segment or regular one
-                let segment = match proxy_segment {
-                    LockedSegment::Proxy(proxy_segment) => {
-                        let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
-                        wrapped_segment.get()
-                    }
-                    // All segments to snapshot should be proxy, warn if this is not the case
-                    LockedSegment::Original(segment) => {
-                        log::warn!("Reached non-proxy segment while applying operation to proxies, this should not happen, ignoring");
-                        segment.clone()
-                    }
-                };
+    fn unproxy_all_segments(
+        segments: LockedSegmentHolder,
+        proxy_ids: Vec<SegmentId>,
+        tmp_segment: LockedSegment,
+    ) -> OperationResult<()> {
+        let mut write_segments = segments.write();
+        for proxy_id in proxy_ids {
+            let Some(proxy_segment) = write_segments.get(proxy_id) else {
+                log::error!("Unproxying temporary shard segment proxies, but a proxy segment is missing, cannot unproxy: {proxy_id}");
+                continue;
+            };
 
-                f(segment)?;
+            match proxy_segment {
+                // Propagate proxied changes to wrapped segment, take it out and swap with proxy
+                LockedSegment::Proxy(proxy_segment) => {
+                    let wrapped_segment = {
+                        let proxy_segment = proxy_segment.read();
+                        proxy_segment.propagate_to_writeable()?;
+                        proxy_segment.wrapped_segment.clone()
+                    };
+                    write_segments.swap(wrapped_segment, &[proxy_id]);
+                }
+                // If already unproxied, do nothing
+                LockedSegment::Original(_) => continue,
             }
         }
 
-        // Unproxy all segments
-        {
-            let mut write_segments = segments.write();
-            for proxy_id in proxy_ids {
-                let Some(proxy_segment) = write_segments.get(proxy_id) else {
-                    log::error!("Unproxying temporary shard segment proxies, but a proxy segment is missing, cannot unproxy: {proxy_id}");
-                    continue;
-                };
-
-                match proxy_segment {
-                    // Propagate proxied changes to wrapped segment, take it out and swap with proxy
-                    LockedSegment::Proxy(proxy_segment) => {
-                        let wrapped_segment = {
-                            let proxy_segment = proxy_segment.read();
-                            proxy_segment.propagate_to_writeable()?;
-                            proxy_segment.wrapped_segment.clone()
-                        };
-                        write_segments.swap(wrapped_segment, &[proxy_id]);
-                    }
-                    // If already unproxied, do nothing
-                    LockedSegment::Original(_) => continue,
-                }
-            }
-
-            // Finalize temporary segment we proxied writes to
-            // Append a temp segment to collection if it is not empty or there is no other appendable segment
-            let has_appendable_segments = write_segments.random_appendable_segment().is_some();
-            if tmp_segment.get().read().available_point_count() > 0 || !has_appendable_segments {
-                write_segments.add_locked(tmp_segment);
-
-                // Unlock collection for search and updates
-                drop(write_segments);
-            } else {
-                // Unlock collection for search and updates, then drop empty temporary segment
-                drop(write_segments);
-                tmp_segment.drop_data()?;
-            }
+        // Finalize temporary segment we proxied writes to
+        // Append a temp segment to collection if it is not empty or there is no other appendable segment
+        let has_appendable_segments = write_segments.random_appendable_segment().is_some();
+        let available_points = tmp_segment.get().read().available_point_count();
+        if available_points > 0 || !has_appendable_segments {
+            log::trace!("Keeping temporary segment with {available_points} points");
+            write_segments.add_locked(tmp_segment);
+            drop(write_segments);
+        } else {
+            log::trace!("Dropping temporary segment with no changes");
+            drop(write_segments);
+            tmp_segment.drop_data()?;
         }
 
         Ok(())

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -596,6 +596,9 @@ impl<'s> SegmentHolder {
     /// the function is called. All segments are also unproxied again when the given function
     /// returns.
     ///
+    /// It is possible for the provided function to get a non-proxified segment, if external
+    /// factors are modifying the segment holder at the same time.
+    ///
     /// As part of this process, a new segment is created. All proxies direct their writes to this
     /// segment. The segment is added to the collection if it has any operations, otherwise it is
     /// deleted when all segments are unproxied again.
@@ -689,13 +692,6 @@ impl<'s> SegmentHolder {
             None => {
                 segments_lock
                     .random_appendable_segment()
-                    .or_else(|| {
-                        segments_lock
-                            .non_appendable_segments()
-                            .first()
-                            .and_then(|id| segments_lock.get(*id))
-                            .cloned()
-                    })
                     .ok_or_else(|| OperationError::service_error("No existing segment to source temporary segment configuration from"))?
                     .get()
                     .read()
@@ -761,7 +757,6 @@ impl<'s> SegmentHolder {
                 proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
             }
             proxy_ids
-
         };
 
         Ok((proxy_ids, tmp_segment))

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -743,6 +743,7 @@ impl<'s> SegmentHolder {
         }
 
         // Replace all segments with proxies
+        // We cannot fail past this point to prevent only having some segments proxified
         let proxy_ids: Vec<_> = {
             // Exclusive lock for the segments operations.
             let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
@@ -753,7 +754,9 @@ impl<'s> SegmentHolder {
                 // The probability is small, though,
                 // so we can afford this operation under the full collection write lock
                 let op_num = 0;
-                proxy.replicate_field_indexes(op_num)?; // Slow only in case the index is change in the gap between two calls
+                if let Err(err) = proxy.replicate_field_indexes(op_num) {
+                    log::error!("Failed to replicate proxy segment field indexes, ignoring: {err}");
+                }
                 proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
             }
             proxy_ids

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -15,7 +15,7 @@ use segment::common::version::StorageVersion;
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::build_segment;
-use segment::types::{PayloadStorageType, PointIdType, SegmentConfig, SeqNumberType};
+use segment::types::{PointIdType, SegmentConfig, SeqNumberType};
 
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::config::CollectionParams;
@@ -683,11 +683,7 @@ impl<'s> SegmentHolder {
                 sparse_vector_data: collection_params
                     .into_sparse_vector_data()
                     .map_err(|err| OperationError::service_error(format!("Failed to source sparse vector configuration from collection parameters: {err:?}")))?,
-                payload_storage_type: if collection_params.on_disk_payload {
-                    PayloadStorageType::OnDisk
-                } else {
-                    PayloadStorageType::InMemory
-                },
+                payload_storage_type: collection_params.payload_storage_type(),
             },
             // Base config on existing appendable or non-appendable segment
             None => {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -708,15 +708,11 @@ impl<'s> SegmentHolder {
         let proxy_created_indexes = Arc::new(RwLock::default());
 
         // List all segments we want to snapshot
-        let segment_ids = segments_lock
-            .segments
-            .keys()
-            .cloned()
-            .collect::<Vec<SegmentId>>();
+        let segment_ids = segments_lock.segments.keys().collect::<Vec<&SegmentId>>();
 
         // Create proxy for all segments
-        let mut proxies = Vec::new();
-        for segment_id in &segment_ids {
+        let mut new_proxies = Vec::with_capacity(segment_ids.len());
+        for segment_id in segment_ids {
             let segment = segments_lock.segments.get(segment_id).unwrap();
             let mut proxy = ProxySegment::new(
                 segment.clone(),
@@ -729,7 +725,7 @@ impl<'s> SegmentHolder {
             // Wrapped segment is fresh, so it has no operations
             // Operation with number 0 will be applied
             proxy.replicate_field_indexes(0)?;
-            proxies.push(proxy);
+            new_proxies.push((*segment_id, proxy));
         }
 
         // Save segment version once all payload indices have been converted
@@ -744,11 +740,10 @@ impl<'s> SegmentHolder {
 
         // Replace all segments with proxies
         // We cannot fail past this point to prevent only having some segments proxified
-        let proxy_ids: Vec<_> = {
-            // Exclusive lock for the segments operations.
+        let mut proxies = Vec::with_capacity(new_proxies.len());
+        {
             let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
-            let mut proxy_ids = Vec::new();
-            for (mut proxy, idx) in proxies.into_iter().zip(segment_ids) {
+            for (segment_id, mut proxy) in new_proxies {
                 // replicate_field_indexes for the second time,
                 // because optimized segments could have been changed.
                 // The probability is small, though,
@@ -757,12 +752,11 @@ impl<'s> SegmentHolder {
                 if let Err(err) = proxy.replicate_field_indexes(op_num) {
                     log::error!("Failed to replicate proxy segment field indexes, ignoring: {err}");
                 }
-                proxy_ids.push(write_segments.swap(proxy, &[idx]).0);
+                proxies.push(write_segments.swap(proxy, &[segment_id]).0);
             }
-            proxy_ids
-        };
+        }
 
-        Ok((proxy_ids, tmp_segment))
+        Ok((proxies, tmp_segment))
     }
 
     /// Unproxy all shard segments for [`proxy_all_segments_and_apply`]

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -20,6 +20,7 @@ use segment::types::{
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
+use super::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
 use crate::collection_manager::probabilistic_segment_search_sampling::find_search_sampling_over_point_distribution;
 use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
@@ -152,7 +153,7 @@ impl SegmentsSearcher {
     }
 
     pub async fn search(
-        segments: Arc<RwLock<SegmentHolder>>,
+        segments: LockedSegmentHolder,
         batch_request: Arc<CoreSearchRequestBatch>,
         runtime_handle: &Handle,
         sampling_enabled: bool,

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -11,8 +11,8 @@ use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::types::{
-    Distance, HnswConfig, Indexes, QuantizationConfig, SparseVectorDataConfig, VectorDataConfig,
-    VectorStorageType,
+    Distance, HnswConfig, Indexes, PayloadStorageType, QuantizationConfig, SparseVectorDataConfig,
+    VectorDataConfig, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -104,6 +104,16 @@ pub struct CollectionParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate]
     pub sparse_vectors: Option<BTreeMap<String, SparseVectorParams>>,
+}
+
+impl CollectionParams {
+    pub fn payload_storage_type(&self) -> PayloadStorageType {
+        if self.on_disk_payload {
+            PayloadStorageType::OnDisk
+        } else {
+            PayloadStorageType::InMemory
+        }
+    }
 }
 
 impl Anonymize for CollectionParams {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -663,8 +663,6 @@ impl LocalShard {
         let temp_path = temp_path.to_owned();
 
         tokio::task::spawn_blocking(move || {
-            let segments_read = segments.read();
-
             // Do not change segments while snapshotting
             SegmentHolder::snapshot_all_segments(
                 segments.clone(),

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -657,9 +657,10 @@ impl LocalShard {
             rx.await?;
         }
 
-        let collection_path = self.path.clone();
+        let collection_path = self.path.parent().map(Path::to_path_buf).ok_or_else(|| {
+            CollectionError::service_error("Failed to determine collection path for shard")
+        })?;
         let collection_params = self.collection_config.read().await.params.clone();
-
         let temp_path = temp_path.to_owned();
 
         tokio::task::spawn_blocking(move || {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -657,13 +657,22 @@ impl LocalShard {
             rx.await?;
         }
 
+        let collection_path = self.path.clone();
+        let collection_params = self.collection_config.read().await.params.clone();
+
         let temp_path = temp_path.to_owned();
 
         tokio::task::spawn_blocking(move || {
             let segments_read = segments.read();
 
             // Do not change segments while snapshotting
-            segments_read.snapshot_all_segments(&temp_path, &snapshot_segments_shard_path)?;
+            SegmentHolder::snapshot_all_segments(
+                segments.clone(),
+                &collection_path,
+                Some(&collection_params),
+                &temp_path,
+                &snapshot_segments_shard_path,
+            )?;
 
             if save_wal {
                 // snapshot all shard's WAL

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -36,7 +36,9 @@ use wal::{Wal, WalOptions};
 use self::clock_map::{ClockMap, RecoveryPoint};
 use super::update_tracker::UpdateTracker;
 use crate::collection_manager::collection_updater::CollectionUpdater;
-use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
+use crate::collection_manager::holders::segment_holder::{
+    LockedSegment, LockedSegmentHolder, SegmentHolder,
+};
 use crate::collection_manager::optimizers::TrackerLog;
 use crate::common::file_utils::{move_dir, move_file};
 use crate::config::CollectionConfig;
@@ -64,7 +66,7 @@ const WAL_LOAD_REPORT_EVERY: Duration = Duration::from_secs(60);
 ///
 /// Holds all object, required for collection functioning
 pub struct LocalShard {
-    pub(super) segments: Arc<RwLock<SegmentHolder>>,
+    pub(super) segments: LockedSegmentHolder,
     pub(super) collection_config: Arc<TokioRwLock<CollectionConfig>>,
     pub(super) shared_storage_config: Arc<SharedStorageConfig>,
     pub(super) wal: RecoverableWal,

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -34,7 +34,6 @@ pub type ShardsPlacement = Vec<ShardReplicasPlacement>;
 /// Shard
 ///
 /// Contains a part of the collection's points
-///
 #[allow(clippy::large_enum_variant)]
 pub enum Shard {
     Local(LocalShard),

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ struct Args {
     /// Path to an alternative configuration file.
     /// Format: <config_file_path>
     ///
-    /// Default path : config/config.yaml
+    /// Default path: config/config.yaml
     #[arg(long, value_name = "PATH")]
     config_path: Option<String>,
 

--- a/tests/consensus_tests/test_snapshot_consistency.py
+++ b/tests/consensus_tests/test_snapshot_consistency.py
@@ -1,0 +1,107 @@
+import multiprocessing
+import pathlib
+import random
+from time import sleep
+
+from .fixtures import upsert_random_points, create_collection
+from .utils import *
+
+COLLECTION_NAME = "test_collection"
+
+
+def update_points_in_loop(peer_url, collection_name, offset=0, throttle=False, duration=None):
+    start = time.time()
+    limit = 3
+
+    while True:
+        upsert_random_points(peer_url, limit, collection_name, offset=offset)
+        offset += limit
+
+        if throttle:
+            sleep(random.uniform(0.4, 0.6))
+        if duration is not None and (time.time() - start) > duration:
+            break
+
+
+def run_update_points_in_background(peer_url, collection_name, init_offset=0, throttle=False, duration=None):
+    p = multiprocessing.Process(target=update_points_in_loop, args=(peer_url, collection_name, init_offset, throttle, duration))
+    p.start()
+    return p
+
+def check_data_consistency(data):
+
+    assert(len(data) > 1)
+
+    for i in range(len(data) - 1):
+        j = i + 1
+
+        data_i = data[i]
+        data_j = data[j]
+
+        if data_i != data_j:
+            ids_i = set(x.id for x in data_i)
+            ids_j = set(x.id for x in data_j)
+
+            diff = ids_i - ids_j
+
+            if len(diff) < 100:
+                print(f"Diff between {i} and {j}: {diff}")
+            else:
+                print(f"Diff len between {i} and {j}: {len(diff)}")
+
+            assert False, "Data on all nodes should be consistent"
+
+
+# Test data consistency across nodes when creating snapshots.
+#
+# We test this because we proxy all segments while creating a snapshot, after
+# which we unproxy all of them again propagating changes. While this is
+# happening we keep upserting new data. Because this is error prone we need to
+# assert data consistency.
+#
+# Test that data on the both sides is consistent
+def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, 3, 20000)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    # Insert points!
+    upsert_random_points(peer_api_uris[0], 10000, batch_size=100)
+
+    # Start pushing points to the cluster
+    upload_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=0, throttle=True)
+    upload_process_2 = run_update_points_in_background(peer_api_uris[1], COLLECTION_NAME, init_offset=100000, throttle=True)
+    upload_process_3 = run_update_points_in_background(peer_api_uris[2], COLLECTION_NAME, init_offset=200000, throttle=True)
+
+    sleep(1)
+
+    # Make 5 snapshots
+    for i in range(0, 5):
+        r = requests.post(f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/snapshots?wait=true")
+        assert_http_ok(r)
+
+    upload_process_1.kill()
+    upload_process_2.kill()
+    upload_process_3.kill()
+    sleep(1)
+
+    # Match all points on all nodes exactly
+    data = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
+            }
+        )
+        assert_http_ok(r)
+        data.append(r.json()["result"])
+    check_data_consistency(data)


### PR DESCRIPTION
Non-blocking collection and segment snapshots, by utilizing segment proxies.

While it already significantly decreases the likeliness of blocking significantly, it may not be fully gone yet.

I've added a few segment holder functions to make this happen in a controlled manner:
- `proxy_all_segments_and_apply`: proxy all segments, run a closure on them, and unproxy all
  - `proxy_all_segments`: proxy all segments
  - `unproxy_all_segments`: unproxy all segments and propagate changes

Snapshotting now simply calls `proxy_all_segments_and_apply` to snapshot each segment individually in a non-blocking manner.

The consensus tests asserts data consistency when upsertions are happening while snapshots are made. It helps detecting unsoundness with proxying and propagating changes because this is error prone.

I cannot think of a good test for asserting upsertions are not blocked. For that we need a huge collection/cluster, which is not suitable for CI.

### Problems
- [x]  Some hick-ups in implementation with concurrent `bfb` inserts, possibly due to saturated disk
   - I could not reproduce this 2 months later
- [x] Non-blocking snapshots and optimizers conflict on segment holder (exclusive locking attempt in [`non-blocking-snapshots-locked`](https://github.com/qdrant/qdrant/tree/non-blocking-snapshots-locked))
  - Fixed by using a single shared lock we upgrade/downgrade, during the whole snapshot process no other write locks can be taken on the segment holder.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
