### PR TITLE
Clean tar dependency management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,7 +4096,6 @@ dependencies = [
  "slog-stdlog",
  "storage",
  "sys-info",
- "tar",
  "tempfile",
  "thiserror",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 tower = { version = "0.4.13" }
 tower-layer = "0.3.2"
-tar = "0.4.40"
 reqwest = { workspace = true }
 # rustls minor version must be synced with actix-web
 rustls = "0.22.4"
@@ -134,6 +133,7 @@ serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_cbor = { version = "0.11.2" }
 serde_json = "~1.0"
 strum = { version = "0.26.2", features = ["derive"] }
+tar = "0.4.40"
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -62,7 +62,7 @@ itertools = "0.12"
 indicatif = "0.17.8"
 chrono = { workspace = true }
 schemars = { workspace = true }
-tar = "0.4.40"
+tar = { workspace = true }
 fs_extra = "1.3.0"
 semver = { workspace = true }
 tempfile = "3.10.1"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -52,7 +52,7 @@ num-cmp = "0.1.0"
 rand = "0.8"
 bitvec = "1.0.1"
 seahash = "4.1.0"
-tar = "0.4.40"
+tar = { workspace = true }
 fs_extra = "1.3.0"
 semver = "1.0.22"
 tinyvec = { version = "1.6.0", features = ["alloc"] }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -30,7 +30,7 @@ tonic = { workspace = true }
 http = "0.2"
 parking_lot = { workspace = true }
 strum = { workspace = true }
-tar = "0.4.40"
+tar = { workspace = true }
 chrono = { workspace = true }
 validator = { workspace = true }
 


### PR DESCRIPTION
Remove unused `tar` dependency declaration at the root level and push it into the workspace for others dependents.