### PR TITLE
Don't produce histograms in /telemetry JSON response

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9453,26 +9453,6 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
-          },
-          "duration_micros_histogram": {
-            "description": "The cumulative histogram of the operation durations. Consists of a list of pairs of [upper_boundary, cumulative_count], sorted by the upper boundary. Note that the last bucket (aka `{le=\"+Inf\"}` in Prometheus terms) is not stored in this list, and `count` should be used instead.",
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
           }
         }
       },

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -38,7 +38,6 @@ pub enum DetailsLevel {
     Level0,
     Level1,
     Level2,
-    Level3,
 }
 
 impl Default for TelemetryDetail {
@@ -55,8 +54,7 @@ impl From<usize> for DetailsLevel {
         match value {
             0 => DetailsLevel::Level0,
             1 => DetailsLevel::Level1,
-            2 => DetailsLevel::Level2,
-            _ => DetailsLevel::Level3,
+            _ => DetailsLevel::Level2,
         }
     }
 }

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -45,8 +45,7 @@ pub struct OperationDurationStatistics {
     /// [upper_boundary, cumulative_count], sorted by the upper boundary. Note that the last bucket
     /// (aka `{le="+Inf"}` in Prometheus terms) is not stored in this list, and `count` should be
     /// used instead.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    #[serde(skip)] // openapi-generator-cli crashes on this field
     pub duration_micros_histogram: Vec<(f32, usize)>,
 }
 

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -38,7 +38,7 @@ async fn telemetry(
         .map_or(DetailsLevel::Level0, Into::into);
     let detail = TelemetryDetail {
         level: details_level,
-        histograms: details_level >= DetailsLevel::Level3,
+        histograms: false,
     };
     let telemetry_collector = telemetry_collector.lock().await;
     let telemetry_data = telemetry_collector.prepare_data(detail).await;


### PR DESCRIPTION
# Issue

An OpenAPI generator chokes on schema changes introduced in #3552, in particular, on [heterogeneous arrays in the `duration_micros_histogram` field](https://github.com/qdrant/qdrant/commit/ff9e3a6ab98c72971b3ad2851227a953e1c92972#diff-1cb4c2c4798cfa586db32c8c5968891f1306c75861d5ede89241be8bb7bedc8fR9452-R9467).

The error message is:

```console
$ docker run --user 1000:100 --rm -v /run/user/1000/tmp.nu7jls5JNY/pydantic_openapi_v3/scripts/output:/generator-output -v /run/user/1000/tmp.nu7jls5JNY/pydantic_openapi_v3/openapi-qdrant.yaml:/local/openapi.yaml openapitools/openapi-generator-cli:v5.1.1 generate -g python --global-property debugModels=true -o /generator-output -i /local/openapi.yaml
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 2, Warning count: 0
Errors: 
	-attribute components.schemas.OperationDurationStatistics.items is not of type `object`
	-attribute components.schemas.OperationDurationStatistics.items is missing

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:433)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

# Solution (this PR)

Drop these statistics from the JSON `/telemetry` output, regardless from the details level. Keep it in the Prometheus `/metrics`.