### PR TITLE
fixes gRPC API return status code.

### DIFF
--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -8,13 +8,13 @@ use crate::content_manager::errors::StorageError;
 pub type Collections = HashMap<CollectionId, Collection>;
 
 pub trait Checker {
-    fn is_collection_exists(&self, collection_name: &str) -> bool;
+    fn collection_exists(&self, collection_name: &str) -> bool;
 
     async fn validate_collection_not_exists(
         &self,
         collection_name: &str,
     ) -> Result<(), StorageError> {
-        if self.is_collection_exists(collection_name) {
+        if self.collection_exists(collection_name) {
             return Err(StorageError::AlreadyExists {
                 description: format!("Collection `{collection_name}` already exists!"),
             });
@@ -23,7 +23,7 @@ pub trait Checker {
     }
 
     async fn validate_collection_exists(&self, collection_name: &str) -> Result<(), StorageError> {
-        if !self.is_collection_exists(collection_name) {
+        if !self.collection_exists(collection_name) {
             return Err(StorageError::NotFound {
                 description: format!("Collection `{collection_name}` doesn't exist!"),
             });
@@ -33,7 +33,7 @@ pub trait Checker {
 }
 
 impl Checker for Collections {
-    fn is_collection_exists(&self, collection_name: &str) -> bool {
+    fn collection_exists(&self, collection_name: &str) -> bool {
         self.contains_key(collection_name)
     }
 }

--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -15,7 +15,7 @@ pub trait Checker {
         collection_name: &str,
     ) -> Result<(), StorageError> {
         if self.is_collection_exists(collection_name) {
-            return Err(StorageError::BadInput {
+            return Err(StorageError::AlreadyExists {
                 description: format!("Collection `{collection_name}` already exists!"),
             });
         }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -18,6 +18,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::BadRequest { .. } => tonic::Code::InvalidArgument,
         StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
         StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
+        StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
     };
     tonic::Status::new(error_code, format!("{error}"))
 }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -48,6 +48,12 @@ impl StorageError {
         }
     }
 
+    pub fn already_exists(description: impl Into<String>) -> StorageError {
+        StorageError::AlreadyExists {
+            description: description.into(),
+        }
+    }
+
     /// Used to override the `description` field of the resulting `StorageError`
     pub fn from_inconsistent_shard_failure(
         err: CollectionError,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 pub enum StorageError {
     #[error("Wrong input: {description}")]
     BadInput { description: String },
+    #[error("Wrong input: {description}")]
+    AlreadyExists { description: String },
     #[error("Not found: {description}")]
     NotFound { description: String },
     #[error("Service internal error: {description}")]

--- a/openapi/tests/openapi_integration/test_alias.py
+++ b/openapi/tests/openapi_integration/test_alias.py
@@ -34,7 +34,7 @@ def test_cant_create_alias_if_collection_exists(on_disk_vectors):
         }
     )
     assert not response.ok
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 def test_cant_create_collection_if_alias_exists(on_disk_vectors):

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -24,6 +24,7 @@ pub fn storage_into_actix_error(err: StorageError) -> Error {
         StorageError::BadRequest { .. } => error::ErrorBadRequest(format!("{err}")),
         StorageError::Locked { .. } => error::ErrorForbidden(format!("{err}")),
         StorageError::Timeout { .. } => error::ErrorRequestTimeout(format!("{err}")),
+        StorageError::AlreadyExists { .. } => error::ErrorConflict(format!("{err}")),
     }
 }
 

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -192,6 +192,9 @@ impl From<StorageError> for HttpError {
             StorageError::Timeout { description } => {
                 (http::StatusCode::REQUEST_TIMEOUT, description)
             }
+            StorageError::AlreadyExists { description } => {
+                (http::StatusCode::CONFLICT, description)
+            }
         };
 
         Self {

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -65,6 +65,7 @@ where
                 StorageError::BadRequest { .. } => HttpResponse::BadRequest(),
                 StorageError::Locked { .. } => HttpResponse::Forbidden(),
                 StorageError::Timeout { .. } => HttpResponse::RequestTimeout(),
+                StorageError::AlreadyExists { .. } => HttpResponse::Conflict(),
             };
 
             resp.json(ApiResponse::<()> {


### PR DESCRIPTION
Fixes  #3217

- This PR fixes the return of AlreadyExists error instead of returning InvalidArgument in case there is an attemp to create a collection that already exists.
- To achieve this i have created a AlreadyExists error type and AlreadyExists function for StorageError enum and changed the return of StorageError from BadInput to AlreadyExists.
- This  uses tonic::Code::AlreadyExists for the returning status code.
- It also adds AlreadyExists error type for actix to handle this.
- This uses HttpResponse::Conflict for building HttpResp.
- It also adds status code and description for HttpError.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


