### PR TITLE
Test WAL ordering property

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -39,6 +39,13 @@ impl ClockMap {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub fn get_tick(&self, peer_id: PeerId, clock_id: u32) -> Option<u64> {
+        self.clocks
+            .get(&Key::new(peer_id, clock_id))
+            .map(|clock| clock.current_tick)
+    }
+
     /// Advance clock referenced by `clock_tag` to `clock_tick`, if it's newer than current tick.
     /// Update `clock_tick` to current tick, if it's older.
     ///

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -39,13 +39,6 @@ impl ClockMap {
         Ok(())
     }
 
-    #[cfg(test)]
-    pub fn get_tick(&self, peer_id: PeerId, clock_id: u32) -> Option<u64> {
-        self.clocks
-            .get(&Key::new(peer_id, clock_id))
-            .map(|clock| clock.current_tick)
-    }
-
     /// Advance clock referenced by `clock_tag` to `clock_tick`, if it's newer than current tick.
     /// Update `clock_tick` to current tick, if it's older.
     ///

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1230,7 +1230,7 @@ mod tests {
                 map
             });
 
-        // Test each WAL operation for the ordering property
+        // Test each clock tag for the ordering property
         for (i, clock_tag) in clock_tags.iter().enumerate() {
             let key = (clock_tag.peer_id, clock_tag.clock_id);
             let highest = highest_clocks[&key];
@@ -1239,7 +1239,7 @@ mod tests {
             let mut must_see_ticks =
                 ((clock_tag.clock_tick + 1)..=highest).collect::<VecDeque<_>>();
 
-            // For all the following operations of the same peer+clock, remove their tick value
+            // For all the following clock tags of the same peer+clock, remove their tick value
             clock_tags
                 .iter()
                 .skip(i + 1)
@@ -1259,7 +1259,7 @@ mod tests {
             // If list is not empty, we have not seen all numbers
             if !must_see_ticks.is_empty() {
                 return Err(format!(
-                    "WAL ordering property violated; following operations did not cover ticks [{}] in order (peer_id: {}, clock_id: {}, max_tick: {highest})",
+                    "WAL ordering property violated; following clock tags did not cover ticks [{}] in order (peer_id: {}, clock_id: {}, max_tick: {highest})",
                     must_see_ticks.into_iter().map(|tick| tick.to_string()).collect::<Vec<_>>().join(", "),
                     clock_tag.peer_id,
                     clock_tag.clock_id,
@@ -1278,10 +1278,10 @@ mod tests {
         // Empty is fine
         check_clock_tag_ordering_property(&[]).unwrap();
 
-        // Any one operation is fine
+        // Any one clock tag is fine
         check_clock_tag_ordering_property(&[ClockTag::new(1, 2, 3)]).unwrap();
 
-        // Operations in order are allowed
+        // Clock tags in order are allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1290,7 +1290,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Operations in order with gaps are not allowed
+        // Clock tags in order with gaps are not allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1303,13 +1303,14 @@ mod tests {
 
         // Not starting at zero (truncated) is allowed
         check_clock_tag_ordering_property(&[
+            // Truncated
             ClockTag::new(1, 0, 2),
             ClockTag::new(1, 0, 3),
             ClockTag::new(1, 0, 4),
         ])
         .unwrap();
 
-        // Repeated operations are allowed
+        // Repeated clock tags are allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 2),
             ClockTag::new(1, 0, 2),
@@ -1317,7 +1318,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Repeating operation sequence is allowed
+        // Repeating clock tag sequence is allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1332,7 +1333,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Repeating part of operation sequence is allowed
+        // Repeating part of clock tag sequence is allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1346,7 +1347,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Repeating operation sequence with extra at the end is allowed
+        // Repeating clock tag sequence with new ones at the end is allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1363,7 +1364,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Repeating operations in random order is allowed, as long as the end is in sequence
+        // Repeating clock tags in random order is allowed, as long as the end is in order
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1385,7 +1386,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Repeating sequence must not miss operations at the end
+        // Repeating clock tag sequence must not miss clock tags at the end
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1396,7 +1397,7 @@ mod tests {
         ])
         .unwrap_err();
 
-        // Repeating sequence must not miss operations in the middle
+        // Repeating clock tag sequence must not miss clock tags in the middle
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1419,7 +1420,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Intermixed repeating operation sequence is allowed
+        // Intermixed repeating clock tag sequence is allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 0, 1),
@@ -1442,7 +1443,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Intermixed sequence where one tick for peer 2 is missing is not allowed
+        // Intermixed clock tag sequence where one tick for peer 2 is missing is not allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(2, 0, 0),
@@ -1455,7 +1456,7 @@ mod tests {
         ])
         .unwrap_err();
 
-        // Intermixed sequence where one tick for clock ID 1 is missing is not allowed
+        // Intermixed clock tag sequence where one tick for clock ID 1 is missing is not allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(1, 1, 0),
@@ -1468,7 +1469,7 @@ mod tests {
         ])
         .unwrap_err();
 
-        // Intermixed sequence where one tick is missing is not allowed
+        // Intermixed clock tag sequence where one tick is missing is not allowed
         check_clock_tag_ordering_property(&[
             ClockTag::new(1, 0, 0),
             ClockTag::new(2, 0, 0),

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -349,6 +349,10 @@ mod tests {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
             });
+
+        assert_wal_ordering_property(a_wal);
+        assert_wal_ordering_property(b_wal);
+        assert_wal_ordering_property(c_wal);
     }
 
     /// Test WAL delta resolution with a many missed operations on node C.
@@ -439,6 +443,10 @@ mod tests {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
             });
+
+        assert_wal_ordering_property(a_wal);
+        assert_wal_ordering_property(b_wal);
+        assert_wal_ordering_property(c_wal);
     }
 
     /// Test WAL delta resolution with a many intermixed operations on node C. Intermixed as in,
@@ -538,6 +546,10 @@ mod tests {
                 assert_eq!(a, b);
                 assert_eq!(b, c);
             });
+
+        assert_wal_ordering_property(a_wal);
+        assert_wal_ordering_property(b_wal);
+        assert_wal_ordering_property(c_wal);
     }
 
     /// Test WAL delta resolution with operations in a different order on node A and B.
@@ -679,6 +691,10 @@ mod tests {
             assert!(b_wal_point_ids.contains(&i.into()));
             assert!(c_wal_point_ids.contains(&i.into()));
         });
+
+        assert_wal_ordering_property(a_wal);
+        assert_wal_ordering_property(b_wal);
+        assert_wal_ordering_property(c_wal);
     }
 
     #[tokio::test]

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1206,7 +1206,7 @@ mod tests {
                 // Clock tags must be equal or higher to cutoff point
                 .filter(|clock_tag| {
                     cutoff
-                        .get_tick(clock_tag.peer_id, clock_tag.clock_id)
+                        .current_tick(clock_tag.peer_id, clock_tag.clock_id)
                         .map_or(true, |cutoff_tick| clock_tag.clock_tick >= cutoff_tick)
                 })
                 .collect::<Vec<_>>()

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1207,7 +1207,7 @@ mod tests {
                 .filter(|clock_tag| {
                     cutoff
                         .get_tick(clock_tag.peer_id, clock_tag.clock_id)
-                        .map_or(true, |a| clock_tag.clock_tick >= a)
+                        .map_or(true, |cutoff_tick| clock_tag.clock_tick >= cutoff_tick)
                 })
                 .collect::<Vec<_>>()
         };
@@ -1491,7 +1491,7 @@ mod tests {
             ClockTag::new(3, 0, 2),
             ClockTag::new(2, 0, 2),
             ClockTag::new(1, 0, 2),
-            // Peer 2 only partially recovering here, missing 3:0:2
+            // Peer 2 only partially recovering here, missing 2:0:2
             ClockTag::new(2, 0, 0),
             ClockTag::new(2, 0, 1),
             // Peer 1 and 3 continue

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1239,7 +1239,7 @@ mod tests {
             // If list is not empty, we have not seen all numbers
             assert!(
                 must_see_ticks.is_empty(),
-                "WAL ordering property violated; following operations did not cover ticks [{}] (peer_id: {}, clock_id: {}, max_tick: {highest})",
+                "WAL ordering property violated; following operations did not cover ticks [{}] in order (peer_id: {}, clock_id: {}, max_tick: {highest})",
                 must_see_ticks.into_iter().map(|tick| tick.to_string()).collect::<Vec<_>>().join(", "),
                 clock_tag.peer_id,
                 clock_tag.clock_id,

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1195,7 +1195,7 @@ mod tests {
 
     /// Assert that we `check_clock_tag_ordering_property` on the WAL.
     async fn assert_wal_ordering_property(wal: &RecoverableWal) {
-        // Grab list of clock tags from WAL records, skip non-existant or below cutoff tags
+        // Grab list of clock tags from WAL records, skip non-existent or below cutoff tags
         let clock_tags = {
             let cutoff = wal.cutoff_clocks.lock().await;
             wal.wal

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1036,6 +1036,10 @@ mod tests {
 
         // Diff expected
         assert_eq!(b_wal.wal.lock().read(delta_from).count(), 1);
+
+        assert_wal_ordering_property(&a_wal);
+        assert_wal_ordering_property(&b_wal);
+        assert_wal_ordering_property(&e_wal);
     }
 
     /// Empty recovery point should not resolve any diff.
@@ -1195,11 +1199,7 @@ mod tests {
             .wal
             .lock()
             .read(0)
-            .map(|(_, operation)| {
-                operation
-                    .clock_tag
-                    .expect("WAL operation does not have a clock tag")
-            })
+            .filter_map(|(_, operation)| operation.clock_tag)
             .collect::<Vec<_>>();
         check_clock_tag_ordering_property(&clock_tags).unwrap();
     }

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -223,7 +223,7 @@ pub enum WalDeltaError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{HashMap, HashSet, VecDeque};
     use std::sync::Arc;
 
     use parking_lot::Mutex as ParkingMutex;
@@ -1193,8 +1193,8 @@ mod tests {
     ///
     /// Property:
     /// For each operation with peer+clock tick X, all following operations having the same
-    /// peer+clock must cover ticks X+1, X+2, ..., X+n up to the highest tick value of that
-    /// peer+clock in the WAL.
+    /// peer+clock must cover ticks X+1, X+2, ..., X+n in order up to the highest tick value of
+    /// that peer+clock in the WAL.
     ///
     /// This property may not be valid if a diff transfer has not been resolved correctly or
     /// completely, or if the WAL got malformed in another way.
@@ -1202,13 +1202,14 @@ mod tests {
         let wal = wal.lock().read(0).collect::<Vec<_>>();
 
         // Get the highest clock value for each clock+peer
-        let mut highest_clocks = HashMap::<_, u64>::new();
-        for (_, operation) in wal.iter() {
-            let clock_tag = operation.clock_tag.unwrap();
+        let highest_clocks = wal.iter().fold(HashMap::new(), |mut map, (_, op)| {
+            let clock_tag = op.clock_tag.unwrap();
             let key = Key::from_tag(clock_tag);
-            let highest = highest_clocks.entry(key).or_default();
-            *highest = (*highest).max(clock_tag.clock_tick);
-        }
+            map.entry(key)
+                .and_modify(|highest| *highest = clock_tag.clock_tick.max(*highest))
+                .or_insert(clock_tag.clock_tick);
+            map
+        });
 
         // Test each WAL operation for the ordering property
         for (op_num, operation) in wal.iter() {
@@ -1216,8 +1217,9 @@ mod tests {
             let key = Key::from_tag(clock_tag);
             let highest = highest_clocks[&key];
 
-            // Make a list of all tick values we must cover
-            let mut seen_ticks = ((clock_tag.clock_tick + 1)..=highest).collect::<HashSet<_>>();
+            // An ordered list of ticks we must see for this peer+clock
+            let mut must_see_ticks =
+                ((clock_tag.clock_tick + 1)..=highest).collect::<VecDeque<_>>();
 
             // For all the following operations of the same peer+clock, remove their tick value
             wal.iter()
@@ -1225,14 +1227,20 @@ mod tests {
                 .map(|(_, op)| op.clock_tag.unwrap())
                 .filter(|later_clock_tag| Key::from_tag(*later_clock_tag) == key)
                 .for_each(|later_clock_tag| {
-                    seen_ticks.remove(&later_clock_tag.clock_tick);
+                    // If this tick is the first we must see, remove it from the list
+                    if must_see_ticks
+                        .front()
+                        .map_or(false, |tick| *tick == later_clock_tag.clock_tick)
+                    {
+                        must_see_ticks.pop_front().unwrap();
+                    }
                 });
 
             // If list is not empty, we have not seen all numbers
             assert!(
-                seen_ticks.is_empty(),
+                must_see_ticks.is_empty(),
                 "WAL ordering property violated; following operations did not cover ticks [{}] (peer_id: {}, clock_id: {}, max_tick: {highest})",
-                seen_ticks.into_iter().map(|tick| tick.to_string()).collect::<Vec<_>>().join(", "),
+                must_see_ticks.into_iter().map(|tick| tick.to_string()).collect::<Vec<_>>().join(", "),
                 clock_tag.peer_id,
                 clock_tag.clock_id,
             );


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Depends on: <https://github.com/qdrant/qdrant/pull/3610>

This extends WAL tests by asserting the WAL ordering property.

This property assertion makes more sense in more dynamic tests, which is what I'll be working on after this PR. But it doesn't hurt to assert our existing tests too. That's what this PR is for.

It asserts this property:
> For each operation with peer+clock tick X, all following operations having the same peer+clock must cover ticks X+1, X+2, ..., X+n in order up to the highest tick value of that peer+clock in the WAL.

The implementation may not be the most efficient ever, but in my opinion that doesn't really matter here since it's purely for testing on WALs with a sane size.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/3610>
- [x] Rebase on `dev`
- [x] Undraft this PR

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
