### PR TITLE
Fix clippy 1.76 lints

### DIFF
--- a/lib/collection/src/save_on_disk.rs
+++ b/lib/collection/src/save_on_disk.rs
@@ -19,8 +19,6 @@ pub struct SaveOnDisk<T> {
     path: PathBuf,
 }
 
-pub struct WriteGuard<'a, T: Serialize>(&'a mut SaveOnDisk<T>);
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Failed to save structure on disk with error: {0}")]

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -15,10 +15,11 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<()> {
         .read(true)
         .write(true)
         .create(true)
-        .truncate(true)
+        // Don't truncate because we explicitly set the length later
+        .truncate(false)
         .open(path)?;
-
     file.set_len(length as u64)?;
+
     Ok(())
 }
 
@@ -28,6 +29,7 @@ pub fn open_read_mmap(path: &Path) -> io::Result<Mmap> {
         .write(false)
         .append(true)
         .create(true)
+        .truncate(false)
         .open(path)?;
 
     let mmap = unsafe { Mmap::map(&file)? };

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -15,6 +15,7 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<()> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(path)?;
 
     file.set_len(length as u64)?;

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -269,10 +269,11 @@ impl GraphLinksConverter {
                 .read(true)
                 .write(true)
                 .create(true)
-                .truncate(true)
+                // Don't truncate because we explicitly set the length later
+                .truncate(false)
                 .open(temp_path.as_path())?;
-
             file.set_len(self.data_size())?;
+
             let m = unsafe { MmapMut::map_mut(&file) };
             let mut mmap = m?;
 

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -269,6 +269,7 @@ impl GraphLinksConverter {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(true)
                 .open(temp_path.as_path())?;
 
             file.set_len(self.data_size())?;

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -79,9 +79,9 @@ impl ChunkedMmapVectors {
                 dim,
             };
             let mut file = OpenOptions::new()
+                .write(true)
                 .create(true)
                 .truncate(true)
-                .write(true)
                 .open(&config_file)?;
             serde_json::to_writer(&mut file, &config)?;
             file.flush()?;

--- a/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
+++ b/lib/segment/src/vector_storage/chunked_mmap_vectors.rs
@@ -80,6 +80,7 @@ impl ChunkedMmapVectors {
             };
             let mut file = OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
                 .open(&config_file)?;
             serde_json::to_writer(&mut file, &config)?;

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -71,13 +71,16 @@ impl QuantizedMmapStorageBuilder {
     ) -> std::io::Result<Self> {
         let encoded_storage_size = quantized_vector_size * vectors_count;
         path.parent().map(std::fs::create_dir_all);
+
         let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .truncate(true)
+            // Don't truncate because we explicitly set the length later
+            .truncate(false)
             .open(path)?;
         file.set_len(encoded_storage_size as u64)?;
+
         let mmap = unsafe { MmapMut::map_mut(&file) }?;
         madvise::madvise(&mmap, madvise::get_global())?;
         Ok(Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -75,6 +75,7 @@ impl QuantizedMmapStorageBuilder {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(path)?;
         file.set_len(encoded_storage_size as u64)?;
         let mmap = unsafe { MmapMut::map_mut(&file) }?;


### PR DESCRIPTION
A new stable rust version is releasing tomorrow (1.76), so I've gone ahead and ran `cargo +beta clippy --all --all-features` to find new lints warnings against the codebase.

Changes:
- Specify `truncate(..)` option when possibly updating a file. Lint: [suspicious_open_options](https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options)
- Remove unused `WriteGuard(SaveOnDisk)` wrapper struct.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
