### PR TITLE
Attempt to improve WAL delta reliability: more throttling

### DIFF
--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -438,7 +438,7 @@ def wait_for_collection_shard_transfer_progress(peer_api_uri: str, collection_na
                                                  expected_transfer_progress: int = None,
                                                  expected_transfer_total: int = None):
     try:
-        wait_for(check_collection_shard_transfer_progress, peer_api_uri, collection_name, expected_transfer_progress, expected_transfer_total)
+        wait_for(check_collection_shard_transfer_progress, peer_api_uri, collection_name, expected_transfer_progress, expected_transfer_total, wait_for_interval=0.1)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name)
         raise e


### PR DESCRIPTION
Attempts to improve reliability for WAL delta tests by increasing the throttling interval.

It now hosts less concurrent insertions during tests - 10x less than before - which caused some flakyness on busy systems.

After merging this, I'll improve upon <https://github.com/qdrant/qdrant/pull/3723>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?