### PR TITLE
Remove duplicated VectorRef conversion

### DIFF
--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -407,7 +407,7 @@ fn recommend_by_best_score(
 
 #[cfg(test)]
 mod tests {
-    use segment::data_types::vectors::Vector;
+    use segment::data_types::vectors::{Vector, VectorRef};
     use sparse::common::sparse_vector::SparseVector;
 
     use super::avg_vectors;
@@ -420,7 +420,7 @@ mod tests {
             vec![1.0, 2.0, 3.0].into(),
         ];
         assert_eq!(
-            avg_vectors(vectors.iter().map(|v| v.to_vec_ref())).unwrap(),
+            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
             vec![1.0, 2.0, 3.0].into(),
         );
 
@@ -433,7 +433,7 @@ mod tests {
                 .into(),
         ];
         assert_eq!(
-            avg_vectors(vectors.iter().map(|v| v.to_vec_ref())).unwrap(),
+            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.55, 1.1])
                 .unwrap()
                 .into(),
@@ -445,6 +445,6 @@ mod tests {
                 .unwrap()
                 .into(),
         ];
-        assert!(avg_vectors(vectors.iter().map(|v| v.to_vec_ref())).is_err());
+        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
     }
 }

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Standard;
 use rand::Rng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-use segment::data_types::vectors::{DenseVector, Vector};
+use segment::data_types::vectors::{DenseVector, Vector, VectorRef};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
@@ -43,7 +43,7 @@ fn init_vector_storage(
         for i in 0..num {
             let vector: Vector = random_vector(dim).into();
             borrowed_storage
-                .insert_vector(i as PointOffsetType, vector.to_vec_ref())
+                .insert_vector(i as PointOffsetType, VectorRef::from(&vector))
                 .unwrap();
         }
     }

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -54,19 +54,19 @@ fn check_query_vector(
 ) -> OperationResult<()> {
     match query_vector {
         QueryVector::Nearest(vector) => {
-            check_vector_against_config(vector.to_vec_ref(), vector_config)?
+            check_vector_against_config(VectorRef::from(vector), vector_config)?
         }
         QueryVector::Recommend(reco_query) => reco_query.flat_iter().try_for_each(|vector| {
-            check_vector_against_config(vector.to_vec_ref(), vector_config)
+            check_vector_against_config(VectorRef::from(vector), vector_config)
         })?,
         QueryVector::Discovery(discovery_query) => {
             discovery_query.flat_iter().try_for_each(|vector| {
-                check_vector_against_config(vector.to_vec_ref(), vector_config)
+                check_vector_against_config(VectorRef::from(vector), vector_config)
             })?
         }
         QueryVector::Context(discovery_context_query) => {
             discovery_context_query.flat_iter().try_for_each(|vector| {
-                check_vector_against_config(vector.to_vec_ref(), vector_config)
+                check_vector_against_config(VectorRef::from(vector), vector_config)
             })?
         }
     }
@@ -80,19 +80,19 @@ fn check_query_sparse_vector(
 ) -> OperationResult<()> {
     match query_vector {
         QueryVector::Nearest(vector) => {
-            check_sparse_vector_against_config(vector.to_vec_ref(), vector_config)?
+            check_sparse_vector_against_config(VectorRef::from(vector), vector_config)?
         }
         QueryVector::Recommend(reco_query) => reco_query.flat_iter().try_for_each(|vector| {
-            check_sparse_vector_against_config(vector.to_vec_ref(), vector_config)
+            check_sparse_vector_against_config(VectorRef::from(vector), vector_config)
         })?,
         QueryVector::Discovery(discovery_query) => {
             discovery_query.flat_iter().try_for_each(|vector| {
-                check_sparse_vector_against_config(vector.to_vec_ref(), vector_config)
+                check_sparse_vector_against_config(VectorRef::from(vector), vector_config)
             })?
         }
         QueryVector::Context(discovery_context_query) => {
             discovery_context_query.flat_iter().try_for_each(|vector| {
-                check_sparse_vector_against_config(vector.to_vec_ref(), vector_config)
+                check_sparse_vector_against_config(VectorRef::from(vector), vector_config)
             })?
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -26,16 +26,6 @@ pub enum VectorRef<'a> {
     MultiDense(&'a [DenseVector]),
 }
 
-impl Vector {
-    pub fn to_vec_ref(&self) -> VectorRef {
-        match self {
-            Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
-            Vector::Sparse(v) => VectorRef::Sparse(v),
-            Vector::MultiDense(v) => VectorRef::MultiDense(v),
-        }
-    }
-}
-
 impl<'a> VectorRef<'a> {
     pub fn to_vec(self) -> Vector {
         match self {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -27,7 +27,7 @@ use crate::common::{
 };
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderingValue};
-use crate::data_types::vectors::{QueryVector, Vector};
+use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::numeric_index::StreamRange;
@@ -217,9 +217,9 @@ impl Segment {
                         | VectorStorageEnum::DenseAppendableMemmap(_) => vec![1.0; dim].into(),
                         VectorStorageEnum::SparseSimple(_) => SparseVector::default().into(),
                     };
-                    vector_storage.insert_vector(new_index, vector.to_vec_ref())?;
+                    vector_storage.insert_vector(new_index, VectorRef::from(&vector))?;
                     vector_storage.delete_vector(new_index)?;
-                    vector_index.update_vector(new_index, vector.to_vec_ref())?;
+                    vector_index.update_vector(new_index, VectorRef::from(&vector))?;
                 }
                 Some(vec) => {
                     vector_storage.insert_vector(new_index, vec)?;


### PR DESCRIPTION
This PR removes the manual `to_vec_ref` converter to use the existing standard `From` implementation instead.