### PR TITLE
fixes #3217 gRPC API should return AlreadyExists status code rather than InvalidArgument if collection already exists

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -853,6 +853,8 @@ pub struct CountResult {
 #[error("{0}")]
 pub enum CollectionError {
     #[error("Wrong input: {description}")]
+    AlreadyExists { description: String },
+    #[error("Wrong input: {description}")]
     BadInput { description: String },
     #[error("{what} not found")]
     NotFound { what: String },
@@ -949,6 +951,7 @@ impl CollectionError {
             Self::Cancelled { .. } => true,
             Self::OutOfMemory { .. } => true,
             // Not transient
+            Self::AlreadyExists { .. } => false,
             Self::BadInput { .. } => false,
             Self::NotFound { .. } => false,
             Self::PointNotFound { .. } => false,
@@ -1102,7 +1105,7 @@ impl From<tonic::Status> for CollectionError {
             tonic::Code::InvalidArgument => CollectionError::BadInput {
                 description: format!("InvalidArgument: {err}"),
             },
-            tonic::Code::AlreadyExists => CollectionError::BadInput {
+            tonic::Code::AlreadyExists => CollectionError::AlreadyExists {
                 description: format!("AlreadyExists: {err}"),
             },
             tonic::Code::NotFound => CollectionError::NotFound {

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -15,7 +15,7 @@ pub trait Checker {
         collection_name: &str,
     ) -> Result<(), StorageError> {
         if self.is_collection_exists(collection_name) {
-            return Err(StorageError::BadInput {
+            return Err(StorageError::AlreadyExists {
                 description: format!("Collection `{collection_name}` already exists!"),
             });
         }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -12,6 +12,7 @@ use crate::content_manager::errors::StorageError;
 
 pub fn error_to_status(error: StorageError) -> tonic::Status {
     let error_code = match &error {
+        StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
         StorageError::BadInput { .. } => tonic::Code::InvalidArgument,
         StorageError::NotFound { .. } => tonic::Code::NotFound,
         StorageError::ServiceError { .. } => tonic::Code::Internal,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 #[error("{0}")]
 pub enum StorageError {
     #[error("Wrong input: {description}")]
+    AlreadyExists { description: String },
+    #[error("Wrong input: {description}")]
     BadInput { description: String },
     #[error("Not found: {description}")]
     NotFound { description: String },
@@ -52,6 +54,9 @@ impl StorageError {
         overriding_description: String,
     ) -> StorageError {
         match err {
+            CollectionError::AlreadyExists { .. } => StorageError::AlreadyExists {
+                description: overriding_description,
+            },
             CollectionError::BadInput { .. } => StorageError::BadInput {
                 description: overriding_description,
             },
@@ -98,6 +103,9 @@ impl StorageError {
 impl From<CollectionError> for StorageError {
     fn from(err: CollectionError) -> Self {
         match err {
+            CollectionError::AlreadyExists { description } => {
+                StorageError::AlreadyExists { description }
+            }
             CollectionError::BadInput { description } => StorageError::BadInput { description },
             CollectionError::NotFound { .. } => StorageError::NotFound {
                 description: format!("{err}"),

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -18,7 +18,7 @@ pub fn collection_into_actix_error(err: CollectionError) -> Error {
 
 pub fn storage_into_actix_error(err: StorageError) -> Error {
     match err {
-        StorageError::AlreadyExists { .. } => error::ErrorBadRequest(format!("{err}")),
+        StorageError::AlreadyExists { .. } => error::ErrorConflict(format!("{err}")),
         StorageError::BadInput { .. } => error::ErrorBadRequest(format!("{err}")),
         StorageError::NotFound { .. } => error::ErrorNotFound(format!("{err}")),
         StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{err}")),
@@ -50,7 +50,7 @@ where
             let error_description = format!("{err}");
 
             let mut resp = match err {
-                StorageError::AlreadyExists { .. } => HttpResponse::BadRequest(),
+                StorageError::AlreadyExists { .. } => HttpResponse::Conflict(),
                 StorageError::BadInput { .. } => HttpResponse::BadRequest(),
                 StorageError::NotFound { .. } => HttpResponse::NotFound(),
                 StorageError::ServiceError {
@@ -181,7 +181,7 @@ impl From<StorageError> for HttpError {
     fn from(err: StorageError) -> Self {
         let (status_code, description) = match err {
             StorageError::AlreadyExists { description } => {
-                (http::StatusCode::BAD_REQUEST, description)
+                (http::StatusCode::CONFLICT, description)
             }
             StorageError::BadInput { description } => (http::StatusCode::BAD_REQUEST, description),
             StorageError::NotFound { description } => (http::StatusCode::NOT_FOUND, description),

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -18,6 +18,7 @@ pub fn collection_into_actix_error(err: CollectionError) -> Error {
 
 pub fn storage_into_actix_error(err: StorageError) -> Error {
     match err {
+        StorageError::AlreadyExists { .. } => error::ErrorBadRequest(format!("{err}")),
         StorageError::BadInput { .. } => error::ErrorBadRequest(format!("{err}")),
         StorageError::NotFound { .. } => error::ErrorNotFound(format!("{err}")),
         StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{err}")),
@@ -49,6 +50,7 @@ where
             let error_description = format!("{err}");
 
             let mut resp = match err {
+                StorageError::AlreadyExists { .. } => HttpResponse::BadRequest(),
                 StorageError::BadInput { .. } => HttpResponse::BadRequest(),
                 StorageError::NotFound { .. } => HttpResponse::NotFound(),
                 StorageError::ServiceError {
@@ -178,6 +180,9 @@ impl actix_web::ResponseError for HttpError {
 impl From<StorageError> for HttpError {
     fn from(err: StorageError) -> Self {
         let (status_code, description) = match err {
+            StorageError::AlreadyExists { description } => {
+                (http::StatusCode::BAD_REQUEST, description)
+            }
             StorageError::BadInput { description } => (http::StatusCode::BAD_REQUEST, description),
             StorageError::NotFound { description } => (http::StatusCode::NOT_FOUND, description),
             StorageError::ServiceError { description, .. } => {


### PR DESCRIPTION
Modifications:
- added error variants StorageError::AlreadyExists and CollectionError::AlreadyExists and code necessary for Error conversion 
- [validate_collection_not_exists](https://github.com/qdrant/qdrant/blob/97b2483660d9190835b8df13ee1b27873d370da5/lib/storage/src/content_manager/collections_ops.rs#L20) now returns the new error StorageError::AlreadyExists

Result:
- gRPC error code changed from InvalidArgument to AlreadyExists 
- Message remains the same: Wrong input: Collection `test_collection` already exists!


Edit:
Second commit inspired by @2k4sm's later pull [request](https://github.com/qdrant/qdrant/pull/3423):
409 Conflict instead of 400 Bad Request
HTTP requests that try to create a collection that already exists will receive 409 Conflict instead of 400 Bad Request

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
