### PR TITLE
Integrate Multivector at segment level

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -12,7 +12,7 @@ use segment::data_types::vectors::{DenseVector, Vector, VectorRef};
 use segment::fixtures::payload_context_fixture::FixtureIdTracker;
 use segment::id_tracker::IdTrackerSS;
 use segment::types::Distance;
-use segment::vector_storage::dense::simple_dense_vector_storage::open_simple_vector_storage;
+use segment::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use segment::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 use tempfile::Builder;
 
@@ -37,7 +37,8 @@ fn init_vector_storage(
     let db = open_db(path, &[DB_VECTOR_CF]).unwrap();
     let id_tracker = Arc::new(AtomicRefCell::new(FixtureIdTracker::new(num)));
     let storage =
-        open_simple_vector_storage(db, DB_VECTOR_CF, dim, dist, &AtomicBool::new(false)).unwrap();
+        open_simple_dense_vector_storage(db, DB_VECTOR_CF, dim, dist, &AtomicBool::new(false))
+            .unwrap();
     {
         let mut borrowed_storage = storage.borrow_mut();
         for i in 0..num {

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -185,7 +185,19 @@ fn check_vector_against_config(
             Ok(())
         }
         VectorRef::Sparse(_) => Err(OperationError::WrongSparse),
-        VectorRef::MultiDense(_) => Err(OperationError::WrongMulti),
+        VectorRef::MultiDense(vectors) => {
+            // Check dimensionality
+            let dim = vector_config.size;
+            for vector in vectors {
+                if vector.len() != dim {
+                    return Err(OperationError::WrongVector {
+                        expected_dim: dim,
+                        received_dim: vector.len(),
+                    });
+                }
+            }
+            Ok(())
+        }
     }
 }
 

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -227,7 +227,11 @@ pub fn default_vector(vec: DenseVector) -> NamedVectors<'static> {
 }
 
 pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
-    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, vec.into())
+    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, VectorRef::from(vec))
+}
+
+pub fn only_default_multi_vector(vec: &[DenseVector]) -> NamedVectors {
+    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, VectorRef::MultiDense(vec))
 }
 
 /// Full vector data per point separator with single and multiple vector modes
@@ -516,6 +520,12 @@ impl From<Vector> for QueryVector {
 impl From<SparseVector> for QueryVector {
     fn from(vec: SparseVector) -> Self {
         Self::Nearest(Vector::Sparse(vec))
+    }
+}
+
+impl From<MultiDenseVector> for QueryVector {
+    fn from(vec: MultiDenseVector) -> Self {
+        Self::Nearest(Vector::MultiDense(vec))
     }
 }
 

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -8,7 +8,7 @@ use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_json::{json, Value};
 
-use crate::data_types::vectors::DenseVector;
+use crate::data_types::vectors::{DenseVector, MultiDenseVector};
 use crate::types::{
     AnyVariants, Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition,
     IsEmptyCondition, Match, MatchAny, Payload, PayloadField, Range as RangeCondition, ValuesCount,
@@ -119,6 +119,18 @@ pub fn random_bool_payload<R: Rng + ?Sized>(
 
 pub fn random_vector<R: Rng + ?Sized>(rnd_gen: &mut R, size: usize) -> DenseVector {
     (0..size).map(|_| rnd_gen.gen()).collect()
+}
+
+pub fn random_multi_vector<R: Rng + ?Sized>(
+    rnd_gen: &mut R,
+    vector_size: usize,
+    num_vector_per_points: usize,
+) -> MultiDenseVector {
+    let mut vectors = vec![];
+    for _ in 0..num_vector_per_points {
+        vectors.push(random_vector(rnd_gen, vector_size));
+    }
+    vectors
 }
 
 pub fn random_uncommon_condition<R: Rng + ?Sized>(rnd_gen: &mut R) -> Condition {

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::IdTracker;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
-    use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_vector_storage;
+    use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
     use crate::vector_storage::new_raw_scorer;
     use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
@@ -258,7 +258,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,
@@ -295,7 +295,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,
@@ -361,7 +361,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,
@@ -492,7 +492,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,
@@ -578,7 +578,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,
@@ -664,7 +664,7 @@ mod tests {
         {
             let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
             let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-            let storage2 = open_simple_vector_storage(
+            let storage2 = open_simple_dense_vector_storage(
                 db,
                 DB_VECTOR_CF,
                 4,

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -85,7 +85,7 @@ fn open_simple_dense_vector_storage_impl<T: PrimitiveVectorElement>(
     })
 }
 
-pub fn open_simple_vector_storage(
+pub fn open_simple_dense_vector_storage(
     database: Arc<RwLock<DB>>,
     database_column_name: &str,
     dim: usize,

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -1,4 +1,5 @@
 use common::types::{PointOffsetType, ScoreType};
+use ordered_float::OrderedFloat;
 
 use crate::data_types::vectors::{MultiDenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
@@ -29,7 +30,8 @@ pub fn score_max_similarity<TMetric: Metric<VectorElementType>>(
         sum += multi_dense_b
             .iter()
             .map(|dense_b| TMetric::similarity(dense_a, dense_b))
-            .fold(ScoreType::NEG_INFINITY, |a, b| if a > b { a } else { b });
+            .max_by(|a, b| OrderedFloat(*a).cmp(&OrderedFloat(*b)))
+            .unwrap_or(ScoreType::NEG_INFINITY);
     }
     sum
 }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -25,13 +25,16 @@ pub fn score_max_similarity<TMetric: Metric<VectorElementType>>(
     multi_dense_a: &MultiDenseVector,
     multi_dense_b: &MultiDenseVector,
 ) -> ScoreType {
+    // TODO(colbert) add user input validation
+    debug_assert!(!multi_dense_a.is_empty());
+    debug_assert!(!multi_dense_b.is_empty());
     let mut sum = 0.0;
     for dense_a in multi_dense_a.iter() {
         sum += multi_dense_b
             .iter()
             .map(|dense_b| TMetric::similarity(dense_a, dense_b))
             .max_by(|a, b| OrderedFloat(*a).cmp(&OrderedFloat(*b)))
-            .unwrap_or(ScoreType::NEG_INFINITY);
+            .expect("At least one element in multi-dense vector")
     }
     sum
 }

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -12,7 +12,7 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTracker;
 use crate::types::Distance;
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
-use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::vector_storage_base::VectorStorage;
 use crate::vector_storage::{async_raw_scorer, new_raw_scorer, VectorStorageEnum};
 
@@ -66,7 +66,7 @@ fn test_async_raw_scorer(
 
         let db = rocksdb_wrapper::open_db(dir.path(), &[rocksdb_wrapper::DB_VECTOR_CF])?;
 
-        let mutable_storage = open_simple_vector_storage(
+        let mutable_storage = open_simple_dense_vector_storage(
             db,
             rocksdb_wrapper::DB_VECTOR_CF,
             4,

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -22,7 +22,7 @@ use crate::types::{
 };
 #[cfg(target_os = "linux")]
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
-use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::context_query::{ContextPair, ContextQuery};
 use crate::vector_storage::query::discovery_query::DiscoveryQuery;
@@ -112,7 +112,7 @@ fn random_context_query<R: Rng + ?Sized>(
 }
 
 fn ram_storage(dir: &Path) -> AtomicRefCell<VectorStorageEnum> {
-    let storage = open_simple_vector_storage(
+    let storage = open_simple_dense_vector_storage(
         rocksdb_wrapper::open_db(dir, &[rocksdb_wrapper::DB_VECTOR_CF]).unwrap(),
         rocksdb_wrapper::DB_VECTOR_CF,
         DIMS,
@@ -197,7 +197,7 @@ fn scoring_equivalency(
 
     let db = rocksdb_wrapper::open_db(raw_dir.path(), &[rocksdb_wrapper::DB_VECTOR_CF])?;
 
-    let raw_storage = open_simple_vector_storage(
+    let raw_storage = open_simple_dense_vector_storage(
         db,
         rocksdb_wrapper::DB_VECTOR_CF,
         DIMS,

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -11,7 +11,7 @@ use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::dense::appendable_mmap_dense_vector_storage::open_appendable_memmap_vector_storage;
-use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_vector_storage;
+use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 
@@ -134,9 +134,14 @@ fn do_test_update_from_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnu
     {
         let dir2 = Builder::new().prefix("db_dir").tempdir().unwrap();
         let db = open_db(dir2.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage2 =
-            open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-                .unwrap();
+        let storage2 = open_simple_dense_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            4,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
         {
             let mut borrowed_storage2 = storage2.borrow_mut();
             points.iter().enumerate().for_each(|(i, vec)| {
@@ -373,16 +378,26 @@ fn test_delete_points_in_simple_vector_storages() {
 
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage =
-            open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-                .unwrap();
+        let storage = open_simple_dense_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            4,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
         do_test_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage =
-        open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-            .unwrap();
+    let _storage = open_simple_dense_vector_storage(
+        db,
+        DB_VECTOR_CF,
+        4,
+        Distance::Dot,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -390,17 +405,27 @@ fn test_update_from_delete_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage =
-            open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-                .unwrap();
+        let storage = open_simple_dense_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            4,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
         do_test_update_from_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage =
-        open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-            .unwrap();
+    let _storage = open_simple_dense_vector_storage(
+        db,
+        DB_VECTOR_CF,
+        4,
+        Distance::Dot,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -408,17 +433,27 @@ fn test_score_points_in_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage =
-            open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-                .unwrap();
+        let storage = open_simple_dense_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            4,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
         do_test_score_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage =
-        open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-            .unwrap();
+    let _storage = open_simple_dense_vector_storage(
+        db,
+        DB_VECTOR_CF,
+        4,
+        Distance::Dot,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -426,17 +461,27 @@ fn test_score_quantized_points_simple_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-        let storage =
-            open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-                .unwrap();
+        let storage = open_simple_dense_vector_storage(
+            db,
+            DB_VECTOR_CF,
+            4,
+            Distance::Dot,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
         test_score_quantized_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
     let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
-    let _storage =
-        open_simple_vector_storage(db, DB_VECTOR_CF, 4, Distance::Dot, &AtomicBool::new(false))
-            .unwrap();
+    let _storage = open_simple_dense_vector_storage(
+        db,
+        DB_VECTOR_CF,
+        4,
+        Distance::Dot,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
 }
 
 // ----------------------------------------------

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -9,6 +9,7 @@ pub mod filtrable_hnsw_test;
 pub mod fixtures;
 pub mod hnsw_discover_test;
 pub mod hnsw_quantized_search_test;
+mod multivector_filtrable_hnsw_test;
 mod multivector_hnsw_test;
 pub mod nested_filtering_test;
 pub mod payload_index_test;

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -101,7 +101,7 @@ fn random_multi_vec_query<R: Rng + ?Sized>(
 #[case::recommend_multi(QueryVariant::RecommendBestScore, 2, 64, 10)]
 fn test_multi_filterable_hnsw(
     #[case] query_variant: QueryVariant,
-    #[case] num_vector_per_points: usize,
+    #[case] max_num_vector_per_points: usize,
     #[case] ef: usize,
     #[case] max_failures: usize, // out of 100
 ) {
@@ -141,7 +141,9 @@ fn test_multi_filterable_hnsw(
     let mut segment = build_segment(dir.path(), &config, true).unwrap();
     for n in 0..num_points {
         let idx = n.into();
-        let multi_vec = random_multi_vector(&mut rnd, vector_dim, num_vector_per_points);
+        // Random number of vectors per multivec point
+        let num_vector_for_point = rnd.gen_range(1..=max_num_vector_per_points);
+        let multi_vec = random_multi_vector(&mut rnd, vector_dim, num_vector_for_point);
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
         let payload: Payload = json!({int_key:int_payload,}).into();
@@ -194,8 +196,10 @@ fn test_multi_filterable_hnsw(
     let mut hits = 0;
     let attempts = 100;
     for i in 0..attempts {
+        // Random number of vectors per multivec query
+        let num_vector_for_query = rnd.gen_range(1..=max_num_vector_per_points);
         let query =
-            random_multi_vec_query(&query_variant, &mut rnd, vector_dim, num_vector_per_points);
+            random_multi_vec_query(&query_variant, &mut rnd, vector_dim, num_vector_for_query);
 
         let range_size = 40;
         let left_range = rnd.gen_range(0..400);

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -94,7 +94,7 @@ fn random_multi_vec_query<R: Rng + ?Sized>(
 /// Check all cases with single vector per multi and several vectors per multi
 #[rstest]
 #[case::nearest_eq(QueryVariant::Nearest, 1, 32, 5)]
-#[case::nearest_multi(QueryVariant::Nearest, 3, 32, 13)]
+#[case::nearest_multi(QueryVariant::Nearest, 3, 32, 20)]
 #[case::discovery_eq(QueryVariant::Discovery, 1, 128, 5)]
 #[case::discovery_multi(QueryVariant::Discovery, 3, 128, 10)]
 #[case::recommend_eq(QueryVariant::RecommendBestScore, 1, 64, 5)]

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -1,0 +1,292 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use common::cpu::CpuPermit;
+use common::types::{PointOffsetType, TelemetryDetail};
+use itertools::Itertools;
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
+use rstest::rstest;
+use segment::data_types::vectors::{only_default_multi_vector, QueryVector, DEFAULT_VECTOR_NAME};
+use segment::entry::entry_point::SegmentEntry;
+use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
+use segment::index::hnsw_index::graph_links::GraphLinksRam;
+use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::num_rayon_threads;
+use segment::index::{PayloadIndex, VectorIndex};
+use segment::segment_constructor::build_segment;
+use segment::types::{
+    Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, MultiVectorConfig, Payload,
+    PayloadSchemaType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
+    VectorStorageType,
+};
+use segment::vector_storage::query::context_query::ContextPair;
+use segment::vector_storage::query::discovery_query::DiscoveryQuery;
+use segment::vector_storage::query::reco_query::RecoQuery;
+use serde_json::json;
+use tempfile::Builder;
+
+use crate::utils::path;
+
+const MAX_EXAMPLE_PAIRS: usize = 4;
+
+enum QueryVariant {
+    Nearest,
+    RecommendBestScore,
+    Discovery,
+}
+
+fn random_multi_vec_discovery_query<R: Rng + ?Sized>(
+    rnd: &mut R,
+    dim: usize,
+    num_vector_per_points: usize,
+) -> QueryVector {
+    let num_pairs: usize = rnd.gen_range(1..MAX_EXAMPLE_PAIRS);
+
+    let target = random_multi_vector(rnd, dim, num_vector_per_points).into();
+
+    let pairs = (0..num_pairs)
+        .map(|_| {
+            let positive = random_multi_vector(rnd, dim, num_vector_per_points).into();
+            let negative = random_multi_vector(rnd, dim, num_vector_per_points).into();
+            ContextPair { positive, negative }
+        })
+        .collect_vec();
+
+    DiscoveryQuery::new(target, pairs).into()
+}
+
+fn random_multi_vec_reco_query<R: Rng + ?Sized>(
+    rnd: &mut R,
+    dim: usize,
+    num_vector_per_points: usize,
+) -> QueryVector {
+    let num_examples: usize = rnd.gen_range(1..MAX_EXAMPLE_PAIRS);
+
+    let positive = (0..num_examples)
+        .map(|_| random_multi_vector(rnd, dim, num_vector_per_points).into())
+        .collect_vec();
+    let negative = (0..num_examples)
+        .map(|_| random_multi_vector(rnd, dim, num_vector_per_points).into())
+        .collect_vec();
+
+    RecoQuery::new(positive, negative).into()
+}
+
+fn random_multi_vec_query<R: Rng + ?Sized>(
+    variant: &QueryVariant,
+    rnd: &mut R,
+    dim: usize,
+    num_vector_per_points: usize,
+) -> QueryVector {
+    match variant {
+        QueryVariant::Nearest => random_multi_vector(rnd, dim, num_vector_per_points).into(),
+        QueryVariant::Discovery => {
+            random_multi_vec_discovery_query(rnd, dim, num_vector_per_points)
+        }
+        QueryVariant::RecommendBestScore => {
+            random_multi_vec_reco_query(rnd, dim, num_vector_per_points)
+        }
+    }
+}
+
+#[rstest]
+#[case::nearest(QueryVariant::Nearest, 32, 5)]
+#[case::discovery(QueryVariant::Discovery, 128, 10)] // tests that check better precision are in `hnsw_discover_test.rs`
+#[case::recommend(QueryVariant::RecommendBestScore, 64, 10)]
+fn test_multi_filterable_hnsw(
+    #[case] query_variant: QueryVariant,
+    #[case] ef: usize,
+    #[case] max_failures: usize, // out of 100
+) {
+    _test_multi_filterable_hnsw(query_variant, ef, max_failures);
+}
+
+fn _test_multi_filterable_hnsw(
+    query_variant: QueryVariant,
+    ef: usize,
+    max_failures: usize, // out of 100
+) {
+    let stopped = AtomicBool::new(false);
+
+    let vector_dim = 8;
+    let m = 8;
+    let num_points: u64 = 5_000;
+    let num_vector_per_points = 2;
+    let ef_construct = 16;
+    let distance = Distance::Cosine;
+    let full_scan_threshold = 16; // KB
+    let indexing_threshold = 500; // num vectors
+    let num_payload_values = 2;
+
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: vector_dim,
+                distance,
+                storage_type: VectorStorageType::Memory,
+                index: Indexes::Plain {}, // uses plain index
+                quantization_config: None,
+                multi_vec_config: Some(MultiVectorConfig::default()), // uses multivec config
+            },
+        )]),
+        sparse_vector_data: Default::default(),
+        payload_storage_type: Default::default(),
+    };
+
+    let int_key = "int";
+
+    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+    for n in 0..num_points {
+        let idx = n.into();
+        let multi_vec = random_multi_vector(&mut rnd, vector_dim, num_vector_per_points);
+
+        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let payload: Payload = json!({int_key:int_payload,}).into();
+
+        let named_vectors = only_default_multi_vector(&multi_vec);
+        segment
+            .upsert_point(n as SeqNumberType, idx, named_vectors)
+            .unwrap();
+        segment
+            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .unwrap();
+    }
+
+    let payload_index_ptr = segment.payload_index.clone();
+
+    let hnsw_config = HnswConfig {
+        m,
+        ef_construct,
+        full_scan_threshold,
+        max_indexing_threads: 2,
+        on_disk: Some(false),
+        payload_m: None,
+    };
+
+    let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
+    let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
+
+    let vector_storage = &segment.vector_data[DEFAULT_VECTOR_NAME].vector_storage;
+    let quantized_vectors = &segment.vector_data[DEFAULT_VECTOR_NAME].quantized_vectors;
+    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+        hnsw_dir.path(),
+        segment.id_tracker.clone(),
+        vector_storage.clone(),
+        quantized_vectors.clone(),
+        payload_index_ptr.clone(),
+        hnsw_config,
+    )
+    .unwrap();
+
+    hnsw_index.build_index(permit.clone(), &stopped).unwrap();
+
+    payload_index_ptr
+        .borrow_mut()
+        .set_indexed(&path(int_key), PayloadSchemaType::Integer.into())
+        .unwrap();
+    let borrowed_payload_index = payload_index_ptr.borrow();
+    let blocks = borrowed_payload_index
+        .payload_blocks(&path(int_key), indexing_threshold)
+        .collect_vec();
+    for block in blocks.iter() {
+        assert!(
+            block.condition.range.is_some(),
+            "only range conditions should be generated for this type of payload"
+        );
+    }
+
+    let mut coverage: HashMap<PointOffsetType, usize> = Default::default();
+    let px = payload_index_ptr.borrow();
+    for block in &blocks {
+        let filter = Filter::new_must(Condition::Field(block.condition.clone()));
+        let points = px.query_points(&filter);
+        for point in points {
+            coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
+        }
+    }
+    let expected_blocks = num_points as usize / indexing_threshold * 2;
+
+    eprintln!("blocks.len() = {:#?}", blocks.len());
+    assert!(
+        (blocks.len() as i64 - expected_blocks as i64).abs() <= 3,
+        "real number of payload blocks is too far from expected"
+    );
+
+    assert_eq!(
+        coverage.len(),
+        num_points as usize,
+        "not all points are covered by payload blocks"
+    );
+
+    hnsw_index.build_index(permit, &stopped).unwrap();
+
+    let top = 3;
+    let mut hits = 0;
+    let attempts = 100;
+    for i in 0..attempts {
+        let query =
+            random_multi_vec_query(&query_variant, &mut rnd, vector_dim, num_vector_per_points);
+
+        let range_size = 40;
+        let left_range = rnd.gen_range(0..400);
+        let right_range = left_range + range_size;
+
+        let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
+            path(int_key),
+            Range {
+                lt: None,
+                gt: None,
+                gte: Some(left_range as f64),
+                lte: Some(right_range as f64),
+            },
+        )));
+
+        let filter_query = Some(&filter);
+
+        let index_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    ..Default::default()
+                }),
+                &false.into(),
+            )
+            .unwrap();
+
+        // check that search was performed using HNSW index
+        assert_eq!(
+            hnsw_index
+                .get_telemetry_data(TelemetryDetail::default())
+                .filtered_large_cardinality
+                .count,
+            i + 1
+        );
+
+        // segment uses a plain index by configuration
+        let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_index
+            .borrow()
+            .search(&[&query], filter_query, top, None, &false.into())
+            .unwrap();
+
+        if plain_result == index_result {
+            hits += 1;
+        }
+    }
+    assert!(
+        attempts - hits <= max_failures,
+        "hits: {hits} of {attempts}"
+    ); // Not more than X% failures
+    eprintln!("hits = {hits:#?} out of {attempts}");
+}


### PR DESCRIPTION
This PR integrates the `MultiVector` support at the segment level.

It was tested using a version of `filtrable_hnsw_test.rs` adapted for `Multivectors`.

Two insights:

1. the accuracy of HNSW degrades as the number of vectors per multi-vectors increases
  * most likely due to the random data
  * could be validated against real data set  
2. the scoring gets expensive as the number of vectors per multi-vectors increases