### PR TITLE
[order-by] Fix remote shard calling

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -249,8 +249,10 @@ impl Collection {
                 return Err(CollectionError::bad_input("Cannot use an `offset` when using `order_by`. The alternative for paging is to use `order_by.start_from` and a filter to exclude the IDs that you've already seen for the `order_by.start_from` value".to_string()));
             }
 
-            // Always request the payload when using order_by
-            with_payload_interface = WithPayloadInterface::Bool(true);
+            // With order_by, we fetch the payloads here, after sorting, because of the "____ordered_with____" payload hack
+            // LocalShard::scroll_by already does not include the requested payload for order_by,
+            // but we specify it here to be more explicit
+            with_payload_interface = WithPayloadInterface::Bool(false);
         };
 
         if limit == 0 {

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -339,7 +339,7 @@ impl Collection {
                     let ids = ordered_records.iter().map(|record| record.id).collect();
                     let request = PointRequestInternal {
                         ids,
-                        with_payload: request.with_payload.clone(),
+                        with_payload: Some(original_with_payload_interface),
                         with_vector: false.into(),
                     };
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -153,7 +153,6 @@ impl LocalShard {
     async fn scroll_by_field(
         &self,
         limit: usize,
-        with_payload_interface: &WithPayloadInterface,
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &Handle,
@@ -196,11 +195,12 @@ impl LocalShard {
             .take(limit)
             .collect_vec();
 
-        let with_payload = WithPayload::from(with_payload_interface);
+        // Payload will be added after merging from shards
+        let with_payload = WithPayload::from(false);
 
         let point_ids = top_records.iter().map(|(_, id)| *id).collect_vec();
 
-        // Fetch with the requested vector and payload
+        // Fetch with the requested vector
         let mut records =
             SegmentsSearcher::retrieve(segments, &point_ids, &with_payload, with_vector)?;
 
@@ -314,15 +314,8 @@ impl ShardOperation for LocalShard {
                 .await
             }
             Some(order_by) => {
-                self.scroll_by_field(
-                    limit,
-                    with_payload_interface,
-                    with_vector,
-                    filter,
-                    search_runtime_handle,
-                    order_by,
-                )
-                .await
+                self.scroll_by_field(limit, with_vector, filter, search_runtime_handle, order_by)
+                    .await
             }
         }
     }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -678,10 +678,13 @@ impl ShardOperation for RemoteShard {
             .await?
             .into_inner();
 
+        // We need the `____ordered_with____` value even if the user didn't request payload
+        let parse_payload = with_payload_interface.is_required() || order_by.is_some();
+
         let result: Result<Vec<Record>, Status> = scroll_response
             .result
             .into_iter()
-            .map(|point| try_record_from_grpc(point, with_payload_interface.is_required()))
+            .map(|point| try_record_from_grpc(point, parse_payload))
             .collect();
 
         result.map_err(|e| e.into())

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -109,14 +109,25 @@ impl OrderBy {
         new_payload
     }
 
-    pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderingValue {
-        payload
-            .and_then(|payload| payload.0.get(INTERNAL_KEY_OF_ORDER_BY_VALUE))
-            .and_then(|v| OrderingValue::try_from(v.clone()).ok())
+    fn json_value_to_ordering_value(&self, value: Option<serde_json::Value>) -> OrderingValue {
+        value
+            .and_then(|v| OrderingValue::try_from(v).ok())
             .unwrap_or_else(|| match self.direction() {
                 Direction::Asc => OrderingValue::MAX,
                 Direction::Desc => OrderingValue::MIN,
             })
+    }
+
+    pub fn get_order_value_from_payload(&self, payload: Option<&Payload>) -> OrderingValue {
+        self.json_value_to_ordering_value(
+            payload.and_then(|payload| payload.0.get(INTERNAL_KEY_OF_ORDER_BY_VALUE).cloned()),
+        )
+    }
+
+    pub fn remove_order_value_from_payload(&self, payload: Option<&mut Payload>) -> OrderingValue {
+        self.json_value_to_ordering_value(
+            payload.and_then(|payload| payload.0.remove(INTERNAL_KEY_OF_ORDER_BY_VALUE)),
+        )
     }
 }
 

--- a/tests/consensus_tests/test_order_by.py
+++ b/tests/consensus_tests/test_order_by.py
@@ -1,0 +1,145 @@
+from .assertions import assert_http_ok
+from .fixtures import create_collection
+from .utils import start_cluster, every_test
+
+import pytest
+import requests
+
+COLL_NAME = "test_collection"
+
+
+def test_order_by_from_remote_shard(tmp_path, every_test):
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, num_peers=2, port_seed=10000)
+
+    uri = peer_api_uris[0]
+
+    create_collection(uri, collection=COLL_NAME, shard_number=2, replication_factor=1)
+
+    requests.put(
+        f"{uri}/collections/{COLL_NAME}/index",
+        json={"field_name": "index", "field_schema": "integer"},
+    ).raise_for_status()
+
+    res = requests.put(
+        f"{uri}/collections/{COLL_NAME}/points",
+        params={"wait": "true", },
+        json={
+            "points": [
+                {
+                    "id": 0,
+                    "payload": {
+                        "index": 0,
+                        "timestamp": "2024-04-12T08:40:06.189301",
+                        "text": "Italy: tomatoes, olive oil, pasta.",
+                        "title": "food",
+                    },
+                    "vector": {},
+                }
+            ]
+        },
+    )
+    assert_http_ok(res)
+
+    requests.put(
+        f"{uri}/collections/{COLL_NAME}/points",
+        params={"wait": "true", },
+        json={
+            "batch": {
+                "ids": [11, 12, 13, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "payloads": [
+                    {
+                        "timestamp": "2024-04-12T08:40:20.015587",
+                        "text": "Japan: Polite, punctual, public transport reliance",
+                        "index": 11,
+                        "title": "travel",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:20.290047",
+                        "text": "Italy: Relaxed, historical tours, slow-paced",
+                        "index": 12,
+                        "title": "travel",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:20.562687",
+                        "text": "USA: Road trips, diverse landscapes.",
+                        "index": 13,
+                        "title": "travel",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:09.482208",
+                        "text": "Japan: seafood-centric with artistic presentation.",
+                        "index": 1,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:09.744967",
+                        "text": "Mexico: beans, chili peppers, and meat.",
+                        "index": 2,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:10.020073",
+                        "text": "India: diverse vegetarian and meat dishes.",
+                        "index": 3,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:10.285342",
+                        "text": "France: Gourmet dining, focuses on cheese, wine",
+                        "index": 4,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:10.883714",
+                        "text": "China: diverse cuisines, emphasizes balance, uses rice",
+                        "index": 5,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:13.166867",
+                        "text": "Thailand: five flavors, spicy, sweet, salty, sour.",
+                        "index": 6,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:15.436143",
+                        "text": "USA: Melting pot, diverse, large portions, fast food.",
+                        "index": 7,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:15.697163",
+                        "text": "Brazil: barbecue heavy",
+                        "index": 8,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:15.963504",
+                        "text": "Greece: Olive oil, feta, yogurt, seafood",
+                        "index": 9,
+                        "title": "food",
+                    },
+                    {
+                        "timestamp": "2024-04-12T08:40:16.738832",
+                        "text": "Ethiopia: bread with spicy stews and vegetables",
+                        "index": 10,
+                        "title": "food",
+                    },
+                ],
+                "vectors": {},
+            }
+        },
+    ).raise_for_status()
+
+    res = requests.post(
+        f"{uri}/collections/{COLL_NAME}/points/scroll", json={"limit": 10, "order_by": "index", "with_payload": False}
+    )
+    
+    res.raise_for_status()
+    
+    ids = [point["id"] for point in res.json()['result']["points"]]
+    
+    assert ids == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    
+    for point in res.json()['result']["points"]:
+        assert point["payload"] is None

--- a/tests/consensus_tests/test_order_by.py
+++ b/tests/consensus_tests/test_order_by.py
@@ -132,7 +132,7 @@ def test_order_by_from_remote_shard(tmp_path, every_test):
     ).raise_for_status()
 
     res = requests.post(
-        f"{uri}/collections/{COLL_NAME}/points/scroll", json={"limit": 10, "order_by": "index", "with_payload": True}
+        f"{uri}/collections/{COLL_NAME}/points/scroll", json={"limit": 10, "order_by": "index"}
     )
     
     res.raise_for_status()

--- a/tests/consensus_tests/test_order_by.py
+++ b/tests/consensus_tests/test_order_by.py
@@ -132,14 +132,14 @@ def test_order_by_from_remote_shard(tmp_path, every_test):
     ).raise_for_status()
 
     res = requests.post(
-        f"{uri}/collections/{COLL_NAME}/points/scroll", json={"limit": 10, "order_by": "index", "with_payload": False}
+        f"{uri}/collections/{COLL_NAME}/points/scroll", json={"limit": 10, "order_by": "index", "with_payload": True}
     )
     
     res.raise_for_status()
     
-    ids = [point["id"] for point in res.json()['result']["points"]]
+    for point in res.json()['result']["points"]:
+        assert point["payload"] is not None
+
+    ids = [point["payload"]["index"] for point in res.json()['result']["points"]]
     
     assert ids == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    
-    for point in res.json()['result']["points"]:
-        assert point["payload"] is None


### PR DESCRIPTION
Fixes #4024

The root cause of the issue is that the remote shards were not actually sending the `____ordered_with____` value, because we were removing it right before sending it.

This fixes 2 main things:
- deserialization of this value into `OrderingValue`
- detects when it is a remote shard call to not erase the `____ordered_with____` value early. Then uglily adds the requested `with_payload` after merging from the shards.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
