### PR TITLE
Demote thread priority setting warning to debug message

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -673,10 +673,10 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                     b = b.stack_size(stack_size);
                 }
                 b.spawn(|| {
-                    // On Linux, use lower thread priority so we don't interfere with serving traffic
+                    // On Linux, use lower thread priority so we interfere less with serving traffic
                     #[cfg(target_os = "linux")]
                     if let Err(err) = linux_low_thread_priority() {
-                        log::warn!(
+                        log::debug!(
                             "Failed to set low thread priority for HNSW building, ignoring: {err}"
                         );
                     }


### PR DESCRIPTION
On some systems we fail to set lower thread priority.

To prevent the noisy warnings below, we downgrade them to a debug message:

```
2024-01-30T16:29:10.443672Z  WARN segment::index::hnsw_index::hnsw: Failed to set low thread priority for HNSW building, ignoring: Failed to set thread priority: PriorityNotInRange(0..=0)    
2024-01-30T16:29:10.443675Z  WARN segment::index::hnsw_index::hnsw: Failed to set low thread priority for HNSW building, ignoring: Failed to set thread priority: PriorityNotInRange(0..=0)
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?