### PR TITLE
Removes method from abort shard transfer operation

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -4,6 +4,7 @@
 ## Table of Contents
 
 - [collections.proto](#collections-proto)
+    - [AbortShardTransfer](#qdrant-AbortShardTransfer)
     - [AliasDescription](#qdrant-AliasDescription)
     - [AliasOperations](#qdrant-AliasOperations)
     - [BinaryQuantization](#qdrant-BinaryQuantization)
@@ -252,6 +253,23 @@
 <p align="right"><a href="#top">Top</a></p>
 
 ## collections.proto
+
+
+
+<a name="qdrant-AbortShardTransfer"></a>
+
+### AbortShardTransfer
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| shard_id | [uint32](#uint32) |  | Local shard id |
+| from_peer_id | [uint64](#uint64) |  |  |
+| to_peer_id | [uint64](#uint64) |  |  |
+
+
+
 
 
 
@@ -1251,7 +1269,7 @@ Note: 1kB = 1 vector of size 256. |
 | collection_name | [string](#string) |  | Name of the collection |
 | move_shard | [MoveShard](#qdrant-MoveShard) |  |  |
 | replicate_shard | [MoveShard](#qdrant-MoveShard) |  |  |
-| abort_transfer | [MoveShard](#qdrant-MoveShard) |  |  |
+| abort_transfer | [AbortShardTransfer](#qdrant-AbortShardTransfer) |  |  |
 | drop_replica | [Replica](#qdrant-Replica) |  |  |
 | create_shard_key | [CreateShardKey](#qdrant-CreateShardKey) |  |  |
 | delete_shard_key | [DeleteShardKey](#qdrant-DeleteShardKey) |  |  |

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9842,7 +9842,32 @@
         ],
         "properties": {
           "abort_transfer": {
-            "$ref": "#/components/schemas/MoveShard"
+            "$ref": "#/components/schemas/AbortShardTransfer"
+          }
+        }
+      },
+      "AbortShardTransfer": {
+        "type": "object",
+        "required": [
+          "from_peer_id",
+          "shard_id",
+          "to_peer_id"
+        ],
+        "properties": {
+          "shard_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "to_peer_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "from_peer_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
         }
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -496,6 +496,12 @@ message MoveShard {
   optional ShardTransferMethod method = 4;
 }
 
+message AbortShardTransfer {
+  uint32 shard_id = 1; // Local shard id
+  uint64 from_peer_id = 2;
+  uint64 to_peer_id = 3;
+}
+
 message RestartTransfer {
   uint32 shard_id = 1; // Local shard id
   uint64 from_peer_id = 2;
@@ -530,7 +536,7 @@ message UpdateCollectionClusterSetupRequest {
   oneof operation {
     MoveShard move_shard = 2;
     MoveShard replicate_shard = 3;
-    MoveShard abort_transfer = 4;
+    AbortShardTransfer abort_transfer = 4;
     Replica drop_replica = 5;
     CreateShardKey create_shard_key = 7;
     DeleteShardKey delete_shard_key = 8;

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -925,6 +925,18 @@ pub struct MoveShard {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AbortShardTransfer {
+    /// Local shard id
+    #[prost(uint32, tag = "1")]
+    pub shard_id: u32,
+    #[prost(uint64, tag = "2")]
+    pub from_peer_id: u64,
+    #[prost(uint64, tag = "3")]
+    pub to_peer_id: u64,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestartTransfer {
     /// Local shard id
     #[prost(uint32, tag = "1")]
@@ -1003,7 +1015,7 @@ pub mod update_collection_cluster_setup_request {
         #[prost(message, tag = "3")]
         ReplicateShard(super::MoveShard),
         #[prost(message, tag = "4")]
-        AbortTransfer(super::MoveShard),
+        AbortTransfer(super::AbortShardTransfer),
         #[prost(message, tag = "5")]
         DropReplica(super::Replica),
         #[prost(message, tag = "7")]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use common::validation::{validate_move_shard_different_peers, validate_range_generic};
+use common::validation::{validate_range_generic, validate_shard_different_peers};
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::qdrant as grpc;
@@ -126,7 +126,13 @@ impl Validate for grpc::update_collection_cluster_setup_request::Operation {
 
 impl Validate for grpc::MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_move_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+    }
+}
+
+impl Validate for crate::grpc::qdrant::AbortShardTransfer {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
     }
 }
 

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use common::validation::validate_move_shard_different_peers;
+use common::validation::validate_shard_different_peers;
 use schemars::JsonSchema;
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
@@ -116,7 +116,7 @@ pub struct DropReplicaOperation {
 #[serde(rename_all = "snake_case")]
 pub struct AbortTransferOperation {
     #[validate]
-    pub abort_transfer: MoveShard,
+    pub abort_transfer: AbortShardTransfer,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
@@ -131,7 +131,13 @@ pub struct MoveShard {
 
 impl Validate for MoveShard {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        validate_move_shard_different_peers(self.from_peer_id, self.to_peer_id)
+        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
+    }
+}
+
+impl Validate for AbortShardTransfer {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        validate_shard_different_peers(self.from_peer_id, self.to_peer_id)
     }
 }
 
@@ -140,4 +146,12 @@ impl Validate for MoveShard {
 pub struct Replica {
     pub shard_id: ShardId,
     pub peer_id: PeerId,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AbortShardTransfer {
+    pub shard_id: ShardId,
+    pub to_peer_id: PeerId,
+    pub from_peer_id: PeerId,
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -38,9 +38,10 @@ use crate::config::{
 use crate::lookup::types::WithLookupInterface;
 use crate::lookup::WithLookup;
 use crate::operations::cluster_ops::{
-    AbortTransferOperation, ClusterOperations, CreateShardingKey, CreateShardingKeyOperation,
-    DropReplicaOperation, DropShardingKey, DropShardingKeyOperation, MoveShard, MoveShardOperation,
-    Replica, ReplicateShardOperation, RestartTransfer, RestartTransferOperation,
+    AbortShardTransfer, AbortTransferOperation, ClusterOperations, CreateShardingKey,
+    CreateShardingKeyOperation, DropReplicaOperation, DropShardingKey, DropShardingKeyOperation,
+    MoveShard, MoveShardOperation, Replica, ReplicateShardOperation, RestartTransfer,
+    RestartTransferOperation,
 };
 use crate::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
@@ -1650,6 +1651,18 @@ impl TryFrom<api::grpc::qdrant::MoveShard> for MoveShard {
             from_peer_id: value.from_peer_id,
             to_peer_id: value.to_peer_id,
             method,
+        })
+    }
+}
+
+impl TryFrom<api::grpc::qdrant::AbortShardTransfer> for AbortShardTransfer {
+    type Error = Status;
+
+    fn try_from(value: api::grpc::qdrant::AbortShardTransfer) -> Result<Self, Self::Error> {
+        Ok(Self {
+            shard_id: value.shard_id,
+            from_peer_id: value.from_peer_id,
+            to_peer_id: value.to_peer_id,
         })
     }
 }

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -90,8 +90,8 @@ where
     Ok(())
 }
 
-/// Validate that move shard request has two different peers.
-pub fn validate_move_shard_different_peers(
+/// Validate that shard request has two different peers.
+pub fn validate_shard_different_peers(
     from_peer_id: u64,
     to_peer_id: u64,
 ) -> Result<(), ValidationErrors> {
@@ -107,7 +107,7 @@ pub fn validate_move_shard_different_peers(
         error.add_param(Cow::from("other_value"), &from_peer_id.to_string());
         error.add_param(
             Cow::from("message"),
-            &format!("cannot move shard to itself, \"to_peer_id\" must be different than {} in \"from_peer_id\"", from_peer_id),
+            &format!("cannot execute shard operation, \"to_peer_id\" must be different than {} in \"from_peer_id\"", from_peer_id),
         );
         error
     });

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -107,7 +107,7 @@ pub fn validate_shard_different_peers(
         error.add_param(Cow::from("other_value"), &from_peer_id.to_string());
         error.add_param(
             Cow::from("message"),
-            &format!("cannot execute shard operation, \"to_peer_id\" must be different than {} in \"from_peer_id\"", from_peer_id),
+            &format!("cannot transfer shard to itself, \"to_peer_id\" must be different than {} in \"from_peer_id\"", from_peer_id),
         );
         error
     });

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -121,7 +121,7 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
         })
     assert not r.ok
     assert r.status_code == 422
-    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot execute shard operation")
+    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot transfer shard to itself")
 
     # Move shard `shard_id` to peer `target_peer_id`
     r = requests.post(

--- a/tests/consensus_tests/test_collection_shard_transfer.py
+++ b/tests/consensus_tests/test_collection_shard_transfer.py
@@ -121,7 +121,7 @@ def test_collection_shard_transfer(tmp_path: pathlib.Path):
         })
     assert not r.ok
     assert r.status_code == 422
-    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot move shard to itself")
+    assert r.json()["status"]["error"].__contains__("Validation error in JSON body: [move_shard.to_peer_id: cannot execute shard operation")
 
     # Move shard `shard_id` to peer `target_peer_id`
     r = requests.post(


### PR DESCRIPTION
Tracked in: https://github.com/qdrant/qdrant/issues/3409

This PR adds a new `AbortShardTransfer` struct, to be used by the `AbortTransfer` operation.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change? - There is one, but the CI does not pass.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
