### PR TITLE
Allow using queue proxy on WAL in the past

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -315,7 +315,7 @@ impl Inner {
         remote_shard: RemoteShard,
         wal_keep_from: Arc<AtomicU64>,
     ) -> Self {
-        let start_from = wrapped_shard.wal.lock().last_index();
+        let start_from = wrapped_shard.wal.lock().last_index() + 1;
 
         let shard = Self {
             wrapped_shard,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -75,7 +75,7 @@ impl QueueProxyShard {
     /// # Errors
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
-    /// `version` is to old or to new, queue proxy creation is rejected.
+    /// `version` is too old or too new, queue proxy creation is rejected.
     pub fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -86,9 +86,9 @@ impl QueueProxyShard {
         let wal = wrapped_shard.wal.clone();
         let wal_lock = wal.lock();
 
-        // If start version is not in current WAL bounds, we cannot reliably transfer WAL
+        // If start version is not in current WAL bounds (first_idx, last_idx), we cannot reliably transfer WAL
         let (first_idx, last_idx) = (wal_lock.first_physical_index(), wal_lock.last_index());
-        if version < first_idx || version > last_idx {
+        if !(first_idx..=last_idx).contains(&version) {
             return Err((wrapped_shard, CollectionError::service_error(format!("Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})"))));
         }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -393,7 +393,7 @@ impl Inner {
         // Lock wall, count pending items to transfer, grab batch
         let (pending_count, batch) = {
             let wal = self.wrapped_shard.wal.lock();
-            let items_left = wal.last_index().saturating_sub(transfer_from - 1);
+            let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let batch = wal.read(transfer_from).take(BATCH_SIZE).collect::<Vec<_>>();
             (items_left, batch)
         };

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -87,7 +87,7 @@ impl QueueProxyShard {
         let wal_lock = wal.lock();
 
         // If start version is not in current WAL bounds, we cannot reliably transfer WAL
-        let (first_idx, last_idx) = (wal_lock.first_index(), wal_lock.last_index());
+        let (first_idx, last_idx) = (wal_lock.first_physical_index(), wal_lock.last_index());
         if version < first_idx || version > last_idx {
             return Err((wrapped_shard, CollectionError::service_error(format!("Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})"))));
         }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -86,7 +86,7 @@ impl QueueProxyShard {
         let wal = wrapped_shard.wal.clone();
         let wal_lock = wal.lock();
 
-        // If start version is not in current WAL bounds (first_idx, last_idx), we cannot reliably transfer WAL
+        // If start version is not in current WAL bounds [first_idx, last_idx], we cannot reliably transfer WAL
         let (first_idx, last_idx) = (wal_lock.first_physical_index(), wal_lock.last_index());
         if !(first_idx..=last_idx).contains(&version) {
             return Err((wrapped_shard, CollectionError::service_error(format!("Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})"))));

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -180,7 +180,7 @@ pub(super) async fn transfer_snapshot(
 
     // Queue proxy local shard
     replica_set
-        .queue_proxify_local(remote_shard.clone())
+        .queue_proxify_local(remote_shard.clone(), None)
         .await?;
 
     debug_assert!(

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -175,6 +175,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
                 .max(minimal_first_index)
                 .min(self.wal.last_index()),
         );
+
         // Update current `first_index`
         if self.first_index != new_first_index {
             self.first_index = new_first_index;
@@ -216,10 +217,18 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         self.wal.path()
     }
 
-    pub fn first_index(&self) -> u64 {
-        self.first_index.unwrap_or_else(|| self.wal.first_index())
+    /// First index that is still available in physical WAL.
+    pub fn first_physical_index(&self) -> u64 {
+        self.wal.first_index()
     }
 
+    /// First index that is still available in logical WAL.
+    pub fn first_index(&self) -> u64 {
+        self.first_index
+            .unwrap_or_else(|| self.first_physical_index())
+    }
+
+    /// Last index that is still available in logical WAL.
     pub fn last_index(&self) -> u64 {
         self.wal.last_index()
     }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Depends on: <https://github.com/qdrant/qdrant/pull/3550>
Required for: https://github.com/qdrant/qdrant/pull/3509

This widens the usability of our queue proxy to allow using it for queuing and transferring WAL entries that are in the past. Before we could only queue and transfer new WAL entries after creating the queue proxy.

This is essential for <https://github.com/qdrant/qdrant/pull/3509>, as it will be used for transferring the WAL diff. I choose to use the queue proxy for this because it already had all the bells and whistles to handle this transfer safely. 

### Tasks
 - [x] Merge <https://github.com/qdrant/qdrant/pull/3550>
 - [x] Rebase this on `dev`
 - [x] Target this PR to merge into `dev`
 - [x] Undraft this PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?