### PR TITLE
Remove unecessary Clippy allows

### DIFF
--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -7,7 +7,6 @@ pub mod local_shard;
 pub mod proxy_shard;
 pub mod queue_proxy_shard;
 pub mod remote_shard;
-#[allow(dead_code)]
 pub mod replica_set;
 pub mod resolve;
 pub mod shard;

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -628,7 +628,6 @@ pub struct CollectionSearchRequest<'a>(pub(crate) (CollectionId, &'a SearchReque
 pub struct CollectionCoreSearchRequest<'a>(pub(crate) (CollectionId, &'a CoreSearchRequest));
 
 #[async_trait]
-#[allow(unused_variables)]
 impl ShardOperation for RemoteShard {
     /// # Cancel safety
     ///
@@ -653,7 +652,7 @@ impl ShardOperation for RemoteShard {
         with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
-        search_runtime_handle: &Handle,
+        _search_runtime_handle: &Handle,
         order_by: Option<&OrderBy>,
     ) -> CollectionResult<Vec<Record>> {
         let scroll_points = ScrollPoints {
@@ -709,7 +708,7 @@ impl ShardOperation for RemoteShard {
     async fn core_search(
         &self,
         batch_request: Arc<CoreSearchRequestBatch>,
-        search_runtime_handle: &Handle,
+        _search_runtime_handle: &Handle,
         timeout: Option<Duration>,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         let mut timer = ScopeDurationMeasurer::new(&self.telemetry_search_durations);

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -596,7 +596,6 @@ impl UpdateHandler {
             .unwrap_or_else(|_| debug!("Optimizer already stopped"));
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn flush_worker(
         segments: LockedSegmentHolder,
         wal: LockedWal,

--- a/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_sparse_vector_storage.rs
@@ -41,7 +41,6 @@ struct StoredRecord {
     pub vector: SparseVector,
 }
 
-#[allow(unused)]
 pub fn open_simple_sparse_vector_storage(
     database: Arc<RwLock<DB>>,
     database_column_name: &str,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -277,7 +277,6 @@ impl Settings {
 }
 
 /// Returns the number of maximum actix workers.
-#[allow(dead_code)]
 pub fn max_web_workers(settings: &Settings) -> usize {
     match settings.service.max_workers {
         Some(0) => {


### PR DESCRIPTION
Found an unnecessary `allow` so I decided to do a quick pass on the codebase.