### PR TITLE
Flatten representation for MultiDenseVectors

### DIFF
--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -185,10 +185,10 @@ fn check_vector_against_config(
             Ok(())
         }
         VectorRef::Sparse(_) => Err(OperationError::WrongSparse),
-        VectorRef::MultiDense(vectors) => {
+        VectorRef::MultiDense(multi_vector) => {
             // Check dimensionality
             let dim = vector_config.size;
-            for vector in vectors {
+            for vector in multi_vector.multi_vectors() {
                 if vector.len() != dim {
                     return Err(OperationError::WrongVector {
                         expected_dim: dim,

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -222,9 +222,7 @@ impl<'a> NamedVectors<'a> {
                     for dense_vector in v.to_mut().multi_vectors_mut() {
                         let preprocessed_vector = distance.preprocess_vector(dense_vector.to_vec());
                         // replace dense vector with preprocessed vector
-                        for (position, value) in preprocessed_vector.iter().enumerate() {
-                            dense_vector[position] = *value;
-                        }
+                        dense_vector.copy_from_slice(&preprocessed_vector);
                     }
                 }
             }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::slice::ChunksMut;
+use std::slice::ChunksExactMut;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -190,11 +190,11 @@ impl MultiDenseVector {
 
     /// Slices the multi vector into the underlying individual vectors
     pub fn multi_vectors(&self) -> impl Iterator<Item = &[VectorElementType]> {
-        self.inner_vector.chunks(self.dim)
+        self.inner_vector.chunks_exact(self.dim)
     }
 
-    pub fn multi_vectors_mut(&mut self) -> ChunksMut<VectorElementType> {
-        self.inner_vector.chunks_mut(self.dim)
+    pub fn multi_vectors_mut(&mut self) -> ChunksExactMut<'_, VectorElementType> {
+        self.inner_vector.chunks_exact_mut(self.dim)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -214,7 +214,12 @@ impl TryFrom<Vec<DenseVector>> for MultiDenseVector {
     type Error = OperationError;
 
     fn try_from(value: Vec<DenseVector>) -> Result<Self, Self::Error> {
-        let dim = value.first().map(|v| v.len()).unwrap_or(0);
+        if value.is_empty() {
+            return Err(OperationError::ValidationError {
+                description: "MultiDenseVector cannot be empty".to_string(),
+            });
+        }
+        let dim = value[0].len();
         // assert all vectors have the same dimension
         if let Some(bad_vec) = value.iter().find(|v| v.len() != dim) {
             Err(OperationError::WrongVector {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -174,7 +174,7 @@ pub type TypedDenseVector<T> = Vec<T>;
 pub type DenseVector = TypedDenseVector<VectorElementType>;
 
 /// Type for multi dense vector
-#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct MultiDenseVector {
     pub inner_vector: DenseVector, // vectors are flattened into a single vector
     pub dim: usize,                // dimension of each vector
@@ -184,6 +184,14 @@ impl MultiDenseVector {
     pub fn new(flattened_vectors: DenseVector, dim: usize) -> Self {
         Self {
             inner_vector: flattened_vectors,
+            dim,
+        }
+    }
+
+    /// MultiDenseVector cannot be empty, so we use a placeholder vector instead
+    pub fn placeholder(dim: usize) -> Self {
+        Self {
+            inner_vector: vec![1.0; dim],
             dim,
         }
     }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -181,9 +181,9 @@ pub struct MultiDenseVector {
 }
 
 impl MultiDenseVector {
-    pub fn new(vectors: DenseVector, dim: usize) -> Self {
+    pub fn new(flattened_vectors: DenseVector, dim: usize) -> Self {
         Self {
-            inner_vector: vectors,
+            inner_vector: flattened_vectors,
             dim,
         }
     }

--- a/lib/segment/src/fixtures/payload_fixtures.rs
+++ b/lib/segment/src/fixtures/payload_fixtures.rs
@@ -128,9 +128,10 @@ pub fn random_multi_vector<R: Rng + ?Sized>(
 ) -> MultiDenseVector {
     let mut vectors = vec![];
     for _ in 0..num_vector_per_points {
-        vectors.push(random_vector(rnd_gen, vector_size));
+        let vec = random_vector(rnd_gen, vector_size);
+        vectors.extend(vec);
     }
-    vectors
+    MultiDenseVector::new(vectors, vector_size)
 }
 
 pub fn random_uncommon_condition<R: Rng + ?Sized>(rnd_gen: &mut R) -> Condition {

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -27,7 +27,7 @@ use crate::common::{
 };
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderingValue};
-use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
+use crate::data_types::vectors::{MultiDenseVector, QueryVector, Vector, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::numeric_index::StreamRange;
@@ -220,7 +220,7 @@ impl Segment {
                         }
                         VectorStorageEnum::SparseSimple(_) => Vector::from(SparseVector::default()),
                         VectorStorageEnum::MultiDenseSimple(_) => {
-                            Vector::from(vec![vec![1.0; dim]])
+                            Vector::from(MultiDenseVector::default())
                         }
                     };
                     vector_storage.insert_vector(new_index, VectorRef::from(&vector))?;

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -220,7 +220,7 @@ impl Segment {
                         }
                         VectorStorageEnum::SparseSimple(_) => Vector::from(SparseVector::default()),
                         VectorStorageEnum::MultiDenseSimple(_) => {
-                            Vector::from(MultiDenseVector::default())
+                            Vector::from(MultiDenseVector::placeholder(dim))
                         }
                     };
                     vector_storage.insert_vector(new_index, VectorRef::from(&vector))?;

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -29,9 +29,9 @@ pub fn score_max_similarity<TMetric: Metric<VectorElementType>>(
     debug_assert!(!multi_dense_a.is_empty());
     debug_assert!(!multi_dense_b.is_empty());
     let mut sum = 0.0;
-    for dense_a in multi_dense_a.iter() {
+    for dense_a in multi_dense_a.multi_vectors() {
         sum += multi_dense_b
-            .iter()
+            .multi_vectors()
             .map(|dense_b| TMetric::similarity(dense_a, dense_b))
             .max_by(|a, b| OrderedFloat(*a).cmp(&OrderedFloat(*b)))
             .expect("At least one element in multi-dense vector")

--- a/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
@@ -12,7 +12,7 @@ use crate::common::operation_error::{check_process_stopped, OperationError, Oper
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
-use crate::data_types::vectors::{DenseVector, MultiDenseVector, VectorRef};
+use crate::data_types::vectors::{MultiDenseVector, VectorRef};
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::bitvec::bitvec_set_deleted;
 use crate::vector_storage::common::StoredRecord;
@@ -44,7 +44,7 @@ pub fn open_simple_multi_dense_vector_storage(
     multi_vector_config: MultiVectorConfig,
     stopped: &AtomicBool,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
-    let mut vectors = vec![];
+    let mut vectors: Vec<MultiDenseVector> = vec![];
     let (mut deleted, mut deleted_count) = (BitVec::new(), 0);
     let db_wrapper = DatabaseColumnWrapper::new(database, database_column_name);
     db_wrapper.lock_db().iter()?;
@@ -61,7 +61,7 @@ pub fn open_simple_multi_dense_vector_storage(
         }
         let point_id_usize = point_id as usize;
         if point_id_usize >= vectors.len() {
-            vectors.resize(point_id_usize + 1, vec![]);
+            vectors.resize(point_id_usize + 1, MultiDenseVector::default());
         }
         vectors[point_id_usize] = stored_record.vector;
 
@@ -155,15 +155,16 @@ impl VectorStorage for SimpleMultiDenseVectorStorage {
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
         let multi_dense_vector = self.vectors.get(key as usize).expect("vector not found");
-        CowVector::from(multi_dense_vector.as_slice())
+        CowVector::from(multi_dense_vector)
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
-        let vector: &[DenseVector] = vector.try_into()?;
-        let multi_vector = vector.to_vec();
+        let vector: &MultiDenseVector = vector.try_into()?;
+        let multi_vector = vector.clone();
         let key_usize = key as usize;
         if key_usize >= self.vectors.len() {
-            self.vectors.resize(key_usize + 1, vec![]);
+            self.vectors
+                .resize(key_usize + 1, MultiDenseVector::default());
         }
         self.vectors[key_usize] = multi_vector.clone();
         self.set_deleted(key, false);
@@ -182,8 +183,8 @@ impl VectorStorage for SimpleMultiDenseVectorStorage {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
             let other_vector = other.get_vector(point_id);
-            let other_vector: &[DenseVector] = other_vector.as_vec_ref().try_into()?;
-            let other_multi_vector = other_vector.to_vec();
+            let other_vector: &MultiDenseVector = other_vector.as_vec_ref().try_into()?;
+            let other_multi_vector = other_vector.clone();
             let other_deleted = other.is_deleted_vector(point_id);
             self.vectors.push(other_multi_vector.clone());
             let new_id = self.vectors.len() as PointOffsetType - 1;

--- a/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
@@ -61,7 +61,7 @@ pub fn open_simple_multi_dense_vector_storage(
         }
         let point_id_usize = point_id as usize;
         if point_id_usize >= vectors.len() {
-            vectors.resize(point_id_usize + 1, MultiDenseVector::default());
+            vectors.resize(point_id_usize + 1, MultiDenseVector::placeholder(dim));
         }
         vectors[point_id_usize] = stored_record.vector;
 
@@ -77,7 +77,7 @@ pub fn open_simple_multi_dense_vector_storage(
             db_wrapper,
             update_buffer: StoredMultiDenseVector {
                 deleted: false,
-                vector: MultiDenseVector::default(),
+                vector: MultiDenseVector::placeholder(dim),
             },
             deleted,
             deleted_count,
@@ -164,7 +164,7 @@ impl VectorStorage for SimpleMultiDenseVectorStorage {
         let key_usize = key as usize;
         if key_usize >= self.vectors.len() {
             self.vectors
-                .resize(key_usize + 1, MultiDenseVector::default());
+                .resize(key_usize + 1, MultiDenseVector::placeholder(self.dim));
         }
         self.vectors[key_usize] = multi_vector.clone();
         self.set_deleted(key, false);

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -24,7 +24,7 @@ fn multi_points_fixtures() -> Vec<MultiDenseVector> {
             vec![value, value, 0.0, value],
             vec![value, 0.0, 0.0, value],
         ];
-        let multi = MultiDenseVector::new(vectors.into_iter().flatten().collect(), 4);
+        let multi = MultiDenseVector::try_from(vectors).unwrap();
         multis.push(multi);
     }
     multis

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -7,7 +7,7 @@ use rand::prelude::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::data_types::vectors::{
-    only_default_vector, QueryVector, Vector, VectorRef, DEFAULT_VECTOR_NAME,
+    only_default_vector, MultiDenseVector, QueryVector, VectorRef, DEFAULT_VECTOR_NAME,
 };
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
@@ -77,7 +77,8 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     for n in 0..num_vectors {
         let idx = n.into();
         let vector = random_vector(&mut rnd, dim);
-        let vector_multi = vec![distance.preprocess_vector(vector.clone())];
+        let vector_multi =
+            MultiDenseVector::new(distance.preprocess_vector(vector.clone()), vector.len());
 
         let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
         let payload: Payload = json!({int_key:int_payload,}).into();
@@ -145,7 +146,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     for _ in 0..10 {
         let random_vector = random_vector(&mut rnd, dim);
         let query_vector = random_vector.clone().into();
-        let query_vector_multi = QueryVector::Nearest(Vector::from(vec![random_vector]));
+        let query_vector_multi = QueryVector::Nearest(vec![random_vector].try_into().unwrap());
 
         let payload_value = random_int_payload(&mut rnd, 1..=1).pop().unwrap();
 


### PR DESCRIPTION
Use a flatten representation for `MultiDenseVector` for mechanical sympathy.

It will help in the future for the mmap and quantization work as well.