### PR TITLE
[experiment] Use `Undroppable<T>` for making sure `Claims` are handled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ dependencies = [
 name = "rbac"
 version = "0.0.0"
 dependencies = [
+ "common",
  "jsonwebtoken",
  "segment",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,15 +89,16 @@ slog-stdlog = "4.1.1"
 prost = { workspace = true }
 raft-proto = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 
-common = { path = "lib/common/common" }
-cancel = { path = "lib/common/cancel" }
-memory = { path = "lib/common/memory" }
-issues = { path = "lib/common/issues" }
-rbac = { path = "lib/rbac" }
-segment = { path = "lib/segment" }
-collection = { path = "lib/collection" }
-storage = { path = "lib/storage" }
-api = { path = "lib/api" }
+common.workspace = true
+cancel.workspace = true
+memory.workspace = true
+issues.workspace = true
+rbac.workspace = true
+segment.workspace = true
+collection.workspace = true
+storage.workspace = true
+api.workspace = true
+
 actix-multipart = "0.6.1"
 constant_time_eq = "0.3.0"
 
@@ -117,6 +118,16 @@ rstack-self = { version = "0.3.0", optional = true }
 tikv-jemallocator = "0.5"
 
 [workspace.dependencies]
+common = { path = "lib/common/common" }
+cancel = { path = "lib/common/cancel" }
+memory = { path = "lib/common/memory" }
+issues = { path = "lib/common/issues" }
+rbac = { path = "lib/rbac" }
+segment = { path = "lib/segment" }
+collection = { path = "lib/collection" }
+storage = { path = "lib/storage" }
+api = { path = "lib/api" }
+
 chrono = { version = "0.4.35", features = ["serde"] }
 fnv = "1.0"
 futures = "0.3.30"

--- a/lib/rbac/Cargo.toml
+++ b/lib/rbac/Cargo.toml
@@ -12,5 +12,6 @@ publish = false
 
 [dependencies]
 jsonwebtoken = "9.2.0"
-segment = { path = "../segment" }
+segment.workspace = true
+common.workspace = true 
 serde.workspace = true

--- a/lib/rbac/src/jwt.rs
+++ b/lib/rbac/src/jwt.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use common::validation::Undroppable;
 use segment::json_path::JsonPath;
 use segment::types::{Condition, FieldCondition, Filter, Match, ValueVariants};
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,9 @@ pub struct Claims {
     /// Validate this token by looking for a value inside a collection.
     pub value_exists: Option<ValueExists>,
 }
+
+/// Special wrapper for making sure that claims are intentionally handled and dropped.
+pub type SafeClaims = Undroppable<Option<Claims>>;
 
 pub type PayloadClaim = HashMap<JsonPath, ValueVariants>;
 

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -11,7 +11,7 @@ use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::{discovery, recommendations};
 use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
-use rbac::jwt::Claims;
+use rbac::jwt::{Claims, SafeClaims};
 use segment::types::{ScoredPoint, ShardKey};
 
 use super::TableOfContent;
@@ -169,7 +169,7 @@ impl TableOfContent {
         mut request: CountRequestInternal,
         read_consistency: Option<ReadConsistency>,
         shard_selection: ShardSelectorInternal,
-        claims: Option<Claims>,
+        claims: SafeClaims,
     ) -> Result<CountResult, StorageError> {
         if let Some(Claims {
             exp: _,
@@ -182,6 +182,7 @@ impl TableOfContent {
             check_collection_name(collections.as_ref(), collection_name)?;
             check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
         }
+        claims.manually_drop();
 
         let collection = self.get_collection(collection_name).await?;
         collection

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -3,6 +3,7 @@ use actix_web::{post, web, Responder};
 use actix_web_validator::{Json, Path, Query};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::CountRequest;
+use common::validation::Undroppable;
 use rbac::jwt::Claims;
 use storage::content_manager::toc::TableOfContent;
 
@@ -38,7 +39,7 @@ async fn count_points(
         count_request,
         params.consistency,
         shard_selector,
-        claims.into_inner(),
+        Undroppable::new(claims.into_inner()),
         // ToDo: use timeout from params
     )
     .await;

--- a/src/common/points.rs
+++ b/src/common/points.rs
@@ -25,7 +25,7 @@ use collection::operations::{
     ClockTag, CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
 use collection::shards::shard::ShardId;
-use rbac::jwt::Claims;
+use rbac::jwt::{Claims, SafeClaims};
 use schemars::JsonSchema;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, ScoredPoint};
@@ -929,7 +929,7 @@ pub async fn do_count_points(
     request: CountRequestInternal,
     read_consistency: Option<ReadConsistency>,
     shard_selection: ShardSelectorInternal,
-    claims: Option<Claims>,
+    claims: SafeClaims,
 ) -> Result<CountResult, StorageError> {
     toc.count(
         collection_name,

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -13,6 +13,7 @@ use api::grpc::qdrant::{
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints,
 };
 use collection::operations::types::CoreSearchRequest;
+use common::validation::Undroppable;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status};
 
@@ -412,6 +413,12 @@ impl Points for PointsService {
 
         let claims = extract_claims(&mut request);
 
-        count(self.dispatcher.as_ref(), request.into_inner(), None, claims).await
+        count(
+            self.dispatcher.as_ref(),
+            request.into_inner(),
+            None,
+            Undroppable::new(claims),
+        )
+        .await
     }
 }

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -33,7 +33,7 @@ use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVect
 use collection::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
 use collection::shards::shard::ShardId;
 use itertools::Itertools;
-use rbac::jwt::Claims;
+use rbac::jwt::{Claims, SafeClaims};
 use segment::data_types::vectors::VectorStruct;
 use segment::types::{
     ExtendedPointId, Filter, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
@@ -1462,7 +1462,7 @@ pub async fn count(
     toc: &TableOfContent,
     count_points: CountPoints,
     shard_selection: Option<ShardId>,
-    claims: Option<Claims>,
+    claims: SafeClaims,
 ) -> Result<Response<CountResponse>, Status> {
     let CountPoints {
         collection_name,

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -11,6 +11,7 @@ use api::grpc::qdrant::{
     SearchPointsInternal, SearchResponse, SetPayloadPointsInternal, SyncPointsInternal,
     UpdateVectorsInternal, UpsertPointsInternal,
 };
+use common::validation::Undroppable;
 use storage::content_manager::toc::TableOfContent;
 use tonic::{Request, Response, Status};
 
@@ -407,7 +408,13 @@ impl PointsInternal for PointsInternalService {
 
         let count_points =
             count_points.ok_or_else(|| Status::invalid_argument("CountPoints is missing"))?;
-        count(self.toc.as_ref(), count_points, shard_id, None).await
+        count(
+            self.toc.as_ref(),
+            count_points,
+            shard_id,
+            Undroppable::new(None),
+        )
+        .await
     }
 
     async fn sync(


### PR DESCRIPTION
This is an experiment to see how would [this hack](https://stackoverflow.com/questions/71694803/rust-type-that-requires-manual-drop) would work for ensuring `Claims` are never just dropped implicitly.

Right now it is not compiling successfully for me :(

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
