### PR TITLE
Test point version handling and moving correctness across segments

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -1075,6 +1075,11 @@ mod tests {
     /// More specifically, this tests the move is still applied correctly even if segments already
     /// have a newer version. That very situation can happen when replaying the WAL after a crash
     /// where only some of the segments have been flushed properly.
+    ///
+    /// Before <https://github.com/qdrant/qdrant/pull/4060> the copy and delete operation to move a
+    /// point to another segment may only be partially executed if an operation ID was given that
+    /// is older than the current segment version. It resulted in missing points. This test asserts
+    /// this cannot happen anymore.
     #[rstest::rstest]
     #[case::segments_older(false, false)]
     #[case::non_appendable_newer_appendable_older(true, false)]

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -2590,7 +2590,7 @@ mod tests {
 
         // Do handle operation on existing point when providing a newer version
         let applied = segment
-            .handle_point_version(100, Some(0), |_segment| Ok((true, None)))
+            .handle_point_version(101, Some(0), |_segment| Ok((true, None)))
             .unwrap();
         assert!(applied);
 

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -2547,6 +2547,10 @@ mod tests {
     ///
     /// Apply if the point version is equal or higher. Always apply if the point does not exist
     /// yet.
+    ///
+    /// Before <https://github.com/qdrant/qdrant/pull/4060> this function would reject operations
+    /// on non-existent points if the operation ID was lower than the current segment version. That
+    /// should not happen, and this test asserts correct behavior.
     #[test]
     fn test_handle_point_version() {
         // Create base segment with a single point


### PR DESCRIPTION
Add two tests to assert correctness of point version handling and moving points across segments, typically with an old operation ID and a newer segment version.

Before <https://github.com/qdrant/qdrant/pull/4057>, these did show wrong behavior when doing a point operation with an operation ID that is older than the current segment version.

In the case of moving points across segments, it resulted in missing points. A move happens if we want to update a point in a non-appendable segment. We copy to a new segment, and delete it from the old segment. If the copy was (silently) rejected due to a version mismatch, the point is deleted and ends up missing.

The tests assert correctness in two places to make sure the same doesn't happen in the future.

The tests now succeed, while they fail before <https://github.com/qdrant/qdrant/pull/4057>.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?