### PR TITLE
Assign clock tags to internal update operations (and update operation responses)

### DIFF
--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -67,10 +67,10 @@ impl From<CollectionUpdateOperations> for OperationWithClockTag {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ClockTag {
-    peer_id: PeerId,
-    clock_id: u32,
-    clock_tick: u64,
-    force: bool,
+    pub peer_id: PeerId,
+    pub clock_id: u32,
+    pub clock_tick: u64,
+    pub force: bool,
 }
 
 impl ClockTag {

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -1,0 +1,91 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Default)]
+pub struct ClockSet {
+    clocks: Vec<Arc<Clock>>,
+}
+
+impl ClockSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_clock(&mut self) -> ClockGuard {
+        for (id, clock) in self.clocks.iter().enumerate() {
+            if clock.lock() {
+                return ClockGuard::new(id, clock.clone());
+            }
+        }
+
+        let id = self.clocks.len();
+        let clock = Arc::new(Clock::new_locked());
+
+        self.clocks.push(clock.clone());
+
+        ClockGuard::new(id, clock)
+    }
+}
+
+#[derive(Debug)]
+pub struct ClockGuard {
+    id: usize,
+    clock: Arc<Clock>,
+}
+
+impl ClockGuard {
+    fn new(id: usize, clock: Arc<Clock>) -> Self {
+        Self { id, clock }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn tick_once(&mut self) -> u64 {
+        self.clock.tick_once()
+    }
+
+    pub fn release(self) {
+        // Do not call `Clock::release` explicitly!
+        //
+        // `Drop` will be called when `self` goes out of scope at the end of this method
+        // and it will call `Clock::release`.
+        //
+        // If call `Clock::release` explicitly, then `ClockGuard::release` will call
+        // `Clock::release` *twice*! (Which is a bug! :D)
+    }
+}
+
+impl Drop for ClockGuard {
+    fn drop(&mut self) {
+        self.clock.release();
+    }
+}
+
+#[derive(Debug)]
+struct Clock {
+    clock: AtomicU64,
+    available: AtomicBool,
+}
+
+impl Clock {
+    pub fn new_locked() -> Self {
+        Self {
+            clock: AtomicU64::new(0),
+            available: AtomicBool::new(false),
+        }
+    }
+
+    pub fn tick_once(&self) -> u64 {
+        self.clock.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn lock(&self) -> bool {
+        self.available.swap(false, Ordering::Relaxed)
+    }
+
+    pub fn release(&self) {
+        self.available.store(true, Ordering::Relaxed);
+    }
+}

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -46,6 +46,10 @@ impl ClockGuard {
         self.clock.tick_once()
     }
 
+    pub fn advance_to(&mut self, tick: u64) -> u64 {
+        self.clock.advance_to(tick)
+    }
+
     pub fn release(self) {
         // Do not call `Clock::release` explicitly!
         //
@@ -79,6 +83,10 @@ impl Clock {
 
     pub fn tick_once(&self) -> u64 {
         self.clock.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn advance_to(&self, tick: u64) -> u64 {
+        self.clock.fetch_max(tick, Ordering::Relaxed)
     }
 
     pub fn lock(&self) -> bool {

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -12,6 +12,7 @@ impl ClockSet {
         Self::default()
     }
 
+    /// Get the first available clock from this set.
     pub fn get_clock(&mut self) -> ClockGuard {
         for (id, clock) in self.clocks.iter().enumerate() {
             if clock.lock() {

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -71,8 +71,8 @@ struct Clock {
 impl Clock {
     fn new_locked() -> Self {
         Self {
-            next_tick: AtomicU64::new(0),
-            available: AtomicBool::new(false),
+            next_tick: 0.into(),
+            available: false.into(),
         }
     }
 

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -108,7 +108,8 @@ impl Clock {
 
     /// Try to acquire exclusive lock over this clock.
     ///
-    /// Returns `true` if the lock was successfuly acquired, or `false` if the clock is already locked.
+    /// Returns `true` if the lock was successfully acquired, or `false` if the clock is already
+    /// locked.
     fn try_lock(&self) -> bool {
         self.available.swap(false, Ordering::Relaxed)
     }

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -76,12 +76,12 @@ impl Clock {
 
     #[must_use = "new clock value must be used"]
     fn tick_once(&self) -> u64 {
-        self.clock.fetch_add(1, Ordering::Relaxed) + 1
+        self.clock.fetch_add(1, Ordering::Relaxed)
     }
 
     fn advance_to(&self, new_tick: u64) -> u64 {
-        let current_tick = self.clock.fetch_max(new_tick, Ordering::Relaxed);
-        cmp::max(current_tick, new_tick)
+        let current_tick = self.clock.fetch_max(new_tick + 1, Ordering::Relaxed);
+        cmp::max(current_tick, new_tick + 1)
     }
 
     fn lock(&self) -> bool {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -185,7 +185,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
-            clock_set: Mutex::new(ClockSet::new()),
+            clock_set: Default::default(),
         })
     }
 
@@ -296,7 +296,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
-            clock_set: Mutex::new(ClockSet::new()),
+            clock_set: Default::default(),
         };
 
         if local_load_failure && replica_set.active_remote_shards().await.is_empty() {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1,3 +1,4 @@
+mod clock_set;
 mod execute_read_operation;
 mod locally_disabled_peers;
 mod read_ops;
@@ -27,6 +28,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::dummy_shard::DummyShard;
+use crate::shards::replica_set::clock_set::ClockSet;
 use crate::shards::shard::{PeerId, Shard, ShardId};
 use crate::shards::shard_config::ShardConfig;
 use crate::shards::telemetry::ReplicaSetTelemetry;
@@ -94,6 +96,7 @@ pub struct ShardReplicaSet {
     optimizer_cpu_budget: CpuBudget,
     /// Lock to serialized write operations on the replicaset when a write ordering is used.
     write_ordering_lock: Mutex<()>,
+    clock_set: Mutex<ClockSet>,
 }
 
 pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;
@@ -181,6 +184,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
+            clock_set: Mutex::new(ClockSet::new()),
         })
     }
 
@@ -291,6 +295,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
+            clock_set: Mutex::new(ClockSet::new()),
         };
 
         if local_load_failure && replica_set.active_remote_shards().await.is_empty() {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -96,6 +96,7 @@ pub struct ShardReplicaSet {
     optimizer_cpu_budget: CpuBudget,
     /// Lock to serialized write operations on the replicaset when a write ordering is used.
     write_ordering_lock: Mutex<()>,
+    /// Local clock set, used to tag new operations on this shard.
     clock_set: Mutex<ClockSet>,
 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -207,6 +207,9 @@ impl ShardReplicaSet {
             None => FuturesUnordered::from_iter(update_futures).collect().await,
         };
 
+        drop(remotes);
+        drop(local);
+
         let total_results = all_res.len();
 
         let write_consistency_factor = self

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -245,9 +245,7 @@ impl ShardReplicaSet {
             .max();
 
         if let Some(new_clock_tick) = new_clock_tick {
-            if new_clock_tick > current_clock_tick || new_clock_tick == 0 {
-                clock.advance_to(new_clock_tick);
-            }
+            clock.advance_to(new_clock_tick);
         }
 
         // Notify consensus about failures if:


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This PR
- add `ClockSet` type to generate clock tags for update operations
- assign clock tags to update operations (and update operation responses)

Currently based on #3408, but will be rebased on `dev` once #3408 is merged.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?