### PR TITLE
Fix Arc unwrap function not respecting timeout

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -58,17 +58,18 @@ fn try_unwrap_with_timeout<T>(
     timeout: Duration,
 ) -> Result<T, Arc<T>> {
     let start = Instant::now();
+
     loop {
-        match Arc::try_unwrap(arc) {
-            Ok(inner) => return Ok(inner),
-            Err(inner) => {
-                arc = inner;
-                if start.elapsed() >= timeout {
-                    return Err(arc);
-                }
-                sleep(spin);
-            }
+        arc = match Arc::try_unwrap(arc) {
+            Ok(unwrapped) => return Ok(unwrapped),
+            Err(arc) => arc,
+        };
+
+        if start.elapsed() >= timeout {
+            return Err(arc);
         }
+
+        sleep(spin);
     }
 }
 


### PR DESCRIPTION
It appears the `try_unwrap_with_timeout` function did not respect the specified timeout.

I've changed the implementation to actually check it each iteration. To keep the implementation simple the timeout has a minimum resolution of `spin`.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?