### PR TITLE
Add grey collection status

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1455,6 +1455,7 @@ Note: 1kB = 1 vector of size 256. |
 | Green | 1 | All segments are ready |
 | Yellow | 2 | Optimization in process |
 | Red | 3 | Something went wrong |
+| Grey | 4 | Optimization is pending |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5299,6 +5299,7 @@
         "enum": [
           "green",
           "yellow",
+          "grey",
           "red"
         ]
       },

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -93,6 +93,7 @@ enum CollectionStatus {
   Green = 1; // All segments are ready
   Yellow = 2; // Optimization in process
   Red = 3; // Something went wrong
+  Grey = 4; // Optimization is pending
 }
 
 enum PayloadSchemaType {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1122,6 +1122,8 @@ pub enum CollectionStatus {
     Yellow = 2,
     /// Something went wrong
     Red = 3,
+    /// Optimization is pending
+    Grey = 4,
 }
 impl CollectionStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1134,6 +1136,7 @@ impl CollectionStatus {
             CollectionStatus::Green => "Green",
             CollectionStatus::Yellow => "Yellow",
             CollectionStatus::Red => "Red",
+            CollectionStatus::Grey => "Grey",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1143,6 +1146,7 @@ impl CollectionStatus {
             "Green" => Some(Self::Green),
             "Yellow" => Some(Self::Yellow),
             "Red" => Some(Self::Red),
+            "Grey" => Some(Self::Grey),
             _ => None,
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -340,6 +340,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                 CollectionStatus::Green => api::grpc::qdrant::CollectionStatus::Green,
                 CollectionStatus::Yellow => api::grpc::qdrant::CollectionStatus::Yellow,
                 CollectionStatus::Red => api::grpc::qdrant::CollectionStatus::Red,
+                CollectionStatus::Grey => api::grpc::qdrant::CollectionStatus::Grey,
             }
             .into(),
             optimizer_status: Some(match optimizer_status {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -63,6 +63,8 @@ pub enum CollectionStatus {
     Green,
     // Collection is available, but some segments might be under optimization
     Yellow,
+    // Collection is available, but some segments are pending optimization
+    Grey,
     // Something is not OK:
     // - some operations failed and was not recovered
     Red,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -885,7 +885,13 @@ impl LocalShard {
 
         // If still green while optimization conditions are triggered, mark as grey
         if self.update_handler.lock().await.has_pending_optimizations() {
-            status = CollectionStatus::Grey;
+            // TODO(1.10): enable grey status in Qdrant 1.10+
+            // status = CollectionStatus::Grey;
+            if optimizer_status == OptimizersStatus::Ok {
+                optimizer_status = OptimizersStatus::Error(
+                    "optimizations pending, awaiting update operation".into(),
+                );
+            }
         }
 
         CollectionInfoInternal {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -884,7 +884,9 @@ impl LocalShard {
         }
 
         // If still green while optimization conditions are triggered, mark as grey
-        if self.update_handler.lock().await.has_pending_optimizations() {
+        if status == CollectionStatus::Green
+            && self.update_handler.lock().await.has_pending_optimizations()
+        {
             // TODO(1.10): enable grey status in Qdrant 1.10+
             // status = CollectionStatus::Grey;
             if optimizer_status == OptimizersStatus::Ok {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -883,6 +883,11 @@ impl LocalShard {
             }
         }
 
+        // If still green while optimization conditions are triggered, mark as grey
+        if self.update_handler.lock().await.has_pending_optimizations() {
+            status = CollectionStatus::Grey;
+        }
+
         CollectionInfoInternal {
             status,
             optimizer_status,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -846,39 +846,42 @@ impl LocalShard {
 
     pub async fn local_shard_info(&self) -> CollectionInfoInternal {
         let collection_config = self.collection_config.read().await.clone();
-        let segments = self.segments().read();
         let mut vectors_count = 0;
         let mut indexed_vectors_count = 0;
         let mut points_count = 0;
         let mut segments_count = 0;
         let mut status = CollectionStatus::Green;
         let mut schema: HashMap<PayloadKeyType, PayloadIndexInfo> = Default::default();
-        for (_idx, segment) in segments.iter() {
-            segments_count += 1;
+        let mut optimizer_status = OptimizersStatus::Ok;
 
-            let segment_info = segment.get().read().info();
+        {
+            let segments = self.segments().read();
+            for (_idx, segment) in segments.iter() {
+                segments_count += 1;
 
-            if segment_info.segment_type == SegmentType::Special {
-                status = CollectionStatus::Yellow;
+                let segment_info = segment.get().read().info();
+
+                if segment_info.segment_type == SegmentType::Special {
+                    status = CollectionStatus::Yellow;
+                }
+                vectors_count += segment_info.num_vectors;
+                indexed_vectors_count += segment_info.num_indexed_vectors;
+                points_count += segment_info.num_points;
+                for (key, val) in segment_info.index_schema {
+                    schema
+                        .entry(key)
+                        .and_modify(|entry| entry.points += val.points)
+                        .or_insert(val);
+                }
             }
-            vectors_count += segment_info.num_vectors;
-            indexed_vectors_count += segment_info.num_indexed_vectors;
-            points_count += segment_info.num_points;
-            for (key, val) in segment_info.index_schema {
-                schema
-                    .entry(key)
-                    .and_modify(|entry| entry.points += val.points)
-                    .or_insert(val);
+            if !segments.failed_operation.is_empty() || segments.optimizer_errors.is_some() {
+                status = CollectionStatus::Red;
+            }
+
+            if let Some(error) = &segments.optimizer_errors {
+                optimizer_status = OptimizersStatus::Error(error.to_string());
             }
         }
-        if !segments.failed_operation.is_empty() || segments.optimizer_errors.is_some() {
-            status = CollectionStatus::Red;
-        }
-
-        let optimizer_status = match &segments.optimizer_errors {
-            None => OptimizersStatus::Ok,
-            Some(error) => OptimizersStatus::Error(error.to_string()),
-        };
 
         CollectionInfoInternal {
             status,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -372,6 +372,18 @@ impl UpdateHandler {
         handles
     }
 
+    /// Checks conditions for all optimizers and returns whether any is satisfied
+    ///
+    /// In other words, if this returns true we have pending optimizations.
+    pub(crate) fn has_pending_optimizations(&self) -> bool {
+        let excluded_ids = HashSet::<_>::default();
+        self.optimizers.iter().any(|optimizer| {
+            let nonoptimal_segment_ids =
+                optimizer.check_condition(self.segments.clone(), &excluded_ids);
+            !nonoptimal_segment_ids.is_empty()
+        })
+    }
+
     pub(crate) async fn process_optimization(
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         segments: LockedSegmentHolder,


### PR DESCRIPTION
Add a 'grey' collection status color to identify:
- pending optimizations
- but no optimizations are running

This happens while an instance is restarted while optimizations are ongoing. In previous versions we triggered optimizations on start, but we don't do this anymore to prevent OOM crash loops. A new update operation is required to trigger optimizations once more.

Currently we just show a green collection status, which may be confusing. This grey status should help identify the above described situation, so that users can act accordingly.

### Compatibility
Due to compatibility reasons the grey status is not used right away. It is not compatible with our current clients. Until that is possible, we set an optimization error instead:

![image](https://github.com/qdrant/qdrant/assets/856222/3dc68ccf-10c1-417a-9707-18edcbfe11f5)

In Qdrant 1.10 we'll actually set the grey status, see the task below.

### Tasks
- [ ] Add documentation describing how to resolve this state (<https://github.com/qdrant/landing_page/pull/779>)
- [ ] Qdrant 1.10: Actually set grey status (see `// TODO(1.10):`)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?