### PR TITLE
Use common helpers in tonic collections API

### DIFF
--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -111,9 +111,9 @@ pub async fn do_list_collection_aliases(
     collection_name: &str,
 ) -> Result<CollectionsAliasesResponse, StorageError> {
     let mut aliases: Vec<AliasDescription> = Default::default();
-    for alias in toc.collection_aliases(collection_name).await? {
+    for alias in toc.collection_aliases(collection_name).await?.into_iter() {
         aliases.push(AliasDescription {
-            alias_name: alias.to_string(),
+            alias_name: alias,
             collection_name: collection_name.to_string(),
         });
     }


### PR DESCRIPTION
Small refactoring.


These two methods (used in Tonic):
- `tonic::api::collections_api::CollectionsService::list_aliases`
- `tonic::api::collections_api::CollectionsService::list_collection_aliases`

are similar to these helper methods (used in Actix):
-  `common::collections::do_list_aliases`
-  `common::collections::do_list_collection_aliases`

This PR drops the former in favor of the latter, so now the same helper methods are used both in Tonic and Actix. This change would make RBAC checking a bit cleaner.