### PR TITLE
Remove checksum path parameter for snapshot recovery in openapi

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -1817,15 +1817,6 @@
             "schema": {
               "type": "boolean"
             }
-          },
-          {
-            "name": "checksum",
-            "in": "query",
-            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -2699,15 +2690,6 @@
             "required": false,
             "schema": {
               "type": "boolean"
-            }
-          },
-          {
-            "name": "checksum",
-            "in": "query",
-            "description": "Optional SHA256 checksum to verify snapshot integrity before recovery.",
-            "required": false,
-            "schema": {
-              "type": "string"
             }
           }
         ],

--- a/openapi/openapi-shard-snapshots.ytt.yaml
+++ b/openapi/openapi-shard-snapshots.ytt.yaml
@@ -78,12 +78,6 @@ paths:
           required: false
           schema:
             type: boolean
-        - name: checksum
-          in: query
-          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
-          required: false
-          schema:
-            type: string
       requestBody:
         description: Snapshot to recover from
         content:

--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -66,12 +66,6 @@ paths:
           required: false
           schema:
             type: boolean
-        - name: checksum
-          in: query
-          description: "Optional SHA256 checksum to verify snapshot integrity before recovery."
-          required: false
-          schema:
-            type: string
       requestBody:
         description: Snapshot to recover from
         content:

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -260,6 +260,7 @@ async fn get_snapshot(
     let (collection_name, snapshot_name) = path.into_inner();
     do_get_snapshot(&toc, &collection_name, &snapshot_name).await
 }
+
 #[get("/snapshots")]
 async fn list_full_snapshots(toc: web::Data<TableOfContent>) -> impl Responder {
     let timing = Instant::now();


### PR DESCRIPTION
Endpoints
```
/collections/{collection_name}/snapshots/recover
/collections/{collection_name}/shards/{shard_id}/snapshots/recover
```
have `checksum` parameter as in a JSON body, not in query path. This PR removes non-exist query path parameters.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
