### PR TITLE
Introduce MultiDenseVector to models

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -487,6 +487,9 @@ impl From<segment::data_types::vectors::Vector> for Vector {
                     data: vector.indices,
                 }),
             },
+            segment::data_types::vectors::Vector::MultiDense(_vector) => {
+                unimplemented!("MultiDenseVector is not supported")
+            }
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -994,6 +994,9 @@ impl<'a> From<CollectionSearchRequest<'a>> for api::grpc::qdrant::SearchPoints {
                     data: vector.indices,
                 }),
             ),
+            Vector::MultiDense(_vector) => {
+                unimplemented!("MultiDenseVector is not supported")
+            }
         };
         Self {
             collection_name: collection_id,
@@ -1409,6 +1412,9 @@ impl TryFrom<api::grpc::qdrant::Vector> for RecommendExample {
         Ok(match vector {
             Vector::Dense(vector) => Self::Dense(vector),
             Vector::Sparse(vector) => Self::Sparse(vector),
+            Vector::MultiDense(_vector) => {
+                unimplemented!("MultiDenseVector is not supported")
+            }
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1070,6 +1070,9 @@ impl From<OperationError> for CollectionError {
             OperationError::WrongSparse => Self::BadInput {
                 description: "Conversion between sparse and regular vectors failed".to_string(),
             },
+            OperationError::WrongMulti => Self::BadInput {
+                description: "Conversion between multi and regular vectors failed".to_string(),
+            },
             OperationError::WrongPayloadKey { description } => Self::BadInput { description },
         }
     }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -48,6 +48,11 @@ fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionRe
                 sparse_count += 1;
                 avg_sparse = vector.combine_aggregate(&avg_sparse, |v1, v2| v1 + v2);
             }
+            VectorRef::MultiDense(_) => {
+                return Err(CollectionError::bad_input(
+                    "MultiDenseVector is not supported".to_owned(),
+                ))
+            }
         }
     }
 

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -186,6 +186,7 @@ fn check_vector_against_config(
             Ok(())
         }
         VectorRef::Sparse(_) => Err(OperationError::WrongSparse),
+        VectorRef::MultiDense(_) => Err(OperationError::WrongMulti),
     }
 }
 
@@ -196,6 +197,7 @@ fn check_sparse_vector_against_config(
     match vector {
         VectorRef::Dense(_) => Err(OperationError::WrongSparse),
         VectorRef::Sparse(_vector) => Ok(()), // TODO(sparse) check vector by config
+        VectorRef::MultiDense(_) => Err(OperationError::WrongMulti),
     }
 }
 

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -52,6 +52,8 @@ pub enum OperationError {
     ValidationError { description: String },
     #[error("Wrong usage of sparse vectors")]
     WrongSparse,
+    #[error("Wrong usage of multi vectors")]
+    WrongMulti,
     #[error("Wrong key of payload")]
     WrongPayloadKey { description: String },
 }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -50,6 +50,7 @@ impl<'a> From<Vector> for CowVector<'a> {
         match v {
             Vector::Dense(v) => CowVector::Dense(Cow::Owned(v)),
             Vector::Sparse(v) => CowVector::Sparse(Cow::Owned(v)),
+            Vector::MultiDense(_) => unimplemented!("MultiDenseVector is not supported"),
         }
     }
 }
@@ -105,6 +106,7 @@ impl<'a> From<VectorRef<'a>> for CowVector<'a> {
         match v {
             VectorRef::Dense(v) => CowVector::Dense(Cow::Borrowed(v)),
             VectorRef::Sparse(v) => CowVector::Sparse(Cow::Borrowed(v)),
+            VectorRef::MultiDense(_) => unimplemented!("MultiDenseVector is not supported"),
         }
     }
 }
@@ -117,6 +119,7 @@ impl<'a> NamedVectors<'a> {
             match value {
                 VectorRef::Dense(v) => CowVector::Dense(Cow::Borrowed(v)),
                 VectorRef::Sparse(v) => CowVector::Sparse(Cow::Borrowed(v)),
+                VectorRef::MultiDense(_) => unimplemented!("MultiDenseVector is not supported"),
             },
         );
         Self { map }
@@ -155,6 +158,7 @@ impl<'a> NamedVectors<'a> {
             match vector {
                 Vector::Dense(v) => CowVector::Dense(Cow::Owned(v)),
                 Vector::Sparse(v) => CowVector::Sparse(Cow::Owned(v)),
+                Vector::MultiDense(_) => unimplemented!("MultiDenseVector is not supported"),
             },
         );
     }
@@ -165,6 +169,7 @@ impl<'a> NamedVectors<'a> {
             match vector {
                 VectorRef::Dense(v) => CowVector::Dense(Cow::Borrowed(v)),
                 VectorRef::Sparse(v) => CowVector::Sparse(Cow::Borrowed(v)),
+                VectorRef::MultiDense(_) => unimplemented!("MultiDenseVector is not supported"),
             },
         );
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -17,12 +17,14 @@ use crate::vector_storage::query::reco_query::RecoQuery;
 pub enum Vector {
     Dense(DenseVector),
     Sparse(SparseVector),
+    MultiDense(MultiDenseVector),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum VectorRef<'a> {
     Dense(&'a [VectorElementType]),
     Sparse(&'a SparseVector),
+    MultiDense(&'a MultiDenseVector),
 }
 
 impl Vector {
@@ -30,6 +32,7 @@ impl Vector {
         match self {
             Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
             Vector::Sparse(v) => VectorRef::Sparse(v),
+            Vector::MultiDense(v) => VectorRef::MultiDense(v),
         }
     }
 }
@@ -39,6 +42,7 @@ impl Validate for Vector {
         match self {
             Vector::Dense(_) => Ok(()),
             Vector::Sparse(v) => v.validate(),
+            Vector::MultiDense(_v) => Ok(()),
         }
     }
 }
@@ -48,6 +52,7 @@ impl<'a> VectorRef<'a> {
         match self {
             VectorRef::Dense(v) => Vector::Dense(v.to_vec()),
             VectorRef::Sparse(v) => Vector::Sparse(v.clone()),
+            VectorRef::MultiDense(v) => Vector::MultiDense(v.to_vec()),
         }
     }
 }
@@ -59,6 +64,7 @@ impl<'a> TryFrom<VectorRef<'a>> for &'a [VectorElementType] {
         match value {
             VectorRef::Dense(v) => Ok(v),
             VectorRef::Sparse(_) => Err(OperationError::WrongSparse),
+            VectorRef::MultiDense(_) => Err(OperationError::WrongMulti),
         }
     }
 }
@@ -70,6 +76,19 @@ impl<'a> TryFrom<VectorRef<'a>> for &'a SparseVector {
         match value {
             VectorRef::Dense(_) => Err(OperationError::WrongSparse),
             VectorRef::Sparse(v) => Ok(v),
+            VectorRef::MultiDense(_) => Err(OperationError::WrongMulti),
+        }
+    }
+}
+
+impl<'a> TryFrom<VectorRef<'a>> for &'a MultiDenseVector {
+    type Error = OperationError;
+
+    fn try_from(value: VectorRef<'a>) -> Result<Self, Self::Error> {
+        match value {
+            VectorRef::Dense(_) => Err(OperationError::WrongMulti),
+            VectorRef::Sparse(_v) => Err(OperationError::WrongSparse),
+            VectorRef::MultiDense(v) => Ok(v),
         }
     }
 }
@@ -91,6 +110,7 @@ impl TryFrom<Vector> for DenseVector {
         match value {
             Vector::Dense(v) => Ok(v),
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
+            Vector::MultiDense(_) => Err(OperationError::WrongMulti),
         }
     }
 }
@@ -102,6 +122,7 @@ impl TryFrom<Vector> for SparseVector {
         match value {
             Vector::Dense(_) => Err(OperationError::WrongSparse),
             Vector::Sparse(v) => Ok(v),
+            Vector::MultiDense(_) => Err(OperationError::WrongMulti),
         }
     }
 }
@@ -141,6 +162,7 @@ impl<'a> From<&'a Vector> for VectorRef<'a> {
         match val {
             Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
             Vector::Sparse(v) => VectorRef::Sparse(v),
+            Vector::MultiDense(v) => VectorRef::MultiDense(v),
         }
     }
 }
@@ -153,12 +175,16 @@ pub const DEFAULT_VECTOR_NAME: &str = "";
 /// Type for dense vector
 pub type DenseVector = Vec<VectorElementType>;
 
+/// Type for multi dense vector
+pub type MultiDenseVector = Vec<DenseVector>;
+
 impl<'a> VectorRef<'a> {
     // Cannot use `ToOwned` trait because of `Borrow` implementation for `Vector`
     pub fn to_owned(self) -> Vector {
         match self {
             VectorRef::Dense(v) => Vector::Dense(v.to_vec()),
             VectorRef::Sparse(v) => Vector::Sparse(v.clone()),
+            VectorRef::MultiDense(v) => Vector::MultiDense(v.to_vec()),
         }
     }
 
@@ -166,6 +192,7 @@ impl<'a> VectorRef<'a> {
         match self {
             VectorRef::Dense(v) => v.len(),
             VectorRef::Sparse(v) => v.indices.len(),
+            VectorRef::MultiDense(v) => v.iter().map(Vec::len).sum(),
         }
     }
 
@@ -181,6 +208,7 @@ impl<'a> TryInto<&'a [VectorElementType]> for &'a Vector {
         match self {
             Vector::Dense(v) => Ok(v),
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
+            Vector::MultiDense(_) => Err(OperationError::WrongMulti),
         }
     }
 }
@@ -192,6 +220,7 @@ impl<'a> TryInto<&'a SparseVector> for &'a Vector {
         match self {
             Vector::Dense(_) => Err(OperationError::WrongSparse),
             Vector::Sparse(v) => Ok(v),
+            Vector::MultiDense(_) => Err(OperationError::WrongMulti),
         }
     }
 }
@@ -220,6 +249,7 @@ impl VectorStruct {
             VectorStruct::Multi(vectors) => vectors.values().all(|v| match v {
                 Vector::Dense(vector) => vector.is_empty(),
                 Vector::Sparse(vector) => vector.indices.is_empty(),
+                Vector::MultiDense(v) => v.iter().all(|v| v.is_empty()),
             }),
         }
     }
@@ -383,6 +413,9 @@ impl NamedVectorStruct {
         match vector {
             Vector::Dense(vector) => NamedVectorStruct::Dense(NamedVector { name, vector }),
             Vector::Sparse(vector) => NamedVectorStruct::Sparse(NamedSparseVector { name, vector }),
+            Vector::MultiDense(_) => {
+                unimplemented!("MultiDenseVector cannot be converted to NamedVectorStruct")
+            }
         }
     }
 

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -283,6 +283,9 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                     Vector::Sparse(_sparse_vector) => Err(OperationError::service_error(
                         "sparse vectors are not supported for async scorer",
                     )), // TODO(sparse) add support?
+                    Vector::MultiDense(_multi_dense_vector) => Err(OperationError::service_error(
+                        "multi-dense vectors are not supported for async scorer",
+                    )), // TODO(multi-dense) add support?
                 }
             }
             QueryVector::Recommend(reco_query) => {


### PR DESCRIPTION
This PR adds a new variant `MultiDenseVector` to our models to bootstrap the work on ColBERT embeddings.

