### PR TITLE
Use SmallVec instead of MultiValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "serde-value",
  "serde_cbor",
  "serde_json",
+ "smallvec",
  "smol_str",
  "sparse",
  "sysinfo",
@@ -4993,9 +4994,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smol_str"

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -46,7 +46,6 @@ impl GroupsAggregator {
             .as_ref()
             .map(|p| {
                 p.get_value(&self.grouped_by)
-                    .values()
                     .into_iter()
                     .flat_map(|v| match v {
                         Value::Array(arr) => arr.iter().collect(),

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -238,5 +238,5 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
     {
         Value::String(value) => assert_eq!("v4", value),
         _ => panic!("unexpected type"),
-    }
+    };
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -63,6 +63,7 @@ smol_str = { version = "0.2.1", features = ["serde"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ahash = { version = "0.8.8", features = ["serde"] }
+smallvec = "1.13.1"
 
 sysinfo = "0.30"
 charabia = { version = "0.8.5", default-features = false, features = ["greek", "hebrew", "thai"] }

--- a/lib/segment/src/index/field_index/binary_index.rs
+++ b/lib/segment/src/index/field_index/binary_index.rs
@@ -354,7 +354,6 @@ mod tests {
 
     use super::BinaryIndex;
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-    use crate::common::utils::MultiValue;
     use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
 
     const FIELD_NAME: &str = "bool_field";
@@ -397,7 +396,7 @@ mod tests {
     fn filter(given: serde_json::Value, match_on: bool, expected_count: usize) {
         let (_tmp_dir, mut index) = new_binary_index();
 
-        index.add_point(0, &MultiValue::one(&given)).unwrap();
+        index.add_point(0, &[&given]).unwrap();
 
         let count = index.filter(&match_bool(match_on)).unwrap().count();
 
@@ -438,8 +437,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .for_each(|(i, value)| {
-                let payload = MultiValue::one(&value);
-                index.add_point(i as u32, &payload).unwrap();
+                index.add_point(i as u32, &[&value]).unwrap();
             });
 
         index.flusher()().unwrap();
@@ -463,12 +461,12 @@ mod tests {
         let (_tmp_dir, mut index) = new_binary_index();
 
         let idx = 1000;
-        index.add_point(idx, &MultiValue::one(&before)).unwrap();
+        index.add_point(idx, &[&before]).unwrap();
 
         let point_offsets = index.filter(&match_bool(false)).unwrap().collect_vec();
         assert_eq!(point_offsets, vec![idx]);
 
-        index.add_point(idx, &MultiValue::one(&after)).unwrap();
+        index.add_point(idx, &[&after]).unwrap();
 
         let point_offsets = index.filter(&match_bool(true)).unwrap().collect_vec();
         assert_eq!(point_offsets, vec![idx]);
@@ -484,8 +482,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .for_each(|(i, value)| {
-                let payload = MultiValue::one(&value);
-                index.add_point(i as u32, &payload).unwrap();
+                index.add_point(i as u32, &[&value]).unwrap();
             });
 
         assert_eq!(index.count_indexed_points(), 9);
@@ -499,8 +496,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .for_each(|(i, value)| {
-                let payload = MultiValue::one(&value);
-                index.add_point(i as u32, &payload).unwrap();
+                index.add_point(i as u32, &[&value]).unwrap();
             });
 
         let blocks = index
@@ -519,8 +515,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .for_each(|(i, value)| {
-                let payload = MultiValue::one(&value);
-                index.add_point(i as u32, &payload).unwrap();
+                index.add_point(i as u32, &[&value]).unwrap();
             });
 
         let cardinality = index.estimate_cardinality(&match_bool(true)).unwrap();

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -242,7 +242,6 @@ mod tests {
 
     use super::*;
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-    use crate::common::utils::MultiValue;
     use crate::data_types::text_index::{TextIndexType, TokenizerType};
 
     fn filter_request(text: &str) -> FieldCondition {
@@ -281,9 +280,7 @@ mod tests {
             index.recreate().unwrap();
 
             for (idx, payload) in payloads.iter().enumerate() {
-                index
-                    .add_point(idx as PointOffsetType, &MultiValue::one(payload))
-                    .unwrap();
+                index.add_point(idx as PointOffsetType, &[payload]).unwrap();
             }
 
             assert_eq!(index.count_indexed_points(), payloads.len());
@@ -312,12 +309,12 @@ mod tests {
                 "The last question was asked for the first time, half in jest, on May 21, 2061,",
                 "at a time when humanity first stepped into the light."
             ]);
-            index.add_point(3, &MultiValue::one(&payload)).unwrap();
+            index.add_point(3, &[&payload]).unwrap();
 
             let payload = serde_json::json!([
                 "The question came about as a result of a five dollar bet over highballs, and it happened this way: "
             ]);
-            index.add_point(4, &MultiValue::one(&payload)).unwrap();
+            index.add_point(4, &[&payload]).unwrap();
 
             assert_eq!(index.count_indexed_points(), payloads.len() - 1);
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -485,7 +485,6 @@ mod tests {
 
     use super::*;
     use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-    use crate::common::utils::MultiValue;
     use crate::fixtures::payload_fixtures::random_geo_payload;
     use crate::types::test_utils::build_polygon;
     use crate::types::{GeoLineString, GeoPolygon, GeoRadius};
@@ -536,8 +535,9 @@ mod tests {
         for idx in 0..num_points {
             let geo_points = random_geo_payload(&mut rnd, num_geo_values..=num_geo_values);
             let array_payload = Value::Array(geo_points);
-            let payload = MultiValue::one(&array_payload);
-            index.add_point(idx as PointOffsetType, &payload).unwrap();
+            index
+                .add_point(idx as PointOffsetType, &[&array_payload])
+                .unwrap();
         }
         assert_eq!(index.points_count(), num_points);
         assert_eq!(index.points_values_count(), num_points * num_geo_values);
@@ -885,8 +885,7 @@ mod tests {
                 "lat": NYC.lat
             }
         ]);
-        let payload = MultiValue::one(&geo_values);
-        index.add_point(1, &payload).unwrap();
+        index.add_point(1, &[&geo_values]).unwrap();
 
         // around NYC
         let nyc_geo_radius = GeoRadius {
@@ -972,8 +971,7 @@ mod tests {
                 "lat": POTSDAM.lat
             }
         ]);
-        let payload = MultiValue::one(&geo_values);
-        index.add_point(1, &payload).unwrap();
+        index.add_point(1, &[&geo_values]).unwrap();
 
         let berlin_geo_radius = GeoRadius {
             center: BERLIN,
@@ -1021,8 +1019,7 @@ mod tests {
                     "lat": POTSDAM.lat
                 }
             ]);
-            let payload = MultiValue::one(&geo_values);
-            index.add_point(1, &payload).unwrap();
+            index.add_point(1, &[&geo_values]).unwrap();
             index.flusher()().unwrap();
             drop(index);
         }
@@ -1069,7 +1066,7 @@ mod tests {
                     "lat": POTSDAM.lat
                 }
             ]);
-            let payload = MultiValue::one(&geo_values);
+            let payload = [&geo_values];
             index.add_point(1, &payload).unwrap();
             index.add_point(2, &payload).unwrap();
             index.remove_point(1).unwrap();

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,7 +6,6 @@ use tempfile::{Builder, TempDir};
 
 use super::*;
 use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
-use crate::common::utils::MultiValue;
 
 const COLUMN_NAME: &str = "test";
 
@@ -82,9 +81,7 @@ fn test_set_empty_payload() {
     assert!(!value.is_empty());
 
     let payload = serde_json::json!(null);
-    index
-        .add_point(point_id, &MultiValue::one(&payload))
-        .unwrap();
+    index.add_point(point_id, &[&payload]).unwrap();
 
     let value = index.get_values(point_id).unwrap();
 

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -98,7 +98,7 @@ pub fn condition_converter<'a>(
 
             Box::new(move |point_id| {
                 payload_provider.with_payload(point_id, |payload| {
-                    let field_values = payload.get_value(&nested_path).values();
+                    let field_values = payload.get_value(&nested_path);
 
                     for value in field_values {
                         if let Value::Object(object) = value {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::types::PointOffsetType;
 
-use crate::common::utils::IndexesMap;
+use crate::common::utils::{check_is_empty, check_is_null, IndexesMap};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::FieldIndex;
 use crate::payload_storage::condition_checker::ValueChecker;
@@ -133,7 +133,6 @@ where
             let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
             get_payload()
                 .get_value(&nested_path)
-                .values()
                 .iter()
                 .filter_map(|value| value.as_object())
                 .any(|object| {
@@ -156,11 +155,11 @@ pub fn check_is_empty_condition(
     is_empty: &IsEmptyCondition,
     payload: &impl PayloadContainer,
 ) -> bool {
-    payload.get_value(&is_empty.is_empty.key).check_is_empty()
+    check_is_empty(payload.get_value(&is_empty.is_empty.key).iter().copied())
 }
 
 pub fn check_is_null_condition(is_null: &IsNullCondition, payload: &impl PayloadContainer) -> bool {
-    payload.get_value(&is_null.is_null.key).check_is_null()
+    check_is_null(payload.get_value(&is_null.is_null.key).iter().copied())
 }
 
 pub fn check_field_condition<R>(

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -22,10 +22,9 @@ use uuid::Uuid;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::utils;
 use crate::common::utils::{
-    check_exclude_pattern, check_include_pattern, filter_json_values, get_value_from_json_map,
-    get_value_from_json_map_opt, MultiValue,
+    self, check_exclude_pattern, check_include_pattern, filter_json_values,
+    get_value_from_json_map, get_value_from_json_map_opt, MultiValue,
 };
 use crate::data_types::integer_index::IntegerIndexParams;
 use crate::data_types::text_index::TextIndexParams;
@@ -930,7 +929,7 @@ impl Payload {
     }
 
     pub fn remove(&mut self, path: &str) -> Vec<Value> {
-        utils::remove_value_from_json_map(path, &mut self.0).values()
+        utils::remove_value_from_json_map(path, &mut self.0).to_vec()
     }
 
     pub fn len(&self) -> usize {
@@ -2254,7 +2253,7 @@ mod tests {
 
     use super::test_utils::build_polygon_with_interiors;
     use super::*;
-    use crate::common::utils::remove_value_from_json_map;
+    use crate::common::utils::{check_is_empty, remove_value_from_json_map};
 
     #[allow(dead_code)]
     fn check_rms_serialization<T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug>(
@@ -3035,26 +3034,26 @@ mod tests {
         "#,
         )
         .unwrap();
-        let removed = remove_value_from_json_map("b.c", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.c", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Number(123.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.f[1]", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.f[1]", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Number(2.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[0].j", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.i[0].j", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Number(1.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[].k", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.i[].k", &mut payload.0).into_vec();
         assert_eq!(
             removed,
             vec![Value::Number(2.into()), Value::Number(4.into())]
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i[]", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.i[]", &mut payload.0).into_vec();
         assert_eq!(
             removed,
             vec![Value::Array(vec![
@@ -3067,31 +3066,31 @@ mod tests {
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.i", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.i", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Array(vec![])]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e.f", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e.f", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Array(vec![1.into(), 3.into()])]);
         assert_ne!(payload, Default::default());
 
         let removed = remove_value_from_json_map("k", &mut payload.0);
-        assert!(removed.as_ref().check_is_empty());
+        assert!(check_is_empty(&removed));
         assert_ne!(payload, Default::default());
 
         let removed = remove_value_from_json_map("", &mut payload.0);
-        assert!(removed.as_ref().check_is_empty());
+        assert!(check_is_empty(&removed));
         assert_ne!(payload, Default::default());
 
         let removed = remove_value_from_json_map("b.e.l", &mut payload.0);
-        assert!(removed.as_ref().check_is_empty());
+        assert!(check_is_empty(&removed));
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("a", &mut payload.0).values();
+        let removed = remove_value_from_json_map("a", &mut payload.0).into_vec();
         assert_eq!(removed, vec![Value::Number(1.into())]);
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b.e", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b.e", &mut payload.0).into_vec();
         assert_eq!(
             removed,
             vec![Value::Object(serde_json::Map::from_iter(vec![
@@ -3102,7 +3101,7 @@ mod tests {
         );
         assert_ne!(payload, Default::default());
 
-        let removed = remove_value_from_json_map("b", &mut payload.0).values();
+        let removed = remove_value_from_json_map("b", &mut payload.0).into_vec();
         assert_eq!(
             removed,
             vec![Value::Object(serde_json::Map::from_iter(vec![]))]


### PR DESCRIPTION
This change is extracted from a bigger PR #3637.

Drop our `struct MultiValue` and use `smallvec::SmallVec` instead. It solves the same problem (avoids heap allocation for small vectors, and uses heap allocation for larger ones), but it's upstream and is more clean to use.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
