### PR TITLE
Add clock set unit tests

### DIFF
--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -144,4 +144,27 @@ mod tests {
         assert_eq!(clock_set.get_clock().tick_once(), 3);
         assert_eq!(clock_set.get_clock().tick_once(), 4);
     }
+
+    /// Test a single clock, but tick it multiple times on the same guard.
+    #[test]
+    fn test_clock_set_single_tick_twice() {
+        let mut clock_set = ClockSet::new();
+
+        // Don't tick from 0 unless we explicitly advance
+        {
+            let mut clock = clock_set.get_clock();
+            assert_eq!(clock.tick_once(), 0);
+            assert_eq!(clock.tick_once(), 0);
+            clock.advance_to(0);
+        }
+
+        // Following ticks should increment
+        {
+            let mut clock = clock_set.get_clock();
+            assert_eq!(clock.tick_once(), 1);
+            assert_eq!(clock.tick_once(), 2);
+            assert_eq!(clock.tick_once(), 3);
+            assert_eq!(clock.tick_once(), 4);
+        }
+    }
 }

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -184,4 +184,24 @@ mod tests {
         clock_set.get_clock().advance_to(100);
         assert_eq!(clock_set.get_clock().tick_once(), 101);
     }
+
+    #[test]
+    fn test_clock_set_single_advance_low() {
+        let mut clock_set = ClockSet::new();
+
+        // Bring the clock up to 4
+        assert_eq!(clock_set.get_clock().tick_once(), 0);
+        clock_set.get_clock().advance_to(0);
+        assert_eq!(clock_set.get_clock().tick_once(), 1);
+        assert_eq!(clock_set.get_clock().tick_once(), 2);
+        assert_eq!(clock_set.get_clock().tick_once(), 3);
+        assert_eq!(clock_set.get_clock().tick_once(), 4);
+
+        // If we advance to a low number, just continue
+        clock_set.get_clock().advance_to(0);
+        assert_eq!(clock_set.get_clock().tick_once(), 5);
+
+        clock_set.get_clock().advance_to(1);
+        assert_eq!(clock_set.get_clock().tick_once(), 6);
+    }
 }

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -171,6 +171,7 @@ mod tests {
         }
     }
 
+    /// Advance a clock to a higher number, which should increase it.
     #[test]
     fn test_clock_set_single_advance_high() {
         let mut clock_set = ClockSet::new();
@@ -188,6 +189,7 @@ mod tests {
         assert_eq!(clock_set.get_clock().tick_once(), 101);
     }
 
+    /// Advance a clock to a lower number, which should not do anything.
     #[test]
     fn test_clock_set_single_advance_low() {
         let mut clock_set = ClockSet::new();
@@ -208,6 +210,7 @@ mod tests {
         assert_eq!(clock_set.get_clock().tick_once(), 6);
     }
 
+    /// Test multiple clocks in various configurations.
     #[test]
     fn test_clock_multi_tick() {
         let mut clock_set = ClockSet::new();
@@ -374,6 +377,7 @@ mod tests {
         }
     }
 
+    /// Test and increment a lot of clocks, but at some point 10% of the clocks gets stuck.
     #[test]
     fn test_clock_set_many() {
         const N: usize = 5000;
@@ -450,6 +454,7 @@ mod tests {
         }
     }
 
+    /// Test and increment a lot of clocks, but each iteration, we get on more clock stuck.
     #[test]
     fn test_clock_set_many_staggered_stuck() {
         const N: usize = 500;

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -167,4 +167,21 @@ mod tests {
             assert_eq!(clock.tick_once(), 4);
         }
     }
+
+    #[test]
+    fn test_clock_set_single_advance_high() {
+        let mut clock_set = ClockSet::new();
+
+        // Bring the clock up to 4
+        assert_eq!(clock_set.get_clock().tick_once(), 0);
+        clock_set.get_clock().advance_to(0);
+        assert_eq!(clock_set.get_clock().tick_once(), 1);
+        assert_eq!(clock_set.get_clock().tick_once(), 2);
+        assert_eq!(clock_set.get_clock().tick_once(), 3);
+        assert_eq!(clock_set.get_clock().tick_once(), 4);
+
+        // If we advance to 100, we should continue from 101
+        clock_set.get_clock().advance_to(100);
+        assert_eq!(clock_set.get_clock().tick_once(), 101);
+    }
 }

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -121,3 +121,27 @@ impl Clock {
         self.available.store(true, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tick a single clock, it should increment after we advance it from 0 (or higher).
+    #[test]
+    fn test_clock_set_single_tick() {
+        let mut clock_set = ClockSet::new();
+
+        // Don't tick from 0 unless we explicitly advance
+        assert_eq!(clock_set.get_clock().tick_once(), 0);
+        assert_eq!(clock_set.get_clock().tick_once(), 0);
+        assert_eq!(clock_set.get_clock().tick_once(), 0);
+
+        clock_set.get_clock().advance_to(0);
+
+        // Following ticks should increment
+        assert_eq!(clock_set.get_clock().tick_once(), 1);
+        assert_eq!(clock_set.get_clock().tick_once(), 2);
+        assert_eq!(clock_set.get_clock().tick_once(), 3);
+        assert_eq!(clock_set.get_clock().tick_once(), 4);
+    }
+}

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -124,8 +124,9 @@ impl Clock {
 
 #[cfg(test)]
 mod tests {
-    use rand::prelude::*;
     use std::iter;
+
+    use rand::prelude::*;
 
     use super::*;
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This adds a bunch of tests for the `ClockSet` structure we added for shard diff transfer (<https://github.com/qdrant/qdrant/issues/3477>).

We'll need to add more tests for other types, but we'll be doing that in separate PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
