### PR TITLE
Stabilize vector renormalisation

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1722,8 +1722,6 @@ impl Drop for Segment {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
-    use rstest::rstest;
     use tempfile::Builder;
 
     use super::*;
@@ -2472,36 +2470,6 @@ mod tests {
                 .vector_by_offset(wrong_name, internal_id)
                 .err()
                 .unwrap();
-        }
-    }
-
-    /// If we preprocess a vector multiple times, we expect the same result.
-    /// Renormalization should not produce something different.
-    #[rstest]
-    fn test_stable_normalize(
-        #[values(Distance::Cosine, Distance::Euclid, Distance::Dot, Distance::Manhattan)] distance: Distance,
-    ) {
-        const DIM: usize = 16;
-        const ATTEMPTS: usize = 100;
-        const TEST_COUNT: usize = 100;
-
-        let mut rng = rand::thread_rng();
-
-        for i in 0..TEST_COUNT {
-            let range = rng.gen_range(-2.5..=0.0)..=rng.gen_range(0.0..2.5);
-            let vector: Vec<_> = (0..DIM).map(|_| rng.gen_range(range.clone())).collect();
-            let mut vectors = NamedVectors::from([("vector1".into(), vector)]);
-
-            vectors.preprocess(|_| distance);
-            let base = vectors.clone();
-
-            for attempt in 2..=ATTEMPTS {
-                vectors.preprocess(|_| distance);
-                assert_eq!(
-                    vectors, base,
-                    "normalization attempt {attempt} gives a different vector (vector #{i})",
-                );
-            }
         }
     }
 }

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -7,6 +7,7 @@ use super::simple_avx::*;
 use super::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::simple_sse::*;
+use super::tools::is_length_zero_or_normalized;
 use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::types::Distance;
 
@@ -226,7 +227,7 @@ pub fn manhattan_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) 
 
 pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
     let mut length: f32 = vector.iter().map(|x| x * x).sum();
-    if length < f32::EPSILON {
+    if is_length_zero_or_normalized(length) {
         return vector;
     }
     length = length.sqrt();

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -254,7 +254,7 @@ mod tests {
     /// Renormalization should not produce something different.
     #[test]
     fn test_cosine_stable_preprocessing() {
-        const DIM: usize = 16;
+        const DIM: usize = 1500;
         const ATTEMPTS: usize = 100;
 
         let mut rng = rand::thread_rng();

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -239,11 +239,38 @@ pub fn dot_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> Sco
 
 #[cfg(test)]
 mod tests {
+    use rand::Rng;
+
     use super::*;
 
     #[test]
     fn test_cosine_preprocessing() {
         let res: DenseVector = CosineMetric::preprocess(vec![0.0, 0.0, 0.0, 0.0]);
         assert_eq!(res, vec![0.0, 0.0, 0.0, 0.0]);
+    }
+
+    /// If we preprocess a vector multiple times, we expect the same result.
+    /// Renormalization should not produce something different.
+    #[test]
+    fn test_cosine_stable_preprocessing() {
+        const DIM: usize = 16;
+        const ATTEMPTS: usize = 100;
+
+        let mut rng = rand::thread_rng();
+
+        for attempt in 0..ATTEMPTS {
+            let range = rng.gen_range(-2.5..=0.0)..=rng.gen_range(0.0..2.5);
+            let vector: Vec<_> = (0..DIM).map(|_| rng.gen_range(range.clone())).collect();
+
+            // Preprocess and re-preprocess
+            let preprocess1 = CosineMetric::preprocess(vector);
+            let preprocess2: DenseVector = CosineMetric::preprocess(preprocess1.clone());
+
+            // All following preprocess attempts must be the same
+            assert_eq!(
+                preprocess1, preprocess2,
+                "renormalization is not stable (vector #{attempt})"
+            );
+        }
     }
 }

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -2,6 +2,7 @@ use std::arch::x86_64::*;
 
 use common::types::ScoreType;
 
+use super::tools::is_length_zero_or_normalized;
 use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "avx")]
@@ -143,7 +144,7 @@ pub(crate) unsafe fn cosine_preprocess_avx(vector: DenseVector) -> DenseVector {
     for i in 0..n - m {
         length += (*ptr.add(i)).powi(2);
     }
-    if length < f32::EPSILON {
+    if is_length_zero_or_normalized(length) {
         return vector;
     }
     length = length.sqrt();

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -4,6 +4,7 @@ use std::arch::aarch64::*;
 #[cfg(target_feature = "neon")]
 use common::types::ScoreType;
 
+use super::tools::is_length_zero_or_normalized;
 use crate::data_types::vectors::DenseVector;
 #[cfg(target_feature = "neon")]
 use crate::data_types::vectors::VectorElementType;
@@ -117,7 +118,7 @@ pub(crate) unsafe fn cosine_preprocess_neon(vector: DenseVector) -> DenseVector 
     for v in vector.iter().take(n).skip(m) {
         length += v.powi(2);
     }
-    if length < f32::EPSILON {
+    if is_length_zero_or_normalized(length) {
         return vector;
     }
     let length = length.sqrt();

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -5,6 +5,7 @@ use std::arch::x86_64::*;
 
 use common::types::ScoreType;
 
+use super::tools::is_length_zero_or_normalized;
 use crate::data_types::vectors::{DenseVector, VectorElementType};
 
 #[target_feature(enable = "sse")]
@@ -135,7 +136,7 @@ pub(crate) unsafe fn cosine_preprocess_sse(vector: DenseVector) -> DenseVector {
     for i in 0..n - m {
         length += (*ptr.add(i)).powi(2);
     }
-    if length < f32::EPSILON {
+    if is_length_zero_or_normalized(length) {
         return vector;
     }
     length = length.sqrt();

--- a/lib/segment/src/spaces/tools.rs
+++ b/lib/segment/src/spaces/tools.rs
@@ -2,6 +2,19 @@ use std::cmp::Reverse;
 
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 
+/// Check if the length is zero or normalized enough.
+///
+/// When checking if normalized, we don't check if it's exactly 1.0 but rather whether it is close
+/// enough. It prevents multiple normalization iterations from being unstable due to floating point
+/// errors.
+///
+/// When checking normalized, we use 1.0e-6 as threshold. It should be big enough to make
+/// renormalizing stable, while small enough to not affect regular normalizations.
+#[inline]
+pub fn is_length_zero_or_normalized(length: f32) -> bool {
+    length < f32::EPSILON || (length - 1.0).abs() <= 1.0e-6
+}
+
 pub fn peek_top_smallest_iterable<I, E: Ord>(elements: I, top: usize) -> Vec<E>
 where
     I: IntoIterator<Item = E>,


### PR DESCRIPTION
Preprocessing or normalizing vectors should be stable. Meaning that preprocessing or normalizing a second time should give the exact same values.

We need stability because transferring points to another shards with stream records transfer (and SyncPoints) normalizes vectors again. Their values must remain exactly the same.

This PR makes renormalization stable by using 1e-6 as normalization threshold. It adds a test to assert it works as expected for our use case.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?