### PR TITLE
Fix shard snapshot transfer flakyness

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -247,7 +247,7 @@ impl ShardOperation for LocalShard {
             let update_sender = self.update_sender.load();
             let channel_permit = update_sender.reserve().await?;
 
-            let operation_id = self.wal.lock_and_write(&mut operation).await?;
+            let (operation_id, wal_lock) = self.wal.lock_and_write(&mut operation).await?;
 
             channel_permit.send(UpdateSignal::Operation(OperationData {
                 op_num: operation_id,
@@ -255,6 +255,7 @@ impl ShardOperation for LocalShard {
                 sender: callback_sender,
                 wait,
             }));
+            drop(wal_lock);
             operation_id
         };
 


### PR DESCRIPTION
Related: <https://github.com/qdrant/qdrant/pull/3635>, <https://github.com/qdrant/qdrant/pull/3658>

Tests are here: https://github.com/qdrant/qdrant/pull/3658/checks (tests from <https://github.com/qdrant/qdrant/pull/3635>)

Fixes shard snapshot transfer problems as shown in <https://github.com/qdrant/qdrant/pull/3635>.

With this change, we keep the WAL lock longer, not just for writing to the WAL, but also for sending the update to the update sender channel.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
