### PR TITLE
Add `force` field to the `ClockTag` type

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -113,6 +113,7 @@ message ClockTag {
   uint64 peer_id = 1;
   uint32 clock_id = 2;
   uint64 clock_tick = 3;
+  bool force = 4;
 }
 
 message SearchPointsInternal {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7235,6 +7235,8 @@ pub struct ClockTag {
     pub clock_id: u32,
     #[prost(uint64, tag = "3")]
     pub clock_tick: u64,
+    #[prost(bool, tag = "4")]
+    pub force: bool,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -70,6 +70,7 @@ pub struct ClockTag {
     peer_id: PeerId,
     clock_id: u32,
     clock_tick: u64,
+    force: bool,
 }
 
 impl ClockTag {
@@ -78,13 +79,19 @@ impl ClockTag {
             peer_id,
             clock_id,
             clock_tick,
+            force: false,
         }
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
     }
 }
 
 impl From<api::grpc::qdrant::ClockTag> for ClockTag {
     fn from(tag: api::grpc::qdrant::ClockTag) -> Self {
-        Self::new(tag.peer_id, tag.clock_id, tag.clock_tick)
+        Self::new(tag.peer_id, tag.clock_id, tag.clock_tick).force(tag.force)
     }
 }
 
@@ -94,6 +101,7 @@ impl From<ClockTag> for api::grpc::qdrant::ClockTag {
             peer_id: tag.peer_id,
             clock_id: tag.clock_id,
             clock_tick: tag.clock_tick,
+            force: tag.force,
         }
     }
 }


### PR DESCRIPTION
Adds `force` field to the `ClockTag` type, to be used for "diff" shard transfer stuff. Currently, does nothing with the field, but it will (may?) be utilized in the future PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
