### PR TITLE
Demote missing client for update ack. log

### DIFF
--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -547,7 +547,7 @@ impl UpdateHandler {
 
                     if let Some(feedback) = sender {
                         feedback.send(res).unwrap_or_else(|_| {
-                            info!(
+                            debug!(
                                 "Can't report operation {} result. Assume already not required",
                                 op_num
                             );


### PR DESCRIPTION
This log is a bit confusing for the users https://github.com/qdrant/qdrant/issues/3507.

Let's demote it to debug because:
- it is not actionable
- this is about an internal implementation