### PR TITLE
Allow paths starting with numbers

### DIFF
--- a/lib/segment/src/json_path/parse.rs
+++ b/lib/segment/src/json_path/parse.rs
@@ -4,7 +4,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, digit1, none_of, satisfy};
 use nom::combinator::{map_res, recognize};
-use nom::multi::many0;
+use nom::multi::{many0, many1};
 use nom::sequence::{delimited, preceded};
 use nom::{IResult, Parser};
 
@@ -39,9 +39,8 @@ fn json_path(input: &str) -> IResult<&str, JsonPathV2> {
 }
 
 fn raw_str(input: &str) -> IResult<&str, &str> {
-    recognize(preceded(
-        satisfy(|c: char| c.is_alphabetic() || c == '_' || c == '-'),
-        many0(satisfy(|c: char| c.is_alphanumeric() || c == '_' || c == '-').map(|_: char| ())),
+    recognize(many1(
+        satisfy(|c: char| c.is_alphanumeric() || c == '_' || c == '-').map(|_: char| ()),
     ))
     .parse(input)
 }

--- a/tests/openapi/openapi_integration/test_payload_indexing.py
+++ b/tests/openapi/openapi_integration/test_payload_indexing.py
@@ -97,7 +97,7 @@ def test_index_with_numeric_key():
         query_params={'wait': 'true'},
         body={
             "field_name": "123",
-            "field_schema": "int"
+            "field_schema": "keyword"
         }
     )
     assert response.ok

--- a/tests/openapi/openapi_integration/test_payload_indexing.py
+++ b/tests/openapi/openapi_integration/test_payload_indexing.py
@@ -89,6 +89,19 @@ def set_payload(payload, points):
     )
     assert response.ok
 
+def test_index_with_numeric_key():
+    response = request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "123",
+            "field_schema": "int"
+        }
+    )
+    assert response.ok
+
 
 def test_boolean_index():
     bool_key = "boolean_payload"


### PR DESCRIPTION
Initially, the new JSON path implementation was rejecting identifiers starting with digits, to match up with `jq` and JavaScript syntax. However, some users reported that they rely on numerical paths which are rejected starting at v1.8.0.

This PR does the following change in accepted syntax for unquoted identifiers:
```diff
-First symbol is a letter, an underscore, or a hyphen.
+First symbol is a letter, a digit, an underscore, or a hyphen.
The rest consists of letters, digits, underscores, and hyphens.
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
