### PR TITLE
Stop uploading logs on consensus test error

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,13 +62,6 @@ jobs:
       - name: Run integration tests - multiple peers - pytest
         run: pytest ./tests/consensus_tests
         timeout-minutes: 60
-      - name: upload logs in case of failure
-        uses: actions/upload-artifact@v4
-        if: failure() || cancelled()
-        with:
-          name: consensus-test-logs
-          retention-days: 90 # default max value
-          path: consensus_test_logs
 
   test-consensus-compose:
 


### PR DESCRIPTION
This PR removes the upload of logs when the consensus tests fail.

The reason is that, since we changed our logs backend in https://github.com/qdrant/qdrant/pull/2381 the logs are now outputted to stdout.

This makes debugging in the GitHub action UI convenient but it also prevents logs from being written to the files.

The consequence is that we are pushing empty archives now, containing only the directories structure.

![empty](https://github.com/qdrant/qdrant/assets/606963/4f8cad0a-e138-4dfb-bac0-6e012486cdb5)

I think it makes sense to sense the upload process and keep the current logging configuration.
