### PR TITLE
Change `max_ack_version` to be `wal_keep_from`

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -55,10 +55,10 @@ impl QueueProxyShard {
     pub fn new(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,
-        max_ack_version: Arc<AtomicU64>,
+        wal_keep_from: Arc<AtomicU64>,
     ) -> Self {
         Self {
-            inner: Some(Inner::new(wrapped_shard, remote_shard, max_ack_version)),
+            inner: Some(Inner::new(wrapped_shard, remote_shard, wal_keep_from)),
         }
     }
 
@@ -144,7 +144,7 @@ impl QueueProxyShard {
             .inner
             .take()
             .expect("Queue proxy has already been finalized");
-        queue_proxy.set_max_ack_version(None);
+        queue_proxy.set_wal_keep_from(None);
 
         (queue_proxy.wrapped_shard, queue_proxy.remote_shard)
     }
@@ -261,17 +261,18 @@ struct Inner {
     /// Lock required to protect transfer-in-progress updates.
     /// It should block data updating operations while the batch is being transferred.
     update_lock: Mutex<()>,
-    /// Maximum acknowledged WAL version of the wrapped shard.
-    /// We keep it here for access in `set_max_ack_version()` without needing async locks.
-    /// See `set_max_ack_version()` and `UpdateHandler::max_ack_version` for more details.
-    max_ack_version: Arc<AtomicU64>,
+    /// Always keep this WAL version and later and prevent acknowledgment/truncation from the WAL.
+    /// We keep it here for access in `set_wal_keep_from()` without needing async locks.
+    /// See `set_wal_keep_from()` and `UpdateHandler::wal_keep_from` for more details.
+    /// Defaults to `u64::MAX` to allow acknowledging all confirmed versions.
+    wal_keep_from: Arc<AtomicU64>,
 }
 
 impl Inner {
     pub fn new(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,
-        max_ack_version: Arc<AtomicU64>,
+        wal_keep_from: Arc<AtomicU64>,
     ) -> Self {
         let last_idx = wrapped_shard.wal.lock().last_index();
 
@@ -280,11 +281,11 @@ impl Inner {
             remote_shard,
             last_update_idx: last_idx.into(),
             update_lock: Default::default(),
-            max_ack_version,
+            wal_keep_from,
         };
 
-        // Set max acknowledged version for WAL to not truncate parts we still need to transfer later
-        shard.set_max_ack_version(Some(last_idx));
+        // Keep all new WAL entries so we don't truncate them off when we still need to transfer
+        shard.set_wal_keep_from(Some(last_idx + 1));
 
         shard
     }
@@ -305,7 +306,7 @@ impl Inner {
 
         // Set max acknowledged version for WAL to last item we transferred
         let last_idx = self.last_update_idx.load(Ordering::Relaxed);
-        self.set_max_ack_version(Some(last_idx));
+        self.set_wal_keep_from(Some(last_idx + 1));
 
         Ok(())
     }
@@ -373,16 +374,16 @@ impl Inner {
         Ok(last_batch)
     }
 
-    /// Set or release maximum version to acknowledge in WAL
+    /// Set or release what WAL versions to keep preventing acknowledgment/truncation.
     ///
     /// Because this proxy shard relies on the WAL to obtain operations history, it cannot be
     /// truncated before all these update operations have been flushed.
-    /// Using this function we set the WAL not to truncate past the given point.
+    /// Using this function we set the WAL not to acknowledge and truncate from a specific point.
     ///
     /// Providing `None` will release this limitation.
-    fn set_max_ack_version(&self, max_version: Option<u64>) {
+    fn set_wal_keep_from(&self, max_version: Option<u64>) {
         let max_version = max_version.unwrap_or(u64::MAX);
-        self.max_ack_version.store(max_version, Ordering::Relaxed);
+        self.wal_keep_from.store(max_version, Ordering::Relaxed);
     }
 }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -376,7 +376,7 @@ impl Inner {
 
     /// Set or release what WAL versions to keep preventing acknowledgment/truncation.
     ///
-    /// Because this proxy shard relies on the WAL to obtain operations history, it cannot be
+    /// Because this proxy shard relies on the WAL to obtain operations in the past, it cannot be
     /// truncated before all these update operations have been flushed.
     /// Using this function we set the WAL not to acknowledge and truncate from a specific point.
     ///

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -381,9 +381,9 @@ impl Inner {
     /// Using this function we set the WAL not to acknowledge and truncate from a specific point.
     ///
     /// Providing `None` will release this limitation.
-    fn set_wal_keep_from(&self, max_version: Option<u64>) {
-        let max_version = max_version.unwrap_or(u64::MAX);
-        self.wal_keep_from.store(max_version, Ordering::Relaxed);
+    fn set_wal_keep_from(&self, version: Option<u64>) {
+        let version = version.unwrap_or(u64::MAX);
+        self.wal_keep_from.store(version, Ordering::Relaxed);
     }
 }
 

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -129,11 +129,11 @@ impl ShardReplicaSet {
             _ => unreachable!(),
         };
 
-        let max_ack_version = local_shard
+        let wal_keep_from = local_shard
             .update_handler
             .lock()
             .await
-            .max_ack_version
+            .wal_keep_from
             .clone();
 
         // Proxify local shard
@@ -145,7 +145,7 @@ impl ShardReplicaSet {
             _ => unreachable!(),
         };
 
-        let proxy_shard = QueueProxyShard::new(local_shard, remote_shard, max_ack_version);
+        let proxy_shard = QueueProxyShard::new(local_shard, remote_shard, wal_keep_from);
         let _ = local.insert(Shard::QueueProxy(proxy_shard));
 
         Ok(())

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -162,8 +162,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     /// # Arguments
     ///
     /// * `until_index` - the newest no longer required record sequence number
-    ///
-    pub fn ack(&mut self, until_index: u64) -> Result<()> {
+    pub(super) fn ack(&mut self, until_index: u64) -> Result<()> {
         // Truncate WAL
         self.wal
             .prefix_truncate(until_index)


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Required for: <https://github.com/qdrant/qdrant/pull/3509>

We had a field called `max_ack_version` to specify limit what the last version was that could be acknowledged/truncated from the WAL. This PR changes to specify what WAL version to keep instead, shifting the logic by one.

To accompany this, I've renamed the field from `max_ack_version` to `wal_keep_from`.

This change is important because it now allows keeping the first entry in the WAL by setting it to `0`, while this was not possible before. It is required for <https://github.com/qdrant/qdrant/pull/3509>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?