### PR TITLE
WAL delta resolution and recovery tests

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -121,7 +121,7 @@ impl ClockMap {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
-struct Key {
+pub(super) struct Key {
     peer_id: PeerId,
     clock_id: u32,
 }
@@ -167,10 +167,14 @@ impl Clock {
 /// recovering node has not seen yet.
 #[derive(Clone, Debug, Default)]
 pub struct RecoveryPoint {
-    clocks: HashMap<Key, u64>,
+    pub(super) clocks: HashMap<Key, u64>,
 }
 
 impl RecoveryPoint {
+    pub fn insert(&mut self, peer_id: PeerId, clock_id: u32, clock_tick: u64) {
+        self.clocks.insert(Key::new(peer_id, clock_id), clock_tick);
+    }
+
     pub fn is_empty(&self) -> bool {
         self.clocks.is_empty()
     }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -171,6 +171,7 @@ pub struct RecoveryPoint {
 }
 
 impl RecoveryPoint {
+    #[cfg(test)]
     pub(crate) fn insert(&mut self, peer_id: PeerId, clock_id: u32, clock_tick: u64) {
         self.clocks.insert(Key::new(peer_id, clock_id), clock_tick);
     }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -205,6 +205,18 @@ impl RecoveryPoint {
         })
     }
 
+    /// Check whether this recovery point has any lower clock value than `other`
+    ///
+    /// A clock in this recovery point that is not in `other` is not considered lower.
+    pub fn has_any_lower(&self, other: &Self) -> bool {
+        self.clocks.iter().any(|(key, tick)| {
+            other
+                .clocks
+                .get(key)
+                .map_or(false, |other_tick| *tick < *other_tick)
+        })
+    }
+
     /// Extend this recovery point with new clocks from `clock_map`
     ///
     /// Clocks that we have not seen yet are added with a tick of `0`, because we must recover all

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -187,7 +187,7 @@ impl RecoveryPoint {
     }
 
     /// Check whether this recovery point has any clocks that are not in `other`
-    pub fn has_clocks_not_in(&mut self, other: &Self) -> bool {
+    pub fn has_clocks_not_in(&self, other: &Self) -> bool {
         self.clocks
             .keys()
             .any(|key| !other.clocks.contains_key(key))

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -182,6 +182,13 @@ impl RecoveryPoint {
             .map(|(key, tick)| ClockTag::new(key.peer_id, key.clock_id, *tick))
     }
 
+    /// Check whether this recovery point has any clocks that are not in `other`
+    pub fn has_clocks_not_in(&mut self, other: &Self) -> bool {
+        self.clocks
+            .keys()
+            .any(|key| !other.clocks.contains_key(key))
+    }
+
     /// Check whether this recovery point has any higher clock value than `other`
     ///
     /// A clock in this recovery point that is not in `other` is always considered to be higher.

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -121,7 +121,7 @@ impl ClockMap {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub(super) struct Key {
+pub struct Key {
     peer_id: PeerId,
     clock_id: u32,
 }
@@ -167,11 +167,11 @@ impl Clock {
 /// recovering node has not seen yet.
 #[derive(Clone, Debug, Default)]
 pub struct RecoveryPoint {
-    pub(super) clocks: HashMap<Key, u64>,
+    clocks: HashMap<Key, u64>,
 }
 
 impl RecoveryPoint {
-    pub fn insert(&mut self, peer_id: PeerId, clock_id: u32, clock_tick: u64) {
+    pub(crate) fn insert(&mut self, peer_id: PeerId, clock_id: u32, clock_tick: u64) {
         self.clocks.insert(Key::new(peer_id, clock_id), clock_tick);
     }
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -511,7 +511,7 @@ impl LocalShard {
     pub async fn load_from_wal(&self, collection_id: CollectionId) -> CollectionResult<()> {
         let mut highest_clocks = self.wal.highest_clocks.lock().await;
         let wal = self.wal.wal.lock();
-        let bar = ProgressBar::new(wal.len());
+        let bar = ProgressBar::new(wal.len(false));
 
         let progress_style = ProgressStyle::default_bar()
             .template("{msg} [{elapsed_precise}] {wide_bar} {pos}/{len} (eta:{eta})")
@@ -527,7 +527,7 @@ impl LocalShard {
         if !show_progress_bar {
             log::info!(
                 "Recovering collection {collection_id}: 0/{} (0%)",
-                wal.len(),
+                wal.len(false),
             );
         }
 
@@ -582,8 +582,8 @@ impl LocalShard {
                 let progress = bar.position();
                 log::info!(
                     "{progress}/{} ({}%)",
-                    wal.len(),
-                    (progress as f32 / wal.len() as f32 * 100.0) as usize,
+                    wal.len(false),
+                    (progress as f32 / wal.len(false) as f32 * 100.0) as usize,
                 );
                 last_progress_report = Instant::now();
             }
@@ -595,7 +595,7 @@ impl LocalShard {
         if !show_progress_bar {
             log::info!(
                 "Recovered collection {collection_id}: {0}/{0} (100%)",
-                wal.len(),
+                wal.len(false),
             );
         }
 

--- a/lib/collection/src/shards/replica_set/clock_set.rs
+++ b/lib/collection/src/shards/replica_set/clock_set.rs
@@ -15,11 +15,11 @@ impl ClockSet {
     pub fn get_clock(&mut self) -> ClockGuard {
         for (id, clock) in self.clocks.iter().enumerate() {
             if clock.try_lock() {
-                return ClockGuard::new(id, clock.clone());
+                return ClockGuard::new(id as u32, clock.clone());
             }
         }
 
-        let id = self.clocks.len();
+        let id = self.clocks.len() as u32;
         let clock = Arc::new(Clock::new_locked());
 
         self.clocks.push(clock.clone());
@@ -30,16 +30,16 @@ impl ClockSet {
 
 #[derive(Debug)]
 pub struct ClockGuard {
-    id: usize,
+    id: u32,
     clock: Arc<Clock>,
 }
 
 impl ClockGuard {
-    fn new(id: usize, clock: Arc<Clock>) -> Self {
+    fn new(id: u32, clock: Arc<Clock>) -> Self {
         Self { id, clock }
     }
 
-    pub fn id(&self) -> usize {
+    pub fn id(&self) -> u32 {
         self.id
     }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1,4 +1,4 @@
-mod clock_set;
+pub(crate) mod clock_set;
 mod execute_read_operation;
 mod locally_disabled_peers;
 mod read_ops;

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -425,7 +425,10 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub async fn resolve_wal_delta(&self, recovery_point: RecoveryPoint) -> CollectionResult<u64> {
+    pub async fn resolve_wal_delta(
+        &self,
+        recovery_point: RecoveryPoint,
+    ) -> CollectionResult<Option<u64>> {
         let local_shard_read = self.local.read().await;
         let Some(local_shard) = local_shard_read.deref() else {
             return Err(CollectionError::service_error(

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -161,7 +161,10 @@ impl Shard {
         }
     }
 
-    pub async fn resolve_wal_delta(&self, recovery_point: RecoveryPoint) -> CollectionResult<u64> {
+    pub async fn resolve_wal_delta(
+        &self,
+        recovery_point: RecoveryPoint,
+    ) -> CollectionResult<Option<u64>> {
         let resolve_result = match self {
             Self::Local(local_shard) => local_shard.wal.resolve_wal_delta(recovery_point).await,
             Self::ForwardProxy(proxy_shard) => {

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -114,13 +114,17 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.len(false) == 0
     }
 
-    pub fn len(&self) -> u64 {
-        self.wal
-            .num_entries()
-            .saturating_sub(self.truncated_prefix_entries_num())
+    pub fn len(&self, with_acknowledged: bool) -> u64 {
+        if with_acknowledged {
+            self.wal.num_entries()
+        } else {
+            self.wal
+                .num_entries()
+                .saturating_sub(self.truncated_prefix_entries_num())
+        }
     }
 
     // WAL operates in *segments*, so when `Wal::prefix_truncate` is called (during `SerdeWal::ack`),
@@ -145,7 +149,7 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
     pub fn read(&'s self, start_from: u64) -> impl Iterator<Item = (u64, R)> + 's {
         let first_index = self.first_index();
-        let len = self.len();
+        let len = self.len(false);
 
         (start_from..(first_index + len)).map(move |idx| {
             let record_bin = self.wal.entry(idx).expect("Can't read entry from WAL");
@@ -170,9 +174,9 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
         } else {
             self.first_index()
         };
-        let last_index = self.last_index();
+        let len = self.len(with_acknowledged);
 
-        (first_index..=last_index).rev().map(move |idx| {
+        (first_index..(first_index + len)).rev().map(move |idx| {
             let record_bin = self.wal.entry(idx).expect("Can't read entry from WAL");
             let record: R = serde_cbor::from_slice(&record_bin)
                 .or_else(|_err| rmp_serde::from_slice(&record_bin))

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -66,6 +66,7 @@ pub struct SerdeWal<R> {
     record: PhantomData<R>,
     wal: Wal,
     options: WalOptions,
+    /// First index of our logical WAL.
     first_index: Option<u64>,
 }
 

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -86,7 +86,7 @@ impl RecoverableWal {
             .filter(|clock_tag| clock_tag.clock_tick >= 1)
             .for_each(|mut clock_tag| {
                 clock_tag.clock_tick -= 1; // ToDO: get rid of
-                // Advance highest clocks we've seen
+                                           // Advance highest clocks we've seen
                 highest_clocks.advance_clock(clock_tag);
 
                 // Advance the cutoff point
@@ -963,7 +963,6 @@ mod tests {
         // Cannot recover E from B, because B has a high cutoff point due to the full transfer
         let delta_from = b_wal.resolve_wal_delta(e_recovery_point.clone()).await;
         assert_eq!(delta_from.unwrap_err(), WalDeltaError::Cutoff);
-        
 
         // Try to recover A from B
 
@@ -992,7 +991,6 @@ mod tests {
 
         // No diff expected
         assert_eq!(delta_from, Ok(None));
-        
 
         let op7 = mock_operation(7);
         // Add operation to B but not A
@@ -1014,7 +1012,11 @@ mod tests {
         }
 
         let a_recovery_point = a_wal.recovery_point().await;
-        let delta_from = b_wal.resolve_wal_delta(a_recovery_point.clone()).await.unwrap().unwrap();
+        let delta_from = b_wal
+            .resolve_wal_delta(a_recovery_point.clone())
+            .await
+            .unwrap()
+            .unwrap();
 
         // Diff expected
         assert_eq!(b_wal.wal.lock().read(delta_from).count(), 1);

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -954,7 +954,7 @@ mod tests {
         // Try to recover E from B
         let e_recovery_point = e_wal.recovery_point().await;
 
-        // Cannot recover E from B, because B has a high cutoff piont due to the full transfer
+        // Cannot recover E from B, because B has a high cutoff point due to the full transfer
         let delta_from = b_wal.resolve_wal_delta(e_recovery_point.clone()).await;
         assert_eq!(delta_from.unwrap_err(), WalDeltaError::Cutoff);
 

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -221,7 +221,7 @@ mod tests {
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
     #[test]
-    fn test_resolve_wal_one_operation() {
+    fn test_resolve_wal_delta_one_operation() {
         // Create WALs for peer A, B and C
         let (mut a_wal, _a_wal_dir) = fixture_empty_wal();
         let (mut b_wal, _b_wal_dir) = fixture_empty_wal();
@@ -328,7 +328,7 @@ mod tests {
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
     #[test]
-    fn test_resolve_wal_many_operations() {
+    fn test_resolve_wal_delta_many_operations() {
         const N: usize = 5;
         const M: usize = 25;
 
@@ -433,7 +433,7 @@ mod tests {
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
     #[test]
-    fn test_resolve_wal_many_intermixed_operations() {
+    fn test_resolve_wal_delta_many_intermixed_operations() {
         const N: usize = 3;
         const M: usize = 50;
 
@@ -545,7 +545,7 @@ mod tests {
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
     #[test]
-    fn test_resolve_wal_unordered_operations() {
+    fn test_resolve_wal_delta_unordered_operations() {
         // Create WALs for peer A, B and C
         let (mut a_wal, _a_wal_dir) = fixture_empty_wal();
         let (mut b_wal, _b_wal_dir) = fixture_empty_wal();

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -166,7 +166,7 @@ fn resolve_wal_delta(
     recovery_point.remove_equal_clocks(local_recovery_point);
 
     // Recovery point may not be below our cutoff point
-    if local_cutoff_point.has_any_higher(&recovery_point) {
+    if recovery_point.has_any_lower(local_cutoff_point) {
         return Err(WalDeltaError::Cutoff);
     }
 
@@ -1115,8 +1115,7 @@ mod tests {
         recovery_point.insert(1, 1, 10);
         local_recovery_point.insert(1, 0, 20);
         local_recovery_point.insert(1, 1, 12);
-        local_cutoff_point.insert(1, 0, 17);
-        local_cutoff_point.insert(1, 1, 10);
+        local_cutoff_point.insert(1, 0, 16);
 
         let resolve_result = resolve_wal_delta(
             recovery_point,

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -99,7 +99,7 @@ impl RecoverableWal {
     ) -> Result<u64, WalDeltaError> {
         resolve_wal_delta(
             recovery_point,
-            &self.wal,
+            self.wal.clone(),
             self.recovery_point().await,
             self.cutoff_clocks.lock().await.to_recovery_point(),
         )
@@ -121,7 +121,7 @@ impl RecoverableWal {
 /// If a WAL delta could not be resolved, an error is returned describing the failure.
 fn resolve_wal_delta(
     mut recovery_point: RecoveryPoint,
-    local_wal: &LockedWal,
+    local_wal: LockedWal,
     local_recovery_point: RecoveryPoint,
     local_cutoff_point: RecoveryPoint,
 ) -> Result<u64, WalDeltaError> {

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -309,6 +309,7 @@ mod tests {
         // Recover WAL on node C by writing delta from node B to it
         b_wal.lock().read(delta_from).for_each(|(_, update)| {
             c_wal.write(&update).unwrap();
+            c_clock_map.advance_clock(update.clock_tag.unwrap());
         });
 
         // WALs should match up perfectly now
@@ -412,6 +413,7 @@ mod tests {
         // Recover WAL on node C by writing delta from node B to it
         b_wal.lock().read(delta_from).for_each(|(_, update)| {
             c_wal.write(&update).unwrap();
+            c_clock_map.advance_clock(update.clock_tag.unwrap());
         });
 
         // WALs should match up perfectly now
@@ -524,6 +526,7 @@ mod tests {
         // Recover WAL on node C by writing delta from node B to it
         b_wal.lock().read(delta_from).for_each(|(_, update)| {
             c_wal.write(&update).unwrap();
+            c_clock_map.advance_clock(update.clock_tag.unwrap());
         });
 
         // WALs should match up perfectly now
@@ -641,6 +644,7 @@ mod tests {
         // Recover WAL on node C by writing delta from node B to it
         b_wal.lock().read(delta_from).for_each(|(_, update)| {
             c_wal.write(&update).unwrap();
+            c_clock_map.advance_clock(update.clock_tag.unwrap());
         });
 
         // WAL on node B and C will match, A is in different order

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -218,7 +218,7 @@ mod tests {
 
     /// Test WAL delta resolution with just one missed operation on node C.
     ///
-    /// Simplified version of: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
+    /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
     #[test]
     fn test_resolve_wal_one_operation() {
         // Create WALs for peer A, B and C
@@ -301,6 +301,107 @@ mod tests {
         )
         .unwrap();
         assert_eq!(delta_from, 1);
+
+        // Diff should have 1 operation, as C missed just one
+        assert_eq!(b_wal.lock().read(delta_from).count(), 1);
+
+        // Recover WAL on node C by writing delta from node B to it
+        b_wal.lock().read(delta_from).for_each(|(_, update)| {
+            c_wal.write(&update).unwrap();
+        });
+
+        // WALs should match up perfectly now
+        a_wal.lock()
+            .read(0)
+            .zip(b_wal.lock().read(0))
+            .zip(c_wal.read(0))
+            .for_each(|((a, b), c)| {
+                assert_eq!(a, b);
+                assert_eq!(b, c);
+            });
+    }
+
+    /// Test WAL delta resolution with a many missed operations on node C.
+    ///
+    /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
+    #[test]
+    fn test_resolve_wal_many_operation() {
+        const N: usize = 5;
+        const M: usize = 25;
+
+        // Create WALs for peer A, B and C
+        let (mut a_wal, _a_wal_dir) = fixture_empty_wal();
+        let (mut b_wal, _b_wal_dir) = fixture_empty_wal();
+        let (mut c_wal, _c_wal_dir) = fixture_empty_wal();
+
+        // Create clock sets for peer A, B and C
+        let mut a_clock_set = ClockSet::new();
+        let mut a_clock_map = ClockMap::default();
+        let mut b_clock_map = ClockMap::default();
+        let mut c_clock_map = ClockMap::default();
+
+        // Create N operation on peer A
+        for i in 0..N {
+            let mut a_clock_0 = a_clock_set.get_clock();
+            let clock_tick = a_clock_0.tick_once();
+            let clock_tag = ClockTag::new(1, 0, clock_tick);
+            let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                PointInsertOperationsInternal::PointsList(vec![PointStruct {
+                    id: (i as u64).into(),
+                    vector: vec![i as f32, -(i as f32), 0.0].into(),
+                    payload: None,
+                }]),
+            ));
+            let operation_with_clock_tag = OperationWithClockTag::new(operation, Some(clock_tag));
+
+            // Write operations to peer A, B and C, and advance clocks
+            a_wal.write(&operation_with_clock_tag).unwrap();
+            b_wal.write(&operation_with_clock_tag).unwrap();
+            c_wal.write(&operation_with_clock_tag).unwrap();
+            a_clock_0.advance_to(clock_tick);
+            a_clock_map.advance_clock(clock_tag);
+            b_clock_map.advance_clock(clock_tag);
+            c_clock_map.advance_clock(clock_tag);
+        }
+
+        // Create M operations on peer A, which are missed on node C
+        for i in N..N + M {
+            let mut a_clock_0 = a_clock_set.get_clock();
+            let clock_tick = a_clock_0.tick_once();
+            let clock_tag = ClockTag::new(1, 0, clock_tick);
+            let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                PointInsertOperationsInternal::PointsList(vec![PointStruct {
+                    id: (i as u64).into(),
+                    vector: vec![i as f32, -(i as f32), 0.0].into(),
+                    payload: None,
+                }]),
+            ));
+            let operation_with_clock_tag = OperationWithClockTag::new(operation, Some(clock_tag));
+
+            // Write operations to peer A and B, not C, and advance clocks
+            a_wal.write(&operation_with_clock_tag).unwrap();
+            b_wal.write(&operation_with_clock_tag).unwrap();
+            a_clock_0.advance_to(clock_tick);
+            a_clock_map.advance_clock(clock_tag);
+            b_clock_map.advance_clock(clock_tag);
+        }
+
+        let a_wal = Arc::new(ParkingMutex::new(a_wal));
+        let b_wal = Arc::new(ParkingMutex::new(b_wal));
+        let a_recovery_point = a_clock_map.to_recovery_point();
+        let b_recovery_point = b_clock_map.to_recovery_point();
+        let c_recovery_point = c_clock_map.to_recovery_point();
+
+        // Resolve delta on node A for node C, assert correctness
+        let delta_from = resolve_wal_delta(c_recovery_point.clone(), a_wal.clone(), &a_recovery_point).unwrap();
+        assert_eq!(delta_from, N as u64);
+
+        // Resolve delta on node B for node C, assert correctness
+        let delta_from = resolve_wal_delta(c_recovery_point, b_wal.clone(), &b_recovery_point).unwrap();
+        assert_eq!(delta_from, N as u64);
+
+        // Diff should have M operations, as node C missed M operations
+        assert_eq!(b_wal.lock().read(delta_from).count(), M);
 
         // Recover WAL on node C by writing delta from node B to it
         b_wal.lock().read(delta_from).for_each(|(_, update)| {

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -237,6 +237,16 @@ mod tests {
         )
     }
 
+    fn mock_operation(id: u64) -> CollectionUpdateOperations {
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![PointStruct {
+                id: id.into(),
+                vector: vec![1.0, 2.0, 3.0].into(),
+                payload: None,
+            }]),
+        ))
+    }
+
     /// Test WAL delta resolution with just one missed operation on node C.
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
@@ -254,14 +264,7 @@ mod tests {
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
         let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-        let bare_operation =
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                    id: 1.into(),
-                    vector: vec![1.0, 2.0, 3.0].into(),
-                    payload: None,
-                }]),
-            ));
+        let bare_operation = mock_operation(1);
         let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
         // Write operations to peer A, B and C, and advance clocks
@@ -280,14 +283,7 @@ mod tests {
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
         let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-        let bare_operation =
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                    id: 2.into(),
-                    vector: vec![3.0, 2.0, 1.0].into(),
-                    payload: None,
-                }]),
-            ));
+        let bare_operation = mock_operation(2);
         let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
         // Write operations to peer A and B, not C, and advance clocks
@@ -355,14 +351,7 @@ mod tests {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
             let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-            let bare_operation =
-                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                    PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                        id: (i as u64).into(),
-                        vector: vec![i as f32, -(i as f32), 0.0].into(),
-                        payload: None,
-                    }]),
-                ));
+            let bare_operation = mock_operation(i as u64);
             let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
             // Write operations to peer A, B and C, and advance clocks
@@ -382,14 +371,7 @@ mod tests {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
             let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-            let bare_operation =
-                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                    PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                        id: (i as u64).into(),
-                        vector: vec![i as f32, -(i as f32), 0.0].into(),
-                        payload: None,
-                    }]),
-                ));
+            let bare_operation = mock_operation(i as u64);
             let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
             // Write operations to peer A and B, not C, and advance clocks
@@ -456,14 +438,7 @@ mod tests {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
             let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-            let bare_operation =
-                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                    PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                        id: (i as u64).into(),
-                        vector: vec![i as f32, -(i as f32), 0.0].into(),
-                        payload: None,
-                    }]),
-                ));
+            let bare_operation = mock_operation(i as u64);
             let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
             // Write operations to peer A, B and C, and advance clocks
@@ -490,14 +465,7 @@ mod tests {
             };
             let clock_tick = clock.tick_once();
             let clock_tag = ClockTag::new(peer_id, clock.id(), clock_tick);
-            let bare_operation =
-                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                    PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                        id: (i as u64).into(),
-                        vector: vec![i as f32, -(i as f32), 0.0].into(),
-                        payload: None,
-                    }]),
-                ));
+            let bare_operation = mock_operation(i as u64);
             let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
             // Write operations to peer A and B, not C, and advance clocks
@@ -559,14 +527,7 @@ mod tests {
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
         let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
-        let bare_operation =
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                    id: 1.into(),
-                    vector: vec![1.0, 2.0, 3.0].into(),
-                    payload: None,
-                }]),
-            ));
+        let bare_operation = mock_operation(1);
         let operation = OperationWithClockTag::new(bare_operation, Some(clock_tag));
 
         // Write operations to peer A, B and C, and advance clocks
@@ -588,22 +549,8 @@ mod tests {
         let b_clock_tick = b_clock_0.tick_once();
         let a_clock_tag = ClockTag::new(1, a_clock_0.id(), a_clock_tick);
         let b_clock_tag = ClockTag::new(2, a_clock_0.id(), b_clock_tick);
-        let bare_operation_1 =
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                    id: 2.into(),
-                    vector: vec![3.0, 2.0, 1.0].into(),
-                    payload: None,
-                }]),
-            ));
-        let bare_operation_2 =
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                    id: 3.into(),
-                    vector: vec![9.0, 8.0, 7.0].into(),
-                    payload: None,
-                }]),
-            ));
+        let bare_operation_1 = mock_operation(2);
+        let bare_operation_2 = mock_operation(3);
         let operation_1 = OperationWithClockTag::new(bare_operation_1, Some(a_clock_tag));
         let operation_2 = OperationWithClockTag::new(bare_operation_2, Some(b_clock_tag));
 
@@ -699,6 +646,357 @@ mod tests {
             assert!(b_wal_point_ids.contains(&i.into()));
             assert!(c_wal_point_ids.contains(&i.into()));
         });
+    }
+
+    #[tokio::test]
+    async fn test_recover_from_previously_recoverred_with_forward_proxy() {
+        // Consider a situation
+
+        // Steps:
+        //
+        // 1. We initialize 2 operations on A and B, that are successfully written to both from C
+        // 2. Operation 3 is written to A, but not B
+        // 2.1. Operation 30  is written to A, but not B (Second channel)
+        // 3. Operation 4,5 from D is written to both A and B
+        // 4. Now B is reported as failed and we need to recover it from A
+        // 5. During recovery, we send untagged operations from A to B (full transfer) + node C sends an Update
+        // 6. After recoverred (need to check consistency of A and B), node D sends an Update to A and B
+        // 7. Now we want to recover newly created node E from B
+        // 8. Try to recover A from E (expect no diff, as both are supposed to be active)
+
+        //          Recover
+        //     ┌───┬───────►┌───┐
+        //     │ A │        │ B │
+        //     └─▲─┴───────►└─▲─┘
+        //       │  Forward   │
+        //       │            │
+        //       │            │
+        //       │   ┌───┐    │
+        //       └───┤ C ├────┘
+        //  Update   └───┘  Failed Update
+        //
+        //
+        //
+        //           ┌───┐
+        //       ┌───┤ D ├────┐
+        // Update│   └───┘    │Update
+        //       │            │
+        //       │            │
+        //     ┌─▼─┐        ┌─▼─┐
+        //     │ A │        │ B │
+        //     └───┘        └───┘
+        //
+        //
+        //                   (Almost Empty)
+        //     ┌───┐Recover ┌───┐
+        //     │ B ├───────►│ E │
+        //     └───┘        └───┘
+        //
+        //
+        //                   (Identical)
+        //     ┌───┐Recover ┌───┐
+        //     │ E ├───────►│ A │
+        //     └───┘        └───┘
+
+        let (a_wal, _a_wal_dir) = fixture_empty_wal();
+        let (b_wal, _b_wal_dir) = fixture_empty_wal();
+
+        let (e_wal, _e_wal_dir) = fixture_empty_wal();
+
+        let mut c_clock_set = ClockSet::new();
+        let mut d_clock_set = ClockSet::new();
+
+        let node_c_peer_id = 1;
+        let node_d_peer_id = 2;
+
+        let op1: CollectionUpdateOperations = mock_operation(1);
+
+        // Initial normal operation, written to both A and B  + additionally Em but we will need it later
+        {
+            // Node C is sending updates to A and B
+            let mut c_clock_0 = c_clock_set.get_clock();
+            let clock_tick = c_clock_0.tick_once();
+            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
+
+            let operation_with_clock = OperationWithClockTag::new(op1, Some(clock_tag));
+
+            let mut operation_a = operation_with_clock.clone();
+            let mut operation_b = operation_with_clock.clone();
+            let mut operation_e = operation_with_clock.clone();
+
+            a_wal.lock_and_write(&mut operation_a).await.unwrap();
+            b_wal.lock_and_write(&mut operation_b).await.unwrap();
+            e_wal.lock_and_write(&mut operation_e).await.unwrap();
+
+            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
+            c_clock_0.advance_to(operation_e.clock_tag.unwrap().clock_tick);
+        }
+
+        let op2: CollectionUpdateOperations = mock_operation(2);
+
+        // Initial normal operation, written to both
+        {
+            // Node C is sending updates to A and B
+            let mut c_clock_0 = c_clock_set.get_clock();
+            let clock_tick = c_clock_0.tick_once();
+            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
+
+            let operation_with_clock = OperationWithClockTag::new(op2, Some(clock_tag));
+
+            let mut operation_a = operation_with_clock.clone();
+            let mut operation_b = operation_with_clock.clone();
+
+            a_wal.lock_and_write(&mut operation_a).await.unwrap();
+            b_wal.lock_and_write(&mut operation_b).await.unwrap();
+
+            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
+        }
+
+        let op3: CollectionUpdateOperations = mock_operation(3);
+        let op30: CollectionUpdateOperations = mock_operation(30);
+
+        // Next operation gets written to A, but not B
+        {
+            // Node C is sending updates to A and B
+            let mut c_clock_0 = c_clock_set.get_clock();
+            let mut c_clock_1 = c_clock_set.get_clock();
+
+            {
+                // First parallel operation
+                let clock_tick = c_clock_0.tick_once();
+                let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
+
+                let operation_with_clock = OperationWithClockTag::new(op3, Some(clock_tag));
+
+                let mut operation_a = operation_with_clock.clone();
+
+                a_wal.lock_and_write(&mut operation_a).await.unwrap();
+
+                c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            }
+
+            {
+                // Second parallel operation
+                let clock_tick = c_clock_1.tick_once();
+                let clock_tag = ClockTag::new(node_c_peer_id, c_clock_1.id(), clock_tick);
+
+                let operation_with_clock = OperationWithClockTag::new(op30, Some(clock_tag));
+
+                let mut operation_a = operation_with_clock.clone();
+
+                a_wal.lock_and_write(&mut operation_a).await.unwrap();
+
+                c_clock_1.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            }
+        }
+
+        let op4: CollectionUpdateOperations = mock_operation(4);
+
+        // Node D sends an update to both A and B, both successfully written
+        {
+            let mut d_clock_0 = d_clock_set.get_clock();
+            let clock_tick = d_clock_0.tick_once();
+            let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
+
+            let operation_with_clock = OperationWithClockTag::new(op4, Some(clock_tag));
+
+            let mut operation_a = operation_with_clock.clone();
+            let mut operation_b = operation_with_clock.clone();
+
+            a_wal.lock_and_write(&mut operation_a).await.unwrap();
+            b_wal.lock_and_write(&mut operation_b).await.unwrap();
+
+            d_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            d_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
+        }
+
+        let op5: CollectionUpdateOperations = mock_operation(5);
+
+        // Node D sends an update to both A and B, both successfully written
+        {
+            let mut d_clock_0 = d_clock_set.get_clock();
+            let clock_tick = d_clock_0.tick_once();
+            let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
+
+            let operation_with_clock = OperationWithClockTag::new(op5, Some(clock_tag));
+
+            let mut operation_a = operation_with_clock.clone();
+            let mut operation_b = operation_with_clock.clone();
+
+            a_wal.lock_and_write(&mut operation_a).await.unwrap();
+            b_wal.lock_and_write(&mut operation_b).await.unwrap();
+
+            d_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            d_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
+        }
+
+        // Now B is reported as failed and we need to recover it from A
+
+        let b_recovery_point = b_wal.recovery_point().await;
+
+        let delta_from = a_wal
+            .resolve_wal_delta(b_recovery_point.clone())
+            .await
+            .unwrap();
+
+        // Operation 0 and 1 are written to both and do not need to be recovered
+        // All further operations have to be written to B
+        assert_eq!(delta_from, 2);
+
+        // But instead of recovering from WAL, we will check full streaming transfer
+        {
+            let op1 = mock_operation(1);
+            let op1_with_clock = OperationWithClockTag::new(op1, None);
+            b_wal
+                .lock_and_write(&mut op1_with_clock.clone())
+                .await
+                .unwrap();
+
+            let op2 = mock_operation(2);
+            let op2_with_clock = OperationWithClockTag::new(op2, None);
+            b_wal
+                .lock_and_write(&mut op2_with_clock.clone())
+                .await
+                .unwrap();
+        }
+
+        let op6: CollectionUpdateOperations = mock_operation(6);
+
+        // In between the recovery, we have a new update from C
+        // It is written to both A and B, plus forwarded to B with forward proxy
+        {
+            let mut c_clock_0 = c_clock_set.get_clock();
+            let clock_tick = c_clock_0.tick_once();
+            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
+
+            let operation_with_clock = OperationWithClockTag::new(op6, Some(clock_tag));
+
+            let mut operation_a = operation_with_clock.clone();
+            let mut operation_b = operation_with_clock.clone();
+            let mut operation_b_forward = operation_with_clock.clone();
+
+            a_wal.lock_and_write(&mut operation_a).await.unwrap();
+            b_wal.lock_and_write(&mut operation_b).await.unwrap();
+            b_wal
+                .lock_and_write(&mut operation_b_forward)
+                .await
+                .unwrap();
+
+            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
+            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
+        }
+
+        // Continue recovery
+        {
+            let op3 = mock_operation(3);
+            let op3_with_clock = OperationWithClockTag::new(op3, None);
+            b_wal
+                .lock_and_write(&mut op3_with_clock.clone())
+                .await
+                .unwrap();
+
+            let op30 = mock_operation(30);
+            let op30_with_clock = OperationWithClockTag::new(op30, None);
+            b_wal
+                .lock_and_write(&mut op30_with_clock.clone())
+                .await
+                .unwrap();
+
+            let op4 = mock_operation(4);
+            let op4_with_clock = OperationWithClockTag::new(op4, None);
+            b_wal
+                .lock_and_write(&mut op4_with_clock.clone())
+                .await
+                .unwrap();
+
+            let op5 = mock_operation(5);
+            let op5_with_clock = OperationWithClockTag::new(op5, None);
+            b_wal
+                .lock_and_write(&mut op5_with_clock.clone())
+                .await
+                .unwrap();
+        }
+
+        // Try to recover E from B
+        let e_recovery_point = e_wal.recovery_point().await;
+
+        // *******************************************************
+        // ToDo: check what would happened if wal_b were truncated
+        // *******************************************************
+
+        let delta_from = b_wal
+            .resolve_wal_delta(e_recovery_point.clone())
+            .await
+            .unwrap();
+
+        // Operation 0 was written to E, but everything else has to be written to E (including transfers)
+        assert_eq!(delta_from, 1);
+
+        // Total: 2 operations from C
+        // + 1 operation from C_1
+        // + 1 operations from D (one missing)
+        // + 5 recovery operations
+        // + 1 operation from C during recovery
+        // + 1 duplicate operation from C
+        assert_eq!(b_wal.wal.lock().read(delta_from).count(), 11);
+
+        // Recover E from B
+        e_wal.append_from(&b_wal, delta_from).await.unwrap();
+
+        // Now we want to try to recover theoretically active node A from E
+        // Both are active, so we expect no diff
+        let a_recovery_point = a_wal.recovery_point().await;
+
+        /*
+        a_recovery_point = RecoveryPoint {
+            clocks: {
+                C_1: 1,
+                C: 4,
+                D: 2,
+            },
+        }
+        e_recovery_point = RecoveryPoint {
+            clocks: {
+                D: 2,
+                C: 4,
+            },
+        }
+        E entry = (0, PointStruct { id: NumId(1), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 0 }))
+        E entry = (1, PointStruct { id: NumId(2), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 1 }))
+        E entry = (2, PointStruct { id: NumId(4), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 0 }))
+        E entry = (3, PointStruct { id: NumId(5), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 1 }))
+        E entry = (4, PointStruct { id: NumId(1), }, clock_tag: None)
+        E entry = (5, PointStruct { id: NumId(2), }, clock_tag: None)
+        E entry = (6, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
+        E entry = (7, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
+        E entry = (8, PointStruct { id: NumId(3), }, clock_tag: None)
+        E entry = (9, PointStruct { id: NumId(30), }, clock_tag: None)
+        E entry = (10, PointStruct { id: NumId(4), }, clock_tag: None)
+        E entry = (11, PointStruct { id: NumId(5), }, clock_tag: None)
+        ------------------------------
+        A entry = (0, PointStruct { id: NumId(1), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 0 }))
+        A entry = (1, PointStruct { id: NumId(2), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 1 }))
+        A entry = (2, PointStruct { id: NumId(3), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 2 }))
+        A entry = (3, PointStruct { id: NumId(30), }, clock_tag: Some(ClockTag { peer: C_1, clock_tick: 0 }))
+        A entry = (4, PointStruct { id: NumId(4), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 0 }))
+        A entry = (5, PointStruct { id: NumId(5), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 1 }))
+        A entry = (6, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
+         */
+
+        let delta_from = e_wal.resolve_wal_delta(a_recovery_point.clone()).await;
+
+        // No diff expected
+        // **************************************************************************************
+        // ToDo: This check is broken! Expected to be fixed after truncation logic is implemented
+        // **************************************************************************************
+        // assert_eq!(e_wal.wal.lock().read(delta_from).count(), 0);
+
+        assert_eq!(
+            delta_from.unwrap_err().to_string(),
+            "recovery point requests clocks this WAL does not know about",
+        );
     }
 
     /// Empty recovery point should not resolve any diff.
@@ -863,363 +1161,5 @@ mod tests {
             resolve_result.unwrap_err().to_string(),
             "cannot find slice of WAL operations that satisfies the recovery point",
         );
-    }
-
-    fn get_mock_operation(id: u64) -> CollectionUpdateOperations {
-        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-            PointInsertOperationsInternal::PointsList(vec![PointStruct {
-                id: id.into(),
-                vector: vec![1.0, 2.0, 3.0].into(),
-                payload: None,
-            }]),
-        ))
-    }
-
-    #[tokio::test]
-    async fn test_recover_from_previously_recoverred_with_forward_proxy() {
-        // Consider a situation
-
-        // Steps:
-        //
-        // 1. We initialize 2 operations on A and B, that are successfully written to both from C
-        // 2. Operation 3 is written to A, but not B
-        // 2.1. Operation 30  is written to A, but not B (Second channel)
-        // 3. Operation 4,5 from D is written to both A and B
-        // 4. Now B is reported as failed and we need to recover it from A
-        // 5. During recovery, we send untagged operations from A to B (full transfer) + node C sends an Update
-        // 6. After recoverred (need to check consistency of A and B), node D sends an Update to A and B
-        // 7. Now we want to recover newly created node E from B
-        // 8. Try to recover A from E (expect no diff, as both are supposed to be active)
-
-        //          Recover
-        //     ┌───┬───────►┌───┐
-        //     │ A │        │ B │
-        //     └─▲─┴───────►└─▲─┘
-        //       │  Forward   │
-        //       │            │
-        //       │            │
-        //       │   ┌───┐    │
-        //       └───┤ C ├────┘
-        //  Update   └───┘  Failed Update
-        //
-        //
-        //
-        //           ┌───┐
-        //       ┌───┤ D ├────┐
-        // Update│   └───┘    │Update
-        //       │            │
-        //       │            │
-        //     ┌─▼─┐        ┌─▼─┐
-        //     │ A │        │ B │
-        //     └───┘        └───┘
-        //
-        //
-        //                   (Almost Empty)
-        //     ┌───┐Recover ┌───┐
-        //     │ B ├───────►│ E │
-        //     └───┘        └───┘
-        //
-        //
-        //                   (Identical)
-        //     ┌───┐Recover ┌───┐
-        //     │ E ├───────►│ A │
-        //     └───┘        └───┘
-
-        let (a_wal, _a_wal_dir) = fixture_empty_wal();
-        let (b_wal, _b_wal_dir) = fixture_empty_wal();
-
-        let (e_wal, _e_wal_dir) = fixture_empty_wal();
-
-        let mut c_clock_set = ClockSet::new();
-        let mut d_clock_set = ClockSet::new();
-
-        let node_c_peer_id = 1;
-        let node_d_peer_id = 2;
-
-        let op1: CollectionUpdateOperations = get_mock_operation(1);
-
-        // Initial normal operation, written to both A and B  + additionally Em but we will need it later
-        {
-            // Node C is sending updates to A and B
-            let mut c_clock_0 = c_clock_set.get_clock();
-            let clock_tick = c_clock_0.tick_once();
-            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
-
-            let operation_with_clock = OperationWithClockTag::new(op1, Some(clock_tag));
-
-            let mut operation_a = operation_with_clock.clone();
-            let mut operation_b = operation_with_clock.clone();
-            let mut operation_e = operation_with_clock.clone();
-
-            a_wal.lock_and_write(&mut operation_a).await.unwrap();
-            b_wal.lock_and_write(&mut operation_b).await.unwrap();
-            e_wal.lock_and_write(&mut operation_e).await.unwrap();
-
-            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
-            c_clock_0.advance_to(operation_e.clock_tag.unwrap().clock_tick);
-        }
-
-        let op2: CollectionUpdateOperations = get_mock_operation(2);
-
-        // Initial normal operation, written to both
-        {
-            // Node C is sending updates to A and B
-            let mut c_clock_0 = c_clock_set.get_clock();
-            let clock_tick = c_clock_0.tick_once();
-            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
-
-            let operation_with_clock = OperationWithClockTag::new(op2, Some(clock_tag));
-
-            let mut operation_a = operation_with_clock.clone();
-            let mut operation_b = operation_with_clock.clone();
-
-            a_wal.lock_and_write(&mut operation_a).await.unwrap();
-            b_wal.lock_and_write(&mut operation_b).await.unwrap();
-
-            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
-        }
-
-        let op3: CollectionUpdateOperations = get_mock_operation(3);
-        let op30: CollectionUpdateOperations = get_mock_operation(30);
-
-        // Next operation gets written to A, but not B
-        {
-            // Node C is sending updates to A and B
-            let mut c_clock_0 = c_clock_set.get_clock();
-            let mut c_clock_1 = c_clock_set.get_clock();
-
-            {
-                // First parallel operation
-                let clock_tick = c_clock_0.tick_once();
-                let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
-
-                let operation_with_clock = OperationWithClockTag::new(op3, Some(clock_tag));
-
-                let mut operation_a = operation_with_clock.clone();
-
-                a_wal.lock_and_write(&mut operation_a).await.unwrap();
-
-                c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            }
-
-            {
-                // Second parallel operation
-                let clock_tick = c_clock_1.tick_once();
-                let clock_tag = ClockTag::new(node_c_peer_id, c_clock_1.id(), clock_tick);
-
-                let operation_with_clock = OperationWithClockTag::new(op30, Some(clock_tag));
-
-                let mut operation_a = operation_with_clock.clone();
-
-                a_wal.lock_and_write(&mut operation_a).await.unwrap();
-
-                c_clock_1.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            }
-        }
-
-        let op4: CollectionUpdateOperations = get_mock_operation(4);
-
-        // Node D sends an update to both A and B, both successfully written
-        {
-            let mut d_clock_0 = d_clock_set.get_clock();
-            let clock_tick = d_clock_0.tick_once();
-            let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
-
-            let operation_with_clock = OperationWithClockTag::new(op4, Some(clock_tag));
-
-            let mut operation_a = operation_with_clock.clone();
-            let mut operation_b = operation_with_clock.clone();
-
-            a_wal.lock_and_write(&mut operation_a).await.unwrap();
-            b_wal.lock_and_write(&mut operation_b).await.unwrap();
-
-            d_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            d_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
-        }
-
-        let op5: CollectionUpdateOperations = get_mock_operation(5);
-
-        // Node D sends an update to both A and B, both successfully written
-        {
-            let mut d_clock_0 = d_clock_set.get_clock();
-            let clock_tick = d_clock_0.tick_once();
-            let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
-
-            let operation_with_clock = OperationWithClockTag::new(op5, Some(clock_tag));
-
-            let mut operation_a = operation_with_clock.clone();
-            let mut operation_b = operation_with_clock.clone();
-
-            a_wal.lock_and_write(&mut operation_a).await.unwrap();
-            b_wal.lock_and_write(&mut operation_b).await.unwrap();
-
-            d_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            d_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
-        }
-
-        // Now B is reported as failed and we need to recover it from A
-
-        let b_recovery_point = b_wal.recovery_point().await;
-
-        let delta_from = a_wal
-            .resolve_wal_delta(b_recovery_point.clone())
-            .await
-            .unwrap();
-
-        // Operation 0 and 1 are written to both and do not need to be recovered
-        // All further operations have to be written to B
-        assert_eq!(delta_from, 2);
-
-        // But instead of recovering from WAL, we will check full streaming transfer
-        {
-            let op1 = get_mock_operation(1);
-            let op1_with_clock = OperationWithClockTag::new(op1, None);
-            b_wal
-                .lock_and_write(&mut op1_with_clock.clone())
-                .await
-                .unwrap();
-
-            let op2 = get_mock_operation(2);
-            let op2_with_clock = OperationWithClockTag::new(op2, None);
-            b_wal
-                .lock_and_write(&mut op2_with_clock.clone())
-                .await
-                .unwrap();
-        }
-
-        let op6: CollectionUpdateOperations = get_mock_operation(6);
-
-        // In between the recovery, we have a new update from C
-        // It is written to both A and B, plus forwarded to B with forward proxy
-        {
-            let mut c_clock_0 = c_clock_set.get_clock();
-            let clock_tick = c_clock_0.tick_once();
-            let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
-
-            let operation_with_clock = OperationWithClockTag::new(op6, Some(clock_tag));
-
-            let mut operation_a = operation_with_clock.clone();
-            let mut operation_b = operation_with_clock.clone();
-            let mut operation_b_forward = operation_with_clock.clone();
-
-            a_wal.lock_and_write(&mut operation_a).await.unwrap();
-            b_wal.lock_and_write(&mut operation_b).await.unwrap();
-            b_wal
-                .lock_and_write(&mut operation_b_forward)
-                .await
-                .unwrap();
-
-            c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
-            c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);
-        }
-
-        // Continue recovery
-        {
-            let op3 = get_mock_operation(3);
-            let op3_with_clock = OperationWithClockTag::new(op3, None);
-            b_wal
-                .lock_and_write(&mut op3_with_clock.clone())
-                .await
-                .unwrap();
-
-            let op30 = get_mock_operation(30);
-            let op30_with_clock = OperationWithClockTag::new(op30, None);
-            b_wal
-                .lock_and_write(&mut op30_with_clock.clone())
-                .await
-                .unwrap();
-
-            let op4 = get_mock_operation(4);
-            let op4_with_clock = OperationWithClockTag::new(op4, None);
-            b_wal
-                .lock_and_write(&mut op4_with_clock.clone())
-                .await
-                .unwrap();
-
-            let op5 = get_mock_operation(5);
-            let op5_with_clock = OperationWithClockTag::new(op5, None);
-            b_wal
-                .lock_and_write(&mut op5_with_clock.clone())
-                .await
-                .unwrap();
-        }
-
-        // Try to recover E from B
-        let e_recovery_point = e_wal.recovery_point().await;
-
-        // *******************************************************
-        // ToDo: check what would happened if wal_b were truncated
-        // *******************************************************
-
-        let delta_from = b_wal
-            .resolve_wal_delta(e_recovery_point.clone())
-            .await
-            .unwrap();
-
-        // Operation 0 was written to E, but everything else has to be written to E (including transfers)
-        assert_eq!(delta_from, 1);
-
-        // Total: 2 operations from C
-        // + 1 operation from C_1
-        // + 1 operations from D (one missing)
-        // + 5 recovery operations
-        // + 1 operation from C during recovery
-        // + 1 duplicate operation from C
-        assert_eq!(b_wal.wal.lock().read(delta_from).count(), 11);
-
-        // Recover E from B
-        e_wal.append_from(&b_wal, delta_from).await.unwrap();
-
-        // Now we want to try to recover theoretically active node A from E
-        // Both are active, so we expect no diff
-        let a_recovery_point = a_wal.recovery_point().await;
-
-        /*
-        a_recovery_point = RecoveryPoint {
-            clocks: {
-                C_1: 1,
-                C: 4,
-                D: 2,
-            },
-        }
-        e_recovery_point = RecoveryPoint {
-            clocks: {
-                D: 2,
-                C: 4,
-            },
-        }
-        E entry = (0, PointStruct { id: NumId(1), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 0 }))
-        E entry = (1, PointStruct { id: NumId(2), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 1 }))
-        E entry = (2, PointStruct { id: NumId(4), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 0 }))
-        E entry = (3, PointStruct { id: NumId(5), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 1 }))
-        E entry = (4, PointStruct { id: NumId(1), }, clock_tag: None)
-        E entry = (5, PointStruct { id: NumId(2), }, clock_tag: None)
-        E entry = (6, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
-        E entry = (7, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
-        E entry = (8, PointStruct { id: NumId(3), }, clock_tag: None)
-        E entry = (9, PointStruct { id: NumId(30), }, clock_tag: None)
-        E entry = (10, PointStruct { id: NumId(4), }, clock_tag: None)
-        E entry = (11, PointStruct { id: NumId(5), }, clock_tag: None)
-        ------------------------------
-        A entry = (0, PointStruct { id: NumId(1), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 0 }))
-        A entry = (1, PointStruct { id: NumId(2), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 1 }))
-        A entry = (2, PointStruct { id: NumId(3), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 2 }))
-        A entry = (3, PointStruct { id: NumId(30), }, clock_tag: Some(ClockTag { peer: C_1, clock_tick: 0 }))
-        A entry = (4, PointStruct { id: NumId(4), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 0 }))
-        A entry = (5, PointStruct { id: NumId(5), }, clock_tag: Some(ClockTag { peer: D, clock_tick: 1 }))
-        A entry = (6, PointStruct { id: NumId(6), }, clock_tag: Some(ClockTag { peer: C, clock_tick: 3 }))
-         */
-
-        let delta_from = e_wal.resolve_wal_delta(a_recovery_point.clone()).await;
-
-        // No diff expected
-        // **************************************************************************************
-        // ToDo: This check is broken! Expected to be fixed after truncation logic is implemented
-        // **************************************************************************************
-        // assert_eq!(e_wal.wal.lock().read(delta_from).count(), 0);
-
-        assert!(delta_from.is_err());
     }
 }

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -996,7 +996,7 @@ mod tests {
         // Add operation to B but not A
         {
             // Node D is sending updates to B
-            let mut d_clock = c_clock_set.get_clock();
+            let mut d_clock = d_clock_set.get_clock();
 
             // First parallel operation
             let clock_tick = d_clock.tick_once();

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -236,7 +236,7 @@ mod tests {
         // Create operation on peer A
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
-        let clock_tag = ClockTag::new(1, 0, clock_tick);
+        let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
         let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperationsInternal::PointsList(vec![PointStruct {
                 id: 1.into(),
@@ -259,7 +259,7 @@ mod tests {
         // Create operation on peer A
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
-        let clock_tag = ClockTag::new(1, 0, clock_tick);
+        let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
         let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperationsInternal::PointsList(vec![PointStruct {
                 id: 2.into(),
@@ -346,7 +346,7 @@ mod tests {
         for i in 0..N {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
-            let clock_tag = ClockTag::new(1, 0, clock_tick);
+            let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
             let operation =
                 CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                     PointInsertOperationsInternal::PointsList(vec![PointStruct {
@@ -371,7 +371,7 @@ mod tests {
         for i in N..N + M {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
-            let clock_tag = ClockTag::new(1, 0, clock_tick);
+            let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
             let operation =
                 CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                     PointInsertOperationsInternal::PointsList(vec![PointStruct {
@@ -451,7 +451,7 @@ mod tests {
         for i in 0..N {
             let mut a_clock_0 = a_clock_set.get_clock();
             let clock_tick = a_clock_0.tick_once();
-            let clock_tag = ClockTag::new(1, 0, clock_tick);
+            let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
             let operation =
                 CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                     PointInsertOperationsInternal::PointsList(vec![PointStruct {
@@ -483,7 +483,7 @@ mod tests {
                 b_clock_set.get_clock()
             };
             let clock_tick = clock.tick_once();
-            let clock_tag = ClockTag::new(peer_id, 0, clock_tick);
+            let clock_tag = ClockTag::new(peer_id, clock.id(), clock_tick);
             let operation =
                 CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                     PointInsertOperationsInternal::PointsList(vec![PointStruct {
@@ -558,7 +558,7 @@ mod tests {
         // Create operation on peer A
         let mut a_clock_0 = a_clock_set.get_clock();
         let clock_tick = a_clock_0.tick_once();
-        let clock_tag = ClockTag::new(1, 0, clock_tick);
+        let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
         let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperationsInternal::PointsList(vec![PointStruct {
                 id: 1.into(),
@@ -583,8 +583,8 @@ mod tests {
         let mut b_clock_0 = b_clock_set.get_clock();
         let a_clock_tick = a_clock_0.tick_once();
         let b_clock_tick = b_clock_0.tick_once();
-        let a_clock_tag = ClockTag::new(1, 0, a_clock_tick);
-        let b_clock_tag = ClockTag::new(2, 0, b_clock_tick);
+        let a_clock_tag = ClockTag::new(1, a_clock_0.id(), a_clock_tick);
+        let b_clock_tag = ClockTag::new(2, a_clock_0.id(), b_clock_tick);
         let a_operation =
             CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                 PointInsertOperationsInternal::PointsList(vec![PointStruct {

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -323,4 +323,33 @@ mod tests {
             "recovery point has no clocks to resolve delta for",
         );
     }
+
+    /// Recovery point with a clock our source does not know about cannot resolve a diff.
+    #[test]
+    fn test_recover_point_has_unknown_clock() {
+        let wal_dir = Builder::new().prefix("wal_test").tempdir().unwrap();
+        let wal_options = WalOptions {
+            segment_capacity: 1024 * 1024,
+            segment_queue_len: 0,
+        };
+        let wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path().to_str().unwrap(), wal_options).unwrap();
+        let wal = Arc::new(ParkingMutex::new(wal));
+
+        let mut recovery_point = RecoveryPoint::default();
+        let mut local_recovery_point = RecoveryPoint::default();
+
+        // Recovery point has a clock our source does not know about
+        recovery_point.insert(1, 0, 15);
+        recovery_point.insert(1, 1, 8);
+        recovery_point.insert(2, 1, 5);
+        local_recovery_point.insert(1, 0, 20);
+        local_recovery_point.insert(1, 1, 8);
+
+        let resolve_result = resolve_wal_delta(recovery_point, wal, local_recovery_point);
+        assert_eq!(
+            resolve_result.unwrap_err().to_string(),
+            "recovery point requests clocks this WAL does not know about",
+        );
+    }
 }

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -956,10 +956,7 @@ mod tests {
 
         // Cannot recover E from B, because B has a high cutoff piont due to the full transfer
         let delta_from = b_wal.resolve_wal_delta(e_recovery_point.clone()).await;
-        assert_eq!(
-            delta_from.unwrap_err().to_string(),
-            "some recovery point clocks are below the cutoff point in our WAL"
-        );
+        assert_eq!(delta_from.unwrap_err(), WalDeltaError::Cutoff);
 
         // TODO: the following bit fails, because we cannot recover E from B here, since B has a
         // TODO: high cutoff point due to the recent full transfer
@@ -1056,10 +1053,7 @@ mod tests {
             &local_recovery_point,
             &RecoveryPoint::default(),
         );
-        assert_eq!(
-            resolve_result.unwrap_err().to_string(),
-            "recovery point has no clocks to resolve delta for",
-        );
+        assert_eq!(resolve_result.unwrap_err(), WalDeltaError::Empty);
     }
 
     /// Recovery point with a clock our source does not know about cannot resolve a diff.
@@ -1090,10 +1084,7 @@ mod tests {
             &local_recovery_point,
             &RecoveryPoint::default(),
         );
-        assert_eq!(
-            resolve_result.unwrap_err().to_string(),
-            "recovery point requests clocks this WAL does not know about",
-        );
+        assert_eq!(resolve_result.unwrap_err(), WalDeltaError::UnknownClocks);
     }
 
     /// Recovery point with higher clocks than the source cannot resolve a diff.
@@ -1124,8 +1115,8 @@ mod tests {
             &RecoveryPoint::default(),
         );
         assert_eq!(
-            resolve_result.unwrap_err().to_string(),
-            "recovery point requests higher clocks this WAL has",
+            resolve_result.unwrap_err(),
+            WalDeltaError::HigherThanCurrent
         );
     }
 
@@ -1158,10 +1149,7 @@ mod tests {
             &local_recovery_point,
             &local_cutoff_point,
         );
-        assert_eq!(
-            resolve_result.unwrap_err().to_string(),
-            "some recovery point clocks are below the cutoff point in our WAL",
-        );
+        assert_eq!(resolve_result.unwrap_err(), WalDeltaError::Cutoff);
     }
 
     /// Recovery point operations are not in our WAL.
@@ -1191,9 +1179,6 @@ mod tests {
             &local_recovery_point,
             &RecoveryPoint::default(),
         );
-        assert_eq!(
-            resolve_result.unwrap_err().to_string(),
-            "cannot find slice of WAL records that satisfies the recovery point",
-        );
+        assert_eq!(resolve_result.unwrap_err(), WalDeltaError::NotFound);
     }
 }

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -210,7 +210,10 @@ mod tests {
             segment_capacity: 1024 * 1024,
             segment_queue_len: 0,
         };
-        (SerdeWal::new(dir.path().to_str().unwrap(), options).unwrap(), dir)
+        (
+            SerdeWal::new(dir.path().to_str().unwrap(), options).unwrap(),
+            dir,
+        )
     }
 
     /// Test WAL delta resolution with just one missed operation on node C.
@@ -273,11 +276,23 @@ mod tests {
         a_clock_map.advance_clock(clock_tag);
         b_clock_map.advance_clock(clock_tag);
 
+        let a_wal = Arc::new(ParkingMutex::new(a_wal));
         let b_wal = Arc::new(ParkingMutex::new(b_wal));
+        let a_recovery_point = a_clock_map.to_recovery_point();
         let b_recovery_point = b_clock_map.to_recovery_point();
         let c_recovery_point = c_clock_map.to_recovery_point();
 
-        // Recover node C from node B, assert delta point is correct
+        // Resolve delta on node A for node C, assert correctness
+        let delta_from = resolve_wal_delta(
+            c_recovery_point.clone(),
+            a_wal.clone(),
+            a_recovery_point,
+            RecoveryPoint::default(),
+        )
+        .unwrap();
+        assert_eq!(delta_from, 1);
+
+        // Resolve delta on node B for node C, assert correctness
         let delta_from = resolve_wal_delta(
             c_recovery_point,
             b_wal.clone(),
@@ -294,6 +309,7 @@ mod tests {
 
         // WALs should match up perfectly now
         a_wal
+            .lock()
             .read(0)
             .zip(b_wal.lock().read(0))
             .zip(c_wal.read(0))

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -250,10 +250,19 @@ mod tests {
         a_wal.write(&operation_with_clock_tag).unwrap();
         b_wal.write(&operation_with_clock_tag).unwrap();
         c_wal.write(&operation_with_clock_tag).unwrap();
-        a_clock_0.advance_to(clock_tick);
-        a_clock_map.advance_clock(clock_tag);
-        b_clock_map.advance_clock(clock_tag);
-        c_clock_map.advance_clock(clock_tag);
+
+        let mut clock_tag_a = clock_tag;
+        let mut clock_tag_b = clock_tag;
+        let mut clock_tag_c = clock_tag;
+
+        let _ = a_clock_map.advance_clock_and_correct_tag(&mut clock_tag_a);
+        let _ = b_clock_map.advance_clock_and_correct_tag(&mut clock_tag_b);
+        let _ = c_clock_map.advance_clock_and_correct_tag(&mut clock_tag_c);
+
+        a_clock_0.advance_to(clock_tag_a.clock_tick);
+        a_clock_0.advance_to(clock_tag_b.clock_tick);
+        a_clock_0.advance_to(clock_tag_c.clock_tick);
+
         drop(a_clock_0);
 
         // Create operation on peer A


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

A series of WAL delta resolution and recovery related tests. These are similar to what we planned in Notion.

Along with tests this PR brings a few fixes and improvements where needed.

This tests:
- WAL recovery with one operation
- WAL recovery with many operations
- WAL recovery with operations from different entrypoints intermixed
- WAL recovery with operations in a different order on different nodes
- WAL recovery error on empty recovery point
- WAL recovery error with unknown clock
- WAL recovery error with higher requested clock than on the source node
- WAL recovery error where no operation satisfies recovery point

There are more scenarios to be tested for this, but I suggest to do that in a different PR.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/3631>
- [x] Rebase onto `dev`
- [x] Undraft this PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
