### PR TITLE
Bump dev to 1.9.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "api"
-version = "0.11.1"
+version = "1.9.0-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "0.11.1"
+version = "1.9.0-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "0.11.1"
+version = "1.9.0-dev"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.11.1"
+version = "1.9.0-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "0.11.1";
+pub const QDRANT_VERSION_STRING: &str = "1.9.0-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Part of <https://github.com/qdrant/qdrant/pull/3877>.

Change our development version to `1.9.0-dev`. We're confident the current development branch will be released as the next minor version in about two weeks.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/3877>
- [x] Rebase on `dev`
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?