### PR TITLE
Add regex dependency and implement match_pattern fuction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,7 @@ dependencies = [
  "raft",
  "raft-proto",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "rstack-self",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ rustls-pemfile = "2.0.0"
 prometheus = { version = "0.13.3", default-features = false }
 validator = { version = "0.16", features = ["derive"] }
 
+regex = "1.8.4"
+
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 slog = { version="2.7.0", features = ["max_level_trace", "release_max_level_debug"] }


### PR DESCRIPTION
should resolve: #3543 #3547

I opened an issue (https://github.com/qdrant/qdrant-web-ui/issues/158) regarding a read-only pattern matching problem. 

Actix's `match_pattern()` function doesn't distinguish between `GET` and `POST` methods, causing `GET /collections/{name}/points/{id}` to be matched when trying `req.match_pattern()` with `POST /collections/{name}/points/scroll`. 

The issue was addressed in #3544 by @timvisee, however, challenges related to testability and instability still persist.

Given Actix's `match_pattern()` limitations, as discussed in #3547, I've developed our own `match_pattern_to_request_path` function with a straightforward regex implementation. 

This function aims to address the issues discussed in the aforementioned open issues.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

/claim #3547