### PR TITLE
Add `ClockMap` type to track versions of update operations in the local shard WAL

### DIFF
--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -67,9 +67,9 @@ impl From<CollectionUpdateOperations> for OperationWithClockTag {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ClockTag {
-    peer_id: PeerId,
-    clock_id: u32,
-    clock_tick: u64,
+    pub peer_id: PeerId,
+    pub clock_id: u32,
+    pub clock_tick: u64,
 }
 
 impl ClockTag {

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -1,0 +1,91 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Default)]
+pub struct ClockSet {
+    clocks: Vec<Arc<Clock>>,
+}
+
+impl ClockSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_clock(&mut self) -> ClockGuard {
+        for (id, clock) in self.clocks.iter().enumerate() {
+            if clock.lock() {
+                return ClockGuard::new(id, clock.clone());
+            }
+        }
+
+        let id = self.clocks.len();
+        let clock = Arc::new(Clock::new_locked());
+
+        self.clocks.push(clock.clone());
+
+        ClockGuard::new(id, clock)
+    }
+}
+
+#[derive(Debug)]
+pub struct ClockGuard {
+    id: usize,
+    clock: Arc<Clock>,
+}
+
+impl ClockGuard {
+    fn new(id: usize, clock: Arc<Clock>) -> Self {
+        Self { id, clock }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn tick_once(&mut self) -> u64 {
+        self.clock.tick_once()
+    }
+
+    pub fn release(self) {
+        // Do not call `Clock::release` explicitly!
+        //
+        // `Drop` will be called when `self` goes out of scope at the end of this method
+        // and it will call `Clock::release`.
+        //
+        // If call `Clock::release` explicitly, then `ClockGuard::release` will call
+        // `Clock::release` *twice*! (Which is a bug! :D)
+    }
+}
+
+impl Drop for ClockGuard {
+    fn drop(&mut self) {
+        self.clock.release();
+    }
+}
+
+#[derive(Debug)]
+struct Clock {
+    clock: AtomicU64,
+    available: AtomicBool,
+}
+
+impl Clock {
+    pub fn new_locked() -> Self {
+        Self {
+            clock: AtomicU64::new(0),
+            available: AtomicBool::new(false),
+        }
+    }
+
+    pub fn tick_once(&self) -> u64 {
+        self.clock.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn lock(&self) -> bool {
+        self.available.swap(false, Ordering::Relaxed)
+    }
+
+    pub fn release(&self) {
+        self.available.store(true, Ordering::Relaxed);
+    }
+}

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -46,6 +46,10 @@ impl ClockGuard {
         self.clock.tick_once()
     }
 
+    pub fn advance_to(&mut self, tick: u64) -> u64 {
+        self.clock.advance_to(tick)
+    }
+
     pub fn release(self) {
         // Do not call `Clock::release` explicitly!
         //
@@ -79,6 +83,10 @@ impl Clock {
 
     pub fn tick_once(&self) -> u64 {
         self.clock.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn advance_to(&self, tick: u64) -> u64 {
+        self.clock.fetch_max(tick, Ordering::Relaxed)
     }
 
     pub fn lock(&self) -> bool {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1,3 +1,4 @@
+mod clock_set;
 mod execute_read_operation;
 mod locally_disabled_peers;
 mod read_ops;
@@ -27,6 +28,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::save_on_disk::SaveOnDisk;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::dummy_shard::DummyShard;
+use crate::shards::replica_set::clock_set::ClockSet;
 use crate::shards::shard::{PeerId, Shard, ShardId};
 use crate::shards::shard_config::ShardConfig;
 use crate::shards::telemetry::ReplicaSetTelemetry;
@@ -94,6 +96,7 @@ pub struct ShardReplicaSet {
     optimizer_cpu_budget: CpuBudget,
     /// Lock to serialized write operations on the replicaset when a write ordering is used.
     write_ordering_lock: Mutex<()>,
+    clock_set: Mutex<ClockSet>,
 }
 
 pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;
@@ -181,6 +184,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
+            clock_set: Mutex::new(ClockSet::new()),
         })
     }
 
@@ -291,6 +295,7 @@ impl ShardReplicaSet {
             search_runtime,
             optimizer_cpu_budget,
             write_ordering_lock: Mutex::new(()),
+            clock_set: Mutex::new(ClockSet::new()),
         };
 
         if local_load_failure && replica_set.active_remote_shards().await.is_empty() {


### PR DESCRIPTION
This PR *will* add `ClockMap` type.

Currently based on #3426, but pointing to `dev`, cause you can't create an empty PR. 😂

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
