### PR TITLE
Fix broken serialization of ClockMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,6 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "serde_with",
  "sha2",
  "sparse",
  "tar",
@@ -4875,36 +4874,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
-dependencies = [
- "base64 0.21.0",
- "chrono",
- "hex",
- "indexmap 1.9.2",
- "indexmap 2.2.3",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "serde_with",
  "sha2",
  "sparse",
  "tar",
@@ -4874,6 +4875,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+dependencies = [
+ "base64 0.21.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.2",
+ "indexmap 2.2.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -25,8 +25,9 @@ parking_lot = { workspace = true }
 rand = "0.8.5"
 thiserror = "1.0"
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_cbor = { workspace = true }
+serde_json = { workspace = true }
+serde_with = "3.6.1"
 rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
 ordered-float = "4.2"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -27,7 +27,6 @@ thiserror = "1.0"
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
-serde_with = "3.6.1"
 rmp-serde = "~1.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
 ordered-float = "4.2"

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use api::grpc::qdrant::RecoveryPointClockTag;
 use io::file_operations;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::operations::types::CollectionError;
 use crate::operations::ClockTag;
@@ -13,7 +14,9 @@ use crate::shards::shard::PeerId;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
+#[serde_as]
 pub struct ClockMap {
+    #[serde_as(as = "Vec<(_, _)>")]
     clocks: HashMap<Key, Clock>,
 }
 

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -141,7 +141,6 @@ impl Key {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(transparent)]
 struct Clock {
     current_tick: u64,
 }
@@ -292,7 +291,6 @@ impl From<ClockMapHelper> for ClockMap {
 struct KeyClockHelper {
     #[serde(flatten)]
     key: Key,
-
     #[serde(flatten)]
     clock: Clock,
 }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -346,7 +346,7 @@ mod tests {
         let json = serde_json::to_value(&clock_map).unwrap();
         let output = serde_json::from_value(json).unwrap();
 
-        assert_eq!(clock_map, clock_map2);
+        assert_eq!(input, output);
     }
 
     #[test]

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -340,32 +340,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_clock_map_serde_empty() {
-        let clock_map = ClockMap::default();
+    fn clock_map_serde_empty() {
+        let input = ClockMap::default();
 
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("clock_map_empty.json");
-
-        clock_map.store(&path).unwrap();
-        let clock_map2 = ClockMap::load(&path).unwrap();
+        let json = serde_json::to_value(&clock_map).unwrap();
+        let output = serde_json::from_value(json).unwrap();
 
         assert_eq!(clock_map, clock_map2);
     }
 
     #[test]
-    fn test_clock_map_serde() {
-        let mut clock_map = ClockMap::default();
-        clock_map.advance_clock(ClockTag::new(1, 1, 1));
-        clock_map.advance_clock(ClockTag::new(1, 2, 8));
-        clock_map.advance_clock(ClockTag::new(2, 1, 42));
-        clock_map.advance_clock(ClockTag::new(2, 2, 12345));
+    fn clock_map_serde() {
+        let mut input = ClockMap::default();
+        input.advance_clock(ClockTag::new(1, 1, 1));
+        input.advance_clock(ClockTag::new(1, 2, 8));
+        input.advance_clock(ClockTag::new(2, 1, 42));
+        input.advance_clock(ClockTag::new(2, 2, 12345));
 
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("clock_map.json");
+        let json = serde_json::to_value(&input).unwrap();
+        let output = serde_json::form_value(json).unwrap();
 
-        clock_map.store(&path).unwrap();
-        let clock_map2 = ClockMap::load(&path).unwrap();
-
-        assert_eq!(clock_map, clock_map2);
+        assert_eq!(input, output);
     }
 }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -343,7 +343,7 @@ mod tests {
     fn clock_map_serde_empty() {
         let input = ClockMap::default();
 
-        let json = serde_json::to_value(&clock_map).unwrap();
+        let json = serde_json::to_value(&input).unwrap();
         let output = serde_json::from_value(json).unwrap();
 
         assert_eq!(input, output);
@@ -358,7 +358,7 @@ mod tests {
         input.advance_clock(ClockTag::new(2, 2, 12345));
 
         let json = serde_json::to_value(&input).unwrap();
-        let output = serde_json::form_value(json).unwrap();
+        let output = serde_json::from_value(json).unwrap();
 
         assert_eq!(input, output);
     }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -652,10 +652,12 @@ impl UpdateHandler {
             let ack = confirmed_version.min(keep_from.saturating_sub(1));
 
             if let Err(err) = clock_map.lock().await.store(&clock_map_path) {
+                log::warn!("Failed to store clock map to disk: {err}");
                 segments.write().report_optimizer_error(err);
             }
 
             if let Err(err) = wal.lock().ack(ack) {
+                log::warn!("Failed to acknowledge WAL version: {err}");
                 segments.write().report_optimizer_error(err);
             }
         }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Fixes: <https://github.com/qdrant/qdrant/issues/3585>

The current implementation of `ClockMap` fails to serialize when there's any data in it. It holds a `HashMap<Key, Clock>`, but `serde_json` cannot serialize `Key` as it must be a string.

More specifically, when we try to serialize I'm getting this error:

```
Error("key must be a string", line: 0, column: 0)
```

This PR fixes that by utilizing [`serde_with::serde_as`](https://docs.rs/serde_with/3.6.1/serde_with/attr.serde_as.html), mapping our hash map into a `Vec<(Key, Clock)>` on (de)serialization.

We now get:

```json
{"clocks":[[{"peer_id":123,"clock_id":1},152],[{"peer_id":123,"clock_id":0},246]]}
```

If we don't like the tuple representation we may also decide to implement separate serializable types while using `#[serde(into = "SomeType", from = "SomeType")]` ([docs](https://serde.rs/container-attrs.html)). I didn't go that route as it would require more code to make it happen.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?