### PR TITLE
Fix average sparse vector recommendation

### DIFF
--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -46,7 +46,7 @@ fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionRe
             }
             VectorRef::Sparse(vector) => {
                 sparse_count += 1;
-                avg_sparse.combine_aggregate(vector, |v1, v2| v1 + v2);
+                avg_sparse = vector.combine_aggregate(&avg_sparse, |v1, v2| v1 + v2);
             }
             VectorRef::MultiDense(_) => {
                 // TODO(colbert)
@@ -90,12 +90,11 @@ fn merge_positive_and_negative_avg(positive: Vector, negative: Vector) -> Collec
                 .zip(negative.iter())
                 .map(|(pos, neg)| pos + pos - neg)
                 .collect();
-            Ok(Vector::from(vector))
+            Ok(vector.into())
         }
-        (Vector::Sparse(mut positive), Vector::Sparse(negative)) => {
-            positive.combine_aggregate(&negative, |pos, neg| pos + pos - neg);
-            Ok(Vector::from(positive))
-        },
+        (Vector::Sparse(positive), Vector::Sparse(negative)) => Ok(positive
+            .combine_aggregate(&negative, |pos, neg| pos + pos - neg)
+            .into()),
         _ => Err(CollectionError::bad_input(
             "Positive and negative vectors should be of the same type, either all dense or all sparse".to_owned(),
         )),

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use segment::data_types::vectors::{
-    DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType, VectorRef,
-    DEFAULT_VECTOR_NAME,
+    DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType, DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
@@ -16,8 +15,7 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
-    convert_to_vectors, convert_to_vectors_owned, resolve_referenced_vectors_batch,
-    ReferencedVectors,
+    convert_to_vectors_owned, resolve_referenced_vectors_batch, ReferencedVectors,
 };
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
@@ -27,14 +25,14 @@ use crate::operations::types::{
     RecommendRequestInternal, RecommendStrategy, UsingVector,
 };
 
-fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionResult<Vector> {
+fn avg_vectors(mut vectors: Vec<Vector>) -> CollectionResult<Vector> {
     let mut avg_dense = DenseVector::default();
     let mut avg_sparse = SparseVector::default();
     let mut dense_count = 0;
     let mut sparse_count = 0;
-    for vector in vectors {
+    for vector in vectors.iter_mut() {
         match vector {
-            VectorRef::Dense(vector) => {
+            Vector::Dense(vector) => {
                 dense_count += 1;
                 for i in 0..vector.len() {
                     if i >= avg_dense.len() {
@@ -44,11 +42,13 @@ fn avg_vectors<'a>(vectors: impl Iterator<Item = VectorRef<'a>>) -> CollectionRe
                     }
                 }
             }
-            VectorRef::Sparse(vector) => {
+            Vector::Sparse(vector) => {
                 sparse_count += 1;
+                // sort input vector
+                vector.sort_by_indices();
                 avg_sparse = vector.combine_aggregate(&avg_sparse, |v1, v2| v1 + v2);
             }
-            VectorRef::MultiDense(_) => {
+            Vector::MultiDense(_) => {
                 // TODO(colbert)
                 return Err(CollectionError::bad_input(
                     "MultiDenseVector is not supported".to_owned(),
@@ -290,15 +290,15 @@ fn recommend_by_avg_vector(
 
     let lookup_collection_name = lookup_from.as_ref().map(|x| &x.collection);
 
-    let positive_vectors = convert_to_vectors(
-        positive.iter(),
+    let positive_vectors = convert_to_vectors_owned(
+        positive,
         all_vectors_records_map,
         &lookup_vector_name,
         lookup_collection_name,
     );
 
-    let negative_vectors = convert_to_vectors(
-        negative.iter(),
+    let negative_vectors = convert_to_vectors_owned(
+        negative,
         all_vectors_records_map,
         &lookup_vector_name,
         lookup_collection_name,
@@ -310,12 +310,11 @@ fn recommend_by_avg_vector(
     };
 
     let avg_positive = avg_vectors(positive_vectors)?;
-    let negative = negative_vectors.collect_vec();
 
-    let search_vector = if negative.is_empty() {
+    let search_vector = if negative_vectors.is_empty() {
         avg_positive
     } else {
-        let avg_negative = avg_vectors(negative.into_iter())?;
+        let avg_negative = avg_vectors(negative_vectors)?;
         merge_positive_and_negative_avg(avg_positive, avg_negative)?
     };
 
@@ -407,7 +406,7 @@ fn recommend_by_best_score(
 
 #[cfg(test)]
 mod tests {
-    use segment::data_types::vectors::{Vector, VectorRef};
+    use segment::data_types::vectors::Vector;
     use sparse::common::sparse_vector::SparseVector;
 
     use super::avg_vectors;
@@ -419,10 +418,7 @@ mod tests {
             vec![1.0, 2.0, 3.0].into(),
             vec![1.0, 2.0, 3.0].into(),
         ];
-        assert_eq!(
-            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
-            vec![1.0, 2.0, 3.0].into(),
-        );
+        assert_eq!(avg_vectors(vectors).unwrap(), vec![1.0, 2.0, 3.0].into(),);
 
         let vectors: Vec<Vector> = vec![
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
@@ -433,18 +429,35 @@ mod tests {
                 .into(),
         ];
         assert_eq!(
-            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
+            avg_vectors(vectors).unwrap(),
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.55, 1.1])
                 .unwrap()
                 .into(),
         );
 
+        // "Can't average dense and sparse vectors together"
         let vectors: Vec<Vector> = vec![
             vec![1.0, 2.0, 3.0].into(),
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
                 .unwrap()
                 .into(),
         ];
-        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
+        assert!(avg_vectors(vectors).is_err());
+
+        // check that it handles non-sorted sparse vectors
+        let non_sorted_vectors: Vec<Vector> = vec![
+            SparseVector::new(vec![1, 0, 2], vec![0.1, 0.0, 0.2])
+                .unwrap()
+                .into(),
+            SparseVector::new(vec![0, 2, 1], vec![0.0, 2.0, 1.0])
+                .unwrap()
+                .into(),
+        ];
+        assert_eq!(
+            avg_vectors(non_sorted_vectors).unwrap(),
+            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.55, 1.1])
+                .unwrap()
+                .into(),
+        );
     }
 }

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -86,51 +88,75 @@ impl SparseVector {
         }
     }
 
-    /// Construct a new vector that is the result of performing all indices-wise operations
+    /// Update sparse vector with the result of performing all indices-wise operations with `other`
     pub fn combine_aggregate(
-        &self,
+        &mut self,
         other: &SparseVector,
         op: impl Fn(DimWeight, DimWeight) -> DimWeight,
-    ) -> Self {
-        debug_assert!(self.is_sorted());
-        debug_assert!(other.is_sorted());
+    ) {
+        // Sort vectors if not already sorted
+        if !self.is_sorted() {
+            self.sort_by_indices();
+        }
 
-        let mut result = SparseVector::default();
+        // Copy and sort `other` vector if not already sorted
+        let cow_other: Cow<SparseVector> = if !other.is_sorted() {
+            let mut other = other.clone();
+            other.sort_by_indices();
+            Cow::Owned(other)
+        } else {
+            Cow::Borrowed(other)
+        };
+        let other = &cow_other;
+        assert!(other.is_sorted());
+
+        // record initial length of `self` vector
+        let initial_self_len = self.indices.len();
+
+        // update overlapping indices
         let mut i = 0;
         let mut j = 0;
+        // stop when either vector is exhausted
         while i < self.indices.len() && j < other.indices.len() {
             match self.indices[i].cmp(&other.indices[j]) {
                 std::cmp::Ordering::Less => {
-                    result.indices.push(self.indices[i]);
-                    result.values.push(op(self.values[i], 0.0));
+                    // update existing value with missing one in `other` - combine with 0.0
+                    self.values[i] = op(self.values[i], 0.0);
                     i += 1;
                 }
                 std::cmp::Ordering::Greater => {
-                    result.indices.push(other.indices[j]);
-                    result.values.push(op(0.0, other.values[j]));
+                    // value missing in `self` - add index and combine with 0.0
+                    self.indices.push(other.indices[j]);
+                    self.values.push(op(0.0, other.values[j]));
                     j += 1;
                 }
                 std::cmp::Ordering::Equal => {
-                    result.indices.push(self.indices[i]);
-                    result.values.push(op(self.values[i], other.values[j]));
+                    // combine values
+                    self.values[i] = op(self.values[i], other.values[j]);
                     i += 1;
                     j += 1;
                 }
             }
         }
+
+        // add remaining values from `other` if any
         while i < self.indices.len() {
-            result.indices.push(self.indices[i]);
-            result.values.push(op(self.values[i], 0.0));
+            self.values[i] = op(self.values[i], 0.0);
             i += 1;
         }
+
+        // add remaining values from `self` if any
         while j < other.indices.len() {
-            result.indices.push(other.indices[j]);
-            result.values.push(op(0.0, other.values[j]));
+            self.indices.push(other.indices[j]);
+            self.values.push(op(0.0, other.values[j]));
             j += 1;
         }
-        debug_assert!(result.is_sorted());
-        debug_assert!(result.validate().is_ok());
-        result
+
+        // if new indices were added, sort the vector
+        if initial_self_len != self.indices.len() {
+            self.sort_by_indices();
+            assert!(self.validate().is_ok());
+        }
     }
 }
 
@@ -249,14 +275,28 @@ mod tests {
 
     #[test]
     fn combine_aggregate_test() {
-        let a = SparseVector::new(vec![1, 2, 3], vec![0.1, 0.2, 0.3]).unwrap();
+        let mut a = SparseVector::new(vec![1, 2, 3], vec![0.1, 0.2, 0.3]).unwrap();
         let b = SparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
-        let sum = a.combine_aggregate(&b, |x, y| x + 2.0 * y);
-        assert_eq!(sum.indices, vec![1, 2, 3, 4]);
-        assert_eq!(sum.values, vec![0.1, 4.2, 6.3, 8.0]);
+        a.combine_aggregate(&b, |x, y| x + 2.0 * y);
+        assert_eq!(a.indices, vec![1, 2, 3, 4]);
+        assert_eq!(a.values, vec![0.1, 4.2, 6.3, 8.0]);
 
-        let sum = b.combine_aggregate(&a, |x, y| x + 2.0 * y);
-        assert_eq!(sum.indices, vec![1, 2, 3, 4]);
-        assert_eq!(sum.values, vec![0.2, 2.4, 3.6, 4.0]);
+        let a = SparseVector::new(vec![1, 2, 3], vec![0.1, 0.2, 0.3]).unwrap();
+        let mut b = SparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
+        b.combine_aggregate(&a, |x, y| x + 2.0 * y);
+        assert_eq!(b.indices, vec![1, 2, 3, 4]);
+        assert_eq!(b.values, vec![0.2, 2.4, 3.6, 4.0]);
+
+        let mut a = SparseVector::new(vec![1, 2, 3], vec![0.1, 0.2, 0.3]).unwrap();
+        let b = SparseVector::new(vec![4, 2, 3], vec![4.0, 2.0, 3.0]).unwrap();
+        a.combine_aggregate(&b, |x, y| x + 2.0 * y);
+        assert_eq!(a.indices, vec![1, 2, 3, 4]);
+        assert_eq!(a.values, vec![0.1, 4.2, 6.3, 8.0]);
+
+        let a = SparseVector::new(vec![1, 3, 2], vec![0.1, 0.3, 0.2]).unwrap();
+        let mut b = SparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
+        b.combine_aggregate(&a, |x, y| x + 2.0 * y);
+        assert_eq!(b.indices, vec![1, 2, 3, 4]);
+        assert_eq!(b.values, vec![0.2, 2.4, 3.6, 4.0]);
     }
 }

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -87,6 +87,7 @@ impl SparseVector {
     }
 
     /// Construct a new vector that is the result of performing all indices-wise operations
+    /// Warning: Expects both vectors to be sorted by indices.
     pub fn combine_aggregate(
         &self,
         other: &SparseVector,

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -87,7 +87,6 @@ impl SparseVector {
     }
 
     /// Construct a new vector that is the result of performing all indices-wise operations
-    /// Warning: Expects both vectors to be sorted by indices.
     pub fn combine_aggregate(
         &self,
         other: &SparseVector,


### PR DESCRIPTION
The recommendation API must sort the sparse vectors before computing the average because the `combine_aggregate` function requires sorted vectors.

Issue discovered while running the congruence tests locally with debug assertions enabled.