### PR TITLE
Optimize MatchAny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,7 +4571,8 @@ dependencies = [
 [[package]]
 name = "schemars"
 version = "0.8.16"
-source = "git+https://github.com/aumetra/schemars?branch=smol_strv0.2#5fd65e036cb3befda0611eac35094ec8450879c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -4579,7 +4580,6 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "smol_str",
  "url",
  "uuid",
 ]
@@ -4587,7 +4587,8 @@ dependencies = [
 [[package]]
 name = "schemars_derive"
 version = "0.8.16"
-source = "git+https://github.com/aumetra/schemars?branch=smol_strv0.2#5fd65e036cb3befda0611eac35094ec8450879c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,6 +4663,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "fnv",
  "fs_extra",
  "geo",
  "geohash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "hashring",
+ "indexmap 2.0.1",
  "indicatif",
  "io",
  "itertools 0.12.1",
@@ -2418,6 +2419,7 @@ checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
+ "serde",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "indexmap 1.9.2",
+ "indexmap 2.0.1",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4669,6 +4672,7 @@ dependencies = [
  "fs_extra",
  "geo",
  "geohash",
+ "indexmap 2.0.1",
  "io",
  "io-uring",
  "itertools 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,8 +4570,7 @@ dependencies = [
 [[package]]
 name = "schemars"
 version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+source = "git+https://github.com/aumetra/schemars?branch=smol_strv0.2#5fd65e036cb3befda0611eac35094ec8450879c7"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -4579,6 +4578,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "smol_str",
  "url",
  "uuid",
 ]
@@ -4586,8 +4586,7 @@ dependencies = [
 [[package]]
 name = "schemars_derive"
 version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+source = "git+https://github.com/aumetra/schemars?branch=smol_strv0.2#5fd65e036cb3befda0611eac35094ec8450879c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ dependencies = [
  "common",
  "criterion",
  "env_logger 0.11.1",
+ "fnv",
  "fs_extra",
  "futures",
  "hashring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
+fnv = "1.0"
 
 [[bin]]
 name = "schema_generator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ validator = { version = "0.16", features = ["derive"] }
 
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
-slog = { version="2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
+slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 slog-stdlog = "4.1.1"
 prost = { workspace = true }
 raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }
@@ -119,7 +119,7 @@ futures-util = "0.3.30"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
+schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "smol_str02"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
@@ -177,3 +177,8 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
+
+# Temporary patch until <https://github.com/GREsau/schemars/pull/263> is merged
+# For security reasons we should consider cloning this branch into the qdrant organization!
+# Refs are unsupported in patches (https://github.com/rust-lang/cargo/issues/7497)
+schemars = { git = "https://github.com/aumetra/schemars", branch = "smol_strv0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ futures-util = "0.3.30"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
+schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
@@ -130,6 +130,7 @@ tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
 fnv = "1.0"
+indexmap = { version = "2", features = ["serde"] }
 
 [[bin]]
 name = "schema_generator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ futures-util = "0.3.30"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
-schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "smol_str02"] }
+schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
@@ -178,8 +178,3 @@ opt-level = 3
 [patch.crates-io]
 # Temporary patch until <https://github.com/hyperium/tonic/pull/1401> is merged
 tonic = { git = 'https://github.com/qdrant/tonic', branch = "v0.9.2-patched" }
-
-# Temporary patch until <https://github.com/GREsau/schemars/pull/263> is merged
-# For security reasons we should consider cloning this branch into the qdrant organization!
-# Refs are unsupported in patches (https://github.com/rust-lang/cargo/issues/7497)
-schemars = { git = "https://github.com/aumetra/schemars", branch = "smol_strv0.2" }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6575,14 +6575,16 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "uniqueItems": true
           },
           {
             "type": "array",
             "items": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "uniqueItems": true
           }
         ]
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6583,7 +6583,8 @@
             "items": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "uniqueItems": true
           }
         ]
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6583,8 +6583,7 @@
             "items": {
               "type": "integer",
               "format": "int64"
-            },
-            "uniqueItems": true
+            }
           }
         ]
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -308,7 +308,7 @@ impl TryFrom<PayloadSchemaInfo> for segment::types::PayloadIndexInfo {
             None => {
                 return Err(Status::invalid_argument(
                     "Malformed payload schema".to_string(),
-                ))
+                ));
             }
             Some(data_type) => match data_type {
                 PayloadSchemaType::Keyword => segment::types::PayloadSchemaType::Keyword,
@@ -321,7 +321,7 @@ impl TryFrom<PayloadSchemaInfo> for segment::types::PayloadIndexInfo {
                 PayloadSchemaType::UnknownType => {
                     return Err(Status::invalid_argument(
                         "Malformed payload schema".to_string(),
-                    ))
+                    ));
                 }
             },
         };
@@ -645,7 +645,7 @@ impl TryFrom<ScalarQuantization> for segment::types::ScalarQuantization {
                 r#type: match QuantizationType::from_i32(value.r#type) {
                     Some(QuantizationType::Int8) => segment::types::ScalarType::Int8,
                     Some(QuantizationType::UnknownQuantization) | None => {
-                        return Err(Status::invalid_argument("Unknown quantization type"))
+                        return Err(Status::invalid_argument("Unknown quantization type"));
                     }
                 },
                 quantile: value.quantile,
@@ -681,7 +681,7 @@ impl TryFrom<ProductQuantization> for segment::types::ProductQuantization {
                     None => {
                         return Err(Status::invalid_argument(
                             "Unknown compression ratio".to_string(),
-                        ))
+                        ));
                     }
                     Some(CompressionRatio::X4) => segment::types::CompressionRatio::X4,
                     Some(CompressionRatio::X8) => segment::types::CompressionRatio::X8,
@@ -1223,17 +1223,21 @@ impl From<segment::types::Match> for Match {
             }
             segment::types::Match::Any(any) => match any.any {
                 segment::types::AnyVariants::Keywords(strings) => {
+                    let strings = strings.into_iter().map(|i| i.into()).collect();
                     MatchValue::Keywords(RepeatedStrings { strings })
                 }
                 segment::types::AnyVariants::Integers(integers) => {
+                    let integers = integers.into_iter().collect();
                     MatchValue::Integers(RepeatedIntegers { integers })
                 }
             },
             segment::types::Match::Except(except) => match except.except {
                 segment::types::AnyVariants::Keywords(strings) => {
+                    let strings = strings.into_iter().map(|i| i.into()).collect();
                     MatchValue::ExceptKeywords(RepeatedStrings { strings })
                 }
                 segment::types::AnyVariants::Integers(integers) => {
+                    let integers = integers.into_iter().collect();
                     MatchValue::ExceptIntegers(RepeatedIntegers { integers })
                 }
             },
@@ -1317,7 +1321,7 @@ impl TryFrom<Distance> for segment::types::Distance {
             Distance::UnknownDistance => {
                 return Err(Status::invalid_argument(
                     "Malformed distance parameter: UnknownDistance",
-                ))
+                ));
             }
             Distance::Cosine => segment::types::Distance::Cosine,
             Distance::Euclid => segment::types::Distance::Euclid,

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1223,7 +1223,7 @@ impl From<segment::types::Match> for Match {
             }
             segment::types::Match::Any(any) => match any.any {
                 segment::types::AnyVariants::Keywords(strings) => {
-                    let strings = strings.into_iter().map(|i| i.into()).collect();
+                    let strings = strings.into_iter().collect();
                     MatchValue::Keywords(RepeatedStrings { strings })
                 }
                 segment::types::AnyVariants::Integers(integers) => {
@@ -1233,7 +1233,7 @@ impl From<segment::types::Match> for Match {
             },
             segment::types::Match::Except(except) => match except.except {
                 segment::types::AnyVariants::Keywords(strings) => {
-                    let strings = strings.into_iter().map(|i| i.into()).collect();
+                    let strings = strings.into_iter().collect();
                     MatchValue::ExceptKeywords(RepeatedStrings { strings })
                 }
                 segment::types::AnyVariants::Integers(integers) => {

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -66,6 +66,7 @@ tempfile = "3.9.0"
 sha2 = "0.10.8"
 bytes = "1.5.0"
 fnv = { workspace = true }
+indexmap = { workspace = true }
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_cbor = { workspace = true }
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0"}
+wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
@@ -51,9 +51,9 @@ actix-web-validator = "5.0.1"
 common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }
 io = { path = "../common/io" }
-segment = {path = "../segment"}
+segment = { path = "../segment" }
 sparse = { path = "../sparse" }
-api = {path = "../api"}
+api = { path = "../api" }
 
 itertools = "0.12"
 indicatif = "0.17.7"
@@ -65,6 +65,7 @@ semver = "1.0.21"
 tempfile = "3.9.0"
 sha2 = "0.10.8"
 bytes = "1.5.0"
+fnv = { workspace = true }
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::time::Duration;
 
+use fnv::FnvBuildHasher;
 use segment::types::{
     AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
 };
@@ -432,7 +433,7 @@ fn values_to_any_variants(values: Vec<Value>) -> Vec<AnyVariants> {
     }
 
     // gather string values
-    let strs: HashSet<_> = values
+    let strs: HashSet<_, FnvBuildHasher> = values
         .iter()
         .filter_map(|v| v.as_str().map(|s| s.into()))
         .collect();

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::time::Duration;
 
 use fnv::FnvBuildHasher;
+use indexmap::IndexSet;
 use segment::types::{
     AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
 };
@@ -426,14 +427,14 @@ fn values_to_any_variants(values: Vec<Value>) -> Vec<AnyVariants> {
     let mut any_variants = Vec::new();
 
     // gather int values
-    let ints: HashSet<i64> = values.iter().filter_map(|v| v.as_i64()).collect();
+    let ints: Vec<_> = values.iter().filter_map(|v| v.as_i64()).collect();
 
     if !ints.is_empty() {
         any_variants.push(AnyVariants::Integers(ints));
     }
 
     // gather string values
-    let strs: HashSet<_, FnvBuildHasher> = values
+    let strs: IndexSet<_, FnvBuildHasher> = values
         .iter()
         .filter_map(|v| v.as_str().map(|s| s.into()))
         .collect();

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -427,7 +427,7 @@ fn values_to_any_variants(values: Vec<Value>) -> Vec<AnyVariants> {
     let mut any_variants = Vec::new();
 
     // gather int values
-    let ints: Vec<_> = values.iter().filter_map(|v| v.as_i64()).collect();
+    let ints: IndexSet<_, FnvBuildHasher> = values.iter().filter_map(|v| v.as_i64()).collect();
 
     if !ints.is_empty() {
         any_variants.push(AnyVariants::Integers(ints));

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::time::Duration;
 
-use itertools::Itertools;
 use segment::types::{
     AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
 };
@@ -426,17 +425,17 @@ fn values_to_any_variants(values: Vec<Value>) -> Vec<AnyVariants> {
     let mut any_variants = Vec::new();
 
     // gather int values
-    let ints = values.iter().filter_map(|v| v.as_i64()).collect_vec();
+    let ints: HashSet<i64> = values.iter().filter_map(|v| v.as_i64()).collect();
 
     if !ints.is_empty() {
         any_variants.push(AnyVariants::Integers(ints));
     }
 
     // gather string values
-    let strs = values
+    let strs: HashSet<_> = values
         .iter()
-        .filter_map(|v| v.as_str().map(|s| s.to_owned()))
-        .collect_vec();
+        .filter_map(|v| v.as_str().map(|s| s.into()))
+        .collect();
 
     if !strs.is_empty() {
         any_variants.push(AnyVariants::Keywords(strs));

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3.9.0"
 parking_lot = { workspace = true }
 rayon = "1.8.1"
 itertools = "0.12"
-rocksdb = { version = "0.21.0", default-features = false, features = [ "snappy" ] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy"] }
 uuid = { workspace = true }
 bincode = "1.3"
 serde = { workspace = true }
@@ -59,7 +59,7 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 quantization = { git = "https://github.com/qdrant/quantization.git" }
 validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.33", features = ["serde"] }
-smol_str = "0.2.1"
+smol_str = { version = "0.2.1", features = ["serde"] }
 lazy_static = "1.4"
 
 sysinfo = "0.30"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -61,7 +61,7 @@ validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.33", features = ["serde"] }
 smol_str = { version = "0.2.1", features = ["serde"] }
 lazy_static = "1.4"
-fnv = "1"
+fnv = { workspace = true }
 
 sysinfo = "0.30"
 charabia = { version = "0.8.5", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -61,6 +61,7 @@ validator = { version = "0.16", features = ["derive"] }
 chrono = { version = "0.4.33", features = ["serde"] }
 smol_str = { version = "0.2.1", features = ["serde"] }
 lazy_static = "1.4"
+fnv = "1"
 
 sysinfo = "0.30"
 charabia = { version = "0.8.5", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -62,6 +62,7 @@ chrono = { version = "0.4.33", features = ["serde"] }
 smol_str = { version = "0.2.1", features = ["serde"] }
 lazy_static = "1.4"
 fnv = { workspace = true }
+indexmap = { workspace = true }
 
 sysinfo = "0.30"
 charabia = { version = "0.8.5", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -84,6 +84,22 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
     let mut result_size = 0;
     let mut query_count = 0;
 
+    group.bench_function("conditional-search-match-any", |b| {
+        let filter = random_match_any_filter(&mut rng, 2, 51.0);
+        b.iter(|| {
+            let sample = (0..CHECK_SAMPLE_SIZE)
+                .map(|_| rng.gen_range(0..NUM_POINTS) as PointOffsetType)
+                .collect_vec();
+            let context = plain_index.filter_context(&filter);
+            let filtered_sample = sample
+                .into_iter()
+                .filter(|id| context.check(*id))
+                .collect_vec();
+            result_size += filtered_sample.len();
+            query_count += 1;
+        });
+    });
+
     group.bench_function("conditional-search-large-match-any", |b| {
         let filter = random_match_any_filter(&mut rng, 1000, 15.0);
         b.iter(|| {

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -9,7 +9,7 @@ use rand::{Rng, SeedableRng};
 use segment::fixtures::payload_context_fixture::{
     create_plain_payload_index, create_struct_payload_index,
 };
-use segment::fixtures::payload_fixtures::random_must_filter;
+use segment::fixtures::payload_fixtures::{random_match_any_filter, random_must_filter};
 use segment::index::PayloadIndex;
 use tempfile::Builder;
 
@@ -80,6 +80,25 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
         "result_size / query_count = {:#?}",
         result_size / query_count
     );
+
+    let mut result_size = 0;
+    let mut query_count = 0;
+
+    group.bench_function("conditional-search-large-match-any", |b| {
+        let filter = random_match_any_filter(&mut rng, 1000, 15.0);
+        b.iter(|| {
+            let sample = (0..CHECK_SAMPLE_SIZE)
+                .map(|_| rng.gen_range(0..NUM_POINTS) as PointOffsetType)
+                .collect_vec();
+            let context = plain_index.filter_context(&filter);
+            let filtered_sample = sample
+                .into_iter()
+                .filter(|id| context.check(*id))
+                .collect_vec();
+            result_size += filtered_sample.len();
+            query_count += 1;
+        });
+    });
 
     group.finish();
 }

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
 
 use fnv::FnvBuildHasher;
+use indexmap::IndexSet;
 use itertools::Itertools;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::seq::SliceRandom;
@@ -212,7 +212,7 @@ pub fn random_match_any_filter<R: Rng + ?Sized>(
 ) -> Filter {
     let num_existing = (len as f32 * (percent_existing / 100.0)) as usize;
 
-    let mut values: HashSet<String, FnvBuildHasher> = (0..len - num_existing)
+    let mut values: IndexSet<String, FnvBuildHasher> = (0..len - num_existing)
         .map(|_| {
             let slen = rnd_gen.gen_range(1..15);
             Alphanumeric.sample_string(rnd_gen, slen)

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
 
 use itertools::Itertools;
@@ -5,6 +6,7 @@ use rand::distributions::{Alphanumeric, DistString};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
+use smol_str::SmolStr;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::{
@@ -210,14 +212,14 @@ pub fn random_match_any_filter<R: Rng + ?Sized>(
 ) -> Filter {
     let num_existing = (len as f32 * (percent_existing / 100.0)) as usize;
 
-    let mut values: Vec<_> = (0..len - num_existing)
+    let mut values: HashSet<SmolStr> = (0..len - num_existing)
         .map(|_| {
             let slen = rnd_gen.gen_range(1..15);
-            Alphanumeric.sample_string(rnd_gen, slen)
+            Alphanumeric.sample_string(rnd_gen, slen).into()
         })
         .collect();
 
-    values.extend((0..num_existing).map(|_| random_keyword(rnd_gen)));
+    values.extend((0..num_existing).map(|_| random_keyword(rnd_gen).into()));
 
     Filter {
         should: None,

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -7,7 +7,6 @@ use rand::distributions::{Alphanumeric, DistString};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
-use smol_str::SmolStr;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::{
@@ -213,14 +212,14 @@ pub fn random_match_any_filter<R: Rng + ?Sized>(
 ) -> Filter {
     let num_existing = (len as f32 * (percent_existing / 100.0)) as usize;
 
-    let mut values: HashSet<SmolStr, FnvBuildHasher> = (0..len - num_existing)
+    let mut values: HashSet<String, FnvBuildHasher> = (0..len - num_existing)
         .map(|_| {
             let slen = rnd_gen.gen_range(1..15);
-            Alphanumeric.sample_string(rnd_gen, slen).into()
+            Alphanumeric.sample_string(rnd_gen, slen)
         })
         .collect();
 
-    values.extend((0..num_existing).map(|_| random_keyword(rnd_gen).into()));
+    values.extend((0..num_existing).map(|_| random_keyword(rnd_gen)));
 
     Filter {
         should: None,

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,3 +1,4 @@
+use fnv::FnvBuildHasher;
 use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
 
@@ -212,7 +213,7 @@ pub fn random_match_any_filter<R: Rng + ?Sized>(
 ) -> Filter {
     let num_existing = (len as f32 * (percent_existing / 100.0)) as usize;
 
-    let mut values: HashSet<SmolStr> = (0..len - num_existing)
+    let mut values: HashSet<SmolStr, FnvBuildHasher> = (0..len - num_existing)
         .map(|_| {
             let slen = rnd_gen.gen_range(1..15);
             Alphanumeric.sample_string(rnd_gen, slen).into()

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,14 +1,15 @@
 use std::ops::{Range, RangeInclusive};
 
 use itertools::Itertools;
+use rand::distributions::{Alphanumeric, DistString};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
 
 use crate::data_types::vectors::VectorElementType;
 use crate::types::{
-    Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, IsEmptyCondition, Match,
-    Payload, PayloadField, Range as RangeCondition, ValuesCount,
+    AnyVariants, Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition,
+    IsEmptyCondition, Match, MatchAny, Payload, PayloadField, Range as RangeCondition, ValuesCount,
 };
 
 const ADJECTIVE: &[&str] = &[
@@ -198,6 +199,34 @@ pub fn random_must_filter<R: Rng + ?Sized>(rnd_gen: &mut R, num_conditions: usiz
     Filter {
         should: None,
         must: Some(must_conditions),
+        must_not: None,
+    }
+}
+
+pub fn random_match_any_filter<R: Rng + ?Sized>(
+    rnd_gen: &mut R,
+    len: usize,
+    percent_existing: f32,
+) -> Filter {
+    let num_existing = (len as f32 * (percent_existing / 100.0)) as usize;
+
+    let mut values: Vec<_> = (0..len - num_existing)
+        .map(|_| {
+            let slen = rnd_gen.gen_range(1..15);
+            Alphanumeric.sample_string(rnd_gen, slen)
+        })
+        .collect();
+
+    values.extend((0..num_existing).map(|_| random_keyword(rnd_gen)));
+
+    Filter {
+        should: None,
+        must: Some(vec![Condition::Field(FieldCondition::new_match(
+            STR_KEY,
+            Match::Any(MatchAny {
+                any: AnyVariants::Keywords(values),
+            }),
+        ))]),
         must_not: None,
     }
 }

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -1,7 +1,7 @@
-use fnv::FnvBuildHasher;
 use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
 
+use fnv::FnvBuildHasher;
 use itertools::Itertools;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::seq::SliceRandom;

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -3,7 +3,7 @@ pub mod mutable_map_index;
 
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -292,10 +292,13 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MapIndex<N> {
         }
     }
 
-    fn except_iterator<'a>(
+    fn except_iterator<'a, A>(
         &'a self,
-        excluded: &'a HashSet<N>,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+        excluded: &'a HashSet<N, A>,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>
+    where
+        A: BuildHasher,
+    {
         Box::new(
             self.get_values_iterator()
                 .filter(|key| !excluded.contains(*key))

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -292,21 +292,6 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MapIndex<N> {
         }
     }
 
-    fn except_iterator<'a, Q>(
-        &'a self,
-        excluded: &'a [Q],
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>
-    where
-        Q: PartialEq<N>,
-    {
-        Box::new(
-            self.get_values_iterator()
-                .filter(|key| !excluded.iter().any(|e| e.eq(*key)))
-                .flat_map(|key| self.get_iterator(key))
-                .unique(),
-        )
-    }
-
     fn except_set<'a, A, K, S>(
         &'a self,
         excluded: &'a IndexSet<K, A>,
@@ -484,7 +469,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
             },
             Some(Match::Except(MatchExcept {
                 except: AnyVariants::Integers(integers),
-            })) => Ok(self.except_iterator(integers)),
+            })) => Ok(self.except_set(integers)),
             _ => Err(OperationError::service_error("failed to filter")),
         }
     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1,6 +1,7 @@
 pub mod immutable_map_index;
 pub mod mutable_map_index;
 
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::str::FromStr;
@@ -291,16 +292,13 @@ impl<N: Hash + Eq + Clone + Display + FromStr + Default> MapIndex<N> {
         }
     }
 
-    fn except_iterator<'a, Q>(
+    fn except_iterator<'a>(
         &'a self,
-        excluded: &'a [Q],
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>
-    where
-        Q: PartialEq<N>,
-    {
+        excluded: &'a HashSet<N>,
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         Box::new(
             self.get_values_iterator()
-                .filter(|key| !excluded.iter().any(|e| e.eq(*key)))
+                .filter(|key| !excluded.contains(*key))
                 .flat_map(|key| self.get_iterator(key))
                 .unique(),
         )

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -306,9 +306,13 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
                     index.get_values(point_id).map_or(false, |values| {
-                        values
-                            .iter()
-                            .any(|k| list.iter().any(|s| s.as_str() == k.as_ref()))
+                        if list.len() < 13 {
+                            values
+                                .iter()
+                                .any(|k| list.iter().any(|s| s.as_str() == k.as_ref()))
+                        } else {
+                            values.iter().any(|k| list.contains(k.as_str()))
+                        }
                     })
                 }))
             }
@@ -325,9 +329,13 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
                     index.get_values(point_id).map_or(false, |values| {
-                        values
-                            .iter()
-                            .any(|k| !list.iter().any(|s| s.as_str() == k.as_ref()))
+                        if list.len() < 13 {
+                            values
+                                .iter()
+                                .any(|k| !list.iter().any(|s| s.as_str() == k.as_ref()))
+                        } else {
+                            values.iter().any(|k| !list.contains(k.as_str()))
+                        }
                     })
                 }))
             }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -8,6 +8,7 @@ use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
+use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
@@ -306,7 +307,7 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
                     index.get_values(point_id).map_or(false, |values| {
-                        if list.len() < 13 {
+                        if list.len() < INDEXSET_ITER_THRESHOLD {
                             values
                                 .iter()
                                 .any(|k| list.iter().any(|s| s.as_str() == k.as_ref()))
@@ -318,9 +319,13 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             }
             (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|i| list.contains(i)))
+                    index.get_values(point_id).map_or(false, |values| {
+                        if list.len() < INDEXSET_ITER_THRESHOLD {
+                            values.iter().any(|i| list.iter().any(|k| k == i))
+                        } else {
+                            values.iter().any(|i| list.contains(i))
+                        }
+                    })
                 }))
             }
             _ => None,
@@ -329,7 +334,7 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             (AnyVariants::Keywords(list), FieldIndex::KeywordIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
                     index.get_values(point_id).map_or(false, |values| {
-                        if list.len() < 13 {
+                        if list.len() < INDEXSET_ITER_THRESHOLD {
                             values
                                 .iter()
                                 .any(|k| !list.iter().any(|s| s.as_str() == k.as_ref()))
@@ -341,9 +346,13 @@ pub fn get_match_checkers(index: &FieldIndex, cond_match: Match) -> Option<Condi
             }
             (AnyVariants::Integers(list), FieldIndex::IntMapIndex(index)) => {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    index
-                        .get_values(point_id)
-                        .map_or(false, |values| values.iter().any(|i| !list.contains(i)))
+                    index.get_values(point_id).map_or(false, |values| {
+                        if list.len() < INDEXSET_ITER_THRESHOLD {
+                            values.iter().any(|i| !list.iter().any(|k| k == i))
+                        } else {
+                            values.iter().any(|i| !list.contains(i))
+                        }
+                    })
                 }))
             }
             (_, index) => Some(Box::new(|point_id: PointOffsetType| {

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -86,10 +86,10 @@ impl ValueChecker for Match {
             },
             Match::Any(MatchAny { any }) => match (payload, any) {
                 (Value::String(stored), AnyVariants::Keywords(list)) => {
-                    if list.len() > 3 {
-                        list.contains(stored.as_str())
-                    } else {
+                    if list.len() < 13 {
                         list.iter().any(|i| i.as_str() == stored.as_str())
+                    } else {
+                        list.contains(stored.as_str())
                     }
                 }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored
@@ -100,10 +100,10 @@ impl ValueChecker for Match {
             },
             Match::Except(MatchExcept { except }) => match (payload, except) {
                 (Value::String(stored), AnyVariants::Keywords(list)) => {
-                    if list.len() > 3 {
-                        list.contains(stored.as_str())
+                    if list.len() < 13 {
+                        !list.iter().any(|i| i.as_str() == stored.as_str())
                     } else {
-                        list.iter().any(|i| i.as_str() == stored.as_str())
+                        !list.contains(stored.as_str())
                     }
                 }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,6 +1,7 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
 use serde_json::Value;
+use smol_str::SmolStr;
 
 use crate::types::{
     AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPoint,
@@ -85,7 +86,10 @@ impl ValueChecker for Match {
                 _ => false,
             },
             Match::Any(MatchAny { any }) => match (payload, any) {
-                (Value::String(stored), AnyVariants::Keywords(list)) => list.contains(stored),
+                (Value::String(stored), AnyVariants::Keywords(list)) => {
+                    let s: SmolStr = stored.into();
+                    list.contains(&s)
+                }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored
                     .as_i64()
                     .map(|num| list.contains(&num))
@@ -93,7 +97,10 @@ impl ValueChecker for Match {
                 _ => false,
             },
             Match::Except(MatchExcept { except }) => match (payload, except) {
-                (Value::String(stored), AnyVariants::Keywords(list)) => !list.contains(stored),
+                (Value::String(stored), AnyVariants::Keywords(list)) => {
+                    let s: SmolStr = stored.into();
+                    !list.contains(&s)
+                }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored
                     .as_i64()
                     .map(|num| !list.contains(&num))

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,7 +1,6 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
 use serde_json::Value;
-use smol_str::SmolStr;
 
 use crate::types::{
     AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPoint,
@@ -87,8 +86,11 @@ impl ValueChecker for Match {
             },
             Match::Any(MatchAny { any }) => match (payload, any) {
                 (Value::String(stored), AnyVariants::Keywords(list)) => {
-                    let s: SmolStr = stored.into();
-                    list.contains(&s)
+                    if list.len() > 3 {
+                        list.contains(stored.as_str())
+                    } else {
+                        list.iter().any(|i| i.as_str() == stored.as_str())
+                    }
                 }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored
                     .as_i64()
@@ -98,8 +100,11 @@ impl ValueChecker for Match {
             },
             Match::Except(MatchExcept { except }) => match (payload, except) {
                 (Value::String(stored), AnyVariants::Keywords(list)) => {
-                    let s: SmolStr = stored.into();
-                    !list.contains(&s)
+                    if list.len() > 3 {
+                        list.contains(stored.as_str())
+                    } else {
+                        list.iter().any(|i| i.as_str() == stored.as_str())
+                    }
                 }
                 (Value::Number(stored), AnyVariants::Integers(list)) => stored
                     .as_i64()

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,3 +1,4 @@
+use fnv::{FnvBuildHasher, FnvHashSet};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -1188,7 +1189,7 @@ pub enum ValueVariants {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum AnyVariants {
-    Keywords(HashSet<SmolStr>),
+    Keywords(HashSet<SmolStr, FnvBuildHasher>),
     Integers(HashSet<IntPayloadType>),
 }
 
@@ -1317,7 +1318,8 @@ impl From<IntPayloadType> for Match {
 
 impl From<Vec<String>> for Match {
     fn from(keywords: Vec<String>) -> Self {
-        let keywords: HashSet<SmolStr> = keywords.into_iter().map(|i| i.into()).collect();
+        let keywords: HashSet<SmolStr, FnvBuildHasher> =
+            keywords.into_iter().map(|i| i.into()).collect();
         Self::Any(MatchAny {
             any: AnyVariants::Keywords(keywords),
         })
@@ -1326,7 +1328,8 @@ impl From<Vec<String>> for Match {
 
 impl From<Vec<String>> for MatchExcept {
     fn from(keywords: Vec<String>) -> Self {
-        let keywords: HashSet<SmolStr> = keywords.into_iter().map(|i| i.into()).collect();
+        let keywords: HashSet<SmolStr, FnvBuildHasher> =
+            keywords.into_iter().map(|i| i.into()).collect();
         MatchExcept {
             except: AnyVariants::Keywords(keywords),
         }
@@ -2379,7 +2382,7 @@ mod tests {
         };
         if let AnyVariants::Keywords(kws) = &m.any {
             assert_eq!(kws.len(), 3);
-            let expect: HashSet<SmolStr> = ["Bourne", "Momoa", "Statham"]
+            let expect: HashSet<SmolStr, FnvBuildHasher> = ["Bourne", "Momoa", "Statham"]
                 .iter()
                 .map(|i| (*i).into())
                 .collect();

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,4 +1,3 @@
-use fnv::{FnvBuildHasher, FnvHashSet};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -9,6 +8,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use common::types::ScoreType;
+use fnv::FnvBuildHasher;
 use geo::prelude::HaversineDistance;
 use geo::{Contains, Coord, LineString, Point, Polygon};
 use itertools::Itertools;

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1191,7 +1191,7 @@ pub enum ValueVariants {
 #[serde(untagged)]
 pub enum AnyVariants {
     Keywords(IndexSet<String, FnvBuildHasher>),
-    Integers(Vec<IntPayloadType>),
+    Integers(IndexSet<IntPayloadType, FnvBuildHasher>),
 }
 
 /// Exact match of the given value
@@ -1337,6 +1337,7 @@ impl From<Vec<String>> for MatchExcept {
 
 impl From<Vec<IntPayloadType>> for Match {
     fn from(integers: Vec<IntPayloadType>) -> Self {
+        let integers: IndexSet<_, FnvBuildHasher> = integers.into_iter().collect();
         Self::Any(MatchAny {
             any: AnyVariants::Integers(integers),
         })
@@ -1345,6 +1346,7 @@ impl From<Vec<IntPayloadType>> for Match {
 
 impl From<Vec<IntPayloadType>> for MatchExcept {
     fn from(integers: Vec<IntPayloadType>) -> Self {
+        let integers: IndexSet<_, FnvBuildHasher> = integers.into_iter().collect();
         MatchExcept {
             except: AnyVariants::Integers(integers),
         }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1189,7 +1189,7 @@ pub enum ValueVariants {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum AnyVariants {
-    Keywords(HashSet<SmolStr, FnvBuildHasher>),
+    Keywords(HashSet<String, FnvBuildHasher>),
     Integers(HashSet<IntPayloadType>),
 }
 
@@ -1318,8 +1318,7 @@ impl From<IntPayloadType> for Match {
 
 impl From<Vec<String>> for Match {
     fn from(keywords: Vec<String>) -> Self {
-        let keywords: HashSet<SmolStr, FnvBuildHasher> =
-            keywords.into_iter().map(|i| i.into()).collect();
+        let keywords: HashSet<String, FnvBuildHasher> = keywords.into_iter().collect();
         Self::Any(MatchAny {
             any: AnyVariants::Keywords(keywords),
         })
@@ -1328,8 +1327,7 @@ impl From<Vec<String>> for Match {
 
 impl From<Vec<String>> for MatchExcept {
     fn from(keywords: Vec<String>) -> Self {
-        let keywords: HashSet<SmolStr, FnvBuildHasher> =
-            keywords.into_iter().map(|i| i.into()).collect();
+        let keywords: HashSet<String, FnvBuildHasher> = keywords.into_iter().collect();
         MatchExcept {
             except: AnyVariants::Keywords(keywords),
         }
@@ -2141,6 +2139,7 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use fnv::FnvHashSet;
     use serde::de::DeserializeOwned;
     use serde_json;
     use serde_json::json;
@@ -2382,10 +2381,11 @@ mod tests {
         };
         if let AnyVariants::Keywords(kws) = &m.any {
             assert_eq!(kws.len(), 3);
-            let expect: HashSet<SmolStr, FnvBuildHasher> = ["Bourne", "Momoa", "Statham"]
-                .iter()
-                .map(|i| (*i).into())
-                .collect();
+            let expect = FnvHashSet::from_iter(
+                ["Bourne", "Momoa", "Statham"]
+                    .into_iter()
+                    .map(|i| i.to_string()),
+            );
             assert_eq!(kws, &expect);
         } else {
             panic!("AnyVariants::Keywords expected");

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1,10 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::types::PointOffsetType;
 use fnv::FnvBuildHasher;
+use indexmap::IndexSet;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -858,7 +859,7 @@ fn test_any_matcher_cardinality_estimation() {
 
     let (struct_segment, _) = build_test_segments(dir1.path(), dir2.path());
 
-    let keywords: HashSet<String, FnvBuildHasher> =
+    let keywords: IndexSet<String, FnvBuildHasher> =
         ["value1", "value2"].iter().map(|i| i.to_string()).collect();
     let any_match =
         FieldCondition::new_match(STR_KEY, Match::new_any(AnyVariants::Keywords(keywords)));

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::types::PointOffsetType;
+use fnv::FnvBuildHasher;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -858,7 +859,8 @@ fn test_any_matcher_cardinality_estimation() {
 
     let (struct_segment, _) = build_test_segments(dir1.path(), dir2.path());
 
-    let keywords: HashSet<SmolStr> = ["value1", "value2"].iter().map(|i| (*i).into()).collect();
+    let keywords: HashSet<SmolStr, FnvBuildHasher> =
+        ["value1", "value2"].iter().map(|i| (*i).into()).collect();
     let any_match =
         FieldCondition::new_match(STR_KEY, Match::new_any(AnyVariants::Keywords(keywords)));
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -33,7 +33,6 @@ use segment::types::{
     VectorStorageType, WithPayload,
 };
 use serde_json::json;
-use smol_str::SmolStr;
 use tempfile::Builder;
 
 use crate::utils::scored_point_ties::ScoredPointTies;
@@ -859,8 +858,8 @@ fn test_any_matcher_cardinality_estimation() {
 
     let (struct_segment, _) = build_test_segments(dir1.path(), dir2.path());
 
-    let keywords: HashSet<SmolStr, FnvBuildHasher> =
-        ["value1", "value2"].iter().map(|i| (*i).into()).collect();
+    let keywords: HashSet<String, FnvBuildHasher> =
+        ["value1", "value2"].iter().map(|i| i.to_string()).collect();
     let any_match =
         FieldCondition::new_match(STR_KEY, Match::new_any(AnyVariants::Keywords(keywords)));
 


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

/claim #3522 

**Note:** in /Cargo.toml:181 I used a custom fork of schemars to allow using SmolStr directly in the API. This is unsecure and should be replaced with a fork in the qdrant organization like the tonic patch above!

# Benches
I created a new bench function `conditional-search-large-match-any` that measures the performance increase. To test the performance of the old implementation one can simply checkout the first commit of this PR.

Results for 100k points, 1k MatchAny values of which 15% can be a matching value:
Old: `1.07ms`
This PR: `561.12µs`