### PR TITLE
Do not set empty payload when moving points

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -125,7 +125,9 @@ impl ProxySegment {
         let mut write_segment = segment_arc.write();
 
         write_segment.upsert_point(op_num, point_id, all_vectors)?;
-        write_segment.set_full_payload(op_num, point_id, &payload)?;
+        if !payload.is_empty() {
+            write_segment.set_full_payload(op_num, point_id, &payload)?;
+        }
 
         Ok(true)
     }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -110,6 +110,8 @@ pub trait SegmentEntry {
 
     fn all_vectors(&self, point_id: PointIdType) -> OperationResult<NamedVectors>;
 
+    /// Retrieve payload for the point
+    /// If not found, return empty payload
     fn payload(&self, point_id: PointIdType) -> OperationResult<Payload>;
 
     /// Iterator over all points in segment in ascending order.


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/3629 & https://github.com/qdrant/qdrant/pull/3633

This seems to be the last place where we create empty payloads according to my research.

![move_if_payload](https://github.com/qdrant/qdrant/assets/606963/72459ded-dce2-4aaf-ac62-e5abe3d23759)
