### PR TITLE
Add WAL cutoff clock map

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -175,6 +175,13 @@ impl RecoveryPoint {
         self.clocks.is_empty()
     }
 
+    /// Iterate over all recovery point entries as clock tags.
+    pub fn clock_tag_iter(&self) -> impl Iterator<Item = ClockTag> + '_ {
+        self.clocks
+            .iter()
+            .map(|(key, tick)| ClockTag::new(key.peer_id, key.clock_id, *tick))
+    }
+
     /// Check whether this recovery point has any higher clock value than `other`
     ///
     /// A clock in this recovery point that is not in `other` is always considered to be higher.

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -185,7 +185,7 @@ impl RecoveryPoint {
     /// Check whether this recovery point has any higher clock value than `other`
     ///
     /// A clock in this recovery point that is not in `other` is always considered to be higher.
-    pub fn has_any_higher(&mut self, other: &Self) -> bool {
+    pub fn has_any_higher(&self, other: &Self) -> bool {
         self.clocks.iter().any(|(key, tick)| {
             other
                 .clocks

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -87,10 +87,15 @@ impl LocalShard {
         move_dir(wal_from, wal_to).await?;
         move_dir(segments_from, segments_to).await?;
 
-        let clock_map_from = Self::clock_map_path(from);
-        if clock_map_from.exists() {
-            let clock_map_to = Self::clock_map_path(to);
-            move_file(clock_map_from, clock_map_to).await?;
+        let last_seen_clock_map_path = Self::last_seen_clock_map_path(from);
+        let cutoff_clock_map_path = Self::cutoff_clock_map_path(from);
+        if last_seen_clock_map_path.exists() {
+            let clock_map_to = Self::last_seen_clock_map_path(to);
+            move_file(last_seen_clock_map_path, clock_map_to).await?;
+        }
+        if cutoff_clock_map_path.exists() {
+            let clock_map_to = Self::cutoff_clock_map_path(to);
+            move_file(cutoff_clock_map_path, clock_map_to).await?;
         }
 
         Ok(())
@@ -120,9 +125,13 @@ impl LocalShard {
         }
 
         // Delete clock map
-        let clock_map_path = Self::clock_map_path(shard_path);
-        if clock_map_path.exists() {
-            remove_file(clock_map_path).await?;
+        let last_seen_clock_map = Self::last_seen_clock_map_path(shard_path);
+        let cutoff_clock_map_path = Self::cutoff_clock_map_path(shard_path);
+        if last_seen_clock_map.exists() {
+            remove_file(last_seen_clock_map).await?;
+        }
+        if cutoff_clock_map_path.exists() {
+            remove_file(cutoff_clock_map_path).await?;
         }
 
         Ok(())
@@ -137,15 +146,18 @@ impl LocalShard {
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizer_cpu_budget: CpuBudget,
         shard_path: &Path,
-        clock_map: ClockMap,
+        last_seen_clock_map: ClockMap,
+        cutoff_clock_map: ClockMap,
         update_runtime: Handle,
     ) -> Self {
         let segment_holder = Arc::new(RwLock::new(segment_holder));
         let config = collection_config.read().await;
         let locked_wal = Arc::new(ParkingMutex::new(wal));
         let optimizers_log = Arc::new(ParkingMutex::new(Default::default()));
-        let clock_map = Arc::new(Mutex::new(clock_map));
-        let clock_map_path = Self::clock_map_path(shard_path);
+        let last_seen_clock_map = Arc::new(Mutex::new(last_seen_clock_map));
+        let cutoff_clock_map = Arc::new(Mutex::new(cutoff_clock_map));
+        let last_seen_clock_map_path = Self::last_seen_clock_map_path(shard_path);
+        let cutoff_clock_map_path = Self::cutoff_clock_map_path(shard_path);
 
         let mut update_handler = UpdateHandler::new(
             shared_storage_config.clone(),
@@ -157,8 +169,10 @@ impl LocalShard {
             locked_wal.clone(),
             config.optimizer_config.flush_interval_sec,
             config.optimizer_config.max_optimization_threads,
-            clock_map.clone(),
-            clock_map_path,
+            last_seen_clock_map.clone(),
+            cutoff_clock_map.clone(),
+            last_seen_clock_map_path,
+            cutoff_clock_map_path,
         );
 
         let (update_sender, update_receiver) =
@@ -173,7 +187,7 @@ impl LocalShard {
             segments: segment_holder,
             collection_config,
             shared_storage_config,
-            wal: RecoverableWal::from(locked_wal, clock_map),
+            wal: RecoverableWal::from(locked_wal, last_seen_clock_map, cutoff_clock_map),
             update_handler: Arc::new(Mutex::new(update_handler)),
             update_sender: ArcSwap::from_pointee(update_sender),
             update_tracker,
@@ -202,7 +216,8 @@ impl LocalShard {
 
         let wal_path = Self::wal_path(shard_path);
         let segments_path = Self::segments_path(shard_path);
-        let clock_map_path = Self::clock_map_path(shard_path);
+        let last_seen_clock_map_path = Self::last_seen_clock_map_path(shard_path);
+        let cutoff_clock_map_path = Self::cutoff_clock_map_path(shard_path);
 
         let wal: SerdeWal<OperationWithClockTag> = SerdeWal::new(
             wal_path.to_str().unwrap(),
@@ -293,7 +308,8 @@ impl LocalShard {
 
         drop(collection_config_read); // release `shared_config` from borrow checker
 
-        let clock_map = ClockMap::load_or_default(&clock_map_path)?;
+        let last_seen_clock_map = ClockMap::load_or_default(&last_seen_clock_map_path)?;
+        let cutoff_clock_map = ClockMap::load_or_default(&cutoff_clock_map_path)?;
 
         let collection = LocalShard::new(
             segment_holder,
@@ -303,7 +319,8 @@ impl LocalShard {
             optimizers,
             optimizer_cpu_budget,
             shard_path,
-            clock_map,
+            last_seen_clock_map,
+            cutoff_clock_map,
             update_runtime,
         )
         .await;
@@ -346,8 +363,12 @@ impl LocalShard {
         shard_path.join("segments")
     }
 
-    pub fn clock_map_path(shard_path: &Path) -> PathBuf {
+    pub fn last_seen_clock_map_path(shard_path: &Path) -> PathBuf {
         shard_path.join("clock_map.json")
+    }
+
+    pub fn cutoff_clock_map_path(shard_path: &Path) -> PathBuf {
+        shard_path.join("clock_map_cutoff.json")
     }
 
     pub async fn build_local(
@@ -467,6 +488,7 @@ impl LocalShard {
             optimizers,
             optimizer_cpu_budget,
             shard_path,
+            ClockMap::default(),
             ClockMap::default(),
             update_runtime,
         )
@@ -688,11 +710,16 @@ impl LocalShard {
         .await??;
 
         // copy clock map
-        let clock_map_path = Self::clock_map_path(&self.path);
+        let last_seen_clock_map_path = Self::last_seen_clock_map_path(&self.path);
+        let cutoff_clock_map_path = Self::cutoff_clock_map_path(&self.path);
 
-        if clock_map_path.exists() {
-            let target_clock_map_path = Self::clock_map_path(snapshot_shard_path);
-            copy(clock_map_path, target_clock_map_path).await?;
+        if last_seen_clock_map_path.exists() {
+            let target_clock_map_path = Self::last_seen_clock_map_path(snapshot_shard_path);
+            copy(last_seen_clock_map_path, target_clock_map_path).await?;
+        }
+        if cutoff_clock_map_path.exists() {
+            let target_clock_map_path = Self::cutoff_clock_map_path(snapshot_shard_path);
+            copy(cutoff_clock_map_path, target_clock_map_path).await?;
         }
 
         // copy shard's config

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -84,10 +84,10 @@ impl RecoverableWal {
 
 /// Resolve the WAL delta for the given `recovery_point`
 ///
-/// A `local_wal` and `local_last_seen` are required to resolve the delta. These should be from the
-/// node being the source of recovery, likely the current one. The `local_wal` is used to resolve
-/// the diff. The `local_last_seen` is used to extend the given recovery point with clocks the
-/// failed node does not know about.
+/// A `local_wal` and `local_recovery_point` are required to resolve the delta. These should be
+/// from the node being the source of recovery, likely the current one. The `local_wal` is used to
+/// resolve the diff. The `local_recovery_point` is used to extend the given recovery point with
+/// clocks the failed node does not know about.
 ///
 /// The delta can be sent over to the node which the recovery point is from, to restore its
 /// WAL making it consistent with the current shard.

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -16,11 +16,25 @@ pub struct RecoverableWal {
     pub(super) wal: LockedWal,
     /// Map of all last seen clocks for each peer and clock ID.
     pub(super) last_clocks: Arc<Mutex<ClockMap>>,
+    /// Map of all clocks and ticks that are cut off.
+    ///
+    /// This means two things:
+    /// - this WAL has at least all these clock versions (same as `last_clocks`)
+    /// - this WAL cannot resolve any delta below any of these clocks
+    pub(super) cutoff_clocks: Arc<Mutex<ClockMap>>,
 }
 
 impl RecoverableWal {
-    pub fn from(wal: LockedWal, last_clocks: Arc<Mutex<ClockMap>>) -> Self {
-        Self { wal, last_clocks }
+    pub fn from(
+        wal: LockedWal,
+        last_clocks: Arc<Mutex<ClockMap>>,
+        cutoff_clocks: Arc<Mutex<ClockMap>>,
+    ) -> Self {
+        Self {
+            wal,
+            last_clocks,
+            cutoff_clocks,
+        }
     }
 
     /// Write a record to the WAL but does guarantee durability.


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add a cutoff clock map to our recoverable WAL structure. This defines clocks below which we cannot resolve a WAL delta.

It is similar to the truncation clock map idea we had before, but without actually linking it to truncations. After further investigation, this seems to be unnecessary, as we can derive this from the current WAL and the highest clock map.

Also:
- update the WAL delta resolve function to consider this cutoff point
- add method to update this cutoff point based on a recovery point
- renamed last seen clock map to highest clock map

We still have to:
- test this in practice: I propose to merge this so we can test this in our other [testing](https://github.com/qdrant/qdrant/pull/3610) PRs
- set this cutoff point in case of full transfer: I propose to merge this first so we can test it before implementing it further

Roman suggested that we might want to represent the current clocks in a recovery point, rather than doing +1 when requesting it. We can do +1 locally at the place where we resolve the WAL delta. I guess that's a good improvement but I propose to do that in a separate PR so we at least have something to work with.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
