### PR TITLE
Use idiomatic Rust naming

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -699,10 +699,10 @@ impl<'s> SegmentHolder {
             // Base config on collection params
             Some(collection_params) => SegmentConfig {
                 vector_data: collection_params
-                    .into_base_vector_data()
+                    .to_base_vector_data()
                     .map_err(|err| OperationError::service_error(format!("Failed to source dense vector configuration from collection parameters: {err:?}")))?,
                 sparse_vector_data: collection_params
-                    .into_sparse_vector_data()
+                    .to_sparse_vector_data()
                     .map_err(|err| OperationError::service_error(format!("Failed to source sparse vector configuration from collection parameters: {err:?}")))?,
                 payload_storage_type: collection_params.payload_storage_type(),
             },

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -81,8 +81,8 @@ pub trait SegmentOptimizer {
     fn temp_segment(&self, save_version: bool) -> CollectionResult<LockedSegment> {
         let collection_params = self.collection_params();
         let config = SegmentConfig {
-            vector_data: collection_params.into_base_vector_data()?,
-            sparse_vector_data: collection_params.into_sparse_vector_data()?,
+            vector_data: collection_params.to_base_vector_data()?,
+            sparse_vector_data: collection_params.to_sparse_vector_data()?,
             payload_storage_type: if collection_params.on_disk_payload {
                 PayloadStorageType::OnDisk
             } else {
@@ -154,8 +154,8 @@ pub trait SegmentOptimizer {
         let threshold_is_on_disk = maximal_vector_store_size_bytes
             >= thresholds.memmap_threshold.saturating_mul(BYTES_IN_KB);
 
-        let mut vector_data = collection_params.into_base_vector_data()?;
-        let mut sparse_vector_data = collection_params.into_sparse_vector_data()?;
+        let mut vector_data = collection_params.to_base_vector_data()?;
+        let mut sparse_vector_data = collection_params.to_sparse_vector_data()?;
 
         // If indexing, change to HNSW index and quantization
         if threshold_is_indexed {

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -327,7 +327,7 @@ impl CollectionParams {
     ///
     /// It is the job of the segment optimizer to change this configuration with optimized settings
     /// based on threshold configurations.
-    pub fn into_base_vector_data(&self) -> CollectionResult<HashMap<String, VectorDataConfig>> {
+    pub fn to_base_vector_data(&self) -> CollectionResult<HashMap<String, VectorDataConfig>> {
         Ok(self
             .vectors
             .params_iter()
@@ -359,7 +359,7 @@ impl CollectionParams {
     ///
     /// It is the job of the segment optimizer to change this configuration with optimized settings
     /// based on threshold configurations.
-    pub fn into_sparse_vector_data(
+    pub fn to_sparse_vector_data(
         &self,
     ) -> CollectionResult<HashMap<String, SparseVectorDataConfig>> {
         if let Some(sparse_vectors) = &self.sparse_vectors {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -394,8 +394,8 @@ impl LocalShard {
         let mut segment_holder = SegmentHolder::default();
         let mut build_handlers = vec![];
 
-        let vector_params = config.params.into_base_vector_data()?;
-        let sparse_vector_params = config.params.into_sparse_vector_data()?;
+        let vector_params = config.params.to_base_vector_data()?;
+        let sparse_vector_params = config.params.to_sparse_vector_data()?;
         let segment_number = config.optimizer_config.get_number_segments();
 
         for _sid in 0..segment_number {


### PR DESCRIPTION
Rust rover is complaining that methods starting with `into_*` are by convention consuming their input.

This PR follows the naming convention and rename those methods