### PR TITLE
Fix alignment in graph links file

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 use std::fs::OpenOptions;
-use std::mem::{self, size_of};
+use std::mem::size_of;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -70,17 +70,10 @@ fn get_links_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a 
     mmap_ops::transmute_from_u8_to_slice(links_byte_slice)
 }
 
-fn get_offsets_iter<'a>(
-    data: &'a [u8],
-    header: &'a GraphLinksFileHeader,
-) -> impl Iterator<Item = u64> + 'a {
+fn get_offsets_slice<'a>(data: &'a [u8], header: &'a GraphLinksFileHeader) -> &'a [u64] {
     let offsets_range = header.get_offsets_range();
-    data[offsets_range]
-        .chunks_exact(mem::size_of::<u64>())
-        .map(|chunk| {
-            // unwrap is safe because we know that chunk is always 8 bytes
-            u64::from_ne_bytes(chunk.try_into().unwrap())
-        })
+    let offsets_byte_slice = &data[offsets_range];
+    mmap_ops::transmute_from_u8_to_slice(offsets_byte_slice)
 }
 
 fn get_level_offsets<'a>(data: &'a [u8], header: &GraphLinksFileHeader) -> &'a [u64] {
@@ -434,8 +427,9 @@ impl GraphLinksRam {
         links.try_set_capacity_exact(link_slice.len())?;
         links.extend_from_slice(link_slice);
 
-        offsets.try_set_capacity_exact(header.get_offsets_range().len() / size_of::<u64>())?;
-        offsets.extend(get_offsets_iter(data, &header));
+        let offsets_slice = get_offsets_slice(data, &header);
+        offsets.try_set_capacity_exact(offsets_slice.len())?;
+        offsets.extend_from_slice(offsets_slice);
 
         let level_offsets_slice = get_level_offsets(data, &header);
         level_offsets.try_set_capacity_exact(level_offsets_slice.len())?;
@@ -532,6 +526,14 @@ impl GraphLinksMmap {
         }
     }
 
+    fn get_offsets_slice(&self) -> &[u64] {
+        if let Some(mmap) = &self.mmap {
+            get_offsets_slice(mmap, &self.header)
+        } else {
+            panic!("{}", MMAP_PANIC_MESSAGE);
+        }
+    }
+
     pub fn prefault_mmap_pages(&self, path: &Path) -> Option<mmap_ops::PrefaultMmapPages> {
         mmap_ops::PrefaultMmapPages::new(self.mmap.clone()?, Some(path)).into()
     }
@@ -581,28 +583,8 @@ impl GraphLinks for GraphLinksMmap {
     }
 
     fn get_links_range(&self, idx: usize) -> Range<usize> {
-        let offsets_range = self.header.get_offsets_range();
-        let mmap: &[u8] = if let Some(mmap) = &self.mmap {
-            &mmap[offsets_range]
-        } else {
-            panic!("{}", MMAP_PANIC_MESSAGE);
-        };
-
-        let mut slice_index = mem::size_of::<u64>() * idx;
-        let begin_value = u64::from_ne_bytes(
-            mmap[slice_index..slice_index + mem::size_of::<u64>()]
-                .try_into()
-                .unwrap(),
-        );
-
-        slice_index += mem::size_of::<u64>();
-        let end_value = u64::from_ne_bytes(
-            mmap[slice_index..slice_index + mem::size_of::<u64>()]
-                .try_into()
-                .unwrap(),
-        );
-
-        begin_value as usize..end_value as usize
+        let offsets_slice = self.get_offsets_slice();
+        offsets_slice[idx] as usize..offsets_slice[idx + 1] as usize
     }
 
     fn get_level_offset(&self, level: usize) -> usize {


### PR DESCRIPTION
This PR fixes https://github.com/qdrant/qdrant/issues/3802 with debug assertions, introduced here https://github.com/qdrant/qdrant/pull/3806.

Structure of hnsw links file:
```
1. Header. 4 u64 values (alignment 8 bytes)
2. Reserved bytes for extending header, 32 bytes
3. An array of u64 values describes the size of each HNSW level (alignment 8 bytes)
4. An array with reindexing point id into the internal index, u32 with alignment 4 bytes
5. An array of all flattened links data, u32 with alignment 4 bytes
6. An array of points offset in flattened links data, u64 with alignment 8 bytes
```

All parts definition with the calculation of ranges inside file you can find in `GraphLinksFileHeader` methods:
https://github.com/qdrant/qdrant/blob/master/lib/segment/src/index/hnsw_index/graph_links.rs#L113

The problem is between `5` and `6` parts of file. Part `5` has alignment 4 bytes but part `6` has alignment 8 bytes.

This PR did 2 things:
1. Add additional padding between parts `5` and `6` while construction to guarantee the right aligments
2. Avoid transmutation into slice for part `6` and use conversion `u64::from_ne_bytes`

Technically, only avoiding transmutation may be the correct fix without changing file construction. But I propose to fix the alignment anyway.

This pr adds new field to header - padding size. Adding new header field is safe. Additional header space is defined here:
https://github.com/qdrant/qdrant/blob/master/lib/segment/src/index/hnsw_index/graph_links.rs#L116

And reserved space is zeroed. File allocation is here:
https://github.com/qdrant/qdrant/blob/master/lib/segment/src/index/hnsw_index/graph_links.rs#L275
`set_len` function zeroes file by function documentation.

I expect that avoiding transmutation for wrong-aligned data does not have a performance impact. While HNSW search, we read from wrong-aligned area only 2 `u64` values per search candidate to calculate links slice.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
7. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
8. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
