### PR TITLE
Text index inverted index compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitpacking"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1d3e2bfd8d06048a179f7b17afc3188effa10385e7b00dc65af6aae732ea92"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,6 +4704,7 @@ dependencies = [
  "atomic_refcell",
  "atomicwrites",
  "bincode",
+ "bitpacking",
  "bitvec",
  "cgroups-rs",
  "charabia",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -26,6 +26,7 @@ pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 
 
 [dependencies]
+bitpacking = "0.9.2"
 tempfile = "3.10.0"
 parking_lot = { workspace = true }
 rayon = "1.8.1"

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -180,7 +180,7 @@ impl InvertedIndex {
             };
         }
         // Smallest posting is the largest possible cardinality
-        let smallest_posting = postings.iter().cloned().min().unwrap();
+        let smallest_posting = postings.iter().min().copied().unwrap();
 
         return if postings.len() == 1 {
             CardinalityEstimation {
@@ -544,12 +544,11 @@ impl ImmutableInvertedIndex {
 
 impl From<MutableInvertedIndex> for ImmutableInvertedIndex {
     fn from(mut index: MutableInvertedIndex) -> Self {
-        let mut postings: Vec<Option<CompressedPostingList>> = index
+        let postings: Vec<Option<CompressedPostingList>> = index
             .postings
             .into_iter()
             .map(|x| x.map(CompressedPostingList::new))
             .collect();
-        postings.shrink_to_fit();
         index.vocab.shrink_to_fit();
 
         ImmutableInvertedIndex {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -3,8 +3,10 @@ use std::collections::{BTreeSet, HashMap};
 use common::types::PointOffsetType;
 use serde::{Deserialize, Serialize};
 
-use super::posting_list::PostingList;
-use super::postings_iterator::intersect_postings_iterator;
+use super::posting_list::{CompressedPostingList, PostingList};
+use super::postings_iterator::{
+    intersect_compressed_postings_iterator, intersect_postings_iterator,
+};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::types::{FieldCondition, Match, PayloadKeyType};
@@ -132,9 +134,9 @@ impl InvertedIndex {
         query: &ParsedQuery,
         condition: &FieldCondition,
     ) -> CardinalityEstimation {
-        let (points_count, index_postings) = match self {
-            InvertedIndex::Mutable(index) => (index.points_count, &index.postings),
-            InvertedIndex::Immutable(index) => (index.points_count, &index.postings),
+        let points_count = match self {
+            InvertedIndex::Mutable(index) => index.points_count,
+            InvertedIndex::Immutable(index) => index.points_count,
         };
         let postings_opt: Option<Vec<_>> = query
             .tokens
@@ -142,7 +144,20 @@ impl InvertedIndex {
             .map(|&vocab_idx| match vocab_idx {
                 None => None,
                 // unwrap safety: same as in filter()
-                Some(idx) => index_postings.get(idx as usize).unwrap().as_ref(),
+                Some(idx) => match &self {
+                    Self::Mutable(index) => index
+                        .postings
+                        .get(idx as usize)
+                        .unwrap()
+                        .as_ref()
+                        .map(|p| p.len()),
+                    Self::Immutable(index) => index
+                        .postings
+                        .get(idx as usize)
+                        .unwrap()
+                        .as_ref()
+                        .map(|p| p.len()),
+                },
             })
             .collect();
         if postings_opt.is_none() || points_count == 0 {
@@ -165,7 +180,7 @@ impl InvertedIndex {
             };
         }
         // Smallest posting is the largest possible cardinality
-        let smallest_posting = postings.iter().map(|posting| posting.len()).min().unwrap();
+        let smallest_posting = postings.iter().cloned().min().unwrap();
 
         return if postings.len() == 1 {
             CardinalityEstimation {
@@ -177,7 +192,7 @@ impl InvertedIndex {
         } else {
             let expected_frac: f64 = postings
                 .iter()
-                .map(|posting| posting.len() as f64 / points_count as f64)
+                .map(|posting| *posting as f64 / points_count as f64)
                 .product();
             let exp = (expected_frac * points_count as f64) as usize;
             CardinalityEstimation {
@@ -194,32 +209,31 @@ impl InvertedIndex {
         threshold: usize,
         key: PayloadKeyType,
     ) -> Box<dyn Iterator<Item = PayloadBlockCondition> + '_> {
+        let map_filter_condition = move |(token, postings_len): (&str, usize)| {
+            if postings_len >= threshold {
+                Some(PayloadBlockCondition {
+                    condition: FieldCondition::new_match(key.clone(), Match::new_text(token)),
+                    cardinality: postings_len,
+                })
+            } else {
+                None
+            }
+        };
+
         // It might be very hard to predict possible combinations of conditions,
         // so we only build it for individual tokens
-        let (vocab, postings) = match self {
-            InvertedIndex::Mutable(index) => (&index.vocab, &index.postings),
-            InvertedIndex::Immutable(index) => (&index.vocab, &index.postings),
-        };
-        Box::new(
-            vocab
-                .iter()
-                .filter(|(_token, &posting_idx)| postings[posting_idx as usize].is_some())
-                .filter(move |(_token, &posting_idx)| {
-                    // unwrap crash safety: all tokens that passes the first filter should have postings
-                    postings[posting_idx as usize].as_ref().unwrap().len() >= threshold
-                })
-                .map(|(token, &posting_idx)| {
-                    (
-                        token,
-                        // same as the above case
-                        postings[posting_idx as usize].as_ref().unwrap(),
-                    )
-                })
-                .map(move |(token, posting)| PayloadBlockCondition {
-                    condition: FieldCondition::new_match(key.clone(), Match::new_text(token)),
-                    cardinality: posting.len(),
-                }),
-        )
+        match &self {
+            InvertedIndex::Mutable(index) => Box::new(
+                index
+                    .vocab_with_positngs_len_iter()
+                    .filter_map(map_filter_condition),
+            ),
+            InvertedIndex::Immutable(index) => Box::new(
+                index
+                    .vocab_with_positngs_len_iter()
+                    .filter_map(map_filter_condition),
+            ),
+        }
     }
 
     pub fn build_index(
@@ -401,7 +415,7 @@ impl MutableInvertedIndex {
             // Empty request -> no matches
             return Box::new(vec![].into_iter());
         }
-        intersect_postings_iterator(postings, |_| true)
+        intersect_postings_iterator(postings)
     }
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {
@@ -424,11 +438,21 @@ impl MutableInvertedIndex {
     fn get_doc(&self, idx: PointOffsetType) -> Option<&Document> {
         self.point_to_docs.get(idx as usize)?.as_ref()
     }
+
+    fn vocab_with_positngs_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
+        self.vocab.iter().filter_map(|(token, &posting_idx)| {
+            if let Some(Some(postings)) = self.postings.get(posting_idx as usize) {
+                Some((token.as_str(), postings.len()))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 #[derive(Default)]
 pub struct ImmutableInvertedIndex {
-    postings: Vec<Option<PostingList>>,
+    postings: Vec<Option<CompressedPostingList>>,
     vocab: HashMap<String, TokenId>,
     point_documents_tokens: Vec<Option<usize>>,
     points_count: usize,
@@ -465,10 +489,10 @@ impl ImmutableInvertedIndex {
             return Box::new(vec![].into_iter());
         }
 
-        // deleted documents are still in the postings
+        // in case of immutable index, deleted documents are still in the postings
         let filter =
             move |idx| matches!(self.point_documents_tokens.get(idx as usize), Some(Some(_)));
-        intersect_postings_iterator(postings, filter)
+        intersect_compressed_postings_iterator(postings, filter)
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
@@ -506,22 +530,30 @@ impl ImmutableInvertedIndex {
                 }
             })
     }
+
+    fn vocab_with_positngs_len_iter(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
+        self.vocab.iter().filter_map(|(token, &posting_idx)| {
+            if let Some(Some(postings)) = self.postings.get(posting_idx as usize) {
+                Some((token.as_str(), postings.len()))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl From<MutableInvertedIndex> for ImmutableInvertedIndex {
     fn from(mut index: MutableInvertedIndex) -> Self {
-        index
+        let mut postings: Vec<Option<CompressedPostingList>> = index
             .postings
-            .iter_mut()
-            .filter_map(|posting| posting.as_mut())
-            .for_each(|posting| {
-                posting.shrink_to_fit();
-            });
-        index.postings.shrink_to_fit();
+            .into_iter()
+            .map(|x| x.map(CompressedPostingList::new))
+            .collect();
+        postings.shrink_to_fit();
         index.vocab.shrink_to_fit();
 
         ImmutableInvertedIndex {
-            postings: index.postings,
+            postings,
             vocab: index.vocab,
             point_documents_tokens: index
                 .point_to_docs

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index.rs
@@ -138,7 +138,7 @@ impl InvertedIndex {
             InvertedIndex::Mutable(index) => index.points_count,
             InvertedIndex::Immutable(index) => index.points_count,
         };
-        let postings_opt: Option<Vec<_>> = query
+        let posting_lengths: Option<Vec<usize>> = query
             .tokens
             .iter()
             .map(|&vocab_idx| match vocab_idx {
@@ -160,7 +160,7 @@ impl InvertedIndex {
                 },
             })
             .collect();
-        if postings_opt.is_none() || points_count == 0 {
+        if posting_lengths.is_none() || points_count == 0 {
             // There are unseen tokens -> no matches
             return CardinalityEstimation {
                 primary_clauses: vec![PrimaryCondition::Condition(condition.clone())],
@@ -169,7 +169,7 @@ impl InvertedIndex {
                 max: 0,
             };
         }
-        let postings = postings_opt.unwrap();
+        let postings = posting_lengths.unwrap();
         if postings.is_empty() {
             // Empty request -> no matches
             return CardinalityEstimation {

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -244,7 +244,7 @@ impl<'a> CompressedPostingVisitor<'a> {
     // Check if the next value is in the compressed posting list.
     // This function reuses the decompressed chunk to avoid unnecessary decompression.
     // It is useful when the visitor is used to check the values in the increasing order.
-    pub fn contains_next(&mut self, val: &PointOffsetType) -> bool {
+    pub fn contains_next_and_advance(&mut self, val: &PointOffsetType) -> bool {
         #[cfg(test)]
         {
             // check if the checked values are in the increasing order
@@ -266,7 +266,7 @@ impl<'a> CompressedPostingVisitor<'a> {
             match val.cmp(last_decompressed) {
                 std::cmp::Ordering::Less => {
                     // value is less than the last decompressed value
-                    return self.find_in_decompressed_chunk(val);
+                    return self.find_in_decompressed_and_advance(val);
                 }
                 std::cmp::Ordering::Equal => {
                     // value is equal to the last decompressed value
@@ -298,10 +298,10 @@ impl<'a> CompressedPostingVisitor<'a> {
         self.decompressed_chunk_start_index = 0;
 
         // check if the value is in the decompressed chunk
-        self.find_in_decompressed_chunk(val)
+        self.find_in_decompressed_and_advance(val)
     }
 
-    fn find_in_decompressed_chunk(&mut self, val: &PointOffsetType) -> bool {
+    fn find_in_decompressed_and_advance(&mut self, val: &PointOffsetType) -> bool {
         match self.decompressed_chunk[self.decompressed_chunk_start_index..].binary_search(val) {
             Ok(idx) => {
                 self.decompressed_chunk_start_index = idx;
@@ -353,7 +353,7 @@ mod tests {
                 let mut visitor = CompressedPostingVisitor::new(&compressed_posting_list);
                 for i in 0..build_step * 1000 {
                     if i % search_step == 0 {
-                        assert_eq!(visitor.contains_next(&i), set.contains(&i));
+                        assert_eq!(visitor.contains_next_and_advance(&i), set.contains(&i));
                     }
                 }
             }

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -173,7 +173,7 @@ impl CompressedPostingList {
     }
 
     fn is_in_postings_range(&self, val: PointOffsetType) -> bool {
-        self.chunks.len() > 0 && val >= self.chunks[0].initial && val <= self.last_doc_id
+        !self.chunks.is_empty() && val >= self.chunks[0].initial && val <= self.last_doc_id
     }
 
     fn decompress_chunk(

--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -1,3 +1,4 @@
+use bitpacking::BitPacker;
 use common::types::PointOffsetType;
 
 #[derive(Clone, Debug, Default)]
@@ -37,23 +38,320 @@ impl PostingList {
         self.list.binary_search(val).is_ok()
     }
 
-    pub fn iter<'a>(
-        &'a self,
-        filter: impl Fn(PointOffsetType) -> bool + 'a,
-    ) -> impl Iterator<Item = PointOffsetType> + 'a {
-        self.list.iter().copied().filter(move |&idx| filter(idx))
-    }
-
-    pub fn shrink_to_fit(&mut self) {
-        self.list.shrink_to_fit();
+    pub fn iter(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
+        self.list.iter().copied()
     }
 }
 
-impl IntoIterator for PostingList {
-    type Item = PointOffsetType;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+#[derive(Clone, Debug, Default)]
+pub struct CompressedPostingList {
+    len: usize,
+    last_doc_id: PointOffsetType,
+    data: Box<[u8]>,
+    chunks: Box<[CompressedPostingChunk]>,
+}
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.list.into_iter()
+#[derive(Clone, Debug, Default)]
+pub struct CompressedPostingChunk {
+    initial: PointOffsetType,
+    offset: u32,
+}
+
+impl CompressedPostingList {
+    pub fn new(mut posting_list: PostingList) -> Self {
+        if posting_list.list.is_empty() {
+            return Self::default();
+        }
+        let len = posting_list.len();
+        let last_doc_id = *posting_list.list.last().unwrap();
+
+        let bitpacker = bitpacking::BitPacker4x::new();
+        posting_list.list.sort_unstable();
+
+        let last = *posting_list.list.last().unwrap();
+        while posting_list.list.len() % bitpacking::BitPacker4x::BLOCK_LEN != 0 {
+            posting_list.list.push(last);
+        }
+
+        // calculate chunks count
+        let chunks_count = posting_list
+            .len()
+            .div_ceil(bitpacking::BitPacker4x::BLOCK_LEN);
+        // fill chunks data
+        let mut chunks = Vec::with_capacity(chunks_count);
+        let mut data_size = 0;
+        for chunk_data in posting_list
+            .list
+            .chunks_exact(bitpacking::BitPacker4x::BLOCK_LEN)
+        {
+            let initial = chunk_data[0];
+            let chunk_bits: u8 = bitpacker.num_bits_sorted(initial, chunk_data);
+            let chunk_size = bitpacking::BitPacker4x::compressed_block_size(chunk_bits);
+            chunks.push(CompressedPostingChunk {
+                initial,
+                offset: data_size as u32,
+            });
+            data_size += chunk_size;
+        }
+
+        let mut data = vec![0u8; data_size];
+        for (chunk_index, chunk_data) in posting_list
+            .list
+            .chunks_exact(bitpacking::BitPacker4x::BLOCK_LEN)
+            .enumerate()
+        {
+            let chunk = &chunks[chunk_index];
+            let chunk_size = Self::get_chunk_size(&chunks, &data, chunk_index);
+            let chunk_bits = (chunk_size * 8) / bitpacking::BitPacker4x::BLOCK_LEN;
+            bitpacker.compress_sorted(
+                chunk.initial,
+                chunk_data,
+                &mut data[chunk.offset as usize..chunk.offset as usize + chunk_size],
+                chunk_bits as u8,
+            );
+
+            // debug decompress check
+            // todo: remove
+            let mut decompressed = vec![0u32; bitpacking::BitPacker4x::BLOCK_LEN];
+            bitpacker.decompress_sorted(
+                chunk.initial,
+                &data[chunk.offset as usize..chunk.offset as usize + chunk_size],
+                &mut decompressed,
+                chunk_bits as u8,
+            );
+            if decompressed != chunk_data {
+                panic!("decompressed != chunk");
+            }
+        }
+
+        Self {
+            len,
+            last_doc_id,
+            data: data.into_boxed_slice(),
+            chunks: chunks.into_boxed_slice(),
+        }
+    }
+
+    pub fn contains(&self, val: &PointOffsetType) -> bool {
+        if !self.is_in_postings_range(*val) {
+            return false;
+        }
+
+        // find the chunk that may contain the value and check if the value is in the chunk
+        let chunk_index = self.find_chunk(val, None);
+        if let Some(chunk_index) = chunk_index {
+            if self.chunks[chunk_index].initial == *val {
+                return true;
+            }
+
+            let mut decompressed = [0u32; bitpacking::BitPacker4x::BLOCK_LEN];
+            self.decompress_chunk(
+                &bitpacking::BitPacker4x::new(),
+                chunk_index,
+                &mut decompressed,
+            );
+            decompressed.binary_search(val).is_ok()
+        } else {
+            false
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
+        let bitpacker = bitpacking::BitPacker4x::new();
+        (0..self.chunks.len())
+            .flat_map(move |chunk_index| {
+                let mut decompressed = [0u32; bitpacking::BitPacker4x::BLOCK_LEN];
+                self.decompress_chunk(&bitpacker, chunk_index, &mut decompressed);
+                decompressed.into_iter()
+            })
+            .take(self.len)
+    }
+
+    fn get_chunk_size(chunks: &[CompressedPostingChunk], data: &[u8], chunk_index: usize) -> usize {
+        assert!(chunk_index < chunks.len());
+        if chunk_index + 1 < chunks.len() {
+            chunks[chunk_index + 1].offset as usize - chunks[chunk_index].offset as usize
+        } else {
+            data.len() - chunks[chunk_index].offset as usize
+        }
+    }
+
+    fn find_chunk(&self, doc_id: &PointOffsetType, start_chunk: Option<usize>) -> Option<usize> {
+        let start_chunk = if let Some(idx) = start_chunk { idx } else { 0 };
+        match self.chunks[start_chunk..].binary_search_by(|chunk| chunk.initial.cmp(doc_id)) {
+            // doc_id is the initial value of the chunk with index idx
+            Ok(idx) => Some(start_chunk + idx),
+            // chunk idx has larger initial value than doc_id
+            // so we need the previous chunk
+            Err(idx) => {
+                if idx > 0 {
+                    Some(start_chunk + idx - 1)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn is_in_postings_range(&self, val: PointOffsetType) -> bool {
+        self.chunks.len() > 0 && val >= self.chunks[0].initial && val <= self.last_doc_id
+    }
+
+    fn decompress_chunk(
+        &self,
+        bitpacker: &bitpacking::BitPacker4x,
+        chunk_index: usize,
+        decompressed: &mut [PointOffsetType],
+    ) {
+        let chunk = &self.chunks[chunk_index];
+        let chunk_size = Self::get_chunk_size(&self.chunks, &self.data, chunk_index);
+        let chunk_bits = (chunk_size * 8) / bitpacking::BitPacker4x::BLOCK_LEN;
+        bitpacker.decompress_sorted(
+            chunk.initial,
+            &self.data[chunk.offset as usize..chunk.offset as usize + chunk_size],
+            decompressed,
+            chunk_bits as u8,
+        );
+    }
+}
+
+pub struct CompressedPostingVisitor<'a> {
+    bitpacker: bitpacking::BitPacker4x,
+    postings: &'a CompressedPostingList,
+    decompressed_chunk: [PointOffsetType; bitpacking::BitPacker4x::BLOCK_LEN],
+    decompressed_chunk_idx: Option<usize>,
+    decompressed_chunk_start_index: usize,
+    #[cfg(test)]
+    last_checked: Option<PointOffsetType>,
+}
+
+impl<'a> CompressedPostingVisitor<'a> {
+    pub fn new(postings: &'a CompressedPostingList) -> CompressedPostingVisitor<'a> {
+        CompressedPostingVisitor {
+            bitpacker: bitpacking::BitPacker4x::new(),
+            postings,
+            decompressed_chunk: [0; bitpacking::BitPacker4x::BLOCK_LEN],
+            decompressed_chunk_idx: None,
+            decompressed_chunk_start_index: 0,
+            #[cfg(test)]
+            last_checked: None,
+        }
+    }
+
+    pub fn contains(&mut self, val: &PointOffsetType) -> bool {
+        #[cfg(test)]
+        {
+            // check if the checked values are in the increasing order
+            if let Some(last_checked) = self.last_checked {
+                assert!(*val > last_checked);
+            }
+            self.last_checked = Some(*val);
+        }
+
+        if !self.postings.is_in_postings_range(*val) {
+            return false;
+        }
+
+        // check if current decompressed chunks range contains the value
+        if self.decompressed_chunk_idx.is_some() {
+            // check if value is in decompressed chunk range
+            // check for max value in the chunk only because we already checked for min value while decompression
+            let last_decompressed =
+                &self.decompressed_chunk[bitpacking::BitPacker4x::BLOCK_LEN - 1];
+            match val.cmp(last_decompressed) {
+                std::cmp::Ordering::Less => {
+                    // value is less than the last decompressed value
+                    return self.find_in_decompressed_chunk(val);
+                }
+                std::cmp::Ordering::Equal => {
+                    // value is equal to the last decompressed value
+                    return true;
+                }
+                std::cmp::Ordering::Greater => {}
+            }
+        }
+
+        // decompressed chunk is not in the range, so we need to decompress another chunk
+        // first, check if there is a chunk that contains the value
+        let chunk_index = match self.postings.find_chunk(val, self.decompressed_chunk_idx) {
+            Some(idx) => idx,
+            None => return false,
+        };
+        // if the value is the initial value of the chunk, we don't need to decompress the chunk
+        if self.postings.chunks[chunk_index].initial == *val {
+            return true;
+        }
+
+        // second, decompress the chunk and check if the value is in the decompressed chunk
+        self.postings
+            .decompress_chunk(&self.bitpacker, chunk_index, &mut self.decompressed_chunk);
+        self.decompressed_chunk_idx = Some(chunk_index);
+        self.decompressed_chunk_start_index = 0;
+
+        // check if the value is in the decompressed chunk
+        self.find_in_decompressed_chunk(val)
+    }
+
+    fn find_in_decompressed_chunk(&mut self, val: &PointOffsetType) -> bool {
+        match self.decompressed_chunk[self.decompressed_chunk_start_index..].binary_search(val) {
+            Ok(idx) => {
+                self.decompressed_chunk_start_index = idx;
+                true
+            }
+            Err(idx) => {
+                self.decompressed_chunk_start_index = idx;
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn generate_compressed_posting_list(
+        step: PointOffsetType,
+    ) -> (CompressedPostingList, HashSet<PointOffsetType>) {
+        let mut set = HashSet::new();
+        let mut posting_list = PostingList::default();
+        for i in 0..999 {
+            set.insert(step * i);
+            posting_list.insert(step * i);
+        }
+        let compressed_posting_list = CompressedPostingList::new(posting_list);
+        (compressed_posting_list, set)
+    }
+
+    #[test]
+    fn test_compressed_posting_contains() {
+        for step in 0..3 {
+            let (compressed_posting_list, set) = generate_compressed_posting_list(step);
+            for i in 0..step * 1000 {
+                assert_eq!(compressed_posting_list.contains(&i), set.contains(&i));
+            }
+        }
+    }
+
+    #[test]
+    fn test_compressed_posting_visitor() {
+        for build_step in 0..3 {
+            let (compressed_posting_list, set) = generate_compressed_posting_list(build_step);
+
+            for search_step in 1..512 {
+                let mut visitor = CompressedPostingVisitor::new(&compressed_posting_list);
+                for i in 0..build_step * 1000 {
+                    if i % search_step == 0 {
+                        assert_eq!(visitor.contains(&i), set.contains(&i));
+                    }
+                }
+            }
+        }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -43,7 +43,7 @@ pub fn intersect_compressed_postings_iterator<'a>(
         .filter(move |doc_id| {
             posting_visitors
                 .iter_mut()
-                .all(|posting_visitor| posting_visitor.contains(doc_id))
+                .all(|posting_visitor| posting_visitor.contains_next(doc_id))
         });
 
     Box::new(and_iter)

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -1,10 +1,9 @@
 use common::types::PointOffsetType;
 
-use super::posting_list::PostingList;
+use super::posting_list::{CompressedPostingList, CompressedPostingVisitor, PostingList};
 
 pub fn intersect_postings_iterator<'a>(
     mut postings: Vec<&'a PostingList>,
-    filter: impl Fn(PointOffsetType) -> bool + 'a,
 ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
     let smallest_posting_idx = postings
         .iter()
@@ -15,8 +14,37 @@ pub fn intersect_postings_iterator<'a>(
     let smallest_posting = postings.remove(smallest_posting_idx);
 
     let and_iter = smallest_posting
-        .iter(filter)
+        .iter()
         .filter(move |doc_id| postings.iter().all(|posting| posting.contains(doc_id)));
+
+    Box::new(and_iter)
+}
+
+pub fn intersect_compressed_postings_iterator<'a>(
+    mut postings: Vec<&'a CompressedPostingList>,
+    filter: impl Fn(PointOffsetType) -> bool + 'a,
+) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+    let smallest_posting_idx = postings
+        .iter()
+        .enumerate()
+        .min_by_key(|(_idx, posting)| posting.len())
+        .map(|(idx, _posting)| idx)
+        .unwrap();
+    let smallest_posting = postings.remove(smallest_posting_idx);
+
+    let mut posting_visitors = postings
+        .into_iter()
+        .map(CompressedPostingVisitor::new)
+        .collect::<Vec<_>>();
+
+    let and_iter = smallest_posting
+        .iter()
+        .filter(move |doc_id| filter(*doc_id))
+        .filter(move |doc_id| {
+            posting_visitors
+                .iter_mut()
+                .all(|posting_visitor| posting_visitor.contains(doc_id))
+        });
 
     Box::new(and_iter)
 }
@@ -46,7 +74,17 @@ mod tests {
         p3.insert(7);
 
         let postings = vec![&p1, &p2, &p3];
-        let merged = intersect_postings_iterator(postings, |_| true);
+        let merged = intersect_postings_iterator(postings);
+
+        let res = merged.collect::<Vec<_>>();
+
+        assert_eq!(res, vec![2, 5]);
+
+        let p1_compressed = CompressedPostingList::new(p1);
+        let p2_compressed = CompressedPostingList::new(p2);
+        let p3_compressed = CompressedPostingList::new(p3);
+        let compressed_postings = vec![&p1_compressed, &p2_compressed, &p3_compressed];
+        let merged = intersect_compressed_postings_iterator(compressed_postings, |_| true);
 
         let res = merged.collect::<Vec<_>>();
 

--- a/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
+++ b/lib/segment/src/index/field_index/full_text_index/postings_iterator.rs
@@ -43,7 +43,7 @@ pub fn intersect_compressed_postings_iterator<'a>(
         .filter(move |doc_id| {
             posting_visitors
                 .iter_mut()
-                .all(|posting_visitor| posting_visitor.contains_next(doc_id))
+                .all(|posting_visitor| posting_visitor.contains_next_and_advance(doc_id))
         });
 
     Box::new(and_iter)


### PR DESCRIPTION
Compressing postings list for text field index.

Compression is implemented using `bitpacking` crate: https://github.com/quickwit-oss/bitpacking. Compression works for immutable state only. Mutable state uses old postings list implementation.

Because `bitpacking` compresses only fixed-len chunks (128 of `u32` in this PR), compressed posting list is divided into chunks, each chunk is compressed separately and compressed data is flattened on one large collection.

Because `bitpacking` provides only pack/unpack methods, we have to decompress one chunk is we want to check if value is presented in compressed posting list. For intersection of posting list there are special helping visitor, who reuse decompressed chunks and shorten search ranges.

### RAM difference

RAM difference was tested on https://storage.googleapis.com/common-datasets-snapshots/arxiv_abstracts-3083016565637815127-2023-06-02-07-26-29.snapshot

Measuring method: `/proc/<PID>/status`

VmRSS on dev: `10_116 MB`
VmRSS on branch: `9_696 MB`
There is 420MB difference in VmRSS.

RssAnon on dev: `10_041 MB`
RssAnon on branch: `9_621 MB`
There is 420MB difference in RssAnon.

### Performance difference

Performance was measured on the snapshot mentioned above.
As measurement strategy, I called using Rust client 1000 times filtered recommendation API with 2 different positive points in single thread mode. Call is like:
```
curl -X POST "http://$QDRANT_HOST/collections/text/points/recommend" \
  -H 'Content-Type: application/json' \
  --data-raw '{
      "positive": [ "000004ce-7a38-478f-8d83-2900a72e1d8d", "000004ce-7a38-478f-8d83-6700a12e173t" ],
      "limit": 10,
      "filter": {
          "should": [
              {
                  "key": "abstract",
                  "match": {
                      "text": "<TEST_TEXT>"
                  }
              }
          ]
      },
      "with_payload": false,
      "with_vector": false
    }' | jq
```

For small-cardinality `TEST_TEXT` is `Immediate benefits`.
For large-cardinality `TEST_TEXT` is `the a`.
I checked with telemetry that this texts cover small- and large-cardinality cases.

P95 search time for `Immediate benefits` request:
```
DEV: 0.000173356
PR: 0.000119321
```

P95 search time for `The a` request:
```
DEV: 0.030939524
PR: 0.02868633
```

There is a performance boost. Because such measurement is unexpected, I checked that all search results, used for benchmarking, are the same.
Performance boost can be explained for small-cardinality case, where `visitor` pattern shorten search ranges while postings intersection. For HNSW case I can only guess that doing binary search in two small collections may take much less time that binary search in one large collection - I have only this explanation

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
