### PR TITLE
Rest decouple collection record type

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -85,3 +85,18 @@ pub struct ScoredPoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
 }
+
+/// Point data
+#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Record {
+    /// Id of the point
+    pub id: segment::types::PointIdType,
+    /// Payload - values assigned to the point
+    pub payload: Option<segment::types::Payload>,
+    /// Vector of the point
+    pub vector: Option<VectorStruct>,
+    /// Shard Key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<segment::types::ShardKey>,
+}

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -293,6 +293,7 @@ impl Collection {
                 .flatten()
                 .sorted_unstable_by_key(|point| point.id)
                 .take(limit)
+                .map(api::rest::Record::from)
                 .collect_vec(),
             Some(order_by) => {
                 retrieved_iter
@@ -309,7 +310,7 @@ impl Collection {
                         Direction::Asc => value_a <= value_b,
                         Direction::Desc => value_a >= value_b,
                     })
-                    .map(|(_, record)| record)
+                    .map(|(_, record)| api::rest::Record::from(record))
                     .take(limit)
                     .collect_vec()
             }

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(records.len(), 3);
 
         for record in records {
-            let v: VectorStruct = record.vector.unwrap().into();
+            let v = record.vector.unwrap();
 
             let v1 = vec![2., 2., 2., 2.];
             if record.id == 1.into() {

--- a/lib/collection/src/grouping/builder.rs
+++ b/lib/collection/src/grouping/builder.rs
@@ -116,7 +116,9 @@ where
 
             // Put the lookups in their respective groups
             groups.iter_mut().for_each(|group| {
-                group.lookup = lookups.remove(&PseudoId::from(group.id.clone()));
+                group.lookup = lookups
+                    .remove(&PseudoId::from(group.id.clone()))
+                    .map(api::rest::Record::from);
             });
         }
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -142,7 +142,7 @@ pub fn try_record_from_grpc(
     Ok(Record {
         id,
         payload,
-        vector: vector.map(api::rest::VectorStruct::from),
+        vector,
         shard_key: convert_shard_key_from_grpc_opt(point.shard_key),
     })
 }
@@ -1335,7 +1335,9 @@ impl From<PointGroup> for api::grpc::qdrant::PointGroup {
                 .map_into()
                 .collect(),
             id: Some(group.id.into()),
-            lookup: group.lookup.map(|record| record.into()),
+            lookup: group
+                .lookup
+                .map(|record| api::grpc::qdrant::RetrievedPoint::from(Record::from(record))),
         }
     }
 }

--- a/lib/collection/src/operations/conversions_rest.rs
+++ b/lib/collection/src/operations/conversions_rest.rs
@@ -1,0 +1,25 @@
+use segment::data_types::vectors::VectorStruct;
+
+use super::types::Record;
+
+impl From<Record> for api::rest::Record {
+    fn from(value: Record) -> Self {
+        Self {
+            id: value.id,
+            payload: value.payload,
+            vector: value.vector.map(api::rest::VectorStruct::from),
+            shard_key: value.shard_key,
+        }
+    }
+}
+
+impl From<api::rest::Record> for Record {
+    fn from(value: api::rest::Record) -> Self {
+        Self {
+            id: value.id,
+            payload: value.payload,
+            vector: value.vector.map(VectorStruct::from),
+            shard_key: value.shard_key,
+        }
+    }
+}

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -2,6 +2,7 @@ pub mod cluster_ops;
 pub mod config_diff;
 pub mod consistency_params;
 pub mod conversions;
+pub mod conversions_rest;
 pub mod operation_effect;
 pub mod payload_ops;
 pub mod point_ops;

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -66,7 +66,7 @@ impl TryFrom<Record> for PointStruct {
         Ok(Self {
             id,
             payload,
-            vector: vector.unwrap(),
+            vector: api::rest::VectorStruct::from(vector.unwrap()),
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1271,7 +1271,7 @@ impl Record {
             Some(VectorStruct::Single(vector)) => {
                 (name == DEFAULT_VECTOR_NAME).then_some(vector.into())
             }
-            Some(VectorStruct::Multi(vectors)) => vectors.get(name).map(Vector::to_vec_ref),
+            Some(VectorStruct::Multi(vectors)) => vectors.get(name).map(VectorRef::from),
             None => None,
         }
     }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -19,7 +19,7 @@ use segment::data_types::groups::GroupId;
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{
     DenseVector, Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorRef,
-    DEFAULT_VECTOR_NAME,
+    VectorStruct, DEFAULT_VECTOR_NAME,
 };
 use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
@@ -85,17 +85,15 @@ pub enum OptimizersStatus {
 }
 
 /// Point data
-#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Record {
     /// Id of the point
     pub id: PointIdType,
     /// Payload - values assigned to the point
     pub payload: Option<Payload>,
     /// Vector of the point
-    pub vector: Option<api::rest::VectorStruct>,
+    pub vector: Option<VectorStruct>,
     /// Shard Key
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<ShardKey>,
 }
 
@@ -353,7 +351,7 @@ impl Default for ScrollRequestInternal {
 #[serde(rename_all = "snake_case")]
 pub struct ScrollResult {
     /// List of retrieved points
-    pub points: Vec<Record>,
+    pub points: Vec<api::rest::Record>,
     /// Offset which should be used to retrieve a next page result
     pub next_page_offset: Option<PointIdType>,
 }
@@ -857,7 +855,7 @@ pub struct PointGroup {
     pub id: GroupId,
     /// Record that has been looked up using the group id
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lookup: Option<Record>,
+    pub lookup: Option<api::rest::Record>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1262,24 +1260,18 @@ impl Record {
         match &self.vector {
             None => vec![],
             Some(vectors) => match vectors {
-                api::rest::VectorStruct::Single(_) => vec![DEFAULT_VECTOR_NAME],
-                api::rest::VectorStruct::Multi(vectors) => {
-                    vectors.keys().map(|x| x.as_str()).collect()
-                }
+                VectorStruct::Single(_) => vec![DEFAULT_VECTOR_NAME],
+                VectorStruct::Multi(vectors) => vectors.keys().map(|x| x.as_str()).collect(),
             },
         }
     }
 
     pub fn get_vector_by_name(&self, name: &str) -> Option<VectorRef> {
         match &self.vector {
-            Some(api::rest::VectorStruct::Single(vector)) => {
+            Some(VectorStruct::Single(vector)) => {
                 (name == DEFAULT_VECTOR_NAME).then_some(vector.into())
             }
-            // TODO(colbert): remove this match and use `into`
-            Some(api::rest::VectorStruct::Multi(vectors)) => vectors.get(name).map(|v| match v {
-                api::rest::Vector::Dense(v) => VectorRef::Dense(v),
-                api::rest::Vector::Sparse(v) => VectorRef::Sparse(v),
-            }),
+            Some(VectorStruct::Multi(vectors)) => vectors.get(name).map(Vector::to_vec_ref),
             None => None,
         }
     }

--- a/lib/collection/tests/integration/lookup_test.rs
+++ b/lib/collection/tests/integration/lookup_test.rs
@@ -145,7 +145,6 @@ async fn happy_lookup_ids() {
             record.payload,
             Some(Payload::from(json!({ "foo": format!("bar {}", id_value) })))
         );
-        let vector: api::rest::VectorStruct = vector.into();
         assert_eq!(record.vector, Some(vector));
     }
 }

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -227,8 +227,8 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
 
     assert_eq!(retrieve.len(), 1);
     match retrieve[0].vector.as_ref().unwrap() {
-        api::rest::VectorStruct::Single(_) => panic!("expected multi vector"),
-        api::rest::VectorStruct::Multi(vectors) => {
+        VectorStruct::Single(_) => panic!("expected multi vector"),
+        VectorStruct::Multi(vectors) => {
             assert!(vectors.contains_key(VEC_NAME1));
             assert!(!vectors.contains_key(VEC_NAME2));
         }

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -4,6 +4,7 @@ use actix_web_validator::{Json, Path, Query};
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{PointRequest, PointRequestInternal, Record, ScrollRequest};
+use itertools::Itertools;
 use rbac::jwt::Claims;
 use segment::types::{PointIdType, WithPayloadInterface};
 use serde::Deserialize;
@@ -87,7 +88,7 @@ async fn get_point(
             None => Err(StorageError::NotFound {
                 description: format!("Point with id {point_id} does not exists!"),
             }),
-            Some(record) => Ok(record),
+            Some(record) => Ok(api::rest::Record::from(record)),
         },
         Err(e) => Err(e),
     };
@@ -123,6 +124,7 @@ async fn get_points(
         claims.into_inner(),
     )
     .await;
+    let response = response.map(|v| v.into_iter().map(api::rest::Record::from).collect_vec());
     process_response(response, timing)
 }
 

--- a/src/schema_generator.rs
+++ b/src/schema_generator.rs
@@ -1,5 +1,5 @@
 use api::grpc::models::{CollectionsResponse, VersionInfo};
-use api::rest::ScoredPoint;
+use api::rest::{Record, ScoredPoint};
 use collection::operations::cluster_ops::ClusterOperations;
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::payload_ops::{DeletePayload, SetPayload};
@@ -11,7 +11,7 @@ use collection::operations::types::{
     AliasDescription, CollectionClusterInfo, CollectionExistence, CollectionInfo,
     CollectionsAliasesResponse, CountRequest, CountResult, DiscoverRequest, DiscoverRequestBatch,
     GroupsResult, PointGroup, PointRequest, RecommendGroupsRequest, RecommendRequest,
-    RecommendRequestBatch, Record, ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest,
+    RecommendRequestBatch, ScrollRequest, ScrollResult, SearchGroupsRequest, SearchRequest,
     SearchRequestBatch, UpdateResult,
 };
 use collection::operations::vector_ops::{DeleteVectors, UpdateVectors};

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -27,7 +27,7 @@ use collection::operations::shard_key_selector::ShardKeySelector;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     default_exact_count, CoreSearchRequest, CoreSearchRequestBatch, OrderByInterface,
-    PointRequestInternal, QueryEnum, RecommendExample, ScrollRequestInternal,
+    PointRequestInternal, QueryEnum, RecommendExample, Record, ScrollRequestInternal,
 };
 use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVectors};
 use collection::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
@@ -1453,7 +1453,8 @@ pub async fn scroll(
         result: scrolled_points
             .points
             .into_iter()
-            .map(|point| point.into())
+            .map(Record::from)
+            .map(api::grpc::qdrant::RetrievedPoint::from)
             .collect(),
         time: timing.elapsed().as_secs_f64(),
     };


### PR DESCRIPTION
Next step after https://github.com/qdrant/qdrant/pull/3829.
`Record` type has `Vector` inside. This PR decouples `Record` into REST and internal types. Rest one uses rest vector, internal `Record` uses internal vector.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
