### PR TITLE
Native async recursion with Rust 1.77

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,17 +521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,7 +5174,6 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",
- "async-recursion",
  "async-trait",
  "atomicwrites",
  "cancel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.77"
 default-run = "qdrant"
 
 [features]

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -54,7 +54,6 @@ uuid = { workspace = true }
 url = "2.5.0"
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 tempfile = "3.10.1"
-async-recursion = "1.1"
 async-trait = "0.1.79"
 
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#support-for-recursion-in-async-fn

Blocked by the update of the base docker container version.