### PR TITLE
Log errors for snapshot operations

### DIFF
--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -140,6 +140,9 @@ where
         }
 
         Err(error) => {
+            if error.status_code == http::StatusCode::INTERNAL_SERVER_ERROR {
+                log::warn!("error processing request: {}", error.description);
+            }
             let response = ApiResponse {
                 result: None,
                 status: ApiStatus::Error(error.to_string()),


### PR DESCRIPTION
This PR adds logging to help investigate https://github.com/qdrant/qdrant/issues/3875

The REST API for snapshot operations does not use the `process_response` infrastructure since it was changed to be cancel-safe.

The new `time_impl` helpers do not contain the usual error logging on internal server error.

This PR adds it.