### PR TITLE
fix: flaky segment builder cancellation test

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -7,6 +7,7 @@ use std::thread;
 
 use atomic_refcell::AtomicRefCell;
 #[cfg(target_os = "linux")]
+#[cfg(profile = "release")]
 use common::cpu::linux_low_thread_priority;
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset};
@@ -678,6 +679,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
                 b.spawn(|| {
                     // On Linux, use lower thread priority so we interfere less with serving traffic
                     #[cfg(target_os = "linux")]
+                    #[cfg(profile = "release")]
                     if let Err(err) = linux_low_thread_priority() {
                         log::debug!(
                             "Failed to set low thread priority for HNSW building, ignoring: {err}"

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -168,7 +168,7 @@ fn test_building_cancellation() {
     let late_stop_delay = time_baseline / 5;
     let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, late_stop_delay);
 
-    let acceptable_stopping_delay = 600; // millis
+    let acceptable_stopping_delay = time_baseline / 30; // millis
 
     assert!(was_cancelled_early);
     assert!(


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Test changes to minimize flakiness

/claim #2723

The main reason for this test's flakiness is the performance fluctuation of the cancellation teardown running in debug mode on the CI environment.

The acceptance margin for the teardown delay after cancellation being absolute makes this test too dependant on specific performance characteristics of the testing environment.

My proposed solution to the flakiness is to define the `acceptable_stopped_delay` proportionally to the `baseline_time`, decoupling the parameter from specific performance requirements. This should make the test consistent regardless of the performance characteristics of the environment it's running.

Another issue I've identified is that the indexing thread-pool sets threads to a low priority. This could make the entire test starve in a loaded shared-time environment (which is easy to verify by running the test while a CPU stress test is running in background). I've made the low thread priority only be used in release mode, which should eliminate this factor as well.