### PR TITLE
Update Tokio 1.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,9 +5771,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono"
 serde = { version = "~1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
-tokio = { version = "~1.35", features = ["full"] }
+tokio = { version = "~1.36", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"


### PR DESCRIPTION
This [version](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.36.0) has been released 25 days ago but was not picked up by Dependabot.

Looking at the past weeks, the weekly update quota was not reached so I do not understand why it was not proposed automatically.

Maybe the recent workspace setup has some mysterious side effects :man_shrugging: 