### PR TITLE
Add `ShardTransferOperations::RecoveryToPartial`

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -324,28 +324,6 @@ impl Collection {
         state: ReplicaState,
         from_state: Option<ReplicaState>,
     ) -> CollectionResult<()> {
-        self.set_shard_replica_state_impl(shard_id, peer_id, state, |current_state| {
-            let Some(from_state) = from_state else {
-                return Ok(());
-            };
-
-            if current_state == Some(from_state) {
-                Ok(())
-            } else {
-                Err(CollectionError::bad_input(format!(
-                    "Replica {peer_id} of shard {shard_id} has state {current_state:?}, but expected {from_state:?}"
-                )))
-            }
-        }).await
-    }
-
-    pub async fn set_shard_replica_state_impl(
-        &self,
-        shard_id: ShardId,
-        peer_id: PeerId,
-        state: ReplicaState,
-        assert_current_state: impl Fn(Option<ReplicaState>) -> CollectionResult<()>,
-    ) -> CollectionResult<()> {
         let shard_holder = self.shards_holder.read().await;
         let replica_set = shard_holder
             .get_shard(&shard_id)
@@ -358,8 +336,16 @@ impl Collection {
         );
 
         // Validation:
-        // 0. Check that shard is in expected state
-        assert_current_state(replica_set.peer_state(&peer_id))?;
+        // 0. Check that `from_state` matches current state
+
+        if from_state.is_some() {
+            let current_state = replica_set.peer_state(&peer_id);
+            if current_state != from_state {
+                return Err(CollectionError::bad_input(format!(
+                    "Replica {peer_id} of shard {shard_id} has state {current_state:?}, but expected {from_state:?}"
+                )));
+            }
+        }
 
         // 1. Do not deactivate the last active replica
 

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -304,6 +304,11 @@ pub enum ShardTransferOperations {
     /// Called when the snapshot has successfully been recovered on the remote, brings the transfer
     /// to the next stage.
     SnapshotRecovered(ShardTransferKey),
+    /// Used in `ShardTransferMethod::Snapshot` and `ShardTransferMethod::WalDelta`
+    ///
+    /// Called when the first stage of the transfer has been successfully finished, brings the
+    /// transfer to the next stage.
+    RecoveryToPartial(ShardTransferKey),
     Abort {
         transfer: ShardTransferKey,
         reason: String,

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -400,21 +400,51 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
 
-                // Set shard state from `PartialSnapshot` to `Partial`
-                // TODO(1.9): get into Partial state from PartialSnapshot or Recovery
-                let operation = SetShardReplicaState {
-                    collection_name: collection_id,
-                    shard_id: transfer.shard_id,
-                    peer_id: transfer.to,
-                    state: ReplicaState::Partial,
-                    from_state: Some(ReplicaState::PartialSnapshot),
+                let collection = self.get_collection(&collection_id).await?;
+
+                let current_state = collection
+                    .state()
+                    .await
+                    .shards
+                    .get(&transfer.shard_id)
+                    .and_then(|info| info.replicas.get(&transfer.to))
+                    .copied();
+
+                let Some(current_state) = current_state else {
+                    return Err(StorageError::bad_input(format!(
+                        "Replica {} of {collection_id}:{} does not exist",
+                        transfer.to, transfer.shard_id,
+                    )));
                 };
+
+                match current_state {
+                    ReplicaState::PartialSnapshot | ReplicaState::Recovery => (),
+                    _ => {
+                        return Err(StorageError::bad_input(format!(
+                            "Replica {} of {collection_id}:{} has unexpected {current_state:?} \
+                             (expected {:?} or {:?})",
+                            transfer.to,
+                            transfer.shard_id,
+                            ReplicaState::PartialSnapshot,
+                            ReplicaState::Recovery,
+                        )))
+                    }
+                }
+
                 log::debug!(
                     "Set shard replica state from {:?} to {:?} after snapshot recovery",
-                    ReplicaState::PartialSnapshot,
+                    current_state,
                     ReplicaState::Partial,
                 );
-                self.set_shard_replica_state(operation).await?;
+
+                collection
+                    .set_shard_replica_state(
+                        transfer.shard_id,
+                        transfer.to,
+                        ReplicaState::Partial,
+                        Some(current_state),
+                    )
+                    .await?;
             }
             ShardTransferOperations::Abort { transfer, reason } => {
                 // Validate transfer exists to prevent double handling

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use async_recursion::async_recursion;
 use collection::collection_state;
 use collection::config::ShardingMethod;
+use collection::operations::types::CollectionError;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
 use collection::shards::transfer::ShardTransfer;
@@ -400,21 +401,38 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
 
-                // Set shard state from `PartialSnapshot` to `Partial`
-                // TODO(1.9): get into Partial state from PartialSnapshot or Recovery
-                let operation = SetShardReplicaState {
-                    collection_name: collection_id,
-                    shard_id: transfer.shard_id,
-                    peer_id: transfer.to,
-                    state: ReplicaState::Partial,
-                    from_state: Some(ReplicaState::PartialSnapshot),
-                };
                 log::debug!(
-                    "Set shard replica state from {:?} to {:?} after snapshot recovery",
+                    "Set shard replica state from {:?} or {:?} to {:?} after snapshot recovery",
                     ReplicaState::PartialSnapshot,
+                    ReplicaState::Recovery,
                     ReplicaState::Partial,
                 );
-                self.set_shard_replica_state(operation).await?;
+
+                // Set shard state from `PartialSnapshot` or `Recovery` to `Partial`
+                self.get_collection(&collection_id)
+                    .await?
+                    .set_shard_replica_state_impl(
+                        transfer.shard_id,
+                        transfer.to,
+                        ReplicaState::Partial,
+                        |current_state| {
+                            match current_state {
+                                Some(ReplicaState::PartialSnapshot) => Ok(()),
+                                Some(ReplicaState::Recovery) => Ok(()),
+                                _ => {
+                                    Err(CollectionError::bad_input(format!(
+                                        "Replica {} of {collection_id}:{} has unexpected {current_state:?} \
+                                         (expected {:?} or {:?})",
+                                        transfer.to,
+                                        transfer.shard_id,
+                                        ReplicaState::PartialSnapshot,
+                                        ReplicaState::Recovery,
+                                    )))
+                                }
+                            }
+                        }
+                    )
+                    .await?;
             }
             ShardTransferOperations::Abort { transfer, reason } => {
                 // Validate transfer exists to prevent double handling

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -392,7 +392,8 @@ impl TableOfContent {
                 )?;
                 collection.finish_shard_transfer(transfer).await?;
             }
-            ShardTransferOperations::SnapshotRecovered(transfer) => {
+            ShardTransferOperations::SnapshotRecovered(transfer)
+            | ShardTransferOperations::RecoveryToPartial(transfer) => {
                 // Validate transfer exists to prevent double handling
                 transfer::helpers::validate_transfer_exists(
                     &transfer,


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

- Add `RecoveryToPartial` operation (that is, basically, an alias for `SnapshotRecovered`)
- Slightly extend `SnapshotRecovered`/`RecoveryToPartial` handling...
  - so that both operations switch to `Partial` from *either* `PartialSnapshot` *or* `Recovery`
  - this is necessary, because *later*, when upgrading cluster from 1.8.* to 1.9.*, it is possible
    - for 1.8.* nodes to have a replica in `PartialSnapshot` state, and receive `RecoveryToPartial` operation
    - for 1.9.* nodes to have a replica in `Recovery` state, and receive `SnapshotRecovered` operation
  - some other options are possible as well, but allowing switching from both states seems like a simple and safe solution
- Also added `Collection::set_shard_replica_state_impl` method to be able to do the "`PartialSnapshot` *or* `Recovery`" check
  - (please feel free to suggest better method name)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
