### PR TITLE
Use new safe_to_set/safe_to_remove functions

### DIFF
--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -488,9 +488,7 @@ impl PayloadIndex for StructPayloadIndex {
 
         let updated_payload = self.payload(point_id)?;
         for (field, field_index) in &mut self.field_indexes {
-            // `safe_to_set = true` means that `field` was not affected by the update
-            // We can skip index update in this case
-            if JsonPath::safe_to_set(field, &payload.0, key.as_ref()) {
+            if !field.is_affected_by_value_set(&payload.0, key.as_ref()) {
                 continue;
             }
             let field_value = updated_payload.get_value(field);

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -488,6 +488,8 @@ impl PayloadIndex for StructPayloadIndex {
 
         let updated_payload = self.payload(point_id)?;
         for (field, field_index) in &mut self.field_indexes {
+            // `safe_to_set = true` means that `field` was not affected by the update
+            // We can skip index update in this case
             if JsonPath::safe_to_set(field, &payload.0, key.as_ref()) {
                 continue;
             }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -488,6 +488,9 @@ impl PayloadIndex for StructPayloadIndex {
 
         let updated_payload = self.payload(point_id)?;
         for (field, field_index) in &mut self.field_indexes {
+            if JsonPath::safe_to_set(field, &payload.0, key.as_ref()) {
+                continue;
+            }
             let field_value = updated_payload.get_value(field);
             if !field_value.is_empty() {
                 for index in field_index {

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -13,7 +13,7 @@ mod v2;
 pub use string::JsonPathString;
 pub use v2::JsonPathV2;
 
-pub type JsonPath = string::JsonPathString;
+pub type JsonPath = JsonPathV2;
 
 pub trait JsonPathInterface: Sized + Clone + FromStr<Err = ()> + Display {
     // Value operations

--- a/tests/openapi/openapi_integration/test_payload_operations.py
+++ b/tests/openapi/openapi_integration/test_payload_operations.py
@@ -245,7 +245,7 @@ def test_payload_operations():
         body={
             "payload": {"key6": "xxx"},
             "points": [1],
-            "key": ""
+            "key": None,
         }
     )
     assert response.ok


### PR DESCRIPTION
* Use new `safe_to_set`/`safe_to_remove` functions. The new implementation will make features introduced in #3611 and #3548 to play well with each other.
* Fix `PayloadIndex::assign` by using `safe_to_set` check here.
* Make `JsonPathV2::value_remove()` idempotent by prohibiting deleting paths like `a[0]`.

This PR is based on #3709.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
