### PR TITLE
Update storage compatibility version

### DIFF
--- a/tests/storage-compat/README.md
+++ b/tests/storage-compat/README.md
@@ -2,7 +2,7 @@
 
 In order to detect quickly breakage of storage compatibility, we check that the current code understands the storage format from the latest stable release.
 
-To not burden the git repository with tracking the large binary files, we are pushing storage archives to our [S3 bucket](https://storage.googleapis.com/qdrant-backward-compatibility/).
+To not burden the git repository with tracking the large binary files, we are pushing storage archives to our [GCP bucket](https://storage.googleapis.com/qdrant-backward-compatibility/).
 
 As features are added, the storage format may change. This means updating the reference storage data and snapshot. This is done by running the `gen_storage_compat_data.sh` script.
 
@@ -12,4 +12,4 @@ Follow those steps to recreate the reference storage data and snapshot.
 
 1. run `./tests/storage-compat/gen_storage_compat_data.sh`
 2. make sure to pick the right version when asked for which system generated the files
-3. push the new archives to the S3 bucket (ask for the credentials if you don't have them)
+3. push the new archives to the GCP bucket (ask for the credentials if you don't have them)

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -62,6 +62,10 @@ function test_version() {
   # Uncompress snapshot storage
   tar -xvjf ./tests/storage-compat/storage.tar.bz2
 
+  # Delete storage archives
+  rm ./tests/storage-compat/compatibility.tar
+  rm ./tests/storage-compat/storage.tar.bz2
+
   # Test it boots up fine with the old storage
   ./target/debug/qdrant & PID=$!
 
@@ -83,7 +87,13 @@ function test_version() {
   # Test recovering from an old snapshot
   gzip -f -d --keep ./tests/storage-compat/full-snapshot.snapshot.gz
 
+  # Delete archive
+  rm ./tests/storage-compat/full-snapshot.snapshot.gz
+
+  # Delete previous storage
   rm -rf ./storage
+
+  # Start server with the old snapshot
   ./target/debug/qdrant \
     --storage-snapshot ./tests/storage-compat/full-snapshot.snapshot \
     & PID=$!

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -7,88 +7,109 @@ echo $PWD
 cd "$(dirname "$0")/../../"
 
 QDRANT_HOST='localhost:6333'
-LEGACY_QDRANT_VERSION='v1.8.1'
+PREV_PATCH_QDRANT_VERSION='v1.8.1'
+PREV_MINOR_QDRANT_VERSION='v1.7.4'
+
+RETRY_LIMIT=30
+
+# Retrieve collection info_status to make sure the collection is well-formed
+function get_collection_info() {
+  collection=$1
+  info_status=$(curl -s -o /dev/null -w "%{http_code}" "http://$QDRANT_HOST/collections/$collection")
+  if [ "$info_status" -ne 200 ]; then
+      echo "Storage compatibility failed for $collection"
+      return 1
+  fi
+  return 0
+}
+
+# Make sure all collections are loaded properly
+function check_collections() {
+  collections=$(curl http://$QDRANT_HOST/collections | jq -r .result.collections[].name)
+  for collection in $collections; do
+      get_collection_info $collection
+      if [ $? -ne 0 ]; then
+          echo "Storage compatibility failed for $collection"
+          return 1
+      fi
+  done
+  return 0
+}
+
+# Wait for the server to boot up
+function wait_for_server() {
+  declare retry=0
+  until curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/readyz; do
+    if ((retry++ < RETRY_LIMIT)); then
+        printf 'waiting for server to start...'
+        sleep 1
+    else
+        echo "Qdrant failed to boot in ~30 seconds" >&2
+        exit 2
+    fi
+  done
+  echo "server ready to serve traffic"
+}
+
+# Test a specific version
+function test_version() {
+  version=$1
+  wget "https://storage.googleapis.com/qdrant-backward-compatibility/compatibility-${version}.tar" -O ./tests/storage-compat/compatibility.tar
+
+  # Uncompress compatibility
+  tar -xvf ./tests/storage-compat/compatibility.tar -C ./tests/storage-compat/
+
+  # Uncompress snapshot storage
+  tar -xvjf ./tests/storage-compat/storage.tar.bz2
+
+  # Test it boots up fine with the old storage
+  ./target/debug/qdrant & PID=$!
+
+  sleep 1
+
+  wait_for_server
+
+  check_collections
+  if [ $? -ne 0 ]; then
+      echo "Storage compatibility failed for ${version}"
+      kill -9 $PID
+      exit 1
+  fi
+
+  echo "server is going down"
+  kill -9 $PID
+  echo "End of storage compatibility test for ${version}"
+
+  # Test recovering from an old snapshot
+  gzip -f -d --keep ./tests/storage-compat/full-snapshot.snapshot.gz
+
+  rm -rf ./storage
+  ./target/debug/qdrant \
+    --storage-snapshot ./tests/storage-compat/full-snapshot.snapshot \
+    & PID=$!
+
+  wait_for_server
+
+  check_collections
+  if [ $? -ne 0 ]; then
+      echo "Snapshot compatibility failed for ${version}"
+      kill -9 $PID
+      exit 1
+  fi
+
+  echo "server is going down"
+  kill -9 $PID
+
+  rm tests/storage-compat/full-snapshot.snapshot
+
+  echo "End of snapshot compatibility test for ${version}"
+}
 
 # Build
 cargo build
 
-wget "https://storage.googleapis.com/qdrant-backward-compatibility/compatibility-${LEGACY_QDRANT_VERSION}.tar" -O ./tests/storage-compat/compatibility.tar
+# Test previous patch version
+test_version $PREV_PATCH_QDRANT_VERSION
 
-# Uncompress compatibility
-tar -xvf ./tests/storage-compat/compatibility.tar -C ./tests/storage-compat/
-
-# Uncompress snapshot storage
-tar -xvjf ./tests/storage-compat/storage.tar.bz2
-
-# Test it boots up fine with the old storage
-./target/debug/qdrant & PID=$!
-
-sleep 1
-
-declare retry=0
-until curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/collections; do
-  if ((retry++ < 30)); then
-      printf 'waiting for server to start...'
-      sleep 1
-  else
-      echo "Collections failed to load in ~30 seconds" >&2
-      exit 2
-  fi
-done
-
-echo "server ready to serve traffic"
-
-# make sure all collections are loaded properly
-collections=$(curl http://$QDRANT_HOST/collections | jq -r .result.collections[].name)
-for collection in $collections; do
-    info=$(curl -s -o /dev/null -w "%{http_code}" "http://$QDRANT_HOST/collections/$collection")
-    if [ "$info" -ne 200 ]; then
-        echo "Storage compatibility failed for $collection"
-        kill -9 $PID
-        exit 1
-    fi
-done
-
-echo "server is going down"
-kill -9 $PID
-echo "END"
-
-
-# Test recovering from an old snapshot
-gzip -f -d --keep ./tests/storage-compat/full-snapshot.snapshot.gz
-
-rm -rf ./storage
-./target/debug/qdrant \
-  --storage-snapshot ./tests/storage-compat/full-snapshot.snapshot \
-  & PID=$!
-
-declare retry=0
-until curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/readyz; do
-  if ((retry++ < 30)); then
-      printf 'waiting for server to start...'
-      sleep 1
-  else
-      echo "Collection failed to load in ~30 seconds" >&2
-      exit 2
-  fi
-done
-
-echo "server ready to serve traffic"
-
-# make sure all collections are loaded properly
-collections=$(curl http://$QDRANT_HOST/collections | jq -r .result.collections[].name)
-for collection in $collections; do
-    info=$(curl -s -o /dev/null -w "%{http_code}" "http://$QDRANT_HOST/collections/$collection")
-    if [ "$info" -ne 200 ]; then
-        echo "Snapshot compatibility failed for $collection"
-        kill -9 $PID
-        exit 1
-    fi
-done
-
-echo "server is going down"
-kill -9 $PID
-
-rm tests/storage-compat/full-snapshot.snapshot
-
-echo "END"
+# Test previous minor version
+test_version $PREV_MINOR_QDRANT_VERSION

--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -7,7 +7,7 @@ echo $PWD
 cd "$(dirname "$0")/../../"
 
 QDRANT_HOST='localhost:6333'
-LEGACY_QDRANT_VERSION='v1.7.4'
+LEGACY_QDRANT_VERSION='v1.8.1'
 
 # Build
 cargo build


### PR DESCRIPTION
This PR updates our storage compatibility test to `v1.8.1`.

I have generated the data from master and uploaded it to our GCP bucket.

The storage archives contains [two new collections](https://github.com/qdrant/qdrant/pull/3715) with various mmap configuration.

EDIT: I also added the support for testing against the last minor and patch version,