### PR TITLE
Don't rebuild HNSW when updating non-indexed fields

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -64,7 +64,7 @@ pub(crate) fn update_vectors(
             });
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         &ids,
         |id, write_segment| {
@@ -116,7 +116,7 @@ pub(crate) fn overwrite_payload(
     payload: &Payload,
     points: &[PointIdType],
 ) -> CollectionResult<usize> {
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         points,
         |id, write_segment| write_segment.set_full_payload(op_num, id, payload),
@@ -144,7 +144,7 @@ pub(crate) fn set_payload(
     points: &[PointIdType],
     key: &Option<JsonPath>,
 ) -> CollectionResult<usize> {
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         points,
         |id, write_segment| write_segment.set_payload(op_num, id, payload, key),
@@ -216,7 +216,7 @@ pub(crate) fn delete_payload(
     points: &[PointIdType],
     keys: &[PayloadKeyType],
 ) -> CollectionResult<usize> {
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         points,
         |id, write_segment| {
@@ -248,7 +248,7 @@ pub(crate) fn clear_payload(
     op_num: SeqNumberType,
     points: &[PointIdType],
 ) -> CollectionResult<usize> {
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         points,
         |id, write_segment| write_segment.clear_payload(op_num, id),
@@ -267,7 +267,7 @@ pub(crate) fn clear_payload_by_filter(
 ) -> CollectionResult<usize> {
     let points_to_clear = points_by_filter(segments, filter)?;
 
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         points_to_clear.as_slice(),
         |id, write_segment| write_segment.clear_payload(op_num, id),
@@ -412,7 +412,7 @@ where
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
     // Update points in writable segments
-    let updated_points = segments.apply_points_and_reindex(
+    let updated_points = segments.apply_points_with_conditional_move(
         op_num,
         &ids,
         |id, write_segment| {

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -6,7 +6,7 @@ use parking_lot::{RwLock, RwLockWriteGuard};
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
-use segment::json_path::JsonPath;
+use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
     Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, PointIdType,
     SeqNumberType,
@@ -38,9 +38,11 @@ pub(crate) fn delete_points(
     ids: &[PointIdType],
 ) -> CollectionResult<usize> {
     segments
-        .apply_points(ids, |id, _idx, write_segment| {
-            write_segment.delete_point(op_num, id)
-        })
+        .apply_points(
+            ids,
+            |_| (),
+            |id, _idx, write_segment, ()| write_segment.delete_point(op_num, id),
+        )
         .map_err(Into::into)
 }
 
@@ -62,11 +64,15 @@ pub(crate) fn update_vectors(
             });
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, &ids, |id, write_segment| {
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        &ids,
+        |id, write_segment| {
             let vectors = points_map[&id].vector.clone().into_all_vectors();
             write_segment.update_vectors(op_num, id, vectors)
-        })?;
+        },
+        |_| false,
+    )?;
     check_unprocessed_points(&ids, &updated_points)?;
     Ok(updated_points.len())
 }
@@ -79,13 +85,17 @@ pub(crate) fn delete_vectors(
     vector_names: &[String],
 ) -> CollectionResult<usize> {
     segments
-        .apply_points(points, |id, _idx, write_segment| {
-            let mut res = true;
-            for name in vector_names {
-                res &= write_segment.delete_vector(op_num, id, name)?;
-            }
-            Ok(res)
-        })
+        .apply_points(
+            points,
+            |_| (),
+            |id, _idx, write_segment, ()| {
+                let mut res = true;
+                for name in vector_names {
+                    res &= write_segment.delete_vector(op_num, id, name)?;
+                }
+                Ok(res)
+            },
+        )
         .map_err(Into::into)
 }
 
@@ -106,10 +116,12 @@ pub(crate) fn overwrite_payload(
     payload: &Payload,
     points: &[PointIdType],
 ) -> CollectionResult<usize> {
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
-            write_segment.set_full_payload(op_num, id, payload)
-        })?;
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        points,
+        |id, write_segment| write_segment.set_full_payload(op_num, id, payload),
+        |segment| segment.get_indexed_fields().is_empty(),
+    )?;
 
     check_unprocessed_points(points, &updated_points)?;
     Ok(updated_points.len())
@@ -132,13 +144,46 @@ pub(crate) fn set_payload(
     points: &[PointIdType],
     key: &Option<JsonPath>,
 ) -> CollectionResult<usize> {
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
-            write_segment.set_payload(op_num, id, payload, key)
-        })?;
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        points,
+        |id, write_segment| write_segment.set_payload(op_num, id, payload, key),
+        |segment| safe_to_set_payload(&segment.get_indexed_fields(), payload, key),
+    )?;
 
     check_unprocessed_points(points, &updated_points)?;
     Ok(updated_points.len())
+}
+
+fn safe_to_set_payload<P: JsonPathInterface>(
+    indexed_fields: &HashMap<P, PayloadFieldSchema>,
+    payload: &Payload,
+    key: &Option<P>,
+) -> bool {
+    if key.is_some() {
+        // Not supported yet
+        return false;
+    }
+    // Set is safe when the provided payload doesn't intersect with any of the indexed fields.
+    // Note that if we have, e.g., an index on "a.c" and the payload being set is `{"a": {"b": 1}}`,
+    // it is not safe because the whole value of "a" is being replaced.
+    indexed_fields
+        .keys()
+        .all(|path| !payload.0.contains_key(path.head()))
+}
+
+fn safe_to_delete_payload_keys<P: JsonPathInterface>(
+    indexed_fields: &HashMap<P, PayloadFieldSchema>,
+    keys_to_delete: &[P],
+) -> bool {
+    // Deletion is safe when the keys being deleted don't intersect with any of the indexed fields.
+    // Note that if we have, e.g., indexed field "a.b", then it is not safe to delete any of of "a",
+    // "a.b", or "a.b.c".
+    indexed_fields.keys().all(|indexed_path| {
+        keys_to_delete
+            .iter()
+            .all(|path_to_delete| !indexed_path.check_include_pattern(path_to_delete))
+    })
 }
 
 fn points_by_filter(
@@ -171,14 +216,18 @@ pub(crate) fn delete_payload(
     points: &[PointIdType],
     keys: &[PayloadKeyType],
 ) -> CollectionResult<usize> {
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        points,
+        |id, write_segment| {
             let mut res = true;
             for key in keys {
                 res &= write_segment.delete_payload(op_num, id, key)?;
             }
             Ok(res)
-        })?;
+        },
+        |segment| safe_to_delete_payload_keys(&segment.get_indexed_fields(), keys),
+    )?;
 
     check_unprocessed_points(points, &updated_points)?;
     Ok(updated_points.len())
@@ -199,10 +248,12 @@ pub(crate) fn clear_payload(
     op_num: SeqNumberType,
     points: &[PointIdType],
 ) -> CollectionResult<usize> {
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, points, |id, write_segment| {
-            write_segment.clear_payload(op_num, id)
-        })?;
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        points,
+        |id, write_segment| write_segment.clear_payload(op_num, id),
+        |segment| segment.get_indexed_fields().is_empty(),
+    )?;
 
     check_unprocessed_points(points, &updated_points)?;
     Ok(updated_points.len())
@@ -216,10 +267,11 @@ pub(crate) fn clear_payload_by_filter(
 ) -> CollectionResult<usize> {
     let points_to_clear = points_by_filter(segments, filter)?;
 
-    let updated_points = segments.apply_points_to_appendable(
+    let updated_points = segments.apply_points_and_reindex(
         op_num,
         points_to_clear.as_slice(),
         |id, write_segment| write_segment.clear_payload(op_num, id),
+        |segment| segment.get_indexed_fields().is_empty(),
     )?;
 
     Ok(updated_points.len())
@@ -360,8 +412,10 @@ where
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
     // Update points in writable segments
-    let updated_points =
-        segments.apply_points_to_appendable(op_num, &ids, |id, write_segment| {
+    let updated_points = segments.apply_points_and_reindex(
+        op_num,
+        &ids,
+        |id, write_segment| {
             let point = points_map[&id];
             upsert_with_payload(
                 write_segment,
@@ -370,7 +424,9 @@ where
                 point.get_vectors(),
                 point.payload.as_ref(),
             )
-        })?;
+        },
+        |_| false,
+    )?;
 
     let mut res = updated_points.len();
     // Insert new points, which was not updated or existed
@@ -551,4 +607,77 @@ pub(crate) fn delete_points_by_filter(
         Ok(true)
     })?;
     Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_indexed_fields(keys: &[&str]) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
+        keys.iter()
+            .map(|&s| {
+                (
+                    s.parse().unwrap(),
+                    PayloadFieldSchema::FieldType(segment::types::PayloadSchemaType::Integer),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_safe_to_set_payload() {
+        assert!(safe_to_set_payload(
+            &make_indexed_fields(&[]),
+            &serde_json::json!({"a": 1}).into(),
+            &None,
+        ));
+        assert!(safe_to_set_payload(
+            &make_indexed_fields(&["a", "b"]),
+            &serde_json::json!({"c": 1, "d": 1}).into(),
+            &None,
+        ));
+        assert!(!safe_to_set_payload(
+            &make_indexed_fields(&["a", "b"]),
+            &serde_json::json!({"b": 1, "c": 1}).into(),
+            &None,
+        ));
+        assert!(!safe_to_set_payload(
+            &make_indexed_fields(&["a.x"]),
+            &serde_json::json!({"a": {"y": 1}}).into(),
+            &None,
+        ));
+        assert!(safe_to_set_payload(
+            &make_indexed_fields(&["a.x"]),
+            &serde_json::json!({"b": {"x": 1}}).into(),
+            &None,
+        ));
+    }
+
+    #[test]
+    fn test_safe_to_delete_payload_keys() {
+        assert!(safe_to_delete_payload_keys(
+            &make_indexed_fields(&[]),
+            &["a".parse().unwrap()],
+        ));
+        assert!(safe_to_delete_payload_keys(
+            &make_indexed_fields(&["a", "b"]),
+            &["c".parse().unwrap(), "d".parse().unwrap()],
+        ));
+        assert!(!safe_to_delete_payload_keys(
+            &make_indexed_fields(&["a", "b"]),
+            &["a".parse().unwrap(), "c".parse().unwrap()],
+        ));
+        assert!(!safe_to_delete_payload_keys(
+            &make_indexed_fields(&["a.b"]),
+            &["a".parse().unwrap()]
+        ));
+        assert!(!safe_to_delete_payload_keys(
+            &make_indexed_fields(&["a.b"]),
+            &["a.b".parse().unwrap()]
+        ));
+        assert!(!safe_to_delete_payload_keys(
+            &make_indexed_fields(&["a.b"]),
+            &["a.b.c".parse().unwrap()]
+        ));
+    }
 }

--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -1205,6 +1205,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_get_path_head<P: JsonPathInterface>() {
+        assert_eq!(path::<P>("a.b.c").head(), "a");
+        assert_eq!(path::<P>("a[0].b").head(), "a");
+        assert_eq!(path::<P>("a").head(), "a");
+        assert_eq!(path::<P>("").head(), "");
+    }
+
     #[instantiate_tests(<JsonPathString>)]
     mod string {}
 

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -35,6 +35,10 @@ pub trait JsonPathInterface: Sized + Clone + FromStr<Err = ()> + Display {
 
     fn validate_not_empty(&self) -> Result<(), ValidationError>;
 
+    /// Get the first part of a path.
+    /// E.g., `"a.b.c"` -> `"a"`, `"a[0].b"` -> `"a"`.
+    fn head(&self) -> &str;
+
     fn strip_wildcard_suffix(&self) -> Self;
 
     fn strip_prefix(&self, prefix: &Self) -> Option<Self>;

--- a/lib/segment/src/json_path/string.rs
+++ b/lib/segment/src/json_path/string.rs
@@ -63,6 +63,10 @@ impl JsonPathInterface for JsonPathString {
         Ok(())
     }
 
+    fn head(&self) -> &str {
+        self.0.split(['.', '[']).next().unwrap_or(&self.0)
+    }
+
     fn strip_wildcard_suffix(&self) -> JsonPathString {
         match self.0.strip_suffix("[]") {
             Some(s) => JsonPathString(s.to_string()),

--- a/lib/segment/src/json_path/v2.rs
+++ b/lib/segment/src/json_path/v2.rs
@@ -44,6 +44,10 @@ impl JsonPathInterface for JsonPathV2 {
         Ok(())
     }
 
+    fn head(&self) -> &str {
+        unimplemented!()
+    }
+
     fn strip_wildcard_suffix(&self) -> Self {
         unimplemented!()
     }


### PR DESCRIPTION
Closes #2705.

This PR lets the caller of `SegmentHolder::apply_points_to_appendable()` (renamed to `apply_points_and_reindex`) to specify whether it is OK to update non-appendable segments.
It is safe when a non-indexed field is set or removed, or when the payload is being cleared in case if there are no indices at all.

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
