### PR TITLE
make sure that collection files are deleted even if the collection is not loaded

### DIFF
--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -191,6 +191,14 @@ impl TableOfContent {
             });
             Ok(true)
         } else {
+            let path = self.get_collection_path(collection_name);
+            if path.exists() {
+                log::warn!(
+                    "Collection {} is not loaded, but its directory still exists. Deleting it.",
+                    collection_name
+                );
+                tokio::fs::remove_dir_all(path).await?;
+            }
             Ok(false)
         }
     }


### PR DESCRIPTION
There were several reports, that it is impossible to create collection, even if it doesn't exist.

This change doesn't eliminate the root problem (if any), but allows to simply re-try deletion even if the collection is not loaded.