### PR TITLE
Bump version to 1.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "api"
-version = "1.8.3"
+version = "1.8.4"
 dependencies = [
  "chrono",
  "common",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.8.3"
+version = "1.8.4"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.8.3"
+version = "1.8.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.8.3"
+version = "1.8.4"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version
-pub const QDRANT_VERSION: Version = Version::new(1, 8, 3);
+pub const QDRANT_VERSION: Version = Version::new(1, 8, 4);
 
 /// Default timeout for consensus meta operations.
 pub const CONSENSUS_META_OP_WAIT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
A new patch version for Qdrant, [fixing](https://github.com/qdrant/qdrant/pull/3948) a nasty bug that could corrupt the consensus WAL bringing down a cluster.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/3868>.