### PR TITLE
[Docs] Make the protobuf installation instruction work for linux aarch64

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -62,7 +62,7 @@ To run Qdrant on local development environment you need to install below:
 - Install `protoc` from source
     ```shell
     PROTOC_VERSION=22.2
-    PKG_NAME=$(uname -s | awk '{print ($1 == "Darwin") ? "osx-universal_binary" : (($1 == "Linux") ? "linux-x86_64" : "")}')
+    PKG_NAME=$(uname -sm | awk '{print ($1 == "Darwin") ? "osx-universal_binary" : (($1 == "Linux") ? (($2 == "aarch64") ? "linux-aarch_64" : "linux-x86_64") : "")}')
 
     # curl `proto` source file
     curl -LO https://github.com/protocolbuffers/protobuf/releases//download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-$PKG_NAME.zip


### PR DESCRIPTION


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

---

The documentation around installing protobuf wasn't working on linux aarch64, fixed it. Tested on an aarch64 machine and mac to ensure the change works and intended and there is no regression.

Paired with @TwistingTwists.
