### PR TITLE
Fix: Update Qdrant configuration to use absolute paths

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -29,12 +29,12 @@ And once you need a fine-grained setup, you can also define a storage path and c
 
 ```bash
 docker run -p 6333:6333 \
-    -v $(pwd)/path/to/data:/qdrant/storage \
+    -v $(pwd)/path/to/data:/var/lib/qdrant/storage \
     -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
     qdrant/qdrant
 ```
 
-- `/qdrant/storage` - is a place where Qdrant persists all your data.
+- `/var/lib/qdrant/storage` - is a place where Qdrant persists all your data.
   Make sure to mount it as a volume, otherwise docker will drop it with the container.
 - `/qdrant/config/production.yaml` - is the file with engine configuration. You can override any value from the [reference config](https://github.com/qdrant/qdrant/blob/master/config/config.yaml)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,14 +2,14 @@ log_level: INFO
 
 storage:
   # Where to store all the data
-  storage_path: ./storage
+  storage_path: /var/lib/qdrant/storage
 
   # Where to store snapshots
-  snapshots_path: ./snapshots
+  snapshots_path: /var/lib/qdrant/snapshots
 
   # Where to store temporary files
   # If null, temporary snapshot are stored in: storage/snapshots_temp/
-  temp_path: null
+  temp_path: /var/lib/qdrant/temp
 
   # If true - point's payload will not be stored in memory.
   # It will be read from the disk every time it is requested.


### PR DESCRIPTION
- Previously, Qdrant used the current working directory for configuration, storage, and snapshots, potentially causing issues when starting Qdrant from different directories.
- This commit addresses the problem by updating the configuration to use absolute paths:
  - Storage directory: `/var/lib/qdrant/storage`
  - Snapshots directory: `/var/lib/qdrant/snapshots`
  - temp_path: `/var/lib/qdrant/temp`
- This change ensures that Qdrant files are consistently located, regardless of the working directory from which it is started. The new paths also follow the conventions used by similar tools.

Fixes #3370 