### PR TITLE
Remove off-by-one logic in recovery point

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -103,18 +103,14 @@ impl ClockMap {
     /// Create a recovery point based on the current clock map state, so that we can recover any
     /// new operations with new clock values
     ///
-    /// The recovery point will contain every clock that is in this clock map, but with a tick of
-    /// one higher. That is because we already have an operation for the current clock tick, but
-    /// would like to receive the operation with the next tick on recovery.
-    ///
-    /// In other words, the recovery point will contain the first clock tick values the clock map
-    /// has not seen yet.
+    /// The recovery point contains every clock that is in this clock map. So, it represents all
+    /// the clock ticks we have.
     pub fn to_recovery_point(&self) -> RecoveryPoint {
         RecoveryPoint {
             clocks: self
                 .clocks
                 .iter()
-                .map(|(key, clock)| (*key, clock.current_tick + 1))
+                .map(|(key, clock)| (*key, clock.current_tick))
                 .collect(),
         }
     }
@@ -194,6 +190,11 @@ impl RecoveryPoint {
         self.clocks
             .iter()
             .map(|(key, tick)| ClockTag::new(key.peer_id, key.clock_id, *tick))
+    }
+
+    /// Increase all existing clocks in this recovery point by the given amount
+    pub fn increase_by(&mut self, amount: u64) {
+        self.clocks.values_mut().for_each(|tick| *tick += amount);
     }
 
     /// Check whether this recovery point has any clocks that are not in `other`


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Our recovery point was a copy of a click map, but with all clocks +1. This removes the +1, making a recovery point the same as the current clock map.

It should help reduce confusion regarding the values in the recovery point.

The existing test suite added as part of <https://github.com/qdrant/qdrant/issues/3477> proves that this change is behaving fine.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
