### PR TITLE
Add basic integration tests for WAL delta transfer

### DIFF
--- a/tests/consensus_tests/test_shard_snapshot_transfer.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer.py
@@ -69,7 +69,7 @@ def test_shard_snapshot_transfer(tmp_path: pathlib.Path):
                 "shard_id": shard_id,
                 "from_peer_id": from_peer_id,
                 "to_peer_id": to_peer_id,
-                "method": "snapshot"
+                "method": "snapshot",
             }
         })
     assert_http_ok(r)
@@ -137,7 +137,7 @@ def test_shard_snapshot_transfer_throttled_updates(tmp_path: pathlib.Path):
                 "shard_id": shard_id,
                 "from_peer_id": from_peer_id,
                 "to_peer_id": to_peer_id,
-                "method": "snapshot"
+                "method": "snapshot",
             }
         })
     assert_http_ok(r)
@@ -211,7 +211,7 @@ def test_shard_snapshot_transfer_fast_burst(tmp_path: pathlib.Path):
                 "shard_id": shard_id,
                 "from_peer_id": from_peer_id,
                 "to_peer_id": to_peer_id,
-                "method": "snapshot"
+                "method": "snapshot",
             }
         })
     assert_http_ok(r)

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -37,7 +37,7 @@ def run_update_points_in_background(peer_url, collection_name, init_offset=0, th
 # assert that property in this test however. It is tested both ways.
 #
 # Test that data on the both sides is consistent
-def test_empty_shard_wal_delta_transfer(tmp_path: pathlib.Path):
+def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
     assert_project_root()
 
     # seed port to reuse the same port for the restarted nodes
@@ -72,6 +72,10 @@ def test_empty_shard_wal_delta_transfer(tmp_path: pathlib.Path):
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
+    # Confirm emtpy WAL delta based on debug message in stdout
+    stdout, stderr = capfd.readouterr()
+    assert "Resolved WAL delta that is empty" in stdout
+
     # Doing it the other way around should result in exactly the same
     r = requests.post(
         f"{peer_api_uris[1]}/collections/{COLLECTION_NAME}/cluster", json={
@@ -86,6 +90,10 @@ def test_empty_shard_wal_delta_transfer(tmp_path: pathlib.Path):
 
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[1], COLLECTION_NAME, 0)
+
+    # Confirm emtpy WAL delta based on debug message in stdout
+    stdout, stderr = capfd.readouterr()
+    assert "Resolved WAL delta that is empty" in stdout
 
     cluster_info_0 = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
     cluster_info_1 = get_collection_cluster_info(peer_api_uris[1], COLLECTION_NAME)

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -186,6 +186,10 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path, capfd)
     number_local_shards = len(receiver_collection_cluster_info['local_shards'])
     assert number_local_shards == 1
 
+    upload_process_1.kill()
+    upload_process_2.kill()
+    sleep(1)
+
     # Point counts must be consistent across nodes
     counts = []
     for uri in peer_api_uris:

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -7,9 +7,6 @@ from time import sleep
 from .fixtures import upsert_random_points, create_collection
 from .utils import *
 
-N_PEERS = 3
-N_SHARDS = 3
-N_REPLICA = 1
 COLLECTION_NAME = "test_collection"
 
 
@@ -213,7 +210,7 @@ def test_shard_wal_delta_transfer_fallback(capfd, tmp_path: pathlib.Path):
     assert_project_root()
 
     # seed port to reuse the same port for the restarted nodes
-    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, 20000)
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, 3, 20000)
 
     create_collection(peer_api_uris[0], shard_number=3, replication_factor=1)
     wait_collection_exists_and_active_on_all_peers(

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -1,0 +1,105 @@
+import multiprocessing
+import pathlib
+from time import sleep
+
+from .fixtures import upsert_random_points, create_collection
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 3
+N_REPLICA = 1
+COLLECTION_NAME = "test_collection"
+
+
+def update_points_in_loop(peer_url, collection_name, offset=0, throttle=False, duration=None):
+    start = time.time()
+    limit = 3
+
+    while True:
+        upsert_random_points(peer_url, limit, collection_name, offset=offset)
+        offset += limit
+
+        if throttle:
+            sleep(0.1)
+        if duration is not None and (time.time() - start) > duration:
+            break
+
+
+def run_update_points_in_background(peer_url, collection_name, init_offset=0, throttle=False, duration=None):
+    p = multiprocessing.Process(target=update_points_in_loop, args=(peer_url, collection_name, init_offset, throttle, duration))
+    p.start()
+    return p
+
+
+# Test a WAL delta transfer between two that have no difference.
+#
+# No WAL records will be transferred as the WAL should be empty. We cannot
+# assert that property in this test however. It is tested both ways.
+#
+# Test that data on the both sides is consistent
+def test_empty_shard_wal_delta_transfer(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, 2, 20000)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    # Insert some initial number of points
+    upsert_random_points(peer_api_uris[0], 100)
+
+    cluster_info_0 = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
+    cluster_info_1 = get_collection_cluster_info(peer_api_uris[1], COLLECTION_NAME)
+
+    shard_id = cluster_info_0['local_shards'][0]['shard_id']
+
+    # Re-replicate shard from one node to another, should be no diff
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": cluster_info_0['peer_id'],
+                "to_peer_id": cluster_info_1['peer_id'],
+                "method": "wal_delta",
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    # Doing it the other way around should result in exactly the same
+    r = requests.post(
+        f"{peer_api_uris[1]}/collections/{COLLECTION_NAME}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": cluster_info_1['peer_id'],
+                "to_peer_id": cluster_info_0['peer_id'],
+                "method": "wal_delta",
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[1], COLLECTION_NAME, 0)
+
+    cluster_info_0 = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
+    cluster_info_1 = get_collection_cluster_info(peer_api_uris[1], COLLECTION_NAME)
+    assert len(cluster_info_0['local_shards']) == 1
+    assert len(cluster_info_1['local_shards']) == 1
+
+    # Point counts must be consistent across nodes
+    counts = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
+                "exact": True
+            }
+        )
+        assert_http_ok(r)
+        counts.append(r.json()["result"]['count'])
+    assert counts[0] == counts[1]

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -71,7 +71,7 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
-    # Confirm emtpy WAL delta based on debug message in stdout
+    # Confirm empty WAL delta based on debug message in stdout
     stdout, stderr = capfd.readouterr()
     assert "Resolved WAL delta that is empty" in stdout
 
@@ -90,7 +90,7 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
     # Wait for end of shard transfer
     wait_for_collection_shard_transfers_count(peer_api_uris[1], COLLECTION_NAME, 0)
 
-    # Confirm emtpy WAL delta based on debug message in stdout
+    # Confirm empty WAL delta based on debug message in stdout
     stdout, stderr = capfd.readouterr()
     assert "Resolved WAL delta that is empty" in stdout
 

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -99,17 +99,19 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
     assert len(cluster_info_0['local_shards']) == 1
     assert len(cluster_info_1['local_shards']) == 1
 
-    # Point counts must be consistent across nodes
-    counts = []
+    # Match all points on all nodes exactly
+    data = []
     for uri in peer_api_uris:
         r = requests.post(
-            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
-                "exact": True
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
             }
         )
         assert_http_ok(r)
-        counts.append(r.json()["result"]['count'])
-    assert counts[0] == counts[1]
+        data.append(r.json()["result"])
+    assert data[0] == data[1]
 
 
 # Test node recovery with a WAL delta transfer.
@@ -190,17 +192,19 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path, capfd)
     upload_process_2.kill()
     sleep(1)
 
-    # Point counts must be consistent across nodes
-    counts = []
+    # Match all points on all nodes exactly
+    data = []
     for uri in peer_api_uris:
         r = requests.post(
-            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
-                "exact": True
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
             }
         )
         assert_http_ok(r)
-        counts.append(r.json()["result"]['count'])
-    assert counts[0] == counts[1] == counts[2]
+        data.append(r.json()["result"])
+    assert data[0] == data[1] == data[2]
 
 
 # Test the shard transfer fallback for WAL delta transfer.
@@ -258,14 +262,16 @@ def test_shard_wal_delta_transfer_fallback(capfd, tmp_path: pathlib.Path):
     number_local_shards = len(receiver_collection_cluster_info['local_shards'])
     assert number_local_shards == 2
 
-    # Point counts must be consistent across nodes
-    counts = []
+    # Match all points on all nodes exactly
+    data = []
     for uri in peer_api_uris:
         r = requests.post(
-            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
-                "exact": True
+            f"{uri}/collections/{COLLECTION_NAME}/points/scroll", json={
+                "limit": 999999999,
+                "with_vectors": True,
+                "with_payload": True,
             }
         )
         assert_http_ok(r)
-        counts.append(r.json()["result"]['count'])
-    assert counts[0] == counts[1] == counts[2]
+        data.append(r.json()["result"])
+    assert data[0] == data[1] == data[2]

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -200,3 +200,71 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path, capfd)
         assert_http_ok(r)
         counts.append(r.json()["result"]['count'])
     assert counts[0] == counts[1] == counts[2]
+
+
+# Test the shard transfer fallback for WAL delta transfer.
+#
+# We replicate a shard with WAL delta transfer to a node that does not have any
+# data for this shard yet. This is not supported in WAL delta transfer, so it
+# should fall back to a different method.
+#
+# Test that data on the both sides is consistent
+def test_shard_wal_delta_transfer_fallback(capfd, tmp_path: pathlib.Path):
+    assert_project_root()
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, 20000)
+
+    create_collection(peer_api_uris[0], shard_number=3, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    # Insert some initial number of points
+    upsert_random_points(peer_api_uris[0], 100)
+
+    transfer_collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+
+    from_peer_id = transfer_collection_cluster_info['peer_id']
+    to_peer_id = receiver_collection_cluster_info['peer_id']
+
+    shard_id = transfer_collection_cluster_info['local_shards'][0]['shard_id']
+
+    # Transfer shard from one node to another
+
+    # Move shard `shard_id` to peer `target_peer_id`
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": from_peer_id,
+                "to_peer_id": to_peer_id,
+                "method": "wal_delta",
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    # Confirm that we fall back to a different method after WAL delta fails
+    stdout, stderr = capfd.readouterr()
+    assert "Failed to do shard diff transfer, falling back to default method" in stdout
+
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+    number_local_shards = len(receiver_collection_cluster_info['local_shards'])
+    assert number_local_shards == 2
+
+    # Point counts must be consistent across nodes
+    counts = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
+                "exact": True
+            }
+        )
+        assert_http_ok(r)
+        counts.append(r.json()["result"]['count'])
+    assert counts[0] == counts[1] == counts[2]

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -1,5 +1,7 @@
 import multiprocessing
 import pathlib
+import random
+import re
 from time import sleep
 
 from .fixtures import upsert_random_points, create_collection
@@ -20,7 +22,7 @@ def update_points_in_loop(peer_url, collection_name, offset=0, throttle=False, d
         offset += limit
 
         if throttle:
-            sleep(0.1)
+            sleep(random.uniform(0.01, 0.1))
         if duration is not None and (time.time() - start) > duration:
             break
 
@@ -111,3 +113,90 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
         assert_http_ok(r)
         counts.append(r.json()["result"]['count'])
     assert counts[0] == counts[1]
+
+
+# Test node recovery with a WAL delta transfer.
+#
+# The second node is killed while operations are ongoing. We later restart the
+# node, and manually trigger rereplication to sync it up again.
+#
+# Test that data on the both sides is consistent
+def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path, capfd):
+    assert_project_root()
+
+    # Prevent automatic recovery on restarted node, so we can manually recover with a specific transfer method
+    env={
+        "QDRANT__STORAGE__PERFORMANCE__INCOMING_SHARD_TRANSFERS_LIMIT": "0",
+        "QDRANT__STORAGE__PERFORMANCE__OUTGOING_SHARD_TRANSFERS_LIMIT": "0",
+    }
+
+    # seed port to reuse the same port for the restarted nodes
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, 3, 20000, extra_env=env)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris
+    )
+
+    transfer_collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+
+    from_peer_id = transfer_collection_cluster_info['peer_id']
+    to_peer_id = receiver_collection_cluster_info['peer_id']
+
+    shard_id = transfer_collection_cluster_info['local_shards'][0]['shard_id']
+
+    # # Start pushing points to the cluster
+    upload_process_1 = run_update_points_in_background(peer_api_uris[0], COLLECTION_NAME, init_offset=100000, throttle=True)
+    upload_process_2 = run_update_points_in_background(peer_api_uris[1], COLLECTION_NAME, init_offset=200000, throttle=True)
+    upload_process_3 = run_update_points_in_background(peer_api_uris[2], COLLECTION_NAME, init_offset=300000, throttle=True)
+
+    sleep(3)
+
+    # Kill last peer
+    upload_process_3.kill()
+    processes.pop().kill()
+
+    sleep(5)
+
+    # Restart the peer
+    peer_api_uris[-1] = start_peer(peer_dirs[-1], "peer_2_restarted.log", bootstrap_uri, extra_env=env)
+    wait_for_peer_online(peer_api_uris[-1], "/")
+
+    # Recover shard with WAL delta transfer
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
+            "replicate_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": from_peer_id,
+                "to_peer_id": to_peer_id,
+                "method": "wal_delta",
+            }
+        })
+    assert_http_ok(r)
+
+    # Wait for end of shard transfer
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    # Confirm WAL delta transfer based on stdout logs, assert its size
+    stdout, stderr = capfd.readouterr()
+    delta_version, delta_size = re.search(r"Resolved WAL delta from (\d+), which counts (\d+) records", stdout).groups()
+    assert int(delta_version) >= 80
+    assert int(delta_size) >= 80
+
+    receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
+    number_local_shards = len(receiver_collection_cluster_info['local_shards'])
+    assert number_local_shards == 1
+
+    # Point counts must be consistent across nodes
+    counts = []
+    for uri in peer_api_uris:
+        r = requests.post(
+            f"{uri}/collections/{COLLECTION_NAME}/points/count", json={
+                "exact": True
+            }
+        )
+        assert_http_ok(r)
+        counts.append(r.json()["result"]['count'])
+    assert counts[0] == counts[1] == counts[2]

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -431,17 +431,17 @@ def wait_for(condition: Callable[..., bool], *args, wait_for_interval=RETRY_INTE
             time.sleep(wait_for_interval)
 
 
-def peer_is_online(peer_api_uri: str) -> bool:
+def peer_is_online(peer_api_uri: str, path: str = "/readyz") -> bool:
     try:
-        r = requests.get(f"{peer_api_uri}/readyz")
+        r = requests.get(f"{peer_api_uri}{path}")
         return r.status_code == 200
     except:
         return False
 
 
-def wait_for_peer_online(peer_api_uri: str):
+def wait_for_peer_online(peer_api_uri: str, path="/readyz"):
     try:
-        wait_for(peer_is_online, peer_api_uri)
+        wait_for(peer_is_online, peer_api_uri, path=path)
     except Exception as e:
         print_clusters_info([peer_api_uri])
         raise e


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This adds three basic integration tests for WAL delta transfer, similar to the tests we had for shard snapshot transfer.

The tests include:
- transfer empty WAL delta between two nodes
- transfer WAL delta to recover a failed node, with concurrent upsertions
- transfer WAL delta to empty node, falling back to default transfer method

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
