### PR TITLE
Add curl in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,9 @@ FROM debian:12-slim AS qdrant
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y ca-certificates tzdata libunwind8 \
+    && if [ "$USER_ID" == 0 ]; then \
+            apt-get install --no-install-recommends -y curl \
+       fi \
     && rm -rf /var/lib/apt/lists/*
 
 ARG APP=/qdrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ FROM debian:12-slim AS qdrant
 RUN apt-get update \
     && apt-get install --no-install-recommends -y ca-certificates tzdata libunwind8 \
     && if [ "$USER_ID" == 0 ]; then \
-            apt-get install --no-install-recommends -y curl \
+            apt-get install --no-install-recommends -y curl; \
        fi \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/3491#issuecomment-1919483977>.

This adds `curl` in our privileged docker image to allow health checking when using Docker compose.

To add some context, Docker compose requires a command for health checking. `curl` can be used to probe our healthcheck endpoints from within the container.

Note: this does not add `curl` in the unprivileged Docker image because we want stricter security there.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?