### PR TITLE
Optimize sparse search with fast eval mode

### DIFF
--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -35,7 +35,7 @@ use tempfile::Builder;
 const MAX_SPARSE_DIM: usize = 4096;
 
 /// Number of vectors to index in tests
-const NUM_VECTORS: usize = 2000;
+const NUM_VECTORS: usize = 1000;
 
 /// Default full scan threshold in tests
 /// very low value to force usage of index
@@ -111,7 +111,16 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
                 .filter(|s| s.score != 0.0)
                 .zip(no_filter_result.iter().filter(|s| s.score != 0.0))
             {
-                assert_eq!(filter_result, no_filter_result);
+                assert_eq!(filter_result.idx, no_filter_result.idx);
+                // the scores are computed differently, but should be very close
+                let score_diff = (filter_result.score - no_filter_result.score).abs();
+                assert!(
+                    score_diff < 0.01,
+                    "query = {:#?}, filter_result = {:#?} no_filter_result = {:#?}",
+                    query,
+                    filter_result,
+                    no_filter_result,
+                );
             }
         }
     }


### PR DESCRIPTION
This PR adds a new mode for fast evaluation of the posting lists which performs all score intersections in memory.

This mode is triggered when they are less than 10k points to score in order to keep the memory usage bounded.

## Perf. numbers

Using the [sparse-vector-benchmarks](https://github.com/qdrant/sparse-vectors-benchmark) with `python main.py --skip-creation false --dataset small`

```
DEV
Latency distribution:
50p: 36.67 millis
95p: 61.06 millis
99p: 72.09 millis
999p: 84.94 millis
max: 98.15 millis

PR
Latency distribution:
50p: 18.81 millis
95p: 27.63 millis
99p: 32.02 millis
999p: 38.33 millis
max: 65.86 millis
```

The gains are great for the 100k benchmark because most requests trigger quickly the fast mode.

```
Collection is ready for querying:
- 100000 points
- 8 segments
Segments stats:
- 14720 points
- 15936 points
- 18944 points
- 9088 points
- 14528 points
- 6240 points
- 5632 points
- 14912 points
```