### PR TITLE
decouple vector storage trait into updater and reader

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -220,6 +220,7 @@ mod tests {
     use segment::entry::entry_point::SegmentEntry;
     use segment::index::hnsw_index::num_rayon_threads;
     use segment::types::{Distance, PayloadContainer, PayloadSchemaType};
+    use segment::vector_storage::VectorStorageUpdater;
     use serde_json::{json, Value};
     use tempfile::Builder;
 

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -19,7 +19,7 @@ use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::index::VectorIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageUpdater;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -13,7 +13,7 @@ use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
 use segment::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
-use segment::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use segment::vector_storage::{new_raw_scorer, VectorStorageEnum, VectorStorageUpdater};
 use tempfile::Builder;
 
 const NUM_VECTORS: usize = 100000;

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -21,7 +21,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::VectorIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{VectorStorage, VectorStorageUpdater};
 
 /// Helper to open a test sparse vector index
 pub fn fixture_open_sparse_index<I: InvertedIndex>(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -45,6 +45,7 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::{
     new_raw_scorer, new_stoppable_raw_scorer, RawScorer, VectorStorage, VectorStorageEnum,
+    VectorStorageReader,
 };
 
 const HNSW_USE_HEURISTIC: bool = true;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -31,6 +31,7 @@ use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD};
 use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
+    VectorStorageReader,
 };
 
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -45,7 +45,9 @@ use crate::types::{
 use crate::utils;
 use crate::utils::fs::find_symlink;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    VectorStorage, VectorStorageEnum, VectorStorageReader, VectorStorageUpdater,
+};
 
 pub const SEGMENT_STATE_FILE: &str = "segment.json";
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -16,7 +16,7 @@ use crate::segment::Segment;
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{Indexes, PayloadFieldSchema, PayloadKeyType, SegmentConfig};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::VectorStorageUpdater;
 
 /// Structure for constructing segment out of several other segments
 pub struct SegmentBuilder {

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -14,7 +14,9 @@ use crate::types::Distance;
 use crate::vector_storage::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::vector_storage_base::VectorStorage;
-use crate::vector_storage::{async_raw_scorer, new_raw_scorer, VectorStorageEnum};
+use crate::vector_storage::{
+    async_raw_scorer, new_raw_scorer, VectorStorageEnum, VectorStorageUpdater,
+};
 
 #[test]
 fn async_raw_scorer_cosine() -> Result<()> {
@@ -76,8 +78,8 @@ fn test_async_raw_scorer(
 
         let mut mutable_storage = mutable_storage.borrow_mut();
 
-        insert_random_vectors(&mut rng, &mut *mutable_storage, points)?;
-        delete_random_vectors(&mut rng, &mut *mutable_storage, &mut id_tracker, delete)?;
+        insert_random_vectors(&mut rng, &mut mutable_storage, points)?;
+        delete_random_vectors(&mut rng, &mut mutable_storage, &mut id_tracker, delete)?;
 
         storage.update_from(&mutable_storage, &mut (0..points as _), &Default::default())?;
     }
@@ -91,7 +93,7 @@ fn test_async_raw_scorer(
 
 fn insert_random_vectors(
     rng: &mut impl rand::Rng,
-    storage: &mut impl VectorStorage,
+    storage: &mut VectorStorageEnum,
     vectors: usize,
 ) -> Result<()> {
     insert_distributed_vectors(storage, vectors, &mut sampler(rng))

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -28,7 +28,9 @@ use crate::vector_storage::query::discovery_query::DiscoveryQuery;
 use crate::vector_storage::query::reco_query::RecoQuery;
 use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
 use crate::vector_storage::tests::utils::score;
-use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    new_raw_scorer, VectorStorage, VectorStorageEnum, VectorStorageUpdater,
+};
 
 const DIMS: usize = 128;
 const NUM_POINTS: usize = 600;
@@ -210,12 +212,12 @@ fn scoring_equivalency(
     let mut rng = StdRng::seed_from_u64(SEED);
     let mut sampler = quant_sampler.unwrap_or(Box::new(sampler(rng.clone())));
 
-    super::utils::insert_distributed_vectors(&mut *raw_storage, NUM_POINTS, &mut sampler)?;
+    super::utils::insert_distributed_vectors(&mut raw_storage, NUM_POINTS, &mut sampler)?;
 
     let mut id_tracker = FixtureIdTracker::new(NUM_POINTS);
     super::utils::delete_random_vectors(
         &mut rng,
-        &mut *raw_storage,
+        &mut raw_storage,
         &mut id_tracker,
         NUM_POINTS / 10,
     )?;

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -13,7 +13,9 @@ use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantization
 use crate::vector_storage::appendable_mmap_dense_vector_storage::open_appendable_memmap_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::simple_dense_vector_storage::open_simple_vector_storage;
-use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    new_raw_scorer, VectorStorage, VectorStorageEnum, VectorStorageUpdater,
+};
 
 fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points = [

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -11,7 +11,9 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
 use crate::types::Distance;
 use crate::vector_storage::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
-use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    new_raw_scorer, VectorStorage, VectorStorageEnum, VectorStorageReader, VectorStorageUpdater,
+};
 
 fn multi_points_fixtures() -> Vec<MultiDenseVector> {
     let mut vec = Vec::new();

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -12,7 +12,9 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
 use crate::vector_storage::query::reco_query::RecoQuery;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
-use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    new_raw_scorer, VectorStorage, VectorStorageEnum, VectorStorageReader, VectorStorageUpdater,
+};
 
 fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     let points: Vec<SparseVector> = vec![

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -5,7 +5,7 @@ use rand::seq::IteratorRandom;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::id_tracker::IdTracker;
-use crate::vector_storage::{RawScorer, VectorStorage};
+use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, VectorStorageUpdater};
 
 pub type Result<T, E = Error> = result::Result<T, E>;
 pub type Error = Box<dyn error::Error>;
@@ -15,7 +15,7 @@ pub fn sampler(rng: impl rand::Rng) -> impl Iterator<Item = f32> {
 }
 
 pub fn insert_distributed_vectors(
-    storage: &mut impl VectorStorage,
+    storage: &mut VectorStorageEnum,
     vectors: usize,
     sampler: &mut impl Iterator<Item = VectorElementType>,
 ) -> Result<()> {
@@ -37,7 +37,7 @@ pub fn insert_distributed_vectors(
 
 pub fn delete_random_vectors(
     rng: &mut impl rand::Rng,
-    storage: &mut impl VectorStorage,
+    storage: &mut VectorStorageEnum,
     id_tracker: &mut impl IdTracker,
     vectors: usize,
 ) -> Result<()> {

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -21,7 +21,7 @@ use segment::types::{
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
 use segment::vector_storage::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageUpdater;
 use serde_json::json;
 use tempfile::Builder;
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -24,7 +24,7 @@ use segment::types::{
     Condition, FieldCondition, Filter, Payload, SegmentConfig, SeqNumberType,
     SparseVectorDataConfig, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{VectorStorage, VectorStorageReader, VectorStorageUpdater};
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};


### PR DESCRIPTION
Refactoring of `VectorStorage` trait, decompose it into `VectorStorageUpdater` and `VectorStorageReader`.

The idea is to simplify further refactoring of Vector Storage trait for supporting different types of vector datatype