### PR TITLE
fix: Make thread id visible for shard loading thread

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -217,7 +217,7 @@ impl LocalShard {
             let segments_path = entry.unwrap().path();
             load_handlers.push(
                 thread::Builder::new()
-                    .name(format!("shard-load-{id}-{collection_id}"))
+                    .name(format!("load-{id}-{collection_id}"))
                     .spawn(move || {
                         let mut res = load_segment(&segments_path, &AtomicBool::new(false))?;
                         if let Some(segment) = &mut res {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -217,7 +217,7 @@ impl LocalShard {
             let segments_path = entry.unwrap().path();
             load_handlers.push(
                 thread::Builder::new()
-                    .name(format!("shard-load-{collection_id}-{id}"))
+                    .name(format!("shard-load-{id}-{collection_id}"))
                     .spawn(move || {
                         let mut res = load_segment(&segments_path, &AtomicBool::new(false))?;
                         if let Some(segment) = &mut res {


### PR DESCRIPTION
Linux kernel [limits thread names to 15 chars](https://stackoverflow.com/questions/5026531/thread-name-longer-than-15-chars). 

This means thread that's loading `benchmark` collection is named as `shard-load-bench` (gets trimmed to 15 chars). This hides the thread id that we put in the custom thread name (useful for perf analysis tools). So it's (slightly) better to put the id before so it's visible to some extent.  This obviously can trim collection name. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

