### PR TITLE
Fix different wal crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
- "env_logger 0.11.3",
+ "env_logger",
  "fnv",
  "fs_extra",
  "futures",
@@ -1100,7 +1100,7 @@ dependencies = [
  "url",
  "uuid",
  "validator",
- "wal 0.1.2 (git+https://github.com/qdrant/wal.git?rev=fad0e7c48be58d8e7db4cc739acd9b1cf6735de0)",
+ "wal",
 ]
 
 [[package]]
@@ -1701,19 +1701,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
@@ -1856,12 +1843,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
+checksum = "21dabded2e32cd57ded879041205c60a4a4c4bab47bd0fd2fa8b01f30849f02b"
 dependencies = [
  "rustix 0.38.31",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2834,7 +2821,7 @@ dependencies = [
  "byteorder",
  "csv",
  "encoding",
- "env_logger 0.11.3",
+ "env_logger",
  "glob",
  "lindera-core",
  "lindera-decompress",
@@ -2913,7 +2900,7 @@ dependencies = [
  "csv",
  "encoding_rs",
  "encoding_rs_io",
- "env_logger 0.11.3",
+ "env_logger",
  "glob",
  "lindera-core",
  "lindera-decompress",
@@ -2934,7 +2921,7 @@ dependencies = [
  "csv",
  "encoding_rs",
  "encoding_rs_io",
- "env_logger 0.11.3",
+ "env_logger",
  "glob",
  "lindera-core",
  "lindera-decompress",
@@ -2971,7 +2958,7 @@ dependencies = [
  "byteorder",
  "csv",
  "encoding",
- "env_logger 0.11.3",
+ "env_logger",
  "glob",
  "lindera-compress",
  "lindera-core",
@@ -3022,7 +3009,7 @@ dependencies = [
  "byteorder",
  "csv",
  "encoding",
- "env_logger 0.11.3",
+ "env_logger",
  "glob",
  "lindera-compress",
  "lindera-core",
@@ -4124,7 +4111,7 @@ dependencies = [
  "tracing-tracy",
  "uuid",
  "validator",
- "wal 0.1.2 (git+https://github.com/qdrant/wal.git?rev=fad0e7c48be58d8e7db4cc739acd9b1cf6735de0)",
+ "wal",
 ]
 
 [[package]]
@@ -5258,7 +5245,7 @@ dependencies = [
  "chrono",
  "collection",
  "common",
- "env_logger 0.11.3",
+ "env_logger",
  "futures",
  "http 0.2.9",
  "io",
@@ -5287,7 +5274,7 @@ dependencies = [
  "url",
  "uuid",
  "validator",
- "wal 0.1.2 (git+https://github.com/qdrant/wal.git?rev=acaf1b2ebd5de3a871f4d2c48e13fc8788ffa43b)",
+ "wal",
 ]
 
 [[package]]
@@ -6155,38 +6142,19 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=acaf1b2ebd5de3a871f4d2c48e13fc8788ffa43b#acaf1b2ebd5de3a871f4d2c48e13fc8788ffa43b"
+source = "git+https://github.com/qdrant/wal.git?rev=a7870900f29811a24e20882887d60e6a2febf945#a7870900f29811a24e20882887d60e6a2febf945"
 dependencies = [
  "byteorder",
  "crc32c",
  "crossbeam-channel",
  "docopt",
- "env_logger 0.11.3",
+ "env_logger",
  "fs4",
  "log",
  "memmap2 0.9.4",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.38.31",
- "serde",
-]
-
-[[package]]
-name = "wal"
-version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=fad0e7c48be58d8e7db4cc739acd9b1cf6735de0#fad0e7c48be58d8e7db4cc739acd9b1cf6735de0"
-dependencies = [
- "byteorder",
- "crc32c",
- "crossbeam-channel",
- "docopt",
- "env_logger 0.10.2",
- "fs4",
- "log",
- "memmap2 0.9.4",
- "rand 0.8.5",
- "rand_distr",
- "rustix 0.38.31",
+ "rustix 0.37.27",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 serde_cbor = { workspace = true }
 uuid = { workspace = true }
 sys-info = "0.9.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
+wal = { workspace = true }
 
 config = "~0.14.0"
 
@@ -141,6 +141,7 @@ tonic-reflection = "0.9.2"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.8", features = ["v4", "serde"] }
 validator = { version = "0.16.1", features = ["derive"] }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "a7870900f29811a24e20882887d60e6a2febf945" }
 
 [[bin]]
 name = "schema_generator"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 rmp-serde = "~1.1"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fad0e7c48be58d8e7db4cc739acd9b1cf6735de0" }
+wal = { workspace = true }
 ordered-float = "4.2"
 hashring = "0.3.3"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.11"
 [dependencies]
 thiserror = "1.0"
 rand = "0.8.5"
-wal = { git = "https://github.com/qdrant/wal.git", rev = "acaf1b2ebd5de3a871f4d2c48e13fc8788ffa43b" }
+wal = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
The `collection` crate and the `storage` crate use different version of the [wal](https://github.com/qdrant/wal) crate.

The gap is represented by those two PRs:
- https://github.com/qdrant/wal/pull/71
- https://github.com/qdrant/wal/pull/68 

In order to avoid subtle compatibility issues, I have unified the version in the workspace and bumped to the latest revision.