### PR TITLE
Add missing validation for gRPC UpsertPoints

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -181,6 +181,7 @@ fn configure_validation(builder: Builder) -> Builder {
         // Service: points.proto
         .validates(&[
             ("UpsertPoints.collection_name", "length(min = 1, max = 255)"),
+            ("UpsertPoints.points", ""),
             ("DeletePoints.collection_name", "length(min = 1, max = 255)"),
             ("UpdatePointVectors.collection_name", "length(min = 1, max = 255)"),
             ("UpdatePointVectors.vectors", "custom(function = \"crate::grpc::validate::validate_named_vectors_not_empty\", message = \"must specify vectors to update\")"),
@@ -251,6 +252,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("Filter.must_not", ""),
             ("NestedCondition.filter", ""),
             ("Condition.condition_one_of", ""),
+            ("PointStruct.vectors", ""),
             ("Vectors.vectors_options", ""),
             ("NamedVectors.vectors", ""),
             ("RecoQuery.positives", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3668,6 +3668,7 @@ pub struct UpsertPoints {
     #[prost(bool, optional, tag = "2")]
     pub wait: ::core::option::Option<bool>,
     #[prost(message, repeated, tag = "3")]
+    #[validate]
     pub points: ::prost::alloc::vec::Vec<PointStruct>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
@@ -5263,6 +5264,7 @@ pub struct PointsIdsList {
     #[prost(message, repeated, tag = "1")]
     pub ids: ::prost::alloc::vec::Vec<PointId>,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5272,6 +5274,7 @@ pub struct PointStruct {
     #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     #[prost(message, optional, tag = "4")]
+    #[validate]
     pub vectors: ::core::option::Option<Vectors>,
 }
 #[derive(serde::Serialize)]

--- a/tests/basic_sparse_grpc_test.sh
+++ b/tests/basic_sparse_grpc_test.sh
@@ -193,7 +193,7 @@ response=$(
     ]
   }' $QDRANT_HOST qdrant.Points/Upsert 2>&1
 )
-if [[ $response != *"Sparse indices does not match sparse vector conditions"* ]]; then
+if [[ $response != *"Validation error in body: [points.[].vectors.vectors_options.vectors.[].values: Validation error: must be the same length as indices [{}]]"* ]]; then
     echo Unexpected response, expected validation error: $response
     exit 1
 fi


### PR DESCRIPTION
The validation of `grpc::Vector` was not wired properly in `UpsertPoints`.

This validation is only relevant for sparse vectors currently.

Before this change we would return a validation during a conversion happening later instead of blocking the input right away.