### PR TITLE
Remove unused proptest on Sparse crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,17 +4062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5379,8 +5368,6 @@ dependencies = [
  "memory",
  "ordered-float 4.2.0",
  "parking_lot",
- "proptest",
- "proptest-derive",
  "rand 0.8.5",
  "schemars",
  "serde",

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -8,9 +8,6 @@ authors = [
 license = "Apache-2.0"
 edition = "2021"
 
-[features]
-proptest = ["dep:proptest", "dep:proptest-derive"]
-
 [dependencies]
 common = { path = "../common/common" }
 io = { path = "../common/io" }
@@ -24,6 +21,3 @@ rand = "0.8.5"
 validator = "0.16"
 itertools = "0.12.1"
 parking_lot = "0.12.1"
-
-proptest = { version = "1.4", optional = true }
-proptest-derive = { version = "0.4", optional = true }


### PR DESCRIPTION
Not sure why it was added in https://github.com/qdrant/qdrant/pull/3408/files#diff-7b0aab90d02b16dd5489af3b665000e80c5eef3d4a9c12b18441f6a1ae7de6ebL10