### PR TITLE
Configure development version on dev branch

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1809,12 +1809,12 @@ pub struct PeerMetadata {
 impl PeerMetadata {
     pub fn current() -> Self {
         Self {
-            version: defaults::QDRANT_VERSION,
+            version: defaults::QDRANT_VERSION.clone(),
         }
     }
 
     /// Whether this metadata has a different version than our current Qdrant instance.
     pub fn is_different_version(&self) -> bool {
-        self.version != defaults::QDRANT_VERSION
+        self.version != *defaults::QDRANT_VERSION
     }
 }

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -5,8 +5,13 @@ use semver::Version;
 
 use crate::cpu;
 
-/// Current Qdrant version
-pub const QDRANT_VERSION: Version = Version::new(0, 11, 1);
+/// Current Qdrant version string
+pub const QDRANT_VERSION_STRING: &str = "0.11.1";
+
+lazy_static! {
+    /// Current Qdrant semver version
+    pub static ref QDRANT_VERSION: Version = Version::parse(QDRANT_VERSION_STRING).expect("malformed version string");
+}
 
 /// Number of retries for confirming a consensus operation.
 pub const CONSENSUS_CONFIRM_RETRIES: usize = 3;


### PR DESCRIPTION
Before this PR our development branch was rocking version 0.11.1 for a long while. In this PR I propose to assign an up-to-date development version to our development branch branch to closely match our release versions.

Please feel free to comment here if there are any questions/concerns.

My motivation for this is as follows: We've just implemented tracking of node versions in consensus (<https://github.com/qdrant/qdrant/pull/3702>, <https://github.com/qdrant/qdrant/pull/3792>, <https://github.com/qdrant/qdrant/pull/3800>). This allows version based gating for new features. In fact, that is already used for WAL delta transfer. Because of that our development version must have an up-to-date version number too, otherwise version gated features are not properly tested. Also, if an end user decides to build Qdrant themselves from the development branch, it should have an updated version number configured to prevent things from breaking apart.

I propose to follow this rough scheme:
- Our development versions are always suffixed with `-dev`
- If we're confident the current development branch will be release as the next major version, such as 1.8.0, update the version in our development branch to it with a dev suffix: `1.8.0-dev`
- If doing a `1.8.0` release, we update our development version to `1.8.1-dev` to represent the next potential release
- If doing a `1.8.1` release, we update the development version to `1.8.2-dev`

According to [semver](https://semver.org/), versions are in the following order: `1.0 < 1.1-dev < 1.1`. That means that the development version would always be lower than the actual release. That is a good property.

In this PR I've left the version number as is, as we want to merge changes surrounding this separately first. In a [follow up PR](https://github.com/qdrant/qdrant/pull/3881) I'll set the version number to `1.9.0-dev`. We're confident the current development branch will be released as the next minor version in about two weeks.

If we ever make a mistake we can simply change back to a lower version number. We don't have strict version compatibility guarantees on the development branch itself.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?