### PR TITLE
Test WAL delta resolution with gaps, improve resolution logic

### DIFF
--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -293,27 +293,25 @@ impl RecoveryPoint {
     }
 
     /// Remove a clock referenced by the clock tag from this recovery point, if the clock is
-    /// *equal* than the tick in the tag.
-    pub fn remove_clock_if_equal_to_tag(&mut self, tag: ClockTag) {
+    /// *newer or equal* to the tick in the tag.
+    ///
+    /// Returns `true` if any clock with an equal tick value was removed. `false` if all removed
+    /// clocks had newer tick values.
+    pub fn remove_clock_if_newer_or_equal_to_tag(&mut self, tag: ClockTag) -> bool {
         let key = Key::from_tag(tag);
 
+        let mut any_equal = false;
         if let Some(&(tick, _)) = self.clocks.get(&key) {
+            if tick >= tag.clock_tick {
+                self.clocks.remove(&key);
+            }
+
             if tick == tag.clock_tick {
-                self.clocks.remove(&key);
+                any_equal = true;
             }
         }
-    }
 
-    /// Remove a clock referenced by the clock tag from this recovery point, if the clock is
-    /// *newer* than the tick in the tag.
-    pub fn remove_clock_if_newer_than_tag(&mut self, tag: ClockTag) {
-        let key = Key::from_tag(tag);
-
-        if let Some(&(tick, _)) = self.clocks.get(&key) {
-            if tick > tag.clock_tick {
-                self.clocks.remove(&key);
-            }
-        }
+        any_equal
     }
 
     #[cfg(test)]

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -293,12 +293,24 @@ impl RecoveryPoint {
     }
 
     /// Remove a clock referenced by the clock tag from this recovery point, if the clock is
-    /// *newer or equal* than the tick in the tag.
-    pub fn remove_clock_if_newer_than_or_equal_to_tag(&mut self, tag: ClockTag) {
+    /// *equal* than the tick in the tag.
+    pub fn remove_clock_if_equal_to_tag(&mut self, tag: ClockTag) {
         let key = Key::from_tag(tag);
 
         if let Some(&(tick, _)) = self.clocks.get(&key) {
-            if tick >= tag.clock_tick {
+            if tick == tag.clock_tick {
+                self.clocks.remove(&key);
+            }
+        }
+    }
+
+    /// Remove a clock referenced by the clock tag from this recovery point, if the clock is
+    /// *newer* than the tick in the tag.
+    pub fn remove_clock_if_newer_than_tag(&mut self, tag: ClockTag) {
+        let key = Key::from_tag(tag);
+
+        if let Some(&(tick, _)) = self.clocks.get(&key) {
+            if tick > tag.clock_tick {
                 self.clocks.remove(&key);
             }
         }

--- a/lib/collection/src/shards/local_shard/clock_map.rs
+++ b/lib/collection/src/shards/local_shard/clock_map.rs
@@ -305,10 +305,7 @@ impl RecoveryPoint {
             if tick >= tag.clock_tick {
                 self.clocks.remove(&key);
             }
-
-            if tick == tag.clock_tick {
-                any_equal = true;
-            }
+            any_equal |= tick == tag.clock_tick;
         }
 
         any_equal

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -215,9 +215,8 @@ fn resolve_wal_delta(
         // We cannot resolve a delta if we have untagged records
         .take_while(|(_, clock_tag)| clock_tag.is_some())
         // Keep scrolling until we have no clocks left
-        .filter_map(|(op_num, clock_tag)| Some((op_num, clock_tag?)))
         .find(|&(_, clock_tag)| {
-            recovery_point.remove_clock_if_newer_than_or_equal_to_tag(clock_tag);
+            recovery_point.remove_clock_if_newer_than_or_equal_to_tag(clock_tag.unwrap());
             recovery_point.is_empty()
         })
         .map(|(op_num, _)| op_num);

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -395,8 +395,9 @@ mod tests {
     /// unexpectedly.
     ///
     /// See: <https://www.notion.so/qdrant/Testing-suite-4e28a978ec05476080ff26ed07757def?pvs=4>
+    #[rstest]
     #[tokio::test]
-    async fn test_resolve_wal_delta_with_gaps() {
+    async fn test_resolve_wal_delta_with_gaps(#[values(true, false)] with_gap: bool) {
         const N: usize = 5;
         const GAP_SIZE: usize = 10;
 
@@ -430,10 +431,12 @@ mod tests {
         }
 
         // Introduce a gap in the clocks on A
-        for _ in 0..GAP_SIZE {
-            let mut a_clock_0 = a_clock_set.get_clock();
-            let clock_tick = a_clock_0.tick_once();
-            a_clock_0.advance_to(clock_tick);
+        if with_gap {
+            for _ in 0..GAP_SIZE {
+                let mut a_clock_0 = a_clock_set.get_clock();
+                let clock_tick = a_clock_0.tick_once();
+                a_clock_0.advance_to(clock_tick);
+            }
         }
 
         // Create N operations on peer A, which are missed on node C

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -230,7 +230,7 @@ fn resolve_wal_delta(
         last_op_num.replace(op_num);
     }
 
-    last_op_num.map(Some).ok_or(WalDeltaError::NotFound)
+    Err(WalDeltaError::NotFound)
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Tracked in: <https://github.com/qdrant/qdrant/issues/3477>

Add a test asserting that WAL delta resolution works when there is gaps in our WAL clocks. It extends and improves our existing WAL delta code.

We normally don't expect this situation, but it's good to support it in case it ever happens unexpectedly.

As a bonus, this improves our WAL delta resolution logic. It appeared that the resolved delta included an extra and obsolete record if our records have any gap. The improvement prevent this, so that a resolved delta exclusively contains records that are not in the target shard yet. Note that the previous version is perfectly sound in terms of consistency, so we don't have to worry about this in the 1.8 releases.

The test function to assert WAL delta ordering got a new parameter to specify whether we allow any clock tick gaps in that specific assertion. We normally don't allow this, but we obviously we do in the new test with gaps.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?