### PR TITLE
Improve recovery point display formatting

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -219,10 +219,10 @@ impl Display for RecoveryPoint {
         let clocks = self
             .clocks
             .iter()
-            .map(|(key, tick)| format!("{}({}): {tick})", key.peer_id, key.clock_id))
+            .map(|(key, tick)| format!("{}({}): {tick}", key.peer_id, key.clock_id))
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "RecoveryPoint [ {clocks} ]")
+        write!(f, "RecoveryPoint[{clocks}]")
     }
 }
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This changes the `Display` implementation for `RecoveryPoint`. Most importantly, this removes the `)` after each entry, which should not be there.

Changes from
```
RecoveryPoint [ 6538154117724707(1): 53), 6538154117724707(0): 245) ]
```
to
```
RecoveryPoint[6538154117724707(1):53, 6538154117724707(0):245]
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
