### PR TITLE
Optimize sparse vector remapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.5",
+ "ahash 0.8.8",
  "base64 0.21.0",
  "bitflags 2.4.1",
  "brotli",
@@ -242,7 +242,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.5",
+ "ahash 0.8.8",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -355,13 +355,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -2191,7 +2192,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.5",
+ "ahash 0.8.8",
  "allocator-api2",
 ]
 
@@ -2476,7 +2477,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfb2e51b23c338595ae0b6bdaaa7a4a8b860b8d788a4331cb07b50fe5dea71b"
 dependencies = [
- "ahash 0.8.5",
+ "ahash 0.8.8",
  "indexmap 2.2.3",
  "is-terminal",
  "itoa",
@@ -4709,6 +4710,7 @@ dependencies = [
 name = "segment"
 version = "0.6.0"
 dependencies = [
+ "ahash 0.8.8",
  "atomic_refcell",
  "atomicwrites",
  "bincode",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -62,6 +62,7 @@ chrono = { version = "0.4.34", features = ["serde"] }
 smol_str = { version = "0.2.1", features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
+ahash = { version = "0.8.8", features = ["serde"] }
 
 sysinfo = "0.30"
 charabia = { version = "0.8.5", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use ahash::AHashMap;
 use io::file_operations::{atomic_save_json, read_json};
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::SparseVector;
@@ -12,7 +12,7 @@ const INDICES_TRACKER_FILE_NAME: &str = "indices_tracker.json";
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct IndicesTracker {
-    pub map: HashMap<DimId, DimId>,
+    pub map: AHashMap<DimId, DimId>,
 }
 
 impl IndicesTracker {


### PR DESCRIPTION
This PR optimizes sparse vector remapping which happens a lot during index build.

The remapping was introduced in https://github.com/qdrant/qdrant/pull/3230 to not use the user defined sparse dimensions in order to avoid memory issues.

The remapping takes place during:
- index rebuild
- vector search
- vector update

For those reasons it makes sense to make it as fast as possible.

This PR yields the best benefit for the build use case where every vector is remapped in a tight loop from storage.

```
sparse-vector-build-group/build-ram-index
                        time:   [89.460 ms 91.249 ms 93.034 ms]
                        change: [-12.800% -10.444% -7.8901%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The mapped indices are persisted via the `IndiceTracker` into a JSON file. 
The `AHashmap` uses the same serde format as a tradionnal `HashMap`, only the hashing algorithm is modified.