### PR TITLE
Switch to Recovery state, deprecated PartialSnapshot, for Qdrant 1.9

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1512,7 +1512,7 @@ Note: 1kB = 1 vector of size 256. |
 | Partial | 2 | The shard is partially loaded and is currently receiving data from other shards |
 | Initializing | 3 | Collection is being created |
 | Listener | 4 | A shard which receives data, but is not used for search; Useful for backup shards |
-| PartialSnapshot | 5 | Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard |
+| PartialSnapshot | 5 | Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard |
 | Recovery | 6 | Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true |
 
 

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -450,7 +450,6 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
-  // TODO(1.9): deprecate PartialSnapshot state
 }
 
 message ShardKey {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -448,7 +448,7 @@ enum ReplicaState {
   Partial = 2; // The shard is partially loaded and is currently receiving data from other shards
   Initializing = 3; // Collection is being created
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
-  PartialSnapshot = 5; // Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+  PartialSnapshot = 5; // Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
   // TODO(1.9): deprecate PartialSnapshot state
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1322,7 +1322,7 @@ pub enum ReplicaState {
     Initializing = 3,
     /// A shard which receives data, but is not used for search; Useful for backup shards
     Listener = 4,
-    /// Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+    /// Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
     PartialSnapshot = 5,
     /// Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
     Recovery = 6,

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -81,9 +81,8 @@ impl Collection {
 
             let initial_state = match shard_transfer.method.unwrap_or_default() {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
-                // TODO(1.9): switch into recovery state instead
                 ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
-                    ReplicaState::PartialSnapshot
+                    ReplicaState::Recovery
                 }
             };
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -909,9 +909,11 @@ pub enum ReplicaState {
     // A shard which receives data, but is not used for search
     // Useful for backup shards
     Listener,
+    // Deprecated since Qdrant 1.9.0, used in Qdrant 1.7.0 and 1.8.0
+    //
     // Snapshot shard transfer is in progress, updates aren't sent to the shard
     // Normally rejects updates. Since 1.8 it allows updates if force is true.
-    // TODO(1.9): deprecate this state
+    // TODO(1.10): remove PartialSnapshot state entirely?
     PartialSnapshot,
     // Shard is undergoing recovery by an external node
     // Normally rejects updates, accepts updates if force is true

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -45,7 +45,6 @@ impl ShardReplicaSet {
                     Ok(Some(local_shard.get().update(operation, false).await?))
                 }
                 // In recovery state, only allow operations with force flag
-                // TODO(1.9): deprecate accepting partialsnapshot operations if force is true
                 Some(ReplicaState::PartialSnapshot | ReplicaState::Recovery)
                     if operation.clock_tag.map_or(false, |tag| tag.force) =>
                 {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -419,11 +419,9 @@ impl ShardReplicaSet {
 
         for (peer_id, err) in failures {
             log::warn!(
-                "Failed to update shard {}:{} on peer {}, error: {}",
+                "Failed to update shard {}:{} on peer {peer_id}, error: {err}",
                 self.collection_id,
                 self.shard_id,
-                peer_id,
-                err
             );
 
             let Some(&peer_state) = state.get_peer_state(peer_id) else {
@@ -443,8 +441,7 @@ impl ShardReplicaSet {
             }
 
             log::debug!(
-                "Deactivating peer {} because of failed update of shard {}:{}",
-                peer_id,
+                "Deactivating peer {peer_id} because of failed update of shard {}:{}",
                 self.collection_id,
                 self.shard_id
             );

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -432,8 +432,7 @@ impl TableOfContent {
                 }
 
                 log::debug!(
-                    "Set shard replica state from {:?} to {:?} after snapshot recovery",
-                    current_state,
+                    "Set shard replica state from {current_state:?} to {:?} after snapshot recovery",
                     ReplicaState::Partial,
                 );
 


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Related: <https://github.com/qdrant/qdrant/pull/3848>

Deprecate the `PartialSnapshot` state and change both the snapshot and WAL delta transfers to use the `Recovery` shard replica set state instead.

This is compatible with nodes running 1.8 and up.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?