### PR TITLE
Prometheus histogram support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,6 +2845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_sorted"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
+
+[[package]]
 name = "issues"
 version = "0.0.0"
 dependencies = [
@@ -5051,6 +5057,7 @@ dependencies = [
  "indexmap 2.2.3",
  "io",
  "io-uring",
+ "is_sorted",
  "itertools 0.12.1",
  "log",
  "macro_rules_attribute",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9417,24 +9417,54 @@
             "minimum": 0
           },
           "avg_duration_micros": {
+            "description": "The average time taken by 128 latest operations, calculated as a weighted mean.",
             "type": "number",
             "format": "float",
             "nullable": true
           },
           "min_duration_micros": {
+            "description": "The minimum duration of the operations across all the measurements.",
             "type": "number",
             "format": "float",
             "nullable": true
           },
           "max_duration_micros": {
+            "description": "The maximum duration of the operations across all the measurements.",
             "type": "number",
             "format": "float",
             "nullable": true
+          },
+          "total_duration_micros": {
+            "description": "The total duration of all operations in microseconds.",
+            "default": 0,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           },
           "last_responded": {
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "duration_micros_histogram": {
+            "description": "The cumulative histogram of the operation durations. Consists of a list of pairs of [upper_boundary, cumulative_count], sorted by the upper boundary. Note that the last bucket (aka `{le=\"+Inf\"}` in Prometheus terms) is not stored in this list, and `count` should be used instead.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "number",
+                  "format": "float"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -262,8 +262,8 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
         self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
-    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {
-        self.telemetry_durations_aggregator.clone()
+    fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
+        &self.telemetry_durations_aggregator
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -3,11 +3,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::types::TelemetryDetail;
 use parking_lot::Mutex;
-use segment::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator,
-};
+use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::types::{HnswConfig, Indexes, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE};
 
@@ -256,10 +253,6 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
         excluded_ids: &HashSet<SegmentId>,
     ) -> Vec<SegmentId> {
         self.worst_segment(segments, excluded_ids)
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -2,11 +2,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::types::TelemetryDetail;
 use parking_lot::Mutex;
-use segment::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator,
-};
+use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::types::{HnswConfig, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE};
 
 use crate::collection_manager::holders::segment_holder::{
@@ -271,10 +268,6 @@ impl SegmentOptimizer for IndexingOptimizer {
         excluded_ids: &HashSet<SegmentId>,
     ) -> Vec<SegmentId> {
         self.worst_segment(segments, excluded_ids)
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -277,8 +277,8 @@ impl SegmentOptimizer for IndexingOptimizer {
         self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
-    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {
-        self.telemetry_durations_aggregator.clone()
+    fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
+        &self.telemetry_durations_aggregator
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -2,12 +2,9 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::Mutex;
-use segment::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator,
-};
+use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::types::{HnswConfig, QuantizationConfig, SegmentType, VECTOR_ELEMENT_SIZE};
 
 use crate::collection_manager::holders::segment_holder::{
@@ -149,10 +146,6 @@ impl SegmentOptimizer for MergeOptimizer {
         }
         log::debug!("Merge candidates: {:?}", candidates);
         candidates
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -155,8 +155,8 @@ impl SegmentOptimizer for MergeOptimizer {
         self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
-    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {
-        self.telemetry_durations_aggregator.clone()
+    fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
+        &self.telemetry_durations_aggregator
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -78,7 +78,7 @@ pub trait SegmentOptimizer {
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics;
 
-    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>>;
+    fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator>;
 
     /// Build temp segment
     fn temp_segment(&self, save_version: bool) -> CollectionResult<LockedSegment> {
@@ -437,7 +437,7 @@ pub trait SegmentOptimizer {
     ) -> CollectionResult<bool> {
         check_process_stopped(stopped)?;
 
-        let mut timer = ScopeDurationMeasurer::new(&self.get_telemetry_counter());
+        let mut timer = ScopeDurationMeasurer::new(self.get_telemetry_counter());
         timer.set_success(false);
 
         // On the one hand - we want to check consistently if all provided segments are

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -4,12 +4,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
-use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::check_process_stopped;
 use segment::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
+    OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use segment::common::version::StorageVersion;
 use segment::entry::entry_point::SegmentEntry;
@@ -75,8 +74,6 @@ pub trait SegmentOptimizer {
         segments: LockedSegmentHolder,
         excluded_ids: &HashSet<SegmentId>,
     ) -> Vec<SegmentId>;
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics;
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator>;
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -209,8 +209,8 @@ impl SegmentOptimizer for VacuumOptimizer {
         self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
-    fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {
-        self.telemetry_durations_aggregator.clone()
+    fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {
+        &self.telemetry_durations_aggregator
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -2,12 +2,9 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::types::TelemetryDetail;
 use ordered_float::OrderedFloat;
 use parking_lot::Mutex;
-use segment::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator,
-};
+use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::entry::entry_point::SegmentEntry;
 use segment::index::VectorIndex;
 use segment::types::{HnswConfig, QuantizationConfig, SegmentType};
@@ -203,10 +200,6 @@ impl SegmentOptimizer for VacuumOptimizer {
             None => vec![],
             Some((segment_id, _segment)) => vec![segment_id],
         }
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator> {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -835,7 +835,12 @@ impl LocalShard {
         let optimizations = self
             .optimizers
             .iter()
-            .map(|optimizer| optimizer.get_telemetry_data(detail))
+            .map(|optimizer| {
+                optimizer
+                    .get_telemetry_counter()
+                    .lock()
+                    .get_statistics(detail)
+            })
             .fold(Default::default(), |acc, x| acc + x);
 
         LocalShardTelemetry {

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -38,6 +38,7 @@ pub enum DetailsLevel {
     Level0,
     Level1,
     Level2,
+    Level3,
 }
 
 impl Default for TelemetryDetail {
@@ -54,7 +55,8 @@ impl From<usize> for DetailsLevel {
         match value {
             0 => DetailsLevel::Level0,
             1 => DetailsLevel::Level1,
-            _ => DetailsLevel::Level2,
+            2 => DetailsLevel::Level2,
+            _ => DetailsLevel::Level3,
         }
     }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -64,6 +64,7 @@ fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { version = "0.8.8", features = ["serde"] }
 smallvec = "1.13.1"
+is_sorted = "0.1.1"
 
 sysinfo = "0.30"
 charabia = { version = "0.8.7", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -48,8 +48,8 @@ pub struct OperationDurationsAggregator {
     last_response_date: Option<DateTime<Utc>>,
 }
 
-pub struct ScopeDurationMeasurer {
-    aggregator: Arc<Mutex<OperationDurationsAggregator>>,
+pub struct ScopeDurationMeasurer<'a> {
+    aggregator: &'a Mutex<OperationDurationsAggregator>,
     instant: Instant,
     success: bool,
 }
@@ -138,21 +138,21 @@ impl OperationDurationStatistics {
     }
 }
 
-impl ScopeDurationMeasurer {
-    pub fn new(aggregator: &Arc<Mutex<OperationDurationsAggregator>>) -> Self {
+impl<'a> ScopeDurationMeasurer<'a> {
+    pub fn new(aggregator: &'a Mutex<OperationDurationsAggregator>) -> Self {
         Self {
-            aggregator: aggregator.clone(),
+            aggregator,
             instant: Instant::now(),
             success: true,
         }
     }
 
     pub fn new_with_instant(
-        aggregator: &Arc<Mutex<OperationDurationsAggregator>>,
+        aggregator: &'a Mutex<OperationDurationsAggregator>,
         instant: Instant,
     ) -> Self {
         Self {
-            aggregator: aggregator.clone(),
+            aggregator,
             instant,
             success: true,
         }
@@ -163,7 +163,7 @@ impl ScopeDurationMeasurer {
     }
 }
 
-impl Drop for ScopeDurationMeasurer {
+impl Drop for ScopeDurationMeasurer<'_> {
     fn drop(&mut self) {
         self.aggregator
             .lock()

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, SubsecRound, Utc};
 use common::types::TelemetryDetail;
+use is_sorted::IsSorted;
 use itertools::Itertools as _;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
@@ -383,6 +384,15 @@ fn merge_histograms(
     total_a: usize,
     total_b: usize,
 ) -> Vec<(f32, usize)> {
+    // TODO: drop is_sorted crate and use Iterator::is_sorted once it's stable
+    debug_assert!(
+        IsSorted::is_sorted(&mut a.iter().map(|(le, _)| le)),
+        "Boundaries are not sorted"
+    );
+    debug_assert!(
+        IsSorted::is_sorted(&mut b.iter().map(|(le, _)| le)),
+        "Boundaries are not sorted"
+    );
     let unique_boundaries =
         itertools::merge(a.iter().map(|(le, _)| le), b.iter().map(|(le, _)| le))
             .dedup()

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -33,11 +33,12 @@ async fn telemetry(
 ) -> impl Responder {
     let timing = Instant::now();
     let anonymize = params.anonymize.unwrap_or(false);
+    let details_level = params
+        .details_level
+        .map_or(DetailsLevel::Level0, Into::into);
     let detail = TelemetryDetail {
-        level: params
-            .details_level
-            .map_or(DetailsLevel::Level0, Into::into),
-        histograms: false,
+        level: details_level,
+        histograms: details_level >= DetailsLevel::Level3,
     };
     let telemetry_collector = telemetry_collector.lock().await;
     let telemetry_data = telemetry_collector.prepare_data(detail).await;


### PR DESCRIPTION
Part of to #2857.

<details>
<summary>Example /metrics output.</summary>

```
# HELP rest_responses_duration_seconds response duration histogram
# TYPE rest_responses_duration_seconds histogram
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.000001"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.000005"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.00001"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.00005"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.0001"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.0005"} 0
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.001"} 6
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.005"} 8
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.01"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.05"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.1"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="0.5"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="1"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="5"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="10"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="50"} 24
rest_responses_duration_seconds_bucket{method="POST",endpoint="/collections/{name}/points/payload",status="200",le="+Inf"} 24
rest_responses_duration_seconds_sum{method="POST",endpoint="/collections/{name}/points/payload",status="200"} 0.129942
rest_responses_duration_seconds_count{method="POST",endpoint="/collections/{name}/points/payload",status="200"} 24
```

</details>

Since `/metrics` is intended to be an alternative output format for `/telemetry`, it's also added to `/telemetry`.

<details>
<summary>Example of /telemetry output.</summary>

```json
{
  "result": {
    ...
    "requests": {
      "rest": {
        "responses": {
          ...
          "POST /collections/{name}/points/payload": {
            "200": {
              "count": 24,
              "avg_duration_micros": 6362.5874,
              "min_duration_micros": 705.0,
              "max_duration_micros": 9332.0,
              "total_duration_micros": 129942,
              "last_responded": "2024-02-06T18:38:10.250Z",
              "duration_micros_histogram": [
                [ 1.0, 0 ],
                [ 5.0, 0 ],
                [ 10.0, 0 ],
                [ 50.0, 0 ],
                [ 100.0, 0 ],
                [ 500.0, 0 ],
                [ 1000.0, 6 ],
                [ 5000.0, 8 ],
                [ 10000.0, 24 ],
                [ 50000.0, 24 ],
                [ 100000.0, 24 ],
                [ 500000.0, 24 ],
                [ 1000000.0, 24 ],
                [ 5000000.0, 24 ],
                [ 10000000.0, 24 ],
                [ 50000000.0, 24 ]
              ]
            }
          }
        }
      },
      ...
    }
  },
  "status": "ok",
  "time": 0.016345248
}

```

</details>

In this PR, histogram buckets are not configurable. Configuration will be added in subsequent pull requests. Current hardcoded values are the following (open to discussion):
- 1µs, 5µs, 10µs, 50µs, 100µs, 500µs,
- 1ms, 5ms, 10ms, 50ms, 100ms, 500ms,
- 1s, 5s, 10s, 50s, +Inf

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
