### PR TITLE
Support for an HTTP publish port

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -166,6 +166,9 @@ service:
   # HTTP(S) port to bind the service on
   http_port: 6333
 
+  # HTTP(S) port to publish to the world
+  http_publish_port: 6333
+
   # gRPC port to bind the service on.
   # If `null` - gRPC is disabled. Default: null
   # Comment to disable gRPC:
@@ -193,7 +196,7 @@ service:
   #
   # Uncomment to enable.
   # api_key: your_secret_api_key_here
-   
+
   # Set an api-key for read-only operations.
   # If set, all requests must include a header with the api-key.
   # example header: `api-key: <API-KEY>`

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,6 +3,8 @@ log_level: DEBUG
 service:
   host: 127.0.0.1
   http_port: 6333
+  # Uncomment to set a separate publish port
+  #http_publish_port: 6333
   # Uncomment to enable gRPC:
   #grpc_port: 6334
   #api_key: your_secret_api_key_here

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -3,5 +3,7 @@ log_level: INFO
 service:
   host: 0.0.0.0
   http_port: 6333
+  # Uncomment to set a separate publish port
+  #http_publish_port: 6333
   # Uncomment to enable gRPC:
   #grpc_port: 6334

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1194,7 +1194,12 @@ mod tests {
             update_runtime,
             general_runtime,
             CpuBudget::default(),
-            ChannelService::new(settings.service.http_port),
+            ChannelService::new(
+                settings
+                    .service
+                    .http_publish_port
+                    .expect("Publish port not set (should default to http_port)."),
+            ),
             persistent_state.this_peer_id(),
             Some(operation_sender.clone()),
         );

--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -109,7 +109,7 @@ pub fn welcome(settings: &Settings) {
         } else {
             &settings.service.host
         },
-        settings.service.http_port
+        settings.service.http_publish_port.expect("Publish port not set (should default to http_port).")
     );
 
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,12 @@ fn main() -> anyhow::Result<()> {
 
     // Channel service is used to manage connections between peers.
     // It allocates required number of channels and manages proper reconnection handling
-    let mut channel_service = ChannelService::new(settings.service.http_port);
+    let mut channel_service = ChannelService::new(
+        settings
+            .service
+            .http_publish_port
+            .expect("Publish port not set (should default to http_port)"),
+    );
 
     if is_distributed_deployment {
         // We only need channel_service in case if cluster is enabled.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,7 +16,9 @@ pub struct ServiceConfig {
     #[validate(length(min = 1))]
     pub host: String,
     pub http_port: u16,
+    pub http_publish_port: Option<u16>,
     pub grpc_port: Option<u16>, // None means that gRPC is disabled
+    // grpc is not currently used for any internal communication (p2p is), so there is no publish port.
     pub max_request_size_mb: usize,
     pub max_workers: Option<usize>,
     #[serde(default = "default_cors")]
@@ -274,6 +276,13 @@ impl Settings {
         // Build and merge config and deserialize into Settings, attach any load errors we had
         let mut settings: Settings = config.build()?.try_deserialize()?;
         settings.load_errors.extend(load_errors);
+
+        // Set any defaults that are based on other values.
+        settings.service.http_publish_port = settings
+            .service
+            .http_publish_port
+            .or(Some(settings.service.http_port));
+
         Ok(settings)
     }
 }


### PR DESCRIPTION
When running Qdrant inside an orchestrator, the port published for clients to connect to a peer can be different than the host port bound to, i.e. `docker run -p 26333:6333`. 

Before v1.7.0 and shard snapshot transfers, this was fine, because Qdrant never referenced its own HTTP port towards itself. However, [shard snapshot transfers refer to a peers own port](https://github.com/qdrant/qdrant/blob/v1.8.4/lib/collection/src/shards/transfer/snapshot.rs#L174) when transferring data to another snapshot, so without a publish port a remote shard is unable to be transferred.

A gRPC port is not needed as of now because a node never references its own gRPC server. p2p is not needed because nodes connect to each other using --uri, which simply contains the published p2p port.

I've tested this PR to confirm replication still works with and without the published port.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --all --all-features` command?