### PR TITLE
Fix: Validate `datetime_range` in `FieldCondition` validation

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1211,10 +1211,10 @@ impl TryFrom<DatetimeRange> for segment::types::RangeInterface {
 
     fn try_from(value: DatetimeRange) -> Result<Self, Self::Error> {
         Ok(Self::DateTime(segment::types::Range {
-            lt: value.lt.map(date_time_from_proto).transpose()?,
-            gt: value.gt.map(date_time_from_proto).transpose()?,
-            gte: value.gte.map(date_time_from_proto).transpose()?,
-            lte: value.lte.map(date_time_from_proto).transpose()?,
+            lt: value.lt.map(try_date_time_from_proto).transpose()?,
+            gt: value.gt.map(try_date_time_from_proto).transpose()?,
+            gte: value.gte.map(try_date_time_from_proto).transpose()?,
+            lte: value.lte.map(try_date_time_from_proto).transpose()?,
         }))
     }
 }
@@ -1384,7 +1384,7 @@ pub fn date_time_to_proto(date_time: DateTimePayloadType) -> prost_wkt_types::Ti
     naive_date_time_to_proto(date_time.0.naive_utc())
 }
 
-pub fn date_time_from_proto(
+pub fn try_date_time_from_proto(
     date_time: prost_wkt_types::Timestamp,
 ) -> Result<DateTimePayloadType, Status> {
     chrono::NaiveDateTime::from_timestamp_opt(

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use common::validation::{validate_move_shard_different_peers, validate_range_generic};
 use validator::{Validate, ValidationError, ValidationErrors};
 
-use super::qdrant::{GeoLineString, NamedVectors};
+use super::qdrant as grpc;
 
 const TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800; // 0001-01-01T00:00:00Z
 const TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799; // 9999-12-31T23:59:59Z
@@ -66,9 +66,9 @@ where
     }
 }
 
-impl Validate for crate::grpc::qdrant::vectors_config::Config {
+impl Validate for grpc::vectors_config::Config {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::vectors_config::Config;
+        use grpc::vectors_config::Config;
         match self {
             Config::Params(params) => params.validate(),
             Config::ParamsMap(params_map) => params_map.validate(),
@@ -76,9 +76,9 @@ impl Validate for crate::grpc::qdrant::vectors_config::Config {
     }
 }
 
-impl Validate for crate::grpc::qdrant::vectors_config_diff::Config {
+impl Validate for grpc::vectors_config_diff::Config {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::vectors_config_diff::Config;
+        use grpc::vectors_config_diff::Config;
         match self {
             Config::Params(params) => params.validate(),
             Config::ParamsMap(params_map) => params_map.validate(),
@@ -86,9 +86,9 @@ impl Validate for crate::grpc::qdrant::vectors_config_diff::Config {
     }
 }
 
-impl Validate for crate::grpc::qdrant::quantization_config::Quantization {
+impl Validate for grpc::quantization_config::Quantization {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::quantization_config::Quantization;
+        use grpc::quantization_config::Quantization;
         match self {
             Quantization::Scalar(scalar) => scalar.validate(),
             Quantization::Product(product) => product.validate(),
@@ -97,9 +97,9 @@ impl Validate for crate::grpc::qdrant::quantization_config::Quantization {
     }
 }
 
-impl Validate for crate::grpc::qdrant::quantization_config_diff::Quantization {
+impl Validate for grpc::quantization_config_diff::Quantization {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::quantization_config_diff::Quantization;
+        use grpc::quantization_config_diff::Quantization;
         match self {
             Quantization::Scalar(scalar) => scalar.validate(),
             Quantization::Product(product) => product.validate(),
@@ -109,9 +109,9 @@ impl Validate for crate::grpc::qdrant::quantization_config_diff::Quantization {
     }
 }
 
-impl Validate for crate::grpc::qdrant::update_collection_cluster_setup_request::Operation {
+impl Validate for grpc::update_collection_cluster_setup_request::Operation {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::update_collection_cluster_setup_request::Operation;
+        use grpc::update_collection_cluster_setup_request::Operation;
         match self {
             Operation::MoveShard(op) => op.validate(),
             Operation::ReplicateShard(op) => op.validate(),
@@ -124,13 +124,13 @@ impl Validate for crate::grpc::qdrant::update_collection_cluster_setup_request::
     }
 }
 
-impl Validate for crate::grpc::qdrant::MoveShard {
+impl Validate for grpc::MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
         validate_move_shard_different_peers(self.from_peer_id, self.to_peer_id)
     }
 }
 
-impl Validate for crate::grpc::qdrant::CreateShardKey {
+impl Validate for grpc::CreateShardKey {
     fn validate(&self) -> Result<(), ValidationErrors> {
         if self.replication_factor == Some(0) {
             let mut errors = ValidationErrors::new();
@@ -154,21 +154,21 @@ impl Validate for crate::grpc::qdrant::CreateShardKey {
     }
 }
 
-impl Validate for crate::grpc::qdrant::DeleteShardKey {
+impl Validate for grpc::DeleteShardKey {
     fn validate(&self) -> Result<(), ValidationErrors> {
         Ok(())
     }
 }
 
-impl Validate for crate::grpc::qdrant::RestartTransfer {
+impl Validate for grpc::RestartTransfer {
     fn validate(&self) -> Result<(), ValidationErrors> {
         Ok(())
     }
 }
 
-impl Validate for crate::grpc::qdrant::condition::ConditionOneOf {
+impl Validate for grpc::condition::ConditionOneOf {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        use crate::grpc::qdrant::condition::ConditionOneOf;
+        use grpc::condition::ConditionOneOf;
         match self {
             ConditionOneOf::Field(field_condition) => field_condition.validate(),
             ConditionOneOf::Nested(nested) => nested.validate(),
@@ -180,14 +180,26 @@ impl Validate for crate::grpc::qdrant::condition::ConditionOneOf {
     }
 }
 
-impl Validate for crate::grpc::qdrant::FieldCondition {
+impl Validate for grpc::FieldCondition {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        let all_fields_none = self.r#match.is_none()
-            && self.range.is_none()
-            && self.geo_bounding_box.is_none()
-            && self.geo_radius.is_none()
-            && self.geo_polygon.is_none()
-            && self.values_count.is_none();
+        let grpc::FieldCondition {
+            key: _,
+            r#match,
+            range,
+            datetime_range,
+            geo_bounding_box,
+            geo_radius,
+            geo_polygon,
+            values_count,
+        } = self;
+
+        let all_fields_none = r#match.is_none()
+            && range.is_none()
+            && datetime_range.is_none()
+            && geo_bounding_box.is_none()
+            && geo_radius.is_none()
+            && geo_polygon.is_none()
+            && values_count.is_none();
 
         if all_fields_none {
             let mut errors = ValidationErrors::new();
@@ -202,7 +214,7 @@ impl Validate for crate::grpc::qdrant::FieldCondition {
     }
 }
 
-impl Validate for crate::grpc::qdrant::Vector {
+impl Validate for grpc::Vector {
     fn validate(&self) -> Result<(), ValidationErrors> {
         if let Some(indices) = &self.indices {
             sparse::common::sparse_vector::validate_sparse_vector_impl(&indices.data, &self.data)
@@ -279,7 +291,7 @@ pub fn validate_f64_range_min_1(value: &Option<f64>) -> Result<(), ValidationErr
 
 /// Validate the list of named vectors is not empty.
 pub fn validate_named_vectors_not_empty(
-    value: &Option<NamedVectors>,
+    value: &Option<grpc::NamedVectors>,
 ) -> Result<(), ValidationError> {
     // If length is non-zero, we're good
     match value {
@@ -293,7 +305,7 @@ pub fn validate_named_vectors_not_empty(
 }
 
 /// Validate that GeoLineString has at least 4 points and is closed.
-pub fn validate_geo_polygon_line_helper(line: &GeoLineString) -> Result<(), ValidationError> {
+pub fn validate_geo_polygon_line_helper(line: &grpc::GeoLineString) -> Result<(), ValidationError> {
     let points = &line.points;
     let min_length = 4;
     if points.len() < min_length {
@@ -312,7 +324,9 @@ pub fn validate_geo_polygon_line_helper(line: &GeoLineString) -> Result<(), Vali
     Ok(())
 }
 
-pub fn validate_geo_polygon_exterior(line: &Option<GeoLineString>) -> Result<(), ValidationError> {
+pub fn validate_geo_polygon_exterior(
+    line: &Option<grpc::GeoLineString>,
+) -> Result<(), ValidationError> {
     match line {
         Some(l) => {
             if l.points.is_empty() {
@@ -325,7 +339,9 @@ pub fn validate_geo_polygon_exterior(line: &Option<GeoLineString>) -> Result<(),
     }
 }
 
-pub fn validate_geo_polygon_interiors(lines: &Vec<GeoLineString>) -> Result<(), ValidationError> {
+pub fn validate_geo_polygon_interiors(
+    lines: &Vec<grpc::GeoLineString>,
+) -> Result<(), ValidationError> {
     for line in lines {
         validate_geo_polygon_line_helper(line)?;
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use api::grpc::conversions::{
     convert_shard_key_from_grpc, convert_shard_key_from_grpc_opt, convert_shard_key_to_grpc,
-    date_time_from_proto, from_grpc_dist, json_path_from_proto, payload_to_proto,
-    proto_to_payloads,
+    from_grpc_dist, json_path_from_proto, payload_to_proto, proto_to_payloads,
+    try_date_time_from_proto,
 };
 use api::grpc::qdrant::quantization_config_diff::Quantization;
 use api::grpc::qdrant::update_collection_cluster_setup_request::{
@@ -1829,7 +1829,7 @@ impl TryFrom<api::grpc::qdrant::OrderBy> for OrderByInterface {
                         Ok(StartFrom::Float(float))
                     }
                     api::grpc::qdrant::start_from::Value::Timestamp(timestamp) => {
-                        Ok(StartFrom::Datetime(date_time_from_proto(timestamp)?))
+                        Ok(StartFrom::Datetime(try_date_time_from_proto(timestamp)?))
                     }
                     api::grpc::qdrant::start_from::Value::Datetime(datetime_str) => Ok(
                         StartFrom::Datetime(DateTimeWrapper::from_str(&datetime_str).map_err(


### PR DESCRIPTION
We were missing to include `datetime_range.is_none()` in the validation of FieldCondition, which caused any field condition with only a datetime range to fail validation, as if no condition was set.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
