### PR TITLE
Add peer metadata to consensus, tracking Qdrant versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "lazy_static",
  "num_cpus",
  "ordered-float 4.2.0",
+ "semver",
  "serde",
  "thiserror",
  "thread-priority",
@@ -4311,6 +4312,7 @@ dependencies = [
  "schemars",
  "sealed_test",
  "segment",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -5109,6 +5111,9 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -5449,6 +5454,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "segment",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,7 +4312,6 @@ dependencies = [
  "schemars",
  "sealed_test",
  "segment",
- "semver",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,6 +3282,7 @@ checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,11 +117,11 @@ tikv-jemallocator = "0.5"
 [workspace.dependencies]
 futures = "0.3.30"
 futures-util = "0.3.30"
-parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
+parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
 schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
-serde = { version = "~1.0", features = ["derive"] }
+serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
 tokio = { version = "~1.36", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ serde_cbor = { workspace = true }
 uuid = { workspace = true }
 sys-info = "0.9.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
-semver = { workspace = true }
 
 config = "~0.14.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde_cbor = { workspace = true }
 uuid = { workspace = true }
 sys-info = "0.9.1"
 wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
+semver = { workspace = true }
 
 config = "~0.14.0"
 
@@ -115,12 +116,15 @@ rstack-self = { version = "0.3.0", optional = true }
 tikv-jemallocator = "0.5"
 
 [workspace.dependencies]
+fnv = "1.0"
 futures = "0.3.30"
 futures-util = "0.3.30"
+indexmap = { version = "2", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["deadlock_detection", "serde"] }
 prost = "0.11.9"
 prost-wkt-types = "0.4.2"
 schemars = { version = "0.8.16", features = ["uuid1", "preserve_order", "chrono", "url", "indexmap2"] }
+semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
@@ -130,8 +134,6 @@ tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
-fnv = "1.0"
-indexmap = { version = "2", features = ["serde"] }
 
 [[bin]]
 name = "schema_generator"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true, optional = true }
 [build-dependencies]
 tonic-build = { version = "0.10.2", features = ["prost"] }
 prost-build = { version = "0.11.8", features = ["cleanup-markdown"] }
+common = { path = "../common/common" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -2,9 +2,17 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::{env, str};
 
+use common::defaults;
 use tonic_build::Builder;
 
 fn main() -> std::io::Result<()> {
+    // Ensure Qdrant version is configured correctly
+    assert_eq!(
+        defaults::QDRANT_VERSION.to_string(),
+        env!("CARGO_PKG_VERSION"),
+        "crate version does not match with defaults.rs",
+    );
+
     let build_out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Build gRPC bits from proto file

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 tokio = { workspace = true }
 validator = { version = "0.16", features = ["derive"] }
 lazy_static = "1.4.0"
+semver = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 thiserror = "1.0"

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -1,11 +1,12 @@
 use std::time::Duration;
 
 use lazy_static::lazy_static;
+use semver::Version;
 
 use crate::cpu;
 
 /// Current Qdrant version
-pub const QDRANT_VERSION: &str = "0.11.1";
+pub const QDRANT_VERSION: Version = Version::new(0, 11, 1);
 
 /// Default timeout for consensus meta operations.
 pub const CONSENSUS_META_OP_WAIT: Duration = Duration::from_secs(10);

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -4,6 +4,9 @@ use lazy_static::lazy_static;
 
 use crate::cpu;
 
+/// Current Qdrant version
+pub const QDRANT_VERSION: &str = "1.7.4";
+
 /// Default timeout for consensus meta operations.
 pub const CONSENSUS_META_OP_WAIT: Duration = Duration::from_secs(10);
 

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use crate::cpu;
 
 /// Current Qdrant version
-pub const QDRANT_VERSION: &str = "1.7.4";
+pub const QDRANT_VERSION: &str = "0.11.1";
 
 /// Default timeout for consensus meta operations.
 pub const CONSENSUS_META_OP_WAIT: Duration = Duration::from_secs(10);

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -32,6 +32,7 @@ parking_lot = { workspace = true }
 tar = "0.4.40"
 chrono = { version = "~0.4", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
+semver = { workspace = true }
 
 # Consensus related
 atomicwrites = { version = "0.4.3" }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -39,7 +39,7 @@ pub struct Persistent {
     /// Last known cluster topology
     #[serde(with = "serialize_peer_addresses")]
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
-    #[serde(with = "serialize_peer_metadata")]
+    #[serde(default, with = "serialize_peer_metadata")]
     pub peer_metadata_by_id: Arc<RwLock<PeerMetadataById>>,
     pub this_peer_id: PeerId,
     #[serde(skip)]

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -39,7 +39,7 @@ pub struct Persistent {
     /// Last known cluster topology
     #[serde(with = "serialize_peer_addresses")]
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
-    #[serde(default, with = "serialize_peer_metadata")]
+    #[serde(default)]
     pub peer_metadata_by_id: Arc<RwLock<PeerMetadataById>>,
     pub this_peer_id: PeerId,
     #[serde(skip)]
@@ -307,34 +307,6 @@ mod serialize_peer_addresses {
     {
         let addresses: HashMap<u64, Uri> = serialize_peer_addresses::deserialize(deserializer)?;
         Ok(Arc::new(RwLock::new(addresses)))
-    }
-}
-
-mod serialize_peer_metadata {
-    use std::collections::HashMap;
-    use std::sync::Arc;
-
-    use parking_lot::RwLock;
-    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-
-    use crate::types::{PeerMetadata, PeerMetadataById};
-
-    pub fn serialize<S>(
-        metadata: &Arc<RwLock<PeerMetadataById>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        metadata.read().serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<RwLock<PeerMetadataById>>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let metadata: HashMap<u64, PeerMetadata> = PeerMetadataById::deserialize(deserializer)?;
-        Ok(Arc::new(RwLock::new(metadata)))
     }
 }
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -320,13 +320,13 @@ mod serialize_peer_metadata {
     use crate::types::{PeerMetadata, PeerMetadataById};
 
     pub fn serialize<S>(
-        versions: &Arc<RwLock<PeerMetadataById>>,
+        metadata: &Arc<RwLock<PeerMetadataById>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        versions.read().serialize(serializer)
+        metadata.read().serialize(serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<RwLock<PeerMetadataById>>, D::Error>

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -189,7 +189,7 @@ impl Persistent {
         self.peer_metadata_by_id
             .read()
             .get(&self.this_peer_id())
-            .map_or(true, |metadata| metadata.is_outdated())
+            .map_or(true, |metadata| metadata.is_different_version())
     }
 
     pub fn this_peer_id(&self) -> PeerId {

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -14,7 +14,7 @@ use raft::RaftState;
 use serde::{Deserialize, Serialize};
 
 use crate::content_manager::consensus::entry_queue::{EntryApplyProgressQueue, EntryId};
-use crate::types::PeerAddressById;
+use crate::types::{PeerAddressById, PeerMetadata, PeerMetadataById};
 use crate::StorageError;
 
 // Deprecated, use `STATE_FILE_NAME` instead
@@ -39,6 +39,8 @@ pub struct Persistent {
     /// Last known cluster topology
     #[serde(with = "serialize_peer_addresses")]
     pub peer_address_by_id: Arc<RwLock<PeerAddressById>>,
+    #[serde(with = "serialize_peer_metadata")]
+    pub peer_metadata_by_id: Arc<RwLock<PeerMetadataById>>,
     pub this_peer_id: PeerId,
     #[serde(skip)]
     pub path: PathBuf,
@@ -60,8 +62,10 @@ impl Persistent {
         &mut self,
         meta: &SnapshotMetadata,
         address_by_id: PeerAddressById,
+        metadata_by_id: PeerMetadataById,
     ) -> Result<(), StorageError> {
         *self.peer_address_by_id.write() = address_by_id;
+        *self.peer_metadata_by_id.write() = metadata_by_id;
         self.state.conf_state = meta.get_conf_state().clone();
         self.state.hard_state.term = cmp::max(self.state.hard_state.term, meta.term);
         self.state.hard_state.commit = meta.index;
@@ -150,12 +154,42 @@ impl Persistent {
         self.save()
     }
 
+    pub fn update_peer_metadata(
+        &mut self,
+        peer_id: PeerId,
+        metadata: PeerMetadata,
+    ) -> Result<(), StorageError> {
+        if let Some(prev_metadata) = self
+            .peer_metadata_by_id
+            .write()
+            .insert(peer_id, metadata.clone())
+        {
+            log::warn!(
+                "Replaced metadata of peer {peer_id} from {prev_metadata:?} to {metadata:?}"
+            );
+        } else {
+            log::debug!("Added metadata for peer with id {peer_id}: {metadata:?}")
+        }
+        self.save()
+    }
+
     pub fn last_applied_entry(&self) -> Option<u64> {
         self.apply_progress_queue.get_last_applied()
     }
 
     pub fn peer_address_by_id(&self) -> PeerAddressById {
         self.peer_address_by_id.read().clone()
+    }
+
+    pub fn peer_metadata_by_id(&self) -> PeerMetadataById {
+        self.peer_metadata_by_id.read().clone()
+    }
+
+    pub fn is_our_metadata_outdated(&self) -> bool {
+        self.peer_metadata_by_id
+            .read()
+            .get(&self.this_peer_id())
+            .map_or(true, |metadata| metadata.is_outdated())
     }
 
     pub fn this_peer_id(&self) -> PeerId {
@@ -188,6 +222,7 @@ impl Persistent {
             },
             apply_progress_queue: Default::default(),
             peer_address_by_id: Default::default(),
+            peer_metadata_by_id: Default::default(),
             this_peer_id,
             path,
             latest_snapshot_meta: Default::default(),
@@ -272,6 +307,34 @@ mod serialize_peer_addresses {
     {
         let addresses: HashMap<u64, Uri> = serialize_peer_addresses::deserialize(deserializer)?;
         Ok(Arc::new(RwLock::new(addresses)))
+    }
+}
+
+mod serialize_peer_metadata {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+    use crate::types::{PeerMetadata, PeerMetadataById};
+
+    pub fn serialize<S>(
+        versions: &Arc<RwLock<PeerMetadataById>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        versions.read().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<RwLock<PeerMetadataById>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let metadata: HashMap<u64, PeerMetadata> = PeerMetadataById::deserialize(deserializer)?;
+        Ok(Arc::new(RwLock::new(metadata)))
     }
 }
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -164,7 +164,7 @@ impl Persistent {
             .write()
             .insert(peer_id, metadata.clone())
         {
-            log::warn!(
+            log::info!(
                 "Replaced metadata of peer {peer_id} from {prev_metadata:?} to {metadata:?}"
             );
         } else {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -717,21 +717,22 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     }
 
     pub fn sync_local_state(&self) -> Result<(), StorageError> {
-        // Update our own metadata if outdated
-        if self.persistent.read().is_our_metadata_outdated() {
-            log::debug!("Proposing consensus peer metadata update for this peer");
-            let result = self
-                .propose_sender
-                .send(ConsensusOperations::UpdatePeerMetadata {
-                    peer_id: self.this_peer_id(),
-                    metadata: PeerMetadata::current(),
-                });
-            if let Err(err) = result {
-                log::error!(
-                    "Failed to propose consensus peer metadata update for this peer: {err}"
-                );
-            }
-        }
+        // TODO(1.9): enable in Qdrant 1.9
+        // // Update our own metadata if outdated
+        // if self.persistent.read().is_our_metadata_outdated() {
+        //     log::debug!("Proposing consensus peer metadata update for this peer");
+        //     let result = self
+        //         .propose_sender
+        //         .send(ConsensusOperations::UpdatePeerMetadata {
+        //             peer_id: self.this_peer_id(),
+        //             metadata: PeerMetadata::current(),
+        //         });
+        //     if let Err(err) = result {
+        //         log::error!(
+        //             "Failed to propose consensus peer metadata update for this peer: {err}"
+        //         );
+        //     }
+        // }
 
         self.toc.sync_local_state()
     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -33,7 +33,7 @@ use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::consensus::persistent::Persistent;
 use crate::types::{
     ClusterInfo, ClusterStatus, ConsensusThreadStatus, MessageSendErrors, PeerAddressById,
-    PeerInfo, PeerMetadata, PeerMetadataById, RaftInfo,
+    PeerInfo, PeerMetadataById, RaftInfo,
 };
 
 pub mod prelude {

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -29,6 +29,7 @@ pub mod consensus_ops {
         CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations, UpdateCollection,
         UpdateCollectionOperation,
     };
+    use crate::types::PeerMetadata;
 
     /// Operation that should pass consensus
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
@@ -39,6 +40,10 @@ pub mod consensus_ops {
             uri: String,
         },
         RemovePeer(PeerId),
+        UpdatePeerMetadata {
+            peer_id: PeerId,
+            metadata: PeerMetadata,
+        },
         RequestSnapshot,
         ReportSnapshot {
             peer_id: PeerId,

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -114,7 +114,10 @@ impl TableOfContent {
                 .path();
 
             if !CollectionConfig::check(&collection_path) {
-                log::warn!("Collection config is not found in the collection directory: {collection_path:?}, skipping");
+                log::warn!(
+                    "Collection config is not found in the collection directory: {}, skipping",
+                    collection_path.display(),
+                );
                 continue;
             }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -114,10 +114,7 @@ impl TableOfContent {
                 .path();
 
             if !CollectionConfig::check(&collection_path) {
-                log::warn!(
-                    "Collection config is not found in the collection directory: {:?}, skipping",
-                    collection_path
-                );
+                log::warn!("Collection config is not found in the collection directory: {collection_path:?}, skipping");
                 continue;
             }
 
@@ -132,7 +129,7 @@ impl TableOfContent {
             create_dir_all(&collection_snapshots_path).unwrap_or_else(|e| {
                 panic!("Can't create a directory for snapshot of {collection_name}: {e}")
             });
-            log::info!("Loading collection: {}", collection_name);
+            log::info!("Loading collection: {collection_name}");
             let collection = general_runtime.block_on(Collection::load(
                 collection_name.clone(),
                 this_peer_id,
@@ -175,8 +172,7 @@ impl TableOfContent {
                     // Select number of working threads as a guess.
                     let limit = max(get_num_cpus(), 2);
                     log::debug!(
-                        "Auto adjusting update rate limit to {} parallel update requests",
-                        limit
+                        "Auto adjusting update rate limit to {limit} parallel update requests"
                     );
                     Some(Semaphore::new(limit))
                 } else {

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -11,6 +11,7 @@ use collection::operations::types::NodeType;
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::shard::PeerId;
 use collection::shards::transfer::ShardTransferMethod;
+use common::defaults;
 use memory::madvise;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -276,7 +277,7 @@ pub struct PeerMetadata {
 impl PeerMetadata {
     pub fn current() -> Self {
         Self {
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version: Some(defaults::QDRANT_VERSION.into()),
         }
     }
 
@@ -284,6 +285,6 @@ impl PeerMetadata {
     pub fn is_outdated(&self) -> bool {
         self.version
             .as_ref()
-            .map_or(false, |v| v != env!("CARGO_PKG_VERSION"))
+            .map_or(false, |v| v != defaults::QDRANT_VERSION)
     }
 }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -282,8 +282,8 @@ impl PeerMetadata {
         }
     }
 
-    /// Whether t his metadata is outdated based on the current version.
-    pub fn is_outdated(&self) -> bool {
+    /// Whether this metadata has a different version than our current Qdrant instance.
+    pub fn is_different_version(&self) -> bool {
         self.version != defaults::QDRANT_VERSION
     }
 }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -20,6 +20,7 @@ use tonic::transport::Uri;
 use validator::Validate;
 
 pub type PeerAddressById = HashMap<PeerId, Uri>;
+pub type PeerMetadataById = HashMap<PeerId, PeerMetadata>;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PerformanceConfig {
@@ -262,5 +263,27 @@ impl Anonymize for ClusterStatus {
                 ClusterStatus::Enabled(cluster_info.anonymize())
             }
         }
+    }
+}
+
+/// Metadata describing extra properties for each peer
+#[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct PeerMetadata {
+    /// Peer Qdrant version string
+    version: Option<String>,
+}
+
+impl PeerMetadata {
+    pub fn current() -> Self {
+        Self {
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        }
+    }
+
+    /// Whether t his metadata is outdated based on the current version.
+    pub fn is_outdated(&self) -> bool {
+        self.version
+            .as_ref()
+            .map_or(false, |v| v != env!("CARGO_PKG_VERSION"))
     }
 }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -16,6 +16,7 @@ use memory::madvise;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::types::{HnswConfig, QuantizationConfig};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use tonic::transport::Uri;
 use validator::Validate;
@@ -270,21 +271,19 @@ impl Anonymize for ClusterStatus {
 /// Metadata describing extra properties for each peer
 #[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct PeerMetadata {
-    /// Peer Qdrant version string
-    version: Option<String>,
+    /// Peer Qdrant version
+    version: Version,
 }
 
 impl PeerMetadata {
     pub fn current() -> Self {
         Self {
-            version: Some(defaults::QDRANT_VERSION.into()),
+            version: defaults::QDRANT_VERSION,
         }
     }
 
     /// Whether t his metadata is outdated based on the current version.
     pub fn is_outdated(&self) -> bool {
-        self.version
-            .as_ref()
-            .map_or(false, |v| v != defaults::QDRANT_VERSION)
+        self.version != defaults::QDRANT_VERSION
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -316,7 +316,7 @@ impl Consensus {
             tls_config,
         )
         .await
-        .map_err(|err| anyhow!("Failed to create timeout channel: {}", err))?;
+        .map_err(|err| anyhow!("Failed to create timeout channel: {err}"))?;
         let mut client = RaftClient::new(channel);
         let all_peers = client
             .add_peer_to_known(tonic::Request::new(
@@ -327,7 +327,7 @@ impl Consensus {
                 },
             ))
             .await
-            .map_err(|err| anyhow!("Failed to add peer to known: {}", err))?
+            .map_err(|err| anyhow!("Failed to add peer to known: {err}"))?
             .into_inner();
         Ok(all_peers)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn main() -> anyhow::Result<()> {
     // Here we load all stored collections.
     runtime_handle.block_on(async {
         for collection in toc.all_collections().await {
-            log::debug!("Loaded collection: {}", collection);
+            log::debug!("Loaded collection: {collection}");
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,11 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ::common::cpu::{get_cpu_budget, CpuBudget};
-use ::common::defaults;
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
 use collection::shards::channel_service::ChannelService;
 use consensus::Consensus;
-use semver::Version;
 use slog::Drain;
 use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
@@ -115,12 +113,6 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    debug_assert_eq!(
-        defaults::QDRANT_VERSION,
-        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
-        "crate version does not match with defaults.rs",
-    );
-
     let args = Args::parse();
 
     // Run backtrace collector, expected to used by `rstack` crate

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ::common::cpu::{get_cpu_budget, CpuBudget};
+use ::common::defaults;
 use ::tonic::transport::Uri;
 use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
@@ -113,6 +114,12 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    debug_assert_eq!(
+        defaults::QDRANT_VERSION,
+        env!("CARGO_PKG_VERSION"),
+        "crate version does not match with defaults.rs",
+    );
+
     let args = Args::parse();
 
     // Run backtrace collector, expected to used by `rstack` crate

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use api::grpc::transport_channel_pool::TransportChannelPool;
 use clap::Parser;
 use collection::shards::channel_service::ChannelService;
 use consensus::Consensus;
+use semver::Version;
 use slog::Drain;
 use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
@@ -116,7 +117,7 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     debug_assert_eq!(
         defaults::QDRANT_VERSION,
-        env!("CARGO_PKG_VERSION"),
+        Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         "crate version does not match with defaults.rs",
     );
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add peer metadata to consensus. Peers may propose new metadata once it becomes outdated.

At this time it holds the Qdrant version number. We may add more fields in the future.

Knowing the version number of all nodes is useful for feature gating. It may prevent us a lot of headaches in the future.

### Tasks
- [x] Disable updating metadata automatically until Qdrant 1.9

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?