### PR TITLE
Switch to RecoveryToPartial, deprecated SnapshotRecovered in consensus, for Qdrant 1.9

### DIFF
--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -299,6 +299,8 @@ pub enum ShardTransferOperations {
     /// If the given transfer is ongoing, it is aborted and restarted with the new configuration.
     Restart(ShardTransferRestart),
     Finish(ShardTransfer),
+    /// Deprecated since Qdrant 1.9.0, used in Qdrant 1.7.0 and 1.8.0
+    ///
     /// Used in `ShardTransferMethod::Snapshot`
     ///
     /// Called when the snapshot has successfully been recovered on the remote, brings the transfer

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -392,8 +392,8 @@ impl TableOfContent {
                 )?;
                 collection.finish_shard_transfer(transfer).await?;
             }
-            ShardTransferOperations::SnapshotRecovered(transfer)
-            | ShardTransferOperations::RecoveryToPartial(transfer) => {
+            ShardTransferOperations::RecoveryToPartial(transfer)
+            | ShardTransferOperations::SnapshotRecovered(transfer) => {
                 // Validate transfer exists to prevent double handling
                 transfer::helpers::validate_transfer_exists(
                     &transfer,

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -57,7 +57,7 @@ impl ShardTransferConsensus for ShardTransferDispatcher {
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
                 collection_name,
-                ShardTransferOperations::SnapshotRecovered(transfer_config.key()),
+                ShardTransferOperations::RecoveryToPartial(transfer_config.key()),
             )));
         proposal_sender.send(operation).map_err(|err| {
             CollectionError::service_error(format!("Failed to submit consensus proposal: {err}"))


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>
Related: <https://github.com/qdrant/qdrant/pull/3847>

Deprecate the `SnapshotRecovered` consensus call and change both the snapshot and WAL delta transfers to use the `RecoveryToPartial` consensus call instead.

This is compatible with nodes running 1.8 and up.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?