### PR TITLE
Detect malformed collection during storage compatibility

### DIFF
--- a/tests/storage-compat/storage-compatibility.sh
+++ b/tests/storage-compat/storage-compatibility.sh
@@ -38,6 +38,17 @@ done
 
 echo "server ready to serve traffic"
 
+# make sure all collections are loaded properly
+collections=$(curl http://$QDRANT_HOST/collections | jq -r .result.collections[].name)
+for collection in $collections; do
+    info=$(curl -s -o /dev/null -w "%{http_code}" "http://$QDRANT_HOST/collections/$collection")
+    if [ "$info" -ne 200 ]; then
+        echo "Storage compatibility failed for $collection"
+        kill -9 $PID
+        exit 1
+    fi
+done
+
 echo "server is going down"
 kill -9 $PID
 echo "END"
@@ -63,6 +74,17 @@ until curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/readyz; 
 done
 
 echo "server ready to serve traffic"
+
+# make sure all collections are loaded properly
+collections=$(curl http://$QDRANT_HOST/collections | jq -r .result.collections[].name)
+for collection in $collections; do
+    info=$(curl -s -o /dev/null -w "%{http_code}" "http://$QDRANT_HOST/collections/$collection")
+    if [ "$info" -ne 200 ]; then
+        echo "Snapshot compatibility failed for $collection"
+        kill -9 $PID
+        exit 1
+    fi
+done
 
 echo "server is going down"
 kill -9 $PID


### PR DESCRIPTION
This PR fixes https://github.com/qdrant/qdrant/pull/3807

It appears the storage compatibility tests did **not** detect when collections were not loaded properly.

```
2024-03-12T15:20:48.305815Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/index/hnsw_index/graph_links.rs at line 73: boom
2024-03-12T15:20:48.310643Z ERROR collection::shards::replica_set: Failed to load local shard "./storage/collections/test_collection_product_x64/0", initializing "dummy" shard instead: Service internal error: Can't join segment load thread: TypeId { t: 337271291176647618489964333718931667905 }
```

In case of loading issue, we would simply setup a dummy shard and continue with the remaining collections.
The server would then be operational to serve data for other collections.

To detect malformed collection, this PR proposes to fetch the collection info of each collection and make sure it returns a 200.

A dummy shard currently returns a 500.

```
++ curl -s -o /dev/null -w '%{http_code}' http://localhost:6333/collections/test_collection
2024-03-12T15:20:49.338045Z  WARN qdrant::actix::helpers: error processing request: 0 of 0 read operations failed
2024-03-12T15:20:49.338298Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /collections/test_collection HTTP/1.1" 500 95 "-" "curl/8.2.1" 0.053309
+ info=500
+ '[' 500 -ne 200 ']'
+ echo 'Storage compatibility failed for test_collection'
Storage compatibility failed for test_collection
+ kill -9 274698
+ exit 1
```