### PR TITLE
Do not make up empty payloads during optimization

### DIFF
--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -756,7 +756,12 @@ impl TryFrom<api::grpc::qdrant::PointStruct> for PointStruct {
             payload,
         } = value;
 
-        let converted_payload = proto_to_payloads(payload)?;
+        // empty payload means None in PointStruct
+        let converted_payload = if payload.is_empty() {
+            None
+        } else {
+            Some(proto_to_payloads(payload)?)
+        };
 
         let vector_struct: VectorStruct = match vectors {
             None => return Err(Status::invalid_argument("Expected some vectors")),
@@ -768,7 +773,7 @@ impl TryFrom<api::grpc::qdrant::PointStruct> for PointStruct {
                 .ok_or_else(|| Status::invalid_argument("Empty ID is not allowed"))?
                 .try_into()?,
             vector: vector_struct,
-            payload: Some(converted_payload),
+            payload: converted_payload,
         })
     }
 }

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -26,6 +26,7 @@ pub trait PayloadStorage {
     ) -> OperationResult<()>;
 
     /// Get payload for point
+    /// If no payload found, return empty payload
     fn payload(&self, point_id: PointOffsetType) -> OperationResult<Payload>;
 
     /// Delete payload by key

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -143,11 +143,11 @@ impl SegmentBuilder {
                         // New point, just insert
                         id_tracker.set_link(external_id, new_internal_id)?;
                         id_tracker.set_internal_version(new_internal_id, other_version)?;
-                        payload_index.assign(
-                            new_internal_id,
-                            &other_payload_index.payload(old_internal_id)?,
-                            &None,
-                        )?;
+                        let other_payload = other_payload_index.payload(old_internal_id)?;
+                        // Propagate payload to new segment
+                        if !other_payload.is_empty() {
+                            payload_index.assign(new_internal_id, &other_payload, &None)?;
+                        }
                     }
                     Some(existing_internal_id) => {
                         // Point exists in both: newly constructed and old segments, so we need to merge them
@@ -160,11 +160,11 @@ impl SegmentBuilder {
                             id_tracker.set_link(external_id, new_internal_id)?;
                             id_tracker.set_internal_version(new_internal_id, other_version)?;
                             payload_index.drop(existing_internal_id)?;
-                            payload_index.assign(
-                                new_internal_id,
-                                &other_payload_index.payload(old_internal_id)?,
-                                &None,
-                            )?;
+                            let other_payload = other_payload_index.payload(old_internal_id)?;
+                            // Propagate payload to new segment
+                            if !other_payload.is_empty() {
+                                payload_index.assign(new_internal_id, &other_payload, &None)?;
+                            }
                             existing_internal_id
                         } else {
                             // Old version is still good, do not move anything else


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/3629

Found another case where we make up non existing payload.

![more-secret-payload](https://github.com/qdrant/qdrant/assets/606963/6108ee6a-db53-4754-ae50-388ae0afad41)
