### PR TITLE
Fix flaky invalid URI snapshot test

### DIFF
--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -361,3 +361,6 @@ def test_snapshot_invalid_file_uri():
     )
     assert response.status_code == 400
     assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
+
+    # Give file system some time to clean up temporary snapshot files
+    sleep(1)

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -324,9 +324,6 @@ def test_snapshot_operations_non_wait():
             sleep(0.1)
             continue
 
-    # Give file system some time to clean up temporary snapshot files
-    sleep(1)
-
 
 def test_snapshot_invalid_file_uri():
     # Invalid file:// host

--- a/tests/openapi/openapi_integration/test_snapshot.py
+++ b/tests/openapi/openapi_integration/test_snapshot.py
@@ -11,8 +11,8 @@ collection_name = 'test_collection_snapshot'
 @pytest.fixture(autouse=True)
 def setup(on_disk_vectors):
     basic_collection_setup(collection_name=collection_name, on_disk_vectors=on_disk_vectors)
-    drop_snapshots(collection_name)
     yield
+    drop_snapshots(collection_name)
     drop_collection(collection_name=collection_name)
 
 
@@ -205,7 +205,7 @@ def test_full_snapshot_operations():
     assert len(response.json()['result']) == 0
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(30)
 def test_snapshot_operations_non_wait():
     # there no snapshot on collection
     response = request_with_validation(
@@ -269,7 +269,7 @@ def test_snapshot_operations_non_wait():
             sleep(0.1)
             continue
 
-    # no full snapshot
+    # do full snapshot
     response = request_with_validation(
         api='/snapshots',
         method="GET",
@@ -324,6 +324,9 @@ def test_snapshot_operations_non_wait():
             sleep(0.1)
             continue
 
+    # Give file system some time to clean up temporary snapshot files
+    sleep(1)
+
 
 def test_snapshot_invalid_file_uri():
     # Invalid file:// host
@@ -361,6 +364,3 @@ def test_snapshot_invalid_file_uri():
     )
     assert response.status_code == 400
     assert response.json()["status"]["error"] == "Bad request: Snapshot file \"/whatever.snapshot\" does not exist"
-
-    # Give file system some time to clean up temporary snapshot files
-    sleep(1)


### PR DESCRIPTION
Fixes: <https://github.com/qdrant/qdrant/issues/3627>

Tested in <https://github.com/qdrant/qdrant/pull/3707> running it 100s of times: https://github.com/qdrant/qdrant/actions/runs/8078479540/job/22070892084?pr=3707

Our snapshot tests did not clean up snapshot files properly.
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?