### PR TITLE
Use WAL delta transfer by default for shard recovery for 1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,7 +5228,6 @@ dependencies = [
  "reqwest",
  "schemars",
  "segment",
- "semver",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -148,7 +148,7 @@ storage:
 
   # Default shard transfer method to use if none is defined.
   # If null - don't have a shard transfer preference, choose automatically.
-  # If stream_records or snapshot - prefer this specific method.
+  # If stream_records, snapshot or wal_delta - prefer this specific method.
   # More info: https://qdrant.tech/documentation/guides/distributed_deployment/#shard-transfer-method
   shard_transfer_method: null
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -63,7 +63,7 @@ chrono = { version = "~0.4", features = ["serde"] }
 schemars = { workspace = true }
 tar = "0.4.40"
 fs_extra = "1.3.0"
-semver = "1.0.22"
+semver = { workspace = true }
 tempfile = "3.10.1"
 sha2 = "0.10.8"
 bytes = "1.5.0"

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -565,7 +565,7 @@ impl Collection {
 
             // Select shard transfer method, prefer user configured method or choose one now
             // If all peers are 1.8+, we try WAL delta transfer, otherwise we use the default method
-            let auto_shard_transfer_method = self
+            let shard_transfer_method = self
                 .shared_storage_config
                 .default_shard_transfer_method
                 .unwrap_or_else(|| {
@@ -587,7 +587,7 @@ impl Collection {
                     shard_id,
                     sync: true,
                     // For automatic shard transfers, always select some default method from this point on
-                    method: Some(auto_shard_transfer_method),
+                    method: Some(shard_transfer_method),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -565,7 +565,7 @@ impl Collection {
 
             // Select shard transfer method, prefer user configured method or choose one now
             // If all peers are 1.8+, we try WAL delta transfer, otherwise we use the default method
-            let default_shard_transfer_method = self
+            let auto_shard_transfer_method = self
                 .shared_storage_config
                 .default_shard_transfer_method
                 .unwrap_or_else(|| {
@@ -587,7 +587,7 @@ impl Collection {
                     shard_id,
                     sync: true,
                     // For automatic shard transfers, always select some default method from this point on
-                    method: Some(default_shard_transfer_method),
+                    method: Some(auto_shard_transfer_method),
                 };
 
                 if check_transfer_conflicts_strict(&transfer, transfers.iter()).is_some() {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU64;
 use std::time::SystemTimeError;
 
 use api::grpc::transport_channel_pool::RequestError;
+use common::defaults;
 use common::types::ScoreType;
 use common::validation::validate_range_generic;
 use io::file_operations::FileStorageError;
@@ -29,6 +30,7 @@ use segment::types::{
 use segment::vector_storage::query::context_query::ContextQuery;
 use segment::vector_storage::query::discovery_query::DiscoveryQuery;
 use segment::vector_storage::query::reco_query::RecoQuery;
+use semver::Version;
 use serde;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
@@ -1790,4 +1792,24 @@ impl From<QueryEnum> for QueryVector {
 #[derive(Serialize, JsonSchema, Debug)]
 pub struct IssuesReport {
     pub issues: Vec<IssueRecord>,
+}
+
+/// Metadata describing extra properties for each peer
+#[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct PeerMetadata {
+    /// Peer Qdrant version
+    version: Version,
+}
+
+impl PeerMetadata {
+    pub fn current() -> Self {
+        Self {
+            version: defaults::QDRANT_VERSION,
+        }
+    }
+
+    /// Whether this metadata has a different version than our current Qdrant instance.
+    pub fn is_different_version(&self) -> bool {
+        self.version != defaults::QDRANT_VERSION
+    }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1798,7 +1798,7 @@ pub struct IssuesReport {
 #[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct PeerMetadata {
     /// Peer Qdrant version
-    version: Version,
+    pub(crate) version: Version,
 }
 
 impl PeerMetadata {

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -12,13 +12,15 @@ use tonic::transport::{Channel, Uri};
 use tonic::{Request, Status};
 use url::Url;
 
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::{CollectionError, CollectionResult, PeerMetadata};
 use crate::shards::shard::PeerId;
 
 #[derive(Clone)]
 pub struct ChannelService {
     // Shared with consensus_state
     pub id_to_address: Arc<parking_lot::RwLock<HashMap<PeerId, Uri>>>,
+    // Shared with consensus_state
+    pub id_to_metadata: Arc<parking_lot::RwLock<HashMap<PeerId, PeerMetadata>>>,
     pub channel_pool: Arc<TransportChannelPool>,
     /// Port at which the public REST API is exposed for the current peer.
     pub current_rest_port: u16,
@@ -29,6 +31,7 @@ impl ChannelService {
     pub fn new(current_rest_port: u16) -> Self {
         Self {
             id_to_address: Default::default(),
+            id_to_metadata: Default::default(),
             channel_pool: Default::default(),
             current_rest_port,
         }
@@ -182,6 +185,7 @@ impl Default for ChannelService {
     fn default() -> Self {
         Self {
             id_to_address: Default::default(),
+            id_to_metadata: Default::default(),
             channel_pool: Default::default(),
             current_rest_port: 6333,
         }

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -7,6 +7,7 @@ use api::grpc::qdrant::WaitOnConsensusCommitRequest;
 use api::grpc::transport_channel_pool::{AddTimeout, TransportChannelPool};
 use futures::future::try_join_all;
 use futures::Future;
+use semver::Version;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Uri};
 use tonic::{Request, Status};
@@ -152,6 +153,17 @@ impl ChannelService {
             })
             .await
             .map_err(Into::into)
+    }
+
+    /// Check whether all peers are running at least the given version
+    ///
+    /// If the version is not known for any peer, this returns `false`.
+    /// Peer versions are known since 1.9 and up.
+    pub fn all_peers_at_version(&self, version: Version) -> bool {
+        self.id_to_metadata
+            .read()
+            .values()
+            .all(|metadata| metadata.version >= version)
     }
 
     /// Get the REST address for the current peer.

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -160,8 +160,15 @@ impl ChannelService {
     /// If the version is not known for any peer, this returns `false`.
     /// Peer versions are known since 1.9 and up.
     pub fn all_peers_at_version(&self, version: Version) -> bool {
-        self.id_to_metadata
-            .read()
+        let id_to_address = self.id_to_address.read();
+        let id_to_metadata = self.id_to_metadata.read();
+
+        // Ensure there aren't more peer addresses than metadata
+        if id_to_address.len() > id_to_metadata.len() {
+            return false;
+        }
+
+        id_to_metadata
             .values()
             .all(|metadata| metadata.version >= version)
     }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -32,7 +32,6 @@ parking_lot = { workspace = true }
 tar = "0.4.40"
 chrono = { version = "~0.4", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
-semver = { workspace = true }
 
 # Consensus related
 atomicwrites = { version = "0.4.3" }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use atomicwrites::{AllowOverwrite, AtomicFile};
+use collection::operations::types::PeerMetadata;
 use collection::shards::shard::PeerId;
 use http::Uri;
 use parking_lot::RwLock;
@@ -14,7 +15,7 @@ use raft::RaftState;
 use serde::{Deserialize, Serialize};
 
 use crate::content_manager::consensus::entry_queue::{EntryApplyProgressQueue, EntryId};
-use crate::types::{PeerAddressById, PeerMetadata, PeerMetadataById};
+use crate::types::{PeerAddressById, PeerMetadataById};
 use crate::StorageError;
 
 // Deprecated, use `STATE_FILE_NAME` instead

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -17,6 +17,7 @@ pub mod snapshots;
 pub mod toc;
 
 pub mod consensus_ops {
+    use collection::operations::types::PeerMetadata;
     use collection::shards::replica_set::ReplicaState;
     use collection::shards::replica_set::ReplicaState::Initializing;
     use collection::shards::shard::PeerId;
@@ -29,7 +30,6 @@ pub mod consensus_ops {
         CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations, UpdateCollection,
         UpdateCollectionOperation,
     };
-    use crate::types::PeerMetadata;
 
     /// Operation that should pass consensus
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -8,16 +8,14 @@ use collection::config::WalConfig;
 use collection::operations::shared_storage_config::{
     SharedStorageConfig, DEFAULT_IO_SHARD_TRANSFER_LIMIT, DEFAULT_SNAPSHOTS_PATH,
 };
-use collection::operations::types::NodeType;
+use collection::operations::types::{NodeType, PeerMetadata};
 use collection::optimizers_builder::OptimizersConfig;
 use collection::shards::shard::PeerId;
 use collection::shards::transfer::ShardTransferMethod;
-use common::defaults;
 use memory::madvise;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use segment::types::{HnswConfig, QuantizationConfig};
-use semver::Version;
 use serde::{Deserialize, Serialize};
 use tonic::transport::Uri;
 use validator::Validate;
@@ -270,25 +268,5 @@ impl Anonymize for ClusterStatus {
                 ClusterStatus::Enabled(cluster_info.anonymize())
             }
         }
-    }
-}
-
-/// Metadata describing extra properties for each peer
-#[derive(Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct PeerMetadata {
-    /// Peer Qdrant version
-    version: Version,
-}
-
-impl PeerMetadata {
-    pub fn current() -> Self {
-        Self {
-            version: defaults::QDRANT_VERSION,
-        }
-    }
-
-    /// Whether this metadata has a different version than our current Qdrant instance.
-    pub fn is_different_version(&self) -> bool {
-        self.version != defaults::QDRANT_VERSION
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,7 @@ fn main() -> anyhow::Result<()> {
             tls_config,
         ));
         channel_service.id_to_address = persistent_consensus_state.peer_address_by_id.clone();
+        channel_service.id_to_metadata = persistent_consensus_state.peer_metadata_by_id.clone();
     }
 
     // Table of content manages the list of collections.


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Depends on: <https://github.com/qdrant/qdrant/pull/3792>

Enable WAL delta transfer by default for automatic shard recovery.

As extra safety measure I've added a check to ensure that all nodes are running 1.8+.

We only detect version 1.9 and higher through consensus. I still decided to keep the check at 1.8 and up because that's the first true version in which WAL delta transfer was available.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/3792>
- [ ] Our dev version is currently 0.11.1, we need to change that for this to work

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?