### PR TITLE
Fix arbitrary path traversal vulnerability in full snapshot REST API

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -959,6 +959,10 @@ impl CollectionError {
         CollectionError::BadInput { description }
     }
 
+    pub fn not_found(what: impl Into<String>) -> CollectionError {
+        CollectionError::NotFound { what: what.into() }
+    }
+
     pub fn bad_request(description: String) -> CollectionError {
         CollectionError::BadRequest { description }
     }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -56,6 +56,12 @@ impl StorageError {
         }
     }
 
+    pub fn not_found(description: impl Into<String>) -> StorageError {
+        StorageError::NotFound {
+            description: description.into(),
+        }
+    }
+
     pub fn checksum_mismatch(expected: impl Into<String>, actual: impl Into<String>) -> Self {
         StorageError::ChecksumMismatch {
             expected: expected.into(),


### PR DESCRIPTION
Fix arbitrary path traversal in our full snapshot API.

We now enforce snapshot files to be within their snapshot directories.

A simple integration test is added to assert this behavior.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?