### PR TITLE
Expose the WAL delta transfer method in our OpenAPI specification

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8684,6 +8684,13 @@
             "enum": [
               "snapshot"
             ]
+          },
+          {
+            "description": "Attempt to transfer shard difference by WAL delta.",
+            "type": "string",
+            "enum": [
+              "wal_delta"
+            ]
           }
         ]
       },

--- a/lib/collection/src/shards/transfer/mod.rs
+++ b/lib/collection/src/shards/transfer/mod.rs
@@ -102,7 +102,6 @@ pub enum ShardTransferMethod {
     /// Snapshot the shard, transfer and restore it on the receiver.
     Snapshot,
     /// Attempt to transfer shard difference by WAL delta.
-    #[schemars(skip)]
     WalDelta,
 }
 


### PR DESCRIPTION
Track: <https://github.com/qdrant/qdrant/issues/3477>

Expose the WAL delta transfer in our OpenAPI specification. It was hidden before, but it is totally fine for users to explicitly select it if desired.

Our gRPC specification already exposes it because we cannot hide it there.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?