### PR TITLE
Fix indexed-only behavior for proxy shard

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -300,6 +300,7 @@ impl SegmentEntry for ProxySegment {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        search_optimized_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
         let deleted_points = self.deleted_points.read();
 
@@ -323,6 +324,7 @@ impl SegmentEntry for ProxySegment {
                 top,
                 params,
                 is_stopped,
+                search_optimized_threshold_kb,
             )?
         } else {
             self.wrapped_segment.get().read().search_batch(
@@ -334,6 +336,7 @@ impl SegmentEntry for ProxySegment {
                 top,
                 params,
                 is_stopped,
+                search_optimized_threshold_kb,
             )?
         };
         let mut write_results = self.write_segment.get().read().search_batch(
@@ -345,6 +348,7 @@ impl SegmentEntry for ProxySegment {
             top,
             params,
             is_stopped,
+            search_optimized_threshold_kb,
         )?;
         for (index, write_result) in write_results.iter_mut().enumerate() {
             wrapped_results[index].append(write_result)
@@ -1022,6 +1026,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
+                10_000,
             )
             .unwrap();
 
@@ -1077,6 +1082,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
+                10_000,
             )
             .unwrap();
 
@@ -1142,6 +1148,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
+                10_000,
             )
             .unwrap();
 

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -91,7 +91,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     group.bench_function("mmap-inverted-index-search", |b| {
         b.iter(|| {
             let results = sparse_vector_index_mmap
-                .search(&[&query_vector], None, TOP, None, &stopped)
+                .search(&[&query_vector], None, TOP, None, &stopped, usize::MAX)
                 .unwrap();
 
             assert_eq!(results[0].len(), TOP);
@@ -102,7 +102,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     group.bench_function("inverted-index-search", |b| {
         b.iter(|| {
             let results = sparse_vector_index
-                .search(&[&query_vector], None, TOP, None, &stopped)
+                .search(&[&query_vector], None, TOP, None, &stopped, usize::MAX)
                 .unwrap();
 
             assert_eq!(results[0].len(), TOP);
@@ -146,7 +146,14 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     group.bench_function("inverted-index-filtered-payload-index", |b| {
         b.iter(|| {
             let results = sparse_vector_index
-                .search(&[&query_vector], Some(&filter), TOP, None, &stopped)
+                .search(
+                    &[&query_vector],
+                    Some(&filter),
+                    TOP,
+                    None,
+                    &stopped,
+                    usize::MAX,
+                )
                 .unwrap();
 
             assert_eq!(results[0].len(), TOP);

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -52,6 +52,7 @@ pub trait SegmentEntry {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        search_optimized_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>>;
 
     fn upsert_point(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -514,6 +514,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        _search_optimized_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let exact = params.map(|params| params.exact).unwrap_or(false);
         match filter {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -367,6 +367,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         top: usize,
         _params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        _search_optimized_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let mut results = Vec::with_capacity(vectors.len());
         let mut prefiltered_points = None;

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -26,6 +26,7 @@ pub trait VectorIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        search_optimized_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>>;
 
     /// Force internal index rebuild.
@@ -70,20 +71,23 @@ impl VectorIndex for VectorIndexEnum {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
+        opt_threshold_kb: usize,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match self {
-            VectorIndexEnum::Plain(index) => index.search(vectors, filter, top, params, is_stopped),
+            VectorIndexEnum::Plain(index) => {
+                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+            }
             VectorIndexEnum::HnswRam(index) => {
-                index.search(vectors, filter, top, params, is_stopped)
+                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
             }
             VectorIndexEnum::HnswMmap(index) => {
-                index.search(vectors, filter, top, params, is_stopped)
+                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
             }
             VectorIndexEnum::SparseRam(index) => {
-                index.search(vectors, filter, top, params, is_stopped)
+                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
             }
             VectorIndexEnum::SparseMmap(index) => {
-                index.search(vectors, filter, top, params, is_stopped)
+                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
             }
         }
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -22,7 +22,10 @@ use crate::common::operation_error::{
     get_service_error, OperationError, OperationResult, SegmentFailedState,
 };
 use crate::common::version::{StorageVersion, VERSION_FILE};
-use crate::common::{BYTES_IN_KB, check_named_vectors, check_query_vectors, check_stopped, check_vector, check_vector_name};
+use crate::common::{
+    check_named_vectors, check_query_vectors, check_stopped, check_vector, check_vector_name,
+    BYTES_IN_KB,
+};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderingValue};
 use crate::data_types::vectors::{QueryVector, Vector, VectorRef};

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -120,6 +120,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
+                10_000,
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -176,11 +176,25 @@ fn test_batch_and_single_request_equivalency() {
         )));
 
         let search_res_1 = hnsw_index
-            .search(&[&query_vector_1], Some(&filter), 10, None, &false.into())
+            .search(
+                &[&query_vector_1],
+                Some(&filter),
+                10,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         let search_res_2 = hnsw_index
-            .search(&[&query_vector_2], Some(&filter), 10, None, &false.into())
+            .search(
+                &[&query_vector_2],
+                Some(&filter),
+                10,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         let batch_res = hnsw_index
@@ -190,6 +204,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -163,12 +163,13 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into())
+            .search(&[&query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         assert_eq!(
@@ -202,12 +203,20 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into())
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         assert_eq!(

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -240,6 +240,7 @@ fn _test_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 
@@ -255,7 +256,14 @@ fn _test_filterable_hnsw(
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into())
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         if plain_result == index_result {

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -139,13 +139,14 @@ fn hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 
         let plain_discovery_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into())
+            .search(&[&query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         if plain_discovery_result == index_discovery_result {
@@ -269,13 +270,21 @@ fn filtered_hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 
         let plain_discovery_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into())
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         if plain_discovery_result == index_discovery_result {

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -197,7 +197,7 @@ fn check_matches(
             segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], filter, top, None, &false.into())
+                .search(&[&query], filter, top, None, &false.into(), usize::MAX)
                 .unwrap()
         })
         .collect::<Vec<_>>();
@@ -215,6 +215,7 @@ fn check_matches(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         sames += sames_count(&index_result, plain_result);
@@ -248,6 +249,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         let best_1 = oversampling_1_result[0][0];
@@ -268,6 +270,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         let best_2 = oversampling_2_result[0][0];
@@ -305,6 +308,7 @@ fn check_rescoring(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
         for result in &index_result[0] {

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -227,6 +227,7 @@ fn test_multi_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 
@@ -243,7 +244,14 @@ fn test_multi_filterable_hnsw(
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], filter_query, top, None, &false.into())
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         if plain_result == index_result {

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -155,7 +155,14 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         )));
 
         let search_res_dense = hnsw_index_dense
-            .search(&[&query_vector], Some(&filter), 10, None, &false.into())
+            .search(
+                &[&query_vector],
+                Some(&filter),
+                10,
+                None,
+                &false.into(),
+                usize::MAX,
+            )
             .unwrap();
 
         let search_res_multi = hnsw_index_multi
@@ -165,6 +172,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
                 10,
                 None,
                 &false.into(),
+                usize::MAX,
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -188,13 +188,13 @@ fn sparse_index_discover_test() {
         let (sparse_query, dense_query) = random_discovery_query(&mut rnd, dim);
 
         let sparse_discovery_result = sparse_index
-            .search(&[&sparse_query], None, top, None, &false.into())
+            .search(&[&sparse_query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         let dense_discovery_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &false.into())
+            .search(&[&dense_query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         // check id only because scores can be epsilon-size different
@@ -212,13 +212,13 @@ fn sparse_index_discover_test() {
         // do regular nearest search
         let (sparse_query, dense_query) = random_nearest_query(&mut rnd, dim);
         let sparse_search_result = sparse_index
-            .search(&[&sparse_query], None, top, None, &false.into())
+            .search(&[&sparse_query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         let dense_search_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &false.into())
+            .search(&[&dense_query], None, top, None, &false.into(), usize::MAX)
             .unwrap();
 
         // check that nearest search uses sparse index

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -88,12 +88,19 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
         let query_vector: QueryVector = query.clone().into();
         // with filter
         let index_results_filter = sparse_vector_index
-            .search(&[&query_vector], Some(&filter), top, None, &stopped)
+            .search(
+                &[&query_vector],
+                Some(&filter),
+                top,
+                None,
+                &stopped,
+                usize::MAX,
+            )
             .unwrap();
 
         // without filter
         let index_results_no_filter = sparse_vector_index
-            .search(&[&query_vector], None, top, None, &stopped)
+            .search(&[&query_vector], None, top, None, &stopped, usize::MAX)
             .unwrap();
 
         assert_eq!(index_results_filter.len(), index_results_no_filter.len());
@@ -167,7 +174,7 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
         let top = sparse_vector_index.max_result_count(vector);
         let query_vector: QueryVector = vector.to_owned().into();
         let results = sparse_vector_index
-            .search(&[&query_vector], None, top, None, &false.into())
+            .search(&[&query_vector], None, top, None, &false.into(), usize::MAX)
             .unwrap();
         assert!(results[0].iter().any(|s| s.idx == id));
     }
@@ -300,7 +307,7 @@ fn sparse_vector_index_ram_deleted_points_search() {
     // query index
     let query_vector: QueryVector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM).into();
     let before_deletion_results: Vec<_> = sparse_vector_index
-        .search(&[&query_vector], None, top, None, &stopped)
+        .search(&[&query_vector], None, top, None, &stopped, usize::MAX)
         .unwrap();
 
     // pick a point to delete
@@ -353,7 +360,7 @@ fn sparse_vector_index_ram_deleted_points_search() {
 
     // assert that the deleted point is no longer in the index
     let after_deletion_results: Vec<_> = sparse_vector_index
-        .search(&[&query_vector], None, top, None, &stopped)
+        .search(&[&query_vector], None, top, None, &stopped, usize::MAX)
         .unwrap();
     assert_ne!(before_deletion_results, after_deletion_results);
     assert!(after_deletion_results
@@ -389,7 +396,14 @@ fn sparse_vector_index_ram_filtered_search() {
     // query all sparse dimension to get all points
     let query_vector: QueryVector = random_full_sparse_vector(&mut rnd, MAX_SPARSE_DIM).into();
     let before_result = sparse_vector_index
-        .search(&[&query_vector], Some(&filter), 10, None, &stopped)
+        .search(
+            &[&query_vector],
+            Some(&filter),
+            10,
+            None,
+            &stopped,
+            usize::MAX,
+        )
         .unwrap();
     assert_eq!(before_result.len(), 1);
     assert_eq!(before_result[0].len(), 0);
@@ -443,6 +457,7 @@ fn sparse_vector_index_ram_filtered_search() {
             half_indexed_count * 2, // original top
             None,
             &stopped,
+            usize::MAX,
         )
         .unwrap();
     assert_eq!(after_result.len(), 1);
@@ -478,7 +493,14 @@ fn sparse_vector_index_plain_search() {
 
     // empty when searching payload index directly
     let before_plain_results = sparse_vector_index
-        .search(&[&query_vector], Some(&filter), 10, None, &stopped)
+        .search(
+            &[&query_vector],
+            Some(&filter),
+            10,
+            None,
+            &stopped,
+            usize::MAX,
+        )
         .unwrap();
 
     assert_eq!(before_plain_results.len(), 1);
@@ -500,7 +522,14 @@ fn sparse_vector_index_plain_search() {
 
     // same results when searching payload index directly
     let after_plain_results = sparse_vector_index
-        .search(&[&query_vector], Some(&filter), NUM_VECTORS, None, &stopped)
+        .search(
+            &[&query_vector],
+            Some(&filter),
+            NUM_VECTORS,
+            None,
+            &stopped,
+            usize::MAX,
+        )
         .unwrap();
 
     assert_eq!(after_plain_results.len(), 1);
@@ -561,7 +590,7 @@ fn handling_empty_sparse_vectors() {
 
     // empty vectors are not searchable (recommend using scroll API to retrieve those)
     let results = sparse_vector_index
-        .search(&[&query_vector], None, 10, None, &stopped)
+        .search(&[&query_vector], None, 10, None, &stopped, usize::MAX)
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].len(), 0);
@@ -691,7 +720,7 @@ fn sparse_vector_index_persistence_test() {
 
     // check that the loaded index performs the same search
     let search_after_reload_result = sparse_vector_index_ram
-        .search(&[&query_vector], None, top, None, &stopped)
+        .search(&[&query_vector], None, top, None, &stopped, usize::MAX)
         .unwrap();
     assert_eq!(search_after_reload_result[0].len(), top);
     for (search_1, search_2) in search_result
@@ -752,7 +781,7 @@ fn sparse_vector_index_persistence_test() {
 
     // check that the loaded index performs the same search
     let search_after_reload_result = sparse_vector_index_mmap
-        .search(&[&query_vector], None, top, None, &stopped)
+        .search(&[&query_vector], None, top, None, &stopped, usize::MAX)
         .unwrap();
     assert_eq!(search_after_reload_result[0].len(), top);
     for (search_1, search_2) in search_result


### PR DESCRIPTION
This is an attempt to rethink a suggestion proposed in https://github.com/qdrant/qdrant/pull/3186

Instead of introducing a new parameter, we simply fix the problem of excluding proxy shard with too many changes from the search by allowing each individual raw segment to decide if it can do search or not.


P.S.
There is a follow-up PR with post-refactoring of simple `search` method.