### PR TITLE
Move common dependencies to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,7 +2846,6 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,37 +42,37 @@ rusty-hook = "^0.11.2"
 
 
 [dependencies]
-
-parking_lot = { version = "0.12.1", features = ["deadlock_detection"], optional = true }
+parking_lot = { workspace = true, optional = true }
 
 thiserror = "1.0"
 log = "0.4"
 colored = "2"
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = "~1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 chrono = { version = "~0.4", features = ["serde"] }
 rand = "0.8.5"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"] }
+schemars = { workspace = true }
 itertools = "0.12"
 anyhow = "1.0.79"
-futures = "0.3.30"
-futures-util = "0.3.30"
+futures = { workspace = true }
+futures-util = { workspace = true }
 clap = { version = "4.4.18", features = ["derive"] }
-serde_cbor = { version = "0.11.2" }
-uuid = { version = "1.7", features = ["v4", "serde"] }
+serde_cbor = { workspace = true }
+uuid = { workspace = true }
 sys-info = "0.9.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
 
 config = "~0.13.4"
 
-tokio = { version = "~1.35", features = ["full"] }
+tokio = { workspace = true }
 
-actix-web = { version = "4.4.1", optional = true, features = ["rustls-0_21", "actix-tls"] }
 actix-cors = "0.7.0"
 actix-files = "0.6.5"
+actix-web = { version = "4.4.1", optional = true, features = ["rustls-0_21", "actix-tls"] }
 actix-web-httpauth = "0.8.1"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
-tonic-reflection = "0.9.2"
+actix-web-validator = "5.0.1"
+tonic = { workspace = true }
+tonic-reflection = { workspace = true }
 tower = "0.4.13"
 tower-layer = "0.3.2"
 tar = "0.4.40"
@@ -81,13 +81,12 @@ rustls = "0.21.10"
 rustls-pemfile = "2.0.0"
 prometheus = { version = "0.13.3", default-features = false }
 validator = { version = "0.16", features = ["derive"] }
-actix-web-validator = "5.0.1"
 
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 slog = { version="2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 slog-stdlog = "4.1.1"
-prost = "0.11.9"
+prost = { workspace = true }
 raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 
 common = { path = "lib/common/common" }
@@ -101,7 +100,7 @@ actix-multipart = "0.6.1"
 constant_time_eq = "0.3.0"
 
 # Profiling
-tracing = { version = "0.1", features = ["async-await"] }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
 console-subscriber = { version = "0.1", default-features = false, features = ["parking_lot"], optional = true }
@@ -113,6 +112,23 @@ rstack-self = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
+
+[workspace.dependencies]
+futures = "0.3.30"
+futures-util = "0.3.30"
+parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
+prost = "0.11.9"
+prost-types = "0.11.9"
+schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
+serde = { version = "~1.0", features = ["derive"] }
+serde_cbor = { version = "0.11.2" }
+serde_json = "~1.0"
+tokio = { version = "~1.35", features = ["full"] }
+tokio-util = "0.7"
+tonic = { version = "0.9.2", features = ["gzip", "tls"] }
+tonic-reflection = "0.9.2"
+tracing = { version = "0.1", features = ["async-await"] }
+uuid = { version = "1.7", features = ["v4", "serde"] }
 
 [[bin]]
 name = "schema_generator"

--- a/benches/search-points/Cargo.toml
+++ b/benches/search-points/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0"
 qdrant-client = { version = "0.11", default-features = false }
 rand = "0.8"
-tokio = { version = "1.23", features = ["rt"] }
+tokio = { workspace = true }
 
 [dependencies.criterion]
 version = "0.3"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -12,29 +12,29 @@ edition = "2021"
 tracing = ["dep:tracing", "segment/tracing"]
 
 [dependencies]
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
-prost = "0.11.9"
-prost-types = "0.11.9"
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = "~1.0"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"] }
-uuid = { version = "1.7", features = ["v4", "serde"] }
-tokio = "1.35.1"
+tonic = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
 rand = "0.8.5"
 chrono = { version = "~0.4", features = ["serde"] }
 thiserror = "1.0"
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 validator = { version = "0.16", features = ["derive"] }
 
-common = {path = "../common/common"}
-segment = {path = "../segment"}
+common = { path = "../common/common" }
+segment = { path = "../segment" }
 sparse = { path = "../sparse" }
 
-tracing = { version = "0.1", features = ["async-await"], optional = true }
+tracing = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.10.2", features = ["prost"] }
 prost-build = { version = "0.11.8", features = ["cleanup-markdown"] }
 
 [dev-dependencies]
-tokio = { version = "~1.35", features = ["full"] }
+tokio = { workspace = true }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -19,31 +19,30 @@ rstest = "0.18.2"
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 
 [dependencies]
-
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 
 rand = "0.8.5"
 thiserror = "1.0"
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = { version = "~1.0", features = ["std"] }
-serde_cbor = "0.11.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_cbor = { workspace = true }
 rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0"}
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 
-tokio = {version = "~1.35", features = ["full"]}
-tokio-util = "0.7"
-futures = "0.3.30"
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+futures = { workspace = true }
 atomicwrites = "0.4.3"
 log = "0.4"
 env_logger = "0.10.2"
 merge = "0.1.0"
 async-trait = "0.1.77"
 arc-swap = "1.6.0"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
-uuid = { version = "1.7", features = ["v4", "serde"] }
+tonic = { workspace = true }
+uuid = { workspace = true }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 actix-web-validator = "5.0.1"
@@ -58,7 +57,7 @@ api = {path = "../api"}
 itertools = "0.12"
 indicatif = "0.17.7"
 chrono = { version = "~0.4", features = ["serde"] }
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
+schemars = { workspace = true }
 tar = "0.4.40"
 fs_extra = "1.3.0"
 semver = "1.0.21"
@@ -66,8 +65,7 @@ tempfile = "3.9.0"
 sha2 = "0.10.8"
 bytes = "1.5.0"
 
-
-tracing = { version = "0.1", features = ["async-await"], optional = true }
+tracing = { workspace = true, optional = true }
 
 [[bench]]
 name = "hash_ring_bench"

--- a/lib/common/cancel/Cargo.toml
+++ b/lib/common/cancel/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 
 [dependencies]
 thiserror = "1.0"
-tokio = "1.35"
-tokio-util = "0.7"
+tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 ordered-float = "4.2"
-serde = { version = "~1.0", features = ["derive"] }
+serde = { workspace = true }
 validator = { version = "0.16", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/lib/common/io/Cargo.toml
+++ b/lib/common/io/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 [dependencies]
 atomicwrites = "0.4.3"
 bincode = "1.3.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = "1.0.56"

--- a/lib/common/memory/Cargo.toml
+++ b/lib/common/memory/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 [dependencies]
 memmap2 = "0.9.4"
 log = "0.4"
-parking_lot = "0.12.1"
-serde = { version = "1", features = ["derive"] }
+parking_lot = { workspace = true }
+serde = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -27,23 +27,23 @@ pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 
 [dependencies]
 tempfile = "3.9.0"
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 rayon = "1.8.1"
 num_cpus = "1.16"
 itertools = "0.12"
 rocksdb = { version = "0.21.0", default-features = false, features = [ "snappy" ] }
-uuid = { version = "1.7", features = ["v4", "serde"] }
+uuid = { workspace = true }
 bincode = "1.3"
-serde = { version = "~1.0", features = ["derive", "rc"] }
-serde_json = "~1.0"
-serde_cbor = "0.11.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_cbor = { workspace = true }
 serde-value = "0.7"
 ordered-float = "4.2"
 thiserror = "1.0"
 atomic_refcell = "0.1.13"
 atomicwrites = "0.4.3"
 memmap2 = "0.9.4"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"] }
+schemars = { workspace = true }
 log = "0.4"
 geo = "0.27.0"
 geohash = "0.13.0"
@@ -70,7 +70,7 @@ io = { path = "../common/io" }
 memory = { path = "../common/memory" }
 sparse = { path = "../sparse" }
 
-tracing = { version = "0.1", features = ["async-await"], optional = true }
+tracing = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -14,8 +14,8 @@ common = { path = "../common/common" }
 io = { path = "../common/io" }
 memory = { path = "../common/memory" }
 memmap2 = "0.9.4"
-schemars = { version = "0.8.16" }
-serde = { version = "1", features = ["derive"] }
+schemars = { workspace = true }
+serde = { workspace = true }
 tempfile = "3.9.0"
 ordered-float = "4.2"
 rand = "0.8.5"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -20,15 +20,15 @@ env_logger = "0.10.2"
 thiserror = "1.0"
 rand = "0.8.5"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
-tokio = { version = "~1.35", features = ["rt-multi-thread"] }
-serde = { version = "~1.0", features = ["derive"] }
-serde_json = "~1.0"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
 itertools = "0.12"
 log = "0.4"
-tonic = { version = "0.9.2", features = ["gzip", "tls"] }
+tonic = { workspace = true }
 http = "0.2"
-parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
+parking_lot = { workspace = true }
 tar = "0.4.40"
 chrono = { version = "~0.4", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
@@ -36,9 +36,9 @@ validator = { version = "0.16", features = ["derive"] }
 # Consensus related
 atomicwrites = { version = "0.4.3" }
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
-prost = { version = "0.11.9" } # version of prost used by raft
+prost = { workspace = true } # version of prost used by raft
 protobuf = "2.28.0" # version of protobuf used by raft
-serde_cbor = { version = "0.11.2" }
+serde_cbor = { workspace = true }
 
 common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }
@@ -47,11 +47,11 @@ memory = { path = "../common/memory" }
 segment = { path = "../segment" }
 collection = { path = "../collection" }
 api = { path = "../api" }
-futures = "0.3.30"
+futures = { workspace = true }
 anyhow = "1.0.79"
-uuid = "1.7.0"
+uuid = { workspace = true }
 url = "2.5.0"
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 tempfile = "3.9.0"
 
-tracing = { version = "0.1", features = ["async-await"], optional = true }
+tracing = { workspace = true, optional = true }


### PR DESCRIPTION
This explores the idea of moving dependencies we use often to our workspace as described [here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace).

It forces us to use the same dependency definition (version, features) in all our sub crates, because we only define it once. Before this change, we had wildly different definitions across all crates.

I manually selected these to subjectively be:
- used often
- having difficult feature flags
- having inconsistent configurations across our sub-crates
- requiring strict versions across multiple crates

With this PR I'd like to **request for comment**. What do we think about this? We can include more/less dependencies on the workspace level if we do desire.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?