### PR TITLE
RBAC: Route `Claims` into `TableOfContent` for points API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,6 +5225,7 @@ dependencies = [
  "protobuf",
  "raft",
  "rand 0.8.5",
+ "rbac",
  "reqwest",
  "schemars",
  "segment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,11 +94,11 @@ common = { path = "lib/common/common" }
 cancel = { path = "lib/common/cancel" }
 memory = { path = "lib/common/memory" }
 issues = { path = "lib/common/issues" }
+rbac = { path = "lib/rbac" }
 segment = { path = "lib/segment" }
 collection = { path = "lib/collection" }
 storage = { path = "lib/storage" }
 api = { path = "lib/api" }
-rbac = { path = "lib/rbac" }
 actix-multipart = "0.6.1"
 constant_time_eq = "0.3.0"
 

--- a/lib/rbac/src/jwt.rs
+++ b/lib/rbac/src/jwt.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Claims {
     /// Expiration time (seconds since UNIX epoch)
     pub exp: Option<u64>,

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -45,6 +45,7 @@ common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }
 io = { path = "../common/io" }
 memory = { path = "../common/memory" }
+rbac = { path = "../rbac" }
 segment = { path = "../segment" }
 collection = { path = "../collection" }
 api = { path = "../api" }

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -131,7 +131,9 @@ impl TableOfContent {
         request: CountRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
+        _claims: Option<Claims>,
     ) -> Result<CountResult, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         collection
             .count(request, read_consistency, &shard_selection)

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -174,8 +174,10 @@ impl TableOfContent {
         request: GroupRequest,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<GroupsResult, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
 
         let collection_by_name = |name| self.get_collection_opt(name);

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -307,7 +307,10 @@ impl TableOfContent {
         wait: bool,
         ordering: WriteOrdering,
         shard_selector: ShardSelectorInternal,
+        _claims: Option<Claims>,
     ) -> Result<UpdateResult, StorageError> {
+        // TODO(RBAC): handle claims
+
         // `TableOfContent::_update_shard_keys` and `Collection::update_from_*` are cancel safe,
         // so this method is cancel safe.
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -11,6 +11,7 @@ use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
 use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
+use rbac::jwt::Claims;
 use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
@@ -97,8 +98,10 @@ impl TableOfContent {
         request: CoreSearchRequestBatch,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
+        _claims: Option<&Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         collection
             .core_search_batch(request, read_consistency, shard_selection, timeout)

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -102,7 +102,7 @@ impl TableOfContent {
         request: CoreSearchRequestBatch,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<&Claims>,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         // TODO(RBAC): handle claims

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -256,7 +256,9 @@ impl TableOfContent {
         request: ScrollRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
+        _claims: Option<Claims>,
     ) -> Result<ScrollResult, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         collection
             .scroll_by(request, read_consistency, &shard_selection)

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -200,8 +200,10 @@ impl TableOfContent {
         request: DiscoverRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selector: ShardSelectorInternal,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         discovery::discover(
             request,
@@ -220,8 +222,10 @@ impl TableOfContent {
         collection_name: &str,
         requests: Vec<(DiscoverRequestInternal, ShardSelectorInternal)>,
         read_consistency: Option<ReadConsistency>,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
 
         discovery::discover_batch(

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -158,7 +158,9 @@ impl TableOfContent {
         request: PointRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
+        _claims: Option<Claims>,
     ) -> Result<Vec<Record>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         collection
             .retrieve(request, read_consistency, &shard_selection)

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -34,8 +34,10 @@ impl TableOfContent {
         request: RecommendRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selector: ShardSelectorInternal,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         recommendations::recommend_by(
             request,
@@ -64,8 +66,10 @@ impl TableOfContent {
         collection_name: &str,
         requests: Vec<(RecommendRequestInternal, ShardSelectorInternal)>,
         read_consistency: Option<ReadConsistency>,
+        _claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
+        // TODO(RBAC): handle claims
         let collection = self.get_collection(collection_name).await?;
         recommendations::recommend_batch_by(
             requests,

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -3,11 +3,12 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
+use rbac::jwt::Claims;
 use storage::content_manager::toc::TableOfContent;
 
 use super::CollectionPath;
 use crate::actix::api::read_params::ReadParams;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_count_points;
 
@@ -17,7 +18,7 @@ async fn count_points(
     collection: Path<CollectionPath>,
     request: Json<CountRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -37,7 +38,7 @@ async fn count_points(
         count_request,
         params.consistency,
         shard_selector,
-        claims,
+        claims.into_inner(),
         // ToDo: use timeout from params
     )
     .await;

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -7,6 +7,7 @@ use storage::content_manager::toc::TableOfContent;
 
 use super::CollectionPath;
 use crate::actix::api::read_params::ReadParams;
+use crate::actix::auth::ActixClaims;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_count_points;
 
@@ -16,6 +17,7 @@ async fn count_points(
     collection: Path<CollectionPath>,
     request: Json<CountRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -35,6 +37,7 @@ async fn count_points(
         count_request,
         params.consistency,
         shard_selector,
+        claims,
         // ToDo: use timeout from params
     )
     .await;

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -8,6 +8,7 @@ use tokio::time::Instant;
 
 use crate::actix::api::read_params::ReadParams;
 use crate::actix::api::CollectionPath;
+use crate::actix::auth::ActixClaims;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_discover_batch_points;
 
@@ -17,6 +18,7 @@ async fn discover_points(
     collection: Path<CollectionPath>,
     request: Json<DiscoverRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -36,6 +38,7 @@ async fn discover_points(
             discover_request,
             params.consistency,
             shard_selection,
+            claims,
             params.timeout(),
         )
         .await
@@ -55,6 +58,7 @@ async fn discover_batch_points(
     collection: Path<CollectionPath>,
     request: Json<DiscoverRequestBatch>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -63,6 +67,7 @@ async fn discover_batch_points(
         &collection.name,
         request.into_inner(),
         params.consistency,
+        claims,
         params.timeout(),
     )
     .await

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -3,12 +3,13 @@ use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
 use itertools::Itertools;
+use rbac::jwt::Claims;
 use storage::content_manager::toc::TableOfContent;
 use tokio::time::Instant;
 
 use crate::actix::api::read_params::ReadParams;
 use crate::actix::api::CollectionPath;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_discover_batch_points;
 
@@ -18,7 +19,7 @@ async fn discover_points(
     collection: Path<CollectionPath>,
     request: Json<DiscoverRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -38,7 +39,7 @@ async fn discover_points(
             discover_request,
             params.consistency,
             shard_selection,
-            claims,
+            claims.into_inner(),
             params.timeout(),
         )
         .await
@@ -58,7 +59,7 @@ async fn discover_batch_points(
     collection: Path<CollectionPath>,
     request: Json<DiscoverRequestBatch>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -67,7 +68,7 @@ async fn discover_batch_points(
         &collection.name,
         request.into_inner(),
         params.consistency,
-        claims,
+        claims.into_inner(),
         params.timeout(),
     )
     .await

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -16,7 +16,7 @@ use storage::content_manager::toc::TableOfContent;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 
 #[post("/collections/{name}/points/recommend")]
@@ -25,7 +25,7 @@ async fn recommend_points(
     collection: Path<CollectionPath>,
     request: Json<RecommendRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -45,7 +45,7 @@ async fn recommend_points(
             recommend_request,
             params.consistency,
             shard_selection,
-            claims,
+            claims.into_inner(),
             params.timeout(),
         )
         .await
@@ -90,7 +90,7 @@ async fn recommend_batch_points(
     collection: Path<CollectionPath>,
     request: Json<RecommendRequestBatch>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -99,7 +99,7 @@ async fn recommend_batch_points(
         &collection.name,
         request.into_inner(),
         params.consistency,
-        claims,
+        claims.into_inner(),
         params.timeout(),
     )
     .await
@@ -124,7 +124,7 @@ async fn recommend_point_groups(
     collection: Path<CollectionPath>,
     request: Json<RecommendGroupsRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -144,7 +144,7 @@ async fn recommend_point_groups(
         recommend_group_request,
         params.consistency,
         shard_selection,
-        claims,
+        claims.into_inner(),
         params.timeout(),
     )
     .await;

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -124,6 +124,7 @@ async fn recommend_point_groups(
     collection: Path<CollectionPath>,
     request: Json<RecommendGroupsRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -143,6 +144,7 @@ async fn recommend_point_groups(
         recommend_group_request,
         params.consistency,
         shard_selection,
+        claims,
         params.timeout(),
     )
     .await;

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -13,7 +13,7 @@ use validator::Validate;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_get_points;
 
@@ -56,7 +56,7 @@ async fn get_point(
     collection: Path<CollectionPath>,
     point: Path<PointPath>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -78,7 +78,7 @@ async fn get_point(
         &collection.name,
         point_id,
         params.consistency,
-        claims,
+        claims.into_inner(),
     )
     .await;
 
@@ -100,7 +100,7 @@ async fn get_points(
     collection: Path<CollectionPath>,
     request: Json<PointRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -120,7 +120,7 @@ async fn get_points(
         point_request,
         params.consistency,
         shard_selection,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -132,7 +132,7 @@ async fn scroll_points(
     collection: Path<CollectionPath>,
     request: Json<ScrollRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -153,7 +153,7 @@ async fn scroll_points(
             params.consistency,
             // TODO: handle params.timeout
             shard_selection,
-            claims,
+            claims.into_inner(),
         )
         .await;
 

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -132,6 +132,7 @@ async fn scroll_points(
     collection: Path<CollectionPath>,
     request: Json<ScrollRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -152,6 +153,7 @@ async fn scroll_points(
             params.consistency,
             // TODO: handle params.timeout
             shard_selection,
+            claims,
         )
         .await;
 

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -4,6 +4,7 @@ use actix_web_validator::{Json, Path, Query};
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{PointRequest, PointRequestInternal, Record, ScrollRequest};
+use rbac::jwt::Claims;
 use segment::types::{PointIdType, WithPayloadInterface};
 use serde::Deserialize;
 use storage::content_manager::errors::StorageError;
@@ -12,6 +13,7 @@ use validator::Validate;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
+use crate::actix::auth::ActixClaims;
 use crate::actix::helpers::process_response;
 use crate::common::points::do_get_points;
 
@@ -27,6 +29,7 @@ async fn do_get_point(
     collection_name: &str,
     point_id: PointIdType,
     read_consistency: Option<ReadConsistency>,
+    claims: Option<Claims>,
 ) -> Result<Option<Record>, StorageError> {
     let request = PointRequestInternal {
         ids: vec![point_id],
@@ -36,9 +39,15 @@ async fn do_get_point(
 
     let shard_selection = ShardSelectorInternal::All;
 
-    toc.retrieve(collection_name, request, read_consistency, shard_selection)
-        .await
-        .map(|points| points.into_iter().next())
+    toc.retrieve(
+        collection_name,
+        request,
+        read_consistency,
+        shard_selection,
+        claims,
+    )
+    .await
+    .map(|points| points.into_iter().next())
 }
 
 #[get("/collections/{name}/points/{id}")]
@@ -47,6 +56,7 @@ async fn get_point(
     collection: Path<CollectionPath>,
     point: Path<PointPath>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -68,6 +78,7 @@ async fn get_point(
         &collection.name,
         point_id,
         params.consistency,
+        claims,
     )
     .await;
 
@@ -89,6 +100,7 @@ async fn get_points(
     collection: Path<CollectionPath>,
     request: Json<PointRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -108,6 +120,7 @@ async fn get_points(
         point_request,
         params.consistency,
         shard_selection,
+        claims,
     )
     .await;
     process_response(response, timing)

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -115,6 +115,7 @@ async fn search_point_groups(
     collection: Path<CollectionPath>,
     request: Json<SearchGroupsRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -134,6 +135,7 @@ async fn search_point_groups(
         search_group_request,
         params.consistency,
         shard_selection,
+        claims,
         params.timeout(),
     )
     .await;

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -10,6 +10,7 @@ use storage::content_manager::toc::TableOfContent;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
+use crate::actix::auth::ActixClaims;
 use crate::actix::helpers::process_response;
 use crate::common::points::{
     do_core_search_points, do_search_batch_points, do_search_point_groups,
@@ -21,6 +22,7 @@ async fn search_points(
     collection: Path<CollectionPath>,
     request: Json<SearchRequest>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -40,6 +42,7 @@ async fn search_points(
         search_request.into(),
         params.consistency,
         shard_selection,
+        claims.as_ref(),
         params.timeout(),
     )
     .await
@@ -59,6 +62,7 @@ async fn batch_search_points(
     collection: Path<CollectionPath>,
     request: Json<SearchRequestBatch>,
     params: Query<ReadParams>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -86,6 +90,7 @@ async fn batch_search_points(
         &collection.name,
         requests,
         params.consistency,
+        claims.as_ref(),
         params.timeout(),
     )
     .await

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -43,7 +43,7 @@ async fn search_points(
         search_request.into(),
         params.consistency,
         shard_selection,
-        claims.into_inner().as_ref(),
+        claims.into_inner(),
         params.timeout(),
     )
     .await
@@ -91,7 +91,7 @@ async fn batch_search_points(
         &collection.name,
         requests,
         params.consistency,
-        claims.into_inner().as_ref(),
+        claims.into_inner(),
         params.timeout(),
     )
     .await

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -6,11 +6,12 @@ use collection::operations::types::{
     CoreSearchRequest, SearchGroupsRequest, SearchRequest, SearchRequestBatch,
 };
 use itertools::Itertools;
+use rbac::jwt::Claims;
 use storage::content_manager::toc::TableOfContent;
 
 use super::read_params::ReadParams;
 use super::CollectionPath;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::points::{
     do_core_search_points, do_search_batch_points, do_search_point_groups,
@@ -22,7 +23,7 @@ async fn search_points(
     collection: Path<CollectionPath>,
     request: Json<SearchRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -42,7 +43,7 @@ async fn search_points(
         search_request.into(),
         params.consistency,
         shard_selection,
-        claims.as_ref(),
+        claims.into_inner().as_ref(),
         params.timeout(),
     )
     .await
@@ -62,7 +63,7 @@ async fn batch_search_points(
     collection: Path<CollectionPath>,
     request: Json<SearchRequestBatch>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -90,7 +91,7 @@ async fn batch_search_points(
         &collection.name,
         requests,
         params.consistency,
-        claims.as_ref(),
+        claims.into_inner().as_ref(),
         params.timeout(),
     )
     .await
@@ -115,7 +116,7 @@ async fn search_point_groups(
     collection: Path<CollectionPath>,
     request: Json<SearchGroupsRequest>,
     params: Query<ReadParams>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
 
@@ -135,7 +136,7 @@ async fn search_point_groups(
         search_group_request,
         params.consistency,
         shard_selection,
-        claims,
+        claims.into_inner(),
         params.timeout(),
     )
     .await;

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -4,6 +4,7 @@ use actix_web_validator::{Json, Path, Query};
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
 use collection::operations::point_ops::{PointInsertOperations, PointsSelector, WriteOrdering};
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
+use rbac::jwt::Claims;
 use schemars::JsonSchema;
 use segment::json_path::{JsonPath, JsonPathInterface};
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use storage::dispatcher::Dispatcher;
 use validator::Validate;
 
 use super::CollectionPath;
-use crate::actix::auth::ActixClaims;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::points::{
     do_batch_update_points, do_clear_payload, do_create_index, do_delete_index, do_delete_payload,
@@ -39,7 +40,7 @@ async fn upsert_points(
     collection: Path<CollectionPath>,
     operation: Json<PointInsertOperations>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -54,7 +55,7 @@ async fn upsert_points(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -66,7 +67,7 @@ async fn delete_points(
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -81,7 +82,7 @@ async fn delete_points(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -93,7 +94,7 @@ async fn update_vectors(
     collection: Path<CollectionPath>,
     operation: Json<UpdateVectors>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -108,7 +109,7 @@ async fn update_vectors(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -120,7 +121,7 @@ async fn delete_vectors(
     collection: Path<CollectionPath>,
     operation: Json<DeleteVectors>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -135,7 +136,7 @@ async fn delete_vectors(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -147,7 +148,7 @@ async fn set_payload(
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -162,7 +163,7 @@ async fn set_payload(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -174,7 +175,7 @@ async fn overwrite_payload(
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -189,7 +190,7 @@ async fn overwrite_payload(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -201,7 +202,7 @@ async fn delete_payload(
     collection: Path<CollectionPath>,
     operation: Json<DeletePayload>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -216,7 +217,7 @@ async fn delete_payload(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -228,7 +229,7 @@ async fn clear_payload(
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -243,7 +244,7 @@ async fn clear_payload(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -255,7 +256,7 @@ async fn update_batch(
     collection: Path<CollectionPath>,
     operations: Json<UpdateOperations>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operations = operations.into_inner();
@@ -270,7 +271,7 @@ async fn update_batch(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -281,7 +282,7 @@ async fn create_field_index(
     collection: Path<CollectionPath>,
     operation: Json<CreateFieldIndex>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -296,7 +297,7 @@ async fn create_field_index(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)
@@ -308,7 +309,7 @@ async fn delete_field_index(
     collection: Path<CollectionPath>,
     field: Path<FieldPath>,
     params: Query<UpdateParam>,
-    ActixClaims(claims): ActixClaims,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let wait = params.wait.unwrap_or(false);
@@ -322,7 +323,7 @@ async fn delete_field_index(
         None,
         wait,
         ordering,
-        claims,
+        claims.into_inner(),
     )
     .await;
     process_response(response, timing)

--- a/src/actix/api/update_api.rs
+++ b/src/actix/api/update_api.rs
@@ -12,6 +12,7 @@ use storage::dispatcher::Dispatcher;
 use validator::Validate;
 
 use super::CollectionPath;
+use crate::actix::auth::ActixClaims;
 use crate::actix::helpers::process_response;
 use crate::common::points::{
     do_batch_update_points, do_clear_payload, do_create_index, do_delete_index, do_delete_payload,
@@ -38,6 +39,7 @@ async fn upsert_points(
     collection: Path<CollectionPath>,
     operation: Json<PointInsertOperations>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -52,6 +54,7 @@ async fn upsert_points(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -63,6 +66,7 @@ async fn delete_points(
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -77,6 +81,7 @@ async fn delete_points(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -88,6 +93,7 @@ async fn update_vectors(
     collection: Path<CollectionPath>,
     operation: Json<UpdateVectors>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -102,6 +108,7 @@ async fn update_vectors(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -113,6 +120,7 @@ async fn delete_vectors(
     collection: Path<CollectionPath>,
     operation: Json<DeleteVectors>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -127,6 +135,7 @@ async fn delete_vectors(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -138,6 +147,7 @@ async fn set_payload(
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -152,6 +162,7 @@ async fn set_payload(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -163,6 +174,7 @@ async fn overwrite_payload(
     collection: Path<CollectionPath>,
     operation: Json<SetPayload>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -177,6 +189,7 @@ async fn overwrite_payload(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -188,6 +201,7 @@ async fn delete_payload(
     collection: Path<CollectionPath>,
     operation: Json<DeletePayload>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -202,6 +216,7 @@ async fn delete_payload(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -213,6 +228,7 @@ async fn clear_payload(
     collection: Path<CollectionPath>,
     operation: Json<PointsSelector>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -227,6 +243,7 @@ async fn clear_payload(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -238,6 +255,7 @@ async fn update_batch(
     collection: Path<CollectionPath>,
     operations: Json<UpdateOperations>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operations = operations.into_inner();
@@ -252,6 +270,7 @@ async fn update_batch(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -262,6 +281,7 @@ async fn create_field_index(
     collection: Path<CollectionPath>,
     operation: Json<CreateFieldIndex>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let operation = operation.into_inner();
@@ -276,6 +296,7 @@ async fn create_field_index(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)
@@ -287,6 +308,7 @@ async fn delete_field_index(
     collection: Path<CollectionPath>,
     field: Path<FieldPath>,
     params: Query<UpdateParam>,
+    ActixClaims(claims): ActixClaims,
 ) -> impl Responder {
     let timing = Instant::now();
     let wait = params.wait.unwrap_or(false);
@@ -300,6 +322,7 @@ async fn delete_field_index(
         None,
         wait,
         ordering,
+        claims,
     )
     .await;
     process_response(response, timing)

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -149,9 +149,17 @@ where
     }
 }
 
-pub struct ActixClaims(pub Option<Claims>);
+pub struct Extension<T> {
+    inner: Option<T>,
+}
 
-impl FromRequest for ActixClaims {
+impl<T> Extension<T> {
+    pub fn into_inner(self) -> Option<T> {
+        self.inner
+    }
+}
+
+impl<T: 'static> FromRequest for Extension<T> {
     type Error = Infallible;
     type Future = Ready<Result<Self, Self::Error>>;
 
@@ -159,7 +167,8 @@ impl FromRequest for ActixClaims {
         req: &actix_web::HttpRequest,
         _payload: &mut actix_web::dev::Payload,
     ) -> Self::Future {
-        ready(Ok(ActixClaims(req.extensions_mut().remove::<Claims>())))
+        let ext = req.extensions_mut().remove::<T>();
+        ready(Ok(Extension { inner: ext }))
     }
 }
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -802,6 +802,7 @@ pub async fn do_search_point_groups(
     request: SearchGroupsRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
@@ -809,6 +810,7 @@ pub async fn do_search_point_groups(
         request.into(),
         read_consistency,
         shard_selection,
+        claims,
         timeout,
     )
     .await
@@ -820,6 +822,7 @@ pub async fn do_recommend_point_groups(
     request: RecommendGroupsRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<GroupsResult, StorageError> {
     toc.group(
@@ -827,6 +830,7 @@ pub async fn do_recommend_point_groups(
         request.into(),
         read_consistency,
         shard_selection,
+        claims,
         timeout,
     )
     .await

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -923,7 +923,14 @@ pub async fn do_scroll_points(
     request: ScrollRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<Claims>,
 ) -> Result<ScrollResult, StorageError> {
-    toc.scroll(collection_name, request, read_consistency, shard_selection)
-        .await
+    toc.scroll(
+        collection_name,
+        request,
+        read_consistency,
+        shard_selection,
+        claims,
+    )
+    .await
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -158,6 +158,7 @@ fn get_shard_selector_for_update(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_upsert_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -166,6 +167,7 @@ pub async fn do_upsert_points(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let (shard_key, operation) = operation.decompose();
     let collection_operation =
@@ -179,10 +181,12 @@ pub async fn do_upsert_points(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_delete_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -191,6 +195,7 @@ pub async fn do_delete_points(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let (point_operation, shard_key) = match points {
         PointsSelector::PointIdsSelector(PointIdsList { points, shard_key }) => {
@@ -209,10 +214,12 @@ pub async fn do_delete_points(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_update_vectors(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -221,6 +228,7 @@ pub async fn do_update_vectors(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let UpdateVectors { points, shard_key } = operation;
 
@@ -236,10 +244,12 @@ pub async fn do_update_vectors(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_delete_vectors(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -248,6 +258,7 @@ pub async fn do_delete_vectors(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     // TODO: Is this cancel safe!?
 
@@ -276,6 +287,7 @@ pub async fn do_delete_vectors(
                 wait,
                 ordering,
                 shard_selector.clone(),
+                claims.clone(),
             )
             .await?,
         );
@@ -291,6 +303,7 @@ pub async fn do_delete_vectors(
                 wait,
                 ordering,
                 shard_selector,
+                claims,
             )
             .await?,
         );
@@ -299,6 +312,7 @@ pub async fn do_delete_vectors(
     result.ok_or_else(|| StorageError::bad_request("No filter or points provided"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_set_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -307,6 +321,7 @@ pub async fn do_set_payload(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let SetPayload {
         points,
@@ -332,10 +347,12 @@ pub async fn do_set_payload(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_overwrite_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -344,6 +361,7 @@ pub async fn do_overwrite_payload(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let SetPayload {
         points,
@@ -370,10 +388,12 @@ pub async fn do_overwrite_payload(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_delete_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -382,6 +402,7 @@ pub async fn do_delete_payload(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let DeletePayload {
         keys,
@@ -405,10 +426,12 @@ pub async fn do_delete_payload(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_clear_payload(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -417,6 +440,7 @@ pub async fn do_clear_payload(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let (point_operation, shard_key) = match points {
         PointsSelector::PointIdsSelector(PointIdsList { points, shard_key }) => {
@@ -437,10 +461,12 @@ pub async fn do_clear_payload(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_batch_update_points(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -449,6 +475,7 @@ pub async fn do_batch_update_points(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<Vec<UpdateResult>, StorageError> {
     let mut results = Vec::with_capacity(operations.len());
     for operation in operations {
@@ -462,6 +489,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -474,6 +502,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -486,6 +515,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -498,6 +528,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -510,6 +541,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -522,6 +554,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -534,6 +567,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -546,6 +580,7 @@ pub async fn do_batch_update_points(
                     shard_selection,
                     wait,
                     ordering,
+                    claims.clone(),
                 )
                 .await
             }
@@ -565,6 +600,7 @@ pub async fn do_create_index_internal(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
@@ -585,10 +621,12 @@ pub async fn do_create_index_internal(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_create_index(
     dispatcher: Arc<Dispatcher>,
     collection_name: String,
@@ -597,6 +635,7 @@ pub async fn do_create_index(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     // TODO: Is this cancel safe!?
 
@@ -633,10 +672,12 @@ pub async fn do_create_index(
         shard_selection,
         wait,
         ordering,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_delete_index_internal(
     toc: Arc<TableOfContent>,
     collection_name: String,
@@ -645,6 +686,7 @@ pub async fn do_delete_index_internal(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::DeleteIndex(index_name),
@@ -662,10 +704,12 @@ pub async fn do_delete_index_internal(
         wait,
         ordering,
         shard_selector,
+        claims,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_delete_index(
     dispatcher: Arc<Dispatcher>,
     collection_name: String,
@@ -674,6 +718,7 @@ pub async fn do_delete_index(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
+    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     // TODO: Is this cancel safe!?
 
@@ -698,6 +743,7 @@ pub async fn do_delete_index(
         shard_selection,
         wait,
         ordering,
+        claims,
     )
     .await
 }

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -880,9 +880,16 @@ pub async fn do_count_points(
     request: CountRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<Claims>,
 ) -> Result<CountResult, StorageError> {
-    toc.count(collection_name, request, read_consistency, shard_selection)
-        .await
+    toc.count(
+        collection_name,
+        request,
+        read_consistency,
+        shard_selection,
+        claims,
+    )
+    .await
 }
 
 pub async fn do_get_points(

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -25,6 +25,7 @@ use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
 use collection::shards::shard::ShardId;
+use rbac::jwt::Claims;
 use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint};
@@ -707,6 +708,7 @@ pub async fn do_core_search_points(
     request: CoreSearchRequest,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<&Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let batch_res = do_core_search_batch_points(
@@ -717,6 +719,7 @@ pub async fn do_core_search_points(
         },
         read_consistency,
         shard_selection,
+        claims,
         timeout,
     )
     .await?;
@@ -731,6 +734,7 @@ pub async fn do_search_batch_points(
     collection_name: &str,
     requests: Vec<(CoreSearchRequest, ShardSelectorInternal)>,
     read_consistency: Option<ReadConsistency>,
+    claims: Option<&Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = batch_requests::<
@@ -759,6 +763,7 @@ pub async fn do_search_batch_points(
                 core_batch,
                 read_consistency,
                 shard_selector,
+                claims,
                 timeout,
             );
             res.push(req);
@@ -777,6 +782,7 @@ pub async fn do_core_search_batch_points(
     request: CoreSearchRequestBatch,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<&Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.core_search_batch(
@@ -784,6 +790,7 @@ pub async fn do_core_search_batch_points(
         request,
         read_consistency,
         shard_selection,
+        claims,
         timeout,
     )
     .await

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -842,6 +842,7 @@ pub async fn do_discover_points(
     request: DiscoverRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selector: ShardSelectorInternal,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     toc.discover(
@@ -849,6 +850,7 @@ pub async fn do_discover_points(
         request,
         read_consistency,
         shard_selector,
+        claims,
         timeout,
     )
     .await
@@ -859,6 +861,7 @@ pub async fn do_discover_batch_points(
     collection_name: &str,
     request: DiscoverRequestBatch,
     read_consistency: Option<ReadConsistency>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = request
@@ -874,7 +877,7 @@ pub async fn do_discover_batch_points(
         })
         .collect();
 
-    toc.discover_batch(collection_name, requests, read_consistency, timeout)
+    toc.discover_batch(collection_name, requests, read_consistency, claims, timeout)
         .await
 }
 

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -898,9 +898,16 @@ pub async fn do_get_points(
     request: PointRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
+    claims: Option<Claims>,
 ) -> Result<Vec<Record>, StorageError> {
-    toc.retrieve(collection_name, request, read_consistency, shard_selection)
-        .await
+    toc.retrieve(
+        collection_name,
+        request,
+        read_consistency,
+        shard_selection,
+        claims,
+    )
+    .await
 }
 
 pub async fn do_scroll_points(

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -754,7 +754,7 @@ pub async fn do_core_search_points(
     request: CoreSearchRequest,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<ScoredPoint>, StorageError> {
     let batch_res = do_core_search_batch_points(
@@ -780,7 +780,7 @@ pub async fn do_search_batch_points(
     collection_name: &str,
     requests: Vec<(CoreSearchRequest, ShardSelectorInternal)>,
     read_consistency: Option<ReadConsistency>,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     let requests = batch_requests::<
@@ -809,7 +809,7 @@ pub async fn do_search_batch_points(
                 core_batch,
                 read_consistency,
                 shard_selector,
-                claims,
+                claims.clone(),
                 timeout,
             );
             res.push(req);
@@ -828,7 +828,7 @@ pub async fn do_core_search_batch_points(
     request: CoreSearchRequestBatch,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
     toc.core_search_batch(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -70,9 +70,12 @@ impl Points for PointsService {
         .map(|resp| resp.map(Into::into))
     }
 
-    async fn get(&self, request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
+    async fn get(&self, mut request: Request<GetPoints>) -> Result<Response<GetResponse>, Status> {
         validate(request.get_ref())?;
-        get(self.dispatcher.as_ref(), request.into_inner(), None).await
+
+        let claims = extract_claims(&mut request);
+
+        get(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
     }
 
     async fn update_vectors(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -262,13 +262,7 @@ impl Points for PointsService {
     ) -> Result<Response<SearchResponse>, Status> {
         validate(request.get_ref())?;
         let claims = extract_claims(&mut request);
-        search(
-            self.dispatcher.as_ref(),
-            request.into_inner(),
-            None,
-            claims.as_ref(),
-        )
-        .await
+        search(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
     }
 
     async fn search_batch(
@@ -304,7 +298,7 @@ impl Points for PointsService {
             collection_name,
             requests,
             read_consistency,
-            claims.as_ref(),
+            claims,
             timeout,
         )
         .await

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -42,14 +42,18 @@ impl PointsService {
 impl Points for PointsService {
     async fn upsert(
         &self,
-        request: Request<UpsertPoints>,
+        mut request: Request<UpsertPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         upsert(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -57,14 +61,18 @@ impl Points for PointsService {
 
     async fn delete(
         &self,
-        request: Request<DeletePoints>,
+        mut request: Request<DeletePoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         delete(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -80,14 +88,18 @@ impl Points for PointsService {
 
     async fn update_vectors(
         &self,
-        request: Request<UpdatePointVectors>,
+        mut request: Request<UpdatePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         update_vectors(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -95,14 +107,18 @@ impl Points for PointsService {
 
     async fn delete_vectors(
         &self,
-        request: Request<DeletePointVectors>,
+        mut request: Request<DeletePointVectors>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         delete_vectors(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -110,14 +126,18 @@ impl Points for PointsService {
 
     async fn set_payload(
         &self,
-        request: Request<SetPayloadPoints>,
+        mut request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         set_payload(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -125,14 +145,18 @@ impl Points for PointsService {
 
     async fn overwrite_payload(
         &self,
-        request: Request<SetPayloadPoints>,
+        mut request: Request<SetPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         overwrite_payload(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -140,14 +164,18 @@ impl Points for PointsService {
 
     async fn delete_payload(
         &self,
-        request: Request<DeletePayloadPoints>,
+        mut request: Request<DeletePayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         delete_payload(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -155,14 +183,18 @@ impl Points for PointsService {
 
     async fn clear_payload(
         &self,
-        request: Request<ClearPayloadPoints>,
+        mut request: Request<ClearPayloadPoints>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         clear_payload(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
         .map(|resp| resp.map(Into::into))
@@ -170,36 +202,58 @@ impl Points for PointsService {
 
     async fn update_batch(
         &self,
-        request: Request<UpdateBatchPoints>,
+        mut request: Request<UpdateBatchPoints>,
     ) -> Result<Response<UpdateBatchResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         update_batch(
             self.dispatcher.toc().clone(),
             request.into_inner(),
             None,
             None,
+            claims,
         )
         .await
     }
 
     async fn create_field_index(
         &self,
-        request: Request<CreateFieldIndexCollection>,
+        mut request: Request<CreateFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        create_field_index(self.dispatcher.clone(), request.into_inner(), None, None)
-            .await
-            .map(|resp| resp.map(Into::into))
+
+        let claims = extract_claims(&mut request);
+
+        create_field_index(
+            self.dispatcher.clone(),
+            request.into_inner(),
+            None,
+            None,
+            claims,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn delete_field_index(
         &self,
-        request: Request<DeleteFieldIndexCollection>,
+        mut request: Request<DeleteFieldIndexCollection>,
     ) -> Result<Response<PointsOperationResponse>, Status> {
         validate(request.get_ref())?;
-        delete_field_index(self.dispatcher.clone(), request.into_inner(), None, None)
-            .await
-            .map(|resp| resp.map(Into::into))
+
+        let claims = extract_claims(&mut request);
+
+        delete_field_index(
+            self.dispatcher.clone(),
+            request.into_inner(),
+            None,
+            None,
+            claims,
+        )
+        .await
+        .map(|resp| resp.map(Into::into))
     }
 
     async fn search(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -267,10 +267,13 @@ impl Points for PointsService {
 
     async fn scroll(
         &self,
-        request: Request<ScrollPoints>,
+        mut request: Request<ScrollPoints>,
     ) -> Result<Response<ScrollResponse>, Status> {
         validate(request.get_ref())?;
-        scroll(self.dispatcher.as_ref(), request.into_inner(), None).await
+
+        let claims = extract_claims(&mut request);
+
+        scroll(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
     }
 
     async fn recommend(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -258,10 +258,11 @@ impl Points for PointsService {
 
     async fn search_groups(
         &self,
-        request: Request<SearchPointGroups>,
+        mut request: Request<SearchPointGroups>,
     ) -> Result<Response<SearchGroupsResponse>, Status> {
         validate(request.get_ref())?;
-        search_groups(self.dispatcher.as_ref(), request.into_inner(), None).await
+        let claims = extract_claims(&mut request);
+        search_groups(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
     }
 
     async fn scroll(
@@ -306,10 +307,13 @@ impl Points for PointsService {
 
     async fn recommend_groups(
         &self,
-        request: Request<RecommendPointGroups>,
+        mut request: Request<RecommendPointGroups>,
     ) -> Result<Response<RecommendGroupsResponse>, Status> {
         validate(request.get_ref())?;
-        recommend_groups(self.dispatcher.as_ref(), request.into_inner()).await
+
+        let claims = extract_claims(&mut request);
+
+        recommend_groups(self.dispatcher.as_ref(), request.into_inner(), claims).await
     }
 
     async fn discover(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -318,28 +318,36 @@ impl Points for PointsService {
 
     async fn discover(
         &self,
-        request: Request<DiscoverPoints>,
+        mut request: Request<DiscoverPoints>,
     ) -> Result<Response<DiscoverResponse>, Status> {
         validate(request.get_ref())?;
-        discover(self.dispatcher.as_ref(), request.into_inner()).await
+
+        let claims = extract_claims(&mut request);
+
+        discover(self.dispatcher.as_ref(), request.into_inner(), claims).await
     }
 
     async fn discover_batch(
         &self,
-        request: Request<DiscoverBatchPoints>,
+        mut request: Request<DiscoverBatchPoints>,
     ) -> Result<Response<DiscoverBatchResponse>, Status> {
         validate(request.get_ref())?;
+
+        let claims = extract_claims(&mut request);
+
         let DiscoverBatchPoints {
             collection_name,
             discover_points,
             read_consistency,
             timeout,
         } = request.into_inner();
+
         discover_batch(
             self.dispatcher.as_ref(),
             collection_name,
             discover_points,
             read_consistency,
+            claims,
             timeout.map(Duration::from_secs),
         )
         .await

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -340,9 +340,12 @@ impl Points for PointsService {
 
     async fn count(
         &self,
-        request: Request<CountPoints>,
+        mut request: Request<CountPoints>,
     ) -> Result<Response<CountResponse>, Status> {
         validate(request.get_ref())?;
-        count(self.dispatcher.as_ref(), request.into_inner(), None).await
+
+        let claims = extract_claims(&mut request);
+
+        count(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
     }
 }

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -271,17 +271,19 @@ impl Points for PointsService {
 
     async fn recommend(
         &self,
-        request: Request<RecommendPoints>,
+        mut request: Request<RecommendPoints>,
     ) -> Result<Response<RecommendResponse>, Status> {
         validate(request.get_ref())?;
-        recommend(self.dispatcher.as_ref(), request.into_inner()).await
+        let claims = extract_claims(&mut request);
+        recommend(self.dispatcher.as_ref(), request.into_inner(), claims).await
     }
 
     async fn recommend_batch(
         &self,
-        request: Request<RecommendBatchPoints>,
+        mut request: Request<RecommendBatchPoints>,
     ) -> Result<Response<RecommendBatchResponse>, Status> {
         validate(request.get_ref())?;
+        let claims = extract_claims(&mut request);
         let RecommendBatchPoints {
             collection_name,
             recommend_points,
@@ -293,6 +295,7 @@ impl Points for PointsService {
             collection_name,
             recommend_points,
             read_consistency,
+            claims,
             timeout.map(Duration::from_secs),
         )
         .await

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1370,6 +1370,7 @@ pub async fn scroll(
     toc: &TableOfContent,
     scroll_points: ScrollPoints,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<ScrollResponse>, Status> {
     let ScrollPoints {
         collection_name,
@@ -1405,6 +1406,7 @@ pub async fn scroll(
         scroll_request,
         read_consistency,
         shard_selector,
+        claims,
     )
     .await
     .map_err(error_to_status)?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1291,6 +1291,7 @@ pub async fn recommend_groups(
 pub async fn discover(
     toc: &TableOfContent,
     discover_points: DiscoverPoints,
+    claims: Option<Claims>,
 ) -> Result<Response<DiscoverResponse>, Status> {
     let (request, collection_name, read_consistency, timeout, shard_key_selector) =
         try_discover_request_from_grpc(discover_points)?;
@@ -1305,6 +1306,7 @@ pub async fn discover(
             request,
             read_consistency,
             shard_selector,
+            claims,
             timeout,
         )
         .await
@@ -1326,6 +1328,7 @@ pub async fn discover_batch(
     collection_name: String,
     discover_points: Vec<DiscoverPoints>,
     read_consistency: Option<ReadConsistencyGrpc>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Response<DiscoverBatchResponse>, Status> {
     let mut requests = Vec::with_capacity(discover_points.len());
@@ -1341,7 +1344,13 @@ pub async fn discover_batch(
 
     let timing = Instant::now();
     let scored_points = toc
-        .discover_batch(&collection_name, requests, read_consistency, timeout)
+        .discover_batch(
+            &collection_name,
+            requests,
+            read_consistency,
+            claims,
+            timeout,
+        )
         .await
         .map_err(error_to_status)?;
 

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1070,6 +1070,7 @@ pub async fn search_groups(
     toc: &TableOfContent,
     search_point_groups: SearchPointGroups,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<SearchGroupsResponse>, Status> {
     let search_groups_request = search_point_groups.clone().try_into()?;
 
@@ -1092,6 +1093,7 @@ pub async fn search_groups(
         search_groups_request,
         read_consistency,
         shard_selector,
+        claims,
         timeout.map(Duration::from_secs),
     )
     .await
@@ -1249,6 +1251,7 @@ pub async fn recommend_batch(
 pub async fn recommend_groups(
     toc: &TableOfContent,
     recommend_point_groups: RecommendPointGroups,
+    claims: Option<Claims>,
 ) -> Result<Response<RecommendGroupsResponse>, Status> {
     let recommend_groups_request = recommend_point_groups.clone().try_into()?;
 
@@ -1271,6 +1274,7 @@ pub async fn recommend_groups(
         recommend_groups_request,
         read_consistency,
         shard_selector,
+        claims,
         timeout.map(Duration::from_secs),
     )
     .await

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -98,6 +98,7 @@ pub async fn upsert(
     upsert_points: UpsertPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let UpsertPoints {
         collection_name,
@@ -123,6 +124,7 @@ pub async fn upsert(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -136,6 +138,7 @@ pub async fn sync(
     sync_points: SyncPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let SyncPoints {
         collection_name,
@@ -175,6 +178,7 @@ pub async fn sync(
             wait.unwrap_or(false),
             write_ordering_from_proto(ordering)?,
             shard_selector,
+            claims,
         )
         .await
         .map_err(error_to_status)?;
@@ -188,6 +192,7 @@ pub async fn delete(
     delete_points: DeletePoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeletePoints {
         collection_name,
@@ -211,6 +216,7 @@ pub async fn delete(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -224,6 +230,7 @@ pub async fn update_vectors(
     update_point_vectors: UpdatePointVectors,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let UpdatePointVectors {
         collection_name,
@@ -264,6 +271,7 @@ pub async fn update_vectors(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -277,6 +285,7 @@ pub async fn delete_vectors(
     delete_point_vectors: DeletePointVectors,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeletePointVectors {
         collection_name,
@@ -309,6 +318,7 @@ pub async fn delete_vectors(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -322,6 +332,7 @@ pub async fn set_payload(
     set_payload_points: SetPayloadPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let SetPayloadPoints {
         collection_name,
@@ -352,6 +363,7 @@ pub async fn set_payload(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -365,6 +377,7 @@ pub async fn overwrite_payload(
     set_payload_points: SetPayloadPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let SetPayloadPoints {
         collection_name,
@@ -395,6 +408,7 @@ pub async fn overwrite_payload(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -408,6 +422,7 @@ pub async fn delete_payload(
     delete_payload_points: DeletePayloadPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeletePayloadPoints {
         collection_name,
@@ -436,6 +451,7 @@ pub async fn delete_payload(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -449,6 +465,7 @@ pub async fn clear_payload(
     clear_payload_points: ClearPayloadPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let ClearPayloadPoints {
         collection_name,
@@ -472,6 +489,7 @@ pub async fn clear_payload(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -485,6 +503,7 @@ pub async fn update_batch(
     update_batch_points: UpdateBatchPoints,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<UpdateBatchResponse>, Status> {
     let UpdateBatchPoints {
         collection_name,
@@ -517,6 +536,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -532,6 +552,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -556,6 +577,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -581,6 +603,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -603,6 +626,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -621,6 +645,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -641,6 +666,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -663,6 +689,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -678,6 +705,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -696,6 +724,7 @@ pub async fn update_batch(
                     },
                     clock_tag,
                     shard_selection,
+                    claims.clone(),
                 )
                 .await
             }
@@ -771,6 +800,7 @@ pub async fn create_field_index(
     create_field_index_collection: CreateFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let CreateFieldIndexCollection {
         collection_name,
@@ -798,6 +828,7 @@ pub async fn create_field_index(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -811,6 +842,7 @@ pub async fn create_field_index_internal(
     create_field_index_collection: CreateFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let CreateFieldIndexCollection {
         collection_name,
@@ -834,6 +866,7 @@ pub async fn create_field_index_internal(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -847,6 +880,7 @@ pub async fn delete_field_index(
     delete_field_index_collection: DeleteFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeleteFieldIndexCollection {
         collection_name,
@@ -866,6 +900,7 @@ pub async fn delete_field_index(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -879,6 +914,7 @@ pub async fn delete_field_index_internal(
     delete_field_index_collection: DeleteFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeleteFieldIndexCollection {
         collection_name,
@@ -898,6 +934,7 @@ pub async fn delete_field_index_internal(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
+        claims,
     )
     .await
     .map_err(error_to_status)?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1456,6 +1456,7 @@ pub async fn get(
     toc: &TableOfContent,
     get_points: GetPoints,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<GetResponse>, Status> {
     let GetPoints {
         collection_name,
@@ -1489,6 +1490,7 @@ pub async fn get(
         point_request,
         read_consistency,
         shard_selector,
+        claims,
     )
     .await
     .map_err(error_to_status)?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -947,7 +947,7 @@ pub async fn search(
     toc: &TableOfContent,
     search_points: SearchPoints,
     shard_selection: Option<ShardId>,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
 ) -> Result<Response<SearchResponse>, Status> {
     let SearchPoints {
         collection_name,
@@ -1017,7 +1017,7 @@ pub async fn core_search_batch(
     collection_name: String,
     requests: Vec<(CoreSearchRequest, ShardSelectorInternal)>,
     read_consistency: Option<ReadConsistencyGrpc>,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Response<SearchBatchResponse>, Status> {
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
@@ -1054,7 +1054,7 @@ pub async fn core_search_list(
     search_points: Vec<CoreSearchPoints>,
     read_consistency: Option<ReadConsistencyGrpc>,
     shard_selection: Option<ShardId>,
-    claims: Option<&Claims>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Response<SearchBatchResponse>, Status> {
     let searches: Result<Vec<_>, Status> =

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1413,6 +1413,7 @@ pub async fn count(
     toc: &TableOfContent,
     count_points: CountPoints,
     shard_selection: Option<ShardId>,
+    claims: Option<Claims>,
 ) -> Result<Response<CountResponse>, Status> {
     let CountPoints {
         collection_name,
@@ -1438,6 +1439,7 @@ pub async fn count(
         count_request,
         read_consistency,
         shard_selector,
+        claims,
     )
     .await
     .map_err(error_to_status)?;

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -1108,6 +1108,7 @@ pub async fn search_groups(
 pub async fn recommend(
     toc: &TableOfContent,
     recommend_points: RecommendPoints,
+    claims: Option<Claims>,
 ) -> Result<Response<RecommendResponse>, Status> {
     // TODO(luis): check if we can make this into a From impl
     let RecommendPoints {
@@ -1183,6 +1184,7 @@ pub async fn recommend(
             request,
             read_consistency,
             shard_selector,
+            claims,
             timeout,
         )
         .await
@@ -1204,6 +1206,7 @@ pub async fn recommend_batch(
     collection_name: String,
     recommend_points: Vec<RecommendPoints>,
     read_consistency: Option<ReadConsistencyGrpc>,
+    claims: Option<Claims>,
     timeout: Option<Duration>,
 ) -> Result<Response<RecommendBatchResponse>, Status> {
     let mut requests = Vec::with_capacity(recommend_points.len());
@@ -1220,7 +1223,13 @@ pub async fn recommend_batch(
 
     let timing = Instant::now();
     let scored_points = toc
-        .recommend_batch(&collection_name, requests, read_consistency, timeout)
+        .recommend_batch(
+            &collection_name,
+            requests,
+            read_consistency,
+            claims,
+            timeout,
+        )
         .await
         .map_err(error_to_status)?;
 

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -363,9 +363,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn get(
         &self,
-        request: Request<GetPointsInternal>,
+        mut request: Request<GetPointsInternal>,
     ) -> Result<Response<GetResponse>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let GetPointsInternal {
             get_points,
             shard_id,
@@ -376,7 +379,7 @@ impl PointsInternal for PointsInternalService {
 
         get_points.read_consistency = None; // *Have* to be `None`!
 
-        get(self.toc.as_ref(), get_points, shard_id).await
+        get(self.toc.as_ref(), get_points, shard_id, claims).await
     }
 
     async fn count(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -381,9 +381,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn count(
         &self,
-        request: Request<CountPointsInternal>,
+        mut request: Request<CountPointsInternal>,
     ) -> Result<Response<CountResponse>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let CountPointsInternal {
             count_points,
             shard_id,
@@ -391,7 +394,7 @@ impl PointsInternal for PointsInternalService {
 
         let count_points =
             count_points.ok_or_else(|| Status::invalid_argument("CountPoints is missing"))?;
-        count(self.toc.as_ref(), count_points, shard_id).await
+        count(self.toc.as_ref(), count_points, shard_id, claims).await
     }
 
     async fn sync(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -38,9 +38,12 @@ impl PointsInternalService {
 impl PointsInternal for PointsInternalService {
     async fn upsert(
         &self,
-        request: Request<UpsertPointsInternal>,
+        mut request: Request<UpsertPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let UpsertPointsInternal {
             upsert_points,
             shard_id,
@@ -55,15 +58,19 @@ impl PointsInternal for PointsInternalService {
             upsert_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn delete(
         &self,
-        request: Request<DeletePointsInternal>,
+        mut request: Request<DeletePointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let DeletePointsInternal {
             delete_points,
             shard_id,
@@ -78,15 +85,19 @@ impl PointsInternal for PointsInternalService {
             delete_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn update_vectors(
         &self,
-        request: Request<UpdateVectorsInternal>,
+        mut request: Request<UpdateVectorsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let request = request.into_inner();
 
         let shard_id = request.shard_id;
@@ -101,15 +112,19 @@ impl PointsInternal for PointsInternalService {
             update_point_vectors,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn delete_vectors(
         &self,
-        request: Request<DeleteVectorsInternal>,
+        mut request: Request<DeleteVectorsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let request = request.into_inner();
 
         let shard_id = request.shard_id;
@@ -124,15 +139,19 @@ impl PointsInternal for PointsInternalService {
             delete_point_vectors,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn set_payload(
         &self,
-        request: Request<SetPayloadPointsInternal>,
+        mut request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,
@@ -147,15 +166,19 @@ impl PointsInternal for PointsInternalService {
             set_payload_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn overwrite_payload(
         &self,
-        request: Request<SetPayloadPointsInternal>,
+        mut request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let SetPayloadPointsInternal {
             set_payload_points,
             shard_id,
@@ -170,15 +193,19 @@ impl PointsInternal for PointsInternalService {
             set_payload_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn delete_payload(
         &self,
-        request: Request<DeletePayloadPointsInternal>,
+        mut request: Request<DeletePayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let DeletePayloadPointsInternal {
             delete_payload_points,
             shard_id,
@@ -193,15 +220,19 @@ impl PointsInternal for PointsInternalService {
             delete_payload_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn clear_payload(
         &self,
-        request: Request<ClearPayloadPointsInternal>,
+        mut request: Request<ClearPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let ClearPayloadPointsInternal {
             clear_payload_points,
             shard_id,
@@ -216,15 +247,19 @@ impl PointsInternal for PointsInternalService {
             clear_payload_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn create_field_index(
         &self,
-        request: Request<CreateFieldIndexCollectionInternal>,
+        mut request: Request<CreateFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let CreateFieldIndexCollectionInternal {
             create_field_index_collection,
             shard_id,
@@ -239,15 +274,19 @@ impl PointsInternal for PointsInternalService {
             create_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
 
     async fn delete_field_index(
         &self,
-        request: Request<DeleteFieldIndexCollectionInternal>,
+        mut request: Request<DeleteFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let DeleteFieldIndexCollectionInternal {
             delete_field_index_collection,
             shard_id,
@@ -262,6 +301,7 @@ impl PointsInternal for PointsInternalService {
             delete_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }
@@ -405,9 +445,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn sync(
         &self,
-        request: Request<SyncPointsInternal>,
+        mut request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let SyncPointsInternal {
             sync_points,
             shard_id,
@@ -421,6 +464,7 @@ impl PointsInternal for PointsInternalService {
             sync_points,
             clock_tag.map(Into::into),
             shard_id,
+            claims,
         )
         .await
     }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -323,9 +323,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn recommend(
         &self,
-        request: Request<RecommendPointsInternal>,
+        mut request: Request<RecommendPointsInternal>,
     ) -> Result<Response<RecommendResponse>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let RecommendPointsInternal {
             recommend_points,
             ..  // shard_id - is not used in internal API,
@@ -337,7 +340,7 @@ impl PointsInternal for PointsInternalService {
 
         recommend_points.read_consistency = None; // *Have* to be `None`!
 
-        recommend(self.toc.as_ref(), recommend_points).await
+        recommend(self.toc.as_ref(), recommend_points, claims).await
     }
 
     async fn scroll(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -355,7 +355,7 @@ impl PointsInternal for PointsInternalService {
             search_points,
             None, // *Has* to be `None`!
             shard_id,
-            claims.as_ref(),
+            claims,
             timeout,
         )
         .await

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -21,6 +21,7 @@ use crate::tonic::api::points_common::{
     delete_payload, delete_vectors, get, overwrite_payload, recommend, scroll, set_payload, sync,
     update_vectors, upsert,
 };
+use crate::tonic::auth::extract_claims;
 
 /// This API is intended for P2P communication within a distributed deployment.
 pub struct PointsInternalService {
@@ -287,9 +288,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn core_search_batch(
         &self,
-        request: Request<CoreSearchBatchPointsInternal>,
+        mut request: Request<CoreSearchBatchPointsInternal>,
     ) -> Result<Response<SearchBatchResponse>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let CoreSearchBatchPointsInternal {
             collection_name,
             search_points,
@@ -311,6 +315,7 @@ impl PointsInternal for PointsInternalService {
             search_points,
             None, // *Has* to be `None`!
             shard_id,
+            claims.as_ref(),
             timeout,
         )
         .await

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -345,9 +345,12 @@ impl PointsInternal for PointsInternalService {
 
     async fn scroll(
         &self,
-        request: Request<ScrollPointsInternal>,
+        mut request: Request<ScrollPointsInternal>,
     ) -> Result<Response<ScrollResponse>, Status> {
         validate_and_log(request.get_ref());
+
+        let claims = extract_claims(&mut request);
+
         let ScrollPointsInternal {
             scroll_points,
             shard_id,
@@ -358,7 +361,7 @@ impl PointsInternal for PointsInternalService {
 
         scroll_points.read_consistency = None; // *Have* to be `None`!
 
-        scroll(self.toc.as_ref(), scroll_points, shard_id).await
+        scroll(self.toc.as_ref(), scroll_points, shard_id, claims).await
     }
 
     async fn get(

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -21,7 +21,6 @@ use crate::tonic::api::points_common::{
     delete_payload, delete_vectors, get, overwrite_payload, recommend, scroll, set_payload, sync,
     update_vectors, upsert,
 };
-use crate::tonic::auth::extract_claims;
 
 /// This API is intended for P2P communication within a distributed deployment.
 pub struct PointsInternalService {
@@ -38,11 +37,9 @@ impl PointsInternalService {
 impl PointsInternal for PointsInternalService {
     async fn upsert(
         &self,
-        mut request: Request<UpsertPointsInternal>,
+        request: Request<UpsertPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let UpsertPointsInternal {
             upsert_points,
@@ -58,18 +55,16 @@ impl PointsInternal for PointsInternalService {
             upsert_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn delete(
         &self,
-        mut request: Request<DeletePointsInternal>,
+        request: Request<DeletePointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let DeletePointsInternal {
             delete_points,
@@ -85,18 +80,16 @@ impl PointsInternal for PointsInternalService {
             delete_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn update_vectors(
         &self,
-        mut request: Request<UpdateVectorsInternal>,
+        request: Request<UpdateVectorsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let request = request.into_inner();
 
@@ -112,18 +105,16 @@ impl PointsInternal for PointsInternalService {
             update_point_vectors,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn delete_vectors(
         &self,
-        mut request: Request<DeleteVectorsInternal>,
+        request: Request<DeleteVectorsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let request = request.into_inner();
 
@@ -139,18 +130,16 @@ impl PointsInternal for PointsInternalService {
             delete_point_vectors,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn set_payload(
         &self,
-        mut request: Request<SetPayloadPointsInternal>,
+        request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let SetPayloadPointsInternal {
             set_payload_points,
@@ -166,18 +155,16 @@ impl PointsInternal for PointsInternalService {
             set_payload_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn overwrite_payload(
         &self,
-        mut request: Request<SetPayloadPointsInternal>,
+        request: Request<SetPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let SetPayloadPointsInternal {
             set_payload_points,
@@ -193,18 +180,16 @@ impl PointsInternal for PointsInternalService {
             set_payload_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn delete_payload(
         &self,
-        mut request: Request<DeletePayloadPointsInternal>,
+        request: Request<DeletePayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let DeletePayloadPointsInternal {
             delete_payload_points,
@@ -220,18 +205,16 @@ impl PointsInternal for PointsInternalService {
             delete_payload_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn clear_payload(
         &self,
-        mut request: Request<ClearPayloadPointsInternal>,
+        request: Request<ClearPayloadPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let ClearPayloadPointsInternal {
             clear_payload_points,
@@ -247,18 +230,16 @@ impl PointsInternal for PointsInternalService {
             clear_payload_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn create_field_index(
         &self,
-        mut request: Request<CreateFieldIndexCollectionInternal>,
+        request: Request<CreateFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let CreateFieldIndexCollectionInternal {
             create_field_index_collection,
@@ -274,18 +255,16 @@ impl PointsInternal for PointsInternalService {
             create_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
 
     async fn delete_field_index(
         &self,
-        mut request: Request<DeleteFieldIndexCollectionInternal>,
+        request: Request<DeleteFieldIndexCollectionInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let DeleteFieldIndexCollectionInternal {
             delete_field_index_collection,
@@ -301,7 +280,7 @@ impl PointsInternal for PointsInternalService {
             delete_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }
@@ -328,11 +307,9 @@ impl PointsInternal for PointsInternalService {
 
     async fn core_search_batch(
         &self,
-        mut request: Request<CoreSearchBatchPointsInternal>,
+        request: Request<CoreSearchBatchPointsInternal>,
     ) -> Result<Response<SearchBatchResponse>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let CoreSearchBatchPointsInternal {
             collection_name,
@@ -355,7 +332,7 @@ impl PointsInternal for PointsInternalService {
             search_points,
             None, // *Has* to be `None`!
             shard_id,
-            claims,
+            None,
             timeout,
         )
         .await
@@ -363,11 +340,9 @@ impl PointsInternal for PointsInternalService {
 
     async fn recommend(
         &self,
-        mut request: Request<RecommendPointsInternal>,
+        request: Request<RecommendPointsInternal>,
     ) -> Result<Response<RecommendResponse>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let RecommendPointsInternal {
             recommend_points,
@@ -380,16 +355,14 @@ impl PointsInternal for PointsInternalService {
 
         recommend_points.read_consistency = None; // *Have* to be `None`!
 
-        recommend(self.toc.as_ref(), recommend_points, claims).await
+        recommend(self.toc.as_ref(), recommend_points, None).await
     }
 
     async fn scroll(
         &self,
-        mut request: Request<ScrollPointsInternal>,
+        request: Request<ScrollPointsInternal>,
     ) -> Result<Response<ScrollResponse>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let ScrollPointsInternal {
             scroll_points,
@@ -401,16 +374,14 @@ impl PointsInternal for PointsInternalService {
 
         scroll_points.read_consistency = None; // *Have* to be `None`!
 
-        scroll(self.toc.as_ref(), scroll_points, shard_id, claims).await
+        scroll(self.toc.as_ref(), scroll_points, shard_id, None).await
     }
 
     async fn get(
         &self,
-        mut request: Request<GetPointsInternal>,
+        request: Request<GetPointsInternal>,
     ) -> Result<Response<GetResponse>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let GetPointsInternal {
             get_points,
@@ -422,16 +393,14 @@ impl PointsInternal for PointsInternalService {
 
         get_points.read_consistency = None; // *Have* to be `None`!
 
-        get(self.toc.as_ref(), get_points, shard_id, claims).await
+        get(self.toc.as_ref(), get_points, shard_id, None).await
     }
 
     async fn count(
         &self,
-        mut request: Request<CountPointsInternal>,
+        request: Request<CountPointsInternal>,
     ) -> Result<Response<CountResponse>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let CountPointsInternal {
             count_points,
@@ -440,16 +409,14 @@ impl PointsInternal for PointsInternalService {
 
         let count_points =
             count_points.ok_or_else(|| Status::invalid_argument("CountPoints is missing"))?;
-        count(self.toc.as_ref(), count_points, shard_id, claims).await
+        count(self.toc.as_ref(), count_points, shard_id, None).await
     }
 
     async fn sync(
         &self,
-        mut request: Request<SyncPointsInternal>,
+        request: Request<SyncPointsInternal>,
     ) -> Result<Response<PointsOperationResponseInternal>, Status> {
         validate_and_log(request.get_ref());
-
-        let claims = extract_claims(&mut request);
 
         let SyncPointsInternal {
             sync_points,
@@ -464,7 +431,7 @@ impl PointsInternal for PointsInternalService {
             sync_points,
             clock_tag.map(Into::into),
             shard_id,
-            claims,
+            None,
         )
         .await
     }

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -58,7 +58,6 @@ impl Predicate<Request> for AuthMiddleware {
     }
 }
 
-#[allow(dead_code)] // TODO(RBAC): will be used later
 pub fn extract_claims<R>(req: &mut tonic::Request<R>) -> Option<Claims> {
     req.extensions_mut().remove::<Claims>()
 }


### PR DESCRIPTION
Tracked by #3777 

There are some claims, like `filter` and `payload` which need to access the deserialized structures from `Filter` and `Payload`. To avoid code duplication in both tonic and actix layers, we'll handle these cases in the table of contents.

- Extracts claims from the extensions of the request in tonic and actix interfaces
- Routes them into table of contents

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
