### PR TITLE
Cancel shard transfers when shard is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "io",
  "issues",
  "itertools 0.12.1",
+ "lazy_static",
  "log",
  "merge",
  "ordered-float 4.2.0",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -33,6 +33,7 @@ wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
+lazy_static = "1.4.0"
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -376,7 +376,7 @@ impl Collection {
             // Terminate transfer if source or target replicas are now dead
             let related_transfers = shard_holder.get_related_transfers(&shard_id, &peer_id);
             for transfer in related_transfers {
-                self._abort_shard_transfer(transfer.key(), &shard_holder)
+                self.abort_shard_transfer(transfer.key(), Some(&shard_holder))
                     .await?;
             }
         }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -54,7 +54,6 @@ pub struct Collection {
     channel_service: ChannelService,
     transfer_tasks: Mutex<TransferTasksPool>,
     request_shard_transfer_cb: RequestShardTransfer,
-    #[allow(dead_code)] //Might be useful in case of repartition implementation
     notify_peer_failure_cb: ChangePeerState,
     abort_shard_transfer_cb: replica_set::AbortShardTransfer,
     init_time: Duration,

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -371,7 +371,7 @@ impl ShardReplicaSet {
 
     /// Send all queue proxy updates to remote
     ///
-    /// This method allows to transfer queued updates at any point, fbefore the shard is
+    /// This method allows to transfer queued updates at any point, before the shard is
     /// unproxified for example. This allows for proper error handling at the time this method is
     /// called. Because the shard is transformed into a forward proxy after this operation it will
     /// not error again when the shard is eventually unproxified again.

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -452,7 +452,7 @@ impl TableOfContent {
                     &collection.state().await.transfers,
                 )?;
                 log::warn!("Aborting shard transfer: {reason}");
-                collection.abort_shard_transfer(transfer).await?;
+                collection.abort_shard_transfer(transfer, None).await?;
             }
         };
         Ok(())

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -390,7 +390,7 @@ impl TableOfContent {
                     &transfer.key(),
                     &collection.state().await.transfers,
                 )?;
-                collection.finish_shard_transfer(transfer).await?;
+                collection.finish_shard_transfer(transfer, None).await?;
             }
             ShardTransferOperations::RecoveryToPartial(transfer)
             | ShardTransferOperations::SnapshotRecovered(transfer) => {


### PR DESCRIPTION
Currently, when "remove shard replica" consensus operation is processed, we don't handle shard transfers related to the removed replica in any way.

This PR:
- cancels all shard transfer tasks and then remove all shard transfers related to the removed shard
- when processing `ShardTransferOperations::Abort`, check all preconditions more carefully, before changing local state:
  - do *not* change replica state to `Dead`, if replica does not exist (happens if replica was deleted, and then transfer was aborted)
  - do *not* remove replica, if shard transfer does not exist (could happen due to `Option::map_or` call)
  - only revert local proxy shard, if transfer *exists* (it was possible to revert wrong shard if multiple `Abort`s were sent)

So far, @generall and I decided to *not* version gate these changes, because it's annoying to do, and it seems unlikely to trigger this code during cluster version upgrade.

__TODO:__
- [x] Can these changes introduce backward compatibility issues?
  - because local state will be slightly different on different versions
    - updated nodes will *not* have the transfer
    - but older nodes will *still* have one
  - __UPD:__ probably not, or, at least, it's non-critical, cause deleting shard replica is a *manual* operation, and it should also be possible to *manually* resolve these inconsistencies
- [x] Explicitly check that shard exists, when restarting the transfer?
  - __UPD:__ this one is still nice to have, and easy to implement, so it stays
- [ ] ~~Handle "shard not found" error during the transfer? Don't report error/don't restart the transfer automatically?~~
  - __UPD:__ seems like this is not strictly necessary, because if *transfer-receiver* node is updated, other fixes in this PR will prevent recreating the shard and restarting transfer infinitely

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
