### PR TITLE
RBAC: introduce CollectionPass

### DIFF
--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -44,6 +44,7 @@ use crate::content_manager::collections_ops::{Checker, Collections};
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
+use crate::rbac::access::CollectionPass;
 use crate::types::{PeerAddressById, StorageConfig};
 use crate::ConsensusOperations;
 
@@ -240,6 +241,13 @@ impl TableOfContent {
         Ok(RwLockReadGuard::map(read_collection, |collection| {
             collection.get(&real_collection_name).unwrap()
         }))
+    }
+
+    pub async fn get_collection_by_pass<'a>(
+        &self,
+        collection: &CollectionPass<'a>,
+    ) -> Result<RwLockReadGuard<Collection>, StorageError> {
+        self.get_collection(collection.name()).await
     }
 
     async fn get_collection_opt(

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -10,6 +10,7 @@ use super::TableOfContent;
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::errors::StorageError;
+use crate::rbac::access::CollectionPass;
 
 impl TableOfContent {
     pub fn get_snapshots_storage_manager(&self) -> SnapshotStorageManager {
@@ -47,11 +48,11 @@ impl TableOfContent {
         Ok(snapshots_path)
     }
 
-    pub async fn create_snapshot(
+    pub async fn create_snapshot<'a>(
         &self,
-        collection_name: &str,
+        collection: &CollectionPass<'a>,
     ) -> Result<SnapshotDescription, StorageError> {
-        let collection = self.get_collection(collection_name).await?;
+        let collection = self.get_collection_by_pass(collection).await?;
         // We want to use temp dir inside the temp_path (storage if not specified), because it is possible, that
         // snapshot directory is mounted as network share and multiple writes to it could be slow
         let temp_dir = self.optional_temp_or_storage_temp_path()?;

--- a/lib/storage/src/rbac/access.rs
+++ b/lib/storage/src/rbac/access.rs
@@ -1,9 +1,16 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use segment::json_path::JsonPath;
 use segment::types::ValueVariants;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+use crate::content_manager::claims::{
+    check_collection_name, incompatible_with_collection_claim, incompatible_with_payload_claim,
+};
+use crate::content_manager::errors::StorageError;
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Access {
     /// Collection names that are allowed to be accessed
     pub collections: Option<Vec<String>>,
@@ -20,6 +27,81 @@ impl Access {
             collections: None,
             payload: None,
         }
+    }
+
+    /// Check if a access object is allowed to manage everything.
+    pub fn check_manage_rights(&self) -> Result<CollectionMultipass, StorageError> {
+        let Access {
+            collections,
+            payload,
+        } = self;
+        if collections.is_some() {
+            return incompatible_with_collection_claim();
+        }
+        if payload.is_some() {
+            return incompatible_with_payload_claim();
+        }
+        Ok(CollectionMultipass)
+    }
+
+    /// Check if a claim object has access to the whole collection.
+    pub fn check_whole_collection_rights<'a>(
+        &self,
+        collection_name: &'a str,
+    ) -> Result<CollectionPass<'a>, StorageError> {
+        let Access {
+            collections,
+            payload,
+        } = self;
+        if let Some(collections) = collections {
+            check_collection_name(Some(collections), collection_name)?;
+        }
+        if payload.is_some() {
+            return incompatible_with_payload_claim();
+        }
+        Ok(CollectionPass(Cow::Borrowed(collection_name)))
+    }
+
+    /// Check if a claim object has read access to a collection.
+    pub fn check_partial_collection_rights<'a>(
+        &self,
+        collection_name: &'a str,
+    ) -> Result<CollectionPass<'a>, StorageError> {
+        let Access {
+            collections,
+            payload: _,
+        } = self;
+        if let Some(collections) = collections {
+            check_collection_name(Some(collections), collection_name)?;
+        }
+        Ok(CollectionPass(Cow::Borrowed(collection_name)))
+    }
+}
+
+pub struct CollectionMultipass;
+
+impl CollectionMultipass {
+    pub fn issue_pass<'a>(&self, name: &'a str) -> CollectionPass<'a> {
+        CollectionPass(Cow::Borrowed(name))
+    }
+}
+
+/// A pass that allows access to a specific collection.
+pub struct CollectionPass<'a>(Cow<'a, str>);
+
+impl<'a> CollectionPass<'a> {
+    pub fn name(&'a self) -> &'a str {
+        &self.0
+    }
+
+    pub fn into_static(self) -> CollectionPass<'static> {
+        CollectionPass(Cow::Owned(self.0.into_owned()))
+    }
+}
+
+impl std::fmt::Display for CollectionPass<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -5,3 +5,5 @@ pub mod access_token;
 pub mod collection_access;
 #[allow(dead_code)]
 pub mod error;
+
+mod ops_checks;

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -1,0 +1,44 @@
+use super::access::Access;
+use crate::content_manager::claims::{incompatible_with_collection_claim, PointsOpClaimsChecker};
+use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
+use crate::content_manager::errors::StorageError;
+
+impl Access {
+    pub fn check_point_op(&self, op: &mut impl PointsOpClaimsChecker) -> Result<(), StorageError> {
+        for collection in op.collections_used() {
+            self.check_partial_collection_rights(collection)?;
+        }
+        if let Some(payload) = self.payload.as_ref() {
+            op.apply_payload_claim(payload)?;
+        }
+        Ok(())
+    }
+
+    pub fn check_collection_meta_operation(
+        &self,
+        operation: &CollectionMetaOperations,
+    ) -> Result<(), StorageError> {
+        match operation {
+            CollectionMetaOperations::CreateCollection(_)
+            | CollectionMetaOperations::UpdateCollection(_)
+            | CollectionMetaOperations::DeleteCollection(_)
+            | CollectionMetaOperations::ChangeAliases(_)
+            | CollectionMetaOperations::TransferShard(_, _)
+            | CollectionMetaOperations::SetShardReplicaState(_)
+            | CollectionMetaOperations::CreateShardKey(_)
+            | CollectionMetaOperations::DropShardKey(_) => {
+                if self.collections.is_some() {
+                    return incompatible_with_collection_claim();
+                }
+            }
+            CollectionMetaOperations::CreatePayloadIndex(op) => {
+                self.check_whole_collection_rights(&op.collection_name)?;
+            }
+            CollectionMetaOperations::DropPayloadIndex(op) => {
+                self.check_whole_collection_rights(&op.collection_name)?;
+            }
+            CollectionMetaOperations::Nop { token: _ } => (),
+        }
+        Ok(())
+    }
+}

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use actix_web::{delete, get, post, web, HttpResponse};
 use actix_web_validator::Query;
 use serde::Deserialize;
-use storage::content_manager::claims::check_manage_rights;
 use storage::content_manager::consensus_ops::ConsensusOperations;
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
@@ -28,7 +27,7 @@ fn cluster_status(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         Ok(dispatcher.cluster_status())
     })
 }
@@ -39,7 +38,7 @@ fn recover_current_peer(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         toc.request_snapshot()?;
         Ok(true)
     })
@@ -53,7 +52,7 @@ fn remove_peer(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
 
         let dispatcher = dispatcher.into_inner();
         let peer_id = peer_id.into_inner();

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -11,7 +11,6 @@ use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
-use storage::content_manager::claims::check_manage_rights;
 use storage::content_manager::toc::TableOfContent;
 use tokio::sync::Mutex;
 
@@ -36,7 +35,7 @@ fn telemetry(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         let anonymize = params.anonymize.unwrap_or(false);
         let details_level = params
             .details_level
@@ -67,7 +66,7 @@ async fn metrics(
     params: Query<MetricsParam>,
     ActixAccess(access): ActixAccess,
 ) -> HttpResponse {
-    if let Err(err) = check_manage_rights(&access) {
+    if let Err(err) = access.check_manage_rights() {
         return process_response_error(err, Instant::now());
     }
 
@@ -97,7 +96,7 @@ fn put_locks(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         let result = LocksOption {
             write: toc.get_ref().is_write_locked(),
             error_message: toc.get_ref().get_lock_error_message(),
@@ -114,7 +113,7 @@ fn get_locks(
     ActixAccess(access): ActixAccess,
 ) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         let result = LocksOption {
             write: toc.get_ref().is_write_locked(),
             error_message: toc.get_ref().get_lock_error_message(),
@@ -126,7 +125,7 @@ fn get_locks(
 #[get("/stacktrace")]
 fn get_stacktrace(ActixAccess(access): ActixAccess) -> impl Future<Output = HttpResponse> {
     helpers::time(async move {
-        check_manage_rights(&access)?;
+        access.check_manage_rights()?;
         Ok(get_stack_trace())
     })
 }

--- a/src/common/auth/claims.rs
+++ b/src/common/auth/claims.rs
@@ -1,7 +1,7 @@
 use segment::json_path::JsonPath;
 use segment::types::{Condition, FieldCondition, Filter, Match, ValueVariants};
 use serde::{Deserialize, Serialize};
-use storage::rbac::access::PayloadClaim;
+use storage::rbac::access::Access;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Claims {
@@ -11,12 +11,8 @@ pub struct Claims {
     /// Write access, default is false. Read access is always enabled with a valid token.
     pub w: Option<bool>,
 
-    /// Collection names that are allowed to be accessed
-    pub collections: Option<Vec<String>>,
-
-    /// Payload constraints.
-    /// An object where each key is a JSON path, and each value is JSON value.
-    pub payload: Option<PayloadClaim>,
+    #[serde(flatten)]
+    pub access: Access,
 
     /// Validate this token by looking for a value inside a collection.
     pub value_exists: Option<ValueExists>,

--- a/src/common/auth/jwt_parser.rs
+++ b/src/common/auth/jwt_parser.rs
@@ -39,6 +39,7 @@ impl JwtParser {
 #[cfg(test)]
 mod tests {
     use segment::types::ValueVariants;
+    use storage::rbac::access::Access;
 
     use super::*;
 
@@ -59,19 +60,21 @@ mod tests {
         let claims = Claims {
             exp: Some(exp),
             w: Some(true),
-            collections: Some(vec!["collection".to_string()]),
-            payload: Some(
-                vec![
-                    (
-                        "field1".parse().unwrap(),
-                        ValueVariants::Keyword("value".to_string()),
-                    ),
-                    ("field2".parse().unwrap(), ValueVariants::Integer(42)),
-                    ("field2".parse().unwrap(), ValueVariants::Bool(true)),
-                ]
-                .into_iter()
-                .collect(),
-            ),
+            access: Access {
+                collections: Some(vec!["collection".to_string()]),
+                payload: Some(
+                    vec![
+                        (
+                            "field1".parse().unwrap(),
+                            ValueVariants::Keyword("value".to_string()),
+                        ),
+                        ("field2".parse().unwrap(), ValueVariants::Integer(42)),
+                        ("field2".parse().unwrap(), ValueVariants::Bool(true)),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            },
             value_exists: None,
         };
         let token = create_token(&claims);
@@ -94,8 +97,10 @@ mod tests {
         let mut claims = Claims {
             exp: Some(exp),
             w: Some(false),
-            collections: None,
-            payload: None,
+            access: Access {
+                collections: None,
+                payload: None,
+            },
             value_exists: None,
         };
 

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -90,9 +90,8 @@ impl AuthKeys {
             let Claims {
                 exp: _, // already validated on decoding
                 w: write_access,
+                access,
                 value_exists,
-                collections,
-                payload,
             } = claims;
 
             if !write_access.unwrap_or(false) && !is_read_only {
@@ -103,10 +102,7 @@ impl AuthKeys {
                 self.validate_value_exists(&value_exists).await?;
             }
 
-            return Ok(Some(Access {
-                collections,
-                payload,
-            }));
+            return Ok(Some(access));
         }
 
         Err("Invalid API key or JWT".to_string())

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -24,10 +24,16 @@ pub async fn handle_existing_collections(
     collections: Vec<String>,
 ) {
     let full_access = Access::full();
+    let multipass = full_access
+        .check_manage_rights()
+        .expect("Full access should have manage rights");
 
     consensus_state.is_leader_established.await_ready();
     for collection_name in collections {
-        let collection_obj = match toc_arc.get_collection(&collection_name).await {
+        let collection_obj = match toc_arc
+            .get_collection_by_pass(&multipass.issue_pass(&collection_name))
+            .await
+        {
             Ok(collection_obj) => collection_obj,
             Err(_) => break,
         };

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -106,10 +106,9 @@ impl<S> Layer<S> for AuthLayer {
 }
 
 pub fn extract_access<R>(req: &mut tonic::Request<R>) -> Access {
-    req.extensions_mut().remove::<Access>().unwrap_or(Access {
-        collections: None,
-        payload: None,
-    })
+    req.extensions_mut()
+        .remove::<Access>()
+        .unwrap_or(Access::full())
 }
 
 fn is_read_only<R>(req: &tonic::codegen::http::Request<R>) -> bool {


### PR DESCRIPTION
Part of #3777.

This PR introduces the concept of `CollectionPass`.
It is used to get `Collection` object from `TableOfContent`.
Instead of getting collection by raw string name, now we are forced to perform validation check using `Access` object.

```rust
// Old way:
let collection = toc.get_collection(collection_name /*: &str */)?;

// New way:
let collection_pass = access.check_whole_collection_rights(collection_name)?;
let collection = toc.get_collection_by_pass(&collection_pass /*: &CollectionPass */)?;
```

Additionally, this PR moves `Access` object deconstruction into its methods so the switch to the new claims schema would be easier.

There are still a few places where the old approach is used, we could cover them after updating the claims schema.