### PR TITLE
Order-by: use pre-filtering for high-constraining filters

### DIFF
--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -58,11 +58,13 @@ impl OrderBy {
         self.direction.unwrap_or_default()
     }
 
-    pub fn value_offset(&self) -> f64 {
-        self.start_from.unwrap_or_else(|| match self.direction() {
-            Direction::Asc => f64::NEG_INFINITY,
-            Direction::Desc => f64::INFINITY,
-        })
+    pub fn start_from(&self) -> OrderingValue {
+        self.start_from
+            .unwrap_or_else(|| match self.direction() {
+                Direction::Asc => f64::NEG_INFINITY,
+                Direction::Desc => f64::INFINITY,
+            })
+            .into()
     }
 
     pub fn insert_order_value_in_payload(

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -403,3 +403,29 @@ impl<'a> StreamRange<OrderingValue> for NumericFieldIndex<'a> {
         }
     }
 }
+
+impl<'a> NumericFieldIndex<'a> {
+    pub fn get_ordering_values(
+        &self,
+        idx: PointOffsetType,
+    ) -> Box<dyn Iterator<Item = OrderingValue> + 'a> {
+        match self {
+            NumericFieldIndex::IntIndex(index) => Box::new(
+                index
+                    .get_values(idx)
+                    .into_iter()
+                    .flatten()
+                    .copied()
+                    .map(OrderingValue::Int),
+            ),
+            NumericFieldIndex::FloatIndex(index) => Box::new(
+                index
+                    .get_values(idx)
+                    .into_iter()
+                    .flatten()
+                    .copied()
+                    .map(OrderingValue::Float),
+            ),
+        }
+    }
+}

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -34,7 +34,7 @@ use crate::index::field_index::numeric_index::StreamRange;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex, VectorIndexEnum};
-use crate::spaces::tools::peek_top_smallest_iterable;
+use crate::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterable};
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
     Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType, PayloadKeyTypeRef,
@@ -621,6 +621,49 @@ impl Segment {
             .collect()
     }
 
+    /// Estimates how many checks it would need for getting `limit` amount of points by streaming and then
+    /// filtering, versus getting all filtered points from the index and then sorting them afterwards.
+    ///
+    /// If the filter is restrictive enough to yield fewer points than the amount of points a streaming
+    /// approach would need to advance, it returns true.
+    fn should_pre_filter(&self, filter: &Filter, limit: Option<usize>) -> bool {
+        let query_cardinality = {
+            let payload_index = self.payload_index.borrow();
+            payload_index.estimate_cardinality(filter)
+        };
+
+        // ToDo: Add telemetry for this heuristics
+
+        // Calculate expected number of condition checks required for
+        // this scroll request with is stream strategy.
+        // Example:
+        //  - cardinality = 1000
+        //  - limit = 10
+        //  - total = 10000
+        //  - point filter prob = 1000 / 10000 = 0.1
+        //  - expected_checks = 10 / 0.1  = 100
+        //  -------------------------------
+        //  - cardinality = 10
+        //  - limit = 10
+        //  - total = 10000
+        //  - point filter prob = 10 / 10000 = 0.001
+        //  - expected_checks = 10 / 0.001  = 10000
+
+        let available_points = self.available_point_count() + 1 /* + 1 for division-by-zero */;
+        // Expected number of successful checks per point
+        let check_probability =
+            (query_cardinality.exp as f64 + 1.0/* protect from zero */) / available_points as f64;
+        let exp_stream_checks =
+            (limit.unwrap_or(available_points) as f64 / check_probability) as usize;
+
+        // Assume it would require about `query cardinality` checks.
+        // We are interested in approximate number of checks, so we can
+        // use `query cardinality` as a starting point.
+        let exp_index_checks = query_cardinality.max;
+
+        exp_stream_checks > exp_index_checks
+    }
+
     fn read_by_id_stream(
         &self,
         offset: Option<PointIdType>,
@@ -665,6 +708,58 @@ impl Segment {
         page.sort_unstable();
 
         page
+    }
+
+    pub fn filtered_read_by_index_ordered(
+        &self,
+        order_by: &OrderBy,
+        limit: Option<usize>,
+        condition: &Filter,
+    ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
+        let payload_index = self.payload_index.borrow();
+        let id_tracker = self.id_tracker.borrow();
+
+        let numeric_index = payload_index
+            .field_indexes
+            .get(&order_by.key)
+            .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
+            .ok_or_else(|| OperationError::ValidationError { description: "There is no range index for the `order_by` key, please create one to use `order_by`".to_string() })?;
+
+        let values_ids_iterator = payload_index
+            .query_points(condition)
+            .into_iter()
+            .flat_map(|internal_id| {
+                // repeat point for as many values as it has
+                numeric_index
+                    .get_ordering_values(internal_id)
+                    .map(move |ordering_value| (ordering_value, internal_id))
+            })
+            .filter_map(|(value, internal_id)| {
+                id_tracker
+                    .external_id(internal_id)
+                    .map(|external_id| (value, external_id))
+            });
+
+        let page = match order_by.direction() {
+            Direction::Asc => {
+                let mut page = match limit {
+                    Some(limit) => peek_top_smallest_iterable(values_ids_iterator, limit),
+                    None => values_ids_iterator.collect(),
+                };
+                page.sort_unstable_by(|(value_a, _), (value_b, _)| value_a.cmp(value_b));
+                page
+            }
+            Direction::Desc => {
+                let mut page = match limit {
+                    Some(limit) => peek_top_largest_iterable(values_ids_iterator, limit),
+                    None => values_ids_iterator.collect(),
+                };
+                page.sort_unstable_by(|(value_a, _), (value_b, _)| value_b.cmp(value_a));
+                page
+            }
+        };
+
+        Ok(page)
     }
 
     pub fn filtered_read_by_id_stream(
@@ -1093,41 +1188,7 @@ impl SegmentEntry for Segment {
         match filter {
             None => self.read_by_id_stream(offset, limit),
             Some(condition) => {
-                let query_cardinality = {
-                    let payload_index = self.payload_index.borrow();
-                    payload_index.estimate_cardinality(condition)
-                };
-
-                // ToDo: Add telemetry for this heuristics
-
-                // Calculate expected number of condition checks required for
-                // this scroll request with is stream strategy.
-                // Example:
-                //  - cardinality = 1000
-                //  - limit = 10
-                //  - total = 10000
-                //  - point filter prob = 1000 / 10000 = 0.1
-                //  - expected_checks = 10 / 0.1  = 100
-                //  -------------------------------
-                //  - cardinality = 10
-                //  - limit = 10
-                //  - total = 10000
-                //  - point filter prob = 10 / 10000 = 0.001
-                //  - expected_checks = 10 / 0.001  = 10000
-
-                let available_points = self.available_point_count() + 1 /* + 1 for division-by-zero */;
-                // Expected number of successful checks per point
-                let check_probability = (query_cardinality.exp as f64 + 1.0/* protect from zero */)
-                    / available_points as f64;
-                let exp_stream_checks =
-                    (limit.unwrap_or(available_points) as f64 / check_probability) as usize;
-
-                // Assume it would require about `query cardinality` checks.
-                // We are interested in approximate number of checks, so we can
-                // use `query cardinality` as a starting point.
-                let exp_index_checks = query_cardinality.max;
-
-                if exp_stream_checks > exp_index_checks {
+                if self.should_pre_filter(condition, limit) {
                     self.filtered_read_by_index(offset, limit, condition)
                 } else {
                     self.filtered_read_by_id_stream(offset, limit, condition)
@@ -1142,10 +1203,16 @@ impl SegmentEntry for Segment {
         filter: Option<&'a Filter>,
         order_by: &'a OrderBy,
     ) -> OperationResult<Vec<(OrderingValue, PointIdType)>> {
-        // TODO: make same optimization for high-constraining filters as in `read_filtered`
-        let reads = self.filtered_read_by_value_stream(order_by, limit, filter)?;
-
-        Ok(reads)
+        match filter {
+            None => self.filtered_read_by_value_stream(order_by, limit, None),
+            Some(filter) => {
+                if self.should_pre_filter(filter, limit) {
+                    self.filtered_read_by_index_ordered(order_by, limit, filter)
+                } else {
+                    self.filtered_read_by_value_stream(order_by, limit, Some(filter))
+                }
+            }
+        }
     }
 
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType> {

--- a/openapi/tests/openapi_integration/test_order_by.py
+++ b/openapi/tests/openapi_integration/test_order_by.py
@@ -120,7 +120,10 @@ def test_order_by_int_descending():
     assert len(result["points"]) == 5
 
     ids = [x["id"] for x in result["points"]]
-    assert [999, 998, 997, 996, 995] == ids
+    
+    # We expect the last ids
+    expected_ids = [total_points - (i + 1) for i in range(5)]
+    assert expected_ids == ids
     # Offset is not supported for order_by
     assert result["next_page_offset"] == None
 


### PR DESCRIPTION
Tracked by: #3521 

Currently all `order_by` calls use a streaming approach from the BTree of the numeric index. But this is inefficient when there is already a high-constraining filter in the request, which can potentially make the stream have to iterate through an excessive amount of values to fulfill the requested `limit`. In this case, it makes more sense to get iterate through the filtered points first, and then sort the top points only.

This is the same optimization that is done without `order_by` on scroll calls, so it reuses the same estimation logic to choose streaming vs pre-filtering.

I have confirmed locally that this yields performance improvements by manually querying with web-ui dashboard. It can be between 4-10x faster, compared to `dev` branch.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
