### PR TITLE
Fix flaky `dashboard::tests::test_singleton`

### DIFF
--- a/lib/common/issues/src/dashboard.rs
+++ b/lib/common/issues/src/dashboard.rs
@@ -83,39 +83,31 @@ mod tests {
     #[serial]
     fn test_singleton() -> std::thread::Result<()> {
         clear();
+
         let handle1 = std::thread::spawn(|| {
             submit(DummyIssue::new("issue1"));
             submit(DummyIssue::new("issue2"));
             submit(DummyIssue::new("issue3"));
-
-            std::thread::sleep(std::time::Duration::from_millis(50));
-
-            assert!(!submit(DummyIssue::new("issue4")));
         });
 
         let handle2 = std::thread::spawn(|| {
             submit(DummyIssue::new("issue4"));
             submit(DummyIssue::new("issue5"));
             submit(DummyIssue::new("issue6"));
-
-            std::thread::sleep(std::time::Duration::from_millis(50));
-
-            assert!(!submit(DummyIssue::new("issue1")));
-
-            std::thread::sleep(std::time::Duration::from_millis(40));
-
-            assert!(solve("issue1"));
-            assert!(solve("issue2"));
-            assert!(solve("issue3"));
-            assert!(solve("issue4"));
-            assert!(solve("issue5"));
-            assert!(solve("issue6"));
         });
-
-        std::thread::sleep(std::time::Duration::from_millis(140));
 
         handle1.join()?;
         handle2.join()?;
+
+        assert_eq!(all_issues().len(), 6);
+        assert!(solve("issue1"));
+        assert!(solve("issue2"));
+        assert!(solve("issue3"));
+        assert!(solve("issue4"));
+        assert!(solve("issue5"));
+        assert!(solve("issue6"));
+
+        clear();
         Ok(())
     }
 }


### PR DESCRIPTION
The mistake here was to make the test depend on timings, which made the test brittle for CI.

I've refactored it to avoid using them, it should completely remove flakiness.

Fixes #3566

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


