### PR TITLE
Add WAL type with integrated clock map

### DIFF
--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -15,6 +15,7 @@ pub mod shards;
 pub mod telemetry;
 mod update_handler;
 pub mod wal;
+pub mod wal_delta;
 
 #[cfg(test)]
 mod tests;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1,6 +1,5 @@
 pub mod clock_map;
 mod shard_ops;
-pub mod wal_delta;
 
 use std::collections::{BTreeSet, HashMap};
 use std::mem::size_of;
@@ -52,7 +51,8 @@ use crate::shards::shard_config::{ShardConfig, SHARD_CONFIG_FILE};
 use crate::shards::telemetry::{LocalShardTelemetry, OptimizerTelemetry};
 use crate::shards::CollectionId;
 use crate::update_handler::{Optimizer, UpdateHandler, UpdateSignal};
-use crate::wal::{LockedWal, RecoverableWal, SerdeWal};
+use crate::wal::SerdeWal;
+use crate::wal_delta::{LockedWal, RecoverableWal};
 
 /// If rendering WAL load progression in basic text form, report progression every 60 seconds.
 const WAL_LOAD_REPORT_EVERY: Duration = Duration::from_secs(60);

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -487,7 +487,7 @@ impl LocalShard {
 
     /// Loads latest collection operations from WAL
     pub async fn load_from_wal(&self, collection_id: CollectionId) -> CollectionResult<()> {
-        let mut clock_map = self.wal.clock_map.lock().await;
+        let mut last_clocks = self.wal.last_clocks.lock().await;
         let wal = self.wal.wal.lock();
         let bar = ProgressBar::new(wal.len());
 
@@ -524,7 +524,7 @@ impl LocalShard {
 
         for (op_num, update) in wal.read_all() {
             if let Some(clock_tag) = update.clock_tag {
-                clock_map.advance_clock(clock_tag);
+                last_clocks.advance_clock(clock_tag);
             }
 
             // Propagate `CollectionError::ServiceError`, but skip other error types.

--- a/lib/collection/src/shards/local_shard/wal_delta.rs
+++ b/lib/collection/src/shards/local_shard/wal_delta.rs
@@ -1,15 +1,19 @@
 use thiserror::Error;
 
 use super::clock_map::RecoveryPoint;
-use super::{LocalShard, LockedWal};
+use super::LocalShard;
+use crate::wal::LockedWal;
 
 impl LocalShard {
     pub async fn resolve_wal_delta(
         &self,
         recovery_point: RecoveryPoint,
     ) -> Result<u64, WalDeltaError> {
-        let local_recovery_point = self.clock_map.lock().await.to_recovery_point();
-        resolve_wal_delta(recovery_point, &self.wal, local_recovery_point)
+        resolve_wal_delta(
+            recovery_point,
+            &self.wal.wal,
+            self.wal.recovery_point().await,
+        )
     }
 }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -83,7 +83,7 @@ impl QueueProxyShard {
         version: u64,
     ) -> Result<Self, (LocalShard, CollectionError)> {
         // Lock WAL until we've successfully created the queue proxy shard
-        let wal = wrapped_shard.wal.clone();
+        let wal = wrapped_shard.wal.wal.clone();
         let wal_lock = wal.lock();
 
         // If start version is not in current WAL bounds [first_idx, last_idx], we cannot reliably transfer WAL
@@ -315,7 +315,7 @@ impl Inner {
         remote_shard: RemoteShard,
         wal_keep_from: Arc<AtomicU64>,
     ) -> Self {
-        let start_from = wrapped_shard.wal.lock().last_index() + 1;
+        let start_from = wrapped_shard.wal.wal.lock().last_index() + 1;
 
         let shard = Self {
             wrapped_shard,
@@ -392,7 +392,7 @@ impl Inner {
 
         // Lock wall, count pending items to transfer, grab batch
         let (pending_count, batch) = {
-            let wal = self.wrapped_shard.wal.lock();
+            let wal = self.wrapped_shard.wal.wal.lock();
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let batch = wal.read(transfer_from).take(BATCH_SIZE).collect::<Vec<_>>();
             (items_left, batch)

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -163,10 +163,11 @@ impl Shard {
 
     pub async fn resolve_wal_delta(&self, recovery_point: RecoveryPoint) -> CollectionResult<u64> {
         let resolve_result = match self {
-            Self::Local(local_shard) => local_shard.resolve_wal_delta(recovery_point).await,
+            Self::Local(local_shard) => local_shard.wal.resolve_wal_delta(recovery_point).await,
             Self::ForwardProxy(proxy_shard) => {
                 proxy_shard
                     .wrapped_shard
+                    .wal
                     .resolve_wal_delta(recovery_point)
                     .await
             }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -150,10 +150,8 @@ impl Shard {
 
     pub async fn shard_recovery_point(&self) -> CollectionResult<RecoveryPoint> {
         match self {
-            Self::Local(local_shard) => Ok(local_shard.shard_recovery_point().await),
-            Self::ForwardProxy(proxy_shard) => {
-                Ok(proxy_shard.wrapped_shard.shard_recovery_point().await)
-            }
+            Self::Local(local_shard) => Ok(local_shard.recovery_point().await),
+            Self::ForwardProxy(proxy_shard) => Ok(proxy_shard.wrapped_shard.recovery_point().await),
             Self::Proxy(_) | Self::QueueProxy(_) | Self::Dummy(_) => {
                 Err(CollectionError::service_error(format!(
                     "Recovery point not supported on {}",

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -28,8 +28,7 @@ use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::clock_map::ClockMap;
-use crate::shards::local_shard::LockedWal;
-use crate::wal::WalError;
+use crate::wal::{LockedWal, WalError};
 
 /// Interval at which the optimizer worker cleans up old optimization handles
 ///

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -28,7 +28,8 @@ use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
 use crate::shards::local_shard::clock_map::ClockMap;
-use crate::wal::{LockedWal, WalError};
+use crate::wal::WalError;
+use crate::wal_delta::LockedWal;
 
 /// Interval at which the optimizer worker cleans up old optimization handles
 ///

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -2,21 +2,13 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
-use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use io::file_operations::{atomic_save_json, read_json};
-use parking_lot::Mutex as ParkingMutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::Mutex;
 use wal::{Wal, WalOptions};
-
-use crate::operations::OperationWithClockTag;
-use crate::shards::local_shard::clock_map::{ClockMap, RecoveryPoint};
-
-pub type LockedWal = Arc<ParkingMutex<SerdeWal<OperationWithClockTag>>>;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
@@ -271,53 +263,6 @@ impl<'s, R: DeserializeOwned + Serialize + Debug> SerdeWal<R> {
 
     pub fn segment_capacity(&self) -> usize {
         self.options.segment_capacity
-    }
-}
-
-/// A WAL that is recoverable, with operations having clock tags and a corresponding clock map.
-pub struct RecoverableWal {
-    pub(super) wal: LockedWal,
-    /// Map of all last seen clocks for each peer and clock ID.
-    pub(super) last_clocks: Arc<Mutex<ClockMap>>,
-}
-
-impl RecoverableWal {
-    pub fn from(wal: LockedWal, last_clocks: Arc<Mutex<ClockMap>>) -> Self {
-        Self { wal, last_clocks }
-    }
-
-    /// Write a record to the WAL but does guarantee durability.
-    pub async fn lock_and_write(&self, operation: &mut OperationWithClockTag) -> Result<u64> {
-        // Update last seen clock map and correct clock tag if necessary
-        if let Some(clock_tag) = &mut operation.clock_tag {
-            // TODO:
-            //
-            // Temporarily accept *all* operations, even if their `clock_tag` is older than
-            // current clock tracked by the clock map
-
-            // TODO: do not manually advance here!
-            let _operation_accepted = self
-                .last_clocks
-                .lock()
-                .await
-                .advance_clock_and_correct_tag(clock_tag);
-
-            // if !operation_accepted {
-            //     return Ok(UpdateResult {
-            //         operation_id: None,
-            //         status: UpdateStatus::Acknowledged,
-            //         clock_tag: Some(*clock_tag),
-            //     });
-            // }
-        }
-
-        // Write operation to WAL
-        self.wal.lock().write(operation)
-    }
-
-    /// Get a recovery point for this WAL.
-    pub async fn recovery_point(&self) -> RecoveryPoint {
-        self.last_clocks.lock().await.to_recovery_point()
     }
 }
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This adds a `RecoverableWal` type which is a `SerdeWal` with integrated `ClockMap`. Since these two types are almost always used in close proximity, this merges them together.

Writing to it ensures that we also update the clock map, without having to do this manually. This is especially useful for testing in <https://github.com/qdrant/qdrant/pull/3610>, to ensure we use the same logic in practice versus tests.

In specialized use cases we can extend this type when needed.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
