### PR TITLE
Adding some derive_build attributes to gRPC types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ version = "1.9.0-dev"
 dependencies = [
  "chrono",
  "common",
+ "derive_builder",
  "log",
  "parking_lot",
  "prost 0.11.9",
@@ -1473,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1483,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1497,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
@@ -1526,6 +1527,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6154,7 +6186,7 @@ dependencies = [
  "memmap2 0.9.4",
  "rand 0.8.5",
  "rand_distr",
- "rustix 0.37.27",
+ "rustix 0.38.31",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.8", features = ["v4", "serde"] }
 validator = { version = "0.16.1", features = ["derive"] }
 wal = { git = "https://github.com/qdrant/wal.git", rev = "a7870900f29811a24e20882887d60e6a2febf945" }
+derive_builder = "0.20.0"
 
 [[bin]]
 name = "schema_generator"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 parking_lot = { workspace = true }
 validator = { workspace = true }
 log = "0.4"
+derive_builder = { workspace = true }
 
 common = { path = "../common/common" }
 segment = { path = "../segment" }

--- a/lib/api/grpc_macros.rs
+++ b/lib/api/grpc_macros.rs
@@ -1,0 +1,19 @@
+/// Default type conversions between builders and their built types.
+macro_rules! builder_type_conversions {
+    ($main_type:ident,$builder_type:ident,$build_fn:ident) => {
+        impl From<$builder_type> for $main_type {
+            fn from(value: $builder_type) -> Self {
+                value.$build_fn().unwrap()
+            }
+        }
+
+        impl From<&mut $builder_type> for $main_type {
+            fn from(value: &mut $builder_type) -> Self {
+                value.clone().$build_fn().unwrap()
+            }
+        }
+    };
+    ($main_type:ident,$builder_type:ident) => {
+        builder_type_conversions!($main_type, $builder_type, build_inner);
+    };
+}


### PR DESCRIPTION
Allows adding custom derive_build attributes to gRPC structs and fields at code generation