### PR TITLE
Update h2 0.3.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,9 +2044,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2054,7 +2054,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.2",
+ "indexmap 2.0.1",
  "slab",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
Tackling https://github.com/qdrant/qdrant/security/dependabot/61

Initial PR to master was stuck by clippy https://github.com/qdrant/qdrant/pull/3429.

This PR can be backported later to master.