### PR TITLE
Remove deprecated `PointsUpdateOperation` variants

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -2601,11 +2601,9 @@ Additionally, the first and last points of each GeoLineString must be the same.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | upsert | [PointsUpdateOperation.PointStructList](#qdrant-PointsUpdateOperation-PointStructList) |  |  |
-| delete_deprecated | [PointsSelector](#qdrant-PointsSelector) |  | **Deprecated.**  |
 | set_payload | [PointsUpdateOperation.SetPayload](#qdrant-PointsUpdateOperation-SetPayload) |  |  |
 | overwrite_payload | [PointsUpdateOperation.SetPayload](#qdrant-PointsUpdateOperation-SetPayload) |  |  |
 | delete_payload | [PointsUpdateOperation.DeletePayload](#qdrant-PointsUpdateOperation-DeletePayload) |  |  |
-| clear_payload_deprecated | [PointsSelector](#qdrant-PointsSelector) |  | **Deprecated.**  |
 | update_vectors | [PointsUpdateOperation.UpdateVectors](#qdrant-PointsUpdateOperation-UpdateVectors) |  |  |
 | delete_vectors | [PointsUpdateOperation.DeleteVectors](#qdrant-PointsUpdateOperation-DeleteVectors) |  |  |
 | delete_points | [PointsUpdateOperation.DeletePoints](#qdrant-PointsUpdateOperation-DeletePoints) |  |  |

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -493,15 +493,18 @@ message PointsUpdateOperation {
 
   oneof operation {
     PointStructList upsert = 1;
-    PointsSelector delete_deprecated = 2 [deprecated=true];
     SetPayload set_payload = 3;
     SetPayload overwrite_payload = 4;
     DeletePayload delete_payload = 5;
-    PointsSelector clear_payload_deprecated = 6 [deprecated=true];
     UpdateVectors update_vectors = 7;
     DeleteVectors delete_vectors = 8;
     DeletePoints delete_points = 9;
     ClearPayload clear_payload = 10;
+
+    /* ⬇⬇⬇ Proto spec does not allow reserved fields in oneOf, so we can keep track of them here ⬇⬇⬇ 
+    PointsSelector delete_deprecated = 2 [deprecated=true];
+    PointsSelector clear_payload_deprecated = 6 [deprecated=true];
+    */
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3758,7 +3758,7 @@ pub struct CountPoints {
 pub struct PointsUpdateOperation {
     #[prost(
         oneof = "points_update_operation::Operation",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
+        tags = "1, 3, 4, 5, 7, 8, 9, 10"
     )]
     pub operation: ::core::option::Option<points_update_operation::Operation>,
 }
@@ -3860,16 +3860,12 @@ pub mod points_update_operation {
     pub enum Operation {
         #[prost(message, tag = "1")]
         Upsert(PointStructList),
-        #[prost(message, tag = "2")]
-        DeleteDeprecated(super::PointsSelector),
         #[prost(message, tag = "3")]
         SetPayload(SetPayload),
         #[prost(message, tag = "4")]
         OverwritePayload(SetPayload),
         #[prost(message, tag = "5")]
         DeletePayload(DeletePayload),
-        #[prost(message, tag = "6")]
-        ClearPayloadDeprecated(super::PointsSelector),
         #[prost(message, tag = "7")]
         UpdateVectors(UpdateVectors),
         #[prost(message, tag = "8")]

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -512,21 +512,6 @@ pub async fn update_batch(
                 )
                 .await
             }
-            points_update_operation::Operation::DeleteDeprecated(points) => {
-                delete(
-                    toc.clone(),
-                    DeletePoints {
-                        collection_name,
-                        wait,
-                        points: Some(points),
-                        ordering,
-                        shard_key_selector: None,
-                    },
-                    clock_tag,
-                    shard_selection,
-                )
-                .await
-            }
             points_update_operation::Operation::SetPayload(
                 points_update_operation::SetPayload {
                     payload,
@@ -652,21 +637,6 @@ pub async fn update_batch(
                         vectors,
                         ordering,
                         shard_key_selector,
-                    },
-                    clock_tag,
-                    shard_selection,
-                )
-                .await
-            }
-            Operation::ClearPayloadDeprecated(selector) => {
-                clear_payload(
-                    toc.clone(),
-                    ClearPayloadPoints {
-                        collection_name,
-                        wait,
-                        points: Some(selector),
-                        ordering,
-                        shard_key_selector: None,
                     },
                     clock_tag,
                     shard_selection,


### PR DESCRIPTION
In Qdrant 1.7, we deprecated these fields. ~For 1.8, we can safely remove them.~ Edit: We will remove these eventually

Related PR: qdrant/qdrant-client#502

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
