### PR TITLE
RBAC: add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sparse",
+ "strum",
  "tar",
  "tempfile",
  "thiserror",
@@ -2239,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -3889,7 +3890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -3913,7 +3914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "log",
  "multimap",
@@ -3993,7 +3994,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4dca8bcead3b728a6a7da017cc95e7f4cb2320ec4f6896bc593a1c4700f7328"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "prost 0.11.9",
  "prost-build 0.11.9",
  "prost-types 0.11.9",
@@ -5276,6 +5277,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "strum",
  "tar",
  "tempfile",
  "thiserror",
@@ -5305,6 +5307,28 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
+strum = { version = "0.26.2", features = ["derive"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -71,6 +71,7 @@ bytes = "1.6.0"
 fnv = { workspace = true }
 indexmap = { workspace = true }
 ringbuffer = "0.15.0"
+strum = { workspace = true }
 
 tracing = { workspace = true, optional = true }
 

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -27,13 +27,13 @@ use crate::recommendations::recommend_into_core_search;
 const MAX_GET_GROUPS_REQUESTS: usize = 5;
 const MAX_GROUP_FILLING_REQUESTS: usize = 5;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SourceRequest {
     Search(SearchRequestInternal),
     Recommend(RecommendRequestInternal),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GroupRequest {
     /// Request to use (search or recommend)
     pub source: SourceRequest,

--- a/lib/collection/src/lookup/mod.rs
+++ b/lib/collection/src/lookup/mod.rs
@@ -15,7 +15,7 @@ use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{CollectionError, CollectionResult, PointRequestInternal, Record};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct WithLookup {
     /// Name of the collection to use for points lookup
     #[serde(rename = "collection")]

--- a/lib/collection/src/lookup/types.rs
+++ b/lib/collection/src/lookup/types.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use super::WithLookup;
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum WithLookupInterface {
     Collection(String),

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -34,7 +34,8 @@ pub struct CreateIndex {
     pub field_schema: Option<PayloadFieldSchema>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum FieldIndexOperations {
     /// Create index for payload field

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use segment::json_path::JsonPath;
 use segment::types::{ExtendedPointId, PayloadFieldSchema};
 use serde::{Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use crate::hash_ring::HashRing;
@@ -130,7 +131,8 @@ impl From<ClockTag> for api::grpc::qdrant::ClockTag {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum CollectionUpdateOperations {
     PointOperation(point_ops::PointOperations),

--- a/lib/collection/src/operations/payload_ops.rs
+++ b/lib/collection/src/operations/payload_ops.rs
@@ -3,6 +3,7 @@ use segment::json_path::JsonPath;
 use segment::types::{Filter, Payload, PayloadKeyType, PointIdType};
 use serde;
 use serde::{Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{split_iter_by_shard, OperationToShard, SplitByShard};
@@ -134,7 +135,8 @@ impl TryFrom<DeletePayloadShadow> for DeletePayload {
 }
 
 /// Define operations description for point payloads manipulation
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum PayloadOps {
     /// Set payload value, overrides if it is already exists

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -337,7 +337,8 @@ impl From<Vec<PointStruct>> for PointInsertOperationsInternal {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum PointOperations {
     /// Insert or update points

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -9,6 +9,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{Vector, DEFAULT_VECTOR_NAME};
 use segment::types::{Filter, Payload, PointIdType};
 use serde::{Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumIter};
 use validator::Validate;
 
 use super::{point_to_shard, split_iter_by_shard, OperationToShard, SplitByShard};
@@ -221,7 +222,8 @@ impl PointInsertOperations {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum PointInsertOperationsInternal {
     /// Inset points from a batch.

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -291,7 +291,7 @@ pub struct ScrollRequest {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum OrderByInterface {
     Key(JsonPath),
@@ -312,7 +312,7 @@ impl From<OrderByInterface> for OrderBy {
 }
 
 /// Scroll request - paginate over all points which matches given condition
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct ScrollRequestInternal {
     /// Start ID to read points from.
@@ -374,7 +374,7 @@ pub struct SearchRequest {
 /// Search request.
 /// Holds all conditions and parameters for the search of most similar points by vector similarity
 /// given the filtering restrictions.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SearchRequestInternal {
     /// Look for vectors closest to this
@@ -413,7 +413,7 @@ pub struct SearchRequestBatch {
     pub searches: Vec<SearchRequest>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum QueryEnum {
     Nearest(NamedVectorStruct),
     RecommendBestScore(NamedQuery<RecoQuery<Vector>>),
@@ -450,7 +450,7 @@ impl AsRef<QueryEnum> for QueryEnum {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CoreSearchRequest {
     /// Every kind of query that can be performed on segment level
     pub query: QueryEnum,
@@ -528,7 +528,7 @@ pub struct PointRequest {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct PointRequestInternal {
     /// Look for points with ids
@@ -590,7 +590,7 @@ pub enum RecommendStrategy {
     BestScore,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum UsingVector {
     Name(String),
@@ -604,7 +604,7 @@ impl From<String> for UsingVector {
 
 /// Defines a location to use for looking up the vector.
 /// Specifies collection and vector field name.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LookupLocation {
     /// Name of the collection used for lookup
@@ -637,7 +637,7 @@ pub struct RecommendRequest {
 /// Service should look for the points which are closer to positive examples and at the same time
 /// further to negative examples. The concrete way of how to compare negative and positive distances
 /// is up to the `strategy` chosen.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Default, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct RecommendRequestInternal {
     /// Look for vectors closest to those
@@ -712,7 +712,7 @@ pub struct RecommendGroupsRequest {
     pub shard_key: Option<ShardKeySelector>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 pub struct RecommendGroupsRequestInternal {
     /// Look for vectors closest to those
     #[serde(default)]
@@ -760,7 +760,7 @@ pub struct RecommendGroupsRequestInternal {
     pub group_request: BaseGroupRequest,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 pub struct ContextExamplePair {
     #[validate]
     pub positive: RecommendExample,
@@ -785,7 +785,7 @@ pub struct DiscoverRequest {
 }
 
 /// Use context and a target to find the most similar points, constrained by the context.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
 pub struct DiscoverRequestInternal {
     /// Look for vectors closest to this.
     ///
@@ -881,7 +881,7 @@ pub struct CountRequest {
 /// Count Request
 /// Counts the number of points which satisfy the given filter.
 /// If filter is not provided, the count of all points in the collection will be returned.
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate)]
+#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct CountRequestInternal {
     /// Look only for points which satisfies this conditions
@@ -1748,7 +1748,7 @@ pub enum NodeType {
     Listener,
 }
 
-#[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct BaseGroupRequest {
     /// Payload field to group by, must be a string or number field.
     /// If the field contains more than 1 value, all values will be used for grouping.

--- a/lib/collection/src/operations/vector_ops.rs
+++ b/lib/collection/src/operations/vector_ops.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use schemars::JsonSchema;
 use segment::types::{Filter, PointIdType};
 use serde::{Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumIter};
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::point_ops::PointIdsList;
@@ -68,7 +69,8 @@ pub struct UpdateVectorsOp {
     pub points: Vec<PointVectors>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum VectorOperations {
     /// Update vectors

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -11,7 +11,7 @@ use crate::types::{
 
 const INTERNAL_KEY_OF_ORDER_BY_VALUE: &str = "____ordered_with____";
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, Default)]
+#[derive(Deserialize, Serialize, JsonSchema, Copy, Clone, Debug, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Direction {
     #[default]
@@ -38,7 +38,7 @@ impl Direction {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum StartFrom {
     Integer(IntPayloadType),
@@ -48,7 +48,7 @@ pub enum StartFrom {
     Datetime(DateTimePayloadType),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Validate, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct OrderBy {
     /// Payload key to order by

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -379,7 +379,7 @@ impl VectorStruct {
 }
 
 /// Vector data with name
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct NamedVector {
     /// Name of vector data
@@ -389,7 +389,7 @@ pub struct NamedVector {
 }
 
 /// Sparse vector data with name
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Validate)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Validate, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct NamedSparseVector {
     /// Name of vector data
@@ -414,7 +414,7 @@ pub struct NamedSparseVector {
 ///     "name": "image-embeddings"
 ///   }
 /// }
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum NamedVectorStruct {
@@ -521,7 +521,7 @@ impl BatchVectorStruct {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NamedQuery<TQuery> {
     pub query: TQuery,
     pub using: Option<String>,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1895,7 +1895,7 @@ impl Validate for Condition {
 }
 
 /// Options for specifying which payload to include or not
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum WithPayloadInterface {
     /// If `true` - return all payload,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1211,6 +1211,16 @@ pub enum ValueVariants {
     Bool(bool),
 }
 
+impl ValueVariants {
+    pub fn to_value(&self) -> Value {
+        match self {
+            ValueVariants::Keyword(keyword) => Value::String(keyword.clone()),
+            &ValueVariants::Integer(integer) => Value::Number(integer.into()),
+            &ValueVariants::Bool(flag) => Value::Bool(flag),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum AnyVariants {

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -8,7 +8,7 @@ use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ContextPair<T> {
     pub positive: T,
     pub negative: T,
@@ -69,7 +69,7 @@ impl<T> From<(T, T)> for ContextPair<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ContextQuery<T> {
     pub pairs: Vec<ContextPair<T>>,
 }

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -22,7 +22,7 @@ impl<T> ContextPair<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DiscoveryQuery<T> {
     pub target: T,
     pub pairs: Vec<ContextPair<T>>,

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -6,7 +6,7 @@ use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RecoQuery<T> {
     pub positives: Vec<T>,
     pub negatives: Vec<T>,

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -29,6 +29,7 @@ log = "0.4"
 tonic = { workspace = true }
 http = "0.2"
 parking_lot = { workspace = true }
+strum = { workspace = true }
 tar = "0.4.40"
 chrono = { workspace = true }
 validator = { workspace = true }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -452,3 +452,709 @@ impl PayloadConstraint {
         incompatible_with_payload_constraint(collection_name) // Reject as not implemented
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use segment::json_path::JsonPath;
+    use segment::types::{MinShould, ValueVariants};
+
+    use super::*;
+    use crate::rbac::{CollectionAccess, CollectionAccessMode};
+
+    #[test]
+    fn test_apply_filter() {
+        let list = CollectionAccessList(vec![CollectionAccess {
+            collection: "col".to_string(),
+            access: CollectionAccessMode::Read,
+            payload: Some(PayloadConstraint(HashMap::from([(
+                "field".parse().unwrap(),
+                ValueVariants::Integer(42),
+            )]))),
+        }]);
+
+        let mut filter = None;
+        list.find_view("col").unwrap().apply_filter(&mut filter);
+        assert_eq!(
+            filter,
+            Some(Filter {
+                must: Some(vec![Condition::Field(FieldCondition::new_match(
+                    "field".parse().unwrap(),
+                    Match::new_value(ValueVariants::Integer(42))
+                ))]),
+                ..Default::default()
+            })
+        );
+
+        let cond = |path: &str| Condition::IsNull(path.parse::<JsonPath>().unwrap().into());
+
+        let mut filter = Some(Filter {
+            should: Some(vec![cond("a")]),
+            min_should: Some(MinShould {
+                conditions: vec![cond("b")],
+                min_count: 1,
+            }),
+            must: Some(vec![cond("c")]),
+            must_not: Some(vec![cond("d")]),
+        });
+        list.find_view("col").unwrap().apply_filter(&mut filter);
+        assert_eq!(
+            filter,
+            Some(Filter {
+                should: Some(vec![cond("a")]),
+                min_should: Some(MinShould {
+                    conditions: vec![cond("b")],
+                    min_count: 1,
+                }),
+                must: Some(vec![
+                    cond("c"),
+                    Condition::Field(FieldCondition::new_match(
+                        "field".parse().unwrap(),
+                        Match::new_value(ValueVariants::Integer(42))
+                    ))
+                ]),
+                must_not: Some(vec![cond("d")]),
+            })
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_ops {
+    use std::fmt::Debug;
+
+    use api::rest::{BatchVectorStruct, VectorStruct};
+    use collection::operations::point_ops::{
+        Batch, PointInsertOperationsInternal, PointStruct, PointSyncOperation,
+    };
+    use collection::operations::types::{
+        OrderByInterface, QueryEnum, RecommendStrategy, SearchRequestInternal, UsingVector,
+    };
+    use collection::operations::vector_ops::{PointVectors, UpdateVectorsOp};
+    use collection::operations::{CreateIndex, FieldIndexOperations};
+    use segment::data_types::vectors::NamedVectorStruct;
+    use segment::types::{PointIdType, SearchParams, WithPayloadInterface, WithVector};
+
+    use super::*;
+    use crate::rbac::{AccessCollectionBuilder, GlobalAccessMode};
+
+    /// Operation is allowed with the given access, and no rewrite is expected.
+    fn assert_allowed<Op: Debug + Clone + PartialEq + CheckableCollectionOperation>(
+        op: &Op,
+        access: &Access,
+    ) {
+        let mut op_actual = op.clone();
+        access
+            .check_point_op("col", &mut op_actual)
+            .expect("Should be allowed");
+        assert_eq!(op, &op_actual, "Expected not to change");
+    }
+
+    /// Operation is allowed with the given access, and the rewrite is expected.
+    /// A closure `rewrite` is expected to produce the same result as the rewritten operation.
+    fn assert_allowed_rewrite<Op: Debug + Clone + PartialEq + CheckableCollectionOperation>(
+        op: &Op,
+        access: &Access,
+        rewrite: impl FnOnce(&mut Op),
+    ) {
+        let mut op_actual = op.clone();
+        access
+            .check_point_op("col", &mut op_actual)
+            .expect("Should be allowed");
+        let mut op_reference = op.clone();
+        rewrite(&mut op_reference);
+        assert_eq!(op_reference, op_actual, "Expected to change");
+    }
+
+    /// Operation is forbidden with the given access.
+    fn assert_forbidden<Op: Clone + CheckableCollectionOperation + PartialEq>(
+        op: &Op,
+        access: &Access,
+    ) {
+        access
+            .check_point_op("col", &mut op.clone())
+            .expect_err("Should be allowed");
+    }
+
+    /// Operation requires write + whole collection access.
+    fn assert_requires_whole_write_access<Op>(op: &Op)
+    where
+        Op: CheckableCollectionOperation + Clone + Debug + PartialEq,
+    {
+        assert_allowed(op, &Access::Global(GlobalAccessMode::Manage));
+        assert_forbidden(op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            op,
+            &AccessCollectionBuilder::new().add("col", true, true).into(),
+        );
+        assert_forbidden(
+            op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+        assert_forbidden(
+            op,
+            &AccessCollectionBuilder::new()
+                .add("col", true, false)
+                .into(),
+        );
+    }
+
+    #[test]
+    fn test_recommend_request_internal() {
+        let op = RecommendRequestInternal {
+            positive: vec![RecommendExample::Dense(vec![0.0, 1.0, 2.0])],
+            negative: vec![RecommendExample::Sparse(vec![(0, 0.0)].try_into().unwrap())],
+            strategy: Some(RecommendStrategy::AverageVector),
+            filter: None,
+            params: Some(SearchParams::default()),
+            limit: 100,
+            offset: Some(100),
+            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: Some(WithVector::Bool(true)),
+            score_threshold: Some(42.0),
+            using: Some(UsingVector::Name("vector".to_string())),
+            lookup_from: Some(LookupLocation {
+                collection: "col2".to_string(),
+                vector: Some("vector".to_string()),
+                shard_key: None,
+            }),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        // Require whole access to col2
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, false)
+                .into(),
+        );
+
+        assert_allowed_rewrite(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+            |op| {
+                op.filter = Some(PayloadConstraint::new_test("col").to_filter());
+            },
+        );
+
+        // Point ID is used
+        assert_forbidden(
+            &RecommendRequestInternal {
+                positive: vec![RecommendExample::PointId(ExtendedPointId::NumId(12345))],
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+        );
+
+        // lookup_from requires read access
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+        assert_allowed(
+            &RecommendRequestInternal {
+                lookup_from: None,
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+    }
+
+    #[test]
+    fn test_scroll_request_internal() {
+        let op = PointRequestInternal {
+            ids: vec![PointIdType::NumId(12345)],
+            with_payload: None,
+            with_vector: WithVector::Bool(true),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .into(),
+        );
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+    }
+
+    #[test]
+    fn test_core_search_request() {
+        let op = CoreSearchRequest {
+            query: QueryEnum::Nearest(NamedVectorStruct::Default(vec![0.0, 1.0, 2.0])),
+            filter: None,
+            params: Some(SearchParams::default()),
+            limit: 100,
+            offset: 100,
+            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: Some(WithVector::Bool(true)),
+            score_threshold: Some(42.0),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+
+        assert_allowed_rewrite(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .into(),
+            |op| {
+                op.filter = Some(PayloadConstraint::new_test("col").to_filter());
+            },
+        );
+    }
+
+    #[test]
+    fn test_count_request_internal() {
+        let op = CountRequestInternal {
+            filter: None,
+            exact: false,
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+
+        assert_allowed_rewrite(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .into(),
+            |op| {
+                op.filter = Some(PayloadConstraint::new_test("col").to_filter());
+            },
+        );
+    }
+
+    #[test]
+    fn test_group_request_source() {
+        let op = GroupRequest {
+            // NOTE: SourceRequest::Recommend is already tested in test_recommend_request_internal
+            source: SourceRequest::Search(SearchRequestInternal {
+                vector: NamedVectorStruct::Default(vec![0.0, 1.0, 2.0]),
+                filter: None,
+                params: Some(SearchParams::default()),
+                limit: 100,
+                offset: Some(100),
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vector: Some(WithVector::Bool(true)),
+                score_threshold: Some(42.0),
+            }),
+            group_by: "path".parse().unwrap(),
+            group_size: 100,
+            limit: 100,
+            with_lookup: Some(WithLookup {
+                collection_name: "col2".to_string(),
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vectors: Some(WithVector::Bool(true)),
+            }),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .add("col2", false, true)
+                .into(),
+        );
+
+        // with_lookup requires whole read access
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .add("col", false, false)
+                .into(),
+        );
+        assert_allowed(
+            &GroupRequest {
+                with_lookup: None,
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+
+        // filter rewrite
+        assert_allowed_rewrite(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+            |op| match &mut op.source {
+                SourceRequest::Search(s) => {
+                    s.filter = Some(PayloadConstraint::new_test("col").to_filter());
+                }
+                SourceRequest::Recommend(_) => unreachable!(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_discover_request_internal() {
+        let op = DiscoverRequestInternal {
+            target: Some(RecommendExample::Dense(vec![0.0, 1.0, 2.0])),
+            context: Some(vec![ContextExamplePair {
+                positive: RecommendExample::Dense(vec![0.0, 1.0, 2.0]),
+                negative: RecommendExample::Dense(vec![0.0, 1.0, 2.0]),
+            }]),
+            filter: None,
+            params: Some(SearchParams::default()),
+            limit: 100,
+            offset: Some(100),
+            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: Some(WithVector::Bool(true)),
+            using: Some(UsingVector::Name("vector".to_string())),
+            lookup_from: Some(LookupLocation {
+                collection: "col2".to_string(),
+                vector: Some("vector".to_string()),
+                shard_key: None,
+            }),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .add("col2", false, true)
+                .into(),
+        );
+
+        assert_allowed_rewrite(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+            |op| {
+                op.filter = Some(PayloadConstraint::new_test("col").to_filter());
+            },
+        );
+
+        // Point ID is used
+        assert_forbidden(
+            &DiscoverRequestInternal {
+                target: Some(RecommendExample::PointId(ExtendedPointId::NumId(12345))),
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+        );
+        assert_forbidden(
+            &DiscoverRequestInternal {
+                context: Some(vec![ContextExamplePair {
+                    positive: RecommendExample::PointId(ExtendedPointId::NumId(12345)),
+                    negative: RecommendExample::Dense(vec![0.0, 1.0, 2.0]),
+                }]),
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+        );
+        assert_forbidden(
+            &DiscoverRequestInternal {
+                context: Some(vec![ContextExamplePair {
+                    positive: RecommendExample::Dense(vec![0.0, 1.0, 2.0]),
+                    negative: RecommendExample::PointId(ExtendedPointId::NumId(12345)),
+                }]),
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .add("col2", false, true)
+                .into(),
+        );
+
+        // lookup_from requires read access
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+        assert_allowed(
+            &DiscoverRequestInternal {
+                lookup_from: None,
+                ..op.clone()
+            },
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+    }
+
+    #[test]
+    fn check_test_scroll_request_internal() {
+        let op = ScrollRequestInternal {
+            offset: Some(ExtendedPointId::NumId(12345)),
+            limit: Some(100),
+            filter: None,
+            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: WithVector::Bool(true),
+            order_by: Some(OrderByInterface::Key("path".parse().unwrap())),
+        };
+
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Read));
+
+        assert_allowed(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+
+        assert_allowed_rewrite(
+            &ScrollRequestInternal { ..op.clone() },
+            &AccessCollectionBuilder::new()
+                .add("col", false, false)
+                .into(),
+            |op| {
+                op.filter = Some(PayloadConstraint::new_test("col").to_filter());
+            },
+        );
+    }
+
+    #[test]
+    fn test_collection_update_operations_upsert_points() {
+        let op1 = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsBatch(Batch {
+                ids: vec![ExtendedPointId::NumId(12345)],
+                vectors: BatchVectorStruct::Single(vec![vec![0.0, 1.0, 2.0]]),
+                payloads: None,
+            }),
+        ));
+
+        let op2 = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![PointStruct {
+                id: ExtendedPointId::NumId(12345),
+                vector: VectorStruct::Single(vec![0.0, 1.0, 2.0]),
+                payload: None,
+            }]),
+        ));
+
+        for op in &[op1, op2] {
+            assert_requires_whole_write_access(op);
+        }
+    }
+
+    #[test]
+    fn test_collection_update_operations_delete_points() {
+        let op1 = CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+            ids: vec![ExtendedPointId::NumId(12345)],
+        });
+        let op2 =
+            CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
+                make_filter_from_ids(vec![ExtendedPointId::NumId(12345)]),
+            ));
+
+        for op in &[op1, op2] {
+            assert_allowed(op, &Access::Global(GlobalAccessMode::Manage));
+            assert_forbidden(op, &Access::Global(GlobalAccessMode::Read));
+
+            assert_allowed(
+                op,
+                &AccessCollectionBuilder::new().add("col", true, true).into(),
+            );
+            assert_forbidden(
+                op,
+                &AccessCollectionBuilder::new()
+                    .add("col", false, true)
+                    .into(),
+            );
+
+            assert_allowed_rewrite(
+                op,
+                &AccessCollectionBuilder::new()
+                    .add("col", true, false)
+                    .into(),
+                |op| {
+                    *op = CollectionUpdateOperations::PointOperation(
+                        PointOperations::DeletePointsByFilter(
+                            make_filter_from_ids(vec![ExtendedPointId::NumId(12345)])
+                                .merge_owned(PayloadConstraint::new_test("col").to_filter()),
+                        ),
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn test_collection_update_operations_sync_points() {
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::SyncPoints(
+            PointSyncOperation {
+                from_id: None,
+                to_id: None,
+                points: Vec::new(),
+            },
+        ));
+
+        assert_requires_whole_write_access(&op);
+    }
+
+    #[test]
+    fn test_collection_update_operations_update_vectors() {
+        let op = CollectionUpdateOperations::VectorOperation(VectorOperations::UpdateVectors(
+            UpdateVectorsOp {
+                points: vec![PointVectors {
+                    id: ExtendedPointId::NumId(12345),
+                    vector: VectorStruct::Single(vec![0.0, 1.0, 2.0]),
+                }],
+            },
+        ));
+        assert_requires_whole_write_access(&op);
+    }
+
+    #[test]
+    fn test_collection_update_operations_delete_vectors() {
+        let op1 = CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
+            PointIdsList {
+                points: vec![ExtendedPointId::NumId(12345)],
+                shard_key: None,
+            },
+            vec!["vector".to_string()],
+        ));
+
+        let op2 =
+            CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectorsByFilter(
+                make_filter_from_ids(vec![ExtendedPointId::NumId(12345)]),
+                vec!["vector".to_string()],
+            ));
+
+        for op in &[op1, op2] {
+            assert_allowed(op, &Access::Global(GlobalAccessMode::Manage));
+            assert_forbidden(op, &Access::Global(GlobalAccessMode::Read));
+
+            assert_allowed(
+                op,
+                &AccessCollectionBuilder::new().add("col", true, true).into(),
+            );
+            assert_forbidden(
+                op,
+                &AccessCollectionBuilder::new()
+                    .add("col", false, true)
+                    .into(),
+            );
+
+            assert_allowed_rewrite(
+                op,
+                &AccessCollectionBuilder::new()
+                    .add("col", true, false)
+                    .into(),
+                |op| {
+                    *op = CollectionUpdateOperations::VectorOperation(
+                        VectorOperations::DeleteVectorsByFilter(
+                            make_filter_from_ids(vec![ExtendedPointId::NumId(12345)])
+                                .merge_owned(PayloadConstraint::new_test("col").to_filter()),
+                            vec!["vector".to_string()],
+                        ),
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn test_collection_update_operations_payload() {
+        let op1 = CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
+            points: vec![ExtendedPointId::NumId(12345)],
+        });
+
+        let op2 = CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayloadByFilter(
+            make_filter_from_ids(vec![ExtendedPointId::NumId(12345)]),
+        ));
+
+        let op3 = CollectionUpdateOperations::PayloadOperation(PayloadOps::OverwritePayload(
+            SetPayloadOp {
+                payload: Payload::default(),
+                points: Some(vec![ExtendedPointId::NumId(12345)]),
+                filter: None,
+                key: None,
+            },
+        ));
+
+        for op in &[op1, op2, op3] {
+            assert_requires_whole_write_access(op);
+        }
+    }
+
+    #[test]
+    fn test_collection_update_operations_field_index() {
+        let op = CollectionUpdateOperations::FieldIndexOperation(
+            FieldIndexOperations::CreateIndex(CreateIndex {
+                field_name: "path".parse().unwrap(),
+                field_schema: None,
+            }),
+        );
+        assert_allowed(&op, &Access::Global(GlobalAccessMode::Manage));
+        assert_forbidden(&op, &Access::Global(GlobalAccessMode::Read));
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new().add("col", true, true).into(),
+        );
+        assert_forbidden(
+            &op,
+            &AccessCollectionBuilder::new()
+                .add("col", false, true)
+                .into(),
+        );
+    }
+}

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -29,7 +29,7 @@ impl Access {
         collection_name: &'a str,
         op: &mut impl CheckableCollectionOperation,
     ) -> Result<CollectionPass<'a>, StorageError> {
-        let requirements = op.access_requrements();
+        let requirements = op.access_requirements();
         match self {
             Access::Global(mode) => mode.meets_requirements(requirements)?,
             Access::Collection(list) => {
@@ -76,7 +76,7 @@ impl Access {
 
 trait CheckableCollectionOperation {
     /// Used to distinguish whether the operation is read-only or read-write.
-    fn access_requrements(&self) -> AccessRequirements;
+    fn access_requirements(&self) -> AccessRequirements;
 
     fn check_access(
         &mut self,
@@ -123,7 +123,7 @@ impl<'a> CollectionAccessView<'a> {
 }
 
 impl CheckableCollectionOperation for RecommendRequestInternal {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -149,7 +149,7 @@ impl CheckableCollectionOperation for RecommendRequestInternal {
 }
 
 impl CheckableCollectionOperation for PointRequestInternal {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -167,7 +167,7 @@ impl CheckableCollectionOperation for PointRequestInternal {
 }
 
 impl CheckableCollectionOperation for CoreSearchRequest {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -186,7 +186,7 @@ impl CheckableCollectionOperation for CoreSearchRequest {
 }
 
 impl CheckableCollectionOperation for CountRequestInternal {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -205,7 +205,7 @@ impl CheckableCollectionOperation for CountRequestInternal {
 }
 
 impl CheckableCollectionOperation for GroupRequest {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -230,7 +230,7 @@ impl CheckableCollectionOperation for GroupRequest {
 }
 
 impl CheckableCollectionOperation for DiscoverRequestInternal {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -258,7 +258,7 @@ impl CheckableCollectionOperation for DiscoverRequestInternal {
 }
 
 impl CheckableCollectionOperation for ScrollRequestInternal {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         AccessRequirements {
             write: false,
             manage: false,
@@ -277,7 +277,7 @@ impl CheckableCollectionOperation for ScrollRequestInternal {
 }
 
 impl CheckableCollectionOperation for CollectionUpdateOperations {
-    fn access_requrements(&self) -> AccessRequirements {
+    fn access_requirements(&self) -> AccessRequirements {
         match self {
             CollectionUpdateOperations::PointOperation(_)
             | CollectionUpdateOperations::VectorOperation(_)


### PR DESCRIPTION
Tracked in #3777.

This PR adds units tests for operations check/rewrite rules.

Additionally this PR fixes a bug causing `payload` restriction to be ignored.