### PR TITLE
RBAC: Improve errors

### DIFF
--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -20,7 +20,7 @@ pub fn error_to_status(error: StorageError) -> tonic::Status {
         StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
         StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
         StorageError::ChecksumMismatch { .. } => tonic::Code::DataLoss,
-        StorageError::Unauthorized { .. } => tonic::Code::PermissionDenied,
+        StorageError::Forbidden { .. } => tonic::Code::PermissionDenied,
     };
     tonic::Status::new(error_code, format!("{error}"))
 }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -28,8 +28,8 @@ pub enum StorageError {
     Timeout { description: String },
     #[error("Checksum mismatch: expected {expected}, actual {actual}")]
     ChecksumMismatch { expected: String, actual: String },
-    #[error("Unauthorized: {description}")]
-    Unauthorized { description: String },
+    #[error("Forbidden: {description}")]
+    Forbidden { description: String },
 }
 
 impl StorageError {
@@ -71,8 +71,8 @@ impl StorageError {
         }
     }
 
-    pub fn unauthorized(description: impl Into<String>) -> StorageError {
-        StorageError::Unauthorized {
+    pub fn forbidden(description: impl Into<String>) -> StorageError {
+        StorageError::Forbidden {
             description: description.into(),
         }
     }

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -85,7 +85,7 @@ impl Access {
     ) -> Result<CollectionMultipass, StorageError> {
         match self {
             Access::Global(mode) => mode.meets_requirements(requirements)?,
-            _ => return Err(StorageError::unauthorized("Global access is required")),
+            _ => return Err(StorageError::forbidden("Global access is required")),
         }
         Ok(CollectionMultipass)
     }
@@ -121,7 +121,7 @@ impl CollectionAccessList {
                     .any(|name| name == collection_name)
             })
             .ok_or_else(|| {
-                StorageError::unauthorized(format!(
+                StorageError::forbidden(format!(
                     "Access to collection {collection_name} is required"
                 ))
             })?;
@@ -156,7 +156,7 @@ impl<'a> CollectionAccessView<'a> {
         if write {
             match self.access {
                 CollectionAccessMode::Read => {
-                    return Err(StorageError::unauthorized(format!(
+                    return Err(StorageError::forbidden(format!(
                         "Write access to collection {} is required",
                         self.collection,
                     )))
@@ -167,7 +167,7 @@ impl<'a> CollectionAccessView<'a> {
         if manage {
             // Don't specify collection name since the manage access could be enabled globally, and
             // not per collection.
-            return Err(StorageError::unauthorized(
+            return Err(StorageError::forbidden(
                 "Manage access for this operation is required",
             ));
         }
@@ -253,9 +253,7 @@ impl GlobalAccessMode {
         if write || manage {
             match self {
                 GlobalAccessMode::Read => {
-                    return Err(StorageError::unauthorized(
-                        "Global manage access is required",
-                    ))
+                    return Err(StorageError::forbidden("Global manage access is required"))
                 }
                 GlobalAccessMode::Manage => (),
             }
@@ -267,7 +265,7 @@ impl GlobalAccessMode {
 /// Helper function to indicate that the operation is not allowed when `payload` constraint is
 /// present.
 fn incompatible_with_payload_constraint<T>(collection_name: &str) -> Result<T, StorageError> {
-    Err(StorageError::unauthorized(format!(
+    Err(StorageError::forbidden(format!(
         "This operation is not allowed when \"payload\" restriction is present for collection \
          {collection_name}"
     )))

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -156,7 +156,7 @@ impl ResponseError for HttpError {
             StorageError::Timeout { .. } => http::StatusCode::REQUEST_TIMEOUT,
             StorageError::AlreadyExists { .. } => http::StatusCode::CONFLICT,
             StorageError::ChecksumMismatch { .. } => http::StatusCode::BAD_REQUEST,
-            StorageError::Unauthorized { .. } => http::StatusCode::UNAUTHORIZED,
+            StorageError::Forbidden { .. } => http::StatusCode::FORBIDDEN,
         }
     }
 }


### PR DESCRIPTION
- Respond with `401 Unauthorized` for lacking or failed authentication credentials, and with `403 Permission Denied` when not enough permissions.
- Improve wording (see https://github.com/qdrant/qdrant/pull/3941#pullrequestreview-1976695179, https://github.com/qdrant/qdrant/pull/3941#pullrequestreview-1976709335)