### PR TITLE
Fix `GraphLinksConverter::serialize_to` data alignment issues

### DIFF
--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -97,10 +97,10 @@ where
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
 
-    assert_eq!(
+    debug_assert_eq!(
         v.as_ptr().align_offset(align_of::<T>()),
         0,
-        "transmuting byte slice 0x{:p} into {}: \
+        "transmuting byte slice {:p} into {}: \
          required alignment is {} bytes, \
          byte slice misaligned by {} bytes",
         v.as_ptr(),
@@ -119,10 +119,10 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
 
-    assert_eq!(
+    debug_assert_eq!(
         data.as_ptr().align_offset(align_of::<T>()),
         0,
-        "transmuting byte slice 0x{:p} into slice of {}: \
+        "transmuting byte slice {:p} into slice of {}: \
          required alignment is {} bytes, \
          byte slice misaligned by {} bytes",
         data.as_ptr(),
@@ -139,10 +139,10 @@ pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
 pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
 
-    assert_eq!(
+    debug_assert_eq!(
         data.as_ptr().align_offset(align_of::<T>()),
         0,
-        "transmuting byte slice 0x{:p} into mutable slice of {}: \
+        "transmuting byte slice {:p} into mutable slice of {}: \
          required alignment is {} bytes, \
          byte slice misaligned by {} bytes",
         data.as_ptr(),

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -96,7 +96,19 @@ where
 }
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
-    assert_eq!(v.as_ptr().align_offset(align_of::<T>()), 0);
+
+    assert_eq!(
+        v.as_ptr().align_offset(align_of::<T>()),
+        0,
+        "transmuting byte slice 0x{:p} into {}: \
+         required alignment is {} bytes, \
+         byte slice misaligned by {} bytes",
+        v.as_ptr(),
+        std::any::type_name::<T>(),
+        align_of::<T>(),
+        v.as_ptr().align_offset(align_of::<T>()),
+    );
+
     unsafe { &*(v.as_ptr() as *const T) }
 }
 
@@ -106,7 +118,19 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
 
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
-    assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
+
+    assert_eq!(
+        data.as_ptr().align_offset(align_of::<T>()),
+        0,
+        "transmuting byte slice 0x{:p} into slice of {}: \
+         required alignment is {} bytes, \
+         byte slice misaligned by {} bytes",
+        data.as_ptr(),
+        std::any::type_name::<T>(),
+        align_of::<T>(),
+        data.as_ptr().align_offset(align_of::<T>()),
+    );
+
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }
@@ -114,7 +138,19 @@ pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
 
 pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
-    assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
+
+    assert_eq!(
+        data.as_ptr().align_offset(align_of::<T>()),
+        0,
+        "transmuting byte slice 0x{:p} into mutable slice of {}: \
+         required alignment is {} bytes, \
+         byte slice misaligned by {} bytes",
+        data.as_ptr(),
+        std::any::type_name::<T>(),
+        align_of::<T>(),
+        data.as_ptr().align_offset(align_of::<T>()),
+    );
+
     let len = data.len() / size_of::<T>();
     let ptr = data.as_mut_ptr() as *mut T;
     unsafe { std::slice::from_raw_parts_mut(ptr, len) }

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -96,7 +96,7 @@ where
 }
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
-    debug_assert_eq!(v.as_ptr().align_offset(align_of::<T>()), 0);
+    assert_eq!(v.as_ptr().align_offset(align_of::<T>()), 0);
     unsafe { &*(v.as_ptr() as *const T) }
 }
 
@@ -106,7 +106,7 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
 
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
-    debug_assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
+    assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }
@@ -114,7 +114,7 @@ pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
 
 pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
-    debug_assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
+    assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_mut_ptr() as *mut T;
     unsafe { std::slice::from_raw_parts_mut(ptr, len) }

--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -1,6 +1,6 @@
 use std::fs::OpenOptions;
 use std::hint::black_box;
-use std::mem::size_of;
+use std::mem::{align_of, size_of};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{io, mem, ops, time};
@@ -96,6 +96,7 @@ where
 }
 pub fn transmute_from_u8<T>(v: &[u8]) -> &T {
     debug_assert_eq!(v.len(), size_of::<T>());
+    debug_assert_eq!(v.as_ptr().align_offset(align_of::<T>()), 0);
     unsafe { &*(v.as_ptr() as *const T) }
 }
 
@@ -105,6 +106,7 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
 
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
+    debug_assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }
@@ -112,6 +114,7 @@ pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
 
 pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
+    debug_assert_eq!(data.as_ptr().align_offset(align_of::<T>()), 0);
     let len = data.len() / size_of::<T>();
     let ptr = data.as_mut_ptr() as *mut T;
     unsafe { std::slice::from_raw_parts_mut(ptr, len) }

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -255,9 +255,10 @@ impl GraphLinksConverter {
             let links_range = header.get_links_range();
             let offsets_range = header.get_offsets_range();
             let union_range = links_range.start..offsets_range.end;
-            let split_index = offsets_range.start - links_range.start;
-            let (links_mmap, offsets_mmap) =
-                bytes_data[union_range].as_mut().split_at_mut(split_index);
+            let (links_mmap, offsets_with_padding_mmap) = bytes_data[union_range]
+                .as_mut()
+                .split_at_mut(links_range.len());
+            let offsets_mmap = &mut offsets_with_padding_mmap[header.offsets_padding as _..];
             let links_mmap: &mut [PointOffsetType] =
                 mmap_ops::transmute_from_u8_to_mut_slice(links_mmap);
             let offsets_mmap: &mut [u64] = mmap_ops::transmute_from_u8_to_mut_slice(offsets_mmap);


### PR DESCRIPTION
This PR fix data alignment issue in `GraphLinksConverter::serialize_to` that was discovered in #3802.

It also adds a few asserts to the `transmute_from_u8*` functions, to try to catch similar alignment mismatches in the future.

Fixes #3802. Includes #3807.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
