### PR TITLE
Remove doctest usage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,6 @@ jobs:
       uses: taiki-e/install-action@nextest
     - name: Build
       run: cargo build --tests --workspace
-    - name: Run doc tests # nextest does not support doc tests yet
-      run: cargo test --workspace --doc
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -326,14 +326,6 @@ pub fn remove_value_from_json_map(
 /// Check if a path is included in a list of patterns
 ///
 /// Basically, it checks if either the pattern or path is a prefix of the other.
-/// Examples:
-/// ```
-/// assert!(segment::common::utils::check_include_pattern("a.b.c", "a.b.c"));
-/// assert!(segment::common::utils::check_include_pattern("a.b.c", "a.b"));
-/// assert!(!segment::common::utils::check_include_pattern("a.b.c", "a.b.d"));
-/// assert!(segment::common::utils::check_include_pattern("a.b.c", "a"));
-/// assert!(segment::common::utils::check_include_pattern("a", "a.d"));
-/// ```
 pub fn check_include_pattern(pattern: &str, path: &str) -> bool {
     pattern
         .split(['.', '['])
@@ -344,15 +336,6 @@ pub fn check_include_pattern(pattern: &str, path: &str) -> bool {
 /// Check if a path should be excluded by a pattern
 ///
 /// Basically, it checks if pattern is a prefix of path, but not the other way around.
-///
-/// ```
-/// assert!(segment::common::utils::check_exclude_pattern("a.b.c", "a.b.c"));
-/// assert!(!segment::common::utils::check_exclude_pattern("a.b.c", "a.b"));
-/// assert!(!segment::common::utils::check_exclude_pattern("a.b.c", "a.b.d"));
-/// assert!(!segment::common::utils::check_exclude_pattern("a.b.c", "a"));
-/// assert!(segment::common::utils::check_exclude_pattern("a", "a.d"));
-/// ```
-
 pub fn check_exclude_pattern(pattern: &str, path: &str) -> bool {
     if pattern.len() > path.len() {
         return false;
@@ -779,5 +762,23 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_check_include_pattern() {
+        assert!(check_include_pattern("a.b.c", "a.b.c"));
+        assert!(check_include_pattern("a.b.c", "a.b"));
+        assert!(!check_include_pattern("a.b.c", "a.b.d"));
+        assert!(check_include_pattern("a.b.c", "a"));
+        assert!(check_include_pattern("a", "a.d"));
+    }
+
+    #[test]
+    fn test_check_exclude_pattern() {
+        assert!(check_exclude_pattern("a.b.c", "a.b.c"));
+        assert!(!check_exclude_pattern("a.b.c", "a.b"));
+        assert!(!check_exclude_pattern("a.b.c", "a.b.d"));
+        assert!(!check_exclude_pattern("a.b.c", "a"));
+        assert!(check_exclude_pattern("a", "a.d"));
     }
 }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -22,29 +22,6 @@ use crate::types::{Condition, Filter};
 /// # Result
 ///
 /// * `CardinalityEstimation` - new cardinality estimation
-///
-/// # Example
-///
-/// ```
-/// use segment::index::field_index::CardinalityEstimation;
-/// let estimation = CardinalityEstimation {
-///    primary_clauses: vec![],
-///   min: 0,
-///   exp: 64,
-///   max: 100
-/// };
-///
-/// let new_estimation = segment::index::query_estimator::adjust_to_available_vectors(
-///     estimation,
-///     50,
-///     200
-/// );
-///
-/// assert_eq!(new_estimation.min, 0);
-/// assert_eq!(new_estimation.exp, 16);
-/// assert_eq!(new_estimation.max, 50);
-///
-/// ```
 pub fn adjust_to_available_vectors(
     estimation: CardinalityEstimation,
     available_vectors: usize,
@@ -484,5 +461,21 @@ mod tests {
 
         let res = combine_must_estimations(&estimations, 10_000);
         eprintln!("res = {res:#?}");
+    }
+
+    #[test]
+    fn test_adjust_to_available_vectors() {
+        let estimation = CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp: 64,
+            max: 100,
+        };
+
+        let new_estimation = adjust_to_available_vectors(estimation, 50, 200);
+
+        assert_eq!(new_estimation.min, 0);
+        assert_eq!(new_estimation.exp, 16);
+        assert_eq!(new_estimation.max, 50);
     }
 }


### PR DESCRIPTION
This PR migrates all our doctest to regular unit tests.

It is motivated by the fact that we currently spends several minutes on CI for executing only 3 tests.

## before

![before](https://github.com/qdrant/qdrant/assets/606963/2e708ff6-29e3-4dde-9774-577a9ef06416)

## after

![after](https://github.com/qdrant/qdrant/assets/606963/62b295d3-d673-4305-9f25-05c593c5855a)
