### PR TITLE
Optimize sparse vector index build time

### DIFF
--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -148,6 +148,13 @@ impl TryFrom<Vec<(u32, f32)>> for SparseVector {
     }
 }
 
+#[cfg(test)]
+impl<const N: usize> From<[(u32, f32); N]> for SparseVector {
+    fn from(value: [(u32, f32); N]) -> Self {
+        value.to_vec().try_into().unwrap()
+    }
+}
+
 impl Validate for SparseVector {
     fn validate(&self) -> Result<(), ValidationErrors> {
         validate_sparse_vector_impl(&self.indices, &self.values)

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -239,27 +239,17 @@ mod tests {
     #[test]
     fn test_inverted_index_mmap() {
         // skip 4th dimension
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(
-                1,
-                vec![(1, 10.0), (2, 10.0), (3, 10.0), (5, 10.0)]
-                    .try_into()
-                    .unwrap(),
-            )
-            .add(
-                2,
-                vec![(1, 20.0), (2, 20.0), (3, 20.0), (5, 20.0)]
-                    .try_into()
-                    .unwrap(),
-            )
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .add(4, vec![(1, 1.0), (2, 1.0)].try_into().unwrap())
-            .add(5, vec![(1, 2.0)].try_into().unwrap())
-            .add(6, vec![(1, 3.0)].try_into().unwrap())
-            .add(7, vec![(1, 4.0)].try_into().unwrap())
-            .add(8, vec![(1, 5.0)].try_into().unwrap())
-            .add(9, vec![(1, 6.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0), (5, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0), (5, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        builder.add(4, [(1, 1.0), (2, 1.0)].into());
+        builder.add(5, [(1, 2.0)].into());
+        builder.add(6, [(1, 3.0)].into());
+        builder.add(7, [(1, 4.0)].into());
+        builder.add(8, [(1, 5.0)].into());
+        builder.add(9, [(1, 6.0)].into());
+        let inverted_index_ram = builder.build();
 
         let tmp_dir_path = Builder::new().prefix("test_index_dir").tempdir().unwrap();
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -220,8 +220,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use crate::index::inverted_index::inverted_index_ram::InvertedIndexBuilder;
-    use crate::index::posting_list::PostingList;
+    use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 
     fn compare_indexes(
         inverted_index_ram: &InvertedIndexRam,
@@ -239,27 +238,27 @@ mod tests {
 
     #[test]
     fn test_inverted_index_mmap() {
+        // skip 4th dimension
         let inverted_index_ram = InvertedIndexBuilder::new()
             .add(
                 1,
-                PostingList::from(vec![
-                    (1, 10.0),
-                    (2, 20.0),
-                    (3, 30.0),
-                    (4, 1.0),
-                    (5, 2.0),
-                    (6, 3.0),
-                    (7, 4.0),
-                    (8, 5.0),
-                    (9, 6.0),
-                ]),
+                vec![(1, 10.0), (2, 10.0), (3, 10.0), (5, 10.0)]
+                    .try_into()
+                    .unwrap(),
             )
             .add(
                 2,
-                PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0), (4, 1.0)]),
+                vec![(1, 20.0), (2, 20.0), (3, 20.0), (5, 20.0)]
+                    .try_into()
+                    .unwrap(),
             )
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(5, PostingList::from(vec![(1, 10.0), (2, 20.0)])) // skip 4
+            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
+            .add(4, vec![(1, 1.0), (2, 1.0)].try_into().unwrap())
+            .add(5, vec![(1, 2.0)].try_into().unwrap())
+            .add(6, vec![(1, 3.0)].try_into().unwrap())
+            .add(7, vec![(1, 4.0)].try_into().unwrap())
+            .add(8, vec![(1, 5.0)].try_into().unwrap())
+            .add(9, vec![(1, 6.0)].try_into().unwrap())
             .build();
 
         let tmp_dir_path = Builder::new().prefix("test_index_dir").tempdir().unwrap();

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -133,11 +133,11 @@ mod tests {
 
     #[test]
     fn upsert_same_dimension_inverted_index_ram() {
-        let mut inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        let mut inverted_index_ram = builder.build();
 
         assert_eq!(inverted_index_ram.vector_count, 3);
 
@@ -158,11 +158,11 @@ mod tests {
 
     #[test]
     fn upsert_new_dimension_inverted_index_ram() {
-        let mut inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        let mut inverted_index_ram = builder.build();
 
         assert_eq!(inverted_index_ram.vector_count, 3);
 
@@ -199,14 +199,15 @@ mod tests {
 
     #[test]
     fn test_upsert_insert_equivalence() {
-        let first_vec = SparseVector::new(vec![1, 2, 3], vec![10.0, 10.0, 10.0]).unwrap();
-        let second_vec = SparseVector::new(vec![1, 2, 3], vec![20.0, 20.0, 20.0]).unwrap();
-        let third_vec = SparseVector::new(vec![1, 2, 3], vec![30.0, 30.0, 30.0]).unwrap();
-        let inverted_index_ram_built = InvertedIndexBuilder::new()
-            .add(1, first_vec.clone())
-            .add(2, second_vec.clone())
-            .add(3, third_vec.clone())
-            .build();
+        let first_vec: SparseVector = [(1, 10.0), (2, 10.0), (3, 10.0)].into();
+        let second_vec: SparseVector = [(1, 20.0), (2, 20.0), (3, 20.0)].into();
+        let third_vec: SparseVector = [(1, 30.0), (2, 30.0), (3, 30.0)].into();
+
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, first_vec.clone());
+        builder.add(2, second_vec.clone());
+        builder.add(3, third_vec.clone());
+        let inverted_index_ram_built = builder.build();
 
         assert_eq!(inverted_index_ram_built.vector_count, 3);
 
@@ -224,11 +225,12 @@ mod tests {
 
     #[test]
     fn inverted_index_ram_save_load() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap());
+        builder.add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap());
+        builder.add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap());
+        let inverted_index_ram = builder.build();
+
         assert_eq!(inverted_index_ram.vector_count, 3);
 
         let tmp_dir_path = Builder::new().prefix("test_index_dir").tempdir().unwrap();

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -1,15 +1,12 @@
-use std::mem;
-
 use common::types::PointOffsetType;
 
 use crate::common::sparse_vector::SparseVector;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
-use crate::index::posting_list::{PostingElement, PostingList};
+use crate::index::posting_list::PostingBuilder;
 
 /// Builder for InvertedIndexRam
 pub struct InvertedIndexBuilder {
-    /// The PostingList are not sorted by record id until 'build' is called
-    pub postings: Vec<PostingList>,
+    pub posting_builders: Vec<PostingBuilder>,
     pub vector_count: usize,
 }
 
@@ -22,44 +19,41 @@ impl Default for InvertedIndexBuilder {
 impl InvertedIndexBuilder {
     pub fn new() -> InvertedIndexBuilder {
         InvertedIndexBuilder {
-            postings: Vec::new(),
+            posting_builders: Vec::new(),
             vector_count: 0,
         }
     }
 
     /// Add a vector to the inverted index builder
-    pub fn add(&mut self, id: PointOffsetType, vector: SparseVector) -> &mut Self {
+    pub fn add(&mut self, id: PointOffsetType, vector: SparseVector) {
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
-            match self.postings.get_mut(dim_id) {
+            match self.posting_builders.get_mut(dim_id) {
                 Some(posting) => {
                     // update existing posting list
-                    let posting_element = PostingElement::new(id, weight);
-                    posting.append(posting_element);
+                    posting.add(id, weight);
                 }
                 None => {
                     // resize postings vector (fill gaps with empty posting lists)
-                    self.postings.resize_with(dim_id + 1, PostingList::default);
+                    self.posting_builders
+                        .resize_with(dim_id + 1, PostingBuilder::new);
                     // initialize new posting for dimension
-                    self.postings[dim_id] = PostingList::new_one(id, weight);
+                    let mut new_posting_builder = PostingBuilder::new();
+                    new_posting_builder.add(id, weight);
+                    self.posting_builders[dim_id] = new_posting_builder
                 }
             }
         }
         self.vector_count += 1;
-        self
     }
 
-    /// Build the inverted index
-    pub fn build(&mut self) -> InvertedIndexRam {
-        for posting in &mut self.postings {
-            // Sort posting list by record id
-            posting.elements.sort_by_key(|e| e.record_id);
-            // Compute the max next weights for each element
-            posting.compute_max_next_weights();
+    /// Consumes the builder and returns an InvertedIndexRam
+    pub fn build(self) -> InvertedIndexRam {
+        let mut postings = Vec::with_capacity(self.posting_builders.len());
+        for posting_builder in self.posting_builders {
+            postings.push(posting_builder.build());
         }
 
-        // Take ownership of the postings
-        let postings = mem::take(&mut self.postings);
         let vector_count = self.vector_count;
         InvertedIndexRam {
             postings,

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -1,0 +1,69 @@
+use std::mem;
+
+use common::types::PointOffsetType;
+
+use crate::common::sparse_vector::SparseVector;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use crate::index::posting_list::{PostingElement, PostingList};
+
+/// Builder for InvertedIndexRam
+pub struct InvertedIndexBuilder {
+    /// The PostingList are not sorted by record id until 'build' is called
+    pub postings: Vec<PostingList>,
+    pub vector_count: usize,
+}
+
+impl Default for InvertedIndexBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InvertedIndexBuilder {
+    pub fn new() -> InvertedIndexBuilder {
+        InvertedIndexBuilder {
+            postings: Vec::new(),
+            vector_count: 0,
+        }
+    }
+
+    /// Add a vector to the inverted index builder
+    pub fn add(&mut self, id: PointOffsetType, vector: SparseVector) -> &mut Self {
+        for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
+            let dim_id = dim_id as usize;
+            match self.postings.get_mut(dim_id) {
+                Some(posting) => {
+                    // update existing posting list
+                    let posting_element = PostingElement::new(id, weight);
+                    posting.append(posting_element);
+                }
+                None => {
+                    // resize postings vector (fill gaps with empty posting lists)
+                    self.postings.resize_with(dim_id + 1, PostingList::default);
+                    // initialize new posting for dimension
+                    self.postings[dim_id] = PostingList::new_one(id, weight);
+                }
+            }
+        }
+        self.vector_count += 1;
+        self
+    }
+
+    /// Build the inverted index
+    pub fn build(&mut self) -> InvertedIndexRam {
+        for posting in &mut self.postings {
+            // Sort posting list by record id
+            posting.elements.sort_by_key(|e| e.record_id);
+            // Compute the max next weights for each element
+            posting.compute_max_next_weights();
+        }
+
+        // Take ownership of the postings
+        let postings = mem::take(&mut self.postings);
+        let vector_count = self.vector_count;
+        InvertedIndexRam {
+            postings,
+            vector_count,
+        }
+    }
+}

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -9,6 +9,7 @@ use crate::index::posting_list::PostingListIterator;
 
 pub mod inverted_index_mmap;
 pub mod inverted_index_ram;
+pub mod inverted_index_ram_builder;
 
 pub trait InvertedIndex: Sized {
     /// Open existing index based on path

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -96,7 +96,7 @@ impl PostingList {
 
     /// Propagates `max_next_weight` from the entry at `up_to_index` to previous entries.
     /// If an entry has a weight larger than `max_next_weight`, the propagation stops.
-    fn propagate_max_next_weight_to_the_left(&mut self, up_to_index: usize) -> usize {
+    fn propagate_max_next_weight_to_the_left(&mut self, up_to_index: usize) {
         // used element at `up_to_index` as the starting point
         let starting_element = &self.elements[up_to_index];
         let mut max_next_weight = max(
@@ -106,19 +106,17 @@ impl PostingList {
         .0;
 
         // propagate max_next_weight update to the previous entries
-        for (id, element) in self.elements[..up_to_index].iter_mut().enumerate().rev() {
+        for element in self.elements[..up_to_index].iter_mut().rev() {
             // update max_next_weight for element
             element.max_next_weight = max_next_weight;
             if element.weight >= max_next_weight {
                 // no need to propagate further because the current element is larger
-                return id;
+                break;
             } else {
                 // update max_next_weight based on current element
                 max_next_weight = max_next_weight.max(element.weight);
             }
         }
-        // all elements were updated
-        0
     }
 }
 

--- a/lib/sparse/src/index/posting_list.rs
+++ b/lib/sparse/src/index/posting_list.rs
@@ -120,25 +120,6 @@ impl PostingList {
         // all elements were updated
         0
     }
-
-    /// Compute the max_next_weight for each element in the posting list.
-    pub fn compute_max_next_weights(&mut self) {
-        if self.elements.is_empty() {
-            return;
-        }
-        let mut to_sync = self.elements.len() - 1;
-        while to_sync > 0 {
-            to_sync = self.propagate_max_next_weight_to_the_left(to_sync);
-        }
-    }
-
-    /// Append posting element at the end of the list.
-    ///
-    /// Does NOT keep the list sorted.
-    /// Does NOT update max_next_weight of previous elements.
-    pub fn append(&mut self, posting_element: PostingElement) {
-        self.elements.push(posting_element);
-    }
 }
 
 pub struct PostingBuilder {
@@ -158,10 +139,12 @@ impl PostingBuilder {
         }
     }
 
+    /// Add a new record to the posting list.
     pub fn add(&mut self, record_id: PointOffsetType, weight: DimWeight) {
         self.elements.push(PostingElement::new(record_id, weight));
     }
 
+    /// Consume the builder and return the posting list.
     pub fn build(mut self) -> PostingList {
         // Sort by id
         self.elements.sort_unstable_by_key(|e| e.record_id);
@@ -178,7 +161,7 @@ impl PostingBuilder {
             }
         }
 
-        // Calculate max_next_weight
+        // Calculate the `max_next_weight` for all elements starting from the end
         let mut max_next_weight = f32::NEG_INFINITY;
         for element in self.elements.iter_mut().rev() {
             element.max_next_weight = max_next_weight;

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -407,10 +407,8 @@ mod tests {
     use crate::common::scores_memory_pool::ScoresMemoryPool;
     use crate::common::sparse_vector_fixture::random_sparse_vector;
     use crate::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
-    use crate::index::inverted_index::inverted_index_ram::{
-        InvertedIndexBuilder, InvertedIndexRam,
-    };
-    use crate::index::posting_list::PostingList;
+    use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+    use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 
     static TEST_SCORES_POOL: OnceLock<ScoresMemoryPool> = OnceLock::new();
 
@@ -474,9 +472,9 @@ mod tests {
     #[test]
     fn search_test() {
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         // test with ram index
@@ -496,9 +494,9 @@ mod tests {
     fn search_with_update_test() {
         let is_stopped = AtomicBool::new(false);
         let mut inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         let mut search_context = SearchContext::new(
@@ -637,22 +635,15 @@ mod tests {
     #[test]
     fn search_with_hot_key_test() {
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(
-                1,
-                PostingList::from(vec![
-                    (1, 10.0),
-                    (2, 20.0),
-                    (3, 30.0),
-                    (4, 1.0),
-                    (5, 2.0),
-                    (6, 3.0),
-                    (7, 4.0),
-                    (8, 5.0),
-                    (9, 6.0),
-                ]),
-            )
-            .add(2, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
+            .add(4, vec![(1, 1.0)].try_into().unwrap())
+            .add(5, vec![(1, 2.0)].try_into().unwrap())
+            .add(6, vec![(1, 3.0)].try_into().unwrap())
+            .add(7, vec![(1, 4.0)].try_into().unwrap())
+            .add(8, vec![(1, 5.0)].try_into().unwrap())
+            .add(9, vec![(1, 6.0)].try_into().unwrap())
             .build();
 
         // test with ram index
@@ -671,7 +662,9 @@ mod tests {
     #[test]
     fn pruning_single_to_end_test() {
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0)].try_into().unwrap())
             .build();
 
         let is_stopped = AtomicBool::new(false);
@@ -700,12 +693,12 @@ mod tests {
     #[test]
     fn pruning_multi_to_end_test() {
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(
-                1,
-                PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0), (4, 10.0)]),
-            )
-            .add(2, PostingList::from(vec![(6, 20.0), (7, 30.0)]))
-            .add(3, PostingList::from(vec![(5, 10.0), (6, 20.0), (7, 30.0)]))
+            .add(1, vec![(1, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0)].try_into().unwrap())
+            .add(5, vec![(3, 10.0)].try_into().unwrap())
+            .add(6, vec![(2, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(7, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         let is_stopped = AtomicBool::new(false);
@@ -734,19 +727,13 @@ mod tests {
     #[test]
     fn pruning_multi_under_prune_test() {
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(
-                1,
-                PostingList::from(vec![
-                    (1, 10.0),
-                    (2, 20.0),
-                    (3, 20.0),
-                    (4, 10.0),
-                    (6, 20.0),
-                    (7, 40.0),
-                ]),
-            )
-            .add(2, PostingList::from(vec![(6, 20.0), (7, 30.0)]))
-            .add(3, PostingList::from(vec![(5, 10.0), (6, 20.0), (7, 30.0)]))
+            .add(1, vec![(1, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 20.0)].try_into().unwrap())
+            .add(4, vec![(1, 10.0)].try_into().unwrap())
+            .add(5, vec![(3, 10.0)].try_into().unwrap())
+            .add(6, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(7, vec![(1, 40.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         let is_stopped = AtomicBool::new(false);
@@ -794,9 +781,9 @@ mod tests {
     fn promote_longest_test() {
         let is_stopped = AtomicBool::new(false);
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0)]))
-            .add(2, PostingList::from(vec![(1, 10.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         let mut search_context = SearchContext::new(
@@ -831,9 +818,9 @@ mod tests {
     fn plain_search_all_test() {
         let is_stopped = AtomicBool::new(false);
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0)]))
-            .add(2, PostingList::from(vec![(1, 10.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(1, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         let mut search_context = SearchContext::new(
@@ -871,9 +858,9 @@ mod tests {
     fn plain_search_gap_test() {
         let is_stopped = AtomicBool::new(false);
         let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, PostingList::from(vec![(1, 10.0), (2, 20.0)]))
-            .add(2, PostingList::from(vec![(1, 10.0), (3, 30.0)]))
-            .add(3, PostingList::from(vec![(1, 10.0), (2, 20.0), (3, 30.0)]))
+            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
+            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
+            .add(3, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
             .build();
 
         // query vector has a gap for dimension 2

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -471,11 +471,11 @@ mod tests {
 
     #[test]
     fn search_test() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         // test with ram index
         _search_test(&inverted_index_ram);
@@ -493,11 +493,11 @@ mod tests {
     #[test]
     fn search_with_update_test() {
         let is_stopped = AtomicBool::new(false);
-        let mut inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        let mut inverted_index_ram = builder.build();
 
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -634,17 +634,17 @@ mod tests {
 
     #[test]
     fn search_with_hot_key_test() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .add(4, vec![(1, 1.0)].try_into().unwrap())
-            .add(5, vec![(1, 2.0)].try_into().unwrap())
-            .add(6, vec![(1, 3.0)].try_into().unwrap())
-            .add(7, vec![(1, 4.0)].try_into().unwrap())
-            .add(8, vec![(1, 5.0)].try_into().unwrap())
-            .add(9, vec![(1, 6.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (2, 30.0), (3, 30.0)].into());
+        builder.add(4, [(1, 1.0)].into());
+        builder.add(5, [(1, 2.0)].into());
+        builder.add(6, [(1, 3.0)].into());
+        builder.add(7, [(1, 4.0)].into());
+        builder.add(8, [(1, 5.0)].into());
+        builder.add(9, [(1, 6.0)].into());
+        let inverted_index_ram = builder.build();
 
         // test with ram index
         _search_with_hot_key_test(&inverted_index_ram);
@@ -661,11 +661,11 @@ mod tests {
 
     #[test]
     fn pruning_single_to_end_test() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0)].into());
+        builder.add(2, [(1, 20.0)].into());
+        builder.add(3, [(1, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
@@ -692,14 +692,14 @@ mod tests {
 
     #[test]
     fn pruning_multi_to_end_test() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0)].try_into().unwrap())
-            .add(5, vec![(3, 10.0)].try_into().unwrap())
-            .add(6, vec![(2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(7, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0)].into());
+        builder.add(2, [(1, 20.0)].into());
+        builder.add(3, [(1, 30.0)].into());
+        builder.add(5, [(3, 10.0)].into());
+        builder.add(6, [(2, 20.0), (3, 20.0)].into());
+        builder.add(7, [(2, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
@@ -726,15 +726,15 @@ mod tests {
 
     #[test]
     fn pruning_multi_under_prune_test() {
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 20.0)].try_into().unwrap())
-            .add(4, vec![(1, 10.0)].try_into().unwrap())
-            .add(5, vec![(3, 10.0)].try_into().unwrap())
-            .add(6, vec![(1, 20.0), (2, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(7, vec![(1, 40.0), (2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0)].into());
+        builder.add(2, [(1, 20.0)].into());
+        builder.add(3, [(1, 20.0)].into());
+        builder.add(4, [(1, 10.0)].into());
+        builder.add(5, [(3, 10.0)].into());
+        builder.add(6, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
+        builder.add(7, [(1, 40.0), (2, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         let is_stopped = AtomicBool::new(false);
         let mut search_context = SearchContext::new(
@@ -780,11 +780,11 @@ mod tests {
     #[test]
     fn promote_longest_test() {
         let is_stopped = AtomicBool::new(false);
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (3, 20.0)].into());
+        builder.add(3, [(2, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -817,11 +817,11 @@ mod tests {
     #[test]
     fn plain_search_all_test() {
         let is_stopped = AtomicBool::new(false);
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(1, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (3, 20.0)].into());
+        builder.add(3, [(1, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         let mut search_context = SearchContext::new(
             SparseVector {
@@ -857,11 +857,11 @@ mod tests {
     #[test]
     fn plain_search_gap_test() {
         let is_stopped = AtomicBool::new(false);
-        let inverted_index_ram = InvertedIndexBuilder::new()
-            .add(1, vec![(1, 10.0), (2, 10.0), (3, 10.0)].try_into().unwrap())
-            .add(2, vec![(1, 20.0), (3, 20.0)].try_into().unwrap())
-            .add(3, vec![(2, 30.0), (3, 30.0)].try_into().unwrap())
-            .build();
+        let mut builder = InvertedIndexBuilder::new();
+        builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
+        builder.add(2, [(1, 20.0), (3, 20.0)].into());
+        builder.add(3, [(2, 30.0), (3, 30.0)].into());
+        let inverted_index_ram = builder.build();
 
         // query vector has a gap for dimension 2
         let mut search_context = SearchContext::new(


### PR DESCRIPTION
This PR optimizes the sparse vector index build by using a builder that is cheap to update.

It leverages the existing `PostingListBuilder` for convenience.

It yields a significant gains for our micro benchmark.

```
sparse-vector-build-group/build-ram-index
                        time:   [84.856 ms 86.303 ms 87.754 ms]
                        change: [-26.476% -16.670% -9.7342%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The tests have been updated to use the new builder, one needs to perform a bit of mental gymnastic to build the forward index from the inverted ones :)