### PR TITLE
Fix debug assertion, replaced points may be less than points to update

### DIFF
--- a/lib/collection/src/collection_manager/segments_updater.rs
+++ b/lib/collection/src/collection_manager/segments_updater.rs
@@ -373,7 +373,7 @@ pub(crate) fn sync_points(
 
     // 5. Upsert points which differ from the stored ones
     let num_replaced = upsert_points(segments, op_num, points_to_update)?;
-    debug_assert_eq!(num_replaced, num_updated);
+    debug_assert!(num_replaced <= num_updated, "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})");
 
     Ok((deleted, num_new, num_updated))
 }


### PR DESCRIPTION
Fix a debug assertion that fails quite often locally. This happens on stream records transfer with concurrent upsertions.

Our sync points logic is a multi step process. We select a list of points to be replaced, and eventually update all of them. When updating, we expect the number of replaced points to match the list of points we selected.

When concurrent upsertions are ongoing, some of these points may get updated in between this process. Those points will have a newer version and will not be updated. That results in a lower number of replaced points.

Roman and I investigated this some time ago. We believe this is expected, and we should relax the debug assertion as done in this PR.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?