### PR TITLE
Report basic progress for WAL delta and snapshot transfer

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -320,7 +320,7 @@ struct Inner {
     /// See `set_wal_keep_from()` and `UpdateHandler::wal_keep_from` for more details.
     /// Defaults to `u64::MAX` to allow acknowledging all confirmed versions.
     wal_keep_from: Arc<AtomicU64>,
-    /// Optiona progression tracker.
+    /// Optional progression tracker.
     progress: Option<Arc<ParkingMutex<TransferTaskProgress>>>,
 }
 

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -332,21 +332,13 @@ impl Inner {
         progress: Option<Arc<ParkingMutex<TransferTaskProgress>>>,
     ) -> Self {
         let start_from = wrapped_shard.wal.wal.lock().last_index() + 1;
-
-        let shard = Self {
+        Self::new_from_version(
             wrapped_shard,
             remote_shard,
-            started_at: start_from,
-            transfer_from: start_from.into(),
-            update_lock: Default::default(),
             wal_keep_from,
+            start_from,
             progress,
-        };
-
-        // Keep all new WAL entries so we don't truncate them off when we still need to transfer
-        shard.set_wal_keep_from(Some(start_from));
-
-        shard
+        )
     }
 
     pub fn new_from_version(

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -412,6 +412,12 @@ impl Inner {
             (items_left, items_total, batch)
         };
 
+        // Set initial progress on the first batch
+        let is_first = transfer_from == self.started_at;
+        if is_first {
+            self.update_progress(0, total as usize);
+        }
+
         log::trace!(
             "Queue proxy transferring batch of {} updates to peer {}",
             batch.len(),

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -97,7 +97,7 @@ impl ShardReplicaSet {
         &self,
         remote_shard: RemoteShard,
         from_version: Option<u64>,
-        progress: Option<Arc<Mutex<TransferTaskProgress>>>,
+        progress: Arc<Mutex<TransferTaskProgress>>,
     ) -> CollectionResult<()> {
         let mut local = self.local.write().await;
 

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -87,6 +87,7 @@ pub async fn transfer_shard(
             let result = transfer_wal_delta(
                 transfer_config.clone(),
                 shard_holder.clone(),
+                progress.clone(),
                 shard_id,
                 remote_shard.clone(),
                 channel_service.clone(),

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -70,7 +70,8 @@ pub async fn transfer_shard(
         ShardTransferMethod::Snapshot => {
             transfer_snapshot(
                 transfer_config,
-                shard_holder.clone(),
+                shard_holder,
+                progress,
                 shard_id,
                 remote_shard,
                 channel_service,

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -179,7 +179,7 @@ pub(super) async fn transfer_snapshot(
 
     // Queue proxy local shard
     replica_set
-        .queue_proxify_local(remote_shard.clone(), None)
+        .queue_proxify_local(remote_shard.clone(), None, None)
         .await?;
 
     debug_assert!(

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -182,7 +182,7 @@ pub(super) async fn transfer_snapshot(
 
     // Queue proxy local shard
     replica_set
-        .queue_proxify_local(remote_shard.clone(), None, Some(progress))
+        .queue_proxify_local(remote_shard.clone(), None, progress)
         .await?;
 
     debug_assert!(

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -2,8 +2,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use common::defaults;
+use parking_lot::Mutex;
 use tempfile::TempPath;
 
+use super::transfer_tasks_pool::TransferTaskProgress;
 use super::{ShardTransfer, ShardTransferConsensus};
 use crate::operations::snapshot_ops::{get_checksum_path, SnapshotPriority};
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -153,6 +155,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 pub(super) async fn transfer_snapshot(
     transfer_config: ShardTransfer,
     shard_holder: Arc<LockedShardHolder>,
+    progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
     channel_service: ChannelService,
@@ -179,7 +182,7 @@ pub(super) async fn transfer_snapshot(
 
     // Queue proxy local shard
     replica_set
-        .queue_proxify_local(remote_shard.clone(), None, None)
+        .queue_proxify_local(remote_shard.clone(), None, Some(progress))
         .await?;
 
     debug_assert!(

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -115,11 +115,7 @@ pub(super) async fn transfer_wal_delta(
     if let Some(wal_delta_version) = wal_delta_version {
         // Queue proxy local shard
         replica_set
-            .queue_proxify_local(
-                remote_shard.clone(),
-                Some(wal_delta_version),
-                Some(progress),
-            )
+            .queue_proxify_local(remote_shard.clone(), Some(wal_delta_version), progress)
             .await?;
 
         debug_assert!(

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -70,6 +70,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 ///
 /// If cancelled - the remote shard may only be partially recovered/transferred and the local shard
 /// may be left in an unexpected state. This must be resolved manually in case of cancellation.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn transfer_wal_delta(
     transfer_config: ShardTransfer,
     shard_holder: Arc<LockedShardHolder>,

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use common::defaults;
+use parking_lot::Mutex;
 
+use super::transfer_tasks_pool::TransferTaskProgress;
 use super::{ShardTransfer, ShardTransferConsensus};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::channel_service::ChannelService;
@@ -71,6 +73,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 pub(super) async fn transfer_wal_delta(
     transfer_config: ShardTransfer,
     shard_holder: Arc<LockedShardHolder>,
+    progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,
     channel_service: ChannelService,
@@ -111,7 +114,11 @@ pub(super) async fn transfer_wal_delta(
     if let Some(wal_delta_version) = wal_delta_version {
         // Queue proxy local shard
         replica_set
-            .queue_proxify_local(remote_shard.clone(), Some(wal_delta_version))
+            .queue_proxify_local(
+                remote_shard.clone(),
+                Some(wal_delta_version),
+                Some(progress),
+            )
             .await?;
 
         debug_assert!(


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add basic progress reporting for WAL delta and snapshot transfer.

More specifically: enable reporting on how many records are being transferred (and how many to transfer in total) while the queue proxy is transferring updates to a remote shard.

This is not yet reported, and may be done in a separate PR later:
- process of resolving WAL delta
- snapshot creation
- snapshot transfer
- snapshot recovery

Exposing progress like this will help us improve our tests, and assertions we make in it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?