### PR TITLE
For automatic shard transfers, prevent no shard transfer method warning

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -403,7 +403,12 @@ impl Collection {
                     from: transfer_from,
                     to: self.this_peer_id,
                     sync: true,
-                    method: self.shared_storage_config.default_shard_transfer_method,
+                    // For automatic shard transfers, always select some default method from this point on
+                    method: Some(
+                        self.shared_storage_config
+                            .default_shard_transfer_method
+                            .unwrap_or_default(),
+                    ),
                 })
             } else {
                 log::warn!("No alive replicas to recover shard {shard_id}");

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -539,7 +539,12 @@ impl Collection {
                     to: *this_peer_id,
                     shard_id,
                     sync: true,
-                    method: self.shared_storage_config.default_shard_transfer_method,
+                    // For automatic shard transfers, always select some default method from this point on
+                    method: Some(
+                        self.shared_storage_config
+                            .default_shard_transfer_method
+                            .unwrap_or_default(),
+                    ),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/3255> we added a property to set the default shard transfer method, which is `null` by default for automatic selection.

At the call site where we initiate automatic shard transfers, we simply passed this null value along as `None`. Because we didn't selected a specific method here we render the following warning further down the line. This appears for every automatic shard transfer which can be quite noisy:

```
2024-01-22T16:39:27.608842Z  WARN collection::collection::shard_transfer: No shard transfer method selected, defaulting to StreamRecords   
```

This PR makes sure we select `stream_records` as default method from this place to prevent the warnings from popping up. It is the same as our current behavior, but prevents the warning.

In the future we _may_ decide to choose a different default here, possibly based on some heuristic. Our configuration allows this because `null` is auto selection.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?