### PR TITLE
Implement `collection` claims for points API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ name = "rbac"
 version = "0.0.0"
 dependencies = [
  "jsonwebtoken",
+ "segment",
  "serde",
 ]
 

--- a/lib/rbac/Cargo.toml
+++ b/lib/rbac/Cargo.toml
@@ -12,4 +12,5 @@ publish = false
 
 [dependencies]
 jsonwebtoken = "9.2.0"
+segment = { path = "../segment" }
 serde.workspace = true

--- a/lib/rbac/src/jwt.rs
+++ b/lib/rbac/src/jwt.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+use segment::json_path::JsonPath;
+use segment::types::ValueVariants;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
@@ -7,4 +11,13 @@ pub struct Claims {
 
     /// Write access, default is false. Read access is always enabled
     pub w: Option<bool>,
+
+    /// Collection names that are allowed to be accessed
+    pub collections: Option<Vec<String>>,
+
+    /// Payload constraints.
+    /// An object where each key is a JSON path, and each value is JSON value.
+    pub payload: Option<PayloadClaim>,
 }
+
+pub type PayloadClaim = HashMap<JsonPath, ValueVariants>;

--- a/lib/rbac/src/lib.rs
+++ b/lib/rbac/src/lib.rs
@@ -39,6 +39,7 @@ impl JwtParser {
 
 #[cfg(test)]
 mod tests {
+    use segment::types::ValueVariants;
 
     use super::*;
 
@@ -59,6 +60,19 @@ mod tests {
         let claims = Claims {
             exp: Some(exp),
             w: Some(true),
+            collections: Some(vec!["collection".to_string()]),
+            payload: Some(
+                vec![
+                    (
+                        "field1".parse().unwrap(),
+                        ValueVariants::Keyword("value".to_string()),
+                    ),
+                    ("field2".parse().unwrap(), ValueVariants::Integer(42)),
+                    ("field2".parse().unwrap(), ValueVariants::Bool(true)),
+                ]
+                .into_iter()
+                .collect(),
+            ),
         };
         let token = create_token(&claims);
 
@@ -80,6 +94,8 @@ mod tests {
         let mut claims = Claims {
             exp: Some(exp),
             w: Some(false),
+            collections: None,
+            payload: None,
         };
 
         let token = create_token(&claims);

--- a/lib/storage/src/content_manager/claims.rs
+++ b/lib/storage/src/content_manager/claims.rs
@@ -28,7 +28,6 @@ pub fn check_collection_name(
     })
 }
 
-#[allow(private_bounds)]
 pub fn check_points_op(
     collections: &Option<Vec<String>>,
     payload: &Option<PayloadClaim>,
@@ -43,7 +42,7 @@ pub fn check_points_op(
     Ok(())
 }
 
-trait PointsOpClaimsChecker {
+pub trait PointsOpClaimsChecker {
     /// An iterator over the collection names used in the operation, for checking `collections`
     /// claim.
     fn collections_used(&self) -> impl Iterator<Item = &str>;

--- a/lib/storage/src/content_manager/claims.rs
+++ b/lib/storage/src/content_manager/claims.rs
@@ -17,7 +17,7 @@ use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, 
 use super::errors::StorageError;
 
 pub fn check_collection_name(
-    collections: &Option<Vec<String>>,
+    collections: Option<&Vec<String>>,
     collection_name: &str,
 ) -> Result<(), StorageError> {
     let ok = collections
@@ -29,8 +29,8 @@ pub fn check_collection_name(
 }
 
 pub fn check_points_op(
-    collections: &Option<Vec<String>>,
-    payload: &Option<PayloadClaim>,
+    collections: Option<&Vec<String>>,
+    payload: Option<&PayloadClaim>,
     op: &mut impl PointsOpClaimsChecker,
 ) -> Result<(), StorageError> {
     for collection in op.collections_used() {

--- a/lib/storage/src/content_manager/claims.rs
+++ b/lib/storage/src/content_manager/claims.rs
@@ -1,0 +1,306 @@
+use std::collections::HashSet;
+use std::mem::take;
+
+use collection::grouping::group_by::{GroupRequest, SourceRequest};
+use collection::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
+use collection::operations::point_ops::{PointIdsList, PointOperations};
+use collection::operations::types::{
+    ContextExamplePair, CoreSearchRequest, CountRequestInternal, DiscoverRequestInternal,
+    PointRequestInternal, RecommendExample, RecommendRequestInternal, ScrollRequestInternal,
+};
+use collection::operations::vector_ops::VectorOperations;
+use collection::operations::{CollectionUpdateOperations, FieldIndexOperations};
+use itertools::{Either, Itertools as _};
+use rbac::jwt::{Claims, PayloadClaim};
+use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, Payload};
+
+use super::errors::StorageError;
+
+pub fn check_collection_name(claims: &Claims, collection_name: &str) -> Result<(), StorageError> {
+    let ok = claims
+        .collections
+        .as_ref()
+        .map_or(true, |c| c.iter().any(|c| c == collection_name));
+    ok.then_some(()).ok_or_else(|| {
+        StorageError::unauthorized(format!("Collection '{collection_name}' is not allowed"))
+    })
+}
+
+#[allow(private_bounds)]
+pub fn check_points_op(
+    claims: &Claims,
+    op: &mut impl PointsOpClaimsChecker,
+) -> Result<(), StorageError> {
+    for collection in op.collections_used() {
+        check_collection_name(claims, collection)?;
+    }
+    if let Some(payload) = &claims.payload {
+        op.apply_payload_claim(payload)?;
+    }
+    Ok(())
+}
+
+trait PointsOpClaimsChecker {
+    /// An iterator over the collection names used in the operation, for checking `collections`
+    /// claim.
+    fn collections_used(&self) -> impl Iterator<Item = &str>;
+
+    /// Apply the `payload` claim to the operation.
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError>;
+}
+
+impl PointsOpClaimsChecker for RecommendRequestInternal {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        self.lookup_from.iter().map(|l| l.collection.as_str())
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        apply_filter_opt(&mut self.filter, claim)
+    }
+}
+
+impl PointsOpClaimsChecker for PointRequestInternal {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        std::iter::empty()
+    }
+
+    fn apply_payload_claim(&mut self, _claim: &PayloadClaim) -> Result<(), StorageError> {
+        failed_payload_claim()
+    }
+}
+
+impl PointsOpClaimsChecker for CoreSearchRequest {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        std::iter::empty()
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        apply_filter_opt(&mut self.filter, claim)
+    }
+}
+
+impl PointsOpClaimsChecker for CountRequestInternal {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        std::iter::empty()
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        apply_filter_opt(&mut self.filter, claim)
+    }
+}
+
+impl PointsOpClaimsChecker for GroupRequest {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        let source = match &self.source {
+            SourceRequest::Search(_) => Either::Left(std::iter::empty()),
+            SourceRequest::Recommend(r) => Either::Right(r.collections_used()),
+        };
+        let with_lookup = self.with_lookup.iter().map(|l| l.collection_name.as_str());
+        source.merge(with_lookup)
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        match &mut self.source {
+            SourceRequest::Search(s) => apply_filter_opt(&mut s.filter, claim),
+            SourceRequest::Recommend(r) => r.apply_payload_claim(claim),
+        }
+    }
+}
+
+impl PointsOpClaimsChecker for DiscoverRequestInternal {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        self.lookup_from.iter().map(|l| l.collection.as_str())
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        if let Some(target) = &self.target {
+            validate_payload_claim_for_recommended_example(target)?;
+        }
+        for ContextExamplePair { positive, negative } in self.context.iter().flat_map(|c| c.iter())
+        {
+            validate_payload_claim_for_recommended_example(positive)?;
+            validate_payload_claim_for_recommended_example(negative)?;
+        }
+        apply_filter_opt(&mut self.filter, claim)
+    }
+}
+
+impl PointsOpClaimsChecker for ScrollRequestInternal {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        std::iter::empty()
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        apply_filter_opt(&mut self.filter, claim)
+    }
+}
+
+impl PointsOpClaimsChecker for CollectionUpdateOperations {
+    fn collections_used(&self) -> impl Iterator<Item = &str> {
+        std::iter::empty()
+    }
+
+    fn apply_payload_claim(&mut self, claim: &PayloadClaim) -> Result<(), StorageError> {
+        match self {
+            CollectionUpdateOperations::PointOperation(op) => match op {
+                PointOperations::UpsertPoints(_) => failed_payload_claim(),
+                PointOperations::DeletePoints { ids } => {
+                    *op = PointOperations::DeletePointsByFilter(
+                        make_filter_from_ids(take(ids))
+                            .merge_owned(make_filter_from_payload_claim(claim)),
+                    );
+                    Ok(())
+                }
+                PointOperations::DeletePointsByFilter(filter) => apply_filter(filter, claim),
+                PointOperations::SyncPoints(_) => failed_payload_claim(),
+            },
+
+            CollectionUpdateOperations::VectorOperation(op) => match op {
+                VectorOperations::UpdateVectors(_) => failed_payload_claim(),
+                VectorOperations::DeleteVectors(PointIdsList { points, shard_key }, vectors) => {
+                    if shard_key.is_some() {
+                        // It is unclear where to put the shard_key
+                        return failed_payload_claim();
+                    }
+                    *op = VectorOperations::DeleteVectorsByFilter(
+                        make_filter_from_ids(take(points))
+                            .merge_owned(make_filter_from_payload_claim(claim)),
+                        take(vectors),
+                    );
+                    Ok(())
+                }
+                VectorOperations::DeleteVectorsByFilter(filter, _) => apply_filter(filter, claim),
+            },
+
+            CollectionUpdateOperations::PayloadOperation(op) => match op {
+                PayloadOps::SetPayload(SetPayloadOp {
+                    payload: _, // TODO: validate
+                    points,
+                    filter,
+                    key: _, // TODO: validate
+                }) => {
+                    failed_payload_claim()?; // Reject as not implemented
+
+                    let filter = filter.get_or_insert_with(Default::default);
+                    if let Some(points) = take(points) {
+                        *filter = take(filter).merge_owned(make_filter_from_ids(points));
+                    }
+                    Ok(())
+                }
+                PayloadOps::DeletePayload(DeletePayloadOp {
+                    keys: _, // TODO: validate
+                    points,
+                    filter,
+                }) => {
+                    failed_payload_claim()?; // Reject as not implemented
+
+                    let filter = filter.get_or_insert_with(Default::default);
+                    if let Some(points) = take(points) {
+                        *filter = take(filter).merge_owned(make_filter_from_ids(points));
+                    }
+                    Ok(())
+                }
+                PayloadOps::ClearPayload { points } => {
+                    *op = PayloadOps::OverwritePayload(SetPayloadOp {
+                        payload: make_payload_from_payload_claim(claim)?,
+                        points: None,
+                        filter: Some(
+                            make_filter_from_ids(take(points))
+                                .merge_owned(make_filter_from_payload_claim(claim)),
+                        ),
+                        key: None,
+                    });
+                    Ok(())
+                }
+                PayloadOps::ClearPayloadByFilter(filter) => {
+                    *op = PayloadOps::OverwritePayload(SetPayloadOp {
+                        payload: make_payload_from_payload_claim(claim)?,
+                        points: None,
+                        filter: Some(
+                            take(filter).merge_owned(make_filter_from_payload_claim(claim)),
+                        ),
+                        key: None,
+                    });
+                    Ok(())
+                }
+                PayloadOps::OverwritePayload(SetPayloadOp {
+                    payload: _, // TODO: validate
+                    points,
+                    filter,
+                    key: _, // TODO: validate
+                }) => {
+                    failed_payload_claim()?; // Reject as not implemented
+
+                    let filter = filter.get_or_insert_with(Default::default);
+                    if let Some(points) = take(points) {
+                        *filter = take(filter).merge_owned(make_filter_from_ids(points));
+                    }
+                    Ok(())
+                }
+            },
+
+            CollectionUpdateOperations::FieldIndexOperation(op) => match op {
+                FieldIndexOperations::CreateIndex(_) => failed_payload_claim(),
+                FieldIndexOperations::DeleteIndex(_) => failed_payload_claim(),
+            },
+        }
+    }
+}
+
+/// Helper function to indicate that the operation is not allowed when `payload` claim is present.
+/// Usually used when point IDs are involved.
+fn failed_payload_claim<T>() -> Result<T, StorageError> {
+    Err(StorageError::unauthorized(
+        "This operation is not allowed when payload JWT claim is present",
+    ))
+}
+
+fn validate_payload_claim_for_recommended_example(
+    example: &RecommendExample,
+) -> Result<(), StorageError> {
+    match example {
+        RecommendExample::PointId(_) => failed_payload_claim(),
+        RecommendExample::Dense(_) | RecommendExample::Sparse(_) => Ok(()),
+    }
+}
+
+fn apply_filter_opt(filter: &mut Option<Filter>, claim: &PayloadClaim) -> Result<(), StorageError> {
+    apply_filter(filter.get_or_insert_with(Default::default), claim)
+}
+
+fn apply_filter(filter: &mut Filter, claim: &PayloadClaim) -> Result<(), StorageError> {
+    *filter = take(filter).merge_owned(make_filter_from_payload_claim(claim));
+    Ok(())
+}
+
+/// Create a `must` filter from a list of point IDs.
+fn make_filter_from_ids(ids: Vec<ExtendedPointId>) -> Filter {
+    let cond = ids.into_iter().collect::<HashSet<_>>().into();
+    Filter {
+        must: Some(vec![Condition::HasId(cond)]),
+        ..Default::default()
+    }
+}
+
+/// Create a `must` filter from a `payload` claim.
+fn make_filter_from_payload_claim(claim: &PayloadClaim) -> Filter {
+    Filter {
+        must: Some(
+            claim
+                .iter()
+                .map(|(path, value)| {
+                    Condition::Field(FieldCondition::new_match(
+                        path.clone(),
+                        Match::new_value(value.clone()),
+                    ))
+                })
+                .collect(),
+        ),
+        ..Default::default()
+    }
+}
+
+fn make_payload_from_payload_claim(_claim: &PayloadClaim) -> Result<Payload, StorageError> {
+    // TODO: We need to construct a payload, then validate it against the claim
+    failed_payload_claim() // Reject as not implemented
+}

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -20,6 +20,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
         StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
         StorageError::ChecksumMismatch { .. } => tonic::Code::DataLoss,
+        StorageError::Unauthorized { .. } => tonic::Code::PermissionDenied,
     };
     tonic::Status::new(error_code, format!("{error}"))
 }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -28,6 +28,8 @@ pub enum StorageError {
     Timeout { description: String },
     #[error("Checksum mismatch: expected {expected}, actual {actual}")]
     ChecksumMismatch { expected: String, actual: String },
+    #[error("Unauthorized: {description}")]
+    Unauthorized { description: String },
 }
 
 impl StorageError {
@@ -60,6 +62,12 @@ impl StorageError {
         StorageError::ChecksumMismatch {
             expected: expected.into(),
             actual: actual.into(),
+        }
+    }
+
+    pub fn unauthorized(description: impl Into<String>) -> StorageError {
+        StorageError::Unauthorized {
+            description: description.into(),
         }
     }
 

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -5,6 +5,7 @@ use self::consensus_manager::CollectionsSnapshot;
 use self::errors::StorageError;
 
 pub mod alias_mapping;
+mod claims;
 pub mod collection_meta_ops;
 mod collections_ops;
 pub mod consensus;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -5,7 +5,7 @@ use self::consensus_manager::CollectionsSnapshot;
 use self::errors::StorageError;
 
 pub mod alias_mapping;
-mod claims;
+pub mod claims;
 pub mod collection_meta_ops;
 mod collections_ops;
 pub mod consensus;

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -15,6 +15,7 @@ use rbac::jwt::Claims;
 use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
+use crate::content_manager::claims::{check_collection_name, check_points_op};
 use crate::content_manager::errors::StorageError;
 
 impl TableOfContent {
@@ -31,13 +32,17 @@ impl TableOfContent {
     pub async fn recommend(
         &self,
         collection_name: &str,
-        request: RecommendRequestInternal,
+        mut request: RecommendRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selector: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
         recommendations::recommend_by(
             request,
@@ -64,12 +69,18 @@ impl TableOfContent {
     pub async fn recommend_batch(
         &self,
         collection_name: &str,
-        requests: Vec<(RecommendRequestInternal, ShardSelectorInternal)>,
+        mut requests: Vec<(RecommendRequestInternal, ShardSelectorInternal)>,
         read_consistency: Option<ReadConsistency>,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            for (request, _shard_selector) in &mut requests {
+                check_points_op(claims, request)?;
+            }
+        }
+
         let collection = self.get_collection(collection_name).await?;
         recommendations::recommend_batch_by(
             requests,
@@ -99,13 +110,19 @@ impl TableOfContent {
     pub async fn core_search_batch(
         &self,
         collection_name: &str,
-        request: CoreSearchRequestBatch,
+        mut request: CoreSearchRequestBatch,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            for req in &mut request.searches {
+                check_points_op(claims, req)?;
+            }
+        }
+
         let collection = self.get_collection(collection_name).await?;
         collection
             .core_search_batch(request, read_consistency, shard_selection, timeout)
@@ -128,12 +145,16 @@ impl TableOfContent {
     pub async fn count(
         &self,
         collection_name: &str,
-        request: CountRequestInternal,
+        mut request: CountRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
     ) -> Result<CountResult, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
         collection
             .count(request, read_consistency, &shard_selection)
@@ -155,12 +176,16 @@ impl TableOfContent {
     pub async fn retrieve(
         &self,
         collection_name: &str,
-        request: PointRequestInternal,
+        mut request: PointRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
     ) -> Result<Vec<Record>, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
         collection
             .retrieve(request, read_consistency, &shard_selection)
@@ -171,13 +196,17 @@ impl TableOfContent {
     pub async fn group(
         &self,
         collection_name: &str,
-        request: GroupRequest,
+        mut request: GroupRequest,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<GroupsResult, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
 
         let collection_by_name = |name| self.get_collection_opt(name);
@@ -197,13 +226,17 @@ impl TableOfContent {
     pub async fn discover(
         &self,
         collection_name: &str,
-        request: DiscoverRequestInternal,
+        mut request: DiscoverRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selector: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
         discovery::discover(
             request,
@@ -253,12 +286,16 @@ impl TableOfContent {
     pub async fn scroll(
         &self,
         collection_name: &str,
-        request: ScrollRequestInternal,
+        mut request: ScrollRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
     ) -> Result<ScrollResult, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut request)?;
+        }
+
         let collection = self.get_collection(collection_name).await?;
         collection
             .scroll_by(request, read_consistency, &shard_selection)
@@ -303,13 +340,16 @@ impl TableOfContent {
     pub async fn update(
         &self,
         collection_name: &str,
-        operation: OperationWithClockTag,
+        mut operation: OperationWithClockTag,
         wait: bool,
         ordering: WriteOrdering,
         shard_selector: ShardSelectorInternal,
-        _claims: Option<Claims>,
+        claims: Option<Claims>,
     ) -> Result<UpdateResult, StorageError> {
-        // TODO(RBAC): handle claims
+        if let Some(claims) = claims.as_ref() {
+            check_collection_name(claims, collection_name)?;
+            check_points_op(claims, &mut operation.operation)?;
+        }
 
         // `TableOfContent::_update_shard_keys` and `Collection::update_from_*` are cancel safe,
         // so this method is cancel safe.

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -45,8 +45,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -87,9 +87,9 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
             for (request, _shard_selector) in &mut requests {
-                check_points_op(collections, payload, request)?;
+                check_points_op(collections.as_ref(), payload.as_ref(), request)?;
             }
         }
 
@@ -135,9 +135,9 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
             for req in &mut request.searches {
-                check_points_op(collections, payload, req)?;
+                check_points_op(collections.as_ref(), payload.as_ref(), req)?;
             }
         }
 
@@ -175,8 +175,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -212,8 +212,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -239,8 +239,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -275,8 +275,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -307,9 +307,9 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
             for (request, _shard_selector) in &mut requests {
-                check_points_op(collections, payload, request)?;
+                check_points_op(collections.as_ref(), payload.as_ref(), request)?;
             }
         }
         let collection = self.get_collection(collection_name).await?;
@@ -351,8 +351,8 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut request)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -412,8 +412,12 @@ impl TableOfContent {
             payload,
         }) = claims.as_ref()
         {
-            check_collection_name(collections, collection_name)?;
-            check_points_op(collections, payload, &mut operation.operation)?;
+            check_collection_name(collections.as_ref(), collection_name)?;
+            check_points_op(
+                collections.as_ref(),
+                payload.as_ref(),
+                &mut operation.operation,
+            )?;
         }
 
         // `TableOfContent::_update_shard_keys` and `Collection::update_from_*` are cancel safe,

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -38,9 +38,15 @@ impl TableOfContent {
         claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -74,10 +80,16 @@ impl TableOfContent {
         claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
             for (request, _shard_selector) in &mut requests {
-                check_points_op(claims, request)?;
+                check_points_op(collections, payload, request)?;
             }
         }
 
@@ -116,10 +128,16 @@ impl TableOfContent {
         claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
             for req in &mut request.searches {
-                check_points_op(claims, req)?;
+                check_points_op(collections, payload, req)?;
             }
         }
 
@@ -150,9 +168,15 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         claims: Option<Claims>,
     ) -> Result<CountResult, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -181,9 +205,15 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         claims: Option<Claims>,
     ) -> Result<Vec<Record>, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -202,9 +232,15 @@ impl TableOfContent {
         claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<GroupsResult, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -232,9 +268,15 @@ impl TableOfContent {
         claims: Option<Claims>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ScoredPoint>, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -291,9 +333,15 @@ impl TableOfContent {
         shard_selection: ShardSelectorInternal,
         claims: Option<Claims>,
     ) -> Result<ScrollResult, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut request)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -346,9 +394,15 @@ impl TableOfContent {
         shard_selector: ShardSelectorInternal,
         claims: Option<Claims>,
     ) -> Result<UpdateResult, StorageError> {
-        if let Some(claims) = claims.as_ref() {
-            check_collection_name(claims, collection_name)?;
-            check_points_op(claims, &mut operation.operation)?;
+        if let Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload,
+        }) = claims.as_ref()
+        {
+            check_collection_name(collections, collection_name)?;
+            check_points_op(collections, payload, &mut operation.operation)?;
         }
 
         // `TableOfContent::_update_shard_keys` and `Collection::update_from_*` are cancel safe,

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -26,6 +26,7 @@ pub fn storage_into_actix_error(err: StorageError) -> Error {
         StorageError::Timeout { .. } => error::ErrorRequestTimeout(format!("{err}")),
         StorageError::AlreadyExists { .. } => error::ErrorConflict(format!("{err}")),
         StorageError::ChecksumMismatch { .. } => error::ErrorBadRequest(format!("{err}")),
+        StorageError::Unauthorized { .. } => error::ErrorUnauthorized(format!("{err}")),
     }
 }
 
@@ -68,6 +69,7 @@ where
                 StorageError::Timeout { .. } => HttpResponse::RequestTimeout(),
                 StorageError::AlreadyExists { .. } => HttpResponse::Conflict(),
                 StorageError::ChecksumMismatch { .. } => HttpResponse::BadRequest(),
+                StorageError::Unauthorized { .. } => HttpResponse::Unauthorized(),
             };
 
             resp.json(ApiResponse::<()> {
@@ -199,6 +201,9 @@ impl From<StorageError> for HttpError {
             }
             StorageError::ChecksumMismatch { .. } => {
                 (http::StatusCode::BAD_REQUEST, err.to_string())
+            }
+            StorageError::Unauthorized { description } => {
+                (http::StatusCode::UNAUTHORIZED, description)
             }
         };
 


### PR DESCRIPTION
Tracked by #3777.
Depends on #3801.

In this PR changes are made for the Points API:
- The new claim `collections` are checked.
- The contents of the new `payload` claim is added to the filters.
- For the payload editing API (e.g. set payload/delete payload), added stubs that reject this action when the `payload` claim is present. Later we could implement query rewrite/vaidation for them.