### PR TITLE
Use /usr/bin/env bash in shebangs

### DIFF
--- a/tests/basic_api_test.sh
+++ b/tests/basic_api_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test checks that Qdrant answers to all API mentioned in README.md as expected
 
 set -ex

--- a/tests/basic_grpc_test.sh
+++ b/tests/basic_grpc_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test checks that Qdrant answers to all API mentioned in README.md as expected
 
 set -ex

--- a/tests/basic_sparse_grpc_test.sh
+++ b/tests/basic_sparse_grpc_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test checks that Qdrant answers to all API mentioned in README.md as expected
 
 set -ex

--- a/tests/basic_sparse_test.sh
+++ b/tests/basic_sparse_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test checks that Qdrant answers to all API mentioned in README.md as expected
 
 set -ex

--- a/tests/consensus_tests/run_tests.sh
+++ b/tests/consensus_tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/grpc_consistency_check.sh
+++ b/tests/grpc_consistency_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Some gRPC files in this repository are generated and based upon other
 # sources. When these sources change, the generated files must be generated
 # (and committed) again. It is the task of the contributing user to do this

--- a/tests/integration-tests-api-key.sh
+++ b/tests/integration-tests-api-key.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This runs the auth integration tests in isolation
 
 set -eux

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This runs all integration test in isolation
 
 set -ex

--- a/tests/low-ram/low-ram.sh
+++ b/tests/low-ram/low-ram.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xeuo pipefail
 

--- a/tests/openapi_consistency_check.sh
+++ b/tests/openapi_consistency_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Some OpenAPI files in this repository are generated and based upon other
 # sources. When these sources change, the generated files must be generated
 # (and committed) again. It is the task of the contributing user to do this

--- a/tests/openapi_integration_test.sh
+++ b/tests/openapi_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/removes_test.sh
+++ b/tests/removes_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test checks that Qdrant answers to all API mentioned in README.md as expected
 
 
@@ -26,7 +26,6 @@ curl -X PUT "http://$QDRANT_HOST/collections/test_collection" \
     }' | jq
 
 
-#!/bin/bash
 for i in {1..100}
 do
   IDX=$i
@@ -70,7 +69,6 @@ curl -L -X POST "http://$QDRANT_HOST/collections/test_collection/points/delete?w
   --data-raw "$PAYLOAD" | jq
 
 
-#!/bin/bash
 for i in {1..10}
 do
   IDX=$i

--- a/tests/snapshots/snapshots-recovery.sh
+++ b/tests/snapshots/snapshots-recovery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/storage-compat/gen_storage_compat_data.sh
+++ b/tests/storage-compat/gen_storage_compat_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This runs validates the storage compatibility
 
 set -ex

--- a/tests/tls/gen.sh
+++ b/tests/tls/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 openssl req \
   -new \

--- a/tests/tls/test_tls.sh
+++ b/tests/tls/test_tls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tests/tls/test_tls_snapshot_shard_transfer.sh
+++ b/tests/tls/test_tls_snapshot_shard_transfer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tools/clean-old-rocksdb-logs.sh
+++ b/tools/clean-old-rocksdb-logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Clean old RocksDB log files, always leave the last two.
 #

--- a/tools/generate_openapi_models.sh
+++ b/tools/generate_openapi_models.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script generate model definitions for OpenAPI 3.0 documentation
 
 set -e


### PR DESCRIPTION
Script beginning with `#!/bin/bash` are failing to run on systems where `bash` has a different path in the FS, e.g. on NixOS.

```console
$ ./tools/generate_openapi_models.sh
zsh: ./tools/generate_openapi_models.sh: bad interpreter: /bin/bash: no such file or directory

$ file /bin/bash
/bin/bash: cannot open `/bin/bash' (No such file or directory)

$ which bash
/run/current-system/sw/bin/bash
```

Replacing `#!/bin/bash` with `#!/usr/bin/env bash` fixes that.

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
