### PR TITLE
Add integer range condition and integer `start_from` to interface

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -132,6 +132,7 @@
     - [GroupId](#qdrant-GroupId)
     - [GroupsResult](#qdrant-GroupsResult)
     - [HasIdCondition](#qdrant-HasIdCondition)
+    - [IntegerRange](#qdrant-IntegerRange)
     - [IsEmptyCondition](#qdrant-IsEmptyCondition)
     - [IsNullCondition](#qdrant-IsNullCondition)
     - [LookupLocation](#qdrant-LookupLocation)
@@ -2097,6 +2098,7 @@ The JSON representation for `Value` is a JSON value.
 | values_count | [ValuesCount](#qdrant-ValuesCount) |  | Check number of values for a specific field |
 | geo_polygon | [GeoPolygon](#qdrant-GeoPolygon) |  | Check if geo point is within a given polygon |
 | datetime_range | [DatetimeRange](#qdrant-DatetimeRange) |  | Check if datetime is within a given range |
+| integer_range | [IntegerRange](#qdrant-IntegerRange) |  | Check if integer is within a given range |
 
 
 
@@ -2278,6 +2280,24 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | has_id | [PointId](#qdrant-PointId) | repeated |  |
+
+
+
+
+
+
+<a name="qdrant-IntegerRange"></a>
+
+### IntegerRange
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| lt | [int64](#int64) | optional |  |
+| gt | [int64](#int64) | optional |  |
+| gte | [int64](#int64) | optional |  |
+| lte | [int64](#int64) | optional |  |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7401,12 +7401,12 @@
       "StartFrom": {
         "anyOf": [
           {
-            "type": "number",
-            "format": "double"
-          },
-          {
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "type": "number",
+            "format": "double"
           },
           {
             "type": "string",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6617,6 +6617,9 @@
             "$ref": "#/components/schemas/Range"
           },
           {
+            "$ref": "#/components/schemas/IntegerRange"
+          },
+          {
             "$ref": "#/components/schemas/DatetimeRange"
           }
         ]
@@ -6647,6 +6650,36 @@
             "description": "point.key <= range.lte",
             "type": "number",
             "format": "double",
+            "nullable": true
+          }
+        }
+      },
+      "IntegerRange": {
+        "description": "Range filter request",
+        "type": "object",
+        "properties": {
+          "lt": {
+            "description": "point.key < range.lt",
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "gt": {
+            "description": "point.key > range.gt",
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "gte": {
+            "description": "point.key >= range.gte",
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "lte": {
+            "description": "point.key <= range.lte",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           }
         }
@@ -7370,6 +7403,10 @@
           {
             "type": "number",
             "format": "double"
+          },
+          {
+            "type": "integer",
+            "format": "int64"
           },
           {
             "type": "string",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6614,45 +6614,15 @@
       "RangeInterface": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/Range"
+            "$ref": "#/components/schemas/IntegerRange"
           },
           {
-            "$ref": "#/components/schemas/IntegerRange"
+            "$ref": "#/components/schemas/Range"
           },
           {
             "$ref": "#/components/schemas/DatetimeRange"
           }
         ]
-      },
-      "Range": {
-        "description": "Range filter request",
-        "type": "object",
-        "properties": {
-          "lt": {
-            "description": "point.key < range.lt",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "gt": {
-            "description": "point.key > range.gt",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "gte": {
-            "description": "point.key >= range.gte",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "lte": {
-            "description": "point.key <= range.lte",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          }
-        }
       },
       "IntegerRange": {
         "description": "Range filter request",
@@ -6680,6 +6650,36 @@
             "description": "point.key <= range.lte",
             "type": "integer",
             "format": "int64",
+            "nullable": true
+          }
+        }
+      },
+      "Range": {
+        "description": "Range filter request",
+        "type": "object",
+        "properties": {
+          "lt": {
+            "description": "point.key < range.lt",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "gt": {
+            "description": "point.key > range.gt",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "gte": {
+            "description": "point.key >= range.gte",
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "lte": {
+            "description": "point.key <= range.lte",
+            "type": "number",
+            "format": "double",
             "nullable": true
           }
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -691,6 +691,7 @@ message FieldCondition {
   ValuesCount values_count = 6; // Check number of values for a specific field
   GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
   DatetimeRange datetime_range = 8; // Check if datetime is within a given range
+  IntegerRange integer_range = 9; // Check if integer is within a given range
 }
 
 message Match {
@@ -719,6 +720,13 @@ message Range {
   optional double gt = 2;
   optional double gte = 3;
   optional double lte = 4;
+}
+
+message IntegerRange {
+  optional int64 lt = 1;
+  optional int64 gt = 2;
+  optional int64 gte = 3;
+  optional int64 lte = 4;
 }
 
 message DatetimeRange {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4254,6 +4254,9 @@ pub struct FieldCondition {
     /// Check if datetime is within a given range
     #[prost(message, optional, tag = "8")]
     pub datetime_range: ::core::option::Option<DatetimeRange>,
+    /// Check if integer is within a given range
+    #[prost(message, optional, tag = "9")]
+    pub integer_range: ::core::option::Option<IntegerRange>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -4320,6 +4323,19 @@ pub struct Range {
     pub gte: ::core::option::Option<f64>,
     #[prost(double, optional, tag = "4")]
     pub lte: ::core::option::Option<f64>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IntegerRange {
+    #[prost(int64, optional, tag = "1")]
+    pub lt: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "2")]
+    pub gt: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "3")]
+    pub gte: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "4")]
+    pub lte: ::core::option::Option<i64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1804,10 +1804,7 @@ impl TryFrom<api::grpc::qdrant::OrderBy> for OrderByInterface {
                     api::grpc::qdrant::start_from::Value::Float(float) => {
                         Ok(StartFrom::Float(float))
                     }
-                    // TODO(luis): make appropriate conversion once we allow int start_from
-                    api::grpc::qdrant::start_from::Value::Integer(int) => {
-                        Ok(StartFrom::Float(int as _))
-                    }
+                    api::grpc::qdrant::start_from::Value::Integer(int) => Ok(StartFrom::Int(int)),
                     api::grpc::qdrant::start_from::Value::Timestamp(timestamp) => {
                         Ok(StartFrom::Datetime(date_time_from_proto(timestamp)?))
                     }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -42,6 +42,8 @@ impl Direction {
 pub enum StartFrom {
     Float(FloatPayloadType),
 
+    Int(IntPayloadType),
+    
     Datetime(DateTimePayloadType),
 }
 
@@ -65,6 +67,7 @@ impl OrderBy {
             .as_ref()
             .map(|start_from| match start_from {
                 StartFrom::Float(f) => RangeInterface::Float(self.direction().as_range_from(*f)),
+                StartFrom::Int(i) => RangeInterface::Int(self.direction().as_range_from(*i)),
                 StartFrom::Datetime(dt) => {
                     RangeInterface::DateTime(self.direction().as_range_from(*dt))
                 }
@@ -81,6 +84,7 @@ impl OrderBy {
             .as_ref()
             .map(|start_from| match start_from {
                 StartFrom::Float(f) => OrderingValue::Float(*f),
+                StartFrom::Int(i) => OrderingValue::Int(*i),
                 StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp()),
             })
             .unwrap_or_else(|| match self.direction() {

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -43,7 +43,7 @@ pub enum StartFrom {
     Float(FloatPayloadType),
 
     Int(IntPayloadType),
-    
+
     Datetime(DateTimePayloadType),
 }
 

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -19,7 +19,7 @@ pub enum Direction {
 }
 
 impl Direction {
-    pub fn as_range_from<T>(&self, from: T) -> Range<T> {
+    pub fn as_range_from<T: Copy>(&self, from: T) -> Range<T> {
         match self {
             Direction::Asc => Range {
                 gte: Some(from),

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -40,9 +40,9 @@ impl Direction {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
 pub enum StartFrom {
-    Float(FloatPayloadType),
-
     Int(IntPayloadType),
+
+    Float(FloatPayloadType),
 
     Datetime(DateTimePayloadType),
 }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -417,7 +417,7 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
                         _ => None,
                     },
                 };
-                let cardinality = self.range_cardinality(&RangeInterface::Float(range.clone()));
+                let cardinality = self.range_cardinality(&RangeInterface::Float(range));
                 let condition = PayloadBlockCondition {
                     condition: FieldCondition::new_range(key.clone(), range),
                     cardinality: cardinality.exp,
@@ -542,7 +542,7 @@ where
         &self,
         range_interface: &RangeInterface,
     ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
-        let range = Range::from(range_interface.clone());
+        let range = Range::from(*range_interface);
         let (start_bound, end_bound) = range.as_index_key_bounds();
 
         // map.range

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -241,6 +241,7 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
             RangeInterface::DateTime(datetime_range) => {
                 datetime_range.map(|dt| T::from_i64(dt.timestamp()))
             }
+            RangeInterface::Int(int_range) => int_range.map(T::from_i64),
         };
 
         let lbound = if let Some(lte) = range.lte {
@@ -339,18 +340,12 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
         &self,
         condition: &FieldCondition,
     ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
-        let range_cond = condition
+        let range_interface = condition
             .range
             .as_ref()
             .ok_or_else(|| OperationError::service_error("failed to get range condition"))?;
 
-        let (start_bound, end_bound) = match range_cond {
-            RangeInterface::Float(float_range) => float_range.map(T::from_f64),
-            RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
-            }
-        }
-        .as_index_key_bounds();
+        let (start_bound, end_bound) = range_interface.to_range().as_index_key_bounds();
 
         // map.range
         // Panics if range start > end. Panics if range start == end and both bounds are Excluded.
@@ -527,20 +522,27 @@ impl ValueIndexer<FloatPayloadType> for NumericIndex<FloatPayloadType> {
     }
 }
 
+impl RangeInterface {
+    fn to_range<T: Numericable>(&self) -> Range<T> {
+        match self {
+            RangeInterface::Float(float_range) => float_range.map(T::from_f64),
+            RangeInterface::Int(int_range) => int_range.map(T::from_i64),
+            RangeInterface::DateTime(datetime_range) => {
+                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
+            }
+        }
+    }
+}
+
 impl<T> StreamRange<T> for NumericIndex<T>
 where
     T: Encodable + Numericable + Default,
 {
     fn stream_range(
         &self,
-        range: &RangeInterface,
+        range_interface: &RangeInterface,
     ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
-        let range = match range {
-            RangeInterface::Float(float_range) => float_range.map(T::from_f64),
-            RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
-            }
-        };
+        let range = range_interface.to_range();
         let (start_bound, end_bound) = range.as_index_key_bounds();
 
         // map.range

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -56,7 +56,7 @@ fn cardinality_request(
     index: &NumericIndex<f64>,
     query: Range<FloatPayloadType>,
 ) -> CardinalityEstimation {
-    let estimation = index.range_cardinality(&RangeInterface::Float(query.clone()));
+    let estimation = index.range_cardinality(&RangeInterface::Float(query));
 
     let result = index
         .filter(&FieldCondition::new_range("".to_string(), query))

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -256,12 +256,14 @@ pub fn get_int_range_checkers(
                 .get_values(point_id)
                 .is_some_and(|values| values.iter().copied().any(|i| range.check_range(i)))
         })),
-        FieldIndex::FloatIndex(num_index) => Some(Box::new(move |point_id: PointOffsetType| {
+        FieldIndex::FloatIndex(num_index) => {
             let range = range.map(|i| i as FloatPayloadType);
-            num_index
-                .get_values(point_id)
-                .is_some_and(|values| values.iter().copied().any(|f| range.check_range(f)))
-        })),
+            Some(Box::new(move |point_id: PointOffsetType| {
+                num_index
+                    .get_values(point_id)
+                    .is_some_and(|values| values.iter().copied().any(|f| range.check_range(f)))
+            }))
+        }
         _ => None,
     }
 }

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -137,7 +137,7 @@ pub fn field_condition_index<'a>(
 
         FieldCondition {
             range: Some(cond), ..
-        } => get_range_checkers(index, cond.clone()),
+        } => get_range_checkers(index, *cond),
 
         FieldCondition {
             geo_radius: Some(geo_radius),

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -229,14 +229,11 @@ pub fn get_float_range_checkers(
     range: Range<FloatPayloadType>,
 ) -> Option<ConditionCheckerFn> {
     match index {
-        FieldIndex::IntIndex(num_index) => {
-            let range = range.map(|f| f as IntPayloadType);
-            Some(Box::new(move |point_id: PointOffsetType| {
-                num_index
-                    .get_values(point_id)
-                    .is_some_and(|values| values.iter().copied().any(|i| range.check_range(i)))
-            }))
-        }
+        FieldIndex::IntIndex(num_index) => Some(Box::new(move |point_id: PointOffsetType| {
+            num_index
+                .get_values(point_id)
+                .is_some_and(|values| values.iter().copied().any(|i| range.check_range_num_cmp(i)))
+        })),
         FieldIndex::FloatIndex(num_index) => Some(Box::new(move |point_id: PointOffsetType| {
             num_index
                 .get_values(point_id)
@@ -256,14 +253,11 @@ pub fn get_int_range_checkers(
                 .get_values(point_id)
                 .is_some_and(|values| values.iter().copied().any(|i| range.check_range(i)))
         })),
-        FieldIndex::FloatIndex(num_index) => {
-            let range = range.map(|i| i as FloatPayloadType);
-            Some(Box::new(move |point_id: PointOffsetType| {
-                num_index
-                    .get_values(point_id)
-                    .is_some_and(|values| values.iter().copied().any(|f| range.check_range(f)))
-            }))
-        }
+        FieldIndex::FloatIndex(num_index) => Some(Box::new(move |point_id: PointOffsetType| {
+            num_index
+                .get_values(point_id)
+                .is_some_and(|values| values.iter().copied().any(|f| range.check_range_num_cmp(f)))
+        })),
         _ => None,
     }
 }

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -149,25 +149,19 @@ impl ValueChecker for RangeInterface {
 
 impl ValueChecker for Range<FloatPayloadType> {
     fn check_match(&self, payload: &Value) -> bool {
-        match payload {
-            Value::Number(num) => num
-                .as_f64()
-                .map(|number| self.check_range(number))
-                .unwrap_or(false),
-            _ => false,
-        }
+        payload
+            .as_number()
+            .and_then(|x| x.as_f64().or_else(|| x.as_i64().map(|x| x as f64)))
+            .map_or(false, |x| self.check_range(x))
     }
 }
 
 impl ValueChecker for Range<IntPayloadType> {
     fn check_match(&self, payload: &Value) -> bool {
-        match payload {
-            Value::Number(num) => num
-                .as_i64()
-                .map(|number| self.check_range(number))
-                .unwrap_or(false),
-            _ => false,
-        }
+        payload
+            .as_number()
+            .and_then(|x| x.as_i64().or_else(|| x.as_f64().map(|x| x as i64)))
+            .map_or(false, |x| self.check_range(x))
     }
 }
 

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -151,17 +151,17 @@ impl ValueChecker for Range<FloatPayloadType> {
     fn check_match(&self, payload: &Value) -> bool {
         payload
             .as_number()
-            .and_then(|x| x.as_f64().or_else(|| x.as_i64().map(|x| x as f64)))
-            .map_or(false, |x| self.check_range(x))
+            .and_then(|x| x.as_f64())
+            .is_some_and(|x| self.check_range(x))
     }
 }
 
 impl ValueChecker for Range<IntPayloadType> {
     fn check_match(&self, payload: &Value) -> bool {
-        payload
-            .as_number()
-            .and_then(|x| x.as_i64().or_else(|| x.as_f64().map(|x| x as i64)))
-            .map_or(false, |x| self.check_range(x))
+        payload.as_number().is_some_and(|x| {
+            x.as_i64().is_some_and(|x| self.check_range(x))
+                || x.as_f64().is_some_and(|x| self.check_range_num_cmp(x))
+        })
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1391,12 +1391,13 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
 #[serde(untagged)]
 pub enum RangeInterface {
     Float(Range<FloatPayloadType>),
+    Int(Range<IntPayloadType>),
     DateTime(Range<DateTimePayloadType>),
 }
 
 /// Range filter request
 #[macro_rules_attribute::macro_rules_derive(crate::common::macros::schemars_rename_generics)]
-#[derive_args(< FloatPayloadType > => "Range", < DateTimePayloadType > => "DatetimeRange")]
+#[derive_args(<FloatPayloadType> => "Range", <DateTimePayloadType> => "DatetimeRange", <IntPayloadType> => "IntegerRange")]
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Range<T> {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -13,6 +13,7 @@ use geo::prelude::HaversineDistance;
 use geo::{Contains, Coord, LineString, Point, Polygon};
 use indexmap::IndexSet;
 use itertools::Itertools;
+use num_cmp::NumCmp;
 use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -1457,6 +1458,15 @@ impl<T: Copy + PartialOrd> Range<T> {
             && self.gt.map_or(true, |x| number > x)
             && self.lte.map_or(true, |x| number <= x)
             && self.gte.map_or(true, |x| number >= x)
+    }
+}
+
+impl<T: Copy> Range<T> {
+    pub fn check_range_num_cmp(&self, number: impl NumCmp<T>) -> bool {
+        self.lt.map_or(true, |x| number.num_lt(x))
+            && self.gt.map_or(true, |x| number.num_gt(x))
+            && self.lte.map_or(true, |x| number.num_le(x))
+            && self.gte.map_or(true, |x| number.num_ge(x))
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1416,7 +1416,7 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Copy)]
 #[serde(untagged)]
 pub enum RangeInterface {
     Int(Range<IntPayloadType>),
@@ -1427,7 +1427,7 @@ pub enum RangeInterface {
 /// Range filter request
 #[macro_rules_attribute::macro_rules_derive(crate::common::macros::schemars_rename_generics)]
 #[derive_args(<FloatPayloadType> => "Range", <DateTimePayloadType> => "DatetimeRange", <IntPayloadType> => "IntegerRange")]
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Copy)]
 #[serde(rename_all = "snake_case")]
 pub struct Range<T> {
     /// point.key < range.lt
@@ -1442,7 +1442,7 @@ pub struct Range<T> {
 
 impl<T: Copy> Range<T> {
     /// Convert range to a range of another type
-    pub fn map<U, F: Fn(T) -> U>(&self, f: F) -> Range<U> {
+    pub fn map<U: Copy, F: Fn(T) -> U>(&self, f: F) -> Range<U> {
         Range {
             lt: self.lt.map(&f),
             gt: self.gt.map(&f),

--- a/tests/openapi/openapi_integration/helpers/collection_setup.py
+++ b/tests/openapi/openapi_integration/helpers/collection_setup.py
@@ -178,7 +178,7 @@ def basic_collection_setup(
                 {
                     "id": 5,
                     "vector": [0.24, 0.18, 0.22, 0.44],
-                    "payload": {"count": 0}
+                    "payload": {"count": 0, "price": 12.5}
                 },
                 {
                     "id": 6,

--- a/tests/openapi/openapi_integration/test_filter.py
+++ b/tests/openapi/openapi_integration/test_filter.py
@@ -3,7 +3,7 @@ import pytest
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 from .helpers.helpers import request_with_validation
 
-collection_name = 'test_collection_filter'
+collection_name = "test_collection_filter"
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -15,30 +15,21 @@ def setup(on_disk_vectors):
 
 def test_match_any():
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search',
+        api="/collections/{collection_name}/points/search",
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
             "limit": 3,
-            "filter": {
-                "must": [
-                    {
-                        "key": "city",
-                        "match": {
-                            "any": ["London", "Moscow"]
-                        }
-                    }
-                ]
-            }
-        }
+            "filter": {"must": [{"key": "city", "match": {"any": ["London", "Moscow"]}}]},
+        },
     )
     assert response.ok
 
     json = response.json()
-    assert len(json['result']) == 3
+    assert len(json["result"]) == 3
 
-    ids = [x['id'] for x in json['result']]
+    ids = [x["id"] for x in json["result"]]
     assert 2 in ids
     assert 3 in ids
     assert 4 in ids
@@ -47,9 +38,9 @@ def test_match_any():
 def test_just_key():
     # the filter will be ignored as the condition is not well-formed
     response = request_with_validation(
-        api='/collections/{collection_name}/points/search',
+        api="/collections/{collection_name}/points/search",
         method="POST",
-        path_params={'collection_name': collection_name},
+        path_params={"collection_name": collection_name},
         body={
             "vector": [0.2, 0.1, 0.9, 0.7],
             "limit": 3,
@@ -59,11 +50,48 @@ def test_just_key():
                         "key": "city",
                     }
                 ]
-            }
-        }
+            },
+        },
     )
     assert not response.ok
     assert response.status_code == 422
     error = response.json()["status"]["error"]
     assert "Validation error in JSON body" in error
     assert "At least one field condition must be specified" in error
+
+
+@pytest.mark.parametrize(
+    "key, range",
+    [
+        pytest.param("count", {"lt": 2}, id="int_range_for_int_value"),
+        pytest.param("price", {"gte": 2}, id="int_range_for_float_value"),
+        pytest.param("price", {"gte": 12}, id="int_range_for_float_value"),
+        pytest.param("price", {"gte": 12.0}, id="float_range_for_float_value"),
+        pytest.param("price", {"lt": 12.7}, id="float_range_for_float_value"),
+        pytest.param("count", {"lt": 0.5}, id="float_range_for_int_value"),
+        pytest.param("count", {"gt": -1.0}, id="float_range_for_int_value"),
+    ]
+)
+def test_range_interface(key: str, range: dict):
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/scroll",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "limit": 3,
+            "filter": {
+                "must": [
+                    {
+                        "key": key,
+                        "range": range,
+                    }
+                ]
+            },
+        },
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json["result"]["points"]) == 1, json
+    assert json["result"]["points"][0]["id"] == 5, json
+


### PR DESCRIPTION
To finish taking advantage of the newly added range interface. This adds:
- `Range<IntPayloadType>` to `RangeInterface`
- `StartFrom::Int(IntPayloadType)` variant for order-by `scroll` requests.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
