### PR TITLE
Logic tweaks for WAL diff shard transfer

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3641,6 +3641,7 @@ How to use positive and negative vectors to find the results, default is `Averag
 | UnknownUpdateStatus | 0 |  |
 | Acknowledged | 1 | Update is received, but not processed yet |
 | Completed | 2 | Update is applied and ready for search |
+| ClockRejected | 3 | Internal: update is rejected due to an outdated clock |
 
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -530,6 +530,7 @@ enum UpdateStatus {
   UnknownUpdateStatus = 0;
   Acknowledged = 1; // Update is received, but not processed yet
   Completed = 2; // Update is applied and ready for search
+  ClockRejected = 3; // Internal: update is rejected due to an outdated clock
 }
 
 message ScoredPoint {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5409,6 +5409,8 @@ pub enum UpdateStatus {
     Acknowledged = 1,
     /// Update is applied and ready for search
     Completed = 2,
+    /// Internal: update is rejected due to an outdated clock
+    ClockRejected = 3,
 }
 impl UpdateStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -5420,6 +5422,7 @@ impl UpdateStatus {
             UpdateStatus::UnknownUpdateStatus => "UnknownUpdateStatus",
             UpdateStatus::Acknowledged => "Acknowledged",
             UpdateStatus::Completed => "Completed",
+            UpdateStatus::ClockRejected => "ClockRejected",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -5428,6 +5431,7 @@ impl UpdateStatus {
             "UnknownUpdateStatus" => Some(Self::UnknownUpdateStatus),
             "Acknowledged" => Some(Self::Acknowledged),
             "Completed" => Some(Self::Completed),
+            "ClockRejected" => Some(Self::ClockRejected),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -898,6 +898,7 @@ impl From<UpdateStatus> for i32 {
         match status {
             UpdateStatus::Acknowledged => api::grpc::qdrant::UpdateStatus::Acknowledged as i32,
             UpdateStatus::Completed => api::grpc::qdrant::UpdateStatus::Completed as i32,
+            UpdateStatus::ClockRejected => api::grpc::qdrant::UpdateStatus::ClockRejected as i32,
         }
     }
 }
@@ -912,6 +913,7 @@ impl TryFrom<i32> for UpdateStatus {
         let status = match status {
             api::grpc::qdrant::UpdateStatus::Acknowledged => Self::Acknowledged,
             api::grpc::qdrant::UpdateStatus::Completed => Self::Completed,
+            api::grpc::qdrant::UpdateStatus::ClockRejected => Self::ClockRejected,
 
             api::grpc::qdrant::UpdateStatus::UnknownUpdateStatus => {
                 return Err(Status::invalid_argument(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -257,6 +257,9 @@ pub struct RemoteShardInfo {
 pub enum UpdateStatus {
     Acknowledged,
     Completed,
+    /// Internal: update is rejected due to an outdated clock
+    #[schemars(skip)]
+    ClockRejected,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -10,9 +10,6 @@ use crate::operations::types::CollectionError;
 use crate::operations::ClockTag;
 use crate::shards::shard::PeerId;
 
-/// The first valid clock tick.
-const FIRST_CLOCK_TICK: u64 = 1;
-
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(from = "ClockMapHelper", into = "ClockMapHelper")]
 pub struct ClockMap {
@@ -96,16 +93,16 @@ impl ClockMap {
         match self.clocks.entry(key) {
             hash_map::Entry::Occupied(mut entry) => entry.get_mut().advance_to(new_tick),
             hash_map::Entry::Vacant(entry) => {
-                // Initialize new clock and accept the operation if `new_tick >= FIRST_CLOCK_TICK`.
-                // Reject the operation if `new_tick < FIRST_CLOCK_TICK`.
+                // Initialize new clock and accept the operation if `new_tick > 0`.
+                // Reject the operation if `new_tick = 0`.
 
-                let is_valid_clock_tick = new_tick >= FIRST_CLOCK_TICK;
+                let is_non_zero_tick = new_tick > 0;
 
-                if is_valid_clock_tick {
+                if is_non_zero_tick {
                     entry.insert(Clock::new(new_tick));
                 }
 
-                (is_valid_clock_tick, new_tick)
+                (is_non_zero_tick, new_tick)
             }
         }
     }
@@ -239,16 +236,15 @@ impl RecoveryPoint {
 
     /// Extend this recovery point with clocks that are only present in the `other`.
     ///
-    /// Clocks that are not present in this recovery point are initialized to the tick
-    /// `FIRST_CLOCK_TICK`, because we must recover all operations for them.
+    /// Clocks that are not present in this recovery point are initialized to the tick 1,
+    /// because we must recover all operations for them.
     ///
     /// Clocks that are already present in this recovery point are not updated.
     pub fn initialize_clocks_missing_from(&mut self, other: &Self) {
         // Clocks known on our node, that are not in the recovery point, are unknown on the
-        // recovering node. Add them here with tick FIRST_CLOCK_TICK, so that we include all
-        // records for it
+        // recovering node. Add them here with tick 1, so that we include all records for it.
         for &key in other.clocks.keys() {
-            self.clocks.entry(key).or_insert(FIRST_CLOCK_TICK);
+            self.clocks.entry(key).or_insert(1);
         }
     }
 

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -55,17 +55,16 @@ impl ClockMap {
         // correct its clock.
         //
         // There are two special cases:
-        // - we *always* accept operations with `clock_tick = 0`, and also *always* update their `clock_tick`
-        // - and we *always* accept operations with `force = true`, but *never* update their `clock_tick`
+        // - we always *accept* operations with `force = true`
+        //   - (*currently*, this is *stronger* than `clock_tick = 0` condition!)
+        // - we always *reject* operations with `clock_tick = 0`
+        //   - (this is handled by `advance_clock_impl`, so we don't need to check for `clock_tick = 0` explicitly)
+        //
+        // TODO: Should we *reject* operations with `force = true`, *if* `clock_tick = 0`!?
 
-        if clock_tag.force {
-            return true;
-        }
+        let operation_accepted = clock_updated || clock_tag.force;
 
-        let operation_accepted = clock_updated || clock_tag.clock_tick == 0;
-        let update_tag = !operation_accepted || clock_tag.clock_tick == 0;
-
-        if update_tag {
+        if !operation_accepted {
             clock_tag.clock_tick = current_tick;
         }
 
@@ -94,8 +93,16 @@ impl ClockMap {
         match self.clocks.entry(key) {
             hash_map::Entry::Occupied(mut entry) => entry.get_mut().advance_to(new_tick),
             hash_map::Entry::Vacant(entry) => {
-                entry.insert(Clock::new(new_tick));
-                (true, new_tick)
+                // Initialize new clock and accept the operation if `new_tick > 0`.
+                // Reject the operation if `new_tick == 0`.
+
+                let is_non_zero_tick = new_tick > 0;
+
+                if is_non_zero_tick {
+                    entry.insert(Clock::new(new_tick));
+                }
+
+                (is_non_zero_tick, new_tick)
             }
         }
     }
@@ -398,7 +405,6 @@ impl From<Error> for CollectionError {
 #[cfg(test)]
 mod test {
     use proptest::prelude::*;
-    use rstest::rstest;
 
     use super::*;
 
@@ -426,44 +432,23 @@ mod test {
         assert_eq!(input, output);
     }
 
-    #[rstest]
-    #[case::with_empty_clock_map(Helper::empty())]
-    #[case::with_clock_map_at_tick_0(Helper::at_tick_0())]
-    fn clock_map_accept_tick_0(#[case] mut helper: Helper) {
-        // Accept tick `0`
-        helper.advance(tag(0)).assert(true, 0);
-    }
+    #[test]
+    fn clock_map_advance_to_next_tick() {
+        let mut helper = Helper::empty();
 
-    #[rstest]
-    #[case::with_empty_clock_map(Helper::empty())]
-    #[case::with_clock_map_at_tick_0(Helper::at_tick_0())]
-    fn clock_map_advance_to_next_tick(#[case] mut helper: Helper) {
         // Advance to the next tick
         for tick in 1..10 {
             helper.advance(tag(tick)).assert(true, tick);
         }
     }
 
-    #[rstest]
-    #[case::with_empty_clock_map(Helper::empty())]
-    #[case::with_clock_map_at_tick_0(Helper::at_tick_0())]
-    fn clock_map_advance_to_newer_tick(#[case] mut helper: Helper) {
+    #[test]
+    fn clock_map_advance_to_newer_tick() {
+        let mut helper = Helper::empty();
+
         // Advance to a newer tick
         for tick in [10, 20, 30, 40, 50] {
             helper.advance(tag(tick)).assert(true, tick);
-        }
-    }
-
-    #[test]
-    fn clock_map_accept_tick_0_with_non_empty_clock_map() {
-        let mut helper = Helper::default();
-
-        for tick in [10, 20, 30, 40, 50] {
-            // Advance to a non-zero tick (already tested in `clock_map_advance_to_newer_tick`)
-            helper.advance(tag(tick));
-
-            // Accept tick `0`
-            helper.advance(tag(0)).assert(true, tick);
         }
     }
 
@@ -475,9 +460,7 @@ mod test {
         helper.advance(tag(10));
 
         // Reject older tick
-        //
-        // Start from tick `1`, cause tick `0` is a special case that is always accepted
-        for older_tick in 1..10 {
+        for older_tick in 0..10 {
             helper.advance(tag(older_tick)).assert(false, 10);
         }
 
@@ -487,10 +470,28 @@ mod test {
         }
     }
 
-    #[rstest]
-    #[case::with_empty_clock_map(Helper::empty())]
-    #[case::with_clock_map_at_tick_0(Helper::at_tick_0())]
-    fn clock_map_advance_to_newer_tick_with_force_true(#[case] mut helper: Helper) {
+    #[test]
+    fn clock_map_reject_tick_0() {
+        let mut helper = Helper::empty();
+
+        // Reject tick 0, if clock map is empty
+        for _ in 0..5 {
+            helper.advance(tag(0)).assert(false, 0);
+        }
+
+        // Advance to a newer tick (already tested in `clock_map_advance_to_newer_tick`)
+        helper.advance(tag(10));
+
+        // Reject tick 0, if clock map is non-empty
+        for _ in 0..5 {
+            helper.advance(tag(0)).assert(false, 10);
+        }
+    }
+
+    #[test]
+    fn clock_map_advance_to_newer_tick_with_force_true() {
+        let mut helper = Helper::empty();
+
         // Advance to a newer tick with `force = true`
         for tick in [10, 20, 30, 40, 50] {
             helper.advance(tag(tick).force(true)).assert(true, tick);
@@ -506,8 +507,6 @@ mod test {
         helper.advance(tag(10));
 
         // Accept older tick with `force = true`
-        //
-        // Start from `0`, cause `force = true` is "stronger" than tick `0` special case
         for older_tick in 0..10 {
             helper
                 .advance(tag(older_tick).force(true))
@@ -529,16 +528,15 @@ mod test {
 
             for clock_tag in execution {
                 let current_tick = helper.clock_map.current_tick(clock_tag.peer_id, clock_tag.clock_id);
+                assert_ne!(current_tick, Some(0));
 
-                let expected_status = current_tick.is_none()
-                    || current_tick < Some(clock_tag.clock_tick)
-                    || clock_tag.clock_tick == 0
-                    || clock_tag.force;
+                let expected_status =
+                    clock_tag.clock_tick > current_tick.unwrap_or(0) || clock_tag.force;
 
-                let expected_tick = if clock_tag.force {
+                let expected_tick = if expected_status {
                     clock_tag.clock_tick
                 } else {
-                    clock_tag.clock_tick.max(current_tick.unwrap_or(0))
+                    current_tick.unwrap_or(0)
                 };
 
                 helper.advance(clock_tag).assert(expected_status, expected_tick);
@@ -567,7 +565,7 @@ mod test {
                     let current_tick = helper.clock_map.current_tick(key.peer_id, key.clock_id);
 
                     if clock_tag.peer_id == key.peer_id && clock_tag.clock_id == key.clock_id {
-                        assert!(current_tick.is_some());
+                        assert!(current_tick.is_some() || clock_tag.clock_tick == 0);
                     } else {
                         assert_eq!(current_tick, Some(clock.current_tick));
                     }
@@ -595,12 +593,6 @@ mod test {
     impl Helper {
         pub fn empty() -> Self {
             Self::default()
-        }
-
-        pub fn at_tick_0() -> Self {
-            let mut helper = Helper::default();
-            helper.advance(tag(0));
-            helper
         }
 
         pub fn advance(&mut self, mut clock_tag: ClockTag) -> Status {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -254,9 +254,10 @@ impl ShardOperation for LocalShard {
                 Ok(id_and_lock) => id_and_lock,
 
                 Err(crate::wal::WalError::Rejected) => {
+                    // Propagate clock rejection to operation sender
                     return Ok(UpdateResult {
                         operation_id: None,
-                        status: UpdateStatus::Acknowledged,
+                        status: UpdateStatus::ClockRejected,
                         clock_tag: operation.clock_tag,
                     });
                 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -253,7 +253,7 @@ impl ShardOperation for LocalShard {
             let (operation_id, _wal_lock) = match self.wal.lock_and_write(&mut operation).await {
                 Ok(id_and_lock) => id_and_lock,
 
-                Err(crate::wal::WalError::Rejected) => {
+                Err(crate::wal::WalError::ClockRejected) => {
                     // Propagate clock rejection to operation sender
                     return Ok(UpdateResult {
                         operation_id: None,

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -247,13 +247,22 @@ impl ShardOperation for LocalShard {
             let update_sender = self.update_sender.load();
             let channel_permit = update_sender.reserve().await?;
 
-            // TODO:
-            //
-            // - Apply operation, only if it's accepted and written into the WAL...
-            // - ...or *propagate rejection to the sender node*, if it's rejected!
-
             // It is *critical* to hold `_wal_lock` while sending operation to the update handler!
-            let (operation_id, _wal_lock) = self.wal.lock_and_write(&mut operation).await?;
+            //
+            // TODO: Refactor `lock_and_write`, so this is less terrible? :/
+            let (operation_id, _wal_lock) = match self.wal.lock_and_write(&mut operation).await {
+                Ok(id_and_lock) => id_and_lock,
+
+                Err(crate::wal::WalError::Rejected) => {
+                    return Ok(UpdateResult {
+                        operation_id: None,
+                        status: UpdateStatus::Acknowledged,
+                        clock_tag: operation.clock_tag,
+                    });
+                }
+
+                Err(err) => return Err(err.into()),
+            };
 
             channel_permit.send(UpdateSignal::Operation(OperationData {
                 op_num: operation_id,

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -293,12 +293,18 @@ impl ShardReplicaSet {
                 let echo_tag = result.clock_tag?;
 
                 if echo_tag.peer_id != clock_tag.peer_id {
-                    debug_assert!(false, "Echoed clock tag peer_id does not match the original");
+                    debug_assert!(
+                        false,
+                        "Echoed clock tag peer_id does not match the original"
+                    );
                     return None;
                 }
 
                 if echo_tag.clock_id != clock_tag.clock_id {
-                    debug_assert!(false, "Echoed clock tag clock_id does not match the original");
+                    debug_assert!(
+                        false,
+                        "Echoed clock tag clock_id does not match the original"
+                    );
                     return None;
                 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 
 use super::{clock_set, ReplicaSetState, ReplicaState, ShardReplicaSet};
 use crate::operations::point_ops::WriteOrdering;
-use crate::operations::types::{CollectionError, CollectionResult, UpdateResult};
+use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
 use crate::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
 use crate::shards::shard::PeerId;
 use crate::shards::shard_trait::ShardOperation as _;
@@ -355,7 +355,7 @@ impl ShardReplicaSet {
 
         let is_any_operation_rejected = successes
             .iter()
-            .any(|(_, res)| res.operation_id.is_none() && res.clock_tag.is_some());
+            .any(|(_, res)| matches!(res.status, UpdateStatus::ClockRejected));
 
         if is_any_operation_rejected {
             return Ok(None);

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -293,12 +293,12 @@ impl ShardReplicaSet {
                 let echo_tag = result.clock_tag?;
 
                 if echo_tag.peer_id != clock_tag.peer_id {
-                    // TODO: `log::warn`!?
+                    debug_assert!(false, "Echoed clock tag peer_id does not match the original");
                     return None;
                 }
 
                 if echo_tag.clock_id != clock_tag.clock_id {
-                    // TODO: `log::warn`!?
+                    debug_assert!(false, "Echoed clock tag clock_id does not match the original");
                     return None;
                 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -16,7 +16,7 @@ use crate::shards::shard_trait::ShardOperation as _;
 ///
 /// If an update is rejected because of an old clock, we will try again with a new clock. This
 /// describes the maximum number of times we try the update.
-const UPDATE_MAX_CLOCK_RETRIES: usize = 3;
+const UPDATE_MAX_CLOCK_REJECTED_RETRIES: usize = 3;
 
 const DEFAULT_SHARD_DEACTIVATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -152,8 +152,9 @@ impl ShardReplicaSet {
         // - but keep initial `clock` for the whole duration of `update`
         let mut clock = self.clock_set.lock().await.get_clock();
 
-        for attempt in 1..=UPDATE_MAX_CLOCK_RETRIES {
-            let is_tick_zero = clock.peek_tick_once() == 0;
+        for attempt in 1..=UPDATE_MAX_CLOCK_REJECTED_RETRIES {
+            let is_non_zero_tick = clock.current_tick().is_some();
+
             let res = self
                 .update_impl(operation.clone(), wait, &mut clock)
                 .await?;
@@ -162,14 +163,20 @@ impl ShardReplicaSet {
                 return Ok(res);
             }
 
-            // Do not log if our operation had clock tick 0
-            if !is_tick_zero {
-                log::warn!("Operation {operation:?} was rejected by some node(s), retrying... (attempt {attempt}/{UPDATE_MAX_CLOCK_RETRIES})");
+            // Log a warning, if operation was rejected... but only if operation had a non-0 tick,
+            // because operations with tick 0 should *always* be rejected and rejection is *expected*.
+            if is_non_zero_tick {
+                log::warn!(
+                    "Operation {operation:?} was rejected by some node(s), retrying... \
+                     (attempt {attempt}/{UPDATE_MAX_CLOCK_REJECTED_RETRIES})"
+                );
             }
         }
 
         Err(CollectionError::service_error(format!(
-            "Failed to apply operation {operation:?} after {UPDATE_MAX_CLOCK_RETRIES} attempts, could not find correct clock tick internally",
+            "Failed to apply operation {operation:?} \
+             after {UPDATE_MAX_CLOCK_REJECTED_RETRIES} attempts, \
+             all attempts were rejected",
         )))
     }
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -94,7 +94,6 @@ pub enum ShardTransferMethod {
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
-    #[doc(hidden)]
     #[schemars(skip)]
     WalDelta,
 }

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -64,6 +64,7 @@ impl WalState {
 /// Each stored record is enumerated with sequential number.
 /// Sequential number can be used to read stored records starting from some IDs,
 /// for removing old, no longer required, records.
+#[derive(Debug)]
 pub struct SerdeWal<R> {
     record: PhantomData<R>,
     wal: Wal,

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -20,6 +20,8 @@ pub enum WalError {
     WriteWalError(String),
     #[error("Can't truncate WAL: {0}")]
     TruncateWalError(String),
+    #[error("Operation rejected by WAL")]
+    Rejected,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -20,8 +20,8 @@ pub enum WalError {
     WriteWalError(String),
     #[error("Can't truncate WAL: {0}")]
     TruncateWalError(String),
-    #[error("Operation rejected by WAL")]
-    Rejected,
+    #[error("Operation rejected by WAL for old clock")]
+    ClockRejected,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -1266,28 +1266,28 @@ mod tests {
         let (_, _) = wal
             .lock_and_write(&mut OperationWithClockTag::new(
                 mock_operation(1),
-                Some(ClockTag::new(1, 0, 0)),
-            ))
-            .await
-            .unwrap();
-        let (_, _) = wal
-            .lock_and_write(&mut OperationWithClockTag::new(
-                mock_operation(2),
                 Some(ClockTag::new(1, 0, 1)),
             ))
             .await
             .unwrap();
         let (_, _) = wal
             .lock_and_write(&mut OperationWithClockTag::new(
-                mock_operation(3),
+                mock_operation(2),
                 Some(ClockTag::new(1, 0, 2)),
+            ))
+            .await
+            .unwrap();
+        let (_, _) = wal
+            .lock_and_write(&mut OperationWithClockTag::new(
+                mock_operation(3),
+                Some(ClockTag::new(1, 0, 3)),
             ))
             .await
             .unwrap();
 
         // Can resolve a delta for the last clock
         let mut recovery_point = RecoveryPoint::default();
-        recovery_point.insert(1, 0, 1);
+        recovery_point.insert(1, 0, 2);
         let resolve_result = wal.resolve_wal_delta(recovery_point).await.unwrap();
         assert_eq!(resolve_result, Some(2));
 
@@ -1299,20 +1299,20 @@ mod tests {
         let (_, _) = wal
             .lock_and_write(&mut OperationWithClockTag::new(
                 mock_operation(5),
-                Some(ClockTag::new(1, 0, 3)),
+                Some(ClockTag::new(1, 0, 4)),
             ))
             .await
             .unwrap();
 
         // Can still resolve a delta for the last clock
         let mut recovery_point = RecoveryPoint::default();
-        recovery_point.insert(1, 0, 3);
+        recovery_point.insert(1, 0, 4);
         let resolve_result = wal.resolve_wal_delta(recovery_point).await.unwrap();
         assert_eq!(resolve_result, None);
 
         // Cannot resolve a delta for our previous clock, it now has an untagged record after it
         let mut recovery_point = RecoveryPoint::default();
-        recovery_point.insert(1, 0, 1);
+        recovery_point.insert(1, 0, 2);
         let resolve_result = wal.resolve_wal_delta(recovery_point).await;
         assert_eq!(resolve_result.unwrap_err(), WalDeltaError::NotFound);
     }

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -261,7 +261,7 @@ mod tests {
     use crate::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
     use crate::shards::local_shard::clock_map::{ClockMap, RecoveryPoint};
     use crate::shards::replica_set::clock_set::ClockSet;
-    use crate::wal::SerdeWal;
+    use crate::wal::{SerdeWal, WalError};
 
     fn fixture_empty_wal() -> (RecoverableWal, TempDir) {
         let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
@@ -954,10 +954,15 @@ mod tests {
 
             let (_, _) = a_wal.lock_and_write(&mut operation_a).await.unwrap();
             let (_, _) = b_wal.lock_and_write(&mut operation_b).await.unwrap();
-            let (_, _) = b_wal
-                .lock_and_write(&mut operation_b_forward)
-                .await
-                .unwrap();
+
+            // Expect forward proxy rejection, it already has this operation
+            assert!(matches!(
+                b_wal
+                    .lock_and_write(&mut operation_b_forward)
+                    .await
+                    .unwrap_err(),
+                WalError::Rejected
+            ));
 
             c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);
             c_clock_0.advance_to(operation_b.clock_tag.unwrap().clock_tick);

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -300,8 +300,9 @@ mod tests {
         let (b_wal, _b_wal_dir) = fixture_empty_wal();
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
-        // Create clock set for peer A
+        // Create clock set for peer A, start first clock from 1
         let mut a_clock_set = ClockSet::new();
+        a_clock_set.get_clock().advance_to(0);
 
         // Create operation on peer A
         let mut a_clock_0 = a_clock_set.get_clock();
@@ -392,8 +393,9 @@ mod tests {
         let (b_wal, _b_wal_dir) = fixture_empty_wal();
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
-        // Create clock set for peer A
+        // Create clock set for peer A, start first clock from 1
         let mut a_clock_set = ClockSet::new();
+        a_clock_set.get_clock().advance_to(0);
 
         // Create N operations on peer A
         for i in 0..N {
@@ -494,6 +496,7 @@ mod tests {
         // Create N operations on peer A
         for i in 0..N {
             let mut a_clock_0 = a_clock_set.get_clock();
+            a_clock_0.advance_to(0);
             let clock_tick = a_clock_0.tick_once();
             let clock_tag = ClockTag::new(1, a_clock_0.id(), clock_tick);
             let bare_operation = mock_operation(i as u64);
@@ -521,6 +524,7 @@ mod tests {
             } else {
                 b_clock_set.get_clock()
             };
+            clock.advance_to(0);
             let clock_tick = clock.tick_once();
             let clock_tag = ClockTag::new(peer_id, clock.id(), clock_tick);
             let bare_operation = mock_operation(i as u64);
@@ -586,9 +590,11 @@ mod tests {
         let (b_wal, _b_wal_dir) = fixture_empty_wal();
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
-        // Create clock sets for peer A and B
+        // Create clock sets for peer A and B, start first clocks from 1
         let mut a_clock_set = ClockSet::new();
         let mut b_clock_set = ClockSet::new();
+        a_clock_set.get_clock().advance_to(0);
+        b_clock_set.get_clock().advance_to(0);
 
         // Create operation on peer A
         let mut a_clock_0 = a_clock_set.get_clock();
@@ -789,6 +795,7 @@ mod tests {
         {
             // Node C is sending updates to A and B
             let mut c_clock_0 = c_clock_set.get_clock();
+            c_clock_0.advance_to(0);
             let clock_tick = c_clock_0.tick_once();
             let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
 
@@ -813,6 +820,7 @@ mod tests {
         {
             // Node C is sending updates to A and B
             let mut c_clock_0 = c_clock_set.get_clock();
+            c_clock_0.advance_to(0);
             let clock_tick = c_clock_0.tick_once();
             let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
 
@@ -836,6 +844,8 @@ mod tests {
             // Node C is sending updates to A and B
             let mut c_clock_0 = c_clock_set.get_clock();
             let mut c_clock_1 = c_clock_set.get_clock();
+            c_clock_0.advance_to(0);
+            c_clock_1.advance_to(0);
 
             {
                 // First parallel operation
@@ -871,6 +881,7 @@ mod tests {
         // Node D sends an update to both A and B, both successfully written
         {
             let mut d_clock_0 = d_clock_set.get_clock();
+            d_clock_0.advance_to(0);
             let clock_tick = d_clock_0.tick_once();
             let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
 
@@ -891,6 +902,7 @@ mod tests {
         // Node D sends an update to both A and B, both successfully written
         {
             let mut d_clock_0 = d_clock_set.get_clock();
+            d_clock_0.advance_to(0);
             let clock_tick = d_clock_0.tick_once();
             let clock_tag = ClockTag::new(node_d_peer_id, d_clock_0.id(), clock_tick);
 
@@ -943,6 +955,7 @@ mod tests {
         // It is written to both A and B, plus forwarded to B with forward proxy
         {
             let mut c_clock_0 = c_clock_set.get_clock();
+            c_clock_0.advance_to(0);
             let clock_tick = c_clock_0.tick_once();
             let clock_tag = ClockTag::new(node_c_peer_id, c_clock_0.id(), clock_tick);
 
@@ -1042,6 +1055,7 @@ mod tests {
         {
             // Node D is sending updates to B
             let mut d_clock = d_clock_set.get_clock();
+            d_clock.advance_to(0);
 
             // First parallel operation
             let clock_tick = d_clock.tick_once();
@@ -1129,6 +1143,7 @@ mod tests {
                 let entrypoint = rng.gen_range(0..node_count);
 
                 let mut clock = clock_sets[entrypoint].get_clock();
+                clock.advance_to(0);
                 let clock_tick = clock.tick_once();
                 let clock_tag = ClockTag::new(entrypoint as u64, clock.id(), clock_tick);
 
@@ -1172,6 +1187,7 @@ mod tests {
                 let entrypoint = *alive_nodes.choose(&mut rng).unwrap();
 
                 let mut clock = clock_sets[entrypoint].get_clock();
+                clock.advance_to(0);
                 let clock_tick = clock.tick_once();
                 let clock_tag = ClockTag::new(entrypoint as u64, clock.id(), clock_tick);
 

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -66,7 +66,7 @@ impl RecoverableWal {
                 .advance_clock_and_correct_tag(clock_tag);
 
             if !operation_accepted {
-                return Err(crate::wal::WalError::Rejected);
+                return Err(crate::wal::WalError::ClockRejected);
             }
         }
 
@@ -974,7 +974,7 @@ mod tests {
                     .lock_and_write(&mut operation_b_forward)
                     .await
                     .unwrap_err(),
-                WalError::Rejected
+                WalError::ClockRejected
             ));
 
             c_clock_0.advance_to(operation_a.clock_tag.unwrap().clock_tick);


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

This PR tweaks WAL diff transfer related logic:
- [x] `ClockMap` should reject operations with `clock_tick = 0`
  - [x] update `ClockMap` unit-tests
- [x] `LocalShard::update` should honor `ClockMap::advance_*` result
  - [x] accept or *reject* operations
  - [x] and propagate updated `clock_tick` to the caller
  - [x] extend `UpdateResult` type, so that rejection can be propagated more explicitly?
  - [x] refactor `SerdeWal::lock_and_write`, so it will be more ergonomic to work with?
- [x] if *any* replica rejected the operation, `ShardReplicaSet::update` should retry the operation with new tick (on *all* replicas)
- [x] update `wal_delta` tests

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
