### PR TITLE
Chore: use `impl` instead of `dyn` in vector storage

### DIFF
--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -74,7 +74,7 @@ impl<TMetric: Metric> VectorStorage for TestRawScorerProducer<TMetric> {
     fn update_from(
         &mut self,
         _other: &VectorStorageEnum,
-        _other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        _other_ids: &mut impl Iterator<Item = PointOffsetType>,
         _stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         todo!()

--- a/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/appendable_mmap_vector_storage.rs
@@ -123,7 +123,7 @@ impl VectorStorage for AppendableMmapVectorStorage {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -121,7 +121,7 @@ impl VectorStorage for MemmapVectorStorage {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();

--- a/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
@@ -170,7 +170,7 @@ impl VectorStorage for SimpleDenseVectorStorage {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -197,7 +197,7 @@ impl VectorStorage for SimpleSparseVectorStorage {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.total_vector_count as PointOffsetType;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -57,7 +57,7 @@ pub trait VectorStorage {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 
@@ -178,7 +178,7 @@ impl VectorStorage for VectorStorageEnum {
     fn update_from(
         &mut self,
         other: &VectorStorageEnum,
-        other_ids: &mut dyn Iterator<Item = PointOffsetType>,
+        other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         match self {


### PR DESCRIPTION
Since Rust 1.75, now we can use [return-position `impl Trait` in traits](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html#async-fn-and-return-position-impl-trait-in-traits), so we can now turn these return signatures into `impl Iterator<...>`s

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
