### PR TITLE
Update Rustls 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,11 +209,11 @@ dependencies = [
  "futures-core",
  "impl-more",
  "pin-project-lite",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tracing",
- "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -2360,9 +2360,9 @@ checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http 0.2.9",
  "hyper",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3972,8 +3972,9 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rstack-self",
- "rustls",
+ "rustls 0.22.2",
  "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "rusty-hook",
  "schemars",
  "sealed_test",
@@ -4269,14 +4270,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-pemfile 1.0.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -4520,6 +4521,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.5",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -4561,6 +4576,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.5",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.5",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -5157,9 +5183,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "symbolic-common"
@@ -5490,7 +5516,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5585,7 +5622,7 @@ dependencies = [
  "prost 0.11.9",
  "rustls-pemfile 1.0.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -5877,7 +5914,7 @@ dependencies = [
  "base64 0.21.0",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.21.10",
  "rustls-webpki 0.100.2",
  "url",
  "webpki-roots 0.23.1",
@@ -6530,6 +6567,12 @@ name = "zerofrom"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655b0814c5c0b19ade497851070c640773304939a6c0fd5f5fb43da0696d05b7"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ tokio = { workspace = true }
 
 actix-cors = "0.7.0"
 actix-files = "0.6.5"
-actix-web = { version = "4.5.1", optional = true, features = ["rustls-0_21", "actix-tls"] }
+actix-web = { version = "4.5.1", optional = true, features = ["rustls-0_22", "actix-tls"] }
 actix-web-httpauth = "0.8.1"
 actix-web-validator = "5.0.1"
 tonic = { workspace = true }
@@ -77,7 +77,8 @@ tower = "0.4.13"
 tower-layer = "0.3.2"
 tar = "0.4.40"
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls", "blocking"] }
-rustls = "0.21.10"
+rustls = "0.22.2"
+rustls-pki-types = "1.3.1"
 rustls-pemfile = "2.1.1"
 prometheus = { version = "0.13.3", default-features = false }
 validator = { version = "0.16", features = ["derive"] }

--- a/src/actix/certificate_helpers.rs
+++ b/src/actix/certificate_helpers.rs
@@ -154,10 +154,10 @@ pub fn actix_tls_server_config(settings: &Settings) -> Result<ServerConfig> {
         let ca_certs: Vec<CertificateDer> = with_buf_read(&tls_config.ca_cert, |rd| {
             rustls_pemfile::certs(rd).collect()
         })?;
-        root_cert_store.add_parsable_certificates(ca_certs.into_iter());
+        root_cert_store.add_parsable_certificates(ca_certs);
         let client_cert_verifier = WebPkiClientVerifier::builder(root_cert_store.into())
             .build()
-            .map_err(Error::ClientCertVerifierError)?;
+            .map_err(Error::ClientCertVerifier)?;
         config.with_client_cert_verifier(client_cert_verifier)
     } else {
         config.with_no_client_auth()
@@ -198,6 +198,6 @@ pub enum Error {
     InvalidPrivateKey,
     #[error("TLS signing error")]
     Sign(#[source] rustls::Error),
-    #[error("client certificate verification error")]
-    ClientCertVerifierError(#[source] VerifierBuilderError),
+    #[error("client certificate verification")]
+    ClientCertVerifier(#[source] VerifierBuilderError),
 }

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -190,7 +190,7 @@ pub fn init(
 
             let config = certificate_helpers::actix_tls_server_config(&settings)
                 .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-            server.bind_rustls_021(bind_addr, config)?
+            server.bind_rustls_0_22(bind_addr, config)?
         } else {
             log::info!("TLS disabled for REST API");
 


### PR DESCRIPTION
There are numerous breaking changes which made this rather tedious TBH

I followed the official [migration guide](https://github.com/rustls/rustls/releases/tag/v%2F0.22.0).