### PR TITLE
Update peer metadata through consensus for 1.9

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -750,9 +750,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         if let Err(err) = result {
             log::error!("Failed to propose consensus peer metadata update for this peer: {err}");
         }
-        self.next_peer_metadata_update_attempt
-            .lock()
-            .replace(Instant::now() + CONSENSUS_PEER_METADATA_UPDATE_INTERVAL);
+        *self.next_peer_metadata_update_attempt.lock() =
+            Instant::now() + CONSENSUS_PEER_METADATA_UPDATE_INTERVAL;
 
         Ok(())
     }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Enable updating the peer metadata through consensus if it is outdated.

The groundwork for this was already implemented in <https://github.com/qdrant/qdrant/pull/3702>. But we postponed enabling it to 1.9 for backwards compatibility.

To prevent spamming consensus I've added a cooldown, limiting these updates to one per minute.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?