### PR TITLE
Do do not delete data of concurrent collection creation

### DIFF
--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -159,6 +159,7 @@ impl TableOfContent {
         &self,
         collection_name: &str,
     ) -> Result<bool, StorageError> {
+        let _collection_create_guard = self.collection_create_lock.lock().await;
         if let Some(removed) = self.collections.write().await.remove(collection_name) {
             self.alias_persistence
                 .write()
@@ -192,6 +193,8 @@ impl TableOfContent {
             });
             Ok(true)
         } else {
+            // we hold the collection_create lock to make sure no one is creating this collection
+            // otherwise we would delete its content now
             let path = self.get_collection_path(collection_name);
             if path.exists() {
                 log::warn!(


### PR DESCRIPTION
This PR makes sure a collection deletion command cannot delete the storage of an ongoing collection create command.

Without this a user gets:

```
2024-04-12T14:23:49.535595Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.539590Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.539708Z  INFO storage::content_manager::toc::collection_meta_ops: Creating collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.545063Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.547703Z  WARN storage::content_manager::toc::collection_meta_ops: Collection collection-concurrent-lifecycle-drill is not loaded, but its directory still exists. Deleting it.
2024-04-12T14:23:49.551097Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.551797Z  WARN storage::content_manager::toc::collection_meta_ops: Collection collection-concurrent-lifecycle-drill is not loaded, but its directory still exists. Deleting it.
2024-04-12T14:23:49.559417Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.562969Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.565757Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.568542Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.580293Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.583675Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.589647Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.592288Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.594344Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.596662Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.601491Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.603728Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.605679Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.608223Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.610204Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.613679Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.617022Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.618754Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.620634Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.626543Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.629434Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection collection-concurrent-lifecycle-drill
2024-04-12T14:23:49.632377Z ERROR qdrant::tonic::logging: gRPC /qdrant.Collections/Create unexpectedly failed with Internal error "Service internal error: RocksDB open error: IO error: No such file or directory: While mkdir if missing: ./storage/collections/collection-concurrent-lifecycle-drill/0/segments/2f0677a0-c921-4a1f-a107-3691dc8f599f: No such file or directory" 0.093049
```

Found with coach `cargo run -r -- --drills-to-run collection_concurrent_lifecycle`.