### PR TITLE
Fix multivector flaky tests

### DIFF
--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -94,9 +94,9 @@ fn random_multi_vec_query<R: Rng + ?Sized>(
 /// Check all cases with single vector per multi and several vectors per multi
 #[rstest]
 #[case::nearest_eq(QueryVariant::Nearest, 1, 32, 5)]
-#[case::nearest_multi(QueryVariant::Nearest, 3, 32, 20)]
+#[case::nearest_multi(QueryVariant::Nearest, 3, 64, 20)]
 #[case::discovery_eq(QueryVariant::Discovery, 1, 128, 5)]
-#[case::discovery_multi(QueryVariant::Discovery, 3, 128, 10)]
+#[case::discovery_multi(QueryVariant::Discovery, 3, 128, 20)]
 #[case::recommend_eq(QueryVariant::RecommendBestScore, 1, 64, 5)]
 #[case::recommend_multi(QueryVariant::RecommendBestScore, 2, 64, 10)]
 fn test_multi_filterable_hnsw(
@@ -265,7 +265,7 @@ fn test_multi_filterable_hnsw(
     }
     assert!(
         attempts - hits <= max_failures,
-        "hits: {hits} of {attempts}"
+        "hits: {hits}/{attempts} (expected less than {max_failures} failures)"
     ); // Not more than X% failures
     eprintln!("hits = {hits:#?} out of {attempts}");
 }


### PR DESCRIPTION
This PR relaxes the accuracy constraint to fix the following flaky tests.

- https://github.com/qdrant/qdrant/issues/3997
- https://github.com/qdrant/qdrant/issues/4022
