### PR TITLE
Try to make `/readyz` check more reliable

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -20,7 +20,6 @@ use tokio::{runtime, sync, time};
 const READY_CHECK_TIMEOUT: Duration = Duration::from_millis(500);
 const GET_CONSENSUS_COMMITS_RETRIES: usize = 2;
 
-
 /// Structure used to process health checks like `/readyz` endpoints.
 pub struct HealthChecker {
     // The state of the health checker.

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,8 @@ fn main() -> anyhow::Result<()> {
             toc_arc.clone(),
             consensus_state.clone(),
             runtime_handle.clone(),
+            // NOTE: `wait_for_bootstrap` should be calculated *before* starting `Consensus` thread
+            consensus_state.is_new_deployment() && args.bootstrap.is_some(),
         ));
 
         let handle = Consensus::run(


### PR DESCRIPTION
Try to make `/readyz` check more reliable after cluster upgrade incident last week.

__TODO:__
- [x] Explicitly handle bootstrapping *new* cluster node
  - currently, the node may report "ready" right after startup, because for a short moment before *joining* the cluster, it considers itself the *only* node in the cluster, and `/readyz` instantly returns "ready" in that case

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
