### PR TITLE
Remove secondary ordering by id description from `order_by` parameter

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3050,7 +3050,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | with_vectors | [WithVectorsSelector](#qdrant-WithVectorsSelector) | optional | Options for specifying which vectors to include into response |
 | read_consistency | [ReadConsistency](#qdrant-ReadConsistency) | optional | Options for specifying read consistency guarantees |
 | shard_key_selector | [ShardKeySelector](#qdrant-ShardKeySelector) | optional | Specify in which shards to look for the points, if not specified - look in all shards |
-| order_by | [OrderBy](#qdrant-OrderBy) | optional | Order of the results by a payload key |
+| order_by | [OrderBy](#qdrant-OrderBy) | optional | Order the records by a payload field |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7302,7 +7302,7 @@
             "$ref": "#/components/schemas/WithVector"
           },
           "order_by": {
-            "description": "Order the records by a payload field, then by the point id.",
+            "description": "Order the records by a payload field.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OrderByInterface"

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -331,7 +331,7 @@ message ScrollPoints {
   optional WithVectorsSelector with_vectors = 7; // Options for specifying which vectors to include into response
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
   optional ShardKeySelector shard_key_selector = 9; // Specify in which shards to look for the points, if not specified - look in all shards
-  optional OrderBy order_by = 10; // Order of the results by a payload key
+  optional OrderBy order_by = 10; // Order the records by a payload field
 }
 
 // How to use positive and negative vectors to find the results, default is `AverageVector`:

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3430,7 +3430,7 @@ pub struct ScrollPoints {
     /// Specify in which shards to look for the points, if not specified - look in all shards
     #[prost(message, optional, tag = "9")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
-    /// Order of the results by a payload key
+    /// Order the records by a payload field
     #[prost(message, optional, tag = "10")]
     pub order_by: ::core::option::Option<OrderBy>,
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -321,7 +321,7 @@ pub struct ScrollRequestInternal {
     #[serde(default, alias = "with_vectors")]
     pub with_vector: WithVector,
 
-    /// Order the records by a payload field, then by the point id.
+    /// Order the records by a payload field.
     pub order_by: Option<OrderByInterface>,
 }
 


### PR DESCRIPTION
Initially we wanted to keep a (value, id) composite ordering, but implementation details forced us to drop the id ordering guarantee. However, the description wasn't updated. 

This PR reflects those decisions in the description of the `order_by` parameter

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?