### PR TITLE
Enforce that storage compatibility validates master data on dev

### DIFF
--- a/tests/storage-compat/README.md
+++ b/tests/storage-compat/README.md
@@ -4,6 +4,10 @@ In order to detect quickly breakage of storage compatibility, we make sure any P
 
 To not burden the git repository with tracking the large binary files, it is using [Git Large File Storage](https://git-lfs.github.com/).
 
+As features are added, the storage format may change and then must be refreshed on `dev`.
+
+The compatibility is ensured by checking that the current code understands the storage format from the `master` branch.
+
 ## Regenerate storage data
 
 Follow those steps to recreate the reference storage data and snapshot.

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -11,8 +11,8 @@ QDRANT_HOST='localhost:6333'
 # Build
 cargo build
 
-# Sync git large file
-git lfs pull
+# Pull archives from master branch to test compatibility
+git lfs pull origin master
 
 # Uncompress snapshot storage
 tar -xvjf ./tests/storage-compat/storage.tar.bz2


### PR DESCRIPTION
So far our strategy for testing storage compatibility has been to refresh from time to time a set of archives containing data and snapshots and making sure that the current `dev` branch understand those.

This PR proposes to make the contract clearer by only pulling the archives from the master branch during tests.

This makes sure we have a stable point of reference.