### PR TITLE
Order-by: support datetimes

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3276,6 +3276,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | float | [double](#double) |  |  |
 | integer | [int64](#int64) |  |  |
+| datetime | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3276,7 +3276,8 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | float | [double](#double) |  |  |
 | integer | [int64](#int64) |  |  |
-| datetime | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| datetime | [string](#string) |  |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7316,9 +7316,14 @@
           },
           "start_from": {
             "description": "Which payload value to start scrolling from. Default is the lowest value for `asc` and the highest for `desc`",
-            "type": "number",
-            "format": "double",
-            "nullable": true
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StartFrom"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -7327,6 +7332,18 @@
         "enum": [
           "asc",
           "desc"
+        ]
+      },
+      "StartFrom": {
+        "anyOf": [
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "string",
+            "format": "date-time"
+          }
         ]
       },
       "ScrollResult": {

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1271,8 +1271,21 @@ impl From<segment::data_types::order_by::OrderBy> for OrderBy {
         Self {
             key: value.key,
             direction: value.direction.map(|d| Direction::from(d) as i32),
-            start_from: value.start_from.map(|start_from| StartFrom {
-                value: Some(start_from::Value::Float(start_from)), // ToDo: take other types of orderable values into account (int, datetime, etc)
+            start_from: value.start_from.map(|start_from| start_from.into()),
+        }
+    }
+}
+
+impl From<segment::data_types::order_by::StartFrom> for StartFrom {
+    fn from(value: segment::data_types::order_by::StartFrom) -> Self {
+        Self {
+            value: Some(match value {
+                segment::data_types::order_by::StartFrom::Float(float) => {
+                    start_from::Value::Float(float)
+                }
+                segment::data_types::order_by::StartFrom::Datetime(datetime) => {
+                    start_from::Value::Datetime(date_time_to_proto(datetime))
+                }
             }),
         }
     }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1284,7 +1284,7 @@ impl From<segment::data_types::order_by::StartFrom> for StartFrom {
                     start_from::Value::Float(float)
                 }
                 segment::data_types::order_by::StartFrom::Datetime(datetime) => {
-                    start_from::Value::Datetime(date_time_to_proto(datetime))
+                    start_from::Value::Timestamp(date_time_to_proto(datetime))
                 }
             }),
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -310,7 +310,8 @@ message StartFrom {
   oneof value {
     double float = 1;
     int64 integer = 2;
-    google.protobuf.Timestamp datetime = 3;
+    google.protobuf.Timestamp timestamp = 3;
+    string datetime = 4;
   }
 }
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -310,6 +310,7 @@ message StartFrom {
   oneof value {
     double float = 1;
     int64 integer = 2;
+    google.protobuf.Timestamp datetime = 3;
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3880,7 +3880,7 @@ pub struct SearchPointGroups {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartFrom {
-    #[prost(oneof = "start_from::Value", tags = "1, 2, 3")]
+    #[prost(oneof = "start_from::Value", tags = "1, 2, 3, 4")]
     pub value: ::core::option::Option<start_from::Value>,
 }
 /// Nested message and enum types in `StartFrom`.
@@ -3894,7 +3894,9 @@ pub mod start_from {
         #[prost(int64, tag = "2")]
         Integer(i64),
         #[prost(message, tag = "3")]
-        Datetime(::prost_wkt_types::Timestamp),
+        Timestamp(::prost_wkt_types::Timestamp),
+        #[prost(string, tag = "4")]
+        Datetime(::prost::alloc::string::String),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3880,7 +3880,7 @@ pub struct SearchPointGroups {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartFrom {
-    #[prost(oneof = "start_from::Value", tags = "1, 2")]
+    #[prost(oneof = "start_from::Value", tags = "1, 2, 3")]
     pub value: ::core::option::Option<start_from::Value>,
 }
 /// Nested message and enum types in `StartFrom`.
@@ -3893,6 +3893,8 @@ pub mod start_from {
         Float(f64),
         #[prost(int64, tag = "2")]
         Integer(i64),
+        #[prost(message, tag = "3")]
+        Datetime(::prost_wkt_types::Timestamp),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -234,7 +234,7 @@ impl Collection {
 
             if !has_range_index_for_order_by_field {
                 return Err(CollectionError::bad_request(format!(
-                    "No range index for `order_by` key: {}. Please create one to use `order_by`. Integer and float payloads can have range indexes, see https://qdrant.tech/documentation/concepts/indexing/#payload-index.",
+                    "No range index for `order_by` key: {}. Please create one to use `order_by`. Integer, float, and datetime payloads can have range indexes, see https://qdrant.tech/documentation/concepts/indexing/#payload-index.",
                     order_by.key.as_str()
                 )));
             }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1768,6 +1768,7 @@ impl TryFrom<api::grpc::qdrant::OrderBy> for OrderByInterface {
                     api::grpc::qdrant::start_from::Value::Float(float) => {
                         Ok(StartFrom::Float(float))
                     }
+                    // TODO(luis): make appropriate conversion once we allow int start_from
                     api::grpc::qdrant::start_from::Value::Integer(int) => {
                         Ok(StartFrom::Float(int as _))
                     }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -5,7 +5,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-use crate::types::{FloatPayloadType, IntPayloadType, Payload, Range, RangeInterface};
+use crate::types::{
+    deserialize_datetime, FloatPayloadType, IntPayloadType, Payload, Range, RangeInterface,
+};
 
 const INTERNAL_KEY_OF_ORDER_BY_VALUE: &str = "____ordered_with____";
 
@@ -40,6 +42,8 @@ impl Direction {
 #[serde(untagged)]
 pub enum StartFrom {
     Float(FloatPayloadType),
+
+    #[serde(deserialize_with = "deserialize_datetime")]
     Datetime(DateTime<Utc>),
 }
 

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -1,11 +1,11 @@
+use chrono::{DateTime, Utc};
 use num_cmp::NumCmp;
 use ordered_float::OrderedFloat;
-use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-use crate::types::{Payload, Range, RangeInterface};
+use crate::types::{FloatPayloadType, IntPayloadType, Payload, Range, RangeInterface};
 
 const INTERNAL_KEY_OF_ORDER_BY_VALUE: &str = "____ordered_with____";
 
@@ -39,7 +39,7 @@ impl Direction {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
 pub enum StartFrom {
-    Float(f64),
+    Float(FloatPayloadType),
     Datetime(DateTime<Utc>),
 }
 
@@ -98,7 +98,7 @@ impl OrderBy {
 
 pub enum OrderingValue {
     Float(FloatPayloadType),
-    Int(i64),
+    Int(IntPayloadType),
 }
 
 impl From<OrderingValue> for serde_json::Value {
@@ -118,8 +118,8 @@ impl From<FloatPayloadType> for OrderingValue {
     }
 }
 
-impl From<i64> for OrderingValue {
-    fn from(value: i64) -> Self {
+impl From<IntPayloadType> for OrderingValue {
+    fn from(value: IntPayloadType) -> Self {
         OrderingValue::Int(value)
     }
 }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -74,6 +74,19 @@ impl OrderBy {
         self.direction.unwrap_or_default()
     }
 
+    pub fn start_from(&self) -> OrderingValue {
+        self.start_from
+            .as_ref()
+            .map(|start_from| match start_from {
+                StartFrom::Float(f) => OrderingValue::Float(*f),
+                StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp_micros()),
+            })
+            .unwrap_or_else(|| match self.direction() {
+                Direction::Asc => OrderingValue::Int(std::i64::MIN),
+                Direction::Desc => OrderingValue::Int(std::i64::MAX),
+            })
+    }
+
     pub fn insert_order_value_in_payload(
         payload: Option<Payload>,
         value: impl Into<serde_json::Value>,

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -57,7 +57,7 @@ pub struct OrderBy {
 }
 
 impl OrderBy {
-    /// If there is a start value, returns a range representation of OrderBy.
+    /// Returns a range representation of OrderBy.
     pub fn as_range(&self) -> RangeInterface {
         self.start_from
             .as_ref()

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchText,
-    PayloadKeyType, Range,
+    PayloadKeyType, RangeInterface,
 };
 
 pub trait PayloadFieldIndex {
@@ -368,9 +368,9 @@ impl FieldIndex {
     pub fn as_numeric(&self) -> Option<NumericFieldIndex> {
         match self {
             FieldIndex::IntIndex(index) => Some(NumericFieldIndex::IntIndex(index)),
+            FieldIndex::DatetimeIndex(index) => Some(NumericFieldIndex::IntIndex(index)),
             FieldIndex::FloatIndex(index) => Some(NumericFieldIndex::FloatIndex(index)),
             FieldIndex::IntMapIndex(_)
-            | FieldIndex::DatetimeIndex(_) // TODO(luis): move to Some(..) section when datetime index is enabled for order-by
             | FieldIndex::KeywordIndex(_)
             | FieldIndex::GeoIndex(_)
             | FieldIndex::BinaryIndex(_)
@@ -387,7 +387,7 @@ pub enum NumericFieldIndex<'a> {
 impl<'a> StreamRange<OrderingValue> for NumericFieldIndex<'a> {
     fn stream_range(
         &self,
-        range: &Range<FloatPayloadType>,
+        range: &RangeInterface,
     ) -> Box<dyn DoubleEndedIterator<Item = (OrderingValue, PointOffsetType)> + 'a> {
         match self {
             NumericFieldIndex::IntIndex(index) => Box::new(

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1104,9 +1104,9 @@ impl PayloadFieldSchema {
             | PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(_)) => false,
 
             PayloadFieldSchema::FieldParams(PayloadSchemaParams::Integer(IntegerIndexParams {
-                                                                             range,
-                                                                             ..
-                                                                         })) => *range,
+                range,
+                ..
+            })) => *range,
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1094,10 +1094,10 @@ impl PayloadFieldSchema {
     pub fn has_range_index(&self) -> bool {
         match self {
             PayloadFieldSchema::FieldType(PayloadSchemaType::Integer)
+            | PayloadFieldSchema::FieldType(PayloadSchemaType::Datetime)
             | PayloadFieldSchema::FieldType(PayloadSchemaType::Float) => true,
 
             PayloadFieldSchema::FieldType(PayloadSchemaType::Bool)
-            | PayloadFieldSchema::FieldType(PayloadSchemaType::Datetime) // TODO(luis): move to true section once we support order-by datetime
             | PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)
             | PayloadFieldSchema::FieldType(PayloadSchemaType::Text)
             | PayloadFieldSchema::FieldType(PayloadSchemaType::Geo)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1408,6 +1408,20 @@ pub fn try_parse_datetime(s: &str) -> Option<DateTimePayloadType> {
     Some(datetime_utc)
 }
 
+fn deserialize_datetime_str<'de, D>(s: &str) -> Result<DateTimePayloadType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Attempt to parse the input string to datetime
+    let parse_result = try_parse_datetime(s);
+    match parse_result {
+        Some(datetime) => Ok(datetime),
+        None => Err(serde::de::Error::custom(format!(
+            "'{s}' is not in a supported date/time format, please use RFC 3339"
+        ))),
+    }
+}
+
 fn deserialize_datetime_option<'de, D>(
     s: Option<&str>,
 ) -> Result<Option<DateTimePayloadType>, D::Error>
@@ -1417,14 +1431,16 @@ where
     let Some(s) = s else {
         return Ok(None);
     };
+    Some(deserialize_datetime_str::<D>(s)).transpose()
+}
+
+pub(crate) fn deserialize_datetime<'de, D>(deserializer: D) -> Result<DateTimePayloadType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let str_datetime = <&str>::deserialize(deserializer)?;
     // Attempt to parse the input string to datetime
-    let parse_result = try_parse_datetime(s);
-    match parse_result {
-        Some(_) => Ok(parse_result),
-        None => Err(serde::de::Error::custom(format!(
-            "'{s}' is not in a supported date/time format, please use RFC 3339"
-        ))),
-    }
+    deserialize_datetime_str::<D>(str_datetime)
 }
 
 fn deserialize_datetime_range<'de, D>(

--- a/openapi/tests/openapi_integration/test_order_by.py
+++ b/openapi/tests/openapi_integration/test_order_by.py
@@ -257,6 +257,8 @@ def test_paginate_whole_collection(key, direction):
         ("price", "desc"),
         ("maybe_repeated_float", "asc"),
         ("maybe_repeated_float", "desc"),
+        ("date", "asc"),
+        ("date", "desc"),
     ],
 )
 @pytest.mark.timeout(60)  # possibly break of an infinite loop


### PR DESCRIPTION
Tracked by: #3521 

We recently added support for a datetime index, which also has range-able capabilities. This PR enables the usage of datetimes for ordering in scroll with minimal interface changes.

### Future work:
- Allow integers as `start_from` parameter. But this should also be paired with a new `RangeInterface::Int(Range<i64>)`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
