### PR TITLE
When reading points, go over non-appendable segments first

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -472,8 +472,12 @@ impl<'s> SegmentHolder {
     where
         F: FnMut(PointIdType, &RwLockReadGuard<dyn SegmentEntry>) -> OperationResult<bool>,
     {
+        // List non-appendable segments first, then appendable segments
+        let mut segments = self.segments.values().collect::<Vec<_>>();
+        segments.sort_by_key(|segment| segment.get().read().is_appendable());
+
         let mut read_points = 0;
-        for segment in self.segments.values() {
+        for segment in segments {
             let segment_arc = segment.get();
             let read_segment = segment_arc.read();
             for point in ids.iter().cloned().filter(|id| read_segment.has_point(*id)) {


### PR DESCRIPTION
When reading points from segments, always read from non-appendable segments first.

Points may be moved from non-appendable to appendable, because we don't lock all segments together read ordering is very important here.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?