### PR TITLE
Drop unused Deserialize

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9411,7 +9411,8 @@
       "OperationDurationStatistics": {
         "type": "object",
         "required": [
-          "count"
+          "count",
+          "total_duration_micros"
         ],
         "properties": {
           "count": {
@@ -9444,7 +9445,6 @@
           },
           "total_duration_micros": {
             "description": "The total duration of all operations in microseconds.",
-            "default": 0,
             "type": "integer",
             "format": "uint64",
             "minimum": 0

--- a/lib/api/src/grpc/models.rs
+++ b/lib/api/src/grpc/models.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use schemars::JsonSchema;
 use serde;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 pub fn get_git_commit_id() -> Option<String> {
     option_env!("GIT_COMMIT_ID")
@@ -10,7 +10,7 @@ pub fn get_git_commit_id() -> Option<String> {
         .filter(|s| !s.trim().is_empty())
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Serialize, JsonSchema)]
 pub struct VersionInfo {
     pub title: String,
     pub version: String,
@@ -28,7 +28,7 @@ impl Default for VersionInfo {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ApiStatus {
     Ok,
@@ -45,13 +45,13 @@ pub struct ApiResponse<D> {
     pub time: f64,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CollectionDescription {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CollectionsResponse {
     pub collections: Vec<CollectionDescription>,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -54,9 +54,7 @@ use crate::wal::WalError;
 
 /// Current state of the collection.
 /// `Green` - all good. `Yellow` - optimization is running, `Red` - some operations failed and was not recovered
-#[derive(
-    Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Copy, Clone,
-)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionStatus {
     // Collection if completely ready for requests
@@ -70,15 +68,13 @@ pub enum CollectionStatus {
 
 /// State of existence of a collection,
 /// true = exists, false = does not exist
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct CollectionExistence {
     pub exists: bool,
 }
 
 /// Current state of the collection
-#[derive(
-    Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Clone,
-)]
+#[derive(Debug, Default, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum OptimizersStatus {
     /// Optimizers are reporting as expected
@@ -89,7 +85,7 @@ pub enum OptimizersStatus {
 }
 
 /// Point data
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Record {
     /// Id of the point
@@ -99,12 +95,12 @@ pub struct Record {
     /// Vector of the point
     pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 
 /// Current statistics and configuration of the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct CollectionInfo {
     /// Status of the collection
     pub status: CollectionStatus,
@@ -126,7 +122,6 @@ pub struct CollectionInfo {
     /// Each segment has independent vector as payload indexes
     pub segments_count: usize,
     /// Collection settings
-    #[validate]
     pub config: CollectionConfig,
     /// Types of stored payload
     pub payload_schema: HashMap<PayloadKeyType, PayloadIndexInfo>,
@@ -191,7 +186,7 @@ pub struct CollectionInfoInternal {
 }
 
 /// Current clustering distribution for the collection
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct CollectionClusterInfo {
     /// ID of this peer
     pub peer_id: PeerId,
@@ -205,7 +200,7 @@ pub struct CollectionClusterInfo {
     pub shard_transfers: Vec<ShardTransferInfo>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct ShardTransferInfo {
     pub shard_id: ShardId,
 
@@ -219,15 +214,15 @@ pub struct ShardTransferInfo {
     /// If `false` transfer is a moving of a shard from one peer to another
     pub sync: bool,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ShardTransferMethod>,
 
     /// A human-readable report of the transfer progress. Available only on the source peer.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct LocalShardInfo {
     /// Local shard id
@@ -241,7 +236,7 @@ pub struct LocalShardInfo {
     pub state: ReplicaState,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct RemoteShardInfo {
     /// Remote shard id
@@ -257,14 +252,14 @@ pub struct RemoteShardInfo {
 
 /// `Acknowledged` - Request is saved to WAL and will be process in a queue.
 /// `Completed` - Request is completed, changes are actual.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
     Acknowledged,
     Completed,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateResult {
     /// Sequential number of the operation
@@ -351,7 +346,7 @@ impl Default for ScrollRequestInternal {
 }
 
 /// Result of the points read request
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ScrollResult {
     /// List of retrieved points
@@ -851,7 +846,7 @@ pub struct DiscoverRequestBatch {
     pub searches: Vec<DiscoverRequest>,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct PointGroup {
     /// Scored points that have the same value of the group_by key
     pub hits: Vec<ScoredPoint>,
@@ -862,7 +857,7 @@ pub struct PointGroup {
     pub lookup: Option<Record>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct GroupsResult {
     pub groups: Vec<PointGroup>,
 }
@@ -897,7 +892,7 @@ pub const fn default_exact_count() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CountResult {
     /// Number of points which satisfy the conditions
@@ -1717,14 +1712,14 @@ impl Validate for SparseVectorsConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AliasDescription {
     pub alias_name: String,
     pub collection_name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CollectionsAliasesResponse {
     pub aliases: Vec<AliasDescription>,
@@ -1789,7 +1784,7 @@ impl From<QueryEnum> for QueryVector {
 }
 
 /// All the unresolved issues in a Qdrant instance
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, JsonSchema, Debug)]
 pub struct IssuesReport {
     pub issues: Vec<IssueRecord>,
 }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -4,14 +4,14 @@ use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::common::operation_time_statistics::OperationDurationStatistics;
 use segment::telemetry::SegmentTelemetry;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::collection_manager::optimizers::TrackerTelemetry;
 use crate::operations::types::OptimizersStatus;
 use crate::shards::replica_set::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ReplicaSetTelemetry {
     pub id: ShardId,
     pub local: Option<LocalShardTelemetry>,
@@ -19,7 +19,7 @@ pub struct ReplicaSetTelemetry {
     pub replicate_states: HashMap<PeerId, ReplicaState>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct RemoteShardTelemetry {
     pub shard_id: ShardId,
     pub peer_id: Option<PeerId>,
@@ -27,14 +27,14 @@ pub struct RemoteShardTelemetry {
     pub updates: OperationDurationStatistics,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct LocalShardTelemetry {
     pub variant_name: Option<String>,
     pub segments: Vec<SegmentTelemetry>,
     pub optimizations: OptimizerTelemetry,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
+#[derive(Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct OptimizerTelemetry {
     pub status: OptimizersStatus,
     pub optimizations: OperationDurationStatistics,

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -1,12 +1,12 @@
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::config::CollectionConfig;
 use crate::operations::types::ShardTransferInfo;
 use crate::shards::telemetry::ReplicaSetTelemetry;
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct CollectionTelemetry {
     pub id: String,
     pub init_time_ms: u64,

--- a/lib/common/issues/src/issue.rs
+++ b/lib/common/issues/src/issue.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::solution::Solution;
 
@@ -16,7 +16,7 @@ pub trait Issue {
 }
 
 /// An issue that can be identified by its code
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct IssueRecord {
     pub code: CodeType,
     pub description: String,

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -7,7 +7,7 @@ use is_sorted::IsSorted;
 use itertools::Itertools as _;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use smallvec::SmallVec;
 
 use crate::common::anonymize::Anonymize;
@@ -15,7 +15,7 @@ use crate::common::anonymize::Anonymize;
 const AVG_DATASET_LEN: usize = 128;
 const SLIDING_WINDOW_LEN: usize = 8;
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Default, Debug, JsonSchema)]
 pub struct OperationDurationStatistics {
     pub count: usize,
 
@@ -25,25 +25,20 @@ pub struct OperationDurationStatistics {
 
     /// The average time taken by 128 latest operations, calculated as a weighted mean.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub avg_duration_micros: Option<f32>,
 
     /// The minimum duration of the operations across all the measurements.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub min_duration_micros: Option<f32>,
 
     /// The maximum duration of the operations across all the measurements.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub max_duration_micros: Option<f32>,
 
     /// The total duration of all operations in microseconds.
-    #[serde(default)]
     pub total_duration_micros: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub last_responded: Option<DateTime<Utc>>,
 
     /// The cumulative histogram of the operation durations. Consists of a list of pairs of

--- a/lib/segment/src/telemetry.rs
+++ b/lib/segment/src/telemetry.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::common::anonymize::Anonymize;
 use crate::common::operation_time_statistics::OperationDurationStatistics;
@@ -8,12 +8,12 @@ use crate::types::{
     VectorDataInfo,
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct VectorIndexesTelemetry {
     vector_index_searches: Vec<VectorIndexSearchesTelemetry>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct SegmentTelemetry {
     pub info: SegmentInfo,
     pub config: SegmentConfig,
@@ -21,14 +21,13 @@ pub struct SegmentTelemetry {
     pub payload_field_indices: Vec<PayloadIndexTelemetry>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct PayloadIndexTelemetry {
     pub field_name: Option<String>,
     pub points_values_count: usize,
     pub points_count: usize,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub histogram_bucket_size: Option<usize>,
 }
 
@@ -39,7 +38,7 @@ impl PayloadIndexTelemetry {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
+#[derive(Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct VectorIndexSearchesTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_name: Option<String>,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -217,7 +217,7 @@ pub enum Order {
 }
 
 /// Search result
-#[derive(Deserialize, Serialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, JsonSchema, Clone, Debug)]
 pub struct ScoredPoint {
     /// Point id
     pub id: PointIdType,
@@ -230,7 +230,7 @@ pub struct ScoredPoint {
     /// Vector of the point
     pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 
@@ -255,7 +255,7 @@ impl PartialEq for ScoredPoint {
 }
 
 /// Type of segment
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SegmentType {
     // There are no index built for the segment, all operations are available
@@ -267,11 +267,11 @@ pub enum SegmentType {
 }
 
 /// Display payload field type & index information
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct PayloadIndexInfo {
     pub data_type: PayloadSchemaType,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<PayloadSchemaParams>,
     /// Number of points indexed with this index
     pub points: usize,
@@ -301,7 +301,7 @@ impl PayloadIndexInfo {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct VectorDataInfo {
     pub num_vectors: usize,
@@ -310,7 +310,7 @@ pub struct VectorDataInfo {
 }
 
 /// Aggregated information about segment
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SegmentInfo {
     pub segment_type: SegmentType,

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -122,7 +122,7 @@ const fn default_mmap_advice() -> madvise::Advice {
 }
 
 /// Information of a peer in the cluster
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct PeerInfo {
     pub uri: String,
     // ToDo: How long ago was the last communication? In milliseconds
@@ -130,7 +130,7 @@ pub struct PeerInfo {
 }
 
 /// Summary information about the current raft state
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct RaftInfo {
     /// Raft divides time into terms of arbitrary length, each beginning with an election.
     /// If a candidate wins the election, it remains the leader for the rest of the term.
@@ -150,7 +150,7 @@ pub struct RaftInfo {
 }
 
 /// Role of the peer in the consensus
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, JsonSchema, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, JsonSchema)]
 pub enum StateRole {
     // The node is a follower of the leader.
     Follower,
@@ -174,7 +174,7 @@ impl From<raft::StateRole> for StateRole {
 }
 
 /// Message send failures for a particular peer
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+#[derive(Debug, Serialize, JsonSchema, Clone, Default)]
 pub struct MessageSendErrors {
     pub count: usize,
     pub latest_error: Option<String>,
@@ -183,7 +183,7 @@ pub struct MessageSendErrors {
 }
 
 /// Description of enabled cluster
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 pub struct ClusterInfo {
     /// ID of this peer
     pub peer_id: PeerId,
@@ -199,7 +199,7 @@ pub struct ClusterInfo {
 }
 
 /// Information about current cluster status and structure
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 #[serde(tag = "status")]
 #[serde(rename_all = "snake_case")]
 pub enum ClusterStatus {
@@ -208,7 +208,7 @@ pub enum ClusterStatus {
 }
 
 /// Information about current consensus thread status
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 #[serde(tag = "consensus_thread_status")]
 #[serde(rename_all = "snake_case")]
 pub enum ConsensusThreadStatus {

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -4,7 +4,7 @@ use common::types::TelemetryDetail;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use storage::dispatcher::Dispatcher;
 use uuid::Uuid;
 
@@ -26,7 +26,7 @@ pub struct TelemetryCollector {
 }
 
 // Whole telemetry data
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct TelemetryData {
     id: String,
     pub(crate) app: AppBuildTelemetry,

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, SubsecRound, Utc};
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::settings::Settings;
 
@@ -20,7 +20,7 @@ impl AppBuildTelemetryCollector {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct AppFeaturesTelemetry {
     pub debug: bool,
     pub web_feature: bool,
@@ -28,7 +28,7 @@ pub struct AppFeaturesTelemetry {
     pub recovery_mode: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct RunningEnvironmentTelemetry {
     distribution: Option<String>,
     distribution_version: Option<String>,
@@ -39,15 +39,13 @@ pub struct RunningEnvironmentTelemetry {
     cpu_flags: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct AppBuildTelemetry {
     pub name: String,
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub features: Option<AppFeaturesTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub system: Option<RunningEnvironmentTelemetry>,
     pub startup: DateTime<Utc>,
 }

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -2,25 +2,25 @@ use collection::shards::shard::PeerId;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use storage::dispatcher::Dispatcher;
 use storage::types::{ClusterStatus, ConsensusThreadStatus, StateRole};
 
 use crate::settings::Settings;
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct P2pConfigTelemetry {
     connection_pool_size: usize,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ConsensusConfigTelemetry {
     max_message_queue_size: usize,
     tick_period_ms: u64,
     bootstrap_timeout_sec: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ClusterConfigTelemetry {
     grpc_timeout_ms: u64,
     p2p: P2pConfigTelemetry,
@@ -43,7 +43,7 @@ impl From<&Settings> for ClusterConfigTelemetry {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ClusterStatusTelemetry {
     pub number_of_peers: usize,
     pub term: u64,
@@ -55,7 +55,7 @@ pub struct ClusterStatusTelemetry {
     pub consensus_thread_status: ConsensusThreadStatus,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct ClusterTelemetry {
     pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -4,24 +4,24 @@ use collection::telemetry::CollectionTelemetry;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use storage::content_manager::toc::TableOfContent;
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct CollectionsAggregatedTelemetry {
     pub vectors: usize,
     pub optimizers_status: OptimizersStatus,
     pub params: CollectionParams,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 #[serde(untagged)]
 pub enum CollectionTelemetryEnum {
     Full(CollectionTelemetry),
     Aggregated(CollectionsAggregatedTelemetry),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct CollectionsTelemetry {
     pub number_of_collections: usize,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/common/telemetry_ops/requests_telemetry.rs
+++ b/src/common/telemetry_ops/requests_telemetry.rs
@@ -8,16 +8,16 @@ use segment::common::anonymize::Anonymize;
 use segment::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 pub type HttpStatusCode = u16;
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Default, Debug, JsonSchema)]
 pub struct WebApiTelemetry {
     pub responses: HashMap<String, HashMap<HttpStatusCode, OperationDurationStatistics>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Default, Debug, JsonSchema)]
 pub struct GrpcTelemetry {
     pub responses: HashMap<String, OperationDurationStatistics>,
 }
@@ -144,7 +144,7 @@ impl WebApiTelemetry {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 pub struct RequestsTelemetry {
     pub rest: WebApiTelemetry,
     pub grpc: GrpcTelemetry,

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -17,7 +17,7 @@ use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::gen::SchemaSettings;
 use schemars::JsonSchema;
 use segment::types::ScoredPoint;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CreateCollection, UpdateCollection,
 };
@@ -31,7 +31,7 @@ mod actix;
 mod common;
 mod settings;
 
-#[derive(Deserialize, Serialize, JsonSchema)]
+#[derive(Serialize, JsonSchema)]
 struct AllDefinitions {
     a1: CollectionsResponse,
     a2: CollectionInfo,


### PR DESCRIPTION
A lot of structs has a `Deserialize` derive despite we never deserialize them. 

It is inconvenient for the following reasons:
- When adding new fields to structures, we need to provide validation or reason about "what if an user pass an unexpected data?". If a struct is not `Deserialize`, a developer could search and review all the places in the code base where this specific value originates. If it's `Deserialize`, this means that data could be arbitrary. E.g., my histogram bucket merging code works fine for data being generated by my code, but it's not true for arbitrary data.
- Double the work if we decide to add a custom `impl Serialize` for some field since then we have to implement a custom `Deserialize` too.

This PR drops unused `Deserialize` impls. Precisely, the following things removed:
- `#[derive(Deserialize)]`, obviously.
- `#[serde(default)]` for non-deserializable structs.
- `#[derive(Validate)]` and `#[validate]` in one place.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
