### PR TITLE
Proxy shard indexed only post refactor

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -29,19 +29,6 @@ pub trait SegmentEntry {
     fn point_version(&self, point_id: PointIdType) -> Option<SeqNumberType>;
 
     #[allow(clippy::too_many_arguments)]
-    fn search(
-        &self,
-        vector_name: &str,
-        query_vector: &QueryVector,
-        with_payload: &WithPayload,
-        with_vector: &WithVector,
-        filter: Option<&Filter>,
-        top: usize,
-        params: Option<&SearchParams>,
-        is_stopped: &AtomicBool,
-    ) -> OperationResult<Vec<ScoredPoint>>;
-
-    #[allow(clippy::too_many_arguments)]
     fn search_batch(
         &self,
         vector_name: &str,

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -93,7 +93,6 @@ fn test_batch_and_single_request_equivalency() {
                 Some(&filter),
                 10,
                 None,
-                &false.into(),
             )
             .unwrap();
 
@@ -106,7 +105,6 @@ fn test_batch_and_single_request_equivalency() {
                 Some(&filter),
                 10,
                 None,
-                &false.into(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -301,7 +301,6 @@ fn validate_geo_filter(query_filter: Filter) {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
 
@@ -326,7 +325,6 @@ fn validate_geo_filter(query_filter: Filter) {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
 
@@ -611,7 +609,6 @@ fn test_struct_payload_index() {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
         let struct_result = struct_segment
@@ -623,7 +620,6 @@ fn test_struct_payload_index() {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
 
@@ -772,7 +768,6 @@ fn test_struct_payload_index_nested_fields() {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
         let struct_result = struct_segment
@@ -787,7 +782,6 @@ fn test_struct_payload_index_nested_fields() {
                 Some(&query_filter),
                 5,
                 None,
-                &false.into(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -36,7 +36,6 @@ fn test_point_exclusion() {
             None,
             1,
             None,
-            &false.into(),
         )
         .unwrap();
 
@@ -56,7 +55,6 @@ fn test_point_exclusion() {
             Some(&frt),
             1,
             None,
-            &false.into(),
         )
         .unwrap();
 
@@ -91,7 +89,6 @@ fn test_named_vector_search() {
             None,
             1,
             None,
-            &false.into(),
         )
         .unwrap();
 
@@ -116,7 +113,6 @@ fn test_named_vector_search() {
             Some(&frt),
             1,
             None,
-            &false.into(),
         )
         .unwrap();
 
@@ -211,7 +207,6 @@ fn ordered_deletion_test() {
             None,
             1,
             None,
-            &false.into(),
         )
         .unwrap();
     let best_match = res.first().expect("Non-empty result");
@@ -276,7 +271,6 @@ fn test_update_named_vector() {
             None,
             1,
             Some(&search_params),
-            &false.into(),
         )
         .unwrap();
     let nearest_upsert = nearest_upsert.first().unwrap();
@@ -314,7 +308,6 @@ fn test_update_named_vector() {
             None,
             1,
             Some(&search_params),
-            &false.into(),
         )
         .unwrap();
     let nearest_update = nearest_update.first().unwrap();

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -648,7 +648,6 @@ fn sparse_vector_index_persistence_test() {
             None,
             top,
             None,
-            &stopped,
         )
         .unwrap();
 
@@ -669,7 +668,6 @@ fn sparse_vector_index_persistence_test() {
             None,
             top,
             None,
-            &stopped,
         )
         .unwrap();
 


### PR DESCRIPTION
This PR moved `search` method from Segment trait into impl of structures, to make sure that `search`method is only used in integration tests.

For simplicity, it hides some parameters of the "main" method `search_batch`, to make further refactoring of parameters esier. 