### PR TITLE
Shard diff transfer integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1237,7 @@ dependencies = [
  "api",
  "approx",
  "arc-swap",
+ "async-recursion",
  "async-std",
  "async-trait",
  "atomicwrites",

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1504,8 +1504,9 @@ Note: 1kB = 1 vector of size 256. |
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| StreamRecords | 0 |  |
-| Snapshot | 1 |  |
+| StreamRecords | 0 | Stream shard records in batches |
+| Snapshot | 1 | Snapshot the shard and recover it on the target peer |
+| WalDelta | 2 | Resolve WAL delta between peers and transfer the difference |
 
 
 

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -497,8 +497,9 @@ message MoveShard {
 }
 
 enum ShardTransferMethod {
-  StreamRecords = 0;
-  Snapshot = 1;
+  StreamRecords = 0; // Stream shard records in batches
+  Snapshot = 1; // Snapshot the shard and recover it on the target peer
+  WalDelta = 2; // Resolve WAL delta between peers and transfer the difference
 }
 
 message Replica {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -450,7 +450,7 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
-  // TODO(1.9): deprecate this state
+  // TODO(1.9): deprecate PartialSnapshot state
 }
 
 message ShardKey {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1345,8 +1345,12 @@ impl ReplicaState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum ShardTransferMethod {
+    /// Stream shard records in batches
     StreamRecords = 0,
+    /// Snapshot the shard and recover it on the target peer
     Snapshot = 1,
+    /// Resolve WAL delta between peers and transfer the difference
+    WalDelta = 2,
 }
 impl ShardTransferMethod {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1357,6 +1361,7 @@ impl ShardTransferMethod {
         match self {
             ShardTransferMethod::StreamRecords => "StreamRecords",
             ShardTransferMethod::Snapshot => "Snapshot",
+            ShardTransferMethod::WalDelta => "WalDelta",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1364,6 +1369,7 @@ impl ShardTransferMethod {
         match value {
             "StreamRecords" => Some(Self::StreamRecords),
             "Snapshot" => Some(Self::Snapshot),
+            "WalDelta" => Some(Self::WalDelta),
             _ => None,
         }
     }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -71,6 +71,7 @@ bytes = "1.5.0"
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ringbuffer = "0.15.0"
+async-recursion = "1.0"
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -37,7 +37,7 @@ use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_holder::{shard_not_found_error, LockedShardHolder, ShardHolder};
 use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
-use crate::shards::transfer::ShardTransfer;
+use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{replica_set, CollectionId};
 use crate::telemetry::CollectionTelemetry;
 
@@ -570,12 +570,8 @@ impl Collection {
                     to: *this_peer_id,
                     shard_id,
                     sync: true,
-                    // For automatic shard transfers, always select some default method from this point on
-                    method: Some(
-                        self.shared_storage_config
-                            .default_shard_transfer_method
-                            .unwrap_or_default(),
-                    ),
+                    // For automatic shard transfers, always attempt diff transfer from this point on
+                    method: Some(ShardTransferMethod::WalDelta),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -570,8 +570,8 @@ impl Collection {
                     to: *this_peer_id,
                     shard_id,
                     sync: true,
-                    // For automatic shard transfers, always attempt diff transfer from this point on
-                    method: Some(ShardTransferMethod::WalDelta),
+                    // For automatic shard transfers, always select some default method from this point on
+                    method: Some(ShardTransferMethod::default()),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -37,7 +37,7 @@ use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_holder::{shard_not_found_error, LockedShardHolder, ShardHolder};
 use crate::shards::transfer::helpers::check_transfer_conflicts_strict;
 use crate::shards::transfer::transfer_tasks_pool::{TaskResult, TransferTasksPool};
-use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
+use crate::shards::transfer::ShardTransfer;
 use crate::shards::{replica_set, CollectionId};
 use crate::telemetry::CollectionTelemetry;
 
@@ -571,7 +571,11 @@ impl Collection {
                     shard_id,
                     sync: true,
                     // For automatic shard transfers, always select some default method from this point on
-                    method: Some(ShardTransferMethod::default()),
+                    method: Some(
+                        self.shared_storage_config
+                            .default_shard_transfer_method
+                            .unwrap_or_default(),
+                    ),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -80,7 +80,8 @@ impl Collection {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
                 // TODO(1.9): switch into recovery state instead
                 ShardTransferMethod::Snapshot => ReplicaState::PartialSnapshot,
-                ShardTransferMethod::WalDelta => ReplicaState::Partial,
+                // TODO(1.9): switch into recovery state instead
+                ShardTransferMethod::WalDelta => ReplicaState::PartialSnapshot,
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -49,7 +49,7 @@ impl Collection {
     {
         // Select transfer method
         if shard_transfer.method.is_none() {
-            let method = ShardTransferMethod::WalDelta;
+            let method = ShardTransferMethod::default();
             log::warn!("No shard transfer method selected, defaulting to {method:?}");
             shard_transfer.method.replace(method);
         }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -79,9 +79,9 @@ impl Collection {
             let initial_state = match shard_transfer.method.unwrap_or_default() {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
                 // TODO(1.9): switch into recovery state instead
-                ShardTransferMethod::Snapshot => ReplicaState::PartialSnapshot,
-                // TODO(1.9): switch into recovery state instead
-                ShardTransferMethod::WalDelta => ReplicaState::PartialSnapshot,
+                ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
+                    ReplicaState::PartialSnapshot
+                }
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -49,10 +49,7 @@ impl Collection {
     {
         // Select transfer method
         if shard_transfer.method.is_none() {
-            let method = self
-                .shared_storage_config
-                .default_shard_transfer_method
-                .unwrap_or_default();
+            let method = ShardTransferMethod::WalDelta;
             log::warn!("No shard transfer method selected, defaulting to {method:?}");
             shard_transfer.method.replace(method);
         }
@@ -83,6 +80,7 @@ impl Collection {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
                 // TODO(1.9): switch into recovery state instead
                 ShardTransferMethod::Snapshot => ReplicaState::PartialSnapshot,
+                ShardTransferMethod::WalDelta => ReplicaState::Partial,
             };
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -49,7 +49,10 @@ impl Collection {
     {
         // Select transfer method
         if shard_transfer.method.is_none() {
-            let method = ShardTransferMethod::default();
+            let method = self
+                .shared_storage_config
+                .default_shard_transfer_method
+                .unwrap_or_default();
             log::warn!("No shard transfer method selected, defaulting to {method:?}");
             shard_transfer.method.replace(method);
         }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1670,6 +1670,7 @@ impl From<api::grpc::qdrant::ShardTransferMethod> for ShardTransferMethod {
                 ShardTransferMethod::StreamRecords
             }
             api::grpc::qdrant::ShardTransferMethod::Snapshot => ShardTransferMethod::Snapshot,
+            api::grpc::qdrant::ShardTransferMethod::WalDelta => ShardTransferMethod::WalDelta,
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -288,12 +288,12 @@ impl fmt::Display for RecoveryPoint {
     }
 }
 
-impl From<RecoveryPoint> for api::grpc::qdrant::RecoveryPoint {
-    fn from(rp: RecoveryPoint) -> Self {
+impl From<&RecoveryPoint> for api::grpc::qdrant::RecoveryPoint {
+    fn from(rp: &RecoveryPoint) -> Self {
         let clocks = rp
             .clocks
-            .into_iter()
-            .map(|(key, clock_tick)| RecoveryPointClockTag {
+            .iter()
+            .map(|(key, &clock_tick)| RecoveryPointClockTag {
                 peer_id: key.peer_id,
                 clock_id: key.clock_id,
                 clock_tick,
@@ -301,6 +301,12 @@ impl From<RecoveryPoint> for api::grpc::qdrant::RecoveryPoint {
             .collect();
 
         Self { clocks }
+    }
+}
+
+impl From<RecoveryPoint> for api::grpc::qdrant::RecoveryPoint {
+    fn from(rp: RecoveryPoint) -> Self {
+        (&rp).into()
     }
 }
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -104,7 +104,7 @@ pub async fn transfer_shard(
 
                 // Temporary hack for remote shard to get from PartialSnapshot back into Partial state
                 log::trace!("Shard {shard_id} diff recovered on {} for diff transfer, switching into next stage through consensus", remote_shard.peer_id);
-                consensus
+                let result = consensus
                     .snapshot_recovered_switch_to_partial_confirm_remote(
                         &transfer_config,
                         collection_name,
@@ -115,7 +115,10 @@ pub async fn transfer_shard(
                         crate::operations::types::CollectionError::service_error(format!(
                             "Can't switch shard {shard_id} to Partial state after diff transfer: {err}"
                         ))
-                    })?;
+                    });
+                if let Err(err) = result {
+                    log::warn!("Shard {shard_id} coult not be switched from PartialSnapshot to Partial state, ignoring: {err}");
+                }
 
                 // Redo the transfer but set a different method
                 transfer_config

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -54,7 +54,14 @@ pub async fn transfer_shard(
     match transfer_config.method.unwrap_or_default() {
         // Transfer shard record in batches
         ShardTransferMethod::StreamRecords => {
-            transfer_stream_records(shard_holder.clone(), progress, shard_id, remote_shard).await?;
+            transfer_stream_records(
+                shard_holder.clone(),
+                progress,
+                shard_id,
+                remote_shard,
+                collection_name,
+            )
+            .await?;
         }
 
         // Transfer shard as snapshot
@@ -97,7 +104,13 @@ pub async fn transfer_shard(
                 log::warn!(
                     "Failed to do shard diff transfer, falling back to stream records: {err}"
                 );
-                transfer_stream_records(shard_holder.clone(), shard_id, remote_shard).await?;
+                transfer_stream_records(
+                    shard_holder.clone(),
+                    shard_id,
+                    remote_shard,
+                    collection_name,
+                )
+                .await?;
             }
         }
     }

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -51,14 +51,17 @@ pub async fn transfer_shard(
     // Prepare the remote for receiving the shard, waits for the correct state on the remote
     remote_shard.initiate_transfer().await?;
 
-    match transfer_config.method {
+    match transfer_config
+        .method
+        .unwrap_or(ShardTransferMethod::WalDelta)
+    {
         // Transfer shard record in batches
-        Some(ShardTransferMethod::StreamRecords) => {
+        ShardTransferMethod::StreamRecords => {
             transfer_stream_records(shard_holder.clone(), progress, shard_id, remote_shard).await?;
         }
 
         // Transfer shard as snapshot
-        Some(ShardTransferMethod::Snapshot) => {
+        ShardTransferMethod::Snapshot => {
             transfer_snapshot(
                 transfer_config,
                 shard_holder.clone(),
@@ -74,7 +77,7 @@ pub async fn transfer_shard(
         }
 
         // Attempt to transfer shard diff
-        None => {
+        ShardTransferMethod::WalDelta => {
             transfer_wal_delta(
                 transfer_config,
                 shard_holder.clone(),

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -13,7 +13,7 @@ use super::transfer_tasks_pool::TransferTaskProgress;
 use super::wal_delta::transfer_wal_delta;
 use super::{ShardTransfer, ShardTransferConsensus, ShardTransferMethod};
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
@@ -99,25 +99,37 @@ pub async fn transfer_shard(
             if let Err(err) = result {
                 // TODO: fall back to default transfer method as specified in configuration
                 log::warn!(
-                    "Failed to do shard diff transfer, falling back to stream records: {err}"
+                    "Failed to do shard diff transfer, falling back to {:?}: {err}",
+                    ShardTransferMethod::StreamRecords,
                 );
 
                 // Temporary hack for remote shard to get from PartialSnapshot back into Partial state
-                log::trace!("Shard {shard_id} diff recovered on {} for diff transfer, switching into next stage through consensus", remote_shard.peer_id);
-                let result = consensus
-                    .snapshot_recovered_switch_to_partial_confirm_remote(
-                        &transfer_config,
-                        collection_name,
-                        &remote_shard,
-                    )
-                    .await
-                    .map_err(|err| {
-                        crate::operations::types::CollectionError::service_error(format!(
-                            "Can't switch shard {shard_id} to Partial state after diff transfer: {err}"
-                        ))
-                    });
-                if let Err(err) = result {
-                    log::warn!("Shard {shard_id} coult not be switched from PartialSnapshot to Partial state, ignoring: {err}");
+                {
+                    let shard_holder_read = shard_holder.read().await;
+                    let transferring_shard = shard_holder_read.get_shard(&shard_id);
+                    let Some(replica_set) = transferring_shard else {
+                        return Err(CollectionError::service_error(format!(
+                            "Shard {shard_id} cannot be queue proxied because it does not exist"
+                        )));
+                    };
+                    let shard_state = replica_set.peer_state(&transfer_config.to);
+
+                    // Only switch if not in partial already
+                    if shard_state != Some(ReplicaState::Partial) {
+                        log::trace!("Shard {shard_id} diff recovered on {} for diff transfer, switching into next stage through consensus", remote_shard.peer_id);
+                        consensus
+                            .snapshot_recovered_switch_to_partial_confirm_remote(
+                                &transfer_config,
+                                collection_name,
+                                &remote_shard,
+                            )
+                            .await
+                            .map_err(|err| {
+                                crate::operations::types::CollectionError::service_error(format!(
+                                        "Can't switch shard {shard_id} to Partial state after diff transfer: {err}"
+                                ))
+                            })?;
+                    }
                 }
 
                 // Redo the transfer but set a different method

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -82,6 +82,7 @@ pub async fn transfer_shard(
                 remote_shard.clone(),
                 channel_service,
                 consensus,
+                collection_name,
             )
             .await;
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -71,11 +71,11 @@ impl ShardTransferKey {
 #[serde(rename_all = "snake_case")]
 pub enum ShardTransferMethod {
     /// Stream all shard records in batches until the whole shard is transferred.
-    #[default]
     StreamRecords,
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
+    #[default]
     #[doc(hidden)]
     #[schemars(skip)]
     WalDelta,

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -71,11 +71,11 @@ impl ShardTransferKey {
 #[serde(rename_all = "snake_case")]
 pub enum ShardTransferMethod {
     /// Stream all shard records in batches until the whole shard is transferred.
+    #[default]
     StreamRecords,
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
-    #[default]
     #[doc(hidden)]
     #[schemars(skip)]
     WalDelta,

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -18,6 +18,7 @@ pub mod helpers;
 pub mod snapshot;
 pub mod stream_records;
 pub mod transfer_tasks_pool;
+pub mod wal_delta;
 
 /// Number of retries for confirming a consensus operation.
 const CONSENSUS_CONFIRM_RETRIES: usize = 3;

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -75,6 +75,10 @@ pub enum ShardTransferMethod {
     StreamRecords,
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
+    /// Attempt to transfer shard difference by WAL delta.
+    #[doc(hidden)]
+    #[schemars(skip)]
+    WalDelta,
 }
 
 /// Interface to consensus for shard transfer operations.

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -111,6 +111,7 @@ pub(super) async fn transfer_stream_records(
             .update_shard_cutoff_point(collection_name, shard_id, &cutoff)
             .await;
         if let Err(err) = result {
+            // TODO: only ignore 'API unimplemented' errors here!
             log::warn!("Failed to update cutoff point on remote shard, ignoring: {err}");
         }
     }

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -111,6 +111,7 @@ pub(super) async fn transfer_stream_records(
             .await;
 
         // Warn and ignore if remote shard is running an older version, error otherwise
+        // TODO: this is fragile, improve this with stricter matches/checks
         match result {
             // This string match is fragile but there does not seem to be a better way
             Err(err)

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -123,12 +123,6 @@ pub(super) async fn transfer_wal_delta(
         // This way we send a complete WAL diff
         log::trace!("Transfer WAL diff by transferring all queue proxy updates and transform into forward proxy");
         replica_set.queue_proxy_into_forward_proxy().await?;
-
-        // Update cutoff point on remote shard, disallow recovery before our current last seen
-        let cutoff = replica_set.shard_recovery_point().await?;
-        remote_shard
-            .update_shard_cutoff_point(collection_name, shard_id, &cutoff)
-            .await?;
     } else {
         log::trace!("Shard is already up-to-date as WAL diff if zero records");
     }

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -27,7 +27,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 ///
 /// If cancelled - the remote shard may only be partially recovered/transferred and the local shard
 /// may be left in an unexpected state. This must be resolved manually in case of cancellation.
-pub(super) async fn _transfer_wal_delta(
+pub(super) async fn transfer_wal_delta(
     transfer_config: ShardTransfer,
     shard_holder: Arc<LockedShardHolder>,
     shard_id: ShardId,

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -58,8 +58,13 @@ pub(super) async fn transfer_wal_delta(
         )));
     };
 
-    // TODO: resolve diff point, define proper version here!
-    let from_version = 0;
+    // Resolve WAL delta, get the version to start the diff from
+    let from_version = replica_set
+        .resolve_wal_delta(recovery_point)
+        .await
+        .map_err(|err| {
+            CollectionError::service_error(format!("Failed to resolve shard diff: {err}"))
+        })?;
 
     // TODO: send our last seen clock map to remote, set it as truncation point
 

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use common::defaults;
-use tokio::time::sleep;
 
 use super::{ShardTransfer, ShardTransferConsensus};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ReplicaState;
-use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard::ShardId;
 use crate::shards::shard_holder::LockedShardHolder;
 
 /// Orchestrate shard diff transfer
@@ -88,48 +87,9 @@ pub(super) async fn transfer_wal_delta(
         })?;
 
     // Synchronize all nodes
-    await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
+    super::await_consensus_sync(consensus, &channel_service, transfer_config.from).await;
 
     log::debug!("Ending shard {shard_id} transfer to peer {remote_peer_id} using diff transfer");
 
     Ok(())
-}
-
-/// Await for consensus to synchronize across all peers
-///
-/// This will take the current consensus state of this node. It then explicitly waits on all other
-/// nodes to reach the same (or later) consensus.
-///
-/// If awaiting on other nodes fails for any reason, this simply continues after the consensus
-/// timeout.
-///
-/// # Cancel safety
-///
-/// This function is cancel safe.
-// TODO: similar to shard snapshot transer, maybe we can reuse this
-async fn await_consensus_sync(
-    consensus: &dyn ShardTransferConsensus,
-    channel_service: &ChannelService,
-    this_peer_id: PeerId,
-) {
-    let sync_consensus = async {
-        let await_result = consensus
-            .await_consensus_sync(this_peer_id, channel_service)
-            .await;
-        if let Err(err) = &await_result {
-            log::warn!("All peers failed to synchronize consensus: {err}");
-        }
-        await_result
-    };
-    let timeout = sleep(defaults::CONSENSUS_META_OP_WAIT);
-
-    tokio::select! {
-        biased;
-        Ok(_) = sync_consensus => {
-            log::trace!("All peers reached consensus");
-        }
-        _ = timeout => {
-            log::warn!("All peers failed to synchronize consensus, continuing after timeout");
-        }
-    }
 }

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -357,11 +357,7 @@ impl TableOfContent {
     ) -> Result<(), StorageError> {
         // TODO: Ensure cancel safety!
 
-        log::info!(
-            "Initiating receiving shard {}:{}",
-            collection_name,
-            shard_id
-        );
+        log::info!("Initiating receiving shard {collection_name}:{shard_id}");
 
         // TODO: Ensure cancel safety!
         let initiate_shard_transfer_future = self

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -137,7 +137,7 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(source_uri, "test_collection", 0)
 
-    # Check the number of local shard goes down by 1
+    # Check the number of local shards goes down by 1
     assert check_collection_local_shards_count(source_uri, "test_collection", before_local_shard_count - 1)
     assert check_collection_local_shards_count(target_uri, "test_collection", target_before_local_shard_count + 1)
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Depends on: <https://github.com/qdrant/qdrant/pull/3551>, <https://github.com/qdrant/qdrant/pull/3571>

This adds a new `WalDelta` shard transfer method to allow shard diff transfers. This variant remains unused for now and is hidden by default.

It adds a `transfer_wal_delta` function to actually drive such transfer from a source node.

The method currently utilizes a queue proxy shard because it already has all the necessary bits and bots implemented for transferring a WAL including all new incoming updates.

### Tasks
- [x] Resolve all TODOs
- [x] Prevent physical WAL from being truncated if we diff, even if it has already been truncated of the logical WAL
      We can set a `max_ack` version now, but this only limits the logical WAL. The physical WAL probably contains important data too which we should not truncate off while we still need it for transferring the diff.
 - [x] Merge <https://github.com/qdrant/qdrant/pull/3551>
 - [x] Merge <https://github.com/qdrant/qdrant/pull/3571>
 - [x] Rebase this on `dev`
 - [x] Target this PR to merge into `dev`
 - [x] Undraft this PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?