### PR TITLE
Use rest vector type as non segment part

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod grpc;
+pub mod rest;

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -1,0 +1,107 @@
+use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
+
+impl From<segment::data_types::vectors::Vector> for Vector {
+    fn from(value: segment::data_types::vectors::Vector) -> Self {
+        match value {
+            segment::data_types::vectors::Vector::Dense(vector) => Vector::Dense(vector),
+            segment::data_types::vectors::Vector::Sparse(vector) => Vector::Sparse(vector),
+        }
+    }
+}
+
+impl From<Vector> for segment::data_types::vectors::Vector {
+    fn from(value: Vector) -> Self {
+        match value {
+            Vector::Dense(vector) => segment::data_types::vectors::Vector::Dense(vector),
+            Vector::Sparse(vector) => segment::data_types::vectors::Vector::Sparse(vector),
+        }
+    }
+}
+
+impl From<segment::data_types::vectors::VectorStruct> for VectorStruct {
+    fn from(value: segment::data_types::vectors::VectorStruct) -> Self {
+        match value {
+            segment::data_types::vectors::VectorStruct::Single(vector) => {
+                VectorStruct::Single(vector)
+            }
+            segment::data_types::vectors::VectorStruct::Multi(vectors) => {
+                VectorStruct::Multi(vectors.into_iter().map(|(k, v)| (k, v.into())).collect())
+            }
+        }
+    }
+}
+
+impl From<VectorStruct> for segment::data_types::vectors::VectorStruct {
+    fn from(value: VectorStruct) -> Self {
+        match value {
+            VectorStruct::Single(vector) => {
+                segment::data_types::vectors::VectorStruct::Single(vector)
+            }
+            VectorStruct::Multi(vectors) => segment::data_types::vectors::VectorStruct::Multi(
+                vectors.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            ),
+        }
+    }
+}
+
+impl From<segment::data_types::vectors::BatchVectorStruct> for BatchVectorStruct {
+    fn from(value: segment::data_types::vectors::BatchVectorStruct) -> Self {
+        match value {
+            segment::data_types::vectors::BatchVectorStruct::Single(vector) => {
+                BatchVectorStruct::Single(vector)
+            }
+            segment::data_types::vectors::BatchVectorStruct::Multi(vectors) => {
+                BatchVectorStruct::Multi(
+                    vectors
+                        .into_iter()
+                        .map(|(k, v)| (k, v.into_iter().map(|v| v.into()).collect()))
+                        .collect(),
+                )
+            }
+        }
+    }
+}
+
+impl From<BatchVectorStruct> for segment::data_types::vectors::BatchVectorStruct {
+    fn from(value: BatchVectorStruct) -> Self {
+        match value {
+            BatchVectorStruct::Single(vector) => {
+                segment::data_types::vectors::BatchVectorStruct::Single(vector)
+            }
+            BatchVectorStruct::Multi(vectors) => {
+                segment::data_types::vectors::BatchVectorStruct::Multi(
+                    vectors
+                        .into_iter()
+                        .map(|(k, v)| (k, v.into_iter().map(|v| v.into()).collect()))
+                        .collect(),
+                )
+            }
+        }
+    }
+}
+
+impl From<segment::types::ScoredPoint> for ScoredPoint {
+    fn from(value: segment::types::ScoredPoint) -> Self {
+        ScoredPoint {
+            id: value.id,
+            version: value.version,
+            score: value.score,
+            payload: value.payload,
+            vector: value.vector.map(From::from),
+            shard_key: value.shard_key,
+        }
+    }
+}
+
+impl From<ScoredPoint> for segment::types::ScoredPoint {
+    fn from(value: ScoredPoint) -> Self {
+        segment::types::ScoredPoint {
+            id: value.id,
+            version: value.version,
+            score: value.score,
+            payload: value.payload,
+            vector: value.vector.map(From::from),
+            shard_key: value.shard_key,
+        }
+    }
+}

--- a/lib/api/src/rest/mod.rs
+++ b/lib/api/src/rest/mod.rs
@@ -1,0 +1,3 @@
+pub mod conversions;
+pub mod schema;
+pub mod validate;

--- a/lib/api/src/rest/mod.rs
+++ b/lib/api/src/rest/mod.rs
@@ -1,3 +1,5 @@
 pub mod conversions;
 pub mod schema;
 pub mod validate;
+
+pub use schema::*;

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Type for dense vector
+pub type DenseVector = Vec<segment::data_types::vectors::VectorElementType>;
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum Vector {
+    Dense(DenseVector),
+    Sparse(sparse::common::sparse_vector::SparseVector),
+}
+
+/// Full vector data per point separator with single and multiple vector modes
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum VectorStruct {
+    Single(DenseVector),
+    Multi(HashMap<String, Vector>),
+}
+
+impl VectorStruct {
+    /// Check if this vector struct is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            VectorStruct::Single(vector) => vector.is_empty(),
+            VectorStruct::Multi(vectors) => vectors.values().all(|v| match v {
+                Vector::Dense(vector) => vector.is_empty(),
+                Vector::Sparse(vector) => vector.indices.is_empty(),
+            }),
+        }
+    }
+
+    /// TODO(colbert): remove this method and use `merge` from segment::VectorStruct
+    pub fn merge(&mut self, other: Self) {
+        match (self, other) {
+            // If other is empty, merge nothing
+            (_, VectorStruct::Multi(other)) if other.is_empty() => {}
+            // Single overwrites single
+            (VectorStruct::Single(this), VectorStruct::Single(other)) => {
+                *this = other;
+            }
+            // If multi into single, convert this to multi and merge
+            (this @ VectorStruct::Single(_), other @ VectorStruct::Multi(_)) => {
+                let VectorStruct::Single(single) = this.clone() else {
+                    unreachable!();
+                };
+                *this =
+                    VectorStruct::Multi(HashMap::from([(String::new(), Vector::Dense(single))]));
+                this.merge(other);
+            }
+            // Single into multi
+            (VectorStruct::Multi(this), VectorStruct::Single(other)) => {
+                this.insert(String::new(), Vector::Dense(other));
+            }
+            // Multi into multi
+            (VectorStruct::Multi(this), VectorStruct::Multi(other)) => this.extend(other),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum BatchVectorStruct {
+    Single(Vec<DenseVector>),
+    Multi(HashMap<String, Vec<Vector>>),
+}
+
+/// Search result
+#[derive(Serialize, JsonSchema, Clone, Debug)]
+pub struct ScoredPoint {
+    /// Point id
+    pub id: segment::types::PointIdType,
+    /// Point version
+    pub version: segment::types::SeqNumberType,
+    /// Points vector distance to the query vector
+    pub score: common::types::ScoreType,
+    /// Payload - values assigned to the point
+    pub payload: Option<segment::types::Payload>,
+    /// Vector of the point
+    pub vector: Option<VectorStruct>,
+    /// Shard Key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<segment::types::ShardKey>,
+}

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -1,0 +1,32 @@
+use validator::Validate;
+
+use super::schema::{BatchVectorStruct, Vector, VectorStruct};
+
+impl Validate for VectorStruct {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            VectorStruct::Single(_) => Ok(()),
+            VectorStruct::Multi(v) => common::validation::validate_iter(v.values()),
+        }
+    }
+}
+
+impl Validate for BatchVectorStruct {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            BatchVectorStruct::Single(_) => Ok(()),
+            BatchVectorStruct::Multi(v) => {
+                common::validation::validate_iter(v.values().flat_map(|batch| batch.iter()))
+            }
+        }
+    }
+}
+
+impl Validate for Vector {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            Vector::Dense(_) => Ok(()),
+            Vector::Sparse(v) => v.validate(),
+        }
+    }
+}

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -36,7 +36,7 @@ fn create_rnd_batch() -> CollectionUpdateOperations {
         let vectors = only_default_vector(&vector);
         let point = PointStruct {
             id: (i as u64).into(),
-            vector: Into::<VectorStruct>::into(vectors).into(),
+            vector: VectorStruct::from(vectors).into(),
             payload: Some(Payload(payload_map)),
         };
         points.push(point);

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -16,7 +16,7 @@ use collection::shards::shard_trait::ShardOperation;
 use common::cpu::CpuBudget;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::thread_rng;
-use segment::data_types::vectors::only_default_vector;
+use segment::data_types::vectors::{only_default_vector, VectorStruct};
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::types::{Condition, Distance, FieldCondition, Filter, Payload, Range};
 use serde_json::Map;
@@ -36,7 +36,7 @@ fn create_rnd_batch() -> CollectionUpdateOperations {
         let vectors = only_default_vector(&vector);
         let point = PointStruct {
             id: (i as u64).into(),
-            vector: vectors.into(),
+            vector: Into::<VectorStruct>::into(vectors).into(),
             payload: Some(Payload(payload_map)),
         };
         points.push(point);

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -200,7 +200,7 @@ impl Collection {
                 // So we just filter out them.
                 records_map.remove(&scored_point.id).map(|record| {
                     scored_point.payload = record.payload;
-                    scored_point.vector = record.vector;
+                    scored_point.vector = record.vector.map(|v| v.into());
                     scored_point
                 })
             })

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{future, TryFutureExt};
+use segment::data_types::vectors::VectorStruct;
 use segment::spaces::tools;
 use segment::types::{ExtendedPointId, Order, ScoredPoint, WithPayloadInterface, WithVector};
 
@@ -200,7 +201,7 @@ impl Collection {
                 // So we just filter out them.
                 records_map.remove(&scored_point.id).map(|record| {
                     scored_point.payload = record.payload;
-                    scored_point.vector = record.vector.map(|v| v.into());
+                    scored_point.vector = record.vector.map(VectorStruct::from);
                     scored_point
                 })
             })

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -97,27 +97,27 @@ mod tests {
         let points = vec![
             PointStruct {
                 id: 11.into(),
-                vector: Into::<VectorStruct>::into(vec11).into(),
+                vector: VectorStruct::from(vec11).into(),
                 payload: None,
             },
             PointStruct {
                 id: 12.into(),
-                vector: Into::<VectorStruct>::into(vec12).into(),
+                vector: VectorStruct::from(vec12).into(),
                 payload: None,
             },
             PointStruct {
                 id: 13.into(),
-                vector: Into::<VectorStruct>::into(vec13).into(),
+                vector: VectorStruct::from(vec13).into(),
                 payload: Some(json!({ "color": "red" }).into()),
             },
             PointStruct {
                 id: 14.into(),
-                vector: Into::<VectorStruct>::into(vec![0., 0., 0., 0.]).into(),
+                vector: VectorStruct::from(vec![0., 0., 0., 0.]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 500.into(),
-                vector: Into::<VectorStruct>::into(vec![2., 0., 2., 0.]).into(),
+                vector: VectorStruct::from(vec![2., 0., 2., 0.]).into(),
                 payload: None,
             },
         ];
@@ -139,12 +139,12 @@ mod tests {
         let points = vec![
             PointStruct {
                 id: 1.into(),
-                vector: Into::<VectorStruct>::into(vec![2., 2., 2., 2.]).into(),
+                vector: VectorStruct::from(vec![2., 2., 2., 2.]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 500.into(),
-                vector: Into::<VectorStruct>::into(vec![2., 0., 2., 0.]).into(),
+                vector: VectorStruct::from(vec![2., 0., 2., 0.]).into(),
                 payload: None,
             },
         ];

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -72,7 +72,7 @@ impl CollectionUpdater {
 
 #[cfg(test)]
 mod tests {
-    use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
+    use segment::data_types::vectors::{only_default_vector, VectorStruct, DEFAULT_VECTOR_NAME};
     use segment::types::{Payload, WithPayload};
     use serde_json::json;
     use tempfile::Builder;
@@ -97,27 +97,27 @@ mod tests {
         let points = vec![
             PointStruct {
                 id: 11.into(),
-                vector: vec11.into(),
+                vector: Into::<VectorStruct>::into(vec11).into(),
                 payload: None,
             },
             PointStruct {
                 id: 12.into(),
-                vector: vec12.into(),
+                vector: Into::<VectorStruct>::into(vec12).into(),
                 payload: None,
             },
             PointStruct {
                 id: 13.into(),
-                vector: vec13.into(),
+                vector: Into::<VectorStruct>::into(vec13).into(),
                 payload: Some(json!({ "color": "red" }).into()),
             },
             PointStruct {
                 id: 14.into(),
-                vector: vec![0., 0., 0., 0.].into(),
+                vector: Into::<VectorStruct>::into(vec![0., 0., 0., 0.]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 500.into(),
-                vector: vec![2., 0., 2., 0.].into(),
+                vector: Into::<VectorStruct>::into(vec![2., 0., 2., 0.]).into(),
                 payload: None,
             },
         ];
@@ -139,12 +139,12 @@ mod tests {
         let points = vec![
             PointStruct {
                 id: 1.into(),
-                vector: vec![2., 2., 2., 2.].into(),
+                vector: Into::<VectorStruct>::into(vec![2., 2., 2., 2.]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 500.into(),
-                vector: vec![2., 0., 2., 0.].into(),
+                vector: Into::<VectorStruct>::into(vec![2., 0., 2., 0.]).into(),
                 payload: None,
             },
         ];
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(records.len(), 3);
 
         for record in records {
-            let v = record.vector.unwrap();
+            let v: VectorStruct = record.vector.unwrap().into();
 
             let v1 = vec![2., 2., 2., 2.];
             if record.id == 1.into() {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -287,7 +287,7 @@ mod tests {
     use itertools::Itertools;
     use parking_lot::lock_api::RwLock;
     use rand::thread_rng;
-    use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+    use segment::data_types::vectors::{BatchVectorStruct, DEFAULT_VECTOR_NAME};
     use segment::entry::entry_point::SegmentEntry;
     use segment::fixtures::index_fixtures::random_vector;
     use segment::index::hnsw_index::num_rayon_threads;
@@ -615,11 +615,11 @@ mod tests {
         let point_payload: Payload = json!({"number":10000i64}).into();
         let insert_point_ops: PointOperations = Batch {
             ids: vec![501.into(), 502.into(), 503.into()],
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
-            ]
+            ])
             .into(),
             payloads: Some(vec![
                 Some(point_payload.clone()),
@@ -694,11 +694,11 @@ mod tests {
 
         let insert_point_ops: PointOperations = Batch {
             ids: vec![601.into(), 602.into(), 603.into()],
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
-            ]
+            ])
             .into(),
             payloads: None,
         }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -615,7 +615,7 @@ mod tests {
         let point_payload: Payload = json!({"number":10000i64}).into();
         let insert_point_ops: PointOperations = Batch {
             ids: vec![501.into(), 502.into(), 503.into()],
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
@@ -694,7 +694,7 @@ mod tests {
 
         let insert_point_ops: PointOperations = Batch {
             ids: vec![601.into(), 602.into(), 603.into()],
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),
                 random_vector(&mut rng, dim),

--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -457,7 +457,7 @@ pub(crate) fn process_point_operation(
                         None => vectors_iter
                             .map(|(id, vectors)| PointStruct {
                                 id,
-                                vector: Into::<VectorStruct>::into(vectors).into(),
+                                vector: VectorStruct::from(vectors).into(),
                                 payload: None,
                             })
                             .collect(),
@@ -465,7 +465,7 @@ pub(crate) fn process_point_operation(
                             .zip(payloads)
                             .map(|((id, vectors), payload)| PointStruct {
                                 id,
-                                vector: Into::<VectorStruct>::into(vectors).into(),
+                                vector: VectorStruct::from(vectors).into(),
                                 payload,
                             })
                             .collect(),

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use parking_lot::RwLock;
-use segment::data_types::vectors::only_default_vector;
+use segment::data_types::vectors::{only_default_vector, VectorStruct};
 use segment::entry::entry_point::SegmentEntry;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, PointIdType};
 use tempfile::Builder;
@@ -69,12 +69,12 @@ fn test_update_proxy_segments() {
         let points = vec![
             PointStruct {
                 id: (100 * i + 1).into(),
-                vector: vectors[0].clone().into(),
+                vector: Into::<VectorStruct>::into(vectors[0].clone()).into(),
                 payload: None,
             },
             PointStruct {
                 id: (100 * i + 2).into(),
-                vector: vectors[1].clone().into(),
+                vector: Into::<VectorStruct>::into(vectors[1].clone()).into(),
                 payload: None,
             },
         ];
@@ -113,12 +113,12 @@ fn test_move_points_to_copy_on_write() {
     let points = vec![
         PointStruct {
             id: 1.into(),
-            vector: vec![0.0, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
         PointStruct {
             id: 2.into(),
-            vector: vec![0.0, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
     ];
@@ -128,12 +128,12 @@ fn test_move_points_to_copy_on_write() {
     let points = vec![
         PointStruct {
             id: 2.into(),
-            vector: vec![0.0, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
         PointStruct {
             id: 3.into(),
-            vector: vec![0.0, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
     ];

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -69,12 +69,12 @@ fn test_update_proxy_segments() {
         let points = vec![
             PointStruct {
                 id: (100 * i + 1).into(),
-                vector: Into::<VectorStruct>::into(vectors[0].clone()).into(),
+                vector: VectorStruct::from(vectors[0].clone()).into(),
                 payload: None,
             },
             PointStruct {
                 id: (100 * i + 2).into(),
-                vector: Into::<VectorStruct>::into(vectors[1].clone()).into(),
+                vector: VectorStruct::from(vectors[1].clone()).into(),
                 payload: None,
             },
         ];
@@ -113,12 +113,12 @@ fn test_move_points_to_copy_on_write() {
     let points = vec![
         PointStruct {
             id: 1.into(),
-            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
         PointStruct {
             id: 2.into(),
-            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
     ];
@@ -128,12 +128,12 @@ fn test_move_points_to_copy_on_write() {
     let points = vec![
         PointStruct {
             id: 2.into(),
-            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
         PointStruct {
             id: 3.into(),
-            vector: Into::<VectorStruct>::into(vec![0.0, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![0.0, 0.0, 0.0, 0.0]).into(),
             payload: None,
         },
     ];

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -32,7 +32,7 @@ impl Group {
 impl From<Group> for PointGroup {
     fn from(group: Group) -> Self {
         Self {
-            hits: group.hits,
+            hits: group.hits.into_iter().map(Into::into).collect(),
             id: group.key,
             lookup: None,
         }

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -32,7 +32,11 @@ impl Group {
 impl From<Group> for PointGroup {
     fn from(group: Group) -> Self {
         Self {
-            hits: group.hits.into_iter().map(Into::into).collect(),
+            hits: group
+                .hits
+                .into_iter()
+                .map(api::rest::ScoredPoint::from)
+                .collect(),
             id: group.key,
             lookup: None,
         }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -439,7 +439,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
 
 impl From<Record> for api::grpc::qdrant::RetrievedPoint {
     fn from(record: Record) -> Self {
-        let vectors: Option<VectorStruct> = record.vector.map(|vector_struct| vector_struct.into());
+        let vectors = record.vector.map(VectorStruct::from);
 
         Self {
             id: Some(record.id.into()),

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -513,7 +513,7 @@ mod tests {
     fn validate_batch() {
         let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
-            vectors: Into::<BatchVectorStruct>::into(vec![]).into(),
+            vectors: BatchVectorStruct::from(vec![]).into(),
             payloads: None,
         }
         .into();
@@ -521,7 +521,7 @@ mod tests {
 
         let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
-            vectors: Into::<BatchVectorStruct>::into(vec![vec![0.1]]).into(),
+            vectors: BatchVectorStruct::from(vec![vec![0.1]]).into(),
             payloads: None,
         }
         .into();
@@ -529,7 +529,7 @@ mod tests {
 
         let batch: PointInsertOperationsInternal = Batch {
             ids: vec![PointIdType::NumId(0)],
-            vectors: Into::<BatchVectorStruct>::into(vec![vec![0.1]]).into(),
+            vectors: BatchVectorStruct::from(vec![vec![0.1]]).into(),
             payloads: Some(vec![]),
         }
         .into();

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use api::rest::schema::{BatchVectorStruct, VectorStruct};
+use api::rest::{BatchVectorStruct, VectorStruct};
 use itertools::izip;
 use schemars::JsonSchema;
 use segment::common::utils::transpose_map_into_named_vector;
@@ -387,9 +387,10 @@ impl SplitByShard for Batch {
                             let name = name.into_owned();
                             let vector: Vector = vector.to_owned();
                             match &mut batch.vectors {
-                                BatchVectorStruct::Multi(batch_vectors) => {
-                                    batch_vectors.entry(name).or_default().push(vector.into())
-                                }
+                                BatchVectorStruct::Multi(batch_vectors) => batch_vectors
+                                    .entry(name)
+                                    .or_default()
+                                    .push(api::rest::Vector::from(vector)),
                                 _ => unreachable!(), // TODO(sparse) propagate error
                             }
                         }
@@ -432,9 +433,10 @@ impl SplitByShard for Batch {
                             let name = name.into_owned();
                             let vector: Vector = vector.to_owned();
                             match &mut batch.vectors {
-                                BatchVectorStruct::Multi(batch_vectors) => {
-                                    batch_vectors.entry(name).or_default().push(vector.into())
-                                }
+                                BatchVectorStruct::Multi(batch_vectors) => batch_vectors
+                                    .entry(name)
+                                    .or_default()
+                                    .push(api::rest::Vector::from(vector)),
                                 _ => unreachable!(), // TODO(sparse) propagate error
                             }
                         }
@@ -490,12 +492,13 @@ impl PointStruct {
     pub fn get_vectors(&self) -> NamedVectors {
         let mut named_vectors = NamedVectors::default();
         match &self.vector {
-            VectorStruct::Single(vector) => {
-                named_vectors.insert(DEFAULT_VECTOR_NAME.to_string(), vector.clone().into())
-            }
+            VectorStruct::Single(vector) => named_vectors.insert(
+                DEFAULT_VECTOR_NAME.to_string(),
+                Vector::from(vector.clone()),
+            ),
             VectorStruct::Multi(vectors) => {
                 for (name, vector) in vectors {
-                    named_vectors.insert(name.clone(), vector.clone().into());
+                    named_vectors.insert(name.clone(), Vector::from(vector.clone()));
                 }
             }
         }

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
-use api::rest::schema::VectorStruct;
 use schemars::JsonSchema;
 use segment::types::{Filter, PointIdType};
 use serde::{Deserialize, Serialize};
@@ -29,7 +28,7 @@ pub struct PointVectors {
     pub id: PointIdType,
     /// Vectors
     #[serde(alias = "vectors")]
-    pub vector: VectorStruct,
+    pub vector: api::rest::VectorStruct,
 }
 
 impl Validate for PointVectors {

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
+use api::rest::schema::VectorStruct;
 use schemars::JsonSchema;
-use segment::data_types::vectors::VectorStruct;
 use segment::types::{Filter, PointIdType};
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError, ValidationErrors};

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -144,7 +144,7 @@ pub fn internal_update_vectors(
                 .into_iter()
                 .map(|point| PointVectors {
                     id: Some(point.id.into()),
-                    vectors: Some(Into::<VectorStruct>::into(point.vector).into()),
+                    vectors: Some(VectorStruct::from(point.vector).into()),
                 })
                 .collect(),
             ordering: ordering.map(write_ordering_to_proto),

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -9,6 +9,7 @@ use api::grpc::qdrant::{
     SyncPointsInternal, UpdatePointVectors, UpdateVectorsInternal, UpsertPoints,
     UpsertPointsInternal, VectorsSelector,
 };
+use segment::data_types::vectors::VectorStruct;
 use segment::json_path::JsonPath;
 use segment::types::{Filter, PayloadFieldSchema, PayloadSchemaParams, PointIdType, ScoredPoint};
 use tonic::Status;
@@ -143,7 +144,7 @@ pub fn internal_update_vectors(
                 .into_iter()
                 .map(|point| PointVectors {
                     id: Some(point.id.into()),
-                    vectors: Some(point.vector.into()),
+                    vectors: Some(Into::<VectorStruct>::into(point.vector).into()),
                 })
                 .collect(),
             ordering: ordering.map(write_ordering_to_proto),

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -30,7 +30,7 @@ fn wrong_point_struct() -> PointStruct {
         HashMap::from([("sparse".to_owned(), wrong_sparse_vector().into())]);
     PointStruct {
         id: 0.into(),
-        vector: VectorStruct::Multi(vector_data),
+        vector: VectorStruct::Multi(vector_data).into(),
         payload: None,
     }
 }
@@ -59,7 +59,7 @@ fn validate_error_sparse_vector_points_batch() {
     check_validation_error(PointsBatch {
         batch: Batch {
             ids: vec![1.into()],
-            vectors: segment::data_types::vectors::BatchVectorStruct::Multi(vector_data),
+            vectors: segment::data_types::vectors::BatchVectorStruct::Multi(vector_data).into(),
             payloads: None,
         },
         shard_key: None,
@@ -162,6 +162,6 @@ fn validate_error_sparse_vector_point_vectors() {
         HashMap::from([("sparse".to_owned(), wrong_sparse_vector().into())]);
     check_validation_error(PointVectors {
         id: 1.into(),
-        vector: VectorStruct::Multi(vector_data),
+        vector: VectorStruct::Multi(vector_data).into(),
     });
 }

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -52,35 +52,35 @@ fn upsert_operation() -> CollectionUpdateOperations {
         vec![
             PointStruct {
                 id: 1.into(),
-                vector: Into::<VectorStruct>::into(vec![1.0, 2.0, 3.0, 4.0]).into(),
+                vector: VectorStruct::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 10.12, "lon": 32.12  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 2.into(),
-                vector: Into::<VectorStruct>::into(vec![2.0, 1.0, 3.0, 4.0]).into(),
+                vector: VectorStruct::from(vec![2.0, 1.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 11.12, "lon": 34.82  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 3.into(),
-                vector: Into::<VectorStruct>::into(vec![3.0, 2.0, 1.0, 4.0]).into(),
+                vector: VectorStruct::from(vec![3.0, 2.0, 1.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": [ { "lat": 12.12, "lon": 34.82  }, { "lat": 12.2, "lon": 12.82  }] }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 4.into(),
-                vector: Into::<VectorStruct>::into(vec![4.0, 2.0, 3.0, 1.0]).into(),
+                vector: VectorStruct::from(vec![4.0, 2.0, 3.0, 1.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 13.12, "lon": 34.82  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 5.into(),
-                vector: Into::<VectorStruct>::into(vec![5.0, 2.0, 3.0, 4.0]).into(),
+                vector: VectorStruct::from(vec![5.0, 2.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 14.12, "lon": 32.12  } }"#).unwrap(),
                 ),

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use common::cpu::CpuBudget;
+use segment::data_types::vectors::VectorStruct;
 use segment::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
 use tempfile::Builder;
 use tokio::runtime::Handle;
@@ -51,35 +52,35 @@ fn upsert_operation() -> CollectionUpdateOperations {
         vec![
             PointStruct {
                 id: 1.into(),
-                vector: vec![1.0, 2.0, 3.0, 4.0].into(),
+                vector: Into::<VectorStruct>::into(vec![1.0, 2.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 10.12, "lon": 32.12  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 2.into(),
-                vector: vec![2.0, 1.0, 3.0, 4.0].into(),
+                vector: Into::<VectorStruct>::into(vec![2.0, 1.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 11.12, "lon": 34.82  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 3.into(),
-                vector: vec![3.0, 2.0, 1.0, 4.0].into(),
+                vector: Into::<VectorStruct>::into(vec![3.0, 2.0, 1.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": [ { "lat": 12.12, "lon": 34.82  }, { "lat": 12.2, "lon": 12.82  }] }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 4.into(),
-                vector: vec![4.0, 2.0, 3.0, 1.0].into(),
+                vector: Into::<VectorStruct>::into(vec![4.0, 2.0, 3.0, 1.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 13.12, "lon": 34.82  } }"#).unwrap(),
                 ),
             },
             PointStruct {
                 id: 5.into(),
-                vector: vec![5.0, 2.0, 3.0, 4.0].into(),
+                vector: Into::<VectorStruct>::into(vec![5.0, 2.0, 3.0, 4.0]).into(),
                 payload: Some(
                     serde_json::from_str(r#"{ "location": { "lat": 14.12, "lon": 32.12  } }"#).unwrap(),
                 ),

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -285,7 +285,7 @@ mod tests {
         CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperationsInternal::PointsList(vec![PointStruct {
                 id: id.into(),
-                vector: Into::<VectorStruct>::into(vec![1.0, 2.0, 3.0]).into(),
+                vector: VectorStruct::from(vec![1.0, 2.0, 3.0]).into(),
                 payload: None,
             }]),
         ))
@@ -1147,7 +1147,7 @@ mod tests {
                     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                         PointInsertOperationsInternal::PointsList(vec![PointStruct {
                             id: point_id_source.next().unwrap().into(),
-                            vector: Into::<VectorStruct>::into(
+                            vector: VectorStruct::from(
                                 std::iter::repeat_with(|| rng.gen::<f32>())
                                     .take(3)
                                     .collect::<Vec<_>>(),
@@ -1193,7 +1193,7 @@ mod tests {
                     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                         PointInsertOperationsInternal::PointsList(vec![PointStruct {
                             id: point_id_source.next().unwrap().into(),
-                            vector: Into::<VectorStruct>::into(
+                            vector: VectorStruct::from(
                                 std::iter::repeat_with(|| rng.gen::<f32>())
                                     .take(3)
                                     .collect::<Vec<_>>(),

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -251,6 +251,7 @@ mod tests {
     use rand::seq::SliceRandom;
     use rand::{Rng, SeedableRng};
     use rstest::rstest;
+    use segment::data_types::vectors::VectorStruct;
     use tempfile::{Builder, TempDir};
     use wal::WalOptions;
 
@@ -284,7 +285,7 @@ mod tests {
         CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
             PointInsertOperationsInternal::PointsList(vec![PointStruct {
                 id: id.into(),
-                vector: vec![1.0, 2.0, 3.0].into(),
+                vector: Into::<VectorStruct>::into(vec![1.0, 2.0, 3.0]).into(),
                 payload: None,
             }]),
         ))
@@ -1146,10 +1147,12 @@ mod tests {
                     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                         PointInsertOperationsInternal::PointsList(vec![PointStruct {
                             id: point_id_source.next().unwrap().into(),
-                            vector: std::iter::repeat_with(|| rng.gen::<f32>())
-                                .take(3)
-                                .collect::<Vec<_>>()
-                                .into(),
+                            vector: Into::<VectorStruct>::into(
+                                std::iter::repeat_with(|| rng.gen::<f32>())
+                                    .take(3)
+                                    .collect::<Vec<_>>(),
+                            )
+                            .into(),
                             payload: None,
                         }]),
                     ));
@@ -1190,10 +1193,12 @@ mod tests {
                     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
                         PointInsertOperationsInternal::PointsList(vec![PointStruct {
                             id: point_id_source.next().unwrap().into(),
-                            vector: std::iter::repeat_with(|| rng.gen::<f32>())
-                                .take(3)
-                                .collect::<Vec<_>>()
-                                .into(),
+                            vector: Into::<VectorStruct>::into(
+                                std::iter::repeat_with(|| rng.gen::<f32>())
+                                    .take(3)
+                                    .collect::<Vec<_>>(),
+                            )
+                            .into(),
                             payload: None,
                         }]),
                     ));

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -34,7 +34,7 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
-                vectors: Into::<BatchVectorStruct>::into(vec![
+                vectors: BatchVectorStruct::from(vec![
                     vec![1.0, 0.0, 1.0, 1.0],
                     vec![1.0, 0.0, 1.0, 0.0],
                 ])
@@ -78,7 +78,7 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
-                vectors: Into::<BatchVectorStruct>::into(vec![
+                vectors: BatchVectorStruct::from(vec![
                     vec![1.0, 0.0, 1.0, 1.0],
                     vec![1.0, 0.0, 1.0, 0.0],
                 ])
@@ -153,7 +153,7 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0.into(), 1.into()],
-                vectors: Into::<BatchVectorStruct>::into(vec![
+                vectors: BatchVectorStruct::from(vec![
                     vec![1.0, 0.0, 1.0, 1.0],
                     vec![1.0, 0.0, 1.0, 0.0],
                 ])

--- a/lib/collection/tests/integration/collection_restore_test.rs
+++ b/lib/collection/tests/integration/collection_restore_test.rs
@@ -5,6 +5,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::ScrollRequestInternal;
 use collection::operations::CollectionUpdateOperations;
 use itertools::Itertools;
+use segment::data_types::vectors::BatchVectorStruct;
 use segment::types::{PayloadContainer, PayloadSelectorExclude, WithPayloadInterface};
 use serde_json::Value;
 use tempfile::Builder;
@@ -33,7 +34,11 @@ async fn test_collection_reloading_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
-                vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
+                vectors: Into::<BatchVectorStruct>::into(vec![
+                    vec![1.0, 0.0, 1.0, 1.0],
+                    vec![1.0, 0.0, 1.0, 0.0],
+                ])
+                .into(),
                 payloads: None,
             })),
         );
@@ -73,7 +78,11 @@ async fn test_collection_payload_reloading_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0, 1].into_iter().map(|x| x.into()).collect_vec(),
-                vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
+                vectors: Into::<BatchVectorStruct>::into(vec![
+                    vec![1.0, 0.0, 1.0, 1.0],
+                    vec![1.0, 0.0, 1.0, 0.0],
+                ])
+                .into(),
                 payloads: serde_json::from_str(r#"[{ "k": "v1" } , { "k": "v2"}]"#).unwrap(),
             })),
         );
@@ -144,7 +153,11 @@ async fn test_collection_payload_custom_payload_with_shards(shard_number: u32) {
         let insert_points = CollectionUpdateOperations::PointOperation(
             PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(Batch {
                 ids: vec![0.into(), 1.into()],
-                vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
+                vectors: Into::<BatchVectorStruct>::into(vec![
+                    vec![1.0, 0.0, 1.0, 1.0],
+                    vec![1.0, 0.0, 1.0, 0.0],
+                ])
+                .into(),
                 payloads: serde_json::from_str(
                     r#"[{ "k1": "v1" }, { "k1": "v2" , "k2": "v3", "k3": "v4"}]"#,
                 )

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -40,7 +40,7 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
                 vec![1.0, 1.0, 1.0, 1.0],
@@ -108,7 +108,7 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
             ids: vec![0.into(), 1.into()],
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
             ])
@@ -201,7 +201,7 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
                     .into_iter()
                     .map(|x| x.into())
                     .collect_vec(),
-                vectors: Into::<BatchVectorStruct>::into(vec![
+                vectors: BatchVectorStruct::from(vec![
                     vec![1.0, 0.0, 1.0, 1.0],
                     vec![1.0, 0.0, 1.0, 0.0],
                     vec![1.0, 1.0, 1.0, 1.0],
@@ -269,7 +269,7 @@ fn test_deserialization() {
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
             ids: vec![0.into(), 1.into()],
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
             ])
@@ -293,12 +293,12 @@ fn test_deserialization2() {
         vec![
             PointStruct {
                 id: 0.into(),
-                vector: Into::<VectorStruct>::into(vec![1.0, 0.0, 1.0, 1.0]).into(),
+                vector: VectorStruct::from(vec![1.0, 0.0, 1.0, 1.0]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 1.into(),
-                vector: Into::<VectorStruct>::into(vec![1.0, 0.0, 1.0, 0.0]).into(),
+                vector: VectorStruct::from(vec![1.0, 0.0, 1.0, 0.0]).into(),
                 payload: None,
             },
         ]
@@ -331,7 +331,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -389,7 +389,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -479,7 +479,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -731,7 +731,7 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: Into::<BatchVectorStruct>::into(vec![
+            vectors: BatchVectorStruct::from(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
                 vec![1.0, 1.0, 1.0, 1.0],

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -13,7 +13,7 @@ use collection::recommendations::recommend_by;
 use collection::shards::replica_set::{ReplicaSetState, ReplicaState};
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy};
-use segment::data_types::vectors::VectorStruct;
+use segment::data_types::vectors::{BatchVectorStruct, VectorStruct};
 use segment::types::{
     Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, Payload,
     PayloadFieldSchema, PayloadSchemaType, PointIdType, WithPayloadInterface,
@@ -40,13 +40,13 @@ async fn test_collection_updater_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
                 vec![1.0, 1.0, 1.0, 1.0],
                 vec![1.0, 1.0, 0.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
-            ]
+            ])
             .into(),
             payloads: None,
         }
@@ -108,7 +108,11 @@ async fn test_collection_search_with_payload_and_vector_with_shards(shard_number
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
             ids: vec![0.into(), 1.into()],
-            vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
+            vectors: Into::<BatchVectorStruct>::into(vec![
+                vec![1.0, 0.0, 1.0, 1.0],
+                vec![1.0, 0.0, 1.0, 0.0],
+            ])
+            .into(),
             payloads: serde_json::from_str(
                 r#"[{ "k": { "type": "keyword", "value": "v1" } }, { "k": "v2" , "v": "v3"}]"#,
             )
@@ -197,13 +201,13 @@ async fn test_collection_loading_with_shards(shard_number: u32) {
                     .into_iter()
                     .map(|x| x.into())
                     .collect_vec(),
-                vectors: vec![
+                vectors: Into::<BatchVectorStruct>::into(vec![
                     vec![1.0, 0.0, 1.0, 1.0],
                     vec![1.0, 0.0, 1.0, 0.0],
                     vec![1.0, 1.0, 1.0, 1.0],
                     vec![1.0, 1.0, 0.0, 1.0],
                     vec![1.0, 0.0, 0.0, 0.0],
-                ]
+                ])
                 .into(),
                 payloads: None,
             }
@@ -265,7 +269,11 @@ fn test_deserialization() {
     let insert_points = CollectionUpdateOperations::PointOperation(
         Batch {
             ids: vec![0.into(), 1.into()],
-            vectors: vec![vec![1.0, 0.0, 1.0, 1.0], vec![1.0, 0.0, 1.0, 0.0]].into(),
+            vectors: Into::<BatchVectorStruct>::into(vec![
+                vec![1.0, 0.0, 1.0, 1.0],
+                vec![1.0, 0.0, 1.0, 0.0],
+            ])
+            .into(),
             payloads: None,
         }
         .into(),
@@ -285,12 +293,12 @@ fn test_deserialization2() {
         vec![
             PointStruct {
                 id: 0.into(),
-                vector: vec![1.0, 0.0, 1.0, 1.0].into(),
+                vector: Into::<VectorStruct>::into(vec![1.0, 0.0, 1.0, 1.0]).into(),
                 payload: None,
             },
             PointStruct {
                 id: 1.into(),
-                vector: vec![1.0, 0.0, 1.0, 0.0].into(),
+                vector: Into::<VectorStruct>::into(vec![1.0, 0.0, 1.0, 0.0]).into(),
                 payload: None,
             },
         ]
@@ -323,7 +331,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -333,7 +341,7 @@ async fn test_recommendation_api_with_shards(shard_number: u32) {
                 vec![0.0, 0.0, 1.0, 0.0],
                 vec![0.0, 0.0, 0.0, 1.0],
                 vec![0.0, 0.0, 0.0, 1.0],
-            ]
+            ])
             .into(),
             payloads: None,
         }
@@ -381,7 +389,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -391,7 +399,7 @@ async fn test_read_api_with_shards(shard_number: u32) {
                 vec![0.0, 0.0, 1.0, 0.0],
                 vec![0.0, 0.0, 0.0, 1.0],
                 vec![0.0, 0.0, 0.0, 1.0],
-            ]
+            ])
             .into(),
             payloads: None,
         }
@@ -471,7 +479,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 vec![0.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
                 vec![1.0, 0.0, 0.0, 0.0],
@@ -486,7 +494,7 @@ async fn test_ordered_scroll_api_with_shards(shard_number: u32) {
                 vec![0.0, 1.0, 1.0, 1.0],
                 vec![0.0, 1.0, 1.0, 1.0],
                 vec![1.0, 1.0, 1.0, 1.0],
-            ]
+            ])
             .into(),
             payloads: Some(payloads),
         }
@@ -723,13 +731,13 @@ async fn test_collection_delete_points_by_filter_with_shards(shard_number: u32) 
                 .into_iter()
                 .map(|x| x.into())
                 .collect_vec(),
-            vectors: vec![
+            vectors: Into::<BatchVectorStruct>::into(vec![
                 vec![1.0, 0.0, 1.0, 1.0],
                 vec![1.0, 0.0, 1.0, 0.0],
                 vec![1.0, 1.0, 1.0, 1.0],
                 vec![1.0, 1.0, 0.0, 1.0],
                 vec![1.0, 0.0, 0.0, 0.0],
-            ]
+            ])
             .into(),
             payloads: None,
         }

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -56,7 +56,7 @@ mod group_by {
         let insert_points = CollectionUpdateOperations::PointOperation(
             Batch {
                 ids: (0..docs * chunks).map(|x| x.into()).collect_vec(),
-                vectors: Into::<BatchVectorStruct>::into(
+                vectors: BatchVectorStruct::from(
                     (0..docs * chunks)
                         .map(|_| rand_dense_vector(&mut rng, 4))
                         .collect_vec(),
@@ -475,7 +475,7 @@ mod group_by_builder {
             let insert_points = CollectionUpdateOperations::PointOperation(
                 Batch {
                     ids: (0..docs * chunks_per_doc).map(|x| x.into()).collect_vec(),
-                    vectors: Into::<BatchVectorStruct>::into(
+                    vectors: BatchVectorStruct::from(
                         (0..docs * chunks_per_doc)
                             .map(|_| rand_dense_vector(&mut rng, 4))
                             .collect_vec(),
@@ -508,7 +508,7 @@ mod group_by_builder {
             let insert_points = CollectionUpdateOperations::PointOperation(
                 Batch {
                     ids: (0..docs).map(|x| x.into()).collect_vec(),
-                    vectors: Into::<BatchVectorStruct>::into(
+                    vectors: BatchVectorStruct::from(
                         (0..docs)
                             .map(|_| rand_dense_vector(&mut rng, 4))
                             .collect_vec(),

--- a/lib/collection/tests/integration/grouping_test.rs
+++ b/lib/collection/tests/integration/grouping_test.rs
@@ -21,6 +21,7 @@ fn rand_dense_vector(rng: &mut ThreadRng, size: usize) -> DenseVector {
 
 mod group_by {
     use collection::grouping::GroupBy;
+    use segment::data_types::vectors::BatchVectorStruct;
 
     use super::*;
 
@@ -55,10 +56,12 @@ mod group_by {
         let insert_points = CollectionUpdateOperations::PointOperation(
             Batch {
                 ids: (0..docs * chunks).map(|x| x.into()).collect_vec(),
-                vectors: (0..docs * chunks)
-                    .map(|_| rand_dense_vector(&mut rng, 4))
-                    .collect_vec()
-                    .into(),
+                vectors: Into::<BatchVectorStruct>::into(
+                    (0..docs * chunks)
+                        .map(|_| rand_dense_vector(&mut rng, 4))
+                        .collect_vec(),
+                )
+                .into(),
                 payloads: (0..docs)
                     .flat_map(|x| {
                         (0..chunks).map(move |_| {
@@ -434,6 +437,7 @@ mod group_by_builder {
     use collection::grouping::GroupBy;
     use collection::lookup::types::PseudoId;
     use collection::lookup::WithLookup;
+    use segment::data_types::vectors::BatchVectorStruct;
     use tokio::sync::RwLock;
 
     use super::*;
@@ -471,10 +475,12 @@ mod group_by_builder {
             let insert_points = CollectionUpdateOperations::PointOperation(
                 Batch {
                     ids: (0..docs * chunks_per_doc).map(|x| x.into()).collect_vec(),
-                    vectors: (0..docs * chunks_per_doc)
-                        .map(|_| rand_dense_vector(&mut rng, 4))
-                        .collect_vec()
-                        .into(),
+                    vectors: Into::<BatchVectorStruct>::into(
+                        (0..docs * chunks_per_doc)
+                            .map(|_| rand_dense_vector(&mut rng, 4))
+                            .collect_vec(),
+                    )
+                    .into(),
                     payloads: (0..docs)
                         .flat_map(|x| {
                             (0..chunks_per_doc)
@@ -502,10 +508,12 @@ mod group_by_builder {
             let insert_points = CollectionUpdateOperations::PointOperation(
                 Batch {
                     ids: (0..docs).map(|x| x.into()).collect_vec(),
-                    vectors: (0..docs)
-                        .map(|_| rand_dense_vector(&mut rng, 4))
-                        .collect_vec()
-                        .into(),
+                    vectors: Into::<BatchVectorStruct>::into(
+                        (0..docs)
+                            .map(|_| rand_dense_vector(&mut rng, 4))
+                            .collect_vec(),
+                    )
+                    .into(),
                     payloads: (0..docs)
                         .map(|x| {
                             Some(Payload::from(

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -145,7 +145,7 @@ async fn happy_lookup_ids() {
             record.payload,
             Some(Payload::from(json!({ "foo": format!("bar {}", id_value) })))
         );
-        let vector: api::rest::schema::VectorStruct = vector.into();
+        let vector: api::rest::VectorStruct = vector.into();
         assert_eq!(record.vector, Some(vector));
     }
 }

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -58,7 +58,7 @@ async fn setup() -> Resources {
     let upsert_points = collection::operations::CollectionUpdateOperations::PointOperation(
         Batch {
             ids,
-            vectors: Into::<BatchVectorStruct>::into(vectors).into(),
+            vectors: BatchVectorStruct::from(vectors).into(),
             payloads: Some(payloads),
         }
         .into(),

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{self, Rng, SeedableRng};
 use rstest::*;
-use segment::data_types::vectors::VectorStruct;
+use segment::data_types::vectors::{BatchVectorStruct, VectorStruct};
 use segment::types::{Payload, PointIdType};
 use serde_json::json;
 use tempfile::Builder;
@@ -58,7 +58,7 @@ async fn setup() -> Resources {
     let upsert_points = collection::operations::CollectionUpdateOperations::PointOperation(
         Batch {
             ids,
-            vectors: vectors.into(),
+            vectors: Into::<BatchVectorStruct>::into(vectors).into(),
             payloads: Some(payloads),
         }
         .into(),
@@ -145,6 +145,7 @@ async fn happy_lookup_ids() {
             record.payload,
             Some(Payload::from(json!({ "foo": format!("bar {}", id_value) })))
         );
+        let vector: api::rest::schema::VectorStruct = vector.into();
         assert_eq!(record.vector, Some(vector));
     }
 }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -227,8 +227,8 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
     assert_eq!(retrieve.len(), 1);
     match retrieve[0].vector.as_ref().unwrap() {
-        api::rest::schema::VectorStruct::Single(_) => panic!("expected multi vector"),
-        api::rest::schema::VectorStruct::Multi(vectors) => {
+        api::rest::VectorStruct::Single(_) => panic!("expected multi vector"),
+        api::rest::VectorStruct::Multi(vectors) => {
             assert!(vectors.contains_key(VEC_NAME1));
             assert!(!vectors.contains_key(VEC_NAME2));
         }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -101,7 +101,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
         points.push(PointStruct {
             id: i.into(),
-            vector: Into::<VectorStruct>::into(vectors).into(),
+            vector: VectorStruct::from(vectors).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -101,7 +101,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
         points.push(PointStruct {
             id: i.into(),
-            vector: vectors.into(),
+            vector: Into::<VectorStruct>::into(vectors).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }
@@ -227,8 +227,8 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
     assert_eq!(retrieve.len(), 1);
     match retrieve[0].vector.as_ref().unwrap() {
-        VectorStruct::Single(_) => panic!("expected multi vector"),
-        VectorStruct::Multi(vectors) => {
+        api::rest::schema::VectorStruct::Single(_) => panic!("expected multi vector"),
+        api::rest::schema::VectorStruct::Multi(vectors) => {
             assert!(vectors.contains_key(VEC_NAME1));
             assert!(!vectors.contains_key(VEC_NAME2));
         }

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -4,6 +4,7 @@ use collection::operations::point_ops::{
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::SearchRequestInternal;
 use collection::operations::CollectionUpdateOperations;
+use segment::data_types::vectors::VectorStruct;
 use segment::types::WithPayloadInterface;
 use tempfile::Builder;
 
@@ -28,7 +29,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     for i in 0..1000 {
         points.push(PointStruct {
             id: i.into(),
-            vector: vec![i as f32, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![i as f32, 0.0, 0.0, 0.0]).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }

--- a/lib/collection/tests/integration/pagination_test.rs
+++ b/lib/collection/tests/integration/pagination_test.rs
@@ -29,7 +29,7 @@ async fn test_collection_paginated_search_with_shards(shard_number: u32) {
     for i in 0..1000 {
         points.push(PointStruct {
             id: i.into(),
-            vector: Into::<VectorStruct>::into(vec![i as f32, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![i as f32, 0.0, 0.0, 0.0]).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -100,7 +100,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
     for i in 0..100 {
         points.push(PointStruct {
             id: i.into(),
-            vector: Into::<VectorStruct>::into(vec![i as f32, 0.0, 0.0, 0.0]).into(),
+            vector: VectorStruct::from(vec![i as f32, 0.0, 0.0, 0.0]).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -14,6 +14,7 @@ use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::ReplicaState;
 use common::cpu::CpuBudget;
+use segment::data_types::vectors::VectorStruct;
 use segment::types::{Distance, WithPayloadInterface, WithVector};
 use tempfile::Builder;
 
@@ -99,7 +100,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
     for i in 0..100 {
         points.push(PointStruct {
             id: i.into(),
-            vector: vec![i as f32, 0.0, 0.0, 0.0].into(),
+            vector: Into::<VectorStruct>::into(vec![i as f32, 0.0, 0.0, 0.0]).into(),
             payload: Some(serde_json::from_str(r#"{"number": "John Doe"}"#).unwrap()),
         });
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -195,6 +195,7 @@ pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
 }
 
 /// Full vector data per point separator with single and multiple vector modes
+/// TODO(colbert) try to remove this enum and use NamedVectors instead
 #[derive(Clone, Debug, PartialEq)]
 pub enum VectorStruct {
     Single(DenseVector),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -12,8 +12,7 @@ use crate::vector_storage::query::context_query::ContextQuery;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query::reco_query::RecoQuery;
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(untagged, rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Vector {
     Dense(DenseVector),
     Sparse(SparseVector),
@@ -30,15 +29,6 @@ impl Vector {
         match self {
             Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
             Vector::Sparse(v) => VectorRef::Sparse(v),
-        }
-    }
-}
-
-impl Validate for Vector {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            Vector::Dense(_) => Ok(()),
-            Vector::Sparse(v) => v.validate(),
         }
     }
 }
@@ -205,8 +195,7 @@ pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
 }
 
 /// Full vector data per point separator with single and multiple vector modes
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(untagged, rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VectorStruct {
     Single(DenseVector),
     Multi(HashMap<String, Vector>),
@@ -249,15 +238,6 @@ impl VectorStruct {
             }
             // Multi into multi
             (VectorStruct::Multi(this), VectorStruct::Multi(other)) => this.extend(other),
-        }
-    }
-}
-
-impl Validate for VectorStruct {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            VectorStruct::Single(_) => Ok(()),
-            VectorStruct::Multi(v) => common::validation::validate_iter(v.values()),
         }
     }
 }
@@ -413,8 +393,7 @@ impl Validate for NamedVectorStruct {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(untagged, rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BatchVectorStruct {
     Single(Vec<DenseVector>),
     Multi(HashMap<String, Vec<Vector>>),
@@ -436,17 +415,6 @@ impl BatchVectorStruct {
                 } else {
                     transpose_map_into_named_vector(named_vectors)
                 }
-            }
-        }
-    }
-}
-
-impl Validate for BatchVectorStruct {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            BatchVectorStruct::Single(_) => Ok(()),
-            BatchVectorStruct::Multi(v) => {
-                common::validation::validate_iter(v.values().flat_map(|batch| batch.iter()))
             }
         }
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -217,7 +217,7 @@ pub enum Order {
 }
 
 /// Search result
-#[derive(Serialize, JsonSchema, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ScoredPoint {
     /// Point id
     pub id: PointIdType,
@@ -230,7 +230,6 @@ pub struct ScoredPoint {
     /// Vector of the point
     pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -42,7 +42,7 @@ async fn discover_points(
         .map(|scored_points| {
             scored_points
                 .into_iter()
-                .map(api::rest::schema::ScoredPoint::from)
+                .map(api::rest::ScoredPoint::from)
                 .collect_vec()
         });
 
@@ -72,7 +72,7 @@ async fn discover_batch_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(api::rest::schema::ScoredPoint::from)
+                    .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -42,7 +42,7 @@ async fn discover_points(
         .map(|scored_points| {
             scored_points
                 .into_iter()
-                .map(Into::<api::rest::schema::ScoredPoint>::into)
+                .map(api::rest::schema::ScoredPoint::from)
                 .collect_vec()
         });
 
@@ -72,7 +72,7 @@ async fn discover_batch_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(Into::<api::rest::schema::ScoredPoint>::into)
+                    .map(api::rest::schema::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -2,6 +2,7 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{DiscoverRequest, DiscoverRequestBatch};
+use itertools::Itertools;
 use storage::content_manager::toc::TableOfContent;
 use tokio::time::Instant;
 
@@ -37,7 +38,13 @@ async fn discover_points(
             shard_selection,
             params.timeout(),
         )
-        .await;
+        .await
+        .map(|scored_points| {
+            scored_points
+                .into_iter()
+                .map(Into::<api::rest::schema::ScoredPoint>::into)
+                .collect_vec()
+        });
 
     process_response(response, timing)
 }
@@ -58,7 +65,18 @@ async fn discover_batch_points(
         params.consistency,
         params.timeout(),
     )
-    .await;
+    .await
+    .map(|batch_scored_points| {
+        batch_scored_points
+            .into_iter()
+            .map(|scored_points| {
+                scored_points
+                    .into_iter()
+                    .map(Into::<api::rest::schema::ScoredPoint>::into)
+                    .collect_vec()
+            })
+            .collect_vec()
+    });
 
     process_response(response, timing)
 }

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -48,7 +48,7 @@ async fn recommend_points(
         .map(|scored_points| {
             scored_points
                 .into_iter()
-                .map(Into::<api::rest::schema::ScoredPoint>::into)
+                .map(api::rest::schema::ScoredPoint::from)
                 .collect_vec()
         });
 
@@ -102,7 +102,7 @@ async fn recommend_batch_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(Into::<api::rest::schema::ScoredPoint>::into)
+                    .map(api::rest::schema::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -48,7 +48,7 @@ async fn recommend_points(
         .map(|scored_points| {
             scored_points
                 .into_iter()
-                .map(api::rest::schema::ScoredPoint::from)
+                .map(api::rest::ScoredPoint::from)
                 .collect_vec()
         });
 
@@ -102,7 +102,7 @@ async fn recommend_batch_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(api::rest::schema::ScoredPoint::from)
+                    .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -46,7 +46,7 @@ async fn search_points(
     .map(|scored_points| {
         scored_points
             .into_iter()
-            .map(Into::<api::rest::schema::ScoredPoint>::into)
+            .map(api::rest::schema::ScoredPoint::from)
             .collect_vec()
     });
 
@@ -95,7 +95,7 @@ async fn batch_search_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(Into::<api::rest::schema::ScoredPoint>::into)
+                    .map(api::rest::schema::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -5,6 +5,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CoreSearchRequest, SearchGroupsRequest, SearchRequest, SearchRequestBatch,
 };
+use itertools::Itertools;
 use storage::content_manager::toc::TableOfContent;
 
 use super::read_params::ReadParams;
@@ -41,7 +42,13 @@ async fn search_points(
         shard_selection,
         params.timeout(),
     )
-    .await;
+    .await
+    .map(|scored_points| {
+        scored_points
+            .into_iter()
+            .map(Into::<api::rest::schema::ScoredPoint>::into)
+            .collect_vec()
+    });
 
     process_response(response, timing)
 }
@@ -81,7 +88,18 @@ async fn batch_search_points(
         params.consistency,
         params.timeout(),
     )
-    .await;
+    .await
+    .map(|batch_scored_points| {
+        batch_scored_points
+            .into_iter()
+            .map(|scored_points| {
+                scored_points
+                    .into_iter()
+                    .map(Into::<api::rest::schema::ScoredPoint>::into)
+                    .collect_vec()
+            })
+            .collect_vec()
+    });
 
     process_response(response, timing)
 }

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -46,7 +46,7 @@ async fn search_points(
     .map(|scored_points| {
         scored_points
             .into_iter()
-            .map(api::rest::schema::ScoredPoint::from)
+            .map(api::rest::ScoredPoint::from)
             .collect_vec()
     });
 
@@ -95,7 +95,7 @@ async fn batch_search_points(
             .map(|scored_points| {
                 scored_points
                     .into_iter()
-                    .map(api::rest::schema::ScoredPoint::from)
+                    .map(api::rest::ScoredPoint::from)
                     .collect_vec()
             })
             .collect_vec()

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,4 +1,5 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
+use api::rest::schema::ScoredPoint;
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
@@ -16,7 +17,6 @@ use collection::operations::types::{
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};
 use schemars::gen::SchemaSettings;
 use schemars::JsonSchema;
-use segment::types::ScoredPoint;
 use serde::Serialize;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CreateCollection, UpdateCollection,

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,5 +1,5 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
-use api::rest::schema::ScoredPoint;
+use api::rest::ScoredPoint;
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -245,7 +245,7 @@ pub async fn update_vectors(
         };
         op_points.push(PointVectors {
             id,
-            vector: vector.into(),
+            vector: api::rest::VectorStruct::from(vector),
         });
     }
 

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -33,6 +33,7 @@ use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVect
 use collection::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
 use collection::shards::shard::ShardId;
 use itertools::Itertools;
+use segment::data_types::vectors::VectorStruct;
 use segment::types::{
     ExtendedPointId, Filter, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
 };
@@ -238,11 +239,14 @@ pub async fn update_vectors(
             Some(id) => id.try_into()?,
             None => return Err(Status::invalid_argument("id is expected")),
         };
-        let vector = match point.vectors {
+        let vector: VectorStruct = match point.vectors {
             Some(vectors) => vectors.try_into()?,
             None => return Err(Status::invalid_argument("vectors is expected")),
         };
-        op_points.push(PointVectors { id, vector });
+        op_points.push(PointVectors {
+            id,
+            vector: vector.into(),
+        });
     }
 
     let operation = UpdateVectors {


### PR DESCRIPTION
Beginning of https://github.com/qdrant/qdrant/issues/3830.

This PR starts decouple REST API and qdrant internal structures. Currently, changing internal structs means changing public REST API. As an example is ColBERT feature https://github.com/qdrant/qdrant/issues/3684 where we have to extend `Vector` enum but don't want to change public API.

In this PR, `lib/api/rest` folder was created: future place for all REST API definitions and conventions (like `lib/api/grpc` folder). This PR moves `Vector`, `VectorStruct`, `BatchVectorStruct` and `ScoredPoint`. Because moving `Vector` is a blocker for ColBERT issue and others depend on `Vector` on the segment level.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
