### PR TITLE
When restarting shard transfer, keep sync if old transfer was sync

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -52,6 +52,7 @@
     - [RemoteShardInfo](#qdrant-RemoteShardInfo)
     - [RenameAlias](#qdrant-RenameAlias)
     - [Replica](#qdrant-Replica)
+    - [RestartTransfer](#qdrant-RestartTransfer)
     - [ScalarQuantization](#qdrant-ScalarQuantization)
     - [ShardKey](#qdrant-ShardKey)
     - [ShardTransferInfo](#qdrant-ShardTransferInfo)
@@ -1068,6 +1069,24 @@ Note: 1kB = 1 vector of size 256. |
 
 
 
+<a name="qdrant-RestartTransfer"></a>
+
+### RestartTransfer
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| shard_id | [uint32](#uint32) |  | Local shard id |
+| from_peer_id | [uint64](#uint64) |  |  |
+| to_peer_id | [uint64](#uint64) |  |  |
+| method | [ShardTransferMethod](#qdrant-ShardTransferMethod) |  |  |
+
+
+
+
+
+
 <a name="qdrant-ScalarQuantization"></a>
 
 ### ScalarQuantization
@@ -1236,7 +1255,7 @@ Note: 1kB = 1 vector of size 256. |
 | drop_replica | [Replica](#qdrant-Replica) |  |  |
 | create_shard_key | [CreateShardKey](#qdrant-CreateShardKey) |  |  |
 | delete_shard_key | [DeleteShardKey](#qdrant-DeleteShardKey) |  |  |
-| restart_transfer | [MoveShard](#qdrant-MoveShard) |  |  |
+| restart_transfer | [RestartTransfer](#qdrant-RestartTransfer) |  |  |
 | timeout | [uint64](#uint64) | optional | Wait timeout for operation commit in seconds, if not specified - default value will be supplied |
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -10032,6 +10032,7 @@
         "type": "object",
         "required": [
           "from_peer_id",
+          "method",
           "shard_id",
           "to_peer_id"
         ],
@@ -10052,14 +10053,7 @@
             "minimum": 0
           },
           "method": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardTransferMethod"
-              },
-              {
-                "nullable": true
-              }
-            ]
+            "$ref": "#/components/schemas/ShardTransferMethod"
           }
         }
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -496,6 +496,13 @@ message MoveShard {
   optional ShardTransferMethod method = 4;
 }
 
+message RestartTransfer {
+  uint32 shard_id = 1; // Local shard id
+  uint64 from_peer_id = 2;
+  uint64 to_peer_id = 3;
+  ShardTransferMethod method = 4;
+}
+
 enum ShardTransferMethod {
   StreamRecords = 0; // Stream shard records in batches
   Snapshot = 1; // Snapshot the shard and recover it on the target peer
@@ -527,7 +534,7 @@ message UpdateCollectionClusterSetupRequest {
     Replica drop_replica = 5;
     CreateShardKey create_shard_key = 7;
     DeleteShardKey delete_shard_key = 8;
-    MoveShard restart_transfer = 9;
+    RestartTransfer restart_transfer = 9;
   }
   optional uint64 timeout = 6; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -922,6 +922,20 @@ pub struct MoveShard {
     #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
     pub method: ::core::option::Option<i32>,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RestartTransfer {
+    /// Local shard id
+    #[prost(uint32, tag = "1")]
+    pub shard_id: u32,
+    #[prost(uint64, tag = "2")]
+    pub from_peer_id: u64,
+    #[prost(uint64, tag = "3")]
+    pub to_peer_id: u64,
+    #[prost(enumeration = "ShardTransferMethod", tag = "4")]
+    pub method: i32,
+}
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -997,7 +1011,7 @@ pub mod update_collection_cluster_setup_request {
         #[prost(message, tag = "8")]
         DeleteShardKey(super::DeleteShardKey),
         #[prost(message, tag = "9")]
-        RestartTransfer(super::MoveShard),
+        RestartTransfer(super::RestartTransfer),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -160,6 +160,12 @@ impl Validate for crate::grpc::qdrant::DeleteShardKey {
     }
 }
 
+impl Validate for crate::grpc::qdrant::RestartTransfer {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        Ok(())
+    }
+}
+
 impl Validate for crate::grpc::qdrant::condition::ConditionOneOf {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use crate::grpc::qdrant::condition::ConditionOneOf;

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -74,7 +74,7 @@ pub struct RestartTransfer {
     pub shard_id: ShardId,
     pub from_peer_id: PeerId,
     pub to_peer_id: PeerId,
-    pub method: Option<ShardTransferMethod>,
+    pub method: ShardTransferMethod,
 }
 
 impl Validate for ClusterOperations {

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1766,7 +1766,7 @@ impl TryFrom<ClusterOperationsPb> for ClusterOperations {
                         shard_id: op.shard_id,
                         from_peer_id: op.from_peer_id,
                         to_peer_id: op.to_peer_id,
-                        method: op.method.map(TryInto::try_into).transpose()?,
+                        method: op.method.try_into()?,
                     },
                 })
             }

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -52,6 +52,24 @@ impl ShardTransfer {
     }
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ShardTransferRestart {
+    pub shard_id: ShardId,
+    pub from: PeerId,
+    pub to: PeerId,
+    pub method: ShardTransferMethod,
+}
+
+impl ShardTransferRestart {
+    pub fn key(&self) -> ShardTransferKey {
+        ShardTransferKey {
+            shard_id: self.shard_id,
+            from: self.from,
+            to: self.to,
+        }
+    }
+}
+
 /// Unique identifier of a transfer, agnostic of transfer method
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransferKey {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -10,7 +10,7 @@ use collection::operations::types::{
 };
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
-use collection::shards::transfer::{ShardTransfer, ShardTransferKey};
+use collection::shards::transfer::{ShardTransfer, ShardTransferKey, ShardTransferRestart};
 use collection::shards::{replica_set, CollectionId};
 use schemars::JsonSchema;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, QuantizationConfig, ShardKey};
@@ -297,7 +297,7 @@ pub enum ShardTransferOperations {
     /// Restart an existing transfer with a new configuration
     ///
     /// If the given transfer is ongoing, it is aborted and restarted with the new configuration.
-    Restart(ShardTransfer),
+    Restart(ShardTransferRestart),
     Finish(ShardTransfer),
     /// Used in `ShardTransferMethod::Snapshot`
     ///

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -373,9 +373,9 @@ impl TableOfContent {
                 )
                 .await?;
 
+                // Preserve sync flag from the old or new transfer
                 let mut new_transfer = transfer.clone();
-                // Preserve sync flag from the old transfer
-                new_transfer.sync = old_transfer.sync;
+                new_transfer.sync = old_transfer.sync || new_transfer.sync;
 
                 self.handle_transfer(collection_id, ShardTransferOperations::Start(new_transfer))
                     .await?;

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -6,6 +6,7 @@ use collection::collection_state;
 use collection::config::ShardingMethod;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
+use collection::shards::transfer::ShardTransfer;
 use collection::shards::{transfer, CollectionId};
 use uuid::Uuid;
 
@@ -341,11 +342,11 @@ impl TableOfContent {
                     )
                     .await?;
             }
-            ShardTransferOperations::Restart(transfer) => {
+            ShardTransferOperations::Restart(transfer_restart) => {
                 let transfers: HashSet<transfer::ShardTransfer> =
                     collection.state().await.transfers;
 
-                let transfer_key = transfer.key();
+                let transfer_key = transfer_restart.key();
 
                 let Some(old_transfer) = transfer::helpers::get_transfer(&transfer_key, &transfers)
                 else {
@@ -355,11 +356,10 @@ impl TableOfContent {
                     )));
                 };
 
-                // Transfer must have changed configuration
-                if transfers.contains(&transfer) {
+                if old_transfer.method == Some(transfer_restart.method) {
                     return Err(StorageError::bad_request(format!(
                         "Cannot restart transfer for shard {} from {} to {}, its configuration did not change",
-                        transfer.shard_id, transfer.from, transfer.to,
+                        transfer_restart.shard_id, transfer_restart.from, transfer_restart.to,
                     )));
                 }
 
@@ -367,15 +367,19 @@ impl TableOfContent {
                 self.handle_transfer(
                     collection_id.clone(),
                     ShardTransferOperations::Abort {
-                        transfer: transfer.key(),
+                        transfer: transfer_restart.key(),
                         reason: "restart transfer".into(),
                     },
                 )
                 .await?;
 
-                // Preserve sync flag from the old or new transfer
-                let mut new_transfer = transfer.clone();
-                new_transfer.sync = old_transfer.sync || new_transfer.sync;
+                let new_transfer = ShardTransfer {
+                    shard_id: transfer_restart.shard_id,
+                    from: transfer_restart.from,
+                    to: transfer_restart.to,
+                    sync: old_transfer.sync, // Preserve sync flag from the old transfer
+                    method: Some(transfer_restart.method),
+                };
 
                 self.handle_transfer(collection_id, ShardTransferOperations::Start(new_transfer))
                     .await?;

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -14,7 +14,7 @@ use collection::operations::types::{
 };
 use collection::shards::replica_set;
 use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
-use collection::shards::transfer::{ShardTransfer, ShardTransferKey};
+use collection::shards::transfer::{ShardTransfer, ShardTransferKey, ShardTransferRestart};
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use storage::content_manager::collection_meta_ops::ShardTransferOperations::{Abort, Start};
@@ -465,11 +465,10 @@ pub async fn do_update_collection_cluster(
                 .submit_collection_meta_op(
                     CollectionMetaOperations::TransferShard(
                         collection_name,
-                        ShardTransferOperations::Restart(ShardTransfer {
+                        ShardTransferOperations::Restart(ShardTransferRestart {
                             shard_id,
                             to: to_peer_id,
                             from: from_peer_id,
-                            sync: false, // This value will be ignored
                             method,
                         }),
                     ),


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Related to: <https://github.com/qdrant/qdrant/pull/3703#discussion_r1507431125>

When restarting a shard transfer, set `sync=true` if the old transfer was also using sync.

This should have been part of <https://github.com/qdrant/qdrant/pull/3703>, but I accidentally merged too early.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?