### PR TITLE
Add struct combining local shard clock maps

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -951,11 +951,11 @@ impl Drop for LocalShard {
 ///
 /// Holds a clock map for tracking the highest clocks and the cutoff clocks.
 #[derive(Clone)]
-pub(crate) struct ShardClocks {
-    pub(crate) highest_clocks: Arc<Mutex<ClockMap>>,
-    pub(crate) cutoff_clocks: Arc<Mutex<ClockMap>>,
-    pub(crate) highest_clocks_path: PathBuf,
-    pub(crate) cutoff_clocks_path: PathBuf,
+pub struct ShardClocks {
+    highest_clocks: Arc<Mutex<ClockMap>>,
+    cutoff_clocks: Arc<Mutex<ClockMap>>,
+    highest_clocks_path: PathBuf,
+    cutoff_clocks_path: PathBuf,
 }
 
 impl ShardClocks {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -919,7 +919,7 @@ impl Drop for LocalShard {
     }
 }
 
-/// Convenience struct for combining clock maps beloning to a shard
+/// Convenience struct for combining clock maps belonging to a shard
 ///
 /// Holds a clock map for tracking the highest clocks and the cutoff clocks.
 #[derive(Clone)]

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -26,7 +26,7 @@ use crate::common::stoppable_task::{spawn_stoppable, StoppableTaskHandle};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
-use crate::shards::local_shard::ShardClocks;
+use crate::shards::local_shard::LocalShardClocks;
 use crate::wal::WalError;
 use crate::wal_delta::LockedWal;
 
@@ -107,7 +107,7 @@ pub struct UpdateHandler {
     /// Maximum number of concurrent optimization jobs in this update handler.
     max_optimization_threads: Option<usize>,
     /// Highest and cutoff clocks for the shard WAL.
-    clocks: ShardClocks,
+    clocks: LocalShardClocks,
 }
 
 impl UpdateHandler {
@@ -122,7 +122,7 @@ impl UpdateHandler {
         wal: LockedWal,
         flush_interval_sec: u64,
         max_optimization_threads: Option<usize>,
-        clocks: ShardClocks,
+        clocks: LocalShardClocks,
     ) -> UpdateHandler {
         UpdateHandler {
             shared_storage_config,
@@ -596,7 +596,7 @@ impl UpdateHandler {
         wal_keep_from: Arc<AtomicU64>,
         flush_interval_sec: u64,
         mut stop_receiver: oneshot::Receiver<()>,
-        clocks: ShardClocks,
+        clocks: LocalShardClocks,
     ) {
         loop {
             // Stop flush worker on signal or if sender was dropped

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,6 +1,5 @@
 use std::cmp::min;
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
@@ -27,7 +26,7 @@ use crate::common::stoppable_task::{spawn_stoppable, StoppableTaskHandle};
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::CollectionUpdateOperations;
-use crate::shards::local_shard::clock_map::ClockMap;
+use crate::shards::local_shard::ShardClocks;
 use crate::wal::WalError;
 use crate::wal_delta::LockedWal;
 
@@ -107,11 +106,8 @@ pub struct UpdateHandler {
     optimization_handles: Arc<TokioMutex<Vec<StoppableTaskHandle<bool>>>>,
     /// Maximum number of concurrent optimization jobs in this update handler.
     max_optimization_threads: Option<usize>,
-
-    highest_clock_map: Arc<TokioMutex<ClockMap>>,
-    cutoff_clock_map: Arc<TokioMutex<ClockMap>>,
-    highest_clock_map_path: PathBuf,
-    cutoff_clock_map_path: PathBuf,
+    /// Highest and cutoff clocks for the shard WAL.
+    clocks: ShardClocks,
 }
 
 impl UpdateHandler {
@@ -126,10 +122,7 @@ impl UpdateHandler {
         wal: LockedWal,
         flush_interval_sec: u64,
         max_optimization_threads: Option<usize>,
-        highest_clock_map: Arc<TokioMutex<ClockMap>>,
-        cutoff_clock_map: Arc<TokioMutex<ClockMap>>,
-        highest_clock_map_path: PathBuf,
-        cutoff_clock_map_path: PathBuf,
+        clocks: ShardClocks,
     ) -> UpdateHandler {
         UpdateHandler {
             shared_storage_config,
@@ -147,10 +140,7 @@ impl UpdateHandler {
             flush_interval_sec,
             optimization_handles: Arc::new(TokioMutex::new(vec![])),
             max_optimization_threads,
-            highest_clock_map,
-            cutoff_clock_map,
-            highest_clock_map_path,
-            cutoff_clock_map_path,
+            clocks,
         }
     }
 
@@ -180,10 +170,7 @@ impl UpdateHandler {
             self.wal_keep_from.clone(),
             self.flush_interval_sec,
             flush_rx,
-            self.highest_clock_map.clone(),
-            self.cutoff_clock_map.clone(),
-            self.highest_clock_map_path.clone(),
-            self.cutoff_clock_map_path.clone(),
+            self.clocks.clone(),
         )));
         self.flush_stop = Some(flush_tx);
     }
@@ -609,10 +596,7 @@ impl UpdateHandler {
         wal_keep_from: Arc<AtomicU64>,
         flush_interval_sec: u64,
         mut stop_receiver: oneshot::Receiver<()>,
-        highest_clock_map: Arc<tokio::sync::Mutex<ClockMap>>,
-        cutoff_clock_map: Arc<tokio::sync::Mutex<ClockMap>>,
-        highest_clock_map_path: PathBuf,
-        cutoff_clock_map_path: PathBuf,
+        clocks: ShardClocks,
     ) {
         loop {
             // Stop flush worker on signal or if sender was dropped
@@ -662,16 +646,8 @@ impl UpdateHandler {
 
             let ack = confirmed_version.min(keep_from.saturating_sub(1));
 
-            if let Err(err) = cutoff_clock_map.lock().await.store(&cutoff_clock_map_path) {
-                log::warn!("Failed to store cutoff clock map to disk: {err}");
-                segments.write().report_optimizer_error(err);
-            }
-            if let Err(err) = highest_clock_map
-                .lock()
-                .await
-                .store(&highest_clock_map_path)
-            {
-                log::warn!("Failed to store last seen clock map to disk: {err}");
+            if let Err(err) = clocks.store().await {
+                log::warn!("Failed to store clock maps to disk: {err}");
                 segments.write().report_optimizer_error(err);
             }
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add a `LocalShardClocks` struct holding the highest and cutoff clock maps along with their storage paths.

It is a convenience struct because these types are commonly used together. It reduces 4 fields/parameters into 1 in cases where it is used.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?