### PR TITLE
RBAC support for collections API

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -62,6 +62,21 @@ pub struct CreateShardingKey {
     pub placement: Option<Vec<PeerId>>,
 }
 
+impl CreateShardingKey {
+    /// Check if the operation has default parameters.
+    pub fn has_default_params(&self) -> bool {
+        matches!(
+            self,
+            CreateShardingKey {
+                shard_key: _,
+                shards_number: None,
+                replication_factor: None,
+                placement: None,
+            }
+        )
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct DropShardingKey {

--- a/lib/storage/src/content_manager/claims.rs
+++ b/lib/storage/src/content_manager/claims.rs
@@ -241,6 +241,8 @@ impl PointsOpClaimsChecker for CollectionUpdateOperations {
                 }
             },
 
+            // These are already checked in CollectionMetaOperations, but we'll check them anyway
+            // for sure.
             CollectionUpdateOperations::FieldIndexOperation(op) => match op {
                 FieldIndexOperations::CreateIndex(_) => incompatible_with_payload_claim(),
                 FieldIndexOperations::DeleteIndex(_) => incompatible_with_payload_claim(),
@@ -251,9 +253,15 @@ impl PointsOpClaimsChecker for CollectionUpdateOperations {
 
 /// Helper function to indicate that the operation is not allowed when `payload` claim is present.
 /// Usually used when point IDs are involved.
-fn incompatible_with_payload_claim<T>() -> Result<T, StorageError> {
+pub fn incompatible_with_payload_claim<T>() -> Result<T, StorageError> {
     Err(StorageError::unauthorized(
         "This operation is not allowed when payload JWT claim is present",
+    ))
+}
+
+pub fn incompatible_with_collection_claim<T>() -> Result<T, StorageError> {
+    Err(StorageError::unauthorized(
+        "This operation is not allowed when collection JWT claim is present",
     ))
 }
 

--- a/lib/storage/src/content_manager/claims.rs
+++ b/lib/storage/src/content_manager/claims.rs
@@ -242,7 +242,7 @@ impl PointsOpClaimsChecker for CollectionUpdateOperations {
             },
 
             // These are already checked in CollectionMetaOperations, but we'll check them anyway
-            // for sure.
+            // to be sure.
             CollectionUpdateOperations::FieldIndexOperation(op) => match op {
                 FieldIndexOperations::CreateIndex(_) => incompatible_with_payload_claim(),
                 FieldIndexOperations::DeleteIndex(_) => incompatible_with_payload_claim(),

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -144,7 +144,7 @@ async fn _do_recover_from_snapshot(
                     snapshot_config.clone().into(),
                 ));
             dispatcher
-                .submit_collection_meta_op(operation, None)
+                .submit_collection_meta_op(operation, None, None)
                 .await?;
             toc.get_collection(collection_name).await?
         }

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -70,7 +70,9 @@ impl Dispatcher {
                 | CollectionMetaOperations::SetShardReplicaState(_)
                 | CollectionMetaOperations::CreateShardKey(_)
                 | CollectionMetaOperations::DropShardKey(_) => {
-                    return incompatible_with_collection_claim();
+                    if collections.is_some() {
+                        return incompatible_with_collection_claim();
+                    }
                 }
                 CollectionMetaOperations::CreatePayloadIndex(op) => {
                     check_collection_name(collections.as_ref(), &op.collection_name)?;

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -116,6 +116,7 @@ fn test_alias_operation() {
                     },
                 )),
                 None,
+                None,
             ),
         )
         .unwrap();
@@ -129,6 +130,7 @@ fn test_alias_operation() {
                     }
                     .into()],
             }),
+            None,
             None,
         ))
         .unwrap();
@@ -153,6 +155,7 @@ fn test_alias_operation() {
                         .into(),
                     ],
             }),
+            None,
             None,
         ))
         .unwrap();

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -4,6 +4,7 @@ use actix_web::rt::time::Instant;
 use actix_web::{delete, get, patch, post, put, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::cluster_ops::ClusterOperations;
+use rbac::jwt::Claims;
 use serde::Deserialize;
 use storage::content_manager::collection_meta_ops::{
     ChangeAliasesOperation, CollectionMetaOperations, CreateCollection, CreateCollectionOperation,
@@ -15,6 +16,7 @@ use validator::Validate;
 
 use super::CollectionPath;
 use crate::actix::api::StrictCollectionPath;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::collections::*;
 
@@ -31,16 +33,19 @@ impl WaitTimeout {
 }
 
 #[get("/collections")]
-async fn get_collections(toc: web::Data<TableOfContent>) -> impl Responder {
+async fn get_collections(
+    toc: web::Data<TableOfContent>,
+    claims: Extension<Claims>,
+) -> impl Responder {
     let timing = Instant::now();
-    let response = Ok(do_list_collections(toc.get_ref()).await);
+    let response = Ok(do_list_collections(toc.get_ref(), claims.into_inner()).await);
     process_response(response, timing)
 }
 
 #[get("/aliases")]
-async fn get_aliases(toc: web::Data<TableOfContent>) -> impl Responder {
+async fn get_aliases(toc: web::Data<TableOfContent>, claims: Extension<Claims>) -> impl Responder {
     let timing = Instant::now();
-    let response = do_list_aliases(toc.get_ref()).await;
+    let response = do_list_aliases(toc.get_ref(), claims.into_inner()).await;
     process_response(response, timing)
 }
 
@@ -48,9 +53,11 @@ async fn get_aliases(toc: web::Data<TableOfContent>) -> impl Responder {
 async fn get_collection(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = do_get_collection(toc.get_ref(), &collection.name, None).await;
+    let response =
+        do_get_collection(toc.get_ref(), claims.into_inner(), &collection.name, None).await;
     process_response(response, timing)
 }
 
@@ -58,9 +65,10 @@ async fn get_collection(
 async fn get_collection_existence(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = do_collection_exists(toc.get_ref(), &collection.name).await;
+    let response = do_collection_exists(toc.get_ref(), claims.into_inner(), &collection.name).await;
     process_response(response, timing)
 }
 
@@ -68,9 +76,11 @@ async fn get_collection_existence(
 async fn get_collection_aliases(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = do_list_collection_aliases(toc.get_ref(), &collection.name).await;
+    let response =
+        do_list_collection_aliases(toc.get_ref(), claims.into_inner(), &collection.name).await;
     process_response(response, timing)
 }
 
@@ -80,6 +90,7 @@ async fn create_collection(
     collection: Path<StrictCollectionPath>,
     operation: Json<CreateCollection>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher
@@ -88,6 +99,7 @@ async fn create_collection(
                 collection.name.clone(),
                 operation.into_inner(),
             )),
+            claims.into_inner(),
             query.timeout(),
         )
         .await;
@@ -100,6 +112,7 @@ async fn update_collection(
     collection: Path<CollectionPath>,
     operation: Json<UpdateCollection>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let name = collection.name.clone();
@@ -109,6 +122,7 @@ async fn update_collection(
                 name,
                 operation.into_inner(),
             )),
+            claims.into_inner(),
             query.timeout(),
         )
         .await;
@@ -120,6 +134,7 @@ async fn delete_collection(
     dispatcher: web::Data<Dispatcher>,
     collection: Path<CollectionPath>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher
@@ -127,6 +142,7 @@ async fn delete_collection(
             CollectionMetaOperations::DeleteCollection(DeleteCollectionOperation(
                 collection.name.clone(),
             )),
+            claims.into_inner(),
             query.timeout(),
         )
         .await;
@@ -138,11 +154,13 @@ async fn update_aliases(
     dispatcher: web::Data<Dispatcher>,
     operation: Json<ChangeAliasesOperation>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let response = dispatcher
         .submit_collection_meta_op(
             CollectionMetaOperations::ChangeAliases(operation.0),
+            claims.into_inner(),
             query.timeout(),
         )
         .await;
@@ -153,9 +171,11 @@ async fn update_aliases(
 async fn get_cluster_info(
     toc: web::Data<TableOfContent>,
     collection: Path<CollectionPath>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
-    let response = do_get_collection_cluster(toc.get_ref(), &collection.name).await;
+    let response =
+        do_get_collection_cluster(toc.get_ref(), claims.into_inner(), &collection.name).await;
     process_response(response, timing)
 }
 
@@ -165,6 +185,7 @@ async fn update_collection_cluster(
     collection: Path<CollectionPath>,
     operation: Json<ClusterOperations>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let wait_timeout = query.timeout();
@@ -172,6 +193,7 @@ async fn update_collection_cluster(
         &dispatcher.into_inner(),
         collection.name.clone(),
         operation.0,
+        claims.into_inner(),
         wait_timeout,
     )
     .await;

--- a/src/actix/api/shards_api.rs
+++ b/src/actix/api/shards_api.rs
@@ -4,11 +4,13 @@ use collection::operations::cluster_ops::{
     ClusterOperations, CreateShardingKey, CreateShardingKeyOperation, DropShardingKey,
     DropShardingKeyOperation,
 };
+use rbac::jwt::Claims;
 use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
 
 use crate::actix::api::collections_api::WaitTimeout;
 use crate::actix::api::CollectionPath;
+use crate::actix::auth::Extension;
 use crate::actix::helpers::process_response;
 use crate::common::collections::do_update_collection_cluster;
 
@@ -20,6 +22,7 @@ async fn create_shard_key(
     collection: Path<CollectionPath>,
     request: Json<CreateShardingKey>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let wait_timeout = query.timeout();
@@ -35,6 +38,7 @@ async fn create_shard_key(
         &dispatcher,
         collection.name.clone(),
         operation,
+        claims.into_inner(),
         wait_timeout,
     )
     .await;
@@ -48,6 +52,7 @@ async fn delete_shard_key(
     collection: Path<CollectionPath>,
     request: Json<DropShardingKey>,
     Query(query): Query<WaitTimeout>,
+    claims: Extension<Claims>,
 ) -> impl Responder {
     let timing = Instant::now();
     let wait_timeout = query.timeout();
@@ -63,6 +68,7 @@ async fn delete_shard_key(
         &dispatcher,
         collection.name.clone(),
         operation,
+        claims.into_inner(),
         wait_timeout,
     )
     .await;

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -4,8 +4,9 @@ use api::grpc::models::{CollectionDescription, CollectionsResponse};
 use api::grpc::qdrant::CollectionExists;
 use collection::config::ShardingMethod;
 use collection::operations::cluster_ops::{
-    AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShardOperation,
-    ReplicateShardOperation, RestartTransfer, RestartTransferOperation,
+    AbortTransferOperation, ClusterOperations, CreateShardingKeyOperation, DropReplicaOperation,
+    DropShardingKey, DropShardingKeyOperation, MoveShardOperation, ReplicateShardOperation,
+    RestartTransfer, RestartTransferOperation,
 };
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::snapshot_ops::SnapshotDescription;
@@ -17,6 +18,8 @@ use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
 use collection::shards::transfer::{ShardTransfer, ShardTransferKey, ShardTransferRestart};
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
+use rbac::jwt::Claims;
+use storage::content_manager::claims::{check_collection_name, incompatible_with_collection_claim};
 use storage::content_manager::collection_meta_ops::ShardTransferOperations::{Abort, Start};
 use storage::content_manager::collection_meta_ops::{
     CollectionMetaOperations, CreateShardKey, DropShardKey, ShardTransferOperations,
@@ -28,8 +31,20 @@ use storage::dispatcher::Dispatcher;
 
 pub async fn do_collection_exists(
     toc: &TableOfContent,
+    claims: Option<Claims>,
     name: &str,
 ) -> Result<CollectionExists, StorageError> {
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+    check_collection_name(claims_collections, name)?;
+
     // if this returns Ok, it means the collection exists.
     // if not, we check that the error is NotFound
     let Err(error) = toc.get_collection(name).await else {
@@ -43,9 +58,21 @@ pub async fn do_collection_exists(
 
 pub async fn do_get_collection(
     toc: &TableOfContent,
+    claims: Option<Claims>,
     name: &str,
     shard_selection: Option<ShardId>,
 ) -> Result<CollectionInfo, StorageError> {
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+    check_collection_name(claims_collections, name)?;
+
     let collection = toc.get_collection(name).await?;
 
     let shard_selection = match shard_selection {
@@ -56,11 +83,27 @@ pub async fn do_get_collection(
     Ok(collection.info(&shard_selection).await?)
 }
 
-pub async fn do_list_collections(toc: &TableOfContent) -> CollectionsResponse {
+pub async fn do_list_collections(
+    toc: &TableOfContent,
+    claims: Option<Claims>,
+) -> CollectionsResponse {
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+
     let collections = toc
         .all_collections()
         .await
         .into_iter()
+        .filter(|c| {
+            claims_collections.map_or(true, |claims_collections| claims_collections.contains(c))
+        })
         .map(|name| CollectionDescription { name })
         .collect_vec();
 
@@ -108,22 +151,59 @@ fn generate_even_placement(
 
 pub async fn do_list_collection_aliases(
     toc: &TableOfContent,
+    claims: Option<Claims>,
     collection_name: &str,
 ) -> Result<CollectionsAliasesResponse, StorageError> {
-    let mut aliases: Vec<AliasDescription> = Default::default();
-    for alias in toc.collection_aliases(collection_name).await?.into_iter() {
-        aliases.push(AliasDescription {
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+    check_collection_name(claims_collections, collection_name)?;
+
+    let aliases: Vec<AliasDescription> = toc
+        .collection_aliases(collection_name)
+        .await?
+        .into_iter()
+        .filter(|alias| {
+            claims_collections.map_or(true, |claims_collections| {
+                claims_collections.contains(alias)
+            })
+        })
+        .map(|alias| AliasDescription {
             alias_name: alias,
             collection_name: collection_name.to_string(),
-        });
-    }
+        })
+        .collect();
     Ok(CollectionsAliasesResponse { aliases })
 }
 
 pub async fn do_list_aliases(
     toc: &TableOfContent,
+    claims: Option<Claims>,
 ) -> Result<CollectionsAliasesResponse, StorageError> {
-    let aliases = toc.list_aliases().await?;
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+
+    let mut aliases = toc.list_aliases().await?;
+    aliases.retain(|alias| {
+        claims_collections.map_or(true, |claims_collections| {
+            claims_collections.contains(&alias.collection_name)
+                && claims_collections.contains(&alias.alias_name)
+        })
+    });
+
     Ok(CollectionsAliasesResponse { aliases })
 }
 
@@ -160,8 +240,20 @@ pub async fn do_create_snapshot(
 
 pub async fn do_get_collection_cluster(
     toc: &TableOfContent,
+    claims: Option<Claims>,
     name: &str,
 ) -> Result<CollectionClusterInfo, StorageError> {
+    let claims_collections = match claims.as_ref() {
+        Some(Claims {
+            exp: _,
+            w: _,
+            collections,
+            payload: _,
+        }) => collections.as_ref(),
+        None => None,
+    };
+    check_collection_name(claims_collections, name)?;
+
     let collection = toc.get_collection(name).await?;
     Ok(collection.cluster_info(toc.this_peer_id).await?)
 }
@@ -170,8 +262,35 @@ pub async fn do_update_collection_cluster(
     dispatcher: &Dispatcher,
     collection_name: String,
     operation: ClusterOperations,
+    claims: Option<Claims>,
     wait_timeout: Option<Duration>,
 ) -> Result<bool, StorageError> {
+    if let Some(Claims {
+        exp: _,
+        w: _,
+        collections: Some(_),
+        payload: _,
+    }) = claims.as_ref()
+    {
+        match &operation {
+            ClusterOperations::MoveShard(_)
+            | ClusterOperations::ReplicateShard(_)
+            | ClusterOperations::AbortTransfer(_)
+            | ClusterOperations::DropReplica(_)
+            | ClusterOperations::RestartTransfer(_) => return incompatible_with_collection_claim(),
+            ClusterOperations::CreateShardingKey(CreateShardingKeyOperation {
+                create_sharding_key,
+            }) => {
+                if !create_sharding_key.has_default_params() {
+                    return incompatible_with_collection_claim();
+                }
+            }
+            ClusterOperations::DropShardingKey(DropShardingKeyOperation {
+                drop_sharding_key: DropShardingKey { shard_key: _ },
+            }) => (),
+        }
+    }
+
     if dispatcher.consensus_state().is_none() {
         return Err(StorageError::BadRequest {
             description: "Distributed mode disabled".to_string(),
@@ -236,6 +355,7 @@ pub async fn do_update_collection_cluster(
                             method: move_shard.method,
                         }),
                     ),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -270,6 +390,7 @@ pub async fn do_update_collection_cluster(
                             method: replicate_shard.method,
                         }),
                     ),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -299,6 +420,7 @@ pub async fn do_update_collection_cluster(
                             reason: "user request".to_string(),
                         },
                     ),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -325,6 +447,7 @@ pub async fn do_update_collection_cluster(
             dispatcher
                 .submit_collection_meta_op(
                     CollectionMetaOperations::UpdateCollection(update_operation),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -397,6 +520,7 @@ pub async fn do_update_collection_cluster(
                         shard_key: create_sharding_key.shard_key,
                         placement: exact_placement,
                     }),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -434,6 +558,7 @@ pub async fn do_update_collection_cluster(
                         collection_name,
                         shard_key: drop_sharding_key.shard_key,
                     }),
+                    None,
                     wait_timeout,
                 )
                 .await
@@ -472,6 +597,7 @@ pub async fn do_update_collection_cluster(
                             method,
                         }),
                     ),
+                    None,
                     wait_timeout,
                 )
                 .await

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -600,7 +600,6 @@ pub async fn do_create_index_internal(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
-    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
@@ -621,7 +620,7 @@ pub async fn do_create_index_internal(
         wait,
         ordering,
         shard_selector,
-        claims,
+        None,
     )
     .await
 }
@@ -656,7 +655,7 @@ pub async fn do_create_index(
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher
-        .submit_collection_meta_op(consensus_op, wait_timeout)
+        .submit_collection_meta_op(consensus_op, claims, wait_timeout)
         .await?;
 
     // This function is required as long as we want to maintain interface compatibility
@@ -672,7 +671,6 @@ pub async fn do_create_index(
         shard_selection,
         wait,
         ordering,
-        claims,
     )
     .await
 }
@@ -686,7 +684,6 @@ pub async fn do_delete_index_internal(
     shard_selection: Option<ShardId>,
     wait: bool,
     ordering: WriteOrdering,
-    claims: Option<Claims>,
 ) -> Result<UpdateResult, StorageError> {
     let collection_operation = CollectionUpdateOperations::FieldIndexOperation(
         FieldIndexOperations::DeleteIndex(index_name),
@@ -704,7 +701,7 @@ pub async fn do_delete_index_internal(
         wait,
         ordering,
         shard_selector,
-        claims,
+        None,
     )
     .await
 }
@@ -732,7 +729,7 @@ pub async fn do_delete_index(
 
     // TODO: Is `submit_collection_meta_op` cancel-safe!? Should be, I think?.. 🤔
     dispatcher
-        .submit_collection_meta_op(consensus_op, wait_timeout)
+        .submit_collection_meta_op(consensus_op, claims, wait_timeout)
         .await?;
 
     do_delete_index_internal(
@@ -743,7 +740,6 @@ pub async fn do_delete_index(
         shard_selection,
         wait,
         ordering,
-        claims,
     )
     .await
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1262,6 +1262,7 @@ mod tests {
                         },
                     )),
                     None,
+                    None,
                 ),
             )
             .unwrap();

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -107,7 +107,7 @@ pub async fn handle_existing_collections(
 
         for operation in consensus_operations {
             let _res = dispatcher_arc
-                .submit_collection_meta_op(operation, None)
+                .submit_collection_meta_op(operation, None, None)
                 .await;
         }
 
@@ -122,6 +122,7 @@ pub async fn handle_existing_collections(
                             state: ReplicaState::Active,
                             from_state: None,
                         }),
+                        None,
                         None,
                     )
                     .await;

--- a/src/tonic/api/collections_common.rs
+++ b/src/tonic/api/collections_common.rs
@@ -2,6 +2,7 @@ use std::time::Instant;
 
 use api::grpc::qdrant::{GetCollectionInfoRequest, GetCollectionInfoResponse};
 use collection::shards::shard::ShardId;
+use rbac::jwt::Claims;
 use storage::content_manager::conversions::error_to_status;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Response, Status};
@@ -11,11 +12,12 @@ use crate::common::collections::do_get_collection;
 pub async fn get(
     toc: &TableOfContent,
     get_collection_info_request: GetCollectionInfoRequest,
+    claims: Option<Claims>,
     shard_selection: Option<ShardId>,
 ) -> Result<Response<GetCollectionInfoResponse>, Status> {
     let timing = Instant::now();
     let collection_name = get_collection_info_request.collection_name;
-    let result = do_get_collection(toc, &collection_name, shard_selection)
+    let result = do_get_collection(toc, claims, &collection_name, shard_selection)
         .await
         .map_err(error_to_status)?;
     let response = GetCollectionInfoResponse {

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -42,6 +42,7 @@ impl CollectionsInternal for CollectionsInternalService {
         get(
             self.toc.as_ref(),
             get_collection_info_request,
+            None,
             Some(shard_id),
         )
         .await

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -842,7 +842,6 @@ pub async fn create_field_index_internal(
     create_field_index_collection: CreateFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
-    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let CreateFieldIndexCollection {
         collection_name,
@@ -866,7 +865,6 @@ pub async fn create_field_index_internal(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
-        claims,
     )
     .await
     .map_err(error_to_status)?;
@@ -914,7 +912,6 @@ pub async fn delete_field_index_internal(
     delete_field_index_collection: DeleteFieldIndexCollection,
     clock_tag: Option<ClockTag>,
     shard_selection: Option<ShardId>,
-    claims: Option<Claims>,
 ) -> Result<Response<PointsOperationResponseInternal>, Status> {
     let DeleteFieldIndexCollection {
         collection_name,
@@ -934,7 +931,6 @@ pub async fn delete_field_index_internal(
         shard_selection,
         wait.unwrap_or(false),
         write_ordering_from_proto(ordering)?,
-        claims,
     )
     .await
     .map_err(error_to_status)?;

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -255,7 +255,6 @@ impl PointsInternal for PointsInternalService {
             create_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
-            None,
         )
         .await
     }
@@ -280,7 +279,6 @@ impl PointsInternal for PointsInternalService {
             delete_field_index_collection,
             clock_tag.map(Into::into),
             shard_id,
-            None,
         )
         .await
     }


### PR DESCRIPTION
Tracked in #3777.

This PR adds RBAC checks for collections and shard APIs.

## Notes

### Aliases

For `GET /aliases` and `GET /collections/{name}/aliases`, an alias is visible when both the collection name and the alias is listed in the `collections` claim.

### Indexes

This PR drops `claims` argument for `do_create_index_internal()` and `do_delete_index_internal()`. Reason:
- For user-facing APIs, it's checked in `common::points::do_delete_index()`→`submit_collection_meta_op()`.
- For internal APIs, we don't need to check it.

