### PR TITLE
Text field index loading optimization

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/posting_list.rs
+++ b/lib/segment/src/index/field_index/full_text_index/posting_list.rs
@@ -11,12 +11,14 @@ impl PostingList {
     }
 
     pub fn insert(&mut self, idx: PointOffsetType) {
-        if let Err(insertion_idx) = self.list.binary_search(&idx) {
+        if self.list.is_empty() || idx > *self.list.last().unwrap() {
+            self.list.push(idx);
+        } else if let Err(insertion_idx) = self.list.binary_search(&idx) {
             // Yes, this is O(n) but:
             // 1. That would give us maximal search performance with minimal memory usage
             // 2. Documents are inserted mostly sequentially, especially in large segments
             // 3. Vector indexing is more expensive anyway
-            // 4. We can separate updatable and remove-only indexes later
+            // 4. For loading, insertion is strictly in increasing order
             self.list.insert(insertion_idx, idx);
         }
     }


### PR DESCRIPTION
Text index posting loading is `O(N^2)`. Fixing it to `O(N)` decreases loading speed dramatically.

Test snapshot: https://storage.googleapis.com/common-datasets-snapshots/arxiv_abstracts-3083016565637815127-2023-06-02-07-26-29.snapshot

Loading logs on branch (13 seconds):
```
2024-02-14T23:42:01.549756Z  INFO storage::content_manager::toc: Loading collection: text    
2024-02-14T23:42:01.746631Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 0    
2024-02-14T23:42:01.746657Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 0 MB    
2024-02-14T23:42:06.448546Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 260000    
2024-02-14T23:42:06.448572Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 761 MB    
2024-02-14T23:42:06.751848Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 255000    
2024-02-14T23:42:06.751871Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 747 MB    
2024-02-14T23:42:06.956855Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 266000    
2024-02-14T23:42:06.956876Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 779 MB    
2024-02-14T23:42:07.104685Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 263000    
2024-02-14T23:42:07.104704Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 770 MB    
2024-02-14T23:42:08.815939Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 266000    
2024-02-14T23:42:08.815961Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 779 MB    
2024-02-14T23:42:08.833270Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 259000    
2024-02-14T23:42:08.833289Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 758 MB    
2024-02-14T23:42:14.459760Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 685000    
2024-02-14T23:42:14.459777Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 2006 MB    
Recovering collection text [00:00:00] █████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 1/1 (eta:0s)2024-02-14T23:42:14.944856Z DEBUG qdrant: Loaded collection: text    
2024-02-14T23:42:14.944872Z  INFO qdrant: Distributed mode disabled    
2024-02-14T23:42:14.944879Z  INFO qdrant: Telemetry reporting enabled, id: e5a2c7c8-5efd-4a4a-ab93-b26c6b25d862    
2024-02-14T23:42:14.944966Z DEBUG qdrant: Waiting for thread web to finish    
2024-02-14T23:42:14.945313Z  WARN qdrant::actix: Static content folder for Web UI './static' does not exist    
2024-02-14T23:42:14.945446Z DEBUG reqwest::connect: starting new connection: https://telemetry.qdrant.io/    
2024-02-14T23:42:14.947291Z  INFO qdrant::tonic: Qdrant gRPC listening on 6334    
2024-02-14T23:42:14.947303Z  INFO qdrant::tonic: TLS disabled for gRPC API    
2024-02-14T23:42:14.966649Z  INFO qdrant::actix: TLS disabled for REST API    
2024-02-14T23:42:14.966677Z  INFO qdrant::actix: Qdrant HTTP listening on 6333    
2024-02-14T23:42:14.966679Z  INFO actix_server::builder: Starting 11 workers
2024-02-14T23:42:14.966686Z  INFO actix_server::server: Actix runtime found; starting in Actix runtime
```

Loading logs on dev (8mins)
```
2024-02-14T23:48:22.712809Z  INFO storage::content_manager::toc: Loading collection: text    
2024-02-14T23:48:22.913777Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 0    
2024-02-14T23:48:22.913794Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 0 MB    
2024-02-14T23:51:14.984355Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 260000    
2024-02-14T23:51:14.984414Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 761 MB    
2024-02-14T23:51:32.856408Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 255000    
2024-02-14T23:51:32.856476Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 747 MB    
2024-02-14T23:51:46.454704Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 266000    
2024-02-14T23:51:46.454769Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 779 MB    
2024-02-14T23:52:10.554865Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 259000    
2024-02-14T23:52:10.554905Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 758 MB    
2024-02-14T23:52:12.390396Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 266000    
2024-02-14T23:52:12.390427Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 779 MB    
2024-02-14T23:52:32.760872Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 263000    
2024-02-14T23:52:32.760894Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 770 MB    
2024-02-14T23:56:57.493343Z DEBUG segment::vector_storage::simple_dense_vector_storage: Segment vectors: 685000    
2024-02-14T23:56:57.493361Z DEBUG segment::vector_storage::simple_dense_vector_storage: Estimated segment size 2006 MB    
Recovering collection text [00:00:00] █████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 1/1 (eta:0s)2024-02-14T23:56:57.995134Z DEBUG qdrant: Loaded collection: text    
2024-02-14T23:56:57.995159Z  INFO qdrant: Distributed mode disabled    
2024-02-14T23:56:57.995163Z  INFO qdrant: Telemetry reporting enabled, id: 784dbc59-040f-471a-b53b-8537e066f59a    
2024-02-14T23:56:57.995223Z DEBUG qdrant: Waiting for thread web to finish    
2024-02-14T23:56:57.995587Z  WARN qdrant::actix: Static content folder for Web UI './static' does not exist    
2024-02-14T23:56:57.995779Z DEBUG reqwest::connect: starting new connection: https://telemetry.qdrant.io/    
2024-02-14T23:56:57.997377Z  INFO qdrant::tonic: Qdrant gRPC listening on 6334    
2024-02-14T23:56:57.997390Z  INFO qdrant::tonic: TLS disabled for gRPC API    
2024-02-14T23:56:58.014840Z  INFO qdrant::actix: TLS disabled for REST API    
2024-02-14T23:56:58.014861Z  INFO qdrant::actix: Qdrant HTTP listening on 6333    
2024-02-14T23:56:58.014863Z  INFO actix_server::builder: Starting 11 workers
2024-02-14T23:56:58.014867Z  INFO actix_server::server: Actix runtime found; starting in Actix runtime
```

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
