### PR TITLE
Fix REST API pattern match ordering problem

### DIFF
--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -180,7 +180,10 @@ async fn update_collection_cluster(
 
 // Configure services
 pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
-    cfg.service(get_collections)
+    // Ordering of services is important for correct path pattern matching
+    // See: <https://github.com/qdrant/qdrant/issues/3543>
+    cfg.service(update_aliases)
+        .service(get_collections)
         .service(get_collection)
         .service(get_collection_existence)
         .service(create_collection)
@@ -188,7 +191,6 @@ pub fn config_collections_api(cfg: &mut web::ServiceConfig) {
         .service(delete_collection)
         .service(get_aliases)
         .service(get_collection_aliases)
-        .service(update_aliases)
         .service(get_cluster_info)
         .service(update_collection_cluster);
 }

--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -10,18 +10,19 @@ use futures_util::future::LocalBoxFuture;
 
 use crate::common::auth::AuthKeys;
 
+/// List of read-only POST request paths. List MUST be sorted.
 const READ_ONLY_POST_PATTERNS: [&str; 11] = [
     "/collections/{name}/points",
     "/collections/{name}/points/count",
-    "/collections/{name}/points/search",
-    "/collections/{name}/points/scroll",
-    "/collections/{name}/points/search/groups",
-    "/collections/{name}/points/search/batch",
-    "/collections/{name}/points/recommend",
-    "/collections/{name}/points/recommend/groups",
-    "/collections/{name}/points/recommend/batch",
     "/collections/{name}/points/discover",
     "/collections/{name}/points/discover/batch",
+    "/collections/{name}/points/recommend",
+    "/collections/{name}/points/recommend/batch",
+    "/collections/{name}/points/recommend/groups",
+    "/collections/{name}/points/scroll",
+    "/collections/{name}/points/search",
+    "/collections/{name}/points/search/batch",
+    "/collections/{name}/points/search/groups",
 ];
 
 pub struct ApiKey {
@@ -160,7 +161,11 @@ fn is_read_only(req: &ServiceRequest) -> bool {
         Method::GET => true,
         Method::POST => req
             .match_pattern()
-            .map(|pattern| READ_ONLY_POST_PATTERNS.iter().any(|pat| &pattern == pat))
+            .map(|pattern| {
+                READ_ONLY_POST_PATTERNS
+                    .binary_search(&pattern.as_str())
+                    .is_ok()
+            })
             .unwrap_or_default(),
         _ => false,
     }

--- a/src/actix/api_key.rs
+++ b/src/actix/api_key.rs
@@ -170,3 +170,18 @@ fn is_read_only(req: &ServiceRequest) -> bool {
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_post_patterns_sorted() {
+        let mut sorted = READ_ONLY_POST_PATTERNS;
+        sorted.sort_unstable();
+        assert_eq!(
+            READ_ONLY_POST_PATTERNS, sorted,
+            "The READ_ONLY_POST_PATTERNS list must be sorted"
+        );
+    }
+}

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -157,10 +157,12 @@ pub fn init(
                 .configure(config_recommend_api)
                 .configure(config_discovery_api)
                 .configure(config_shards_api)
-                .service(get_point)
-                .service(get_points)
+                // Ordering of services is important for correct path pattern matching
+                // See: <https://github.com/qdrant/qdrant/issues/3543>
                 .service(scroll_points)
-                .service(count_points);
+                .service(count_points)
+                .service(get_point)
+                .service(get_points);
 
             if web_ui_available {
                 app = app.service(


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/3543>, <https://github.com/qdrant/qdrant-web-ui/issues/158>.

This reorders our actix web REST API services so that we don't have pattern matching conflicts.

As a micro optimization, I now also binary search of the list of allowed patterns.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?