### PR TITLE
RBAC: Make read-only api key behave the same as global read-only token

### DIFF
--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use actix_web::body::{BoxBody, EitherBody};
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::Method;
-use actix_web::{Error, FromRequest, HttpMessage as _, HttpResponse, ResponseError};
+use actix_web::{Error, FromRequest, HttpMessage, HttpResponse, ResponseError};
 use futures_util::future::LocalBoxFuture;
 use storage::rbac::Access;
 

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -109,7 +109,6 @@ impl AuthKeys {
             return Ok(access);
         }
 
-        // Err("Invalid API key or JWT".to_string())
         Err(AuthError::Unauthorized(
             "Invalid API key or JWT".to_string(),
         ))

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -14,10 +14,14 @@ use crate::common::strings::ct_eq;
 type Request = tonic::codegen::http::Request<tonic::transport::Body>;
 type Response = tonic::codegen::http::Response<BoxBody>;
 
-const READ_ONLY_RPC_PATHS: [&str; 14] = [
+const READ_ONLY_RPC_PATHS: [&str; 22] = [
+    "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
     "/qdrant.Collections/CollectionExists",
     "/qdrant.Collections/List",
     "/qdrant.Collections/Get",
+    "/qdrant.Collections/ListCollectionAliases",
+    "/qdrant.Collections/ListAliases",
+    "/qdrant.Collections/CollectionClusterInfo",
     "/qdrant.Points/Scroll",
     "/qdrant.Points/Get",
     "/qdrant.Points/Count",
@@ -29,6 +33,10 @@ const READ_ONLY_RPC_PATHS: [&str; 14] = [
     "/qdrant.Points/RecommendBatch",
     "/qdrant.Points/Discover",
     "/qdrant.Points/DiscoverBatch",
+    "/qdrant.Snapshots/List",
+    "/qdrant.Snapshots/ListFull",
+    "/qdrant.Qdrant/HealthCheck",
+    "/grpc.health.v1.Health/Check",
 ];
 
 #[derive(Clone)]

--- a/tests/consensus_tests/auth_tests/conftest.py
+++ b/tests/consensus_tests/auth_tests/conftest.py
@@ -9,6 +9,7 @@ def jwt_cluster(tmp_path_factory: pytest.TempPathFactory):
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_jwt_protected_cluster(tmp_path)
 
-    yield peer_api_uris, peer_dirs, bootstrap_uri
-
-    kill_all_processes()
+    try:
+        yield peer_api_uris, peer_dirs, bootstrap_uri
+    finally:
+        kill_all_processes()

--- a/tests/consensus_tests/auth_tests/utils.py
+++ b/tests/consensus_tests/auth_tests/utils.py
@@ -10,13 +10,17 @@ GRPC_URI = f"127.0.0.1:{PORT_SEED + 1}"
 
 SECRET = "my_top_secret_key"
 
+READ_ONLY_API_KEY = "boo-hoo, this can only read!"
+
 API_KEY_HEADERS = {"Api-Key": SECRET}
 API_KEY_METADATA = [("api-key", SECRET)]
+READ_ONLY_API_KEY_METADATA = [("api-key", READ_ONLY_API_KEY)]
 
 
 def start_jwt_protected_cluster(tmp_path, num_peers=1):
     extra_env = {
         "QDRANT__SERVICE__API_KEY": SECRET,
+        "QDRANT__SERVICE__READ_ONLY_API_KEY": READ_ONLY_API_KEY,
         "QDRANT__SERVICE__JWT_RBAC": "true",
         "QDRANT__STORAGE__WAL__WAL_CAPACITY_MB": "1",  # to speed up snapshot tests
     }


### PR DESCRIPTION
Tracked by #3777 

There were some endpoints in gRPC, which were not allowed by read-only api key, but allowed by the global `read` access token. 

With this we make them behave the same, and we get prepared to remove the `is_read_only` implementation entirely which can be substituted it with an Access struct

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
