### PR TITLE
Qdrant 1.11: Expose grey collection status

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -983,13 +983,7 @@ impl LocalShard {
         if status == CollectionStatus::Green
             && self.update_handler.lock().await.has_pending_optimizations()
         {
-            // TODO(1.10): enable grey status in Qdrant 1.10+
-            // status = CollectionStatus::Grey;
-            if optimizer_status == OptimizersStatus::Ok {
-                optimizer_status = OptimizersStatus::Error(
-                    "optimizations pending, awaiting update operation".into(),
-                );
-            }
+            status = CollectionStatus::Grey;
         }
 
         CollectionInfoInternal {


### PR DESCRIPTION
Implements <https://github.com/qdrant/qdrant/pull/3962>.

In <https://github.com/qdrant/qdrant/pull/3962> we've added the grey collection status. We now start actually reporting it.

It replaces the optimizer status message we had before, because using the grey collection status is more elegant.

![image](https://github.com/qdrant/qdrant/assets/856222/dc2f4b1f-6cb0-4915-8694-84b576a02949)

We couldn't use it right away, but needed to delay it by one version to allow us making all clients compatible.

### Tasks
- [x] Add 'trigger optimizers' button in web UI? (<https://github.com/qdrant/qdrant-web-ui/issues/179>)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?