### PR TITLE
Add consensus operation to restart shard transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,6 +5427,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",
+ "async-recursion",
  "atomicwrites",
  "cancel",
  "chrono",

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -13,7 +13,7 @@ pub fn validate_transfer_exists(
     if !current_transfers.iter().any(|t| &t.key() == transfer_key) {
         return Err(CollectionError::bad_request(format!(
             "There is no transfer for shard {} from {} to {}",
-            transfer_key.shard_id, transfer_key.from, transfer_key.to
+            transfer_key.shard_id, transfer_key.from, transfer_key.to,
         )));
     }
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -53,5 +53,6 @@ uuid = { workspace = true }
 url = "2.5.0"
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 tempfile = "3.10.0"
+async-recursion = "1.0"
 
 tracing = { workspace = true, optional = true }

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -294,6 +294,10 @@ pub struct DeleteCollectionOperation(pub String);
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 pub enum ShardTransferOperations {
     Start(ShardTransfer),
+    /// Restart an existing transfer with a new configuration
+    ///
+    /// If the given transfer is ongoing, it is aborted and restarted with the new configuration.
+    Restart(ShardTransfer),
     Finish(ShardTransfer),
     /// Used in `ShardTransferMethod::Snapshot`
     ///


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add a consensus operation to restart a shard transfer with a different configuration.

This will make falling back to a different shard transfer method a whole lot nicer. We make sure to properly clean up and prepare for the different shard transfer method. Without it, we're manually managing and update shard replica set states to make transfers happen which is very fragile.

The operation ensures that:
- a transfer is currently ongoing
- the transfer configuration has changed (likely a different transfer method)

It is similar to calling abort/start right after each other, but in a single consensus operation.

If we'll merge this in 1.8, we'll be able to make use of it in Qdrant 1.9.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
