### PR TITLE
Only flush clock maps to disk if they have changed

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -16,7 +16,6 @@ use crate::shards::shard::PeerId;
 pub struct ClockMap {
     clocks: HashMap<Key, Clock>,
     /// Whether this clock map has changed since the last time it was persisted.
-    #[serde(skip, default)]
     changed: bool,
 }
 

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -390,9 +390,7 @@ impl From<ClockMapHelper> for ClockMap {
     fn from(helper: ClockMapHelper) -> Self {
         Self {
             clocks: helper.clocks.into_iter().map(Into::into).collect(),
-            // We get a new clock map with non-default state, assume changed so we store it next
-            // time
-            changed: true,
+            changed: false,
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -43,7 +43,7 @@ impl ClockMap {
         Ok(())
     }
 
-    pub fn store_changed(&mut self, path: &Path) -> Result<()> {
+    pub fn store_if_changed(&mut self, path: &Path) -> Result<()> {
         if self.changed {
             self.store(path)?;
         }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -467,7 +467,11 @@ mod test {
         input.advance_clock(ClockTag::new(2, 2, 12345));
 
         let json = serde_json::to_value(&input).unwrap();
-        let output = serde_json::from_value(json).unwrap();
+        let mut output: ClockMap = serde_json::from_value(json).unwrap();
+
+        // Propagate changed flag to allow comparison
+        // Normally we would not need to do this, but we bypass the regular load/store functions
+        output.changed = input.changed;
 
         assert_eq!(input, output);
     }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -952,16 +952,16 @@ impl LocalShardClocks {
     }
 
     /// Persist clock maps to disk
-    pub async fn store_changed(&self, shard_path: &Path) -> CollectionResult<()> {
+    pub async fn store_if_changed(&self, shard_path: &Path) -> CollectionResult<()> {
         self.oldest_clocks
             .lock()
             .await
-            .store_changed(&Self::oldest_clocks_path(shard_path))?;
+            .store_if_changed(&Self::oldest_clocks_path(shard_path))?;
 
         self.newest_clocks
             .lock()
             .await
-            .store_changed(&Self::newest_clocks_path(shard_path))?;
+            .store_if_changed(&Self::newest_clocks_path(shard_path))?;
 
         Ok(())
     }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -952,16 +952,16 @@ impl LocalShardClocks {
     }
 
     /// Persist clock maps to disk
-    pub async fn store(&self, shard_path: &Path) -> CollectionResult<()> {
+    pub async fn store_changed(&self, shard_path: &Path) -> CollectionResult<()> {
         self.oldest_clocks
             .lock()
             .await
-            .store(&Self::oldest_clocks_path(shard_path))?;
+            .store_changed(&Self::oldest_clocks_path(shard_path))?;
 
         self.newest_clocks
             .lock()
             .await
-            .store(&Self::newest_clocks_path(shard_path))?;
+            .store_changed(&Self::newest_clocks_path(shard_path))?;
 
         Ok(())
     }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -652,7 +652,7 @@ impl UpdateHandler {
 
             let ack = confirmed_version.min(keep_from.saturating_sub(1));
 
-            if let Err(err) = clocks.store_changed(&shard_path).await {
+            if let Err(err) = clocks.store_if_changed(&shard_path).await {
                 log::warn!("Failed to store clock maps to disk: {err}");
                 segments.write().report_optimizer_error(err);
             }

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -652,7 +652,7 @@ impl UpdateHandler {
 
             let ack = confirmed_version.min(keep_from.saturating_sub(1));
 
-            if let Err(err) = clocks.store(&shard_path).await {
+            if let Err(err) = clocks.store_changed(&shard_path).await {
                 log::warn!("Failed to store clock maps to disk: {err}");
                 segments.write().report_optimizer_error(err);
             }


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Prevent having a lot of IO writes by flushing clock maps constantly. Only write to disk if they have changed.

Note that I didn't check how this affects IO on syscall level.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?