### PR TITLE
Optimize sparse search by advancing postings without binary search

### DIFF
--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -196,6 +196,11 @@ impl<'a> PostingListIterator<'a> {
         }
     }
 
+    /// Advances the iterator by `count` elements.
+    pub fn advance_by(&mut self, count: usize) {
+        self.current_index = (self.current_index + count).min(self.elements.len());
+    }
+
     /// Returns the next element without advancing the iterator.
     pub fn peek(&self) -> Option<&PostingElement> {
         self.elements.get(self.current_index)

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -134,9 +134,9 @@ impl<'a> SearchContext<'a> {
         filter_condition: &F,
     ) {
         for posting in self.postings_iterators.iter_mut() {
-            // index at which the posting list stops contributing to the batch (relative to the batch start)
+            // offset at which the posting list stops contributing to the batch (relative to the batch start)
             let mut posting_stopped_at = None;
-            for (index, element) in posting
+            for (offset, element) in posting
                 .posting_list_iterator
                 .remaining_elements()
                 .iter()
@@ -145,7 +145,7 @@ impl<'a> SearchContext<'a> {
                 let element_id = element.record_id;
                 if element_id > batch_last_id {
                     // reaching end of the batch
-                    posting_stopped_at = Some(index);
+                    posting_stopped_at = Some(offset);
                     break;
                 }
                 let element_score = element.weight * posting.query_weight;
@@ -160,7 +160,7 @@ impl<'a> SearchContext<'a> {
                     posting.posting_list_iterator.skip_to_end();
                 }
                 Some(stopped_at) => {
-                    // posting list is not exhausted - skip to the next id
+                    // posting list is not exhausted - advance to last id
                     posting.posting_list_iterator.advance_by(stopped_at)
                 }
             };

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -134,10 +134,18 @@ impl<'a> SearchContext<'a> {
         filter_condition: &F,
     ) {
         for posting in self.postings_iterators.iter_mut() {
-            for element in posting.posting_list_iterator.remaining_elements() {
+            // index at which the posting list stops contributing to the batch (relative to the batch start)
+            let mut posting_stopped_at = None;
+            for (index, element) in posting
+                .posting_list_iterator
+                .remaining_elements()
+                .iter()
+                .enumerate()
+            {
                 let element_id = element.record_id;
                 if element_id > batch_last_id {
                     // reaching end of the batch
+                    posting_stopped_at = Some(index);
                     break;
                 }
                 let element_score = element.weight * posting.query_weight;
@@ -145,8 +153,17 @@ impl<'a> SearchContext<'a> {
                 let local_id = (element_id - batch_start_id) as usize;
                 self.batch_scores[local_id] += element_score;
             }
-            // advance posting to the batch last id
-            posting.posting_list_iterator.skip_to(batch_last_id + 1);
+            // advance posting list iterator
+            match posting_stopped_at {
+                None => {
+                    // posting list is exhausted before reaching the end of the batch
+                    posting.posting_list_iterator.skip_to_end();
+                }
+                Some(stopped_at) => {
+                    // posting list is not exhausted - skip to the next id
+                    posting.posting_list_iterator.advance_by(stopped_at)
+                }
+            };
         }
 
         // publish only the non-zero scores above the current min


### PR DESCRIPTION
context: https://github.com/qdrant/qdrant/pull/3464

Optimize sparse vector search by advancing posting lists without binary search.

We know exactly where to move the cursor for the posting list when reaching the end of the batch.

No need to use `skip_to` with a point id which performs a binary search internally.

# Performance numbers

- server `Standard D8ds v5 (8 vcpus, 32 GiB memory)`
- client `Standard D4s v3 (4 vcpus, 16 GiB memory)`
- 8 segments
- index.on_disk=false
- full data set with 9M points
- 6980 queries

```
DEV
min: 125.61 millis
50p: 374.41 millis
95p: 570.08 millis
99p: 644.55 millis
999p: 723.14 millis
max: 772.38 millis
```

```
PR
min: 90.75 millis
50p: 179.43 millis
95p: 310.99 millis
99p: 408.16 millis
999p: 462.66 millis
max: 533.39 millis
```

DEV             |  PR
:-------------------------:|:-------------------------:
![sparse_bench_small_dev](https://github.com/qdrant/qdrant/assets/606963/5ad3e8d7-63ac-418d-bd51-96ebbaf92de6)  | ![sparse_bench_small_PR](https://github.com/qdrant/qdrant/assets/606963/13d06f04-04b4-485a-a962-f43d97572e7e)