### PR TITLE
Attempt to improve WAL delta tests, don't fall through transfers finished barrier

### DIFF
--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -68,8 +68,8 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[0], COLLECTION_NAME, 1)
 
     # Confirm empty WAL delta based on debug message in stdout
     stdout, _stderr = capfd.readouterr()
@@ -87,8 +87,8 @@ def test_empty_shard_wal_delta_transfer(capfd, tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[1], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[1], COLLECTION_NAME, 1)
 
     # Confirm empty WAL delta based on debug message in stdout
     stdout, _stderr = capfd.readouterr()
@@ -173,8 +173,8 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path, capfd)
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[0], COLLECTION_NAME, 1)
 
     # Confirm WAL delta transfer based on stdout logs, assert its size
     stdout, _stderr = capfd.readouterr()
@@ -275,8 +275,8 @@ def test_shard_wal_delta_transfer_manual_recovery_chain(tmp_path: pathlib.Path, 
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[0], COLLECTION_NAME, 1)
 
     # Start inserting into the fourth peer again
     upload_process_4 = run_update_points_in_background(peer_api_uris[3], COLLECTION_NAME, init_offset=600000, throttle=True)
@@ -301,8 +301,8 @@ def test_shard_wal_delta_transfer_manual_recovery_chain(tmp_path: pathlib.Path, 
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[3], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[3], COLLECTION_NAME, 1)
 
     upload_process_1.kill()
     upload_process_2.kill()
@@ -381,8 +381,8 @@ def test_shard_wal_delta_transfer_fallback(capfd, tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[0], COLLECTION_NAME, 1)
 
     # Confirm that we fall back to a different method after WAL delta fails
     stdout, _stderr = capfd.readouterr()
@@ -467,8 +467,8 @@ def test_shard_fallback_on_big_diff(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
-    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+    # Wait for transfer to start and end
+    wait_for_collection_shard_transfers_start_complete(peer_api_uris[0], COLLECTION_NAME, 1)
 
     # Match all points on all nodes exactly
     data = []

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -412,6 +412,19 @@ def wait_for_collection_shard_transfers_count(peer_api_uri: str, collection_name
         raise e
 
 
+def wait_for_collection_shard_transfers_start_complete(peer_api_uri: str, collection_name: str,
+                                              expected_shard_transfer_count: int = 1):
+    # Wait for the given number of shard transfers to start, and then complete
+    # This helps prevent falling through checks for all transfers to be done,
+    # even before the transfer has started
+    try:
+        wait_for(check_collection_shard_transfers_count, peer_api_uri, collection_name, expected_shard_transfer_count)
+        wait_for(check_collection_shard_transfers_count, peer_api_uri, collection_name, 0)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+
 def wait_for_collection_local_shards_count(peer_api_uri: str, collection_name: str, expected_local_shard_count: int):
     try:
         wait_for(check_collection_local_shards_count, peer_api_uri, collection_name, expected_local_shard_count)


### PR DESCRIPTION
This change attempts to improve reliability of some barrier checks in WAL delta tests.

This barrier makes sure to wait until there are no more ongoing shard transfers, before we continue with the rest of the test. But, if we check the condition too early and the shard transfer has not yet started, we simply fall through it, not waiting at all.

To improve on this I've changed this barrier to wait for 2 states in order: first, wait for the specified number of ongoing transfers. Second, wait for no ongoing transfers. This prevents falling through.

This change was my first attempt to fix the recent flaky test we've seen. It didn't solve it directly, but I still think it's a good improvement. That's why I'm submitting it in a separate PR here.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?