### PR TITLE
Separate segment and point level version handling

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -381,9 +381,7 @@ impl Segment {
         }
 
         let applied = operation(self)?;
-
-        self.version = Some(max(op_num, self.version.unwrap_or(0)));
-
+        self.bump_segment_version(op_num);
         Ok(applied)
     }
 
@@ -414,8 +412,7 @@ impl Segment {
 
         let (applied, point_id) = operation(self)?;
 
-        self.version = Some(max(op_num, self.version.unwrap_or(0)));
-
+        self.bump_segment_version(op_num);
         if let Some(point_id) = point_id {
             self.id_tracker
                 .borrow_mut()
@@ -423,6 +420,10 @@ impl Segment {
         }
 
         Ok(applied)
+    }
+
+    fn bump_segment_version(&mut self, op_num: SeqNumberType) {
+        self.version = Some(max(op_num, self.version.unwrap_or(0)));
     }
 
     fn lookup_internal_id(&self, point_id: PointIdType) -> OperationResult<PointOffsetType> {


### PR DESCRIPTION
Supersedes: <https://github.com/qdrant/qdrant/pull/4051>

Separate version handling for segments and points. Some operations only need to do point level version checks, while others only need segment level checks.

Before this PR, point versions check did fall back to segment version checks if that point did not exist yet.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?