### PR TITLE
[RBAC] Access control inside table of content

### DIFF
--- a/lib/rbac/src/access_control/access_token.rs
+++ b/lib/rbac/src/access_control/access_token.rs
@@ -1,0 +1,148 @@
+use crate::access_control::collection_access_token::{CollectionAccess, CollectionsAccessToken};
+use crate::access_control::error::AccessDeniedError;
+use crate::access_control::AccessLevel;
+use crate::jwt::{Claims, PayloadClaim};
+
+pub enum AccessToken {
+    Global(AccessLevel),
+    Collections(CollectionsAccessToken),
+}
+
+impl TryFrom<Claims> for AccessToken {
+    type Error = AccessDeniedError;
+
+    fn try_from(claims: Claims) -> Result<Self, Self::Error> {
+        let allow_write = claims.w.unwrap_or_default();
+
+        // ToDo: this conversion should be refactored as structure of Claims will be finalized.
+        match (claims.collections, claims.payload) {
+            (Some(collections), Some(payload)) => {
+                let collection_access: Vec<_> = collections
+                    .into_iter()
+                    .map(|collection_name| CollectionAccess {
+                        collection_name,
+                        access_level: if allow_write {
+                            AccessLevel::ReadWrite
+                        } else {
+                            AccessLevel::ReadOnly
+                        },
+                        payload: Some(payload),
+                    })
+                    .collect();
+                Ok(AccessToken::Collections(CollectionsAccessToken::new(
+                    collection_access,
+                )))
+            }
+            (Some(collections), None) => {
+                let collection_access: Vec<_> = collections
+                    .into_iter()
+                    .map(|collection_name| CollectionAccess {
+                        collection_name,
+                        access_level: if allow_write {
+                            AccessLevel::ReadWrite
+                        } else {
+                            AccessLevel::ReadOnly
+                        },
+                        payload: None,
+                    })
+                    .collect();
+                Ok(AccessToken::Collections(CollectionsAccessToken::new(
+                    collection_access,
+                )))
+            }
+            (None, Some(_payload)) => Err(AccessDeniedError::new(
+                "Payload claim requires collection to be set.",
+            )),
+            (None, None) => {
+                if allow_write {
+                    Ok(AccessToken::Global(AccessLevel::Manage))
+                } else {
+                    Ok(AccessToken::Global(AccessLevel::ReadOnly))
+                }
+            }
+        }
+    }
+}
+
+impl AccessToken {
+    /// Create a new access token to access given collections.
+    pub fn into_collections_token_with_manage_access(
+        self,
+        collection_names: &[&str],
+    ) -> Result<CollectionsAccessToken, AccessDeniedError> {
+        match self {
+            AccessToken::Global(AccessLevel::Manage) => {
+                let collection_access: Vec<_> = collection_names
+                    .iter()
+                    .map(|collection_name| CollectionAccess {
+                        collection_name: collection_name.to_string(),
+                        access_level: AccessLevel::Manage,
+                        payload: None,
+                    })
+                    .collect();
+                Ok(CollectionsAccessToken::new(collection_access))
+            }
+            AccessToken::Global(AccessLevel::ReadOnly | AccessLevel::ReadWrite) => {
+                return Err(AccessDeniedError::new(
+                    "Not allowed to have manage access for collections",
+                ));
+            }
+            AccessToken::Collections(collections_token) => {
+                collections_token.validate_manage_collections(collection_names)
+            }
+        }
+    }
+
+    /// Create a new access token to access given collections with read-only access.
+    pub fn into_collections_token_with_read_access(
+        self,
+        collection_names: &[&str],
+    ) -> Result<CollectionsAccessToken, AccessDeniedError> {
+        match self {
+            AccessToken::Global(
+                AccessLevel::Manage | AccessLevel::ReadWrite | AccessLevel::ReadOnly,
+            ) => {
+                let collection_access: Vec<_> = collection_names
+                    .iter()
+                    .map(|collection_name| CollectionAccess {
+                        collection_name: collection_name.to_string(),
+                        access_level: AccessLevel::ReadOnly,
+                        payload: None,
+                    })
+                    .collect();
+                Ok(CollectionsAccessToken::new(collection_access))
+            }
+            AccessToken::Collections(collections_token) => {
+                collections_token.validate_read_collections(collection_names)
+            }
+        }
+    }
+
+    /// Create a new access token to access given collections with write access.
+    pub fn into_collections_token_with_write_access(
+        self,
+        collection_names: &[&str],
+    ) -> Result<CollectionsAccessToken, AccessDeniedError> {
+        match self {
+            AccessToken::Global(AccessLevel::Manage | AccessLevel::ReadWrite) => {
+                let collection_access: Vec<_> = collection_names
+                    .iter()
+                    .map(|collection_name| CollectionAccess {
+                        collection_name: collection_name.to_string(),
+                        access_level: AccessLevel::ReadWrite,
+                        payload: None,
+                    })
+                    .collect();
+                Ok(CollectionsAccessToken::new(collection_access))
+            }
+            AccessToken::Global(AccessLevel::ReadOnly) => {
+                return Err(AccessDeniedError::new(
+                    "Not allowed to have write access for collections",
+                ));
+            }
+            AccessToken::Collections(collections_token) => {
+                collections_token.validate_write_collections(collection_names)
+            }
+        }
+    }
+}

--- a/lib/rbac/src/access_control/access_token.rs
+++ b/lib/rbac/src/access_control/access_token.rs
@@ -1,7 +1,7 @@
 use crate::access_control::collection_access_token::{CollectionAccess, CollectionsAccessToken};
 use crate::access_control::error::AccessDeniedError;
 use crate::access_control::AccessLevel;
-use crate::jwt::{Claims, PayloadClaim};
+use crate::jwt::Claims;
 
 pub enum AccessToken {
     Global(AccessLevel),
@@ -26,7 +26,7 @@ impl TryFrom<Claims> for AccessToken {
                         } else {
                             AccessLevel::ReadOnly
                         },
-                        payload: Some(payload),
+                        payload: Some(payload.clone()),
                     })
                     .collect();
                 Ok(AccessToken::Collections(CollectionsAccessToken::new(
@@ -82,11 +82,9 @@ impl AccessToken {
                     .collect();
                 Ok(CollectionsAccessToken::new(collection_access))
             }
-            AccessToken::Global(AccessLevel::ReadOnly | AccessLevel::ReadWrite) => {
-                return Err(AccessDeniedError::new(
-                    "Not allowed to have manage access for collections",
-                ));
-            }
+            AccessToken::Global(AccessLevel::ReadOnly | AccessLevel::ReadWrite) => Err(
+                AccessDeniedError::new("Not allowed to have manage access for collections"),
+            ),
             AccessToken::Collections(collections_token) => {
                 collections_token.validate_manage_collections(collection_names)
             }
@@ -135,11 +133,9 @@ impl AccessToken {
                     .collect();
                 Ok(CollectionsAccessToken::new(collection_access))
             }
-            AccessToken::Global(AccessLevel::ReadOnly) => {
-                return Err(AccessDeniedError::new(
-                    "Not allowed to have write access for collections",
-                ));
-            }
+            AccessToken::Global(AccessLevel::ReadOnly) => Err(AccessDeniedError::new(
+                "Not allowed to have write access for collections",
+            )),
             AccessToken::Collections(collections_token) => {
                 collections_token.validate_write_collections(collection_names)
             }

--- a/lib/rbac/src/access_control/collection_access_token.rs
+++ b/lib/rbac/src/access_control/collection_access_token.rs
@@ -1,0 +1,96 @@
+use crate::access_control::error::AccessDeniedError;
+use crate::access_control::AccessLevel;
+use crate::jwt::PayloadClaim;
+
+pub(crate) struct CollectionAccess {
+    pub(crate) collection_name: String,
+    pub(crate) access_level: AccessLevel,
+    pub(crate) payload: Option<PayloadClaim>,
+}
+
+#[must_use]
+pub struct CollectionsAccessToken {
+    pub(crate) collections: Vec<CollectionAccess>,
+}
+
+impl CollectionsAccessToken {
+    pub(crate) fn new(collections: Vec<CollectionAccess>) -> Self {
+        Self { collections }
+    }
+
+    fn validate_all_collections_found(
+        collection_names: &[&str],
+        collections_access: &[CollectionAccess],
+    ) -> Result<(), AccessDeniedError> {
+        for collection_name in collection_names {
+            if !collections_access
+                .iter()
+                .any(|collection_access| collection_access.collection_name == *collection_name)
+            {
+                return Err(AccessDeniedError::new(&format!(
+                    "Access to collection {} is denied",
+                    collection_name
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn validate_read_collections(
+        self,
+        collection_names: &[&str],
+    ) -> Result<Self, AccessDeniedError> {
+        let collections: Vec<_> = self
+            .collections
+            .into_iter()
+            .filter(|collection_access| {
+                collection_names.contains(&collection_access.collection_name.as_str())
+                    && collection_access.access_level.is_read_allowed()
+            })
+            .collect();
+
+        // Check all collections are found
+        Self::validate_all_collections_found(collection_names, &collections)?;
+
+        Ok(Self { collections })
+    }
+
+    pub(crate) fn validate_write_collections(
+        self,
+        collection_names: &[&str],
+    ) -> Result<Self, AccessDeniedError> {
+        let collections: Vec<_> = self
+            .collections
+            .into_iter()
+            .filter(|collection_access| {
+                collection_names.contains(&collection_access.collection_name.as_str())
+                    && collection_access.access_level.is_write_allowed()
+            })
+            .collect();
+
+        // Check all collections are found
+        Self::validate_all_collections_found(collection_names, &collections)?;
+
+        Ok(Self { collections })
+    }
+
+    pub(crate) fn validate_manage_collections(
+        self,
+        collection_names: &[&str],
+    ) -> Result<Self, AccessDeniedError> {
+        let collections: Vec<_> = self
+            .collections
+            .into_iter()
+            .filter(|collection_access| {
+                collection_names.contains(&collection_access.collection_name.as_str())
+                    && collection_access.access_level.is_manage_allowed()
+            })
+            .collect();
+
+        // Check all collections are found
+        Self::validate_all_collections_found(collection_names, &collections)?;
+
+        Ok(Self { collections })
+    }
+}

--- a/lib/rbac/src/access_control/error.rs
+++ b/lib/rbac/src/access_control/error.rs
@@ -1,0 +1,11 @@
+pub struct AccessDeniedError {
+    message: String,
+}
+
+impl AccessDeniedError {
+    pub fn new(message: &str) -> Self {
+        AccessDeniedError {
+            message: message.to_string(),
+        }
+    }
+}

--- a/lib/rbac/src/access_control/mod.rs
+++ b/lib/rbac/src/access_control/mod.rs
@@ -1,0 +1,32 @@
+mod access_token;
+pub mod error;
+mod collection_access_token;
+
+
+pub enum AccessLevel {
+    ReadOnly,
+    ReadWrite,
+    Manage,
+}
+
+impl AccessLevel {
+    pub fn is_read_allowed(&self) -> bool {
+        match self {
+            AccessLevel::ReadOnly | AccessLevel::ReadWrite | AccessLevel::Manage => true,
+        }
+    }
+
+    pub fn is_write_allowed(&self) -> bool {
+        match self {
+            AccessLevel::ReadWrite | AccessLevel::Manage => true,
+            AccessLevel::ReadOnly => false,
+        }
+    }
+
+    pub fn is_manage_allowed(&self) -> bool {
+        match self {
+            AccessLevel::Manage => true,
+            AccessLevel::ReadOnly | AccessLevel::ReadWrite => false,
+        }
+    }
+}

--- a/lib/rbac/src/access_control/mod.rs
+++ b/lib/rbac/src/access_control/mod.rs
@@ -1,7 +1,6 @@
 mod access_token;
-pub mod error;
 mod collection_access_token;
-
+pub mod error;
 
 pub enum AccessLevel {
     ReadOnly,

--- a/lib/rbac/src/lib.rs
+++ b/lib/rbac/src/lib.rs
@@ -3,6 +3,8 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use jwt::Claims;
 
 pub mod jwt;
+
+#[allow(dead_code)]
 mod access_control;
 
 #[derive(Clone)]

--- a/lib/rbac/src/lib.rs
+++ b/lib/rbac/src/lib.rs
@@ -3,6 +3,7 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use jwt::Claims;
 
 pub mod jwt;
+mod access_control;
 
 #[derive(Clone)]
 pub struct JwtParser {


### PR DESCRIPTION
- Introduces AccessToken data structure, which should be used to
  - check claims inside our code
  - decouple Claims (interface structure) from check implementation
  - Ensure that conditions are validated