### PR TITLE
Fix batch_requests

### DIFF
--- a/tests/openapi/openapi_integration/test_basic_retrieve_api.py
+++ b/tests/openapi/openapi_integration/test_basic_retrieve_api.py
@@ -114,6 +114,42 @@ def test_exclude_payload():
         assert 'city' not in result['payload']
 
 
+def test_batch_search():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/batch",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "searches": [
+                {
+                    "vector": [0.2, 0.1, 0.9, 0.7],
+                    "limit": 3,
+                },
+                {
+                    "filter": {
+                        "should": [{"key": "city", "match": {"value": "London"}}]
+                    },
+                    "vector": [0.2, 0.1, 0.9, 0.7],
+                    "limit": 3,
+                },
+            ],
+        },
+    )
+    assert response.ok
+    assert len(response.json()["result"]) == 2
+    assert len(response.json()["result"][0]) == 3
+    assert len(response.json()["result"][1]) == 2
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search/batch",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={"searches": []},
+    )
+    assert response.ok
+    assert len(response.json()["result"]) == 0
+
+
 def test_is_empty_condition():
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',


### PR DESCRIPTION
This PR fixes a panic reported in #3737. Basically, current qdrant crashes on empty batch searches like this
```
curl -X POST http://localhost:6333/collections/NAME/points/search/batch -d '{"searches": []}'
```
due to `.next().unwrap()` being used on a iterator.

Closes #3737.