### PR TITLE
Make shard diff transfer fallback to different method through consensus for 1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,6 @@ dependencies = [
  "api",
  "approx",
  "arc-swap",
- "async-recursion",
  "async-trait",
  "atomicwrites",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5213,6 +5213,7 @@ dependencies = [
  "anyhow",
  "api",
  "async-recursion",
+ "async-trait",
  "atomicwrites",
  "cancel",
  "chrono",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -70,7 +70,6 @@ bytes = "1.5.0"
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ringbuffer = "0.15.0"
-async-recursion = "1.1"
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -139,10 +139,6 @@ impl Collection {
         let shard_holder = self.shards_holder.clone();
         let collection_id = self.id.clone();
         let channel_service = self.channel_service.clone();
-        let default_shard_transfer_method = self
-            .shared_storage_config
-            .default_shard_transfer_method
-            .unwrap_or_default();
 
         let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
 
@@ -155,7 +151,6 @@ impl Collection {
             channel_service,
             self.snapshots_path.clone(),
             self.name(),
-            default_shard_transfer_method,
             temp_dir,
             on_finish,
             on_error,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -139,6 +139,10 @@ impl Collection {
         let shard_holder = self.shards_holder.clone();
         let collection_id = self.id.clone();
         let channel_service = self.channel_service.clone();
+        let default_shard_transfer_method = self
+            .shared_storage_config
+            .default_shard_transfer_method
+            .unwrap_or_default();
 
         let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
 
@@ -151,6 +155,7 @@ impl Collection {
             channel_service,
             self.snapshots_path.clone(),
             self.name(),
+            default_shard_transfer_method,
             temp_dir,
             on_finish,
             on_error,

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -90,11 +90,11 @@ pub async fn transfer_shard(
         ShardTransferMethod::WalDelta => {
             let result = transfer_wal_delta(
                 transfer_config.clone(),
-                shard_holder.clone(),
-                progress.clone(),
+                shard_holder,
+                progress,
                 shard_id,
-                remote_shard.clone(),
-                channel_service.clone(),
+                remote_shard,
+                channel_service,
                 consensus,
                 collection_name,
             )

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -103,10 +103,7 @@ pub async fn transfer_shard(
 
             // Handle failure, fall back to default transfer method or propagate error
             if let Err(err) = result {
-                log::warn!(
-                    "Failed to do shard diff transfer, falling back to default method {:?}: {err}",
-                    ShardTransferMethod::default(),
-                );
+                log::warn!("Failed to do shard diff transfer, falling back to default method {default_shard_transfer_method:?}: {err}");
                 let did_fall_back = transfer_shard_fallback_default(
                     transfer_config,
                     consensus,

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -41,7 +41,6 @@ pub async fn transfer_shard(
     collection_name: &str,
     channel_service: ChannelService,
     snapshots_path: &Path,
-    default_shard_transfer_method: ShardTransferMethod,
     temp_dir: &Path,
 ) -> CollectionResult<bool> {
     let shard_id = transfer_config.shard_id;
@@ -103,12 +102,13 @@ pub async fn transfer_shard(
 
             // Handle failure, fall back to default transfer method or propagate error
             if let Err(err) = result {
-                log::warn!("Failed to do shard diff transfer, falling back to default method {default_shard_transfer_method:?}: {err}");
+                let fallback_shard_transfer_method = ShardTransferMethod::default();
+                log::warn!("Failed to do shard diff transfer, falling back to default method {fallback_shard_transfer_method:?}: {err}");
                 let did_fall_back = transfer_shard_fallback_default(
                     transfer_config,
                     consensus,
                     collection_name,
-                    default_shard_transfer_method,
+                    fallback_shard_transfer_method,
                 )?;
                 if did_fall_back {
                     return Ok(false);
@@ -256,7 +256,6 @@ pub fn spawn_transfer_task<T, F>(
     channel_service: ChannelService,
     snapshots_path: PathBuf,
     collection_name: String,
-    default_shard_transfer_method: ShardTransferMethod,
     temp_dir: PathBuf,
     on_finish: T,
     on_error: F,
@@ -289,7 +288,6 @@ where
                     &collection_name,
                     channel_service.clone(),
                     &snapshots_path,
-                    default_shard_transfer_method,
                     &temp_dir,
                 )
                 .await

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use tokio::time::sleep;
@@ -10,10 +10,7 @@ use super::snapshot::transfer_snapshot;
 use super::stream_records::transfer_stream_records;
 use super::transfer_tasks_pool::TransferTaskProgress;
 use super::wal_delta::transfer_wal_delta;
-use super::{
-    ShardTransfer, ShardTransferConsensus, ShardTransferMethod, CONSENSUS_CONFIRM_RETRIES,
-    CONSENSUS_CONFIRM_TIMEOUT,
-};
+use super::{ShardTransfer, ShardTransferConsensus, ShardTransferMethod};
 use crate::common::stoppable_task_async::{spawn_async_cancellable, CancellableAsyncTaskHandle};
 use crate::operations::types::CollectionResult;
 use crate::shards::channel_service::ChannelService;
@@ -93,7 +90,7 @@ pub async fn transfer_shard(
         ShardTransferMethod::WalDelta => {
             let result = transfer_wal_delta(
                 transfer_config.clone(),
-                shard_holder.clone(),
+                shard_holder,
                 progress,
                 shard_id,
                 remote_shard,
@@ -109,7 +106,6 @@ pub async fn transfer_shard(
                 log::warn!("Failed to do shard diff transfer, falling back to default method {fallback_shard_transfer_method:?}: {err}");
                 let did_fall_back = transfer_shard_fallback_default(
                     transfer_config,
-                    shard_holder,
                     consensus,
                     collection_name,
                     fallback_shard_transfer_method,
@@ -132,7 +128,6 @@ pub async fn transfer_shard(
 /// Returns true if we arranged falling back. Returns false if we could not fall back.
 pub async fn transfer_shard_fallback_default(
     mut transfer_config: ShardTransfer,
-    shard_holder: Arc<LockedShardHolder>,
     consensus: &dyn ShardTransferConsensus,
     collection_name: &str,
     fallback_method: ShardTransferMethod,
@@ -144,48 +139,12 @@ pub async fn transfer_shard_fallback_default(
         return Ok(false);
     }
 
+    // Propose to restart transfer with a different method
     transfer_config.method.replace(fallback_method);
+    consensus
+        .restart_shard_transfer_confirm_and_retry(&transfer_config, collection_name)
+        .await?;
 
-    // Attempt to propose and confirm the fallback a few times
-    for attempt in 1..=CONSENSUS_CONFIRM_RETRIES {
-        if attempt > 1 {
-            log::warn!("Retrying shard transfer fallback to {fallback_method:?} (attempt {attempt}/{CONSENSUS_CONFIRM_RETRIES})");
-        }
-
-        // Propose to restart transfer with a different method
-        consensus.restart_shard_transfer(transfer_config.clone(), collection_name.into())?;
-
-        // Wait some time to confirm
-        let until = Instant::now() + CONSENSUS_CONFIRM_TIMEOUT;
-        while Instant::now() < until {
-            let transfer = shard_holder
-                .read()
-                .await
-                .get_transfer(&transfer_config.key());
-            match transfer {
-                // Transfer has been restarted with the new method
-                Some(transfer) if transfer.method == Some(fallback_method) => {
-                    return Ok(true);
-                }
-                // Transfer is still using the old method, we expect it to change shortly
-                Some(transfer) if transfer.method == old_method => (),
-                // Transfer has a different unexpected method, something external affected it
-                Some(_transfer) => {
-                    log::error!(
-                        "Failed to do shard transfer fallback, transfer has unexpected method"
-                    );
-                    return Ok(false);
-                }
-                // Currently no ongoing transfer, we expect it to be back shortly
-                None => (),
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    }
-
-    // We failed to arrange falling back
-    log::error!("Failed to do shard transfer fallback, cannot arrange and confirm fallback after {CONSENSUS_CONFIRM_RETRIES} attempts");
     Ok(false)
 }
 

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -70,6 +70,17 @@ impl ShardTransferRestart {
     }
 }
 
+impl From<ShardTransfer> for ShardTransferRestart {
+    fn from(transfer: ShardTransfer) -> Self {
+        Self {
+            shard_id: transfer.shard_id,
+            from: transfer.from,
+            to: transfer.to,
+            method: transfer.method.unwrap_or_default(),
+        }
+    }
+}
+
 /// Unique identifier of a transfer, agnostic of transfer method
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ShardTransferKey {
@@ -190,6 +201,18 @@ pub trait ShardTransferConsensus: Send + Sync {
             ))
         })
     }
+
+    /// Propose to restart a shard transfer with a different given configuration
+    ///
+    /// # Warning
+    ///
+    /// This only submits a proposal to consensus. Calling this does not guarantee that consensus
+    /// will actually apply the operation across the cluster.
+    fn restart_shard_transfer(
+        &self,
+        transfer_config: ShardTransfer,
+        collection_name: CollectionId,
+    ) -> CollectionResult<()>;
 
     /// Wait for all other peers to reach the current consensus
     ///

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -8,6 +8,9 @@ use crate::cpu;
 /// Current Qdrant version
 pub const QDRANT_VERSION: Version = Version::new(0, 11, 1);
 
+/// Number of retries for confirming a consensus operation.
+pub const CONSENSUS_CONFIRM_RETRIES: usize = 3;
+
 /// Default timeout for consensus meta operations.
 pub const CONSENSUS_META_OP_WAIT: Duration = Duration::from_secs(10);
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -56,5 +56,6 @@ url = "2.5.0"
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 tempfile = "3.10.1"
 async-recursion = "1.1"
+async-trait = "0.1.77"
 
 tracing = { workspace = true, optional = true }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -549,15 +549,12 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             .map_err(|_: Elapsed| {
                 StorageError::service_error(format!(
                     "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
-                    wait_timeout.as_secs_f64()
+                    wait_timeout.as_secs_f64(),
                 ))
             })?;
         // 2 possible errors to forward: channel sender dropped OR operation failed
         timeout_res.map_err(|err| {
-            StorageError::service_error(format!(
-                "Error occurred while waiting for consensus operation. Channel sender dropped ({})",
-                err
-            ))
+            StorageError::service_error(format!("Error occurred while waiting for consensus operation. Channel sender dropped ({err})"))
         })?
     }
 

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,5 +1,6 @@
 use std::sync::Weak;
 
+use async_trait::async_trait;
 use collection::operations::types::{CollectionError, CollectionResult};
 use collection::shards::transfer::{ShardTransfer, ShardTransferConsensus};
 use collection::shards::CollectionId;
@@ -31,6 +32,7 @@ impl ShardTransferDispatcher {
     }
 }
 
+#[async_trait]
 impl ShardTransferConsensus for ShardTransferDispatcher {
     fn consensus_commit_term(&self) -> (u64, u64) {
         let state = self.consensus_state.hard_state();
@@ -66,38 +68,23 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
         Ok(())
     }
 
-    /// Propose to restart a shard transfer with a different given configuration
-    ///
-    /// # Warning
-    ///
-    /// This only submits a proposal to consensus. Calling this does not guarantee that consensus
-    /// will actually apply the operation across the cluster.
-    fn restart_shard_transfer(
+    async fn restart_shard_transfer(
         &self,
         transfer_config: ShardTransfer,
         collection_name: CollectionId,
     ) -> CollectionResult<()> {
-        let Some(toc) = self.toc.upgrade() else {
-            return Err(CollectionError::service_error(
-                "Table of contents is dropped",
-            ));
-        };
-        let Some(proposal_sender) = toc.consensus_proposal_sender.as_ref() else {
-            return Err(CollectionError::service_error(
-                "Can't propose shard transfer restart, this is a single node deployment",
-            ));
-        };
-
-        // Propose operation to restart transfer, setting shard state to partial
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
                 collection_name,
                 ShardTransferOperations::Restart(transfer_config.into()),
             )));
-        proposal_sender.send(operation).map_err(|err| {
-            CollectionError::service_error(format!("Failed to submit consensus proposal: {err}"))
-        })?;
-
-        Ok(())
+        self
+            .consensus_state
+            .propose_consensus_op_with_await(operation.clone(), None)
+            .await
+            .map(|_| ())
+            .map_err(|err| {
+                CollectionError::service_error(format!("Failed to propose and confirm shard transfer restart operation through consensus: {err}"))
+            })
     }
 }

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -491,7 +491,7 @@ def test_shard_wal_delta_transfer_fallback(tmp_path: pathlib.Path):
     )
 
     # Insert some initial number of points
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], 2500)
 
     transfer_collection_cluster_info = get_collection_cluster_info(peer_api_uris[0], COLLECTION_NAME)
     receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
@@ -503,7 +503,7 @@ def test_shard_wal_delta_transfer_fallback(tmp_path: pathlib.Path):
 
     # Transfer shard from one node to another
 
-    # Move shard `shard_id` to peer `target_peer_id`
+    # Replicate shard `shard_id` to peer `target_peer_id`
     r = requests.post(
         f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster", json={
             "replicate_shard": {
@@ -515,14 +515,11 @@ def test_shard_wal_delta_transfer_fallback(tmp_path: pathlib.Path):
         })
     assert_http_ok(r)
 
-    # Wait for end of shard transfer
+    # WAL delta transfer should fail because the shard does not exist on the
+    # target node, assert we fall back to the streaming records method
+    # Then wait for the transfer to finish
+    wait_for_collection_shard_transfer_method(peer_api_uris[0], COLLECTION_NAME, "stream_records")
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
-
-    # Assume that the WAL delta could not be resolved, preventing a diff
-    # transfer. 'Failed to do shard diff transfer, falling back to default
-    # method' is reported in the logs. But we cannot assert that at this point.
-    # It falls back to streaming records.
-    # TODO(1.9): assert 'streaming_records' transfer method in cluster state
 
     receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)
     number_local_shards = len(receiver_collection_cluster_info['local_shards'])

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -362,6 +362,21 @@ def check_collection_shard_transfers_count(peer_api_uri: str, collection_name: s
     return local_shard_count == expected_shard_transfers_count
 
 
+def check_collection_shard_transfer_method(peer_api_uri: str, collection_name: str,
+                                            expected_method: str) -> bool:
+    collection_cluster_info = get_collection_cluster_info(peer_api_uri, collection_name)
+
+    # Check method on each transfer
+    for transfer in collection_cluster_info["shard_transfers"]:
+        if "method" not in transfer:
+            continue
+        method = transfer["method"]
+        if method == expected_method:
+            return True
+
+    return False
+
+
 def check_collection_shard_transfer_progress(peer_api_uri: str, collection_name: str,
                                             expected_transfer_progress: int,
                                             expected_transfer_total: int) -> bool:
@@ -466,6 +481,15 @@ def wait_for_collection_shard_transfers_count(peer_api_uri: str, collection_name
                                               expected_shard_transfer_count: int):
     try:
         wait_for(check_collection_shard_transfers_count, peer_api_uri, collection_name, expected_shard_transfer_count)
+    except Exception as e:
+        print_collection_cluster_info(peer_api_uri, collection_name)
+        raise e
+
+
+def wait_for_collection_shard_transfer_method(peer_api_uri: str, collection_name: str,
+                                              expected_method: str):
+    try:
+        wait_for(check_collection_shard_transfer_method, peer_api_uri, collection_name, expected_method)
     except Exception as e:
         print_collection_cluster_info(peer_api_uri, collection_name)
         raise e


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

In 1.8 we introduced WAL delta transfer which could fall back to the default shard transfer method. It was implemented in quite a hacky way.

This PR makes the fallback happen through consensus, which has a few advantages:
- we now properly clean up the old transfer and prepare the new one, preventing unexpected state issues
- all nodes are properly aware of the current shard transfer state (and method)

The WAL delta fallback test has been updated to assert we properly fall back.

### Tasks
- [x] Respect the default transfer method as selected by the user

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?