### PR TITLE
Add replica state: Recovery

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1493,6 +1493,7 @@ Note: 1kB = 1 vector of size 256. |
 | Initializing | 3 | Collection is being created |
 | Listener | 4 | A shard which receives data, but is not used for search; Useful for backup shards |
 | PartialSnapshot | 5 | Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard |
+| Recovery | 6 | Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8650,7 +8650,8 @@
           "Partial",
           "Initializing",
           "Listener",
-          "PartialSnapshot"
+          "PartialSnapshot",
+          "Recovery"
         ]
       },
       "RemoteShardInfo": {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -449,6 +449,8 @@ enum ReplicaState {
   Initializing = 3; // Collection is being created
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+  Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
+  // TODO(1.9): deprecate this state
 }
 
 message ShardKey {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1308,6 +1308,8 @@ pub enum ReplicaState {
     Listener = 4,
     /// Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
     PartialSnapshot = 5,
+    /// Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
+    Recovery = 6,
 }
 impl ReplicaState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1322,6 +1324,7 @@ impl ReplicaState {
             ReplicaState::Initializing => "Initializing",
             ReplicaState::Listener => "Listener",
             ReplicaState::PartialSnapshot => "PartialSnapshot",
+            ReplicaState::Recovery => "Recovery",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1333,6 +1336,7 @@ impl ReplicaState {
             "Initializing" => Some(Self::Initializing),
             "Listener" => Some(Self::Listener),
             "PartialSnapshot" => Some(Self::PartialSnapshot),
+            "Recovery" => Some(Self::Recovery),
             _ => None,
         }
     }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -330,7 +330,7 @@ impl Collection {
                         |state| {
                             state
                                 .get_peer_state(&this_peer_id)
-                                .map_or(false, |peer_state| peer_state.is_partial_like())
+                                .map_or(false, |peer_state| peer_state.is_partial_or_recovery())
                         },
                         defaults::CONSENSUS_META_OP_WAIT,
                     )

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -77,6 +77,7 @@ impl Collection {
 
             let initial_state = match shard_transfer.method.unwrap_or_default() {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
+                // TODO(1.9): switch into recovery state instead
                 ShardTransferMethod::Snapshot => ReplicaState::PartialSnapshot,
             };
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1362,6 +1362,7 @@ impl From<api::grpc::qdrant::ReplicaState> for ReplicaState {
             api::grpc::qdrant::ReplicaState::Initializing => Self::Initializing,
             api::grpc::qdrant::ReplicaState::Listener => Self::Listener,
             api::grpc::qdrant::ReplicaState::PartialSnapshot => Self::PartialSnapshot,
+            api::grpc::qdrant::ReplicaState::Recovery => Self::Recovery,
         }
     }
 }
@@ -1375,6 +1376,7 @@ impl From<ReplicaState> for api::grpc::qdrant::ReplicaState {
             ReplicaState::Initializing => Self::Initializing,
             ReplicaState::Listener => Self::Listener,
             ReplicaState::PartialSnapshot => Self::PartialSnapshot,
+            ReplicaState::Recovery => Self::Recovery,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -660,8 +660,12 @@ impl ShardReplicaSet {
                             .await?;
                         self.notify_peer_failure(peer_id);
                     }
-                    ReplicaState::PartialSnapshot | ReplicaState::Recovery => {
+                    ReplicaState::PartialSnapshot => {
                         self.set_local(local_shard, Some(ReplicaState::PartialSnapshot))
+                            .await?;
+                    }
+                    ReplicaState::Recovery => {
+                        self.set_local(local_shard, Some(ReplicaState::Recovery))
                             .await?;
                     }
                 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -635,38 +635,18 @@ impl ShardReplicaSet {
                 )
                 .await?;
                 match state {
-                    ReplicaState::Active => {
+                    ReplicaState::Active | ReplicaState::Listener => {
                         // No way we can provide up-to-date replica right away at this point,
                         // so we report a failure to consensus
-                        self.set_local(local_shard, Some(ReplicaState::Active))
-                            .await?;
+                        self.set_local(local_shard, Some(state)).await?;
                         self.notify_peer_failure(peer_id);
                     }
-                    ReplicaState::Dead => {
-                        self.set_local(local_shard, Some(ReplicaState::Dead))
-                            .await?;
-                    }
-                    ReplicaState::Partial => {
-                        self.set_local(local_shard, Some(ReplicaState::Partial))
-                            .await?;
-                    }
-                    ReplicaState::Initializing => {
-                        self.set_local(local_shard, Some(ReplicaState::Initializing))
-                            .await?;
-                    }
-                    ReplicaState::Listener => {
-                        // Same as `Active`, we report a failure to consensus
-                        self.set_local(local_shard, Some(ReplicaState::Listener))
-                            .await?;
-                        self.notify_peer_failure(peer_id);
-                    }
-                    ReplicaState::PartialSnapshot => {
-                        self.set_local(local_shard, Some(ReplicaState::PartialSnapshot))
-                            .await?;
-                    }
-                    ReplicaState::Recovery => {
-                        self.set_local(local_shard, Some(ReplicaState::Recovery))
-                            .await?;
+                    ReplicaState::Dead
+                    | ReplicaState::Partial
+                    | ReplicaState::Initializing
+                    | ReplicaState::PartialSnapshot
+                    | ReplicaState::Recovery => {
+                        self.set_local(local_shard, Some(state)).await?;
                     }
                 }
                 continue;

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -914,7 +914,7 @@ pub enum ReplicaState {
     // TODO(1.9): deprecate this state
     PartialSnapshot,
     // Shard is undergoing recovery by an external node
-    // Normally rejects updates, allows updates if force is true.
+    // Normally rejects updates, accepts updates if force is true
     Recovery,
 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -39,7 +39,8 @@ impl ShardReplicaSet {
                     Ok(Some(local_shard.get().update(operation, false).await?))
                 }
                 // In recovery state, only allow operations with force flag
-                Some(ReplicaState::Recovery)
+                // TODO(1.9): deprecate accepting partialsnapshot operations if force is true
+                Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery)
                     if operation.clock_tag.map_or(false, |tag| tag.force) =>
                 {
                     Ok(Some(local_shard.get().update(operation, wait).await?))

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -355,6 +355,7 @@ impl TableOfContent {
                 )?;
 
                 // Set shard state from `PartialSnapshot` to `Partial`
+                // TODO(1.9): get into Partial state from PartialSnapshot or Recovery
                 let operation = SetShardReplicaState {
                     collection_name: collection_id,
                     shard_id: transfer.shard_id,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add a new `ReplicaState::Recovery` state. We don't send updates to this state by default. It only accepts operations that had a force flag set, and rejects all others. We want to have this for shard diff transfer (<https://github.com/qdrant/qdrant/issues/3477>).

Sadly, we cannot use it directly due to backwards compatibility limits. Because of this we repurpose the current `PartialSnapshot` state, and will eventually deprecate it moving over to `Recovery`.

Here's a rough plan:
- Qdrant 1.8:
  - Change `PartialSnapshot` state:
    - Reject operations like before
    - But allow operations if a force flag is set
  - Add `Recovery` state
    - Only allow operations if a force flag is set
    - Cannot be used yet due to backwards compatibility
- Qdrant 1.9:
  - Deprecate `PartialSnapshot`, use `Recovery` everywhere

With the changes in 1.8, the partial snapshot and recovery state are essentially the same.

In 1.9, the recovery state will be used both for snapshot and WAL delta transfers. The partial snapshot state will be deprecated to limit the number of possible states.

Why don't we use Recovery state directly? We need a migration window. A cluster that updates nodes one by one cannot propose the recovery state in consensus, as old (unsupported) nodes will reject it.

Please feel free to suggest a name that is less generic than _recovery_, I couldn't come up with something better myself.

I've left some `// TODO(1.9):` comments to help point to the next steps to take when we'll be releasing 1.9.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
