### PR TITLE
Define segment internal vector type

### DIFF
--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -49,8 +49,7 @@ fn discovery_into_core_search(
         &lookup_vector_name,
         lookup_collection_name,
     )
-    .next()
-    .map(|v| v.to_owned());
+    .next();
 
     let context_pairs = request
         .context
@@ -62,8 +61,7 @@ fn discovery_into_core_search(
                 all_vectors_records_map,
                 &lookup_vector_name,
                 lookup_collection_name,
-            )
-            .map(|v| v.to_owned());
+            );
 
             ContextPair {
                 // SAFETY: we know there are two elements in the iterator

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -986,7 +986,7 @@ impl TryFrom<api::grpc::qdrant::SearchPoints> for CoreSearchRequest {
 impl<'a> From<CollectionSearchRequest<'a>> for api::grpc::qdrant::SearchPoints {
     fn from(value: CollectionSearchRequest<'a>) -> Self {
         let (collection_id, request) = value.0;
-        let (vector, sparse_indices) = match request.vector.get_vector().to_owned() {
+        let (vector, sparse_indices) = match request.vector.clone().to_vector() {
             Vector::Dense(vector) => (vector, None),
             Vector::Sparse(vector) => (
                 vector.values,

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -491,16 +491,6 @@ impl NamedVectorStruct {
         }
     }
 
-    /*
-    pub fn get_vector(&self) -> VectorRef {
-        match self {
-            NamedVectorStruct::Default(v) => v.as_slice().into(),
-            NamedVectorStruct::Dense(v) => v.vector.as_slice().into(),
-            NamedVectorStruct::Sparse(v) => (&v.vector).into(),
-        }
-    }
-     */
-
     pub fn to_vector(self) -> Vector {
         match self {
             NamedVectorStruct::Default(v) => v.into(),

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -23,7 +23,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::common::BYTES_IN_KB;
-use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
+use crate::data_types::vectors::{internal, QueryVector, VectorRef};
 use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
@@ -363,7 +363,7 @@ impl<TGraphLinks: GraphLinks> HNSWIndex<TGraphLinks> {
 
     fn discovery_search_with_graph(
         &self,
-        discovery_query: DiscoveryQuery<Vector>,
+        discovery_query: DiscoveryQuery<internal::Vector>,
         filter: Option<&Filter>,
         top: usize,
         params: Option<&SearchParams>,

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -443,7 +443,7 @@ impl Segment {
                     .get_vector(point_offset)
                     .as_vec_ref()
                     .to_vec();
-                vectors.insert(vector_name.clone(), vector);
+                vectors.insert(vector_name.clone(), vector.into());
             }
         }
         Ok(vectors)

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -10,7 +10,7 @@ use super::query::reco_query::RecoQuery;
 use super::query::TransformInto;
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::vectors::{DenseVector, QueryVector, Vector, VectorElementType};
+use crate::data_types::vectors::{internal, DenseVector, QueryVector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::Distance;
@@ -268,7 +268,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
         match query {
             QueryVector::Nearest(vector) => {
                 match vector {
-                    Vector::Dense(dense_vector) => {
+                    internal::Vector::Dense(dense_vector) => {
                         let query_scorer =
                             MetricQueryScorer::<TMetric, _>::new(dense_vector, storage);
                         Ok(Box::new(AsyncRawScorerImpl::new(
@@ -280,7 +280,7 @@ impl<'a> AsyncRawScorerBuilder<'a> {
                             is_stopped.unwrap_or(&DEFAULT_STOPPED),
                         )))
                     }
-                    Vector::Sparse(_sparse_vector) => Err(OperationError::service_error(
+                    internal::Vector::Sparse(_sparse_vector) => Err(OperationError::service_error(
                         "sparse vectors are not supported for async scorer",
                     )), // TODO(sparse) add support?
                 }

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, Vector};
+use crate::data_types::vectors::{internal, QueryVector, Vector};
 
 #[derive(Debug, Clone)]
 pub struct ContextPair<T> {
@@ -113,9 +113,15 @@ impl<T> From<Vec<ContextPair<T>>> for ContextQuery<T> {
     }
 }
 
-impl From<ContextQuery<Vector>> for QueryVector {
-    fn from(query: ContextQuery<Vector>) -> Self {
+impl From<ContextQuery<internal::Vector>> for QueryVector {
+    fn from(query: ContextQuery<internal::Vector>) -> Self {
         QueryVector::Context(query)
+    }
+}
+
+impl From<ContextQuery<Vector>> for ContextQuery<internal::Vector> {
+    fn from(query: ContextQuery<Vector>) -> Self {
+        query.transform(|v| Ok(v.into())).unwrap()
     }
 }
 

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use super::context_query::ContextPair;
 use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, Vector};
+use crate::data_types::vectors::{internal, QueryVector, Vector};
 
 type RankType = i32;
 
@@ -74,9 +74,15 @@ impl<T> Query<T> for DiscoveryQuery<T> {
     }
 }
 
-impl From<DiscoveryQuery<Vector>> for QueryVector {
-    fn from(query: DiscoveryQuery<Vector>) -> Self {
+impl From<DiscoveryQuery<internal::Vector>> for QueryVector {
+    fn from(query: DiscoveryQuery<internal::Vector>) -> Self {
         QueryVector::Discovery(query)
+    }
+}
+
+impl From<DiscoveryQuery<Vector>> for DiscoveryQuery<internal::Vector> {
+    fn from(query: DiscoveryQuery<Vector>) -> Self {
+        query.transform(|v| Ok(v.into())).unwrap()
     }
 }
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, Vector};
+use crate::data_types::vectors::{internal, QueryVector, Vector};
 
 #[derive(Debug, Clone)]
 pub struct RecoQuery<T> {
@@ -70,9 +70,15 @@ fn merge_similarities(
     }
 }
 
-impl From<RecoQuery<Vector>> for QueryVector {
-    fn from(query: RecoQuery<Vector>) -> Self {
+impl From<RecoQuery<internal::Vector>> for QueryVector {
+    fn from(query: RecoQuery<internal::Vector>) -> Self {
         QueryVector::Recommend(query)
+    }
+}
+
+impl From<RecoQuery<Vector>> for RecoQuery<internal::Vector> {
+    fn from(query: RecoQuery<Vector>) -> Self {
+        query.transform(|v| Ok(v.into())).unwrap()
     }
 }
 


### PR DESCRIPTION
Currently, `Vector` type is both a REST API type and internal segment structure. While working with ColBERT vectors we have to add new variant into `Vector` but we cannot because it changes public API.

After discussion, @generall  and @agourlay decided to decouple this logic and implement REST API's `Vector` as separate entity. It also includes another vector-related types which has to be moved.
Discussion thread: https://qdrant.slack.com/archives/C027ADU2611/p1709198634747509

This goal is mentioned as a step of ColBERT tracking issue: https://github.com/qdrant/qdrant/issues/3684

This PR intoduces first step of such refactoring. Here was defined an `internal::Vector` which is a type of segment API without `JsonSchema`. In this PR `internal::Vector` is already integrated into segment.

In next PR's REST API's `Vector` and related stuff (like `NamedVector`) will be moved from segment crate.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
