### PR TITLE
[RBAC] allow multiple mathes in jwt validation check

### DIFF
--- a/src/common/auth.rs
+++ b/src/common/auth.rs
@@ -110,7 +110,7 @@ impl AuthKeys {
         let res = self
             .toc
             .scroll(
-                &value_exists.collection,
+                value_exists.get_collection(),
                 scroll_req,
                 None,
                 ShardSelectorInternal::All,

--- a/tests/consensus_tests/test_jwt_validation.py
+++ b/tests/consensus_tests/test_jwt_validation.py
@@ -63,7 +63,7 @@ def uri(tmp_path_factory: pytest.TempPathFactory):
 
 
 def create_validation_collection(
-    uri: str, collection: str, shard_number: int, replication_factor: int, timeout=10
+        uri: str, collection: str, shard_number: int, replication_factor: int, timeout=10
 ):
     res = requests.put(
         f"{uri}/collections/{collection}?timeout={timeout}",
@@ -90,13 +90,19 @@ def scroll_with_token(uri: str, collection: str, token: str) -> requests.Respons
 
 
 def test_value_exists_claim(uri: str):
-
     secondary_collection = "secondary_test_collection"
 
     key = "tokenId"
     value = "token_42"
 
-    claims = {"value_exists": {"collection": secondary_collection, "key": key, "value": value}}
+    claims = {
+        "value_exists": {
+            "collection": secondary_collection,
+            "matches": [
+                {"key": key, "value": value}
+            ]
+        }
+    }
     token = encode_jwt(claims, SECRET)
 
     # Check that token does not work with unexisting collection


### PR DESCRIPTION
We might want to check for multiple keys and values. The example would be is that we want to check for the user exists AND they have required access level