### PR TITLE
Update docs to mention safer production practices

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,4 +1,4 @@
-# Quick Start for Production
+# Quick Start
 
 This example covers the most basic use-case - collection creation and basic vector search.
 For additional information please refer to the [API documentation](https://qdrant.github.io/qdrant/redoc/index.html).
@@ -30,13 +30,16 @@ And once you need a fine-grained setup, you can also define a storage path and c
 ```bash
 docker run -p 6333:6333 \
     -v $(pwd)/path/to/data:/qdrant/storage \
+    -v $(pwd)/path/to/snapshots:/qdrant/snapshots \
     -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
     qdrant/qdrant
 ```
 
-- `/qdrant/storage` - is a place where Qdrant persists all your data.
+- `/qdrant/storage` - is the place where Qdrant persists all your data.
   Make sure to mount it as a volume, otherwise docker will drop it with the container.
-- `/qdrant/config/production.yaml` - is the file with engine configuration. You can override any value from the [reference config](https://github.com/qdrant/qdrant/blob/master/config/config.yaml)
+- `/qdrant/snapshots` - is the place where Qdrant stores [snapshots](https://qdrant.tech/documentation/concepts/snapshots/)
+- `/qdrant/config/production.yaml` - is the file with engine configuration. You can override any value from the [reference config](https://github.com/qdrant/qdrant/blob/master/config/config.yaml). In a real production environment, you should enable authentication by setting `service.apiKey`.
+- For production environments, consider also setting [`--read-only`](https://docs.docker.com/reference/cli/docker/container/run/#read-only) and `--user=1000:2000` to further secure your Qdrant instance. Or use [our Helm chart](https://github.com/qdrant/qdrant-helm) or [Qdrant Cloud](https://qdrant.tech/documentation/cloud/) which sets these by default.
 
 Now Qdrant should be accessible at [localhost:6333](http://localhost:6333/).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ client = QdrantClient(path="path/to/db")  # Persists changes to disk, fast proto
 
 ### Client-Server
 
-This is the recommended method for production usage. To run the container, use the command:
+To run the container, use the command:
 
 ```bash
 docker run -p 6333:6333 qdrant/qdrant
@@ -59,7 +59,7 @@ docker run -p 6333:6333 qdrant/qdrant
 Now you can connect to this with any client, including Python:
 
 ```python
-qdrant = QdrantClient("http://localhost:6333") # Connect to existing Qdrant instance, for production
+qdrant = QdrantClient("http://localhost:6333") # Connect to existing Qdrant instance
 ```
 
 ### Clients
@@ -204,7 +204,7 @@ Qdrant offers comprehensive horizontal scaling support through two key mechanism
 * **Query Planning and Payload Indexes** - leverages stored payload information to optimize query execution strategy.
 * **SIMD Hardware Acceleration** - utilizes modern CPU x86-x64 and Neon architectures to deliver better performance.
 * **Async I/O** - uses `io_uring` to maximize disk throughput utilization even on a network-attached storage.
-* **Write-Ahead Logging** - ensures data persistence with update confirmation, even during power outages. 
+* **Write-Ahead Logging** - ensures data persistence with update confirmation, even during power outages.
 
 
 # Integrations

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ client = QdrantClient(path="path/to/db")  # Persists changes to disk, fast proto
 
 ### Client-Server
 
-To run the container, use the command:
+To experience the full power of Qdrant locally, run the container with this command:
 
 ```bash
 docker run -p 6333:6333 qdrant/qdrant
@@ -61,6 +61,8 @@ Now you can connect to this with any client, including Python:
 ```python
 qdrant = QdrantClient("http://localhost:6333") # Connect to existing Qdrant instance
 ```
+
+Before deploying Qdrant to production, be sure to read our [installation](https://qdrant.tech/documentation/guides/installation/) and [security](https://qdrant.tech/documentation/guides/security/) guides.
 
 ### Clients
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,12 +29,14 @@ And once you need a fine-grained setup, you can also define a storage path and c
 ```bash
 docker run -p 6333:6333 \
     -v $(pwd)/path/to/data:/qdrant/storage \
+    -v $(pwd)/path/to/snapshots:/qdrant/snapshots \
     -v $(pwd)/path/to/custom_config.yaml:/qdrant/config/production.yaml \
     qdrant/qdrant
 ```
 
-* `/qdrant/storage` - is a place where Qdrant persists all your data.
+* `/qdrant/storage` - is the place where Qdrant persists all your data.
 Make sure to mount it as a volume, otherwise docker will drop it with the container.
+- `/qdrant/snapshots` - is the place where Qdrant stores [snapshots](https://qdrant.tech/documentation/concepts/snapshots/)
 * `/qdrant/config/production.yaml` - is the file with engine configuration. You can override any value from the [reference config](https://github.com/qdrant/qdrant/blob/master/config/config.yaml)
 
 Now Qdrant should be accessible at [localhost:6333](http://localhost:6333/).


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


Currently, the docs refer to unauthenticated instances of Qdrant as "for production" when we actually discourage that: https://qdrant.tech/documentation/guides/security/

So in the README and QUICK_START guides, I've removed those mentions of "production" and instead included mentions of safer ways to run Qdrant in production.