### PR TITLE
Configure default RocksDB column family

### DIFF
--- a/lib/segment/src/common/rocksdb_wrapper.rs
+++ b/lib/segment/src/common/rocksdb_wrapper.rs
@@ -18,6 +18,8 @@ pub const DB_VECTOR_CF: &str = "vector";
 pub const DB_PAYLOAD_CF: &str = "payload";
 pub const DB_MAPPING_CF: &str = "mapping";
 pub const DB_VERSIONS_CF: &str = "version";
+/// If there is no Column Family specified, key-value pair is associated with Column Family "default".
+pub const DB_DEFAULT_CF: &str = "default";
 
 #[derive(Clone)]
 pub struct DatabaseColumnWrapper {
@@ -61,7 +63,7 @@ pub fn open_db<T: AsRef<str>>(
     path: &Path,
     vector_paths: &[T],
 ) -> Result<Arc<RwLock<DB>>, rocksdb::Error> {
-    let mut column_families = vec![DB_PAYLOAD_CF, DB_MAPPING_CF, DB_VERSIONS_CF];
+    let mut column_families = vec![DB_PAYLOAD_CF, DB_MAPPING_CF, DB_VERSIONS_CF, DB_DEFAULT_CF];
     for vector_path in vector_paths {
         column_families.push(vector_path.as_ref());
     }


### PR DESCRIPTION
This PR configures the `default` column family like all other column families.

After https://github.com/qdrant/qdrant/pull/3557 it was [reported](https://github.com/qdrant/qdrant/pull/3557#discussion_r1482184228) that the RocksDB logs still mentioned an incorrect `write_buffer_size` once at startup.

I was able to see the same locally and after some digging I found out that RocksDB always creates a default column family just in case there are key-value pairs without column.

See https://github.com/facebook/rocksdb/wiki/Column-Families

By applying the following patch I was able to configure properly the default column family.

see `OPTIONS-00000xx` files.

```
[CFOptions "default"]
  ...
  write_buffer_size=10485760
```

I have not found how to disable this column family completely.