### PR TITLE
Vector Storage f16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -2174,6 +2174,17 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "serde",
+]
 
 [[package]]
 name = "hash32"
@@ -4867,6 +4878,7 @@ dependencies = [
  "generic-tests",
  "geo",
  "geohash",
+ "half 2.4.1",
  "indexmap 2.2.6",
  "io",
  "io-uring",
@@ -4947,7 +4959,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.2",
  "serde",
 ]
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 multiling-chinese = ["charabia/chinese"]
 multiling-japanese = ["charabia/japanese"]
 multiling-korean = ["charabia/korean"]
+f16 = ["dep:half"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -78,6 +79,7 @@ tracing = { workspace = true, optional = true }
 macro_rules_attribute = "0.2.0"
 generic-tests = "0.1.2"
 nom = "7.1.3"
+half = { version = "2.4.1", features = ["serde"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -28,7 +28,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
                 GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);
             let fake_filter_context = FakeFilterContext {};
             for idx in 0..(NUM_VECTORS as PointOffsetType) {
-                let added_vector = vector_holder.vectors.get(idx).to_vec();
+                let added_vector = vector_holder.vectors.get(idx);
+                #[cfg(not(feature = "f16"))]
+                let added_vector = added_vector.to_vec();
+                #[cfg(feature = "f16")]
+                let added_vector = half::slice::HalfFloatSliceExt::to_f32_vec(added_vector);
                 let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
                 let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
                 let level = graph_layers_builder.get_random_layer(&mut rng);

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -29,7 +29,11 @@ fn hnsw_benchmark(c: &mut Criterion) {
     let mut graph_layers_builder =
         GraphLayersBuilder::new(NUM_VECTORS, M, M * 2, EF_CONSTRUCT, 10, USE_HEURISTIC);
     for idx in 0..(NUM_VECTORS as PointOffsetType) {
-        let added_vector = vector_holder.vectors.get(idx).to_vec();
+        let added_vector = vector_holder.vectors.get(idx);
+        #[cfg(not(feature = "f16"))]
+        let added_vector = added_vector.to_vec();
+        #[cfg(feature = "f16")]
+        let added_vector = half::slice::HalfFloatSliceExt::to_f32_vec(added_vector);
         let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
         let level = graph_layers_builder.get_random_layer(&mut rng);

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+#[cfg(feature = "f16")]
+use half::f16;
 use serde::{Deserialize, Serialize};
 
 use crate::common::operation_error::OperationResult;
@@ -21,6 +23,23 @@ impl PrimitiveVectorElement for VectorElementType {
 
     fn vector_to_cow(vector: &[Self]) -> CowVector {
         vector.into()
+    }
+}
+
+#[cfg(feature = "f16")]
+impl PrimitiveVectorElement for f16 {
+    fn from_vector_ref(vector: VectorRef) -> OperationResult<Cow<[Self]>> {
+        use half::vec::HalfFloatVecExt;
+
+        let vector_ref: &[VectorElementType] = vector.try_into()?;
+        let f16_vector = Vec::from_f32_slice(vector_ref);
+        Ok(Cow::from(f16_vector))
+    }
+
+    fn vector_to_cow(vector: &[Self]) -> CowVector {
+        use half::slice::HalfFloatSliceExt;
+
+        vector.to_f32_vec().into()
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -357,7 +357,11 @@ mod tests {
         let linking_idx: PointOffsetType = 7;
 
         let fake_filter_context = FakeFilterContext {};
-        let added_vector = vector_holder.vectors.get(linking_idx).to_vec();
+        let added_vector = vector_holder.vectors.get(linking_idx);
+        #[cfg(not(feature = "f16"))]
+        let added_vector = added_vector.to_vec();
+        #[cfg(feature = "f16")]
+        let added_vector = half::slice::HalfFloatSliceExt::to_f32_vec(added_vector);
         let raw_scorer = vector_holder.get_raw_scorer(added_vector).unwrap();
         let mut scorer = FilteredScorer::new(raw_scorer.as_ref(), Some(&fake_filter_context));
 

--- a/lib/segment/src/spaces/metric_f16/mod.rs
+++ b/lib/segment/src/spaces/metric_f16/mod.rs
@@ -1,0 +1,1 @@
+mod simple;

--- a/lib/segment/src/spaces/metric_f16/simple.rs
+++ b/lib/segment/src/spaces/metric_f16/simple.rs
@@ -1,0 +1,196 @@
+use common::types::ScoreType;
+use half::f16;
+use half::vec::HalfFloatVecExt;
+
+use crate::data_types::vectors::{DenseVector, TypedDenseVector};
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
+use crate::spaces::tools::is_length_zero_or_normalized;
+use crate::types::Distance;
+
+impl Metric<f16> for EuclidMetric {
+    fn distance() -> Distance {
+        Distance::Euclid
+    }
+
+    fn similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+        /*
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
+            {
+                return unsafe { euclid_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { euclid_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { euclid_similarity_neon(v1, v2) };
+            }
+        }
+        */
+        euclid_similarity(v1, v2)
+    }
+
+    fn preprocess(vector: DenseVector) -> TypedDenseVector<f16> {
+        TypedDenseVector::from_f32_slice(&vector)
+    }
+}
+
+impl Metric<f16> for ManhattanMetric {
+    fn distance() -> Distance {
+        Distance::Manhattan
+    }
+
+    fn similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+        /*
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
+            {
+                return unsafe { manhattan_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { manhattan_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { manhattan_similarity_neon(v1, v2) };
+            }
+        }
+        */
+        manhattan_similarity(v1, v2)
+    }
+
+    fn preprocess(vector: DenseVector) -> TypedDenseVector<f16> {
+        TypedDenseVector::from_f32_slice(&vector)
+    }
+}
+
+impl Metric<f16> for DotProductMetric {
+    fn distance() -> Distance {
+        Distance::Dot
+    }
+
+    fn similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+        /*
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && v1.len() >= MIN_DIM_SIZE_AVX
+            {
+                return unsafe { dot_similarity_avx(v1, v2) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { dot_similarity_sse(v1, v2) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && v1.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { dot_similarity_neon(v1, v2) };
+            }
+        }
+        */
+        dot_similarity(v1, v2)
+    }
+
+    fn preprocess(vector: DenseVector) -> TypedDenseVector<f16> {
+        TypedDenseVector::from_f32_slice(&vector)
+    }
+}
+
+impl Metric<f16> for CosineMetric {
+    fn distance() -> Distance {
+        Distance::Cosine
+    }
+
+    fn similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+        DotProductMetric::similarity(v1, v2)
+    }
+
+    fn preprocess(vector: DenseVector) -> TypedDenseVector<f16> {
+        /*
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx")
+                && is_x86_feature_detected!("fma")
+                && vector.len() >= MIN_DIM_SIZE_AVX
+            {
+                return unsafe { cosine_preprocess_avx(vector) };
+            }
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") && vector.len() >= MIN_DIM_SIZE_SIMD {
+                return unsafe { cosine_preprocess_sse(vector) };
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= MIN_DIM_SIZE_SIMD
+            {
+                return unsafe { cosine_preprocess_neon(vector) };
+            }
+        }
+        */
+        cosine_preprocess(vector)
+    }
+}
+
+fn euclid_similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+    -v1.iter()
+        .zip(v2)
+        .map(|(a, b)| (a.to_f32() - b.to_f32()).powi(2))
+        .sum::<ScoreType>()
+}
+
+fn manhattan_similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+    -v1.iter()
+        .zip(v2)
+        .map(|(a, b)| (a.to_f32() - b.to_f32()).abs())
+        .sum::<ScoreType>()
+}
+
+fn cosine_preprocess(vector: DenseVector) -> TypedDenseVector<f16> {
+    let mut length: f32 = vector.iter().map(|x| x * x).sum();
+    if is_length_zero_or_normalized(length) {
+        return TypedDenseVector::from_f32_slice(&vector);
+    }
+    length = length.sqrt();
+    vector.iter().map(|x| f16::from_f32(x / length)).collect()
+}
+
+fn dot_similarity(v1: &[f16], v2: &[f16]) -> ScoreType {
+    v1.iter()
+        .zip(v2)
+        .map(|(a, b)| a.to_f32() * b.to_f32())
+        .sum()
+}

--- a/lib/segment/src/spaces/mod.rs
+++ b/lib/segment/src/spaces/mod.rs
@@ -10,5 +10,8 @@ pub mod simple_avx;
 
 pub mod metric_uint;
 
+#[cfg(feature = "f16")]
+mod metric_f16;
+
 #[cfg(target_arch = "aarch64")]
 pub mod simple_neon;

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -12,11 +12,13 @@ use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::data_types::vectors::VectorRef;
 use crate::types::Distance;
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
 use crate::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    DenseVectorStorage, VectorStorage, VectorStorageElementType, VectorStorageEnum,
+};
 
 const VECTORS_DIR_PATH: &str = "vectors";
 const DELETED_DIR_PATH: &str = "deleted";
@@ -39,7 +41,7 @@ pub fn open_appendable_memmap_vector_storage(
     let vectors_path = path.join(VECTORS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors: ChunkedMmapVectors<VectorElementType> =
+    let vectors: ChunkedMmapVectors<VectorStorageElementType> =
         ChunkedMmapVectors::open(&vectors_path, dim)?;
 
     let num_vectors = vectors.len();
@@ -88,8 +90,10 @@ impl<T: PrimitiveVectorElement + 'static> AppendableMmapDenseVectorStorage<T> {
     }
 }
 
-impl DenseVectorStorage<VectorElementType> for AppendableMmapDenseVectorStorage<VectorElementType> {
-    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+impl DenseVectorStorage<VectorStorageElementType>
+    for AppendableMmapDenseVectorStorage<VectorStorageElementType>
+{
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorStorageElementType] {
         self.vectors.get(key)
     }
 }

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -14,11 +14,13 @@ use crate::common::operation_error::{check_process_stopped, OperationResult};
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::data_types::vectors::VectorRef;
 use crate::types::Distance;
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::dense::mmap_dense_vectors::MmapDenseVectors;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    DenseVectorStorage, VectorStorage, VectorStorageElementType, VectorStorageEnum,
+};
 
 const VECTORS_PATH: &str = "matrix.dat";
 const DELETED_PATH: &str = "deleted.dat";
@@ -87,8 +89,10 @@ impl<T: PrimitiveVectorElement> MemmapDenseVectorStorage<T> {
     }
 }
 
-impl DenseVectorStorage<VectorElementType> for MemmapDenseVectorStorage<VectorElementType> {
-    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+impl DenseVectorStorage<VectorStorageElementType>
+    for MemmapDenseVectorStorage<VectorStorageElementType>
+{
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorStorageElementType] {
         self.mmap_store.as_ref().unwrap().get_vector(key)
     }
 }
@@ -222,7 +226,7 @@ mod tests {
 
     use super::*;
     use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-    use crate::data_types::vectors::{DenseVector, QueryVector};
+    use crate::data_types::vectors::{DenseVector, QueryVector, VectorElementType};
     use crate::fixtures::payload_context_fixture::FixtureIdTracker;
     use crate::id_tracker::IdTracker;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -15,12 +15,14 @@ use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::data_types::vectors::VectorRef;
 use crate::types::Distance;
 use crate::vector_storage::bitvec::bitvec_set_deleted;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::common::StoredRecord;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{
+    DenseVectorStorage, VectorStorage, VectorStorageElementType, VectorStorageEnum,
+};
 
 type StoredDenseVector<T> = StoredRecord<Vec<T>>;
 
@@ -92,7 +94,7 @@ pub fn open_simple_dense_vector_storage(
     distance: Distance,
     stopped: &AtomicBool,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
-    let storage = open_simple_dense_vector_storage_impl::<VectorElementType>(
+    let storage = open_simple_dense_vector_storage_impl::<VectorStorageElementType>(
         database,
         database_column_name,
         dim,
@@ -146,8 +148,10 @@ impl<T: PrimitiveVectorElement> SimpleDenseVectorStorage<T> {
     }
 }
 
-impl DenseVectorStorage<VectorElementType> for SimpleDenseVectorStorage<VectorElementType> {
-    fn get_dense(&self, key: PointOffsetType) -> &[VectorElementType] {
+impl DenseVectorStorage<VectorStorageElementType>
+    for SimpleDenseVectorStorage<VectorStorageElementType>
+{
+    fn get_dense(&self, key: PointOffsetType) -> &[VectorStorageElementType] {
         self.vectors.get(key)
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -7,11 +7,11 @@ use crate::data_types::vectors::{DenseVector, MultiDenseVector, VectorElementTyp
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::MultiVectorStorage;
+use crate::vector_storage::{MultiVectorStorage, VectorStorageElementType};
 
 pub struct MultiCustomQueryScorer<
     'a,
-    TMetric: Metric<VectorElementType>,
+    TMetric: Metric<VectorStorageElementType>,
     TVectorStorage: MultiVectorStorage,
     TQuery: Query<MultiDenseVector>,
 > {
@@ -22,7 +22,7 @@ pub struct MultiCustomQueryScorer<
 
 impl<
         'a,
-        TMetric: Metric<VectorElementType>,
+        TMetric: Metric<VectorStorageElementType> + Metric<VectorElementType>,
         TVectorStorage: MultiVectorStorage,
         TQuery: Query<MultiDenseVector> + TransformInto<TQuery, MultiDenseVector, MultiDenseVector>,
     > MultiCustomQueryScorer<'a, TMetric, TVectorStorage, TQuery>
@@ -49,7 +49,7 @@ impl<
 
 impl<
         'a,
-        TMetric: Metric<VectorElementType>,
+        TMetric: Metric<VectorStorageElementType> + Metric<VectorElementType>,
         TVectorStorage: MultiVectorStorage,
         TQuery: Query<MultiDenseVector>,
     > QueryScorer<MultiDenseVector>

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -6,11 +6,11 @@ use super::score_multi;
 use crate::data_types::vectors::{DenseVector, MultiDenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::MultiVectorStorage;
+use crate::vector_storage::{MultiVectorStorage, VectorStorageElementType};
 
 pub struct MultiMetricQueryScorer<
     'a,
-    TMetric: Metric<VectorElementType>,
+    TMetric: Metric<VectorStorageElementType>,
     TVectorStorage: MultiVectorStorage,
 > {
     vector_storage: &'a TVectorStorage,
@@ -18,8 +18,11 @@ pub struct MultiMetricQueryScorer<
     metric: PhantomData<TMetric>,
 }
 
-impl<'a, TMetric: Metric<VectorElementType>, TVectorStorage: MultiVectorStorage>
-    MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
+impl<
+        'a,
+        TMetric: Metric<VectorStorageElementType> + Metric<VectorElementType>,
+        TVectorStorage: MultiVectorStorage,
+    > MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
 {
     pub fn new(query: MultiDenseVector, vector_storage: &'a TVectorStorage) -> Self {
         let slices = query.multi_vectors();
@@ -47,8 +50,11 @@ impl<'a, TMetric: Metric<VectorElementType>, TVectorStorage: MultiVectorStorage>
     }
 }
 
-impl<'a, TMetric: Metric<VectorElementType>, TVectorStorage: MultiVectorStorage>
-    QueryScorer<MultiDenseVector> for MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
+impl<
+        'a,
+        TMetric: Metric<VectorStorageElementType> + Metric<VectorElementType>,
+        TVectorStorage: MultiVectorStorage,
+    > QueryScorer<MultiDenseVector> for MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -12,7 +12,9 @@ use crate::common::operation_error::OperationResult;
 use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{MultiDenseVector, VectorElementType, VectorRef};
+#[cfg(not(feature = "f16"))]
+use crate::data_types::vectors::VectorElementType;
+use crate::data_types::vectors::{MultiDenseVector, VectorRef};
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::dense::appendable_mmap_dense_vector_storage::AppendableMmapDenseVectorStorage;
 use crate::vector_storage::simple_multi_dense_vector_storage::SimpleMultiDenseVectorStorage;
@@ -111,10 +113,18 @@ pub trait MultiVectorStorage: VectorStorage {
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 }
 
+#[cfg(not(feature = "f16"))]
+pub(crate) type VectorStorageElementType = VectorElementType;
+#[cfg(feature = "f16")]
+pub(crate) type VectorStorageElementType = half::f16;
+// for benchmarks
+#[doc(hidden)]
+pub type _VectorStorageElementType = VectorStorageElementType;
+
 pub enum VectorStorageEnum {
-    DenseSimple(SimpleDenseVectorStorage<VectorElementType>),
-    DenseMemmap(Box<MemmapDenseVectorStorage<VectorElementType>>),
-    DenseAppendableMemmap(Box<AppendableMmapDenseVectorStorage<VectorElementType>>),
+    DenseSimple(SimpleDenseVectorStorage<VectorStorageElementType>),
+    DenseMemmap(Box<MemmapDenseVectorStorage<VectorStorageElementType>>),
+    DenseAppendableMemmap(Box<AppendableMmapDenseVectorStorage<VectorStorageElementType>>),
     SparseSimple(SimpleSparseVectorStorage),
     MultiDenseSimple(SimpleMultiDenseVectorStorage),
 }


### PR DESCRIPTION
/claim #3333

Based on feedback from #4032, reduce the scope of the changes to just vector_storage, not change data_types::vectors::VectorElementType.

All changes within segment crate. Changes are not visible outside segment, qdrant builds and passes tests with segment/f16 feature. 

# Key Changes

f16 feature (adds half dependency).

Implement data_types::primitive::PrimitiveVectorElement for f16.

In vector_storage::vector_storage_base:
```
#[cfg(not(feature = "f16"))]
pub(crate) type VectorStorageElementType = VectorElementType;
#[cfg(feature = "f16")]
pub(crate) type VectorStorageElementType = half::f16;
```

This is the type used in VectorStorageEnum:
```
pub enum VectorStorageEnum {
    DenseSimple(SimpleDenseVectorStorage<VectorStorageElementType>),
    DenseMemmap(Box<MemmapDenseVectorStorage<VectorStorageElementType>>),
    DenseAppendableMemmap(Box<AppendableMmapDenseVectorStorage<VectorStorageElementType>>),
    SparseSimple(SimpleSparseVectorStorage),
    MultiDenseSimple(SimpleMultiDenseVectorStorage),
}
```

Add new mod spaces::metric_f16 (feature f16). Implement spaces::Metric for all metrics.

For types::Distance, vector functions are generic:
```
impl Distance {
    pub fn preprocess_vector<T: PrimitiveVectorElement>(
            &self,
            vector: DenseVector,
        ) -> TypedDenseVector<T>
        where
            CosineMetric: Metric<T>,
            EuclidMetric: Metric<T>,
            DotProductMetric: Metric<T>,
            ManhattanMetric: Metric<T>;
    pub fn similarity<T: PrimitiveVectorElement>(&self, v1: &[T], v2: &[T]) -> ScoreType
        where
            CosineMetric: Metric<T>,
            EuclidMetric: Metric<T>,
            DotProductMetric: Metric<T>,
            ManhattanMetric: Metric<T>;
}
```
These are called with both VectorElementType and VectorStorageElementType.

Implementers of vector_storage::query_scorer::QueryScorer and related functions are generic over TMetric: Metric<VectorStorageElementType> (and VectorElementType as required). For example (vector_storage::raw_scorer):
```
fn new_multi_scorer_with_metric<
    'a,
    TMetric: Metric<VectorStorageElementType> + Metric<VectorElementType> + 'a,
    TVectorStorage: MultiVectorStorage,
>(
    query: QueryVector,
    vector_storage: &'a TVectorStorage,
    point_deleted: &'a BitSlice,
    is_stopped: &'a AtomicBool,
) -> OperationResult<Box<dyn RawScorer + 'a>>;
```
This is because the query is VectorElementType, while vector_storage is VectorStorageElementType.

# Test Failures

`cargo test -p segment --features f16`
```
---- multivector_hnsw_test::test_single_multi_and_dense_hnsw_equivalency stdout ----
thread 'multivector_hnsw_test::test_single_multi_and_dense_hnsw_equivalency' panicked at lib/segment/tests/integration/multivector_hnsw_test.rs:180:9:
assertion `left == right` failed
  left: [[ScoredPointOffset { idx: 593, score: 0.2239838 }, ScoredPointOffset { idx: 577, score: -0.024489254 }, ScoredPointOffset { idx: 287, score: -0.45335948 }, ScoredPointOffset { idx: 895, score: -0.493725 }]]
 right: [[ScoredPointOffset { idx: 593, score: 0.2241156 }, ScoredPointOffset { idx: 577, score: -0.024583347 }, ScoredPointOffset { idx: 287, score: -0.45343193 }, ScoredPointOffset { idx: 895, score: -0.49391016 }]]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- segment_tests::test_update_named_vector stdout ----
thread 'segment_tests::test_update_named_vector' panicked at lib/segment/tests/integration/segment_tests.rs:283:13:
assertion failed: (sqrt_distance(v) - 1.).abs() < 1e-5

---- sparse_discover_test::sparse_index_discover_test stdout ----
thread 'sparse_discover_test::sparse_index_discover_test' panicked at lib/segment/tests/integration/sparse_discover_test.rs:201:9:
assertion `left == right` failed
  left: [1827, 906, 2664]
 right: [1827, 906, 2516]


failures:
    multivector_hnsw_test::test_single_multi_and_dense_hnsw_equivalency
    segment_tests::test_update_named_vector
    sparse_discover_test::sparse_index_discover_test
```
Potentially these failures are due to rounding error with the reduced precision of f16.

# Next Steps 

In vector_storage::quantized::quantized_vectors::QuantizedVectors::create_impl: 
```
// TODO: Avoid cloning here by supporting f16 in quantization.
#[cfg(feature = "f16")]
 let vectors: Vec<_> = vectors
       .map(half::slice::HalfFloatSliceExt::to_f32_vec)
       .collect();
  #[cfg(feature = "f16")]
  let vectors = vectors.iter().map(Vec::as_slice);
```
quantization::encoded_vectors_u8::EncodedVectorsU8::encode takes f32 slices, which requires collecting f16 slices into a vec of f32 vecs. Could support f16 or otherwise minimize unnecessary allocation / copying. 

segment::spaces::metric_f16 only has fallback implementations for Metrics. Support for avx, sse, and neon intrinsics should be straightforward. This was somewhat implemented in #4032. 
