### PR TITLE
Use WAL delta transfer for recovery if all nodes are 1.8+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "pprof",
  "proptest",
  "rand 0.8.5",
+ "reqwest",
  "ringbuffer",
  "rmp-serde",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tonic-reflection = { workspace = true }
 tower = "0.4.13"
 tower-layer = "0.3.2"
 tar = "0.4.40"
-reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls", "blocking"] }
+reqwest = { workspace = true }
 rustls = "0.21.10"
 rustls-pemfile = "2.1.0"
 prometheus = { version = "0.13.3", default-features = false }
@@ -115,11 +115,14 @@ rstack-self = { version = "0.3.0", optional = true }
 tikv-jemallocator = "0.5"
 
 [workspace.dependencies]
+fnv = "1.0"
 futures = "0.3.30"
 futures-util = "0.3.30"
+indexmap = { version = "2", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
+reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls", "blocking"] }
 schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
@@ -130,8 +133,6 @@ tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
-fnv = "1.0"
-indexmap = { version = "2", features = ["serde"] }
 
 [[bin]]
 name = "schema_generator"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -49,6 +49,7 @@ uuid = { workspace = true }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 actix-web-validator = "5.0.1"
+reqwest = { workspace = true }
 
 common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -703,8 +703,8 @@ async fn check_all_peers_v1_8(
     let peer_urls = get_peer_rest_urls()?;
     let required_version = Version::parse("1.8.0").unwrap();
 
-    // Do not bother checking more than 9 (8 others + self) nodes
-    if peer_urls.len() > 8 {
+    // Do not bother checking more than 15 (14 others + self) nodes
+    if peer_urls.len() > 15 {
         return Ok(false);
     }
 

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -166,15 +166,18 @@ impl ChannelService {
             })?;
 
         // Construct REST URL from URI
-        let mut url = Url::parse(&local_peer_uri.to_string()).expect("Malformed URL");
-        url.set_port(Some(self.current_rest_port))
-            .map_err(|()| {
-                CollectionError::service_error(format!(
-                    "Cannot determine REST address, cannot specify port on address {url} for peer ID {this_peer_id}",
-                ))
-            })?;
-        Ok(url)
+        peer_uri_to_rest_url(&local_peer_uri, self.current_rest_port)
     }
+}
+
+pub fn peer_uri_to_rest_url(uri: &Uri, current_rest_port: u16) -> CollectionResult<Url> {
+    let mut url = Url::parse(&uri.to_string()).expect("Malformed URL");
+    url.set_port(Some(current_rest_port)).map_err(|()| {
+        CollectionError::service_error(format!(
+            "Cannot determine REST address, cannot specify port on address {url} for peer",
+        ))
+    })?;
+    Ok(url)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

A temporary hack to enable WAL delta transfer by default for shard recovery, only if all nodes are 1.8.

It probes all other peers to see if our whole cluster is 1.8. It probes up to 14 other nodes, otherwise it just assumes false. In later versions we'd simply rely on version information in consensus.

This would only be in version 1.8. In 1.9 it would be obsolete, in which case we'll remove it again.

We probably will not end up using this. I decided to push it anyway because I had already implemented it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?