### PR TITLE
Decrease sparse vector index build bench parameters

### DIFF
--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -26,8 +26,8 @@ use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
 use tempfile::Builder;
 
-const NUM_VECTORS: usize = 100_000;
-const MAX_SPARSE_DIM: usize = 30_000;
+const NUM_VECTORS: usize = 10_000;
+const MAX_SPARSE_DIM: usize = 1_000;
 
 fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse-vector-build-group");


### PR DESCRIPTION
The benchmark for sparse vector index build is not realistic.

The parameters are too high for the benchmark too finish quickly enough.

```
     Running benches/sparse_index_build.rs (target/release/deps/sparse_index_build-a102265c83263f8d)
Benchmarking sparse-vector-build-group/build-ram-index: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 2076.8s, or reduce sample count to 10.
Benchmarking sparse-vector-build-group/build-ram-index: Collecting 100 samples in estimated 2076.8 s (100 iterations)
```

The motivation is to restore this benchmark to be able to use it easily in a later PR comparing with dev.