### PR TITLE
Refactor actix response handlers

### DIFF
--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -46,11 +46,10 @@ async fn remove_peer(
         if !params.force && has_shards {
             return Err(StorageError::BadRequest {
                 description: format!("Cannot remove peer {peer_id} as there are shards on it"),
-            }
-            .into());
+            });
         }
 
-        let res = match dispatcher.consensus_state() {
+        match dispatcher.consensus_state() {
             Some(consensus_state) => {
                 consensus_state
                     .propose_consensus_op_with_await(
@@ -62,8 +61,7 @@ async fn remove_peer(
             None => Err(StorageError::BadRequest {
                 description: "Distributed mode disabled.".to_string(),
             }),
-        };
-        Ok(res?)
+        }
     })
     .await
 }

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -75,8 +75,7 @@ async fn get_point(
         else {
             return Err(StorageError::NotFound {
                 description: format!("Point with id {point_id} does not exists!"),
-            }
-            .into());
+            });
         };
 
         Ok(api::rest::Record::from(record))

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -1,35 +1,13 @@
 use std::fmt::Debug;
 use std::future::Future;
-use std::io;
 
 use actix_web::rt::time::Instant;
-use actix_web::{error, http, Error, HttpResponse};
+use actix_web::{http, HttpResponse, ResponseError};
 use api::grpc::models::{ApiResponse, ApiStatus};
 use collection::operations::types::CollectionError;
 use serde::Serialize;
 use storage::content_manager::errors::StorageError;
 use tokio::task::JoinHandle;
-
-use crate::common::http_client;
-
-pub fn collection_into_actix_error(err: CollectionError) -> Error {
-    let storage_error: StorageError = err.into();
-    storage_into_actix_error(storage_error)
-}
-
-pub fn storage_into_actix_error(err: StorageError) -> Error {
-    match err {
-        StorageError::BadInput { .. } => error::ErrorBadRequest(format!("{err}")),
-        StorageError::NotFound { .. } => error::ErrorNotFound(format!("{err}")),
-        StorageError::ServiceError { .. } => error::ErrorInternalServerError(format!("{err}")),
-        StorageError::BadRequest { .. } => error::ErrorBadRequest(format!("{err}")),
-        StorageError::Locked { .. } => error::ErrorForbidden(format!("{err}")),
-        StorageError::Timeout { .. } => error::ErrorRequestTimeout(format!("{err}")),
-        StorageError::AlreadyExists { .. } => error::ErrorConflict(format!("{err}")),
-        StorageError::ChecksumMismatch { .. } => error::ErrorBadRequest(format!("{err}")),
-        StorageError::Unauthorized { .. } => error::ErrorUnauthorized(format!("{err}")),
-    }
-}
 
 pub fn accepted_response(timing: Instant) -> HttpResponse {
     HttpResponse::Accepted().json(ApiResponse::<()> {
@@ -63,9 +41,9 @@ where
 
             let error: HttpError = err.into();
 
-            HttpResponse::build(error.status_code).json(ApiResponse::<()> {
+            HttpResponse::build(error.status_code()).json(ApiResponse::<()> {
                 result: None,
-                status: ApiStatus::Error(error.description),
+                status: ApiStatus::Error(error.to_string()),
                 time: timing.elapsed().as_secs_f64(),
             })
         }
@@ -79,7 +57,7 @@ where
 /// Future must be cancel safe.
 pub async fn time<T, Fut>(future: Fut) -> impl actix_web::Responder
 where
-    Fut: Future<Output = HttpResult<T>>,
+    Fut: Future<Output = Result<T, StorageError>>,
     T: serde::Serialize,
 {
     time_impl(async { future.await.map(Some) }).await
@@ -87,10 +65,9 @@ where
 
 /// Response wrapper for a ``Future`` returning ``Result``.
 /// If ``wait`` is false, returns ``202 Accepted`` immediately.
-///
 pub async fn time_or_accept<T, Fut>(future: Fut, wait: bool) -> impl actix_web::Responder
 where
-    Fut: Future<Output = HttpResult<T>> + Send + 'static,
+    Fut: Future<Output = Result<T, StorageError>> + Send + 'static,
     T: serde::Serialize + Send + 'static,
 {
     let future = async move {
@@ -125,21 +102,20 @@ where
 /// # Cancel safety
 ///
 /// Future must be cancel safe.
-pub async fn time_or_accept_with_handle<T, Fut, E>(
+pub async fn time_or_accept_with_handle<T, Fut>(
     wait: bool,
     future: Fut,
 ) -> impl actix_web::Responder
 where
-    Fut: Future<Output = HttpResult<JoinHandle<Result<T, E>>>>,
-    HttpError: std::convert::From<E>,
+    Fut: Future<Output = Result<JoinHandle<Result<T, StorageError>>, StorageError>>,
     T: serde::Serialize + Send + 'static,
 {
     let future = async move {
         let res = future.await?;
         if wait {
             res.await
-                .map_err(Into::<HttpError>::into)
-                .and_then(|x| x.map_err(Into::<HttpError>::into))
+                .map_err(Into::<StorageError>::into)
+                .and_then(|x| x)
                 .map(Some)
         } else {
             Ok(None)
@@ -154,78 +130,25 @@ where
 /// Future must be cancel safe.
 async fn time_impl<T, Fut>(future: Fut) -> impl actix_web::Responder
 where
-    Fut: Future<Output = HttpResult<Option<T>>>,
+    Fut: Future<Output = Result<Option<T>, StorageError>>,
     T: serde::Serialize,
 {
     let instant = Instant::now();
-    let result = future.await;
-    let time = instant.elapsed().as_secs_f64();
-
-    let (status_code, response) = match result {
-        Ok(result) => {
-            let (status_code, status) = if result.is_some() {
-                (http::StatusCode::OK, ApiStatus::Ok)
-            } else {
-                (http::StatusCode::ACCEPTED, ApiStatus::Accepted)
-            };
-
-            let response = ApiResponse {
-                result,
-                status,
-                time,
-            };
-
-            (status_code, response)
-        }
-
-        Err(error) => {
-            if error.status_code == http::StatusCode::INTERNAL_SERVER_ERROR {
-                log::warn!("error processing request: {}", error.description);
-            }
-            let response = ApiResponse {
-                result: None,
-                status: ApiStatus::Error(error.to_string()),
-                time,
-            };
-
-            (error.status_code(), response)
-        }
-    };
-
-    HttpResponse::build(status_code).json(response)
+    match future.await.transpose() {
+        Some(v) => process_response(v, instant),
+        None => accepted_response(instant),
+    }
 }
 
 pub type HttpResult<T, E = HttpError> = Result<T, E>;
 
 #[derive(Clone, Debug, thiserror::Error)]
-#[error("{description}")]
-pub struct HttpError {
-    status_code: http::StatusCode,
-    description: String,
-}
+#[error("{0}")]
+pub struct HttpError(StorageError);
 
-impl HttpError {
-    pub fn new(status_code: http::StatusCode, description: impl Into<String>) -> Self {
-        Self {
-            status_code,
-            description: description.into(),
-        }
-    }
-
-    pub fn status_code(&self) -> http::StatusCode {
-        self.status_code
-    }
-}
-
-impl actix_web::ResponseError for HttpError {
+impl ResponseError for HttpError {
     fn status_code(&self) -> http::StatusCode {
-        self.status_code
-    }
-}
-
-impl From<StorageError> for HttpError {
-    fn from(err: StorageError) -> Self {
-        let status_code = match &err {
+        match &self.0 {
             StorageError::BadInput { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::NotFound { .. } => http::StatusCode::NOT_FOUND,
             StorageError::ServiceError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -235,41 +158,24 @@ impl From<StorageError> for HttpError {
             StorageError::AlreadyExists { .. } => http::StatusCode::CONFLICT,
             StorageError::ChecksumMismatch { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::Unauthorized { .. } => http::StatusCode::UNAUTHORIZED,
-        };
-
-        Self {
-            status_code,
-            description: format!("{err}"),
         }
+    }
+}
+
+impl From<StorageError> for HttpError {
+    fn from(err: StorageError) -> Self {
+        HttpError(err)
     }
 }
 
 impl From<CollectionError> for HttpError {
     fn from(err: CollectionError) -> Self {
-        StorageError::from(err).into()
+        HttpError(err.into())
     }
 }
 
-impl From<http_client::Error> for HttpError {
-    fn from(err: http_client::Error) -> Self {
-        StorageError::service_error(format!("failed to initialize HTTP(S) client: {err}")).into()
-    }
-}
-
-impl From<io::Error> for HttpError {
-    fn from(err: io::Error) -> Self {
-        StorageError::from(err).into() // TODO: Is this good enough?.. 🤔
-    }
-}
-
-impl From<tokio::task::JoinError> for HttpError {
-    fn from(err: tokio::task::JoinError) -> Self {
-        StorageError::service_error(err.to_string()).into()
-    }
-}
-
-impl From<cancel::Error> for HttpError {
-    fn from(err: cancel::Error) -> Self {
-        StorageError::from(err).into()
+impl From<std::io::Error> for HttpError {
+    fn from(err: std::io::Error) -> Self {
+        HttpError(err.into()) // TODO: Is this good enough?.. 🤔
     }
 }


### PR DESCRIPTION
This PR refactors actix endpoints to use `helpers::{time, time_or_accept, time_or_accept_with_handle}` more, instead of calling `process_response` manually.

The updated code is more concise, particularly because of using `?` instead of more verbose `match`es.

A new helper function `time_or_accept_with_handle` is added, for handlers consisting of two stages: mandatory (various checks), and optional (runs in a background if `?wait=false`).