### PR TITLE
OrderBy: Allow integer in `StartFrom`

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7431,6 +7431,10 @@
       "StartFrom": {
         "anyOf": [
           {
+            "type": "integer",
+            "format": "int64"
+          },
+          {
             "type": "number",
             "format": "double"
           },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1346,6 +1346,9 @@ impl From<segment::data_types::order_by::StartFrom> for StartFrom {
     fn from(value: segment::data_types::order_by::StartFrom) -> Self {
         Self {
             value: Some(match value {
+                segment::data_types::order_by::StartFrom::Integer(int) => {
+                    start_from::Value::Integer(int)
+                }
                 segment::data_types::order_by::StartFrom::Float(float) => {
                     start_from::Value::Float(float)
                 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1810,12 +1810,11 @@ impl TryFrom<api::grpc::qdrant::OrderBy> for OrderByInterface {
             .and_then(|value| value.value)
             .map(|v| -> Result<StartFrom, Status> {
                 match v {
+                    api::grpc::qdrant::start_from::Value::Integer(int) => {
+                        Ok(StartFrom::Integer(int))
+                    }
                     api::grpc::qdrant::start_from::Value::Float(float) => {
                         Ok(StartFrom::Float(float))
-                    }
-                    // TODO(luis): make appropriate conversion once we allow int start_from
-                    api::grpc::qdrant::start_from::Value::Integer(int) => {
-                        Ok(StartFrom::Float(int as _))
                     }
                     api::grpc::qdrant::start_from::Value::Timestamp(timestamp) => {
                         Ok(StartFrom::Datetime(date_time_from_proto(timestamp)?))

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -41,6 +41,8 @@ impl Direction {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
 pub enum StartFrom {
+    Integer(IntPayloadType),
+
     Float(FloatPayloadType),
 
     Datetime(DateTimePayloadType),
@@ -65,6 +67,11 @@ impl OrderBy {
         self.start_from
             .as_ref()
             .map(|start_from| match start_from {
+                // TODO: When we introduce integer ranges, we'll stop doing lossy conversion to f64 here
+                // Accepting an integer as start_from simplifies the client generation.
+                StartFrom::Integer(i) => {
+                    RangeInterface::Float(self.direction().as_range_from(*i as f64))
+                }
                 StartFrom::Float(f) => RangeInterface::Float(self.direction().as_range_from(*f)),
                 StartFrom::Datetime(dt) => {
                     RangeInterface::DateTime(self.direction().as_range_from(*dt))
@@ -81,6 +88,7 @@ impl OrderBy {
         self.start_from
             .as_ref()
             .map(|start_from| match start_from {
+                StartFrom::Integer(i) => OrderingValue::Int(*i),
                 StartFrom::Float(f) => OrderingValue::Float(*f),
                 StartFrom::Datetime(dt) => OrderingValue::Int(dt.timestamp()),
             })


### PR DESCRIPTION
OrderBy tracked in #3521 

Right now we accept integers in gRPC, but not in REST, this adds integer variant to the `StartFrom` interface

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
