### PR TITLE
PostingElement does not need to be Copy

### DIFF
--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -5,7 +5,7 @@ use ordered_float::OrderedFloat;
 
 use crate::common::types::DimWeight;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PostingElement {
     /// Record ID
     pub record_id: PointOffsetType,


### PR DESCRIPTION
Tiny change spotted during the great sparse vector accelerator program.

