### PR TITLE
Add update response status for clock rejection

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3621,6 +3621,7 @@ How to use positive and negative vectors to find the results, default is `Averag
 | UnknownUpdateStatus | 0 |  |
 | Acknowledged | 1 | Update is received, but not processed yet |
 | Completed | 2 | Update is applied and ready for search |
+| ClockRejected | 3 | Internal: update is rejected due to an outdated clock |
 
 
 

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -530,6 +530,7 @@ enum UpdateStatus {
   UnknownUpdateStatus = 0;
   Acknowledged = 1; // Update is received, but not processed yet
   Completed = 2; // Update is applied and ready for search
+  ClockRejected = 3; // Internal: update is rejected due to an outdated clock
 }
 
 message ScoredPoint {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5393,6 +5393,8 @@ pub enum UpdateStatus {
     Acknowledged = 1,
     /// Update is applied and ready for search
     Completed = 2,
+    /// Internal: update is rejected due to an outdated clock
+    ClockRejected = 3,
 }
 impl UpdateStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -5404,6 +5406,7 @@ impl UpdateStatus {
             UpdateStatus::UnknownUpdateStatus => "UnknownUpdateStatus",
             UpdateStatus::Acknowledged => "Acknowledged",
             UpdateStatus::Completed => "Completed",
+            UpdateStatus::ClockRejected => "ClockRejected",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -5412,6 +5415,7 @@ impl UpdateStatus {
             "UnknownUpdateStatus" => Some(Self::UnknownUpdateStatus),
             "Acknowledged" => Some(Self::Acknowledged),
             "Completed" => Some(Self::Completed),
+            "ClockRejected" => Some(Self::ClockRejected),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -898,6 +898,7 @@ impl From<UpdateStatus> for i32 {
         match status {
             UpdateStatus::Acknowledged => api::grpc::qdrant::UpdateStatus::Acknowledged as i32,
             UpdateStatus::Completed => api::grpc::qdrant::UpdateStatus::Completed as i32,
+            UpdateStatus::ClockRejected => api::grpc::qdrant::UpdateStatus::ClockRejected as i32,
         }
     }
 }
@@ -912,6 +913,7 @@ impl TryFrom<i32> for UpdateStatus {
         let status = match status {
             api::grpc::qdrant::UpdateStatus::Acknowledged => Self::Acknowledged,
             api::grpc::qdrant::UpdateStatus::Completed => Self::Completed,
+            api::grpc::qdrant::UpdateStatus::ClockRejected => Self::ClockRejected,
 
             api::grpc::qdrant::UpdateStatus::UnknownUpdateStatus => {
                 return Err(Status::invalid_argument(

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -254,9 +254,14 @@ pub struct RemoteShardInfo {
 /// `Completed` - Request is completed, changes are actual.
 #[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::manual_non_exhaustive)]
 pub enum UpdateStatus {
     Acknowledged,
     Completed,
+    /// Internal: update is rejected due to an outdated clock
+    #[doc(hidden)]
+    #[schemars(skip)]
+    ClockRejected,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -254,12 +254,10 @@ pub struct RemoteShardInfo {
 /// `Completed` - Request is completed, changes are actual.
 #[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-#[allow(clippy::manual_non_exhaustive)]
 pub enum UpdateStatus {
     Acknowledged,
     Completed,
     /// Internal: update is rejected due to an outdated clock
-    #[doc(hidden)]
     #[schemars(skip)]
     ClockRejected,
 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -254,9 +254,10 @@ impl ShardOperation for LocalShard {
                 Ok(id_and_lock) => id_and_lock,
 
                 Err(crate::wal::WalError::Rejected) => {
+                    // Propagate clock rejection to operation sender
                     return Ok(UpdateResult {
                         operation_id: None,
-                        status: UpdateStatus::Acknowledged,
+                        status: UpdateStatus::ClockRejected,
                         clock_tag: operation.clock_tag,
                     });
                 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 
 use super::{ReplicaSetState, ReplicaState, ShardReplicaSet};
 use crate::operations::point_ops::WriteOrdering;
-use crate::operations::types::{CollectionError, CollectionResult, UpdateResult};
+use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
 use crate::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
 use crate::shards::shard::PeerId;
 use crate::shards::shard_trait::ShardOperation as _;
@@ -343,7 +343,7 @@ impl ShardReplicaSet {
 
         let is_any_operation_rejected = successes
             .iter()
-            .any(|(_, res)| res.operation_id.is_none() && res.clock_tag.is_some());
+            .any(|(_, res)| matches!(res.status, UpdateStatus::ClockRejected));
 
         if is_any_operation_rejected {
             return Ok(None);

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -76,7 +76,6 @@ pub enum ShardTransferMethod {
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
-    #[doc(hidden)]
     #[schemars(skip)]
     WalDelta,
 }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Depends on: <https://github.com/qdrant/qdrant/pull/3719>

Add `UpdateStatus::ClockRejected` so that we can notify the operation sender of the operation being rejected due to an outdated clock.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?