### PR TITLE
Update crc32c 0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
 dependencies = [
  "rustc_version",
 ]


### PR DESCRIPTION
Update `crc32c` to be able to build nightly.

```
error[E0635]: unknown feature `stdsimd`
  --> /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.4/src/lib.rs:23:30
   |
23 | #![cfg_attr(nightly, feature(stdsimd))]
   |
```

https://github.com/zowens/crc32c/commit/8a789240fa1d4aae38427027b9a683be86d8f64b