### PR TITLE
Bump Tokio 1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5575,9 +5575,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
-tokio = { version = "~1.36", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }
 tonic-reflection = "0.9.2"


### PR DESCRIPTION
Dependabot does not try to upgrade Tokio for some reason.

In this PR I bumped the version and remove the `~` as I suspect it might be the issue for Dependabot.