### PR TITLE
refactor: add DateTime wrapper

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1311,18 +1311,18 @@ pub fn naive_date_time_to_proto(date_time: NaiveDateTime) -> prost_wkt_types::Ti
     }
 }
 
-pub fn date_time_to_proto(date_time: chrono::DateTime<chrono::Utc>) -> prost_wkt_types::Timestamp {
-    naive_date_time_to_proto(date_time.naive_utc())
+pub fn date_time_to_proto(date_time: DateTimePayloadType) -> prost_wkt_types::Timestamp {
+    naive_date_time_to_proto(date_time.0.naive_utc())
 }
 
 pub fn date_time_from_proto(
     date_time: prost_wkt_types::Timestamp,
-) -> Result<chrono::DateTime<chrono::Utc>, Status> {
+) -> Result<DateTimePayloadType, Status> {
     chrono::NaiveDateTime::from_timestamp_opt(
         date_time.seconds,
         date_time.nanos.try_into().unwrap_or(0),
     )
-    .map(|naive_date_time| chrono::Utc.from_utc_datetime(&naive_date_time))
+    .map(|naive_date_time| chrono::Utc.from_utc_datetime(&naive_date_time).into())
     .ok_or_else(|| Status::invalid_argument(format!("Unable to parse timestamp: {date_time}")))
 }
 

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use num_cmp::NumCmp;
 use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
@@ -6,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::types::{
-    deserialize_datetime, FloatPayloadType, IntPayloadType, Payload, Range, RangeInterface,
+    DateTimePayloadType, FloatPayloadType, IntPayloadType, Payload, Range, RangeInterface,
 };
 
 const INTERNAL_KEY_OF_ORDER_BY_VALUE: &str = "____ordered_with____";
@@ -43,8 +42,7 @@ impl Direction {
 pub enum StartFrom {
     Float(FloatPayloadType),
 
-    #[serde(deserialize_with = "deserialize_datetime")]
-    Datetime(DateTime<Utc>),
+    Datetime(DateTimePayloadType),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, Default)]
@@ -83,7 +81,7 @@ impl OrderBy {
             .as_ref()
             .map(|start_from| match start_from {
                 StartFrom::Float(f) => OrderingValue::Float(*f),
-                StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp_micros()),
+                StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp()),
             })
             .unwrap_or_else(|| match self.direction() {
                 Direction::Asc => OrderingValue::Int(std::i64::MIN),

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -95,7 +95,7 @@ impl Encodable for FloatPayloadType {
 /// Encodes timestamps as i64 in microseconds
 impl Encodable for DateTimePayloadType {
     fn encode_key(&self, id: PointOffsetType) -> Vec<u8> {
-        encode_i64_key_ascending(self.timestamp_micros(), id)
+        encode_i64_key_ascending(self.timestamp(), id)
     }
 
     fn decode_key(key: &[u8]) -> (PointOffsetType, Self) {
@@ -110,11 +110,11 @@ impl Encodable for DateTimePayloadType {
                 NaiveDateTime::UNIX_EPOCH
             }),
         );
-        (id, datetime)
+        (id, datetime.into())
     }
 
     fn cmp_encoded(&self, other: &Self) -> std::cmp::Ordering {
-        self.timestamp_micros().cmp(&other.timestamp_micros())
+        self.timestamp().cmp(&other.timestamp())
     }
 }
 
@@ -238,7 +238,7 @@ impl<T: Encodable + Numericable + Default> NumericIndex<T> {
         let range = match range {
             RangeInterface::Float(float_range) => float_range.map(T::from_f64),
             RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_i64(dt.timestamp_micros()))
+                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
             }
         };
 
@@ -346,7 +346,7 @@ impl<T: Encodable + Numericable + Default> PayloadFieldIndex for NumericIndex<T>
         let (start_bound, end_bound) = match range_cond {
             RangeInterface::Float(float_range) => float_range.map(T::from_f64),
             RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_i64(dt.timestamp_micros()))
+                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
             }
         }
         .as_index_key_bounds();
@@ -486,7 +486,7 @@ impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType> {
     ) -> OperationResult<()> {
         match self {
             NumericIndex::Mutable(index) => {
-                index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp_micros()))
+                index.add_many_to_list(id, values.into_iter().map(|x| x.timestamp()))
             }
             NumericIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
@@ -537,7 +537,7 @@ where
         let range = match range {
             RangeInterface::Float(float_range) => float_range.map(T::from_f64),
             RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_i64(dt.timestamp_micros()))
+                datetime_range.map(|dt| T::from_i64(dt.timestamp()))
             }
         };
         let (start_bound, end_bound) = range.as_index_key_bounds();

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -7,6 +7,7 @@ mod tests;
 use std::cmp::{max, min};
 use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use chrono::{NaiveDateTime, TimeZone};
@@ -33,8 +34,8 @@ use crate::index::key_encoding::{
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
-    try_parse_datetime, DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType,
-    PayloadKeyType, Range, RangeInterface,
+    DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, PayloadKeyType, Range,
+    RangeInterface,
 };
 
 const HISTOGRAM_MAX_BUCKET_SIZE: usize = 10_000;
@@ -495,7 +496,7 @@ impl ValueIndexer<DateTimePayloadType> for NumericIndex<IntPayloadType> {
     }
 
     fn get_value(&self, value: &Value) -> Option<DateTimePayloadType> {
-        try_parse_datetime(value.as_str()?)
+        DateTimePayloadType::from_str(value.as_str()?).ok()
     }
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -251,7 +251,7 @@ pub fn get_datetime_range_checkers(
 ) -> Option<ConditionCheckerFn> {
     match index {
         FieldIndex::DatetimeIndex(num_index) => {
-            let range = range.map(|ts| ts.timestamp_micros());
+            let range = range.map(|dt| dt.timestamp());
             Some(Box::new(move |point_id: PointOffsetType| {
                 num_index
                     .get_values(point_id)

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,11 +1,13 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
+use std::str::FromStr;
+
 use serde_json::Value;
 
 use crate::types::{
-    try_parse_datetime, AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType,
-    GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchText,
-    MatchValue, Range, RangeInterface, ValueVariants, ValuesCount,
+    AnyVariants, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPoint,
+    GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchText, MatchValue, Range,
+    RangeInterface, ValueVariants, ValuesCount,
 };
 
 /// Threshold representing the point to which iterating through an IndexSet is more efficient than using hashing.
@@ -154,7 +156,7 @@ impl ValueChecker for Range<DateTimePayloadType> {
     fn check_match(&self, payload: &Value) -> bool {
         payload
             .as_str()
-            .and_then(try_parse_datetime)
+            .and_then(|s| DateTimePayloadType::from_str(s).ok())
             .is_some_and(|x| self.check_range(x))
     }
 }

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -267,7 +267,8 @@ mod tests {
     use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
     use crate::payload_storage::PayloadStorage;
     use crate::types::{
-        FieldCondition, GeoBoundingBox, GeoPoint, PayloadField, Range, ValuesCount,
+        try_parse_datetime, FieldCondition, GeoBoundingBox, GeoPoint, PayloadField, Range,
+        ValuesCount,
     };
 
     #[test]
@@ -382,34 +383,18 @@ mod tests {
         let shipped_in_february = Condition::Field(FieldCondition::new_datetime_range(
             "shipped_at".to_string(),
             Range {
-                lt: Some(
-                    chrono::DateTime::parse_from_rfc3339("2020-03-01T00:00:00Z")
-                        .unwrap()
-                        .into(),
-                ),
+                lt: Some(try_parse_datetime("2020-03-01T00:00:00Z").unwrap()),
                 gt: None,
-                gte: Some(
-                    chrono::DateTime::parse_from_rfc3339("2020-02-01T00:00:00Z")
-                        .unwrap()
-                        .into(),
-                ),
+                gte: Some(try_parse_datetime("2020-02-01T00:00:00Z").unwrap()),
                 lte: None,
             },
         ));
         let shipped_in_march = Condition::Field(FieldCondition::new_datetime_range(
             "shipped_at".to_string(),
             Range {
-                lt: Some(
-                    chrono::DateTime::parse_from_rfc3339("2020-04-01T00:00:00Z")
-                        .unwrap()
-                        .into(),
-                ),
+                lt: Some(try_parse_datetime("2020-04-01T00:00:00Z").unwrap()),
                 gt: None,
-                gte: Some(
-                    chrono::DateTime::parse_from_rfc3339("2020-03-01T00:00:00Z")
-                        .unwrap()
-                        .into(),
-                ),
+                gte: Some(try_parse_datetime("2020-03-01T00:00:00Z").unwrap()),
                 lte: None,
             },
         ));

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -256,6 +256,7 @@ impl ConditionChecker for SimpleConditionChecker {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::str::FromStr;
 
     use serde_json::json;
     use tempfile::Builder;
@@ -267,8 +268,7 @@ mod tests {
     use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
     use crate::payload_storage::PayloadStorage;
     use crate::types::{
-        try_parse_datetime, FieldCondition, GeoBoundingBox, GeoPoint, PayloadField, Range,
-        ValuesCount,
+        DateTimeWrapper, FieldCondition, GeoBoundingBox, GeoPoint, PayloadField, Range, ValuesCount,
     };
 
     #[test]
@@ -383,18 +383,18 @@ mod tests {
         let shipped_in_february = Condition::Field(FieldCondition::new_datetime_range(
             "shipped_at".to_string(),
             Range {
-                lt: Some(try_parse_datetime("2020-03-01T00:00:00Z").unwrap()),
+                lt: Some(DateTimeWrapper::from_str("2020-03-01T00:00:00Z").unwrap()),
                 gt: None,
-                gte: Some(try_parse_datetime("2020-02-01T00:00:00Z").unwrap()),
+                gte: Some(DateTimeWrapper::from_str("2020-02-01T00:00:00Z").unwrap()),
                 lte: None,
             },
         ));
         let shipped_in_march = Condition::Field(FieldCondition::new_datetime_range(
             "shipped_at".to_string(),
             Range {
-                lt: Some(try_parse_datetime("2020-04-01T00:00:00Z").unwrap()),
+                lt: Some(DateTimeWrapper::from_str("2020-04-01T00:00:00Z").unwrap()),
                 gt: None,
-                gte: Some(try_parse_datetime("2020-03-01T00:00:00Z").unwrap()),
+                gte: Some(DateTimeWrapper::from_str("2020-03-01T00:00:00Z").unwrap()),
                 lte: None,
             },
         ));

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -45,7 +45,41 @@ pub type FloatPayloadType = f64;
 /// Type of integer point payload
 pub type IntPayloadType = i64;
 /// Type of datetime point payload
-pub type DateTimePayloadType = chrono::DateTime<chrono::Utc>;
+pub type DateTimePayloadType = DateTimeWrapper;
+
+/// Wraps `DateTime<Utc>` to allow more flexible deserialization
+#[derive(Clone, Copy, Serialize, JsonSchema, Debug, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct DateTimeWrapper(pub chrono::DateTime<chrono::Utc>);
+
+impl DateTimeWrapper {
+    /// Qdrant's representation of datetime as timestamp is an i64 of microseconds
+    pub fn timestamp(&self) -> i64 {
+        self.0.timestamp_micros()
+    }
+}
+
+impl<'de> Deserialize<'de> for DateTimeWrapper {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let str_datetime = <&str>::deserialize(deserializer)?;
+        let parse_result = try_parse_datetime(str_datetime);
+        match parse_result {
+            Some(datetime) => Ok(datetime),
+            None => Err(serde::de::Error::custom(format!(
+                "'{str_datetime}' is not in a supported date/time format, please use RFC 3339"
+            ))),
+        }
+    }
+}
+
+impl From<chrono::DateTime<chrono::Utc>> for DateTimeWrapper {
+    fn from(dt: chrono::DateTime<chrono::Utc>) -> Self {
+        DateTimeWrapper(dt)
+    }
+}
 
 pub const VECTOR_ELEMENT_SIZE: usize = size_of::<VectorElementType>();
 
@@ -1357,7 +1391,6 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
 #[serde(untagged)]
 pub enum RangeInterface {
     Float(Range<FloatPayloadType>),
-    #[serde(deserialize_with = "deserialize_datetime_range")]
     DateTime(Range<DateTimePayloadType>),
 }
 
@@ -1380,7 +1413,7 @@ pub struct Range<T> {
 pub fn try_parse_datetime(s: &str) -> Option<DateTimePayloadType> {
     // Attempt to parse the input string in RFC 3339 format
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(s) {
-        return Some(datetime.into());
+        return Some(chrono::DateTime::<chrono::Utc>::from(datetime).into());
     }
 
     // Attempt to parse the input string in the specified formats:
@@ -1404,59 +1437,8 @@ pub fn try_parse_datetime(s: &str) -> Option<DateTimePayloadType> {
     };
 
     // Convert the parsed NaiveDateTime to a DateTime<Utc>
-    let datetime_utc = datetime.and_utc();
+    let datetime_utc = datetime.and_utc().into();
     Some(datetime_utc)
-}
-
-fn deserialize_datetime_str<'de, D>(s: &str) -> Result<DateTimePayloadType, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // Attempt to parse the input string to datetime
-    let parse_result = try_parse_datetime(s);
-    match parse_result {
-        Some(datetime) => Ok(datetime),
-        None => Err(serde::de::Error::custom(format!(
-            "'{s}' is not in a supported date/time format, please use RFC 3339"
-        ))),
-    }
-}
-
-fn deserialize_datetime_option<'de, D>(
-    s: Option<&str>,
-) -> Result<Option<DateTimePayloadType>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let Some(s) = s else {
-        return Ok(None);
-    };
-    Some(deserialize_datetime_str::<D>(s)).transpose()
-}
-
-pub(crate) fn deserialize_datetime<'de, D>(deserializer: D) -> Result<DateTimePayloadType, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let str_datetime = <&str>::deserialize(deserializer)?;
-    // Attempt to parse the input string to datetime
-    deserialize_datetime_str::<D>(str_datetime)
-}
-
-fn deserialize_datetime_range<'de, D>(
-    deserializer: D,
-) -> Result<Range<DateTimePayloadType>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let str_range = Range::<&str>::deserialize(deserializer)?;
-    let datetime_range = Range::<chrono::DateTime<chrono::Utc>> {
-        lt: deserialize_datetime_option::<D>(str_range.lt)?,
-        lte: deserialize_datetime_option::<D>(str_range.lte)?,
-        gt: deserialize_datetime_option::<D>(str_range.gt)?,
-        gte: deserialize_datetime_option::<D>(str_range.gte)?,
-    };
-    Ok(datetime_range)
 }
 
 impl<T: Copy> Range<T> {


### PR DESCRIPTION
Creates a newtype pattern for `DateTime<Utc>`, so that we can encapsulate the special deserialization and conversion to timestamp in a single entity.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
