### PR TITLE
Optimize sparse search reaching single posting list

### DIFF
--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -184,6 +184,11 @@ impl<'a> PostingListIterator<'a> {
         }
     }
 
+    /// Slice of the remaining elements.
+    pub fn remaining_elements(&self) -> &'a [PostingElement] {
+        &self.elements[self.current_index..]
+    }
+
     /// Advances the iterator to the next element.
     pub fn advance(&mut self) {
         if self.current_index < self.elements.len() {


### PR DESCRIPTION
This PR is the logically continuation of https://github.com/qdrant/qdrant/pull/3413 which deletes exhausted empty posting lists.

The insight is that reaching a single posting list enables to quickly generate the scores by-passing the whole "advance" machinery.

## Perf. numbers

Using the [sparse-vector-benchmarks](https://github.com/qdrant/sparse-vectors-benchmark) with `python main.py --skip-creation false --dataset small --graph-y-limit 150`

Best of 3 runs.

```
DEV
Latency distribution:
50p: 39.38 millis
95p: 62.93 millis
99p: 74.37 millis
999p: 90.5 millis
max: 116.35 millis

PR
Latency distribution:
50p: 36.67 millis
95p: 61.06 millis
99p: 72.09 millis
999p: 84.94 millis
max: 98.15 millis
```

DEV             |  PR
:-------------------------:|:-------------------------:
![sparse_bench_small_dev](https://github.com/qdrant/qdrant/assets/606963/971efe74-7049-45c6-8d2c-c87fdbd6ddbc)  | ![sparse_bench_small_PR](https://github.com/qdrant/qdrant/assets/606963/9571025d-0aed-4007-a91c-2d44ab77c5dc)
 