### PR TITLE
Median based TopK for sparse vectors scoring

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -3,5 +3,6 @@ pub mod defaults;
 pub mod fixed_length_priority_queue;
 pub mod math;
 pub mod panic;
+pub mod top_k;
 pub mod types;
 pub mod validation;

--- a/lib/common/common/src/top_k.rs
+++ b/lib/common/common/src/top_k.rs
@@ -1,0 +1,151 @@
+use std::cmp::Reverse;
+
+use ordered_float::Float;
+
+use crate::types::{ScoreType, ScoredPointOffset};
+
+/// TopK implementation following the median algorithm described in
+/// https://quickwit.io/blog/top-k-complexity
+///
+/// Keeps the largest `k` ScoredPointOffset.
+#[derive(Default)]
+pub struct TopK {
+    k: usize,
+    elements: Vec<Reverse<ScoredPointOffset>>,
+    threshold: ScoreType,
+}
+
+impl TopK {
+    pub fn new(k: usize) -> Self {
+        TopK {
+            k,
+            elements: Vec::with_capacity(2 * k),
+            threshold: ScoreType::min_value(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns the minimum score of the top k elements.
+    ///
+    /// Updated every 2k elements.
+    /// Initially set to `ScoreType::MIN`.
+    pub fn threshold(&self) -> ScoreType {
+        self.threshold
+    }
+
+    pub fn push(&mut self, element: ScoredPointOffset) {
+        if element.score > self.threshold {
+            self.elements.push(Reverse(element));
+            // check if full
+            if self.elements.len() == self.k * 2 {
+                let (_, median_el, _) = self.elements.select_nth_unstable(self.k - 1);
+                self.threshold = median_el.0.score;
+                self.elements.truncate(self.k);
+            }
+        }
+    }
+
+    pub fn into_vec(mut self) -> Vec<ScoredPointOffset> {
+        self.elements.sort_unstable();
+        self.elements.truncate(self.k);
+        self.elements.into_iter().map(|Reverse(x)| x).collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_with_double_capacity() {
+        let top_k = TopK::new(3);
+        assert_eq!(top_k.len(), 0);
+        assert_eq!(top_k.elements.capacity(), 2 * 3);
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+    }
+
+    #[test]
+    fn test_top_k_under() {
+        let mut top_k = TopK::new(3);
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 1);
+
+        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 2);
+
+        let res = top_k.into_vec();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].score, 2.0);
+        assert_eq!(res[1].score, 1.0);
+    }
+
+    #[test]
+    fn test_top_k_over() {
+        let mut top_k = TopK::new(3);
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
+        assert_eq!(top_k.len(), 1);
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+
+        top_k.push(ScoredPointOffset { score: 3.0, idx: 3 });
+        assert_eq!(top_k.len(), 2);
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+
+        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(top_k.len(), 3);
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+
+        top_k.push(ScoredPointOffset { score: 4.0, idx: 4 });
+        assert_eq!(top_k.len(), 4);
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+
+        let res = top_k.into_vec();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0].score, 4.0);
+        assert_eq!(res[1].score, 3.0);
+        assert_eq!(res[2].score, 2.0);
+    }
+
+    #[test]
+    fn test_top_k_pruned() {
+        let mut top_k = TopK::new(3);
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 1);
+
+        top_k.push(ScoredPointOffset { score: 4.0, idx: 4 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 2);
+
+        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 3);
+
+        top_k.push(ScoredPointOffset { score: 5.0, idx: 5 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 4);
+
+        top_k.push(ScoredPointOffset { score: 3.0, idx: 3 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 5);
+
+        top_k.push(ScoredPointOffset { score: 6.0, idx: 6 });
+        assert_eq!(top_k.threshold(), 4.0);
+        assert_eq!(top_k.len(), 3);
+        assert_eq!(top_k.elements.capacity(), 6);
+
+        let res = top_k.into_vec();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0].score, 6.0);
+        assert_eq!(res[1].score, 5.0);
+        assert_eq!(res[2].score, 4.0);
+    }
+}

--- a/lib/common/common/src/top_k.rs
+++ b/lib/common/common/src/top_k.rs
@@ -148,4 +148,39 @@ mod test {
         assert_eq!(res[1].score, 5.0);
         assert_eq!(res[2].score, 4.0);
     }
+
+    #[test]
+    fn test_top_same_scores() {
+        let mut top_k = TopK::new(3);
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 1);
+
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 4 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 2);
+
+        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 3);
+
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 5 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 4);
+
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 3 });
+        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 5);
+
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 6 });
+        assert_eq!(top_k.threshold(), 1.0);
+        assert_eq!(top_k.len(), 3);
+        assert_eq!(top_k.elements.capacity(), 6);
+
+        let res = top_k.into_vec();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0], ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(res[1], ScoredPointOffset { score: 1.0, idx: 1 });
+        assert_eq!(res[2], ScoredPointOffset { score: 1.0, idx: 4 });
+    }
 }

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -123,7 +123,12 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
                 .filter(|s| s.score != 0.0)
                 .zip(no_filter_result.iter().filter(|s| s.score != 0.0))
             {
-                assert_eq!(filter_result, no_filter_result);
+                if filter_result.idx != no_filter_result.idx {
+                    // we do not break ties when identical scores
+                    assert_eq!(filter_result.score, no_filter_result.score);
+                } else {
+                    assert_eq!(filter_result, no_filter_result);
+                }
             }
         }
     }


### PR DESCRIPTION
Experiment median TopK based on the article from the nice folks at Quickwit https://quickwit.io/blog/top-k-complexity.


# Performance

## Criterion 

```
sparse-vector-search-group/inverted-index-search
                        time:   [566.19 µs 575.56 µs 584.71 µs]
                        change: [-9.0722% -7.3381% -5.5563%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## End to end

Running https://github.com/qdrant/sparse-vectors-benchmark with full dataset

```
DEV
min: 72.6 millis
50p: 157.3 millis
95p: 210.72 millis
99p: 235.89 millis
999p: 261.57 millis
max: 338.19 millis
```

```
PR
min: 62.32 millis
50p: 148.66 millis
95p: 197.56 millis
99p: 222.33 millis
999p: 246.36 millis
max: 273.89 millis
```

# Validation

- checked congruence tests
- checked ground truth values in benchmarks

# Concerns

We might want to constraint the `limit` argument in search to avoid having someone reserving a huge amount of memory?