### PR TITLE
Change `io` imports because it breaks on auto formatters

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -1,8 +1,8 @@
+use std::cmp;
 use std::collections::{hash_map, HashMap};
 use std::path::Path;
-use std::{cmp, io};
 
-use ::io::file_operations;
+use io::file_operations;
 use serde::{Deserialize, Serialize};
 
 use crate::operations::types::CollectionError;
@@ -20,7 +20,7 @@ impl ClockMap {
         let result = Self::load(path);
 
         if let Err(Error::Io(err)) = &result {
-            if err.kind() == io::ErrorKind::NotFound {
+            if err.kind() == std::io::ErrorKind::NotFound {
                 return Ok(Self::default());
             }
         }
@@ -142,7 +142,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, thiserror::Error)]
 #[error("failed to load/store the clock map: {0}")]
 pub enum Error {
-    Io(#[from] io::Error),
+    Io(#[from] std::io::Error),
     SerdeJson(#[from] serde_json::Error),
 }
 


### PR DESCRIPTION
My auto formatter constantly keeps removing the `::` prefix from `use io::file_operations;`, breaking imports.

I suggest to change imports like this to prevent this problem.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?