### PR TITLE
Fix compilation error on dev due to missing datatype field

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -2579,6 +2579,7 @@ mod tests {
                     index: Indexes::Plain {},
                     quantization_config: None,
                     multi_vec_config: None,
+                    datatype: None,
                 },
             )]),
             sparse_vector_data: Default::default(),


### PR DESCRIPTION
Compilation on `dev` broke very recently, likely due to two PRs conflicting with each other.

This fixes that!

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?