### PR TITLE
Snapshot store

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,8 +6,6 @@ storage:
 
   # Where to store snapshots
   snapshots_path: ./snapshots
-  # Will replace snapshots_path in the future
-  snapshot_path: ./snapshots
 
   # Where to store temporary files
   # If null, temporary snapshot are stored in: storage/snapshots_temp/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,8 @@ storage:
 
   # Where to store snapshots
   snapshots_path: ./snapshots
+  # Will replace snapshots_path in the future
+  snapshot_path: ./snapshots
 
   # Where to store temporary files
   # If null, temporary snapshot are stored in: storage/snapshots_temp/

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -652,6 +652,10 @@ impl Collection {
     pub fn request_shard_transfer(&self, shard_transfer: ShardTransfer) {
         self.request_shard_transfer_cb.deref()(shard_transfer)
     }
+
+    pub fn shared_storage_config(&self) -> Arc<SharedStorageConfig> {
+        self.shared_storage_config.clone()
+    }
 }
 
 struct CollectionVersion;

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -130,10 +130,7 @@ impl Collection {
 
         let snapshot_manager = self.get_snapshots_storage_manager();
         snapshot_manager
-            .store_file(
-                snapshot_temp_arc_file.path(),
-                snapshot_path.as_path(),
-            )
+            .store_file(snapshot_temp_arc_file.path(), snapshot_path.as_path())
             .await
     }
 

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -23,7 +23,8 @@ use crate::shards::shard_versioning;
 
 impl Collection {
     pub async fn list_snapshots(&self) -> CollectionResult<Vec<SnapshotDescription>> {
-        snapshot_ops::list_snapshots_in_directory(&self.snapshots_path).await
+        let snapshot_manager = self.shared_storage_config.snapshot_manager();
+        snapshot_manager.list_snapshots(&self.snapshots_path).await
     }
 
     /// Creates a snapshot of the collection.

--- a/lib/collection/src/common/mod.rs
+++ b/lib/collection/src/common/mod.rs
@@ -5,6 +5,7 @@ pub mod file_utils;
 pub mod is_ready;
 pub mod retrieve_request_trait;
 pub mod sha_256;
+pub mod snapshots_manager;
 pub mod stoppable_task;
 pub mod stoppable_task_async;
 pub mod stopping_guard;

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -176,6 +176,12 @@ impl SnapshotStorageLocalFS {
         storage_path: &Path,
         local_path: &Path,
     ) -> CollectionResult<()> {
+        if let Some(target_dir) = local_path.parent() {
+            if !target_dir.exists() {
+                std::fs::create_dir_all(target_dir)?;
+            }
+        }
+
         if storage_path != local_path {
             move_file(&storage_path, &local_path).await?;
         }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use serde::Deserialize;
+use tempfile::TempPath;
+use tokio::io::AsyncWriteExt;
 
+use crate::common::file_utils::move_file;
+use crate::common::sha_256::hash_file;
 use crate::operations::snapshot_ops::{
     get_checksum_path, get_snapshot_description, SnapshotDescription,
 };
@@ -30,6 +34,12 @@ impl LocalFileSystemConfig {
 pub trait SnapshotStorage: Send + Sync {
     async fn delete_snapshot(&self, snapshot_name: &Path) -> CollectionResult<bool>;
     async fn list_snapshots(&self, directory: &Path) -> CollectionResult<Vec<SnapshotDescription>>;
+    async fn store_file(
+        &self,
+        source_path: &Path,
+        target_path: &Path,
+        shard: bool,
+    ) -> CollectionResult<SnapshotDescription>;
 }
 
 #[async_trait]
@@ -64,6 +74,43 @@ impl SnapshotStorage for LocalFileSystemConfig {
 
         Ok(snapshots)
     }
+
+    async fn store_file(
+        &self,
+        source_path: &Path,
+        target_path: &Path,
+        shard: bool,
+    ) -> CollectionResult<SnapshotDescription> {
+        // Move snapshot to permanent location.
+        // We can't move right away, because snapshot folder can be on another mounting point.
+        // We can't copy to the target location directly, because copy is not atomic.
+        // So we copy to the final location with a temporary name and then rename atomically.
+        let snapshot_path_tmp_move = target_path.with_extension("tmp");
+        // Ensure that the temporary file is deleted on error
+        let _temp_path = TempPath::from_path(&snapshot_path_tmp_move);
+        // compute and store the file's checksum before the final snapshot file is saved
+        // to avoid making snapshot available without checksum
+        let checksum_path = get_checksum_path(target_path);
+        let checksum = hash_file(source_path).await?;
+        let checksum_file = TempPath::from_path(&checksum_path);
+        let mut file = tokio::fs::File::create(checksum_path.as_path()).await?;
+        file.write_all(checksum.as_bytes()).await?;
+
+        if target_path != source_path {
+            if !shard {
+                tokio::fs::copy(&source_path, &target_path).await?;
+            }
+            let snapshot_file = tempfile::TempPath::from_path(target_path);
+            // `tempfile::NamedTempFile::persist` does not work if destination file is on another
+            // file-system, so we have to move the file explicitly
+            move_file(&source_path, &target_path).await?;
+
+            snapshot_file.keep()?;
+        }
+
+        checksum_file.keep()?;
+        get_snapshot_description(target_path).await
+    }
 }
 
 #[async_trait]
@@ -71,10 +118,20 @@ impl SnapshotStorage for S3Config {
     async fn delete_snapshot(&self, _snapshot_path: &Path) -> CollectionResult<bool> {
         unimplemented!()
     }
+
     async fn list_snapshots(
         &self,
         _directory: &Path,
     ) -> CollectionResult<Vec<SnapshotDescription>> {
+        unimplemented!()
+    }
+
+    async fn store_file(
+        &self,
+        _source_path: &Path,
+        _target_path: &Path,
+        _shard: bool,
+    ) -> CollectionResult<SnapshotDescription> {
         unimplemented!()
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -77,6 +77,21 @@ impl SnapshotStorageManager {
             }
         }
     }
+
+    pub async fn get_stored_file(
+        &self,
+        storage_path: &Path,
+        local_path: &Path,
+    ) -> CollectionResult<()> {
+        match self {
+            SnapshotStorageManager::LocalFS(storage_impl) => {
+                storage_impl.get_stored_file(storage_path, local_path).await
+            }
+            SnapshotStorageManager::S3(storage_impl) => {
+                storage_impl.get_stored_file(storage_path, local_path).await
+            }
+        }
+    }
 }
 
 impl SnapshotStorageLocalFS {
@@ -155,6 +170,17 @@ impl SnapshotStorageLocalFS {
         checksum_file.keep()?;
         get_snapshot_description(target_path).await
     }
+
+    async fn get_stored_file(
+        &self,
+        storage_path: &Path,
+        local_path: &Path,
+    ) -> CollectionResult<()> {
+        if storage_path != local_path {
+            move_file(&storage_path, &local_path).await?;
+        }
+        Ok(())
+    }
 }
 
 impl SnapshotStorageS3 {
@@ -174,6 +200,14 @@ impl SnapshotStorageS3 {
         _source_path: &Path,
         _target_path: &Path,
     ) -> CollectionResult<SnapshotDescription> {
+        unimplemented!()
+    }
+
+    async fn get_stored_file(
+        &self,
+        _storage_path: &Path,
+        _local_path: &Path,
+    ) -> CollectionResult<()> {
         unimplemented!()
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use crate::operations::snapshot_ops::get_checksum_path;
+use crate::operations::snapshot_ops::{
+    get_checksum_path, get_snapshot_description, SnapshotDescription,
+};
 use crate::operations::types::CollectionResult;
 
 #[derive(Clone, Deserialize, Debug)]
@@ -27,6 +29,7 @@ impl LocalFileSystemConfig {
 #[async_trait]
 pub trait SnapshotStorage: Send + Sync {
     async fn delete_snapshot(&self, snapshot_name: &Path) -> CollectionResult<bool>;
+    async fn list_snapshots(&self, directory: &Path) -> CollectionResult<Vec<SnapshotDescription>>;
 }
 
 #[async_trait]
@@ -46,11 +49,32 @@ impl SnapshotStorage for LocalFileSystemConfig {
 
         Ok(true)
     }
+
+    async fn list_snapshots(&self, directory: &Path) -> CollectionResult<Vec<SnapshotDescription>> {
+        let mut entries = tokio::fs::read_dir(directory).await?;
+        let mut snapshots = Vec::new();
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+
+            if !path.is_dir() && path.extension().map_or(false, |ext| ext == "snapshot") {
+                snapshots.push(get_snapshot_description(&path).await?);
+            }
+        }
+
+        Ok(snapshots)
+    }
 }
 
 #[async_trait]
 impl SnapshotStorage for S3Config {
     async fn delete_snapshot(&self, _snapshot_path: &Path) -> CollectionResult<bool> {
+        unimplemented!()
+    }
+    async fn list_snapshots(
+        &self,
+        _directory: &Path,
+    ) -> CollectionResult<Vec<SnapshotDescription>> {
         unimplemented!()
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::operations::types::CollectionResult;
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct LocalFileSystemConfig {
+    pub snapshots_path: String,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct S3Config {
+    pub bucket: String,
+    pub region: String,
+    pub snapshots_path: String,
+}
+
+impl LocalFileSystemConfig {
+    pub fn new(snapshots_path: String) -> Self {
+        Self { snapshots_path }
+    }
+}
+
+#[async_trait]
+pub trait SnapshotStorage: Send + Sync {
+    async fn delete_snapshot(&self, snapshot_name: &Path) -> CollectionResult<bool>;
+}
+
+#[async_trait]
+impl SnapshotStorage for LocalFileSystemConfig {
+    async fn delete_snapshot(&self, _snapshot_path: &Path) -> CollectionResult<bool> {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl SnapshotStorage for S3Config {
+    async fn delete_snapshot(&self, _snapshot_path: &Path) -> CollectionResult<bool> {
+        unimplemented!()
+    }
+}

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
-use crate::common::snapshots_manager::{LocalFileSystemConfig, S3Config, SnapshotStorage};
+use crate::common::snapshots_manager::S3Config;
 use crate::operations::types::NodeType;
 use crate::shards::transfer::ShardTransferMethod;
 
@@ -11,6 +11,7 @@ const DEFAULT_SEARCH_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_UPDATE_QUEUE_SIZE: usize = 100;
 const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 10_000;
 pub const DEFAULT_IO_SHARD_TRANSFER_LIMIT: Option<usize> = Some(1);
+pub const DEFAULT_SNAPSHOTS_PATH: &str = "./snapshots";
 
 /// Storage configuration shared between all collections.
 /// Represents a per-node configuration, which might be changes with restart.
@@ -27,8 +28,8 @@ pub struct SharedStorageConfig {
     pub default_shard_transfer_method: Option<ShardTransferMethod>,
     pub incoming_shard_transfers_limit: Option<usize>,
     pub outgoing_shard_transfers_limit: Option<usize>,
-    pub snapshot_lfs: Option<LocalFileSystemConfig>,
-    pub snapshot_s3: Option<S3Config>,
+    pub snapshots_path: String,
+    pub s3_config: Option<S3Config>,
 }
 
 impl Default for SharedStorageConfig {
@@ -44,8 +45,8 @@ impl Default for SharedStorageConfig {
             default_shard_transfer_method: None,
             incoming_shard_transfers_limit: DEFAULT_IO_SHARD_TRANSFER_LIMIT,
             outgoing_shard_transfers_limit: DEFAULT_IO_SHARD_TRANSFER_LIMIT,
-            snapshot_lfs: Some(LocalFileSystemConfig::new("./snapshots".to_string())),
-            snapshot_s3: None,
+            snapshots_path: DEFAULT_SNAPSHOTS_PATH.to_string(),
+            s3_config: None,
         }
     }
 }
@@ -63,8 +64,8 @@ impl SharedStorageConfig {
         default_shard_transfer_method: Option<ShardTransferMethod>,
         incoming_shard_transfers_limit: Option<usize>,
         outgoing_shard_transfers_limit: Option<usize>,
-        snapshots_lfs: Option<LocalFileSystemConfig>,
-        snapshots_s3: Option<S3Config>,
+        snapshots_path: String,
+        s3_config: Option<S3Config>,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,
@@ -81,18 +82,8 @@ impl SharedStorageConfig {
             default_shard_transfer_method,
             incoming_shard_transfers_limit,
             outgoing_shard_transfers_limit,
-            snapshot_lfs: snapshots_lfs,
-            snapshot_s3: snapshots_s3,
+            snapshots_path,
+            s3_config,
         }
-    }
-
-    pub fn snapshot_manager(&self) -> Box<dyn SnapshotStorage> {
-        if let Some(s3) = self.snapshot_s3.clone() {
-            return Box::new(s3);
-        }
-        if let Some(lfs) = self.snapshot_lfs.clone() {
-            return Box::new(lfs);
-        }
-        Box::new(LocalFileSystemConfig::new("./snapshots".to_string()))
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -18,6 +18,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
+use crate::common::snapshots_manager::SnapshotStorageManager;
 
 use super::local_shard::clock_map::RecoveryPoint;
 use super::local_shard::LocalShard;
@@ -843,6 +844,10 @@ impl ShardReplicaSet {
         };
 
         local_shard.update_cutoff(cutoff).await
+    }
+
+    pub(crate) fn get_snapshots_storage_manager(&self) -> SnapshotStorageManager {
+        SnapshotStorageManager::new(self.shared_storage_config.s3_config.clone())
     }
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -92,7 +92,7 @@ pub struct ShardReplicaSet {
     channel_service: ChannelService,
     collection_id: CollectionId,
     collection_config: Arc<RwLock<CollectionConfig>>,
-    shared_storage_config: Arc<SharedStorageConfig>,
+    pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     update_runtime: Handle,
     search_runtime: Handle,
     optimizer_cpu_budget: CpuBudget,

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -18,13 +18,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
-use crate::common::snapshots_manager::SnapshotStorageManager;
 
 use super::local_shard::clock_map::RecoveryPoint;
 use super::local_shard::LocalShard;
 use super::remote_shard::RemoteShard;
 use super::transfer::ShardTransfer;
 use super::CollectionId;
+use crate::common::snapshots_manager::SnapshotStorageManager;
 use crate::config::CollectionConfig;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -680,7 +680,7 @@ impl ShardHolder {
         let shard = self
             .get_shard(&shard_id)
             .ok_or_else(|| shard_not_found_error(shard_id))?;
-        let snapshot_manager = shard.shared_storage_config.snapshot_manager();
+        let snapshot_manager = shard.get_snapshots_storage_manager();
         snapshot_manager.list_snapshots(&snapshots_path).await
     }
 
@@ -774,15 +774,9 @@ impl ShardHolder {
         let snapshot_path =
             self.shard_snapshot_path_unchecked(snapshots_path, shard_id, snapshot_file_name)?;
 
-        if let Some(snapshot_dir) = snapshot_path.parent() {
-            if !snapshot_dir.exists() {
-                std::fs::create_dir_all(snapshot_dir)?;
-            }
-        }
-
-        let snapshot_manager = shard.shared_storage_config.snapshot_manager();
+        let snapshot_manager = shard.get_snapshots_storage_manager();
         let snapshot_description = snapshot_manager
-            .store_file(temp_file.path(), &snapshot_path, true)
+            .store_file(temp_file.path(), &snapshot_path)
             .await;
         if snapshot_description.is_ok() {
             let _ = temp_file.keep();

--- a/lib/collection/src/shards/shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder.rs
@@ -20,7 +20,7 @@ use crate::hash_ring::HashRing;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::snapshot_ops::{
-    get_checksum_path, get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
+    get_checksum_path, get_snapshot_description, SnapshotDescription,
 };
 use crate::operations::types::{CollectionError, CollectionResult, ShardTransferInfo};
 use crate::operations::{OperationToShard, SplitByShard};
@@ -682,7 +682,11 @@ impl ShardHolder {
             return Ok(Vec::new());
         }
 
-        list_snapshots_in_directory(&snapshots_path).await
+        let shard = self
+            .get_shard(&shard_id)
+            .ok_or_else(|| shard_not_found_error(shard_id))?;
+        let snapshot_manager = shard.shared_storage_config.snapshot_manager();
+        snapshot_manager.list_snapshots(&snapshots_path).await
     }
 
     /// # Cancel safety

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -146,9 +146,13 @@ async fn _do_create_full_snapshot(
     }
 
     let full_snapshot_path = snapshot_dir.join(&snapshot_name);
+
     let temp_full_snapshot_path = dispatcher
         .optional_temp_or_storage_temp_path()?
         .join(&snapshot_name);
+
+    // Make sure temporary file is removed in case of error
+    let _temp_full_snapshot_path_file = TempPath::from_path(&temp_full_snapshot_path);
 
     let config_path_clone = config_path.clone();
 

--- a/lib/storage/src/content_manager/snapshots/mod.rs
+++ b/lib/storage/src/content_manager/snapshots/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use collection::common::sha_256::hash_file;
 use collection::operations::snapshot_ops::{
-    get_checksum_path, get_snapshot_description, list_snapshots_in_directory, SnapshotDescription,
+    get_checksum_path, get_snapshot_description, SnapshotDescription,
 };
 use serde::{Deserialize, Serialize};
 use tar::Builder as TarBuilder;
@@ -81,8 +81,9 @@ pub async fn do_delete_collection_snapshot(
 pub async fn do_list_full_snapshots(
     toc: &TableOfContent,
 ) -> Result<Vec<SnapshotDescription>, StorageError> {
+    let snapshots_manager = toc.storage_config.snapshot_manager();
     let snapshots_path = Path::new(toc.snapshots_path());
-    Ok(list_snapshots_in_directory(snapshots_path).await?)
+    Ok(snapshots_manager.list_snapshots(snapshots_path).await?)
 }
 
 pub async fn do_create_full_snapshot(

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use collection::common::snapshots_manager::SnapshotStorageManager;
 
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::shards::replica_set::ReplicaState;
@@ -11,6 +12,10 @@ use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::errors::StorageError;
 
 impl TableOfContent {
+    pub fn get_snapshots_storage_manager(&self) -> SnapshotStorageManager {
+        SnapshotStorageManager::new(self.storage_config.s3_config.clone())
+    }
+
     pub fn snapshots_path(&self) -> &str {
         &self.storage_config.snapshots_path
     }

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
-use collection::common::snapshots_manager::SnapshotStorageManager;
 
+use collection::common::snapshots_manager::SnapshotStorageManager;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -3,10 +3,10 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use collection::common::snapshots_manager::{LocalFileSystemConfig, S3Config, SnapshotStorage};
+use collection::common::snapshots_manager::S3Config;
 use collection::config::WalConfig;
 use collection::operations::shared_storage_config::{
-    SharedStorageConfig, DEFAULT_IO_SHARD_TRANSFER_LIMIT,
+    SharedStorageConfig, DEFAULT_IO_SHARD_TRANSFER_LIMIT, DEFAULT_SNAPSHOTS_PATH,
 };
 use collection::operations::types::NodeType;
 use collection::optimizers_builder::OptimizersConfig;
@@ -54,10 +54,9 @@ pub struct StorageConfig {
     pub storage_path: String,
     #[serde(default = "default_snapshots_path")]
     #[validate(length(min = 1))]
-    //Will replace this later with what is now snapshot_lfs
     pub snapshots_path: String,
-    pub snapshot_lfs: Option<LocalFileSystemConfig>,
-    pub snapshot_s3: Option<S3Config>,
+    #[serde(default)]
+    pub s3_config: Option<S3Config>,
     #[validate(length(min = 1))]
     #[serde(default)]
     pub temp_path: Option<String>,
@@ -109,24 +108,14 @@ impl StorageConfig {
             self.shard_transfer_method,
             self.performance.incoming_shard_transfers_limit,
             self.performance.outgoing_shard_transfers_limit,
-            self.snapshot_lfs.clone(),
-            self.snapshot_s3.clone(),
+            self.snapshots_path.clone(),
+            self.s3_config.clone(),
         )
-    }
-
-    pub fn snapshot_manager(&self) -> Box<dyn SnapshotStorage> {
-        if let Some(s3) = self.snapshot_s3.clone() {
-            return Box::new(s3);
-        }
-        if let Some(lfs) = self.snapshot_lfs.clone() {
-            return Box::new(lfs);
-        }
-        Box::new(LocalFileSystemConfig::new("./snapshots".to_string()))
     }
 }
 
 fn default_snapshots_path() -> String {
-    "./snapshots".to_string()
+    DEFAULT_SNAPSHOTS_PATH.to_string()
 }
 
 const fn default_on_disk_payload() -> bool {

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -30,6 +30,8 @@ fn test_alias_operation() {
             .to_str()
             .unwrap()
             .to_string(),
+        snapshot_lfs: None,
+        snapshot_s3: None,
         temp_path: None,
         on_disk_payload: false,
         optimizers: OptimizersConfig {

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -30,8 +30,7 @@ fn test_alias_operation() {
             .to_str()
             .unwrap()
             .to_string(),
-        snapshot_lfs: None,
-        snapshot_s3: None,
+        s3_config: None,
         temp_path: None,
         on_disk_payload: false,
         optimizers: OptimizersConfig {

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use collection::collection::Collection;
 use collection::common::sha_256::hash_file;
 use collection::operations::snapshot_ops::{
-    get_checksum_path, ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
+    ShardSnapshotLocation, SnapshotDescription, SnapshotPriority,
 };
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::ShardId;
@@ -58,19 +58,10 @@ pub async fn delete_shard_snapshot(
     let snapshot_path = collection
         .get_shard_snapshot_path(shard_id, &snapshot_name)
         .await?;
-    let checksum_path = get_checksum_path(&snapshot_path);
-
+    let snapshot_manager = collection.shared_storage_config().snapshot_manager();
     check_shard_snapshot_file_exists(&snapshot_path)?;
-    let (delete_snapshot, delete_checksum) = tokio::join!(
-        tokio::fs::remove_file(snapshot_path),
-        tokio::fs::remove_file(checksum_path)
-    );
-    delete_snapshot?;
 
-    // We might not have a checksum file for the snapshot, ignore deletion errors in that case
-    if let Err(err) = delete_checksum {
-        log::warn!("Failed to delete checksum file for snapshot, ignoring: {err}");
-    }
+    let _task = tokio::spawn(async move { snapshot_manager.delete_snapshot(&snapshot_path).await });
 
     Ok(())
 }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -58,7 +58,7 @@ pub async fn delete_shard_snapshot(
     let snapshot_path = collection
         .get_shard_snapshot_path(shard_id, &snapshot_name)
         .await?;
-    let snapshot_manager = collection.shared_storage_config().snapshot_manager();
+    let snapshot_manager = collection.get_snapshots_storage_manager();
     check_shard_snapshot_file_exists(&snapshot_path)?;
 
     let _task = tokio::spawn(async move { snapshot_manager.delete_snapshot(&snapshot_path).await });


### PR DESCRIPTION
This PR is a first step in an attempt to fix https://github.com/qdrant/qdrant/issues/3324. 
To be able to add S3 support and other storage back ends later I defined a trait that will contain all needed methods to handle created snapshots. I took a simplifying assumption that the snapshots will first be created in a temp local place and after the snapshotting is completed we will move the snapshot and checksum.
After S3 support is added, it should be straight forward to implement support for additional storage back ends, the only needed action being implementing the trait for the new type. 

To keep the PR small and easy to review, currently it only handles create_snapshot,delete,list (collection/full/shard). If the direction is good others could be implemented in subsequent PRs without breaking compatibility.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
