### PR TITLE
fix: Dev build workflow

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -16,11 +16,15 @@ jobs:
             buildx_containers=$(docker container ls -qf "name=buildx_buildkit")
             buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit")
 
-            echo "Buildx containers to delete: " "$buildx_containers"
-            echo "Buildx volumes to delete: " "$buildx_volumes"
+            if [ -n "$buildx_containers" ]; then
+              echo "Buildx containers to delete: " "$buildx_containers"
+              docker container rm -f "$buildx_containers"
+            fi
 
-            docker container rm -f "$buildx_containers"
-            docker volume rm "$buildx_volumes"
+            if [ -n "$buildx_volumes" ]; then
+              echo "Buildx volumes to delete: " "$buildx_volumes"
+              docker volume rm "$buildx_volumes"
+            fi
 
             # Create build container
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
Because docker throws errors if we call the delete command without any container/volume IDs.

```sh
Buildx containers to delete:  
Buildx containers to delete:  
Container name cannot be empty
Error: Process completed with exit code 1.
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

