### PR TITLE
Refactor: introduce details level enum

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::cpu::CpuBudget;
+use common::types::TelemetryDetail;
 use segment::common::version::StorageVersion;
 use segment::types::ShardKey;
 use semver::Version;
@@ -599,12 +600,12 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn get_telemetry_data(&self) -> CollectionTelemetry {
+    pub async fn get_telemetry_data(&self, detail: TelemetryDetail) -> CollectionTelemetry {
         let (shards_telemetry, transfers) = {
             let mut shards_telemetry = Vec::new();
             let shards_holder = self.shards_holder.read().await;
             for shard in shards_holder.all_shards() {
-                shards_telemetry.push(shard.get_telemetry_data().await)
+                shards_telemetry.push(shard.get_telemetry_data(detail).await)
             }
             (shards_telemetry, shards_holder.get_shard_transfer_info())
         };

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
 use segment::data_types::named_vectors::NamedVectors;
@@ -824,8 +825,8 @@ impl SegmentEntry for ProxySegment {
         Ok(archive_path)
     }
 
-    fn get_telemetry_data(&self) -> SegmentTelemetry {
-        self.wrapped_segment.get().read().get_telemetry_data()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
+        self.wrapped_segment.get().read().get_telemetry_data(detail)
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator,
@@ -257,8 +258,8 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
         self.worst_segment(segments, excluded_ids)
     }
 
-    fn get_telemetry_data(&self) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
+        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator,
@@ -272,8 +273,8 @@ impl SegmentOptimizer for IndexingOptimizer {
         self.worst_segment(segments, excluded_ids)
     }
 
-    fn get_telemetry_data(&self) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
+        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
@@ -150,8 +151,8 @@ impl SegmentOptimizer for MergeOptimizer {
         candidates
     }
 
-    fn get_telemetry_data(&self) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
+        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
+use common::types::TelemetryDetail;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::check_process_stopped;
@@ -75,7 +76,7 @@ pub trait SegmentOptimizer {
         excluded_ids: &HashSet<SegmentId>,
     ) -> Vec<SegmentId>;
 
-    fn get_telemetry_data(&self) -> OperationDurationStatistics;
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics;
 
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>>;
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use ordered_float::OrderedFloat;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
@@ -204,8 +205,8 @@ impl SegmentOptimizer for VacuumOptimizer {
         }
     }
 
-    fn get_telemetry_data(&self) -> OperationDurationStatistics {
-        self.get_telemetry_counter().lock().get_statistics()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
+        self.get_telemetry_counter().lock().get_statistics(detail)
     }
 
     fn get_telemetry_counter(&self) -> Arc<Mutex<OperationDurationsAggregator>> {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::types::TelemetryDetail;
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -155,8 +156,8 @@ impl ForwardProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
-    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
-        self.wrapped_shard.get_telemetry_data()
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
+        self.wrapped_shard.get_telemetry_data(detail)
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use arc_swap::ArcSwap;
 use common::cpu::CpuBudget;
 use common::panic;
+use common::types::TelemetryDetail;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
@@ -819,11 +820,11 @@ impl LocalShard {
         Ok(all_points)
     }
 
-    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         let segments_read_guard = self.segments.read();
         let segments: Vec<_> = segments_read_guard
             .iter()
-            .map(|(_id, segment)| segment.get().read().get_telemetry_data())
+            .map(|(_id, segment)| segment.get().read().get_telemetry_data(detail))
             .collect();
 
         let optimizer_status = match &segments_read_guard.optimizer_errors {
@@ -834,7 +835,7 @@ impl LocalShard {
         let optimizations = self
             .optimizers
             .iter()
-            .map(|optimizer| optimizer.get_telemetry_data())
+            .map(|optimizer| optimizer.get_telemetry_data(detail))
             .fold(Default::default(), |acc, x| acc + x);
 
         LocalShardTelemetry {

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::types::TelemetryDetail;
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, WithPayload, WithPayloadInterface,
@@ -118,8 +119,8 @@ impl ProxyShard {
         Ok(())
     }
 
-    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
-        self.wrapped_shard.get_telemetry_data()
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
+        self.wrapped_shard.get_telemetry_data(detail)
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::types::TelemetryDetail;
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
@@ -144,12 +145,12 @@ impl QueueProxyShard {
             .await
     }
 
-    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         self.inner
             .as_ref()
             .expect("Queue proxy has been finalized")
             .wrapped_shard
-            .get_telemetry_data()
+            .get_telemetry_data(detail)
     }
 
     pub fn update_tracker(&self) -> &UpdateTracker {

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -17,6 +17,7 @@ use api::grpc::qdrant::{
 };
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
 use async_trait::async_trait;
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use segment::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
@@ -179,12 +180,18 @@ impl RemoteShard {
             .map_err(|err| err.into())
     }
 
-    pub fn get_telemetry_data(&self) -> RemoteShardTelemetry {
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> RemoteShardTelemetry {
         RemoteShardTelemetry {
             shard_id: self.id,
             peer_id: Some(self.peer_id),
-            searches: self.telemetry_search_durations.lock().get_statistics(),
-            updates: self.telemetry_update_durations.lock().get_statistics(),
+            searches: self
+                .telemetry_search_durations
+                .lock()
+                .get_statistics(detail),
+            updates: self
+                .telemetry_update_durations
+                .lock()
+                .get_statistics(detail),
         }
     }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::cpu::CpuBudget;
+use common::types::TelemetryDetail;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
@@ -719,11 +720,11 @@ impl ShardReplicaSet {
         Ok(())
     }
 
-    pub(crate) async fn get_telemetry_data(&self) -> ReplicaSetTelemetry {
+    pub(crate) async fn get_telemetry_data(&self, detail: TelemetryDetail) -> ReplicaSetTelemetry {
         let local_shard = self.local.read().await;
         let local = local_shard
             .as_ref()
-            .map(|local_shard| local_shard.get_telemetry_data());
+            .map(|local_shard| local_shard.get_telemetry_data(detail));
         ReplicaSetTelemetry {
             id: self.shard_id,
             local,
@@ -732,7 +733,7 @@ impl ShardReplicaSet {
                 .read()
                 .await
                 .iter()
-                .map(|remote| remote.get_telemetry_data())
+                .map(|remote| remote.get_telemetry_data(detail))
                 .collect(),
             replicate_states: self.replica_state.read().peers(),
         }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -2,6 +2,8 @@ use core::marker::{Send, Sync};
 use std::future::{self, Future};
 use std::path::Path;
 
+use common::types::TelemetryDetail;
+
 use super::local_shard::clock_map::RecoveryPoint;
 use super::update_tracker::UpdateTracker;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -63,12 +65,12 @@ impl Shard {
         }
     }
 
-    pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         let mut telemetry = match self {
-            Shard::Local(local_shard) => local_shard.get_telemetry_data(),
-            Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data(),
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
-            Shard::QueueProxy(proxy_shard) => proxy_shard.get_telemetry_data(),
+            Shard::Local(local_shard) => local_shard.get_telemetry_data(detail),
+            Shard::Proxy(proxy_shard) => proxy_shard.get_telemetry_data(detail),
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.get_telemetry_data(detail),
+            Shard::QueueProxy(proxy_shard) => proxy_shard.get_telemetry_data(detail),
             Shard::Dummy(dummy_shard) => dummy_shard.get_telemetry_data(),
         };
         telemetry.variant_name = Some(self.variant_name().to_string());

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -26,3 +26,35 @@ impl PartialOrd for ScoredPointOffset {
         Some(self.cmp(other))
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct TelemetryDetail {
+    pub level: DetailsLevel,
+    pub histograms: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DetailsLevel {
+    Level0,
+    Level1,
+    Level2,
+}
+
+impl Default for TelemetryDetail {
+    fn default() -> Self {
+        TelemetryDetail {
+            level: DetailsLevel::Level0,
+            histograms: false,
+        }
+    }
+}
+
+impl From<usize> for DetailsLevel {
+    fn from(value: usize) -> Self {
+        match value {
+            0 => DetailsLevel::Level0,
+            1 => DetailsLevel::Level1,
+            _ => DetailsLevel::Level2,
+        }
+    }
+}

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, SubsecRound, Utc};
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -210,7 +211,8 @@ impl OperationDurationsAggregator {
         self.last_response_date = Some(Utc::now().round_subsecs(2));
     }
 
-    pub fn get_statistics(&self) -> OperationDurationStatistics {
+    pub fn get_statistics(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
+        let _ = detail.histograms; // TODO: Will be used once histograms PR is merged
         OperationDurationStatistics {
             count: self.ok_count,
             fail_count: self.fail_count,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use common::types::TelemetryDetail;
+
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderingValue};
@@ -215,5 +217,5 @@ pub trait SegmentEntry {
         -> OperationResult<PathBuf>;
 
     // Get collected telemetry data of segment
-    fn get_telemetry_data(&self) -> SegmentTelemetry;
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -9,7 +9,7 @@ use atomic_refcell::AtomicRefCell;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
 use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use log::debug;
 use memory::mmap_ops;
 use parking_lot::Mutex;
@@ -825,18 +825,18 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         self.save()
     }
 
-    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
         let tm = &self.searches_telemetry;
         VectorIndexSearchesTelemetry {
             index_name: None,
-            unfiltered_plain: tm.unfiltered_plain.lock().get_statistics(),
+            unfiltered_plain: tm.unfiltered_plain.lock().get_statistics(detail),
             filtered_plain: Default::default(),
-            unfiltered_hnsw: tm.unfiltered_hnsw.lock().get_statistics(),
-            filtered_small_cardinality: tm.small_cardinality.lock().get_statistics(),
-            filtered_large_cardinality: tm.large_cardinality.lock().get_statistics(),
-            filtered_exact: tm.exact_filtered.lock().get_statistics(),
+            unfiltered_hnsw: tm.unfiltered_hnsw.lock().get_statistics(detail),
+            filtered_small_cardinality: tm.small_cardinality.lock().get_statistics(detail),
+            filtered_large_cardinality: tm.large_cardinality.lock().get_statistics(detail),
+            filtered_exact: tm.exact_filtered.lock().get_statistics(detail),
             filtered_sparse: Default::default(),
-            unfiltered_exact: tm.exact_unfiltered.lock().get_statistics(),
+            unfiltered_exact: tm.exact_unfiltered.lock().get_statistics(detail),
             unfiltered_sparse: Default::default(),
         }
     }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::_serde_json::Value;
 
@@ -285,11 +285,17 @@ impl VectorIndex for PlainIndex {
         Ok(())
     }
 
-    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
         VectorIndexSearchesTelemetry {
             index_name: None,
-            unfiltered_plain: self.unfiltered_searches_telemetry.lock().get_statistics(),
-            filtered_plain: self.filtered_searches_telemetry.lock().get_statistics(),
+            unfiltered_plain: self
+                .unfiltered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            filtered_plain: self
+                .filtered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
             unfiltered_hnsw: OperationDurationStatistics::default(),
             filtered_small_cardinality: OperationDurationStatistics::default(),
             filtered_large_cardinality: OperationDurationStatistics::default(),

--- a/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
+++ b/lib/segment/src/index/sparse_index/sparse_search_telemetry.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
@@ -23,27 +24,25 @@ impl SparseSearchesTelemetry {
             small_cardinality: OperationDurationsAggregator::new(),
         }
     }
+
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: self.unfiltered_plain.lock().get_statistics(detail),
+            filtered_plain: self.filtered_plain.lock().get_statistics(detail),
+            unfiltered_hnsw: Default::default(),
+            filtered_small_cardinality: self.small_cardinality.lock().get_statistics(detail),
+            filtered_large_cardinality: Default::default(),
+            filtered_exact: Default::default(),
+            filtered_sparse: self.filtered_sparse.lock().get_statistics(detail),
+            unfiltered_sparse: self.unfiltered_sparse.lock().get_statistics(detail),
+            unfiltered_exact: Default::default(),
+        }
+    }
 }
 
 impl Default for SparseSearchesTelemetry {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl From<&SparseSearchesTelemetry> for VectorIndexSearchesTelemetry {
-    fn from(value: &SparseSearchesTelemetry) -> Self {
-        VectorIndexSearchesTelemetry {
-            index_name: None,
-            unfiltered_plain: value.unfiltered_plain.lock().get_statistics(),
-            filtered_plain: value.filtered_plain.lock().get_statistics(),
-            unfiltered_hnsw: Default::default(),
-            filtered_small_cardinality: value.small_cardinality.lock().get_statistics(),
-            filtered_large_cardinality: Default::default(),
-            filtered_exact: Default::default(),
-            filtered_sparse: value.filtered_sparse.lock().get_statistics(),
-            unfiltered_sparse: value.unfiltered_sparse.lock().get_statistics(),
-            unfiltered_exact: Default::default(),
-        }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use itertools::Itertools;
 use sparse::common::scores_memory_pool::ScoresMemoryPool;
 use sparse::common::sparse_vector::SparseVector;
@@ -409,9 +409,8 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         Ok(())
     }
 
-    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
-        let tm = &self.searches_telemetry;
-        tm.into()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        self.searches_telemetry.get_telemetry_data(detail)
     }
 
     fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
@@ -31,7 +31,7 @@ pub trait VectorIndex {
     /// Force internal index rebuild.
     fn build_index(&mut self, permit: Arc<CpuPermit>, stopped: &AtomicBool) -> OperationResult<()>;
 
-    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry;
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry;
 
     fn files(&self) -> Vec<PathBuf>;
 
@@ -98,13 +98,13 @@ impl VectorIndex for VectorIndexEnum {
         }
     }
 
-    fn get_telemetry_data(&self) -> VectorIndexSearchesTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
         match self {
-            VectorIndexEnum::Plain(index) => index.get_telemetry_data(),
-            VectorIndexEnum::HnswRam(index) => index.get_telemetry_data(),
-            VectorIndexEnum::HnswMmap(index) => index.get_telemetry_data(),
-            VectorIndexEnum::SparseRam(index) => index.get_telemetry_data(),
-            VectorIndexEnum::SparseMmap(index) => index.get_telemetry_data(),
+            VectorIndexEnum::Plain(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::HnswRam(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::HnswMmap(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseRam(index) => index.get_telemetry_data(detail),
+            VectorIndexEnum::SparseMmap(index) => index.get_telemetry_data(detail),
         }
     }
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use atomic_refcell::AtomicRefCell;
-use common::types::{PointOffsetType, ScoredPointOffset};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use io::file_operations::{atomic_save_json, read_json};
 use itertools::Either;
 use memory::mmap_ops;
@@ -1687,12 +1687,12 @@ impl SegmentEntry for Segment {
         Ok(archive_path)
     }
 
-    fn get_telemetry_data(&self) -> SegmentTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
         let vector_index_searches: Vec<_> = self
             .vector_data
             .iter()
             .map(|(k, v)| {
-                let mut telemetry = v.vector_index.borrow().get_telemetry_data();
+                let mut telemetry = v.vector_index.borrow().get_telemetry_data(detail);
                 telemetry.index_name = Some(k.clone());
                 telemetry
             })

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
-use common::types::PointOffsetType;
+use common::types::{PointOffsetType, TelemetryDetail};
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -243,7 +243,7 @@ fn _test_filterable_hnsw(
         // check that search was performed using HNSW index
         assert_eq!(
             hnsw_index
-                .get_telemetry_data()
+                .get_telemetry_data(TelemetryDetail::default())
                 .filtered_large_cardinality
                 .count,
             i + 1

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
+use common::types::TelemetryDetail;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
@@ -220,7 +221,7 @@ fn sparse_index_discover_test() {
             .unwrap();
 
         // check that nearest search uses sparse index
-        let telemetry = sparse_index.get_telemetry_data();
+        let telemetry = sparse_index.get_telemetry_data(TelemetryDetail::default());
         assert_eq!(telemetry.unfiltered_sparse.count, i + 1);
 
         // check id only because scores can be epsilon-size different

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use common::cpu::CpuPermit;
-use common::types::PointOffsetType;
+use common::types::{PointOffsetType, TelemetryDetail};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::common::operation_error::OperationResult;
@@ -504,7 +504,7 @@ fn sparse_vector_index_plain_search() {
     // check that plain searchers were used
     assert_eq!(
         sparse_vector_index
-            .get_telemetry_data()
+            .get_telemetry_data(TelemetryDetail::default())
             .filtered_small_cardinality
             .count,
         2

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -1,4 +1,5 @@
 mod collection_container;
+use common::types::TelemetryDetail;
 mod collection_meta_ops;
 mod create_collection;
 mod locks;
@@ -401,12 +402,12 @@ impl TableOfContent {
         false
     }
 
-    pub async fn get_telemetry_data(&self) -> Vec<CollectionTelemetry> {
+    pub async fn get_telemetry_data(&self, detail: TelemetryDetail) -> Vec<CollectionTelemetry> {
         let mut result = Vec::new();
         let all_collections = self.all_collections().await;
         for collection_name in &all_collections {
             if let Ok(collection) = self.get_collection(collection_name).await {
-                result.push(collection.get_telemetry_data().await);
+                result.push(collection.get_telemetry_data(detail).await);
             }
         }
         result

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -135,14 +135,20 @@ impl MetricsProvider for CollectionsTelemetry {
 
 impl MetricsProvider for ClusterTelemetry {
     fn add_metrics(&self, metrics: &mut Vec<MetricFamily>) {
+        let ClusterTelemetry {
+            enabled,
+            status,
+            config: _,
+        } = self;
+
         metrics.push(metric_family(
             "cluster_enabled",
             "is cluster support enabled",
             MetricType::COUNTER,
-            vec![counter(if self.enabled { 1.0 } else { 0.0 }, &[])],
+            vec![counter(if *enabled { 1.0 } else { 0.0 }, &[])],
         ));
 
-        if let Some(ref status) = self.status {
+        if let Some(ref status) = status {
             status.add_metrics(metrics);
         }
     }

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -70,15 +71,16 @@ impl TelemetryCollector {
         }
     }
 
-    pub async fn prepare_data(&self, level: usize) -> TelemetryData {
+    pub async fn prepare_data(&self, detail: TelemetryDetail) -> TelemetryData {
         TelemetryData {
             id: self.process_id.to_string(),
-            collections: CollectionsTelemetry::collect(level, self.dispatcher.toc()).await,
-            app: AppBuildTelemetry::collect(level, &self.app_telemetry_collector, &self.settings),
-            cluster: ClusterTelemetry::collect(level, &self.dispatcher, &self.settings),
+            collections: CollectionsTelemetry::collect(detail, self.dispatcher.toc()).await,
+            app: AppBuildTelemetry::collect(detail, &self.app_telemetry_collector, &self.settings),
+            cluster: ClusterTelemetry::collect(detail, &self.dispatcher, &self.settings),
             requests: RequestsTelemetry::collect(
                 &self.actix_telemetry_collector.lock(),
                 &self.tonic_telemetry_collector.lock(),
+                detail,
             ),
         }
     }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -1,4 +1,5 @@
 use collection::shards::shard::PeerId;
+use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
@@ -64,35 +65,30 @@ pub struct ClusterTelemetry {
 }
 
 impl ClusterTelemetry {
-    pub fn collect(level: usize, dispatcher: &Dispatcher, settings: &Settings) -> ClusterTelemetry {
-        let status = if level > 0 {
-            match dispatcher.cluster_status() {
-                ClusterStatus::Disabled => None,
-                ClusterStatus::Enabled(cluster_info) => Some(ClusterStatusTelemetry {
-                    number_of_peers: cluster_info.peers.len(),
-                    term: cluster_info.raft_info.term,
-                    commit: cluster_info.raft_info.commit,
-                    pending_operations: cluster_info.raft_info.pending_operations,
-                    role: cluster_info.raft_info.role,
-                    is_voter: cluster_info.raft_info.is_voter,
-                    peer_id: Some(cluster_info.peer_id),
-                    consensus_thread_status: cluster_info.consensus_thread_status,
-                }),
-            }
-        } else {
-            None
-        };
-
-        let config = if level > 1 {
-            Some(ClusterConfigTelemetry::from(settings))
-        } else {
-            None
-        };
-
+    pub fn collect(
+        detail: TelemetryDetail,
+        dispatcher: &Dispatcher,
+        settings: &Settings,
+    ) -> ClusterTelemetry {
         ClusterTelemetry {
             enabled: settings.cluster.enabled,
-            status,
-            config,
+            status: (detail.level >= DetailsLevel::Level1)
+                .then(|| match dispatcher.cluster_status() {
+                    ClusterStatus::Disabled => None,
+                    ClusterStatus::Enabled(cluster_info) => Some(ClusterStatusTelemetry {
+                        number_of_peers: cluster_info.peers.len(),
+                        term: cluster_info.raft_info.term,
+                        commit: cluster_info.raft_info.commit,
+                        pending_operations: cluster_info.raft_info.pending_operations,
+                        role: cluster_info.raft_info.role,
+                        is_voter: cluster_info.raft_info.is_voter,
+                        peer_id: Some(cluster_info.peer_id),
+                        consensus_thread_status: cluster_info.consensus_thread_status,
+                    }),
+                })
+                .flatten(),
+            config: (detail.level >= DetailsLevel::Level2)
+                .then(|| ClusterConfigTelemetry::from(settings)),
         }
     }
 }

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -1,6 +1,7 @@
 use collection::config::CollectionParams;
 use collection::operations::types::OptimizersStatus;
 use collection::telemetry::CollectionTelemetry;
+use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
@@ -45,15 +46,15 @@ impl From<CollectionTelemetry> for CollectionsAggregatedTelemetry {
 }
 
 impl CollectionsTelemetry {
-    pub async fn collect(level: usize, toc: &TableOfContent) -> Self {
+    pub async fn collect(detail: TelemetryDetail, toc: &TableOfContent) -> Self {
         let number_of_collections = toc.all_collections().await.len();
-        let collections = if level > 0 {
+        let collections = if detail.level >= DetailsLevel::Level1 {
             let telemetry_data = toc
-                .get_telemetry_data()
+                .get_telemetry_data(detail)
                 .await
                 .into_iter()
                 .map(|telemetry| {
-                    if level > 1 {
+                    if detail.level >= DetailsLevel::Level2 {
                         CollectionTelemetryEnum::Full(telemetry)
                     } else {
                         CollectionTelemetryEnum::Aggregated(telemetry.into())

--- a/src/common/telemetry_reporting.rs
+++ b/src/common/telemetry_reporting.rs
@@ -1,12 +1,16 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::types::{DetailsLevel, TelemetryDetail};
 use segment::common::anonymize::Anonymize;
 use tokio::sync::Mutex;
 
-use crate::common::telemetry::TelemetryCollector;
+use super::telemetry::TelemetryCollector;
 
-const DETAIL_LEVEL: usize = 5;
+const DETAIL: TelemetryDetail = TelemetryDetail {
+    level: DetailsLevel::Level2,
+    histograms: false,
+};
 const REPORTING_INTERVAL: Duration = Duration::from_secs(60 * 60); // One hour
 
 pub struct TelemetryReporter {
@@ -33,7 +37,7 @@ impl TelemetryReporter {
             .telemetry
             .lock()
             .await
-            .prepare_data(DETAIL_LEVEL)
+            .prepare_data(DETAIL)
             .await
             .anonymize();
         let client = reqwest::Client::new();


### PR DESCRIPTION
Replace raw `usize` with an enum for telemetry details level. So now we can use "find references" feature of IDEs to find all the places where details level is significant.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
