### PR TITLE
fix: Missing commit ID from dockerhub image builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t $IMAGE_NAME --build-arg GIT_COMMIT_ID=$SOURCE_COMMIT .
+


### PR DESCRIPTION
`docker.io/qdrant/qdrant:{dev,latest}` images are built automatically by docker hub but they don't have commit ID. This PR fixes that.  

- `hooks/build` is a special file that Dockerhub looks for while building the image 
- `SOURCE_COMMIT` and `$IMAGE_NAME` are special env vars inside Dockerhub build env. 

[Reference](https://stackoverflow.com/questions/45277186/is-it-possible-to-add-environment-variables-in-automated-builds-in-docker-hub)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
