### PR TITLE
Fix JSON path string quoting check

### DIFF
--- a/lib/segment/src/json_path/parse.rs
+++ b/lib/segment/src/json_path/parse.rs
@@ -87,4 +87,22 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_key_needs_quoting() {
+        // Key needs no quoting
+        assert!(!key_needs_quoting("f"));
+        assert!(!key_needs_quoting("foo"));
+        assert!(!key_needs_quoting("foo_123-bar"));
+
+        // Key needs quoting
+        assert!(key_needs_quoting(""));
+        assert!(key_needs_quoting(" foo"));
+        assert!(key_needs_quoting("foo "));
+        assert!(key_needs_quoting("foo bar"));
+        assert!(key_needs_quoting("foo bar baz"));
+        assert!(key_needs_quoting("foo.bar.baz"));
+        assert!(key_needs_quoting("foo[]"));
+        assert!(key_needs_quoting("foo[0]"));
+    }
 }

--- a/lib/segment/src/json_path/parse.rs
+++ b/lib/segment/src/json_path/parse.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, digit1, none_of, satisfy};
-use nom::combinator::{map_res, recognize};
+use nom::combinator::{all_consuming, map_res, recognize};
 use nom::multi::{many0, many1};
 use nom::sequence::{delimited, preceded};
 use nom::{IResult, Parser};
@@ -22,7 +22,8 @@ impl FromStr for JsonPathV2 {
 }
 
 pub fn key_needs_quoting(s: &str) -> bool {
-    raw_str(s).is_err()
+    let mut parser = all_consuming(raw_str);
+    parser(s).is_err()
 }
 
 fn json_path(input: &str) -> IResult<&str, JsonPathV2> {


### PR DESCRIPTION
Fixes string quoting check we have in our JSON path implementation.

Before this PR `key_needs_quoting("some test")` returned `false`, but that should be `true`.

The reason for this is that the nom parsers used in it also return an okay status if only part of the given string can be parsed as raw string. I've modified it to make sure the complete string is accepted by the raw string parser.

The broken implementation is also able to break consensus. We have a cloud machine on which this happened. It is hard to resolve this on an instance where the problem occurred, because you need to manually modify WAL files. I'll therefore release patch version that includes this to prevent it from occurring again.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?