### PR TITLE
On read operations, go over non-appendable segments first

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -249,6 +249,22 @@ impl<'s> SegmentHolder {
         segments
     }
 
+    pub fn collect_non_appendable_segments(&self) -> Vec<LockedSegment> {
+        self.segments
+            .values()
+            .cloned()
+            .filter(|segment| !segment.get().read().is_appendable())
+            .collect()
+    }
+
+    pub fn collect_appendable_segments(&self) -> Vec<LockedSegment> {
+        self.segments
+            .values()
+            .cloned()
+            .filter(|segment| segment.get().read().is_appendable())
+            .collect()
+    }
+
     pub fn appendable_segments(&self) -> Vec<SegmentId> {
         self.segments
             .iter()

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -249,20 +249,13 @@ impl<'s> SegmentHolder {
         segments
     }
 
-    pub fn collect_non_appendable_segments(&self) -> Vec<LockedSegment> {
+    pub fn collect_non_appendable_and_appendable_segments(
+        &self,
+    ) -> (Vec<LockedSegment>, Vec<LockedSegment>) {
         self.segments
             .values()
-            .filter(|segment| !segment.get().read().is_appendable())
             .cloned()
-            .collect()
-    }
-
-    pub fn collect_appendable_segments(&self) -> Vec<LockedSegment> {
-        self.segments
-            .values()
-            .filter(|segment| segment.get().read().is_appendable())
-            .cloned()
-            .collect()
+            .partition(|segment| !segment.get().read().is_appendable())
     }
 
     pub fn appendable_segments(&self) -> Vec<SegmentId> {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -252,16 +252,16 @@ impl<'s> SegmentHolder {
     pub fn collect_non_appendable_segments(&self) -> Vec<LockedSegment> {
         self.segments
             .values()
-            .cloned()
             .filter(|segment| !segment.get().read().is_appendable())
+            .cloned()
             .collect()
     }
 
     pub fn collect_appendable_segments(&self) -> Vec<LockedSegment> {
         self.segments
             .values()
-            .cloned()
             .filter(|segment| segment.get().read().is_appendable())
+            .cloned()
             .collect()
     }
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -167,17 +167,16 @@ impl SegmentsSearcher {
             tokio::task::spawn_blocking(move || {
                 let segments = segments.read();
 
-                if !segments.is_empty() {
-                    let segments = segments.non_appendable_then_appendable_segments();
-                    let available_point_count = segments
-                        .into_iter()
-                        .map(|segment| segment.get().read().available_point_count())
-                        .sum();
-
-                    Some(available_point_count)
-                } else {
-                    None
+                if segments.is_empty() {
+                    return None;
                 }
+
+                let segments = segments.non_appendable_then_appendable_segments();
+                let available_point_count = segments
+                    .into_iter()
+                    .map(|segment| segment.get().read().available_point_count())
+                    .sum();
+                Some(available_point_count)
             })
         };
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -11,6 +11,7 @@ use segment::types::{
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 
+use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{
@@ -113,29 +114,31 @@ impl LocalShard {
     ) -> CollectionResult<Vec<Record>> {
         let segments = self.segments();
 
-        let read_handles: Vec<_> = {
-            let segments_guard = segments.read();
-            let segments = segments_guard.non_appendable_then_appendable_segments();
-            segments
-                .into_iter()
-                .map(|segment| {
-                    let segment = segment.clone();
-                    let filter = filter.cloned();
-
-                    search_runtime_handle.spawn_blocking(move || {
-                        segment
-                            .get()
-                            .read()
-                            .read_filtered(offset, Some(limit), filter.as_ref())
-                    })
-                })
-                .collect()
+        let (non_appendable, appendable) = {
+            let segments = segments.read();
+            (
+                segments.collect_non_appendable_segments(),
+                segments.collect_appendable_segments(),
+            )
         };
 
-        let all_points = try_join_all(read_handles).await?;
+        let read_filtered = |segment: LockedSegment| {
+            let filter = filter.cloned();
 
-        let point_ids = all_points
+            search_runtime_handle.spawn_blocking(move || {
+                segment
+                    .get()
+                    .read()
+                    .read_filtered(offset, Some(limit), filter.as_ref())
+            })
+        };
+
+        let non_appendable = try_join_all(non_appendable.into_iter().map(read_filtered)).await?;
+        let appendable = try_join_all(appendable.into_iter().map(read_filtered)).await?;
+
+        let point_ids = non_appendable
             .into_iter()
+            .chain(appendable)
             .flatten()
             .sorted()
             .dedup()
@@ -161,31 +164,34 @@ impl LocalShard {
         order_by: &OrderBy,
     ) -> CollectionResult<Vec<Record>> {
         let segments = self.segments();
-        let read_handles: Vec<_> = {
-            let segments_guard = segments.read();
-            let segments = segments_guard.non_appendable_then_appendable_segments();
-            segments
-                .into_iter()
-                .map(|segment| {
-                    let segment = segment.clone();
-                    let filter = filter.cloned();
 
-                    let order_by = order_by.clone();
-
-                    search_runtime_handle.spawn_blocking(move || {
-                        segment.get().read().read_ordered_filtered(
-                            Some(limit),
-                            filter.as_ref(),
-                            &order_by,
-                        )
-                    })
-                })
-                .collect()
+        let (non_appendable, appendable) = {
+            let segments = segments.read();
+            (
+                segments.collect_non_appendable_segments(),
+                segments.collect_appendable_segments(),
+            )
         };
 
-        let all_reads = try_join_all(read_handles)
-            .await?
+        let read_ordered_filtered = |segment: LockedSegment| {
+            let filter = filter.cloned();
+            let order_by = order_by.clone();
+
+            search_runtime_handle.spawn_blocking(move || {
+                segment
+                    .get()
+                    .read()
+                    .read_ordered_filtered(Some(limit), filter.as_ref(), &order_by)
+            })
+        };
+
+        let non_appendable =
+            try_join_all(non_appendable.into_iter().map(read_ordered_filtered)).await?;
+        let appendable = try_join_all(appendable.into_iter().map(read_ordered_filtered)).await?;
+
+        let all_reads = non_appendable
             .into_iter()
+            .chain(appendable)
             .collect::<Result<Vec<_>, _>>()?;
 
         let top_records = all_reads

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -114,13 +114,9 @@ impl LocalShard {
     ) -> CollectionResult<Vec<Record>> {
         let segments = self.segments();
 
-        let (non_appendable, appendable) = {
-            let segments = segments.read();
-            (
-                segments.collect_non_appendable_segments(),
-                segments.collect_appendable_segments(),
-            )
-        };
+        let (non_appendable, appendable) = segments
+            .read()
+            .collect_non_appendable_and_appendable_segments();
 
         let read_filtered = |segment: LockedSegment| {
             let filter = filter.cloned();
@@ -165,13 +161,9 @@ impl LocalShard {
     ) -> CollectionResult<Vec<Record>> {
         let segments = self.segments();
 
-        let (non_appendable, appendable) = {
-            let segments = segments.read();
-            (
-                segments.collect_non_appendable_segments(),
-                segments.collect_appendable_segments(),
-            )
-        };
+        let (non_appendable, appendable) = segments
+            .read()
+            .collect_non_appendable_and_appendable_segments();
 
         let read_ordered_filtered = |segment: LockedSegment| {
             let filter = filter.cloned();

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -115,9 +115,10 @@ impl LocalShard {
 
         let read_handles: Vec<_> = {
             let segments_guard = segments.read();
-            segments_guard
-                .iter()
-                .map(|(_, segment)| {
+            let segments = segments_guard.non_appendable_then_appendable_segments();
+            segments
+                .into_iter()
+                .map(|segment| {
                     let segment = segment.clone();
                     let filter = filter.cloned();
 
@@ -162,9 +163,10 @@ impl LocalShard {
         let segments = self.segments();
         let read_handles: Vec<_> = {
             let segments_guard = segments.read();
-            segments_guard
-                .iter()
-                .map(|(_, segment)| {
+            let segments = segments_guard.non_appendable_then_appendable_segments();
+            segments
+                .into_iter()
+                .map(|segment| {
                     let segment = segment.clone();
                     let filter = filter.cloned();
 


### PR DESCRIPTION
Extends <https://github.com/qdrant/qdrant/pull/3995>

All segment reading operations must read over non-appendable segments first.

Points may be moved from non-appendable to appendable, because we don't lock all segments together read ordering is very important here.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?