### PR TITLE
Decouple named vector struct

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -6324,7 +6324,7 @@
         ]
       },
       "NamedVector": {
-        "description": "Vector data with name",
+        "description": "Dense vector data with name",
         "type": "object",
         "required": [
           "name",

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -1,4 +1,5 @@
 use super::schema::{BatchVectorStruct, ScoredPoint, Vector, VectorStruct};
+use crate::rest::{DenseVector, NamedVectorStruct};
 
 impl From<segment::data_types::vectors::Vector> for Vector {
     fn from(value: segment::data_types::vectors::Vector) -> Self {
@@ -107,5 +108,49 @@ impl From<ScoredPoint> for segment::types::ScoredPoint {
             vector: value.vector.map(From::from),
             shard_key: value.shard_key,
         }
+    }
+}
+
+impl From<NamedVectorStruct> for segment::data_types::vectors::NamedVectorStruct {
+    fn from(value: NamedVectorStruct) -> Self {
+        match value {
+            NamedVectorStruct::Default(vector) => {
+                segment::data_types::vectors::NamedVectorStruct::Default(vector)
+            }
+            NamedVectorStruct::Dense(vector) => {
+                segment::data_types::vectors::NamedVectorStruct::Dense(vector)
+            }
+            NamedVectorStruct::Sparse(vector) => {
+                segment::data_types::vectors::NamedVectorStruct::Sparse(vector)
+            }
+        }
+    }
+}
+
+impl From<segment::data_types::vectors::NamedVectorStruct> for NamedVectorStruct {
+    fn from(value: segment::data_types::vectors::NamedVectorStruct) -> Self {
+        match value {
+            segment::data_types::vectors::NamedVectorStruct::Default(vector) => {
+                NamedVectorStruct::Default(vector)
+            }
+            segment::data_types::vectors::NamedVectorStruct::Dense(vector) => {
+                NamedVectorStruct::Dense(vector)
+            }
+            segment::data_types::vectors::NamedVectorStruct::Sparse(vector) => {
+                NamedVectorStruct::Sparse(vector)
+            }
+        }
+    }
+}
+
+impl From<DenseVector> for NamedVectorStruct {
+    fn from(v: DenseVector) -> Self {
+        NamedVectorStruct::Default(v)
+    }
+}
+
+impl From<segment::data_types::vectors::NamedVector> for NamedVectorStruct {
+    fn from(v: segment::data_types::vectors::NamedVector) -> Self {
+        NamedVectorStruct::Dense(v)
     }
 }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -139,6 +139,10 @@ impl From<segment::data_types::vectors::NamedVectorStruct> for NamedVectorStruct
             segment::data_types::vectors::NamedVectorStruct::Sparse(vector) => {
                 NamedVectorStruct::Sparse(vector)
             }
+            segment::data_types::vectors::NamedVectorStruct::MultiDense(_vector) => {
+                // TODO(colbert)
+                unimplemented!("MultiDense is not available in the API yet")
+            }
         }
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -116,7 +116,7 @@ pub struct Record {
 ///     "name": "image-embeddings"
 ///   }
 /// }
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum NamedVectorStruct {

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
+use segment::data_types::vectors::{NamedSparseVector, NamedVector};
 use serde::{Deserialize, Serialize};
 
 /// Type for dense vector
@@ -99,4 +100,13 @@ pub struct Record {
     /// Shard Key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<segment::types::ShardKey>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum NamedVectorStruct {
+    Default(segment::data_types::vectors::DenseVector),
+    Dense(NamedVector),
+    Sparse(NamedSparseVector),
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
-use segment::data_types::vectors::{NamedSparseVector, NamedVector};
 use serde::{Deserialize, Serialize};
 
 /// Type for dense vector
@@ -122,6 +121,6 @@ pub struct Record {
 #[serde(untagged)]
 pub enum NamedVectorStruct {
     Default(segment::data_types::vectors::DenseVector),
-    Dense(NamedVector),
-    Sparse(NamedSparseVector),
+    Dense(segment::data_types::vectors::NamedVector),
+    Sparse(segment::data_types::vectors::NamedSparseVector),
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -102,6 +102,21 @@ pub struct Record {
     pub shard_key: Option<segment::types::ShardKey>,
 }
 
+/// Vector data separator for named and unnamed modes
+/// Unnamed mode:
+///
+/// {
+///   "vector": [1.0, 2.0, 3.0]
+/// }
+///
+/// or named mode:
+///
+/// {
+///   "vector": {
+///     "vector": [1.0, 2.0, 3.0],
+///     "name": "image-embeddings"
+///   }
+/// }
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -1,6 +1,7 @@
 use validator::Validate;
 
 use super::schema::{BatchVectorStruct, Vector, VectorStruct};
+use crate::rest::NamedVectorStruct;
 
 impl Validate for VectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
@@ -27,6 +28,16 @@ impl Validate for Vector {
         match self {
             Vector::Dense(_) => Ok(()),
             Vector::Sparse(v) => v.validate(),
+        }
+    }
+}
+
+impl Validate for NamedVectorStruct {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            NamedVectorStruct::Default(_) => Ok(()),
+            NamedVectorStruct::Dense(_) => Ok(()),
+            NamedVectorStruct::Sparse(v) => v.validate(),
         }
     }
 }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -12,12 +12,13 @@ use api::grpc::qdrant::quantization_config_diff::Quantization;
 use api::grpc::qdrant::update_collection_cluster_setup_request::{
     Operation as ClusterOperationsPb, Operation,
 };
-use api::grpc::qdrant::{CreateShardKey, SearchPoints};
+use api::grpc::qdrant::CreateShardKey;
 use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::{OrderBy, StartFrom};
 use segment::data_types::vectors::{
-    BatchVectorStruct, Named, NamedQuery, Vector, VectorStruct, DEFAULT_VECTOR_NAME,
+    BatchVectorStruct, Named, NamedQuery, NamedVectorStruct, Vector, VectorStruct,
+    DEFAULT_VECTOR_NAME,
 };
 use segment::types::{DateTimeWrapper, Distance, QuantizationConfig, ScoredPoint};
 use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
@@ -951,7 +952,7 @@ impl From<CountResult> for api::grpc::qdrant::CountResult {
 impl TryFrom<api::grpc::qdrant::SearchPoints> for CoreSearchRequest {
     type Error = Status;
     fn try_from(value: api::grpc::qdrant::SearchPoints) -> Result<Self, Self::Error> {
-        let SearchPoints {
+        let api::grpc::qdrant::SearchPoints {
             collection_name: _,
             vector,
             filter,
@@ -994,7 +995,12 @@ impl TryFrom<api::grpc::qdrant::SearchPoints> for CoreSearchRequest {
 impl<'a> From<CollectionSearchRequest<'a>> for api::grpc::qdrant::SearchPoints {
     fn from(value: CollectionSearchRequest<'a>) -> Self {
         let (collection_id, request) = value.0;
-        let (vector, sparse_indices) = match request.vector.get_vector().to_owned() {
+        let named_vector = NamedVectorStruct::from(request.clone().vector);
+        let vector_name = match named_vector.get_name() {
+            DEFAULT_VECTOR_NAME => None,
+            vector_name => Some(vector_name.to_string()),
+        };
+        let (vector, sparse_indices) = match named_vector.to_vector() {
             Vector::Dense(vector) => (vector, None),
             Vector::Sparse(vector) => (
                 vector.values,
@@ -1017,10 +1023,7 @@ impl<'a> From<CollectionSearchRequest<'a>> for api::grpc::qdrant::SearchPoints {
             params: request.params.map(|sp| sp.into()),
             score_threshold: request.score_threshold,
             offset: request.offset.map(|x| x as u64),
-            vector_name: match request.vector.get_name() {
-                DEFAULT_VECTOR_NAME => None,
-                vector_name => Some(vector_name.to_string()),
-            },
+            vector_name,
             read_consistency: None,
             timeout: None,
             shard_key_selector: None,
@@ -1251,7 +1254,8 @@ impl TryFrom<api::grpc::qdrant::SearchPoints> for SearchRequestInternal {
                 value.vector_name,
                 value.vector,
                 value.sparse_indices,
-            )?,
+            )?
+            .into(),
             filter: value.filter.map(|f| f.try_into()).transpose()?,
             params: value.params.map(|p| p.into()),
             limit: value.limit as usize,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -379,7 +379,7 @@ pub struct SearchRequest {
 pub struct SearchRequestInternal {
     /// Look for vectors closest to this
     #[validate]
-    pub vector: NamedVectorStruct,
+    pub vector: api::rest::NamedVectorStruct,
     /// Look only for points which satisfies this conditions
     #[validate]
     pub filter: Option<Filter>,
@@ -490,7 +490,7 @@ pub struct SearchGroupsRequest {
 pub struct SearchGroupsRequestInternal {
     /// Look for vectors closest to this
     #[validate]
-    pub vector: NamedVectorStruct,
+    pub vector: api::rest::NamedVectorStruct,
 
     /// Look only for points which satisfies this conditions
     #[validate]
@@ -1772,7 +1772,7 @@ pub struct BaseGroupRequest {
 impl From<SearchRequestInternal> for CoreSearchRequest {
     fn from(request: SearchRequestInternal) -> Self {
         Self {
-            query: QueryEnum::Nearest(request.vector),
+            query: QueryEnum::Nearest(request.vector.into()),
             filter: request.filter,
             params: request.params,
             limit: request.limit,

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -77,7 +77,7 @@ fn validate_error_sparse_vector_points_list() {
 #[test]
 fn validate_error_sparse_vector_search_request_internal() {
     check_validation_error(SearchRequestInternal {
-        vector: wrong_named_vector_struct(),
+        vector: wrong_named_vector_struct().into(),
         filter: None,
         params: None,
         limit: 5,
@@ -91,7 +91,7 @@ fn validate_error_sparse_vector_search_request_internal() {
 #[test]
 fn validate_error_sparse_vector_search_groups_request_internal() {
     check_validation_error(SearchGroupsRequestInternal {
-        vector: wrong_named_vector_struct(),
+        vector: wrong_named_vector_struct().into(),
         filter: None,
         params: None,
         with_payload: None,

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -410,9 +410,7 @@ pub struct NamedSparseVector {
     pub vector: SparseVector,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum NamedVectorStruct {
     Default(DenseVector),
     Dense(NamedVector),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -69,6 +69,7 @@ impl From<NamedVectorStruct> for Vector {
             NamedVectorStruct::Default(v) => Vector::Dense(v),
             NamedVectorStruct::Dense(v) => Vector::Dense(v.vector),
             NamedVectorStruct::Sparse(v) => Vector::Sparse(v.vector),
+            NamedVectorStruct::MultiDense(v) => Vector::MultiDense(v.vector),
         }
     }
 }
@@ -388,6 +389,16 @@ pub struct NamedVector {
     pub vector: DenseVector,
 }
 
+/// MultiDense vector data with name
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct NamedMultiDenseVector {
+    /// Name of vector data
+    pub name: String,
+    /// Vector data
+    pub vector: MultiDenseVector,
+}
+
 /// Sparse vector data with name
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Validate, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -421,6 +432,7 @@ pub enum NamedVectorStruct {
     Default(DenseVector),
     Dense(NamedVector),
     Sparse(NamedSparseVector),
+    MultiDense(NamedMultiDenseVector),
 }
 
 impl From<DenseVector> for NamedVectorStruct {
@@ -451,6 +463,7 @@ impl Named for NamedVectorStruct {
             NamedVectorStruct::Default(_) => DEFAULT_VECTOR_NAME,
             NamedVectorStruct::Dense(v) => &v.name,
             NamedVectorStruct::Sparse(v) => &v.name,
+            NamedVectorStruct::MultiDense(v) => &v.name,
         }
     }
 }
@@ -460,9 +473,8 @@ impl NamedVectorStruct {
         match vector {
             Vector::Dense(vector) => NamedVectorStruct::Dense(NamedVector { name, vector }),
             Vector::Sparse(vector) => NamedVectorStruct::Sparse(NamedSparseVector { name, vector }),
-            Vector::MultiDense(_) => {
-                // TODO(colbert)
-                unimplemented!("MultiDenseVector cannot be converted to NamedVectorStruct")
+            Vector::MultiDense(vector) => {
+                NamedVectorStruct::MultiDense(NamedMultiDenseVector { name, vector })
             }
         }
     }
@@ -472,6 +484,7 @@ impl NamedVectorStruct {
             NamedVectorStruct::Default(v) => v.as_slice().into(),
             NamedVectorStruct::Dense(v) => v.vector.as_slice().into(),
             NamedVectorStruct::Sparse(v) => (&v.vector).into(),
+            NamedVectorStruct::MultiDense(v) => (&v.vector).into(),
         }
     }
 
@@ -480,6 +493,7 @@ impl NamedVectorStruct {
             NamedVectorStruct::Default(v) => v.into(),
             NamedVectorStruct::Dense(v) => v.vector.into(),
             NamedVectorStruct::Sparse(v) => v.vector.into(),
+            NamedVectorStruct::MultiDense(v) => v.vector.into(),
         }
     }
 }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -378,8 +378,8 @@ impl VectorStruct {
     }
 }
 
-/// Vector data with name
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+/// Dense vector data with name
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct NamedVector {
     /// Name of vector data
@@ -414,7 +414,7 @@ pub struct NamedSparseVector {
 ///     "name": "image-embeddings"
 ///   }
 /// }
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 pub enum NamedVectorStruct {
@@ -480,16 +480,6 @@ impl NamedVectorStruct {
             NamedVectorStruct::Default(v) => v.into(),
             NamedVectorStruct::Dense(v) => v.vector.into(),
             NamedVectorStruct::Sparse(v) => v.vector.into(),
-        }
-    }
-}
-
-impl Validate for NamedVectorStruct {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            NamedVectorStruct::Default(_) => Ok(()),
-            NamedVectorStruct::Dense(_) => Ok(()),
-            NamedVectorStruct::Sparse(v) => v.validate(),
         }
     }
 }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -410,21 +410,6 @@ pub struct NamedSparseVector {
     pub vector: SparseVector,
 }
 
-/// Vector data separator for named and unnamed modes
-/// Unnamed mode:
-///
-/// {
-///   "vector": [1.0, 2.0, 3.0]
-/// }
-///
-/// or named mode:
-///
-/// {
-///   "vector": {
-///     "vector": [1.0, 2.0, 3.0],
-///     "name": "image-embeddings"
-///   }
-/// }
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -380,7 +380,7 @@ impl VectorStruct {
 }
 
 /// Dense vector data with name
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct NamedVector {
     /// Name of vector data
@@ -390,8 +390,7 @@ pub struct NamedVector {
 }
 
 /// MultiDense vector data with name
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NamedMultiDenseVector {
     /// Name of vector data
     pub name: String,
@@ -410,7 +409,7 @@ pub struct NamedSparseVector {
     pub vector: SparseVector,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum NamedVectorStruct {
     Default(DenseVector),
     Dense(NamedVector),

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -778,7 +778,7 @@ mod tests_ops {
         let op = GroupRequest {
             // NOTE: SourceRequest::Recommend is already tested in test_recommend_request_internal
             source: SourceRequest::Search(SearchRequestInternal {
-                vector: NamedVectorStruct::Default(vec![0.0, 1.0, 2.0]),
+                vector: NamedVectorStruct::Default(vec![0.0, 1.0, 2.0]).into(),
                 filter: None,
                 params: Some(SearchParams::default()),
                 limit: 100,


### PR DESCRIPTION
This PR decouples the `NamedVectorStruct` segment type from the API.

A new REST only type is introduced with the necessary conversions.
