### PR TITLE
RBAC: Refactor for scoped access claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,6 +4242,7 @@ dependencies = [
  "jsonwebtoken",
  "segment",
  "serde",
+ "validator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ rustls = "0.22.2"
 rustls-pki-types = "1.3.1"
 rustls-pemfile = "2.1.1"
 prometheus = { version = "0.13.3", default-features = false }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 
 # Consensus related crates
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
@@ -136,6 +136,8 @@ tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
+validator = { version = "0.16", features = ["derive"] }
+
 
 [[bin]]
 name = "schema_generator"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8.5"
 chrono = { workspace = true }
 thiserror = "1.0"
 parking_lot = { workspace = true }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 log = "0.4"
 
 common = { path = "../common/common" }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -46,7 +46,7 @@ arc-swap = "1.7.0"
 tonic = { workspace = true }
 uuid = { workspace = true }
 url = { version = "2", features = ["serde"] }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 actix-web-validator = "5.0.1"
 
 common = { path = "../common/common" }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -14,7 +14,7 @@ num_cpus = "1.16"
 ordered-float = "4.2"
 serde = { workspace = true }
 tokio = { workspace = true }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 lazy_static = "1.4.0"
 semver = { workspace = true }
 

--- a/lib/rbac/Cargo.toml
+++ b/lib/rbac/Cargo.toml
@@ -14,3 +14,4 @@ publish = false
 jsonwebtoken = "9.2.0"
 segment = { path = "../segment" }
 serde.workspace = true
+validator.workspace = true

--- a/lib/rbac/src/jwt.rs
+++ b/lib/rbac/src/jwt.rs
@@ -3,24 +3,124 @@ use std::collections::HashMap;
 use segment::json_path::JsonPath;
 use segment::types::{Condition, FieldCondition, Filter, Match, ValueVariants};
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Claims {
     /// Expiration time (seconds since UNIX epoch)
     pub exp: Option<u64>,
 
-    /// Write access, default is false. Read access is always enabled with a valid token.
-    pub w: Option<bool>,
+    /// Validate this token by looking for a value inside a collection.
+    pub value_exists: Option<ValueExists>,
 
+    /// Defines specific access within the cluster.
+    ///
+    /// The default is global read access (same as read-only API key)
+    pub access: AccessClaim,
+}
+
+impl Validate for Claims {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        let mut errors = validator::ValidationErrors::new();
+        let Self {
+            exp: _,
+            value_exists,
+            access,
+        } = self;
+
+        if matches!(access, AccessClaim::Scoped(scoped) if scoped.collections.is_empty()) {
+            errors.add(
+                "access.collections",
+                validator::ValidationError {
+                    code: "invalid_token".into(),
+                    message: Some("Scoped access must allow at least one collection".into()),
+                    params: HashMap::new(),
+                },
+            );
+        }
+        if let Some(value_exists) = value_exists {
+            if access.allows_collection(&value_exists.collection) {
+                errors.add(
+                    "value_exists.collection",
+                    validator::ValidationError {
+                        code: "invalid_token".into(),
+                        message: Some("Collection for `value_exists` is not allowed".into()),
+                        params: HashMap::new(),
+                    },
+                );
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
+pub enum Privilege {
+    #[default]
+    #[serde(rename = "r")]
+    Read,
+
+    #[serde(rename = "rw")]
+    Write,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+pub struct ScopedAccess {
     /// Collection names that are allowed to be accessed
-    pub collections: Option<Vec<String>>,
+    pub collections: Vec<String>,
+
+    /// Access privilege
+    #[serde(default)]
+    pub privilege: Privilege,
 
     /// Payload constraints.
     /// An object where each key is a JSON path, and each value is JSON value.
     pub payload: Option<PayloadClaim>,
+}
 
-    /// Validate this token by looking for a value inside a collection.
-    pub value_exists: Option<ValueExists>,
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+pub enum AccessClaim {
+    Global(Privilege),
+    Scoped(ScopedAccess),
+}
+
+impl Default for AccessClaim {
+    fn default() -> Self {
+        AccessClaim::Global(Privilege::Read)
+    }
+}
+
+impl AccessClaim {
+    pub fn has_some_write_privileges(&self) -> bool {
+        match self {
+            AccessClaim::Global(Privilege::Write) => true,
+            AccessClaim::Scoped(scoped) => scoped.privilege == Privilege::Write,
+            _ => false,
+        }
+    }
+
+    pub fn is_scoped(&self) -> bool {
+        matches!(self, AccessClaim::Scoped(_))
+    }
+
+    pub fn allows_collection(&self, collection: &str) -> bool {
+        match self {
+            AccessClaim::Global(_) => true,
+            AccessClaim::Scoped(scoped) => scoped.collections.contains(&collection.to_string()),
+        }
+    }
+
+    pub fn payload_claim(&self) -> Option<&PayloadClaim> {
+        match self {
+            AccessClaim::Global(_) => None,
+            AccessClaim::Scoped(scoped) => scoped.payload.as_ref(),
+        }
+    }
 }
 
 pub type PayloadClaim = HashMap<JsonPath, ValueVariants>;

--- a/lib/rbac/src/lib.rs
+++ b/lib/rbac/src/lib.rs
@@ -39,9 +39,8 @@ impl JwtParser {
 
 #[cfg(test)]
 mod tests {
-    use segment::types::ValueVariants;
-
     use super::*;
+    use crate::jwt::{AccessClaim, Privilege};
 
     pub fn create_token(claims: &Claims) -> String {
         use jsonwebtoken::{encode, EncodingKey, Header};
@@ -59,20 +58,7 @@ mod tests {
             .as_secs();
         let claims = Claims {
             exp: Some(exp),
-            w: Some(true),
-            collections: Some(vec!["collection".to_string()]),
-            payload: Some(
-                vec![
-                    (
-                        "field1".parse().unwrap(),
-                        ValueVariants::Keyword("value".to_string()),
-                    ),
-                    ("field2".parse().unwrap(), ValueVariants::Integer(42)),
-                    ("field2".parse().unwrap(), ValueVariants::Bool(true)),
-                ]
-                .into_iter()
-                .collect(),
-            ),
+            access: AccessClaim::Global(Privilege::Write),
             value_exists: None,
         };
         let token = create_token(&claims);
@@ -94,9 +80,7 @@ mod tests {
 
         let mut claims = Claims {
             exp: Some(exp),
-            w: Some(false),
-            collections: None,
-            payload: None,
+            access: AccessClaim::Global(Privilege::Write),
             value_exists: None,
         };
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -58,7 +58,7 @@ fs_extra = "1.3.0"
 semver = "1.0.22"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 quantization = { git = "https://github.com/qdrant/quantization.git" }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 chrono = { workspace = true }
 smol_str = { version = "0.2.1", features = ["serde"] }
 fnv = { workspace = true }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -18,6 +18,6 @@ serde = { workspace = true }
 tempfile = "3.10.1"
 ordered-float = "4.2"
 rand = "0.8.5"
-validator = "0.16"
+validator.workspace = true
 itertools = "0.12.1"
 parking_lot = "0.12.1"

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -31,7 +31,7 @@ http = "0.2"
 parking_lot = { workspace = true }
 tar = "0.4.40"
 chrono = { workspace = true }
-validator = { version = "0.16", features = ["derive"] }
+validator.workspace = true
 
 # Consensus related
 atomicwrites = { version = "0.4.3" }

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -40,14 +40,12 @@ impl TableOfContent {
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -83,15 +81,13 @@ impl TableOfContent {
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
+            check_collection_name(access, collection_name)?;
             for (request, _shard_selector) in &mut requests {
-                check_points_op(collections.as_ref(), payload.as_ref(), request)?;
+                check_points_op(access, request)?;
             }
         }
 
@@ -132,15 +128,13 @@ impl TableOfContent {
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
+            check_collection_name(access, collection_name)?;
             for req in &mut request.searches {
-                check_points_op(collections.as_ref(), payload.as_ref(), req)?;
+                check_points_op(access, req)?;
             }
         }
 
@@ -173,14 +167,12 @@ impl TableOfContent {
     ) -> Result<CountResult, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -211,14 +203,12 @@ impl TableOfContent {
     ) -> Result<Vec<Record>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -239,14 +229,12 @@ impl TableOfContent {
     ) -> Result<GroupsResult, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -276,14 +264,12 @@ impl TableOfContent {
     ) -> Result<Vec<ScoredPoint>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -309,15 +295,13 @@ impl TableOfContent {
     ) -> Result<Vec<Vec<ScoredPoint>>, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
+            check_collection_name(access, collection_name)?;
             for (request, _shard_selector) in &mut requests {
-                check_points_op(collections.as_ref(), payload.as_ref(), request)?;
+                check_points_op(access, request)?;
             }
         }
         let collection = self.get_collection(collection_name).await?;
@@ -354,14 +338,12 @@ impl TableOfContent {
     ) -> Result<ScrollResult, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(collections.as_ref(), payload.as_ref(), &mut request)?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut request)?;
         }
 
         let collection = self.get_collection(collection_name).await?;
@@ -416,18 +398,12 @@ impl TableOfContent {
     ) -> Result<UpdateResult, StorageError> {
         if let Some(Claims {
             exp: _,
-            w: _,
             value_exists: _,
-            collections,
-            payload,
+            access,
         }) = claims.as_ref()
         {
-            check_collection_name(collections.as_ref(), collection_name)?;
-            check_points_op(
-                collections.as_ref(),
-                payload.as_ref(),
-                &mut operation.operation,
-            )?;
+            check_collection_name(access, collection_name)?;
+            check_points_op(access, &mut operation.operation)?;
         }
 
         // `TableOfContent::_update_shard_keys` and `Collection::update_from_*` are cancel safe,


### PR DESCRIPTION
Refactors `collections` and `payload` claims into an `AccessClaim`, which ties them together, and allows for possible multi-collection config. Also includes some other refactors.

Extra change:
- move `validator` crate into the workspace deps.

Other possible refactors:
- [ ] Create `rbac` crate specific errors, which implement `Display` to be converted into `StorageError::PermissionDenied` errors, then possibly slim down `lib/storage/src/content_manager/claims.rs`

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
