### PR TITLE
remove consensus op from await queue if it timed out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracy = ["tracing-tracy"]
 tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
+chaos-testing = []
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -19,6 +19,8 @@ use prost::Message as _;
 use raft::eraftpb::Message as RaftMessage;
 use raft::prelude::*;
 use raft::{SoftState, StateRole, INVALID_ID};
+#[cfg(feature = "chaos-test")]
+use rand::Rng;
 use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::consensus_ops::{ConsensusOperations, SnapshotStatus};
 use storage::content_manager::toc::TableOfContent;
@@ -552,7 +554,7 @@ impl Consensus {
                         // For debug:
                         // Drop message with 30% probability
                         #[cfg(feature = "chaos-test")]
-                        if rand::random::<f64>() < 0.3 {
+                        if rand::thread_rng().gen_bool(0.3) {
                             log::warn!("Dropping message with 30% probability: {:?}", &operation);
                             return Ok(true);
                         }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -549,6 +549,14 @@ impl Consensus {
                         Ok(())
                     }
                     _ => {
+                        // For debug:
+                        // Drop message with 30% probability
+                        #[cfg(feature = "chaos-test")]
+                        if rand::random::<f64>() < 0.3 {
+                            log::warn!("Dropping message with 30% probability: {:?}", &operation);
+                            return Ok(true);
+                        }
+
                         let message = match serde_cbor::to_vec(&operation) {
                             Ok(message) => message,
                             Err(err) => {


### PR DESCRIPTION
Consensus Operations might fail at any time, and this is Ok, consensus is design to live with that assumption.
We, however, prevented sent of new messages from repeating if one of them is failed first time.

This created crashloop in out brand new diff shard transfer logic, because we tried to send the same operation over and over, which didn't actually happen because it was already registered and never removed from registry.