### PR TITLE
Report shard transfer progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,7 @@ dependencies = [
  "pprof",
  "proptest",
  "rand 0.8.5",
+ "ringbuffer",
  "rmp-serde",
  "rstest",
  "schemars",
@@ -4651,6 +4652,12 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ringbuffer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "rmp"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ version = "0.4.2"
 dependencies = [
  "actix-web-validator",
  "api",
+ "approx",
  "arc-swap",
  "async-std",
  "async-trait",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8704,11 +8704,13 @@
             "minimum": 0
           },
           "from": {
+            "description": "Source peer id",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "to": {
+            "description": "Destination peer id",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
@@ -8726,6 +8728,32 @@
                 "nullable": true
               }
             ]
+          },
+          "started_at": {
+            "description": "Time when the transfer was started. Available only on the source peer.",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "points_transferred": {
+            "description": "Amount of points transferred. Available only on the source peer.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "points_total": {
+            "description": "Total amount of points to transfer. Available only on the source peer.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "eta_seconds": {
+            "description": "Estimated time of arrival. Available only on the source peer. Null when the transfer is stalled or not started yet.",
+            "type": "number",
+            "format": "double",
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8729,30 +8729,9 @@
               }
             ]
           },
-          "started_at": {
-            "description": "Time when the transfer was started. Available only on the source peer.",
+          "comment": {
+            "description": "A human-readable report of the transfer progress. Available only on the source peer.",
             "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "points_transferred": {
-            "description": "Amount of points transferred. Available only on the source peer.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "points_total": {
-            "description": "Total amount of points to transfer. Available only on the source peer.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "eta_seconds": {
-            "description": "Estimated time of arrival. Available only on the source peer. Null when the transfer is stalled or not started yet.",
-            "type": "number",
-            "format": "double",
             "nullable": true
           }
         }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -70,6 +70,7 @@ sha2 = "0.10.8"
 bytes = "1.5.0"
 fnv = { workspace = true }
 indexmap = { workspace = true }
+ringbuffer = "0.15.0"
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -16,6 +16,7 @@ async-std = { version = "1.12", features = ["attributes"] }
 criterion = "0.5"
 proptest = "1.4.0"
 rstest = "0.18.2"
+approx = "0.5.1"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -307,7 +307,8 @@ impl Collection {
                 });
             }
         }
-        let shard_transfers = shards_holder.get_shard_transfer_info();
+        let shard_transfers =
+            shards_holder.get_shard_transfer_info(&*self.transfer_tasks.lock().await);
 
         // sort by shard_id
         local_shards.sort_by_key(|k| k.shard_id);

--- a/lib/collection/src/common/eta_calculator.rs
+++ b/lib/collection/src/common/eta_calculator.rs
@@ -1,0 +1,71 @@
+use std::time::{Duration, Instant};
+
+/// A progress ETA calculator.
+/// Calculates the ETA roughly based on the last ten seconds of measurements.
+pub struct EtaCalculator {
+    ring: [(Instant, usize); Self::SIZE],
+    ring_pos: usize,
+}
+
+impl EtaCalculator {
+    const SIZE: usize = 16;
+    const DURATION: Duration = Duration::from_millis(625);
+
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            ring: [(now, 0); Self::SIZE],
+            ring_pos: 0,
+        }
+    }
+
+    /// Capture the current progress and time.
+    pub fn set_progress(&mut self, current_progress: usize) {
+        let now = Instant::now();
+        if current_progress < self.ring[self.ring_pos].1 {
+            // Progress went backwards, reset the state.
+            *self = Self::new();
+        }
+        if now - self.ring[(self.ring_pos + Self::SIZE - 1) % Self::SIZE].0 >= Self::DURATION {
+            self.ring_pos = (self.ring_pos + 1) % Self::SIZE;
+        }
+        self.ring[self.ring_pos] = (now, current_progress);
+    }
+
+    /// Calculate the ETA to reach the target progress.
+    pub fn estimate(&self, target_progress: usize) -> Option<Duration> {
+        let now = Instant::now();
+
+        let (last_time, last_progress) = self.ring[self.ring_pos];
+
+        // Check if the progress is already reached.
+        let value_diff = match target_progress.checked_sub(last_progress) {
+            None | Some(0) => return Some(Duration::from_secs(0)),
+            Some(value_diff) => value_diff,
+        };
+
+        // Find the oldest measurement that is not too old.
+        let mut i = self.ring_pos;
+        let (old_time, old_progress) = loop {
+            i = (i + 1) % Self::SIZE;
+            if i == self.ring_pos {
+                // No valid measurements.
+                return None;
+            }
+            if now - self.ring[i].0 <= Self::DURATION * Self::SIZE as u32 {
+                break self.ring[i];
+            }
+        };
+
+        if last_progress == old_progress {
+            // No progress, no rate.
+            return None;
+        }
+
+        let rate = (last_progress - old_progress) as f64 / (last_time - old_time).as_secs_f64();
+        let elapsed = (now - last_time).as_secs_f64();
+        let eta = (value_diff as f64 / rate - elapsed).max(0.0);
+        Duration::try_from_secs_f64(eta).ok()
+    }
+}

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod batching;
+pub mod eta_calculator;
 pub mod fetch_vectors;
 pub mod file_utils;
 pub mod is_ready;

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 
 use api::grpc::transport_channel_pool::RequestError;
+use chrono::{DateTime, Utc};
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
@@ -207,13 +208,36 @@ pub struct CollectionClusterInfo {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct ShardTransferInfo {
     pub shard_id: ShardId,
+
+    /// Source peer id
     pub from: PeerId,
+
+    /// Destination peer id
     pub to: PeerId,
+
     /// If `true` transfer is a synchronization of a replicas
     /// If `false` transfer is a moving of a shard from one peer to another
     pub sync: bool,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<ShardTransferMethod>,
+
+    /// Time when the transfer was started. Available only on the source peer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+
+    /// Amount of points transferred. Available only on the source peer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub points_transferred: Option<usize>,
+
+    /// Total amount of points to transfer. Available only on the source peer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub points_total: Option<usize>,
+
+    /// Estimated time of arrival. Available only on the source peer.
+    /// Null when the transfer is stalled or not started yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eta_seconds: Option<Option<f64>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -7,7 +7,6 @@ use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 
 use api::grpc::transport_channel_pool::RequestError;
-use chrono::{DateTime, Utc};
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
@@ -222,22 +221,9 @@ pub struct ShardTransferInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<ShardTransferMethod>,
 
-    /// Time when the transfer was started. Available only on the source peer.
+    /// A human-readable report of the transfer progress. Available only on the source peer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub started_at: Option<DateTime<Utc>>,
-
-    /// Amount of points transferred. Available only on the source peer.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub points_transferred: Option<usize>,
-
-    /// Total amount of points to transfer. Available only on the source peer.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub points_total: Option<usize>,
-
-    /// Estimated time of arrival. Available only on the source peer.
-    /// Null when the transfer is stalled or not started yet.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub eta_seconds: Option<Option<f64>>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -11,6 +11,8 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::Shard;
 
 impl ShardReplicaSet {
+    /// Convert `Local` shard into `ForwardProxy`.
+    ///
     /// # Cancel safety
     ///
     /// This method is cancel safe.

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -12,6 +12,7 @@ use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 use super::replica_set::AbortShardTransfer;
+use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::common::file_utils::move_file;
 use crate::common::sha_256::hash_file;
 use crate::config::{CollectionConfig, ShardingMethod};
@@ -298,7 +299,10 @@ impl ShardHolder {
         (incoming, outgoing)
     }
 
-    pub fn get_shard_transfer_info(&self) -> Vec<ShardTransferInfo> {
+    pub fn get_shard_transfer_info(
+        &self,
+        tasks_pool: &TransferTasksPool,
+    ) -> Vec<ShardTransferInfo> {
         let mut shard_transfers = vec![];
         for shard_transfer in self.shard_transfers.read().iter() {
             let shard_id = shard_transfer.shard_id;
@@ -306,12 +310,17 @@ impl ShardHolder {
             let from = shard_transfer.from;
             let sync = shard_transfer.sync;
             let method = shard_transfer.method;
+            let status = tasks_pool.get_task_status(&shard_transfer.key());
             shard_transfers.push(ShardTransferInfo {
                 shard_id,
                 from,
                 to,
                 sync,
                 method,
+                started_at: status.as_ref().map(|p| p.started_at),
+                points_transferred: status.as_ref().map(|p| p.points_transferred),
+                points_total: status.as_ref().map(|p| p.points_total),
+                eta_seconds: status.as_ref().map(|p| p.eta.map(|t| t.as_secs_f64())),
             })
         }
         shard_transfers.sort_by_key(|k| k.shard_id);

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -317,12 +317,7 @@ impl ShardHolder {
                 to,
                 sync,
                 method,
-                started_at: status.as_ref().map(|p| p.started_at),
-                points_transferred: status.as_ref().map(|p| p.points_transferred),
-                points_total: status.as_ref().map(|p| p.points_total),
-                eta_seconds: status
-                    .as_ref()
-                    .map(|p| p.eta.map(|t| (t.as_secs_f64() * 100.0).round() / 100.0)),
+                comment: status.map(|p| p.comment),
             })
         }
         shard_transfers.sort_by_key(|k| k.shard_id);

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -320,7 +320,9 @@ impl ShardHolder {
                 started_at: status.as_ref().map(|p| p.started_at),
                 points_transferred: status.as_ref().map(|p| p.points_transferred),
                 points_total: status.as_ref().map(|p| p.points_total),
-                eta_seconds: status.as_ref().map(|p| p.eta.map(|t| t.as_secs_f64())),
+                eta_seconds: status
+                    .as_ref()
+                    .map(|p| p.eta.map(|t| (t.as_secs_f64() * 100.0).round() / 100.0)),
             })
         }
         shard_transfers.sort_by_key(|k| k.shard_id);

--- a/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
+++ b/lib/collection/src/shards/transfer/transfer_tasks_pool.rs
@@ -1,25 +1,54 @@
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
+use parking_lot::Mutex;
+
+use crate::common::eta_calculator::EtaCalculator;
 use crate::common::stoppable_task_async::CancellableAsyncTaskHandle;
 use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::CollectionId;
 
 pub struct TransferTasksPool {
     collection_id: CollectionId,
-    tasks: HashMap<ShardTransferKey, CancellableAsyncTaskHandle<bool>>,
+    tasks: HashMap<ShardTransferKey, TransferTaskItem>,
+}
+
+pub struct TransferTaskItem {
+    pub task: CancellableAsyncTaskHandle<bool>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub progress: Arc<Mutex<TransferTaskProgress>>,
+}
+
+pub struct TransferTaskProgress {
+    pub points_transferred: usize,
+    pub points_total: usize,
+    pub eta: EtaCalculator,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TaskResult {
+    Running,
     Finished,
-    NotFound,
-    Stopped,
     Failed,
 }
 
-impl TaskResult {
-    pub fn is_finished(&self) -> bool {
-        matches!(self, TaskResult::Finished)
+pub struct TransferTaskStatus {
+    pub result: TaskResult,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub points_transferred: usize,
+    pub points_total: usize,
+    pub eta: Option<Duration>,
+}
+
+impl TransferTaskProgress {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            points_transferred: 0,
+            points_total: 0,
+            eta: EtaCalculator::new(),
+        }
     }
 }
 
@@ -31,71 +60,61 @@ impl TransferTasksPool {
         }
     }
 
-    /// Returns true if transfer task is still running
-    pub fn check_if_still_running(&self, transfer_key: &ShardTransferKey) -> bool {
-        if let Some(task) = self.tasks.get(transfer_key) {
-            !task.is_finished()
-        } else {
-            false
-        }
+    /// Get the status of the task. If the task is not found, return None.
+    pub fn get_task_status(&self, transfer_key: &ShardTransferKey) -> Option<TransferTaskStatus> {
+        let task = self.tasks.get(transfer_key)?;
+        let result = match task.task.get_result() {
+            Some(true) => TaskResult::Finished,
+            Some(false) => TaskResult::Failed,
+            None if task.task.is_finished() => TaskResult::Failed,
+            None => TaskResult::Running,
+        };
+        let progress = task.progress.lock();
+        Some(TransferTaskStatus {
+            result,
+            started_at: task.started_at,
+            points_transferred: progress.points_transferred,
+            points_total: progress.points_total,
+            eta: progress.eta.estimate(progress.points_total),
+        })
     }
 
-    /// Return true if task finished
-    /// Return false if task failed or stopped
-    /// Return None if task not found or not finished
-    pub fn get_task_result(&self, transfer_key: &ShardTransferKey) -> Option<bool> {
-        if let Some(task) = self.tasks.get(transfer_key) {
-            task.get_result()
-        } else {
-            None
-        }
-    }
-
-    /// Returns true if the task was actually stopped
-    /// Returns false if the task was not found
-    pub async fn stop_if_exists(&mut self, transfer_key: &ShardTransferKey) -> TaskResult {
-        if let Some(task) = self.tasks.remove(transfer_key) {
-            match task.cancel().await {
-                Ok(res) => {
-                    if res {
-                        log::info!(
-                            "Transfer of shard {}:{} -> {} finished",
-                            self.collection_id,
-                            transfer_key.shard_id,
-                            transfer_key.to
-                        );
-                        TaskResult::Finished
-                    } else {
-                        log::info!(
-                            "Transfer of shard {}:{} -> {} stopped",
-                            self.collection_id,
-                            transfer_key.shard_id,
-                            transfer_key.to
-                        );
-                        TaskResult::Stopped
-                    }
-                }
-                Err(err) => {
-                    log::warn!(
-                        "Transfer task for shard {}:{} -> {} failed: {}",
-                        self.collection_id,
-                        transfer_key.shard_id,
-                        transfer_key.to,
-                        err
-                    );
-                    TaskResult::Failed
-                }
+    /// Stop the task and return the result. If the task is not found, return None.
+    pub async fn stop_task(&mut self, transfer_key: &ShardTransferKey) -> Option<TaskResult> {
+        let task = self.tasks.remove(transfer_key)?;
+        Some(match task.task.cancel().await {
+            Ok(true) => {
+                log::info!(
+                    "Transfer of shard {}:{} -> {} finished",
+                    self.collection_id,
+                    transfer_key.shard_id,
+                    transfer_key.to
+                );
+                TaskResult::Finished
             }
-        } else {
-            TaskResult::NotFound
-        }
+            Ok(false) => {
+                log::info!(
+                    "Transfer of shard {}:{} -> {} stopped",
+                    self.collection_id,
+                    transfer_key.shard_id,
+                    transfer_key.to
+                );
+                TaskResult::Failed
+            }
+            Err(err) => {
+                log::warn!(
+                    "Transfer task for shard {}:{} -> {} failed: {}",
+                    self.collection_id,
+                    transfer_key.shard_id,
+                    transfer_key.to,
+                    err
+                );
+                TaskResult::Failed
+            }
+        })
     }
 
-    pub fn add_task(
-        &mut self,
-        shard_transfer: &ShardTransfer,
-        task: CancellableAsyncTaskHandle<bool>,
-    ) {
-        self.tasks.insert(shard_transfer.key(), task);
+    pub fn add_task(&mut self, shard_transfer: &ShardTransfer, item: TransferTaskItem) {
+        self.tasks.insert(shard_transfer.key(), item);
     }
 }


### PR DESCRIPTION
Closes #3433.

The shard progress state is tracked locally inside `TransferTasksPool` (aka `Collection::transfer_tasks`).
Since it's local, only the sender node shows the progress in the result of `GET collections/{name}/cluster`.

Output of `GET collections/{name}/cluster`:
```json
{"result": {
  "shard_transfers": [
    {
      "shard_id": 1,
      "from": 3351940210608703,
      "to": 7522668664620757,
      "sync": false,
      "method": "stream_records",
      ↓ ↓ ↓   This field is added   ↓ ↓ ↓
      "comment": "Transferring records (136000/193725), started 15s ago, ETA: 6.83s"
      ↑ ↑ ↑   This field is added  ↑ ↑ ↑
    }
  ],
  "peer_id": 3351940210608703,
  "local_shards": [
    {
      "shard_id": 1,
      "points_count": 178839,
      "state": "Active"
    }, …
  ],
  "remote_shards": [
    {
      "shard_id": 1,
      "peer_id": 7522668664620757,
      "state": "Partial"
    }, …
  ], …
}, … }
```


---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
