### PR TITLE
Apply committed Raft entries in a separate thread

### DIFF
--- a/lib/storage/src/content_manager/consensus/entry_queue.rs
+++ b/lib/storage/src/content_manager/consensus/entry_queue.rs
@@ -41,6 +41,15 @@ impl EntryApplyProgressQueue {
         }
     }
 
+    pub fn set(&mut self, first_index: EntryId, last_index: EntryId) {
+        let first_index = match self.0 {
+            Some((first_index, _)) => first_index,
+            None => first_index,
+        };
+
+        self.0 = Some((first_index, last_index));
+    }
+
     pub fn set_from_snapshot(&mut self, snapshot_at_commit: EntryId) {
         self.0 = Some((snapshot_at_commit + 1, snapshot_at_commit))
     }

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -130,7 +130,7 @@ impl Persistent {
         first_index: EntryId,
         last_index: EntryId,
     ) -> Result<(), StorageError> {
-        self.apply_progress_queue = EntryApplyProgressQueue::new(first_index, last_index);
+        self.apply_progress_queue.set(first_index, last_index);
         self.save()
     }
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -120,9 +120,14 @@ impl Persistent {
         self.apply_progress_queue.current()
     }
 
-    pub fn entry_applied(&mut self) -> Result<(), StorageError> {
+    pub fn entry_applied(&mut self, sync: bool) -> Result<(), StorageError> {
         self.apply_progress_queue.applied();
-        self.save()
+
+        if sync {
+            self.save()?;
+        }
+
+        Ok(())
     }
 
     pub fn set_unapplied_entries(

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -305,6 +305,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 .context(format!("Failed to get entry at index {entry_index}"))?;
 
             if entry.data.is_empty() {
+                self.persistent
+                    .write()
+                    .entry_applied()
+                    .context("Failed to save new state of applied entries queue")?;
+
                 continue;
             }
 
@@ -364,6 +369,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 .context(format!("Failed to get entry at index {entry_index}"))?;
 
             if entry.data.is_empty() {
+                self.persistent
+                    .write()
+                    .entry_applied()
+                    .context("Failed to save new state of applied entries queue")?;
+
                 continue;
             }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -969,7 +969,7 @@ impl RaftMessageBroker {
     }
 
     fn message_sender(&self) -> (RaftMessageSender, RaftMessageSenderHandle) {
-        let (messages_tx, messages_rx) = tokio::sync::mpsc::channel(256);
+        let (messages_tx, messages_rx) = tokio::sync::mpsc::channel(128);
         let (heartbeat_tx, heartbeat_rx) = tokio::sync::watch::channel(Default::default());
 
         let task = RaftMessageSender {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -904,8 +904,12 @@ fn handle_committed_entries(
 
     if let (Some(first), Some(last)) = (entries.first(), entries.last()) {
         state.set_unapplied_entries(first.index, last.index)?;
+
         stop_consensus = state.apply_conf_change_entries(raw_node)?;
-        handle.signal()?;
+
+        if !stop_consensus {
+            handle.signal()?
+        }
     }
 
     Ok(stop_consensus)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -482,9 +482,15 @@ impl Consensus {
                 elapsed -= tick_period;
             }
 
-            let state = self.node.store().clone();
-            if state.apply_conf_change_entries(&mut self.node)? {
+            if self
+                .node
+                .store()
+                .clone()
+                .apply_conf_change_entries(&mut self.node)?
+            {
                 return Ok(());
+            } else {
+                self.apply.signal()?;
             }
 
             if self.node.has_ready() {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -482,12 +482,13 @@ impl Consensus {
                 elapsed -= tick_period;
             }
 
-            if self
+            let stop_consensus = self
                 .node
                 .store()
                 .clone()
-                .apply_conf_change_entries(&mut self.node)?
-            {
+                .apply_conf_change_entries(&mut self.node)?;
+
+            if stop_consensus {
                 return Ok(());
             } else {
                 self.apply.signal()?;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -239,7 +239,10 @@ impl Consensus {
             }
             log::debug!("Local raft state found - skipping initialization");
         };
+
         let mut node = Node::new(&raft_config, state_ref.clone(), logger)?;
+        node.set_batch_append(true);
+
         // Before consensus has started apply any unapplied committed entries
         // They might have not been applied due to unplanned Qdrant shutdown
         let _stop_consensus = state_ref.apply_entries(&mut node)?;


### PR DESCRIPTION
This PR applies committed Raft entries in a separate thread (using [`RawNode::advance_append`] and [`RawNode::advance_apply_to`]). This *should* considerably speed up consensus thread...

Currently based on #3964, will be rebased on dev once it's merged.

[`RawNode::advance_append`]: https://docs.rs/raft/latest/raft/raw_node/struct.RawNode.html#method.advance_append
[`RawNode::advance_apply_to`]: https://docs.rs/raft/latest/raft/raw_node/struct.RawNode.html#method.advance_apply_to

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
