### PR TITLE
Make WAL inspector support operations with clock tag

### DIFF
--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -65,13 +65,16 @@ fn print_collection_wal(wal_path: &Path) {
             let mut count = 0;
             for (idx, op) in wal.read_all() {
                 println!("==========================");
-                println!("Entry {}", idx);
-                println!("{:?}", op);
+                println!("Entry: {idx}");
+                println!("Operation: {:?}", op.operation);
+                if let Some(clock_tag) = op.clock_tag {
+                    println!("Clock: {clock_tag:?}");
+                }
                 count += 1;
             }
             println!("==========================");
             println!("End of WAL.");
-            println!("Found {} entries.", count);
+            println!("Found {count} entries.");
         }
     }
 }

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::Path;
 
-use collection::operations::CollectionUpdateOperations;
+use collection::operations::OperationWithClockTag;
 use collection::wal::SerdeWal;
 use storage::content_manager::consensus::consensus_wal::ConsensusOpWal;
 use storage::content_manager::consensus_ops::ConsensusOperations;
@@ -53,7 +53,7 @@ fn print_consensus_wal(wal_path: &Path) {
 }
 
 fn print_collection_wal(wal_path: &Path) {
-    let wal: Result<SerdeWal<CollectionUpdateOperations>, _> =
+    let wal: Result<SerdeWal<OperationWithClockTag>, _> =
         SerdeWal::new(wal_path.to_str().unwrap(), WalOptions::default());
 
     match wal {


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Our WAL inspector binary currently crashes when inspecting WAL's that include the new clock tag.

This fixes the problem by using our wrapper type.

Before this PR I got:

```
thread 'main' panicked at /home/timvisee/git/qdrant/lib/collection/src/wal.rs:154:18:
Can't deserialize entry, probably corrupted WAL on version mismatch: Syntax("data did not match any variant of untagged enum CollectionUpdateOperations")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And now I get:

```
==========================
Entry: 98
Operation: PointOperation(UpsertPoints(PointsList([PointStruct { id: NumId(98), vector: Single([0.3784349, 0.24649405]), payload: Some(Payload({})) }])))
Clock: ClockTag { peer_id: 1561593024934658, clock_id: 1, clock_tick: 48, force: false }
==========================
Entry: 99
Operation: PointOperation(UpsertPoints(PointsList([PointStruct { id: NumId(99), vector: Single([-0.19868898, 0.9496815]), payload: Some(Payload({})) }])))
Clock: ClockTag { peer_id: 1561593024934658, clock_id: 0, clock_tick: 50, force: false }
==========================
End of WAL.
Found 2 entries.
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?