### PR TITLE
POC for rocksdb memory usage metrics

### DIFF
--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
+use segment::telemetry::RocksDBMemoryUsageStats;
 use serde::{Deserialize, Serialize};
 
 use crate::config::CollectionConfig;
@@ -23,6 +24,32 @@ impl CollectionTelemetry {
             .flat_map(|x| x.segments.iter())
             .map(|s| s.info.num_vectors)
             .sum()
+    }
+
+    pub fn get_rocksdb_memory_usage_stats(&self) -> RocksDBMemoryUsageStats {
+        let rocksdb_memory_usage_stats = self
+            .shards
+            .iter()
+            .flat_map(|shard| shard.local.as_ref())
+            .flat_map(|x| x.segments.iter())
+            .map(|s| s.rocksdb_memory_usage_stats.clone())
+            .collect::<Vec<RocksDBMemoryUsageStats>>();
+
+        let mut acc = RocksDBMemoryUsageStats {
+            mem_table_total: 0,
+            mem_table_unflushed: 0,
+            mem_table_readers_total: 0,
+            cache_total: 0,
+        };
+
+        for s in rocksdb_memory_usage_stats {
+            acc.mem_table_total += s.mem_table_total;
+            acc.mem_table_unflushed += s.mem_table_unflushed;
+            acc.mem_table_readers_total += s.mem_table_readers_total;
+            acc.cache_total += s.cache_total;
+        }
+
+        acc
     }
 }
 

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -14,11 +14,20 @@ pub struct VectorIndexesTelemetry {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct RocksDBMemoryUsageStats {
+    pub mem_table_total: u64,
+    pub mem_table_unflushed: u64,
+    pub mem_table_readers_total: u64,
+    pub cache_total: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct SegmentTelemetry {
     pub info: SegmentInfo,
     pub config: SegmentConfig,
     pub vector_index_searches: Vec<VectorIndexSearchesTelemetry>,
     pub payload_field_indices: Vec<PayloadIndexTelemetry>,
+    pub rocksdb_memory_usage_stats: RocksDBMemoryUsageStats,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -72,6 +81,17 @@ pub struct VectorIndexSearchesTelemetry {
     pub unfiltered_exact: OperationDurationStatistics,
 }
 
+impl Anonymize for RocksDBMemoryUsageStats {
+    fn anonymize(&self) -> Self {
+        Self {
+            mem_table_total: self.mem_table_total,
+            mem_table_unflushed: self.mem_table_unflushed,
+            mem_table_readers_total: self.mem_table_readers_total,
+            cache_total: self.cache_total,
+        }
+    }
+}
+
 impl Anonymize for SegmentTelemetry {
     fn anonymize(&self) -> Self {
         Self {
@@ -79,6 +99,7 @@ impl Anonymize for SegmentTelemetry {
             config: self.config.anonymize(),
             vector_index_searches: self.vector_index_searches.anonymize(),
             payload_field_indices: self.payload_field_indices.anonymize(),
+            rocksdb_memory_usage_stats: self.rocksdb_memory_usage_stats.anonymize(),
         }
     }
 }

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -3,6 +3,7 @@ use collection::operations::types::OptimizersStatus;
 use collection::telemetry::CollectionTelemetry;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
+use segment::telemetry::RocksDBMemoryUsageStats;
 use serde::{Deserialize, Serialize};
 use storage::content_manager::toc::TableOfContent;
 
@@ -11,6 +12,7 @@ pub struct CollectionsAggregatedTelemetry {
     pub vectors: usize,
     pub optimizers_status: OptimizersStatus,
     pub params: CollectionParams,
+    pub rocksdb_memory_usage_stats: RocksDBMemoryUsageStats,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -36,10 +38,13 @@ impl From<CollectionTelemetry> for CollectionsAggregatedTelemetry {
             .max()
             .unwrap_or(OptimizersStatus::Ok);
 
+        let rocksdb_memory_usage_stats = telemetry.get_rocksdb_memory_usage_stats();
+
         CollectionsAggregatedTelemetry {
             vectors: telemetry.count_vectors(),
             optimizers_status,
             params: telemetry.config.params,
+            rocksdb_memory_usage_stats,
         }
     }
 }
@@ -101,6 +106,7 @@ impl Anonymize for CollectionsAggregatedTelemetry {
             optimizers_status: self.optimizers_status.clone(),
             vectors: self.vectors.anonymize(),
             params: self.params.anonymize(),
+            rocksdb_memory_usage_stats: self.rocksdb_memory_usage_stats.anonymize(),
         }
     }
 }


### PR DESCRIPTION
Related to payload memory issues discussed in #3501  and tackled in #3557  and #3565 

This PR is a PoC for exposing `get_memory_usage_stats` from `rust-rocksdb` for [tracking memory usage](https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md) in `rocksdb`.

This PR adds segment level stats to `/telemetry` and aggregated stats to `/metrics`.

As far as I can tell, `rust-rocksdb` does not make stats available for column families, only for databases.

However, on my local test bench I saw one trend which correlated with the extreme RAM usage in our production environment, `mem_table_readers_total`, which seems to grow linearly wrt the number of vectors with payloads.

<img width="1458" alt="Screenshot 2024-02-12 at 4 37 43 PM" src="https://github.com/qdrant/qdrant/assets/3887682/a6c6a482-5560-4141-84f2-7b752ec9a08c">

I built this to scratch an itch and try and solve the memory problems plaguing us - but am also interested in getting a concept ACK on this, as I'm sure the code could be improved.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
