### PR TITLE
Datetime index: Introduce `RangeInterface`

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6456,17 +6456,6 @@
               }
             ]
           },
-          "datetime_range": {
-            "description": "Check if datetime is within a given range",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/DatetimeRange"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
           "geo_bounding_box": {
             "description": "Check if points geo location lies in a given area",
             "anyOf": [

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6449,7 +6449,7 @@
             "description": "Check if points value lies in a given range",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Range"
+                "$ref": "#/components/schemas/RangeInterface"
               },
               {
                 "nullable": true
@@ -6608,6 +6608,16 @@
             "$ref": "#/components/schemas/AnyVariants"
           }
         }
+      },
+      "RangeInterface": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Range"
+          },
+          {
+            "$ref": "#/components/schemas/DatetimeRange"
+          }
+        ]
       },
       "Range": {
         "description": "Range filter request",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -974,22 +974,28 @@ impl From<segment::types::FieldCondition> for FieldCondition {
             key,
             r#match,
             range,
-            datetime_range,
+            datetime_range: _,
             geo_bounding_box,
             geo_radius,
             geo_polygon,
             values_count,
         } = value;
 
+        let (range, datetime_range) = match range {
+            Some(segment::types::RangeInterface::Float(range)) => (Some(range.into()), None),
+            Some(segment::types::RangeInterface::DateTime(range)) => (None, Some(range.into())),
+            None => (None, None),
+        };
+
         Self {
             key,
             r#match: r#match.map(Into::into),
-            range: range.map(Into::into),
+            range,
             geo_bounding_box: geo_bounding_box.map(Into::into),
             geo_radius: geo_radius.map(Into::into),
             geo_polygon: geo_polygon.map(Into::into),
             values_count: values_count.map(Into::into),
-            datetime_range: datetime_range.map(Into::into),
+            datetime_range,
         }
     }
 }
@@ -1121,6 +1127,12 @@ impl From<segment::types::Range<FloatPayloadType>> for Range {
             gte: value.gte,
             lte: value.lte,
         }
+    }
+}
+
+impl From<Range> for segment::types::RangeInterface {
+    fn from(value: Range) -> Self {
+        Self::Float(value.into())
     }
 }
 

--- a/lib/segment/src/index/field_index/histogram.rs
+++ b/lib/segment/src/index/field_index/histogram.rs
@@ -40,6 +40,8 @@ pub trait Numericable: Num + Signed + PartialEq + PartialOrd + Copy {
     fn max_value() -> Self;
     fn to_f64(self) -> f64;
     fn from_f64(x: f64) -> Self;
+    fn to_i64(self) -> i64;
+    fn from_i64(x: i64) -> Self;
     fn min(self, b: Self) -> Self {
         if self < b {
             self
@@ -76,6 +78,12 @@ impl Numericable for i64 {
     fn from_f64(x: f64) -> Self {
         x as Self
     }
+    fn to_i64(self) -> i64 {
+        self
+    }
+    fn from_i64(x: i64) -> Self {
+        x as Self
+    }
     fn abs_diff(self, b: Self) -> Self {
         i64::abs_diff(self, b) as i64
     }
@@ -93,6 +101,12 @@ impl Numericable for f64 {
     }
     fn from_f64(x: f64) -> Self {
         x
+    }
+    fn to_i64(self) -> i64 {
+        self as i64
+    }
+    fn from_i64(x: i64) -> Self {
+        x as Self
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -56,7 +56,7 @@ fn cardinality_request(
     index: &NumericIndex<f64>,
     query: Range<FloatPayloadType>,
 ) -> CardinalityEstimation {
-    let estimation = index.range_cardinality(&query);
+    let estimation = index.range_cardinality(&RangeInterface::Float(query.clone()));
 
     let result = index
         .filter(&FieldCondition::new_range("".to_string(), query))

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -247,7 +247,6 @@ mod tests {
         Condition::Field(FieldCondition {
             key,
             r#match: None,
-            datetime_range: None,
             range: None,
             geo_bounding_box: None,
             geo_radius: None,

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::types::{
     AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPoint,
     GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchText, MatchValue, Range,
-    ValueVariants, ValuesCount,
+    RangeInterface, ValueVariants, ValuesCount,
 };
 
 pub trait ValueChecker {
@@ -26,44 +26,42 @@ pub trait ValueChecker {
 
 impl ValueChecker for FieldCondition {
     fn check_match(&self, payload: &Value) -> bool {
-        let mut res = false;
-        // ToDo: Convert onto iterator over checkers, so it would be impossible to forget a condition
-        res = res
-            || self
-                .r#match
+        // Destructuring so compiler can check that we don't forget a condition
+        let FieldCondition {
+            r#match,
+            range,
+            datetime_range,
+            geo_radius,
+            geo_bounding_box,
+            geo_polygon,
+            values_count,
+            key: _,
+        } = self;
+
+        r#match
+            .as_ref()
+            .is_some_and(|condition| condition.check_match(payload))
+            || range
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .range
+                .is_some_and(|range_interface| match range_interface {
+                    RangeInterface::Float(condition) => condition.check_match(payload),
+                    RangeInterface::DateTime(condition) => condition.check_match(payload),
+                })
+            || datetime_range
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .datetime_range
+                .is_some_and(|condition| condition.check_match(payload))
+            || geo_radius
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .geo_radius
+                .is_some_and(|condition| condition.check_match(payload))
+            || geo_bounding_box
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .geo_bounding_box
+                .is_some_and(|condition| condition.check_match(payload))
+            || geo_polygon
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .geo_polygon
+                .is_some_and(|condition| condition.check_match(payload))
+            || values_count
                 .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res = res
-            || self
-                .values_count
-                .as_ref()
-                .map_or(false, |condition| condition.check_match(payload));
-        res
+                .is_some_and(|condition| condition.check_match(payload))
     }
 
     fn check(&self, payload: &Value) -> bool {
@@ -132,7 +130,7 @@ impl ValueChecker for Range<DateTimePayloadType> {
         payload
             .as_str()
             .and_then(|x| chrono::DateTime::parse_from_rfc3339(x).ok())
-            .map_or(false, |x| self.check_range(x.into()))
+            .is_some_and(|x| self.check_range(x.into()))
     }
 }
 

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -30,7 +30,6 @@ impl ValueChecker for FieldCondition {
         let FieldCondition {
             r#match,
             range,
-            datetime_range,
             geo_radius,
             geo_bounding_box,
             geo_polygon,
@@ -47,9 +46,6 @@ impl ValueChecker for FieldCondition {
                     RangeInterface::Float(condition) => condition.check_match(payload),
                     RangeInterface::DateTime(condition) => condition.check_match(payload),
                 })
-            || datetime_range
-                .as_ref()
-                .is_some_and(|condition| condition.check_match(payload))
             || geo_radius
                 .as_ref()
                 .is_some_and(|condition| condition.check_match(payload))

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1354,22 +1354,6 @@ pub enum RangeInterface {
     DateTime(Range<DateTimePayloadType>),
 }
 
-impl RangeInterface {
-    pub fn to_float_range(self) -> Option<Range<FloatPayloadType>> {
-        match self {
-            RangeInterface::Float(range) => Some(range),
-            _ => None,
-        }
-    }
-
-    pub fn to_datetime_range(self) -> Option<Range<DateTimePayloadType>> {
-        match self {
-            RangeInterface::DateTime(range) => Some(range),
-            _ => None,
-        }
-    }
-}
-
 /// Range filter request
 #[macro_rules_attribute::macro_rules_derive(crate::common::macros::schemars_rename_generics)]
 #[derive_args(<FloatPayloadType> => "Range", <DateTimePayloadType> => "DatetimeRange")]
@@ -1709,12 +1693,18 @@ impl FieldCondition {
     }
 
     pub fn all_fields_none(&self) -> bool {
-        self.r#match.is_none()
-            && self.range.is_none()
-            && self.geo_bounding_box.is_none()
-            && self.geo_radius.is_none()
-            && self.geo_polygon.is_none()
-            && self.values_count.is_none()
+        matches!(
+            self,
+            FieldCondition {
+                r#match: None,
+                range: None,
+                geo_bounding_box: None,
+                geo_radius: None,
+                geo_polygon: None,
+                values_count: None,
+                key: _,
+            }
+        )
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1607,8 +1607,6 @@ pub struct FieldCondition {
     pub r#match: Option<Match>,
     /// Check if points value lies in a given range
     pub range: Option<RangeInterface>,
-    /// Check if datetime is within a given range
-    pub datetime_range: Option<Range<DateTimePayloadType>>,
     /// Check if points geo location lies in a given area
     pub geo_bounding_box: Option<GeoBoundingBox>,
     /// Check if geo point is within a given radius
@@ -1625,7 +1623,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: Some(r#match),
             range: None,
-            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1638,7 +1635,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: Some(RangeInterface::Float(range)),
-            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1653,8 +1649,7 @@ impl FieldCondition {
         Self {
             key: key.into(),
             r#match: None,
-            range: None,
-            datetime_range: Some(datetime_range),
+            range: Some(RangeInterface::DateTime(datetime_range)),
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1670,7 +1665,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
-            datetime_range: None,
             geo_bounding_box: Some(geo_bounding_box),
             geo_radius: None,
             geo_polygon: None,
@@ -1683,7 +1677,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
-            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: Some(geo_radius),
             geo_polygon: None,
@@ -1696,7 +1689,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
-            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: Some(geo_polygon),
@@ -1709,7 +1701,6 @@ impl FieldCondition {
             key: key.into(),
             r#match: None,
             range: None,
-            datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -1720,7 +1711,6 @@ impl FieldCondition {
     pub fn all_fields_none(&self) -> bool {
         self.r#match.is_none()
             && self.range.is_none()
-            && self.datetime_range.is_none()
             && self.geo_bounding_box.is_none()
             && self.geo_radius.is_none()
             && self.geo_polygon.is_none()

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1347,6 +1347,29 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum RangeInterface {
+    Float(Range<FloatPayloadType>),
+    DateTime(Range<DateTimePayloadType>),
+}
+
+impl RangeInterface {
+    pub fn to_float_range(self) -> Option<Range<FloatPayloadType>> {
+        match self {
+            RangeInterface::Float(range) => Some(range),
+            _ => None,
+        }
+    }
+
+    pub fn to_datetime_range(self) -> Option<Range<DateTimePayloadType>> {
+        match self {
+            RangeInterface::DateTime(range) => Some(range),
+            _ => None,
+        }
+    }
+}
+
 /// Range filter request
 #[macro_rules_attribute::macro_rules_derive(crate::common::macros::schemars_rename_generics)]
 #[derive_args(<FloatPayloadType> => "Range", <DateTimePayloadType> => "DatetimeRange")]
@@ -1583,7 +1606,7 @@ pub struct FieldCondition {
     /// Check if point has field with a given value
     pub r#match: Option<Match>,
     /// Check if points value lies in a given range
-    pub range: Option<Range<FloatPayloadType>>,
+    pub range: Option<RangeInterface>,
     /// Check if datetime is within a given range
     pub datetime_range: Option<Range<DateTimePayloadType>>,
     /// Check if points geo location lies in a given area
@@ -1614,7 +1637,7 @@ impl FieldCondition {
         Self {
             key: key.into(),
             r#match: None,
-            range: Some(range),
+            range: Some(RangeInterface::Float(range)),
             datetime_range: None,
             geo_bounding_box: None,
             geo_radius: None,

--- a/openapi/tests/openapi_integration/test_payload_indexing.py
+++ b/openapi/tests/openapi_integration/test_payload_indexing.py
@@ -165,10 +165,10 @@ def test_datetime_indexing():
             path_params={"collection_name": collection_name},
             body={
                 "with_vector": False,
-                "filter": {"must": [{"key": datetime_key, "datetime_range": range_}]},
+                "filter": {"must": [{"key": datetime_key, "range": range_}]},
             },
         )
-        assert response.ok
+        assert response.ok, response.json()
         
         point_ids = [p["id"] for p in response.json()["result"]["points"]]
         assert all(id in point_ids for id in expected_ids)


### PR DESCRIPTION
Initially it made sense to me to keep different types separate in `FieldCondition`, but now I propose to handle all `Range` conditions similarly and together, so here we add a new `RangeInterface` enum to wrap them together.

This change also made me realize we missed using the actual index sometimes when filtering `datetime_range` conditions (this is fixed now, but not very pretty, see `PayloadFieldIndex` implementation).

Note: this only affects the REST interface, GRPC is intact.

A bonus change I did is to use pattern matching and destructuring in the checkers section, so it will be checked by compiler to not forget any new conditions.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
