### PR TITLE
Use DenseVector alias where possible

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use chrono::{NaiveDateTime, TimeZone as _, Timelike};
 use segment::data_types::integer_index::IntegerIndexType;
 use segment::data_types::text_index::TextIndexType;
-use segment::data_types::vectors::VectorElementType;
+use segment::data_types::vectors::DenseVector;
 use segment::json_path::JsonPath;
 use segment::types::{default_quantization_ignore_value, DateTimePayloadType, FloatPayloadType};
 use tonic::Status;
@@ -1421,7 +1421,7 @@ pub fn from_grpc_dist(dist: i32) -> Result<segment::types::Distance, Status> {
 
 pub fn into_named_vector_struct(
     vector_name: Option<String>,
-    vector: Vec<VectorElementType>,
+    vector: DenseVector,
     indices: Option<SparseIndices>,
 ) -> Result<segment::data_types::vectors::NamedVectorStruct, Status> {
     use segment::data_types::vectors::{NamedSparseVector, NamedVector, NamedVectorStruct};

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -18,8 +18,8 @@ use segment::common::operation_error::OperationError;
 use segment::data_types::groups::GroupId;
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{
-    DenseVector, Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorElementType,
-    VectorRef, VectorStruct, DEFAULT_VECTOR_NAME,
+    DenseVector, Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorRef,
+    VectorStruct, DEFAULT_VECTOR_NAME,
 };
 use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
@@ -427,8 +427,8 @@ impl QueryEnum {
     }
 }
 
-impl From<Vec<VectorElementType>> for QueryEnum {
-    fn from(vector: Vec<VectorElementType>) -> Self {
+impl From<DenseVector> for QueryEnum {
+    fn from(vector: DenseVector) -> Self {
         QueryEnum::Nearest(NamedVectorStruct::Default(vector))
     }
 }

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Standard;
 use rand::Rng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-use segment::data_types::vectors::{Vector, VectorElementType};
+use segment::data_types::vectors::{DenseVector, Vector};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
@@ -19,7 +19,7 @@ use tempfile::Builder;
 const NUM_VECTORS: usize = 100000;
 const DIM: usize = 1024; // Larger dimensionality - greater the SIMD advantage
 
-fn random_vector(size: usize) -> Vec<VectorElementType> {
+fn random_vector(size: usize) -> DenseVector {
     let rng = rand::thread_rng();
 
     rng.sample_iter(Standard).take(size).collect()

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -122,7 +122,7 @@ impl<'a> NamedVectors<'a> {
         Self { map }
     }
 
-    pub fn from<const N: usize>(arr: [(String, Vec<VectorElementType>); N]) -> Self {
+    pub fn from<const N: usize>(arr: [(String, DenseVector); N]) -> Self {
         NamedVectors {
             map: arr
                 .into_iter()
@@ -140,7 +140,7 @@ impl<'a> NamedVectors<'a> {
         }
     }
 
-    pub fn from_map_ref(map: &'a HashMap<String, Vec<VectorElementType>>) -> Self {
+    pub fn from_map_ref(map: &'a HashMap<String, DenseVector>) -> Self {
         Self {
             map: map
                 .iter()

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -196,7 +196,7 @@ impl<'a> TryInto<&'a SparseVector> for &'a Vector {
     }
 }
 
-pub fn default_vector(vec: Vec<VectorElementType>) -> NamedVectors<'static> {
+pub fn default_vector(vec: DenseVector) -> NamedVectors<'static> {
     NamedVectors::from([(DEFAULT_VECTOR_NAME.to_owned(), vec)])
 }
 

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -20,7 +20,7 @@ use crate::vector_storage::{
     DEFAULT_STOPPED,
 };
 
-pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
+pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
     (0..size).map(|_| rnd_gen.gen_range(-1.0..1.0)).collect()
 }
 

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -8,7 +8,7 @@ use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
 
-use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::DenseVector;
 use crate::types::{
     AnyVariants, Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition,
     IsEmptyCondition, Match, MatchAny, Payload, PayloadField, Range as RangeCondition, ValuesCount,
@@ -117,7 +117,7 @@ pub fn random_bool_payload<R: Rng + ?Sized>(
         .collect_vec()
 }
 
-pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> Vec<VectorElementType> {
+pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
     (0..size).map(|_| rnd_gen.gen()).collect()
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -484,7 +484,7 @@ mod tests {
     use rand::SeedableRng;
 
     use super::*;
-    use crate::data_types::vectors::VectorElementType;
+    use crate::data_types::vectors::DenseVector;
     use crate::fixtures::index_fixtures::{
         random_vector, FakeFilterContext, TestRawScorerProducer,
     };
@@ -836,7 +836,7 @@ mod tests {
         let ef_construct = 32;
 
         // See illustration in docs
-        let points: Vec<Vec<VectorElementType>> = vec![
+        let points: Vec<DenseVector> = vec![
             vec![21.79, 7.18],  // Target
             vec![20.58, 5.46],  // 1  B - yes
             vec![21.19, 4.51],  // 2  C

--- a/lib/segment/src/vector_storage/memmap_vector_storage.rs
+++ b/lib/segment/src/vector_storage/memmap_vector_storage.rs
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_casts() {
-        let data: Vec<VectorElementType> = vec![0.42, 0.069, 333.1, 100500.];
+        let data: DenseVector = vec![0.42, 0.069, 333.1, 100500.];
 
         let raw_data = transmute_to_u8_slice(&data);
 

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -9,7 +9,7 @@ use crate::vector_storage::DenseVectorStorage;
 
 pub struct MetricQueryScorer<'a, TMetric: Metric, TVectorStorage: DenseVectorStorage> {
     vector_storage: &'a TVectorStorage,
-    query: Vec<VectorElementType>,
+    query: DenseVector,
     metric: PhantomData<TMetric>,
 }
 

--- a/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_dense_vector_storage.rs
@@ -18,7 +18,7 @@ use crate::common::operation_error::{check_process_stopped, OperationError, Oper
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
-use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
 use crate::types::Distance;
 use crate::vector_storage::bitvec::bitvec_set_deleted;
 
@@ -38,7 +38,7 @@ pub struct SimpleDenseVectorStorage {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct StoredRecord {
     pub deleted: bool,
-    pub vector: Vec<VectorElementType>,
+    pub vector: DenseVector,
 }
 
 pub fn open_simple_vector_storage(

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::{only_default_vector, VectorElementType};
+use segment::data_types::vectors::{only_default_vector, DenseVector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
@@ -160,7 +160,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
     )
     .unwrap();
 
-    let collect_points_data = |vectors: &[Vec<VectorElementType>]| {
+    let collect_points_data = |vectors: &[DenseVector]| {
         NamedVectors::from([
             ("vector1".to_owned(), vectors[0].clone()),
             ("vector2".to_owned(), vectors[1].clone()),


### PR DESCRIPTION
This PR expands the usage of the `DenseVector` alias where possible.

This is a cleanup phase before possibly introducing `MultiDenseVectors` in the future.