### PR TITLE
tests: Add test on low disk

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -161,7 +161,7 @@ jobs:
         run: ./tests/openapi_consistency_check.sh
 
 
-  test-low-ram:
+  test-low-resources:
     runs-on: ubuntu-latest
 
     steps:
@@ -195,6 +195,10 @@ jobs:
         working-directory: ./tests/low-ram
         shell: bash
         run: ./low-ram.sh
+      - name: Run low Disk test
+        working-directory: ./tests/low-disk
+        shell: bash
+        run: ./low-disk.sh
 
   test-snapshot-operations:
     runs-on: ubuntu-latest

--- a/tests/low-disk/create_items.py
+++ b/tests/low-disk/create_items.py
@@ -1,0 +1,68 @@
+import argparse
+import random
+import uuid
+
+import requests
+
+
+def generate_points(amount: int):
+    for _ in range(amount):
+        result_item = {"points": []}
+        for _ in range(100):
+            result_item["points"].append(
+                {
+                    "id": str(uuid.uuid4()),
+                    "vector": [round(random.uniform(0, 1), 2) for _ in range(4)],
+                    "payload": {"city": ["Berlin", "London"]}
+                }
+            )
+        yield result_item
+
+
+def create_collection(qdrant_host, collection_name):
+    resp = requests.put(
+        f"{qdrant_host}/collections/{collection_name}?timeout=60", json={
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine"
+            }
+        })
+    if resp.status_code != 200:
+        print(f"Collection creation failed with response body:\n{resp.json()}")
+        exit(-1)
+
+
+def insert_points(qdrant_host, collection_name, batch_json):
+    resp = requests.put(
+        f"{qdrant_host}/collections/{collection_name}/points?wait=true", json=batch_json
+    )
+    if resp.status_code == 500 and "No space left on device" in resp.text:
+        print(f"Points insertions failed with response body:\n{resp.json()}")
+        print("Continue attempts to insert points 10 times...")
+        # as of now, this ensures container crashing
+        counter = 0
+        while counter < 10:
+            counter += 1
+            requests.put(f"{qdrant_host}/collections/{collection_name}/points?wait=true", json=batch_json)
+        exit(-2)
+
+
+def initialize_qdrant(qdrant_host, collection_name, points_amount):
+    create_collection(qdrant_host, collection_name)
+    for points_batch in generate_points(points_amount):
+        insert_points(qdrant_host, collection_name, points_batch)
+
+
+def main():
+    parser = argparse.ArgumentParser("Create all required test items")
+    parser.add_argument("collection_name")
+    parser.add_argument("points_amount", type=int)
+    parser.add_argument("ports", type=int, nargs="+")
+    args = parser.parse_args()
+
+    qdrant_host = f"http://127.0.0.1:{args.ports[0]}"
+    initialize_qdrant(qdrant_host, args.collection_name, args.points_amount)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/low-disk/low-disk.sh
+++ b/tests/low-disk/low-disk.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run Qdrant container with limited disk amount
+# and verify that it doesn't crash when disk
+# is running low during points insertion.
+
+set -xeuo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+declare DOCKER_IMAGE_NAME=qdrant-recovery
+
+docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=$DOCKER_IMAGE_NAME
+
+declare OOD_CONTAINER_NAME=qdrant-ood
+
+docker rm -f ${OOD_CONTAINER_NAME} || true
+
+declare container && container=$(
+    docker run --rm -d \
+      --mount type=tmpfs,target=/qdrant/storage,tmpfs-size=10240000 \
+      -p 127.0.0.1:6333:6333 \
+      -p 127.0.0.1:6334:6334 \
+      --name ${OOD_CONTAINER_NAME} \
+      $DOCKER_IMAGE_NAME
+)
+
+function cleanup {
+    docker stop $container || true
+}
+
+trap cleanup EXIT
+
+# Wait (up to ~30 seconds) for the service to start
+declare retry=0
+while [[ $(curl -sS localhost:6333 -w ''%{http_code}'' -o /dev/null) != 200 ]]; do
+    if ((retry++ < 30)); then
+      sleep 1
+    else
+        echo "Service failed to start in ~30 seconds" >&2
+        exit 7
+    fi
+done
+
+#check that low disk is handled OK during points insertion
+python3 create_items.py low-disk 2000 6333
+
+sleep 5
+
+declare EXPECTED_TEXT='"status":"red"'
+
+# Check that curl returns collection's status as red
+CURL_RESPONSE="$(curl -sS localhost:6333/collections/low-disk)"
+
+if ! echo "$CURL_RESPONSE" | grep "${EXPECTED_TEXT}"; then
+    echo "'${EXPECTED_TEXT}' not found in curl output" >&2
+    exit 8
+fi
+
+# Check that there's an OOD log message in service logs
+declare OUT_OF_DISK_MSG='No space left on device:'
+
+if ! docker logs "$container" 2>&1 | grep "$OUT_OF_DISK_MSG"; then
+    echo "'$OUT_OF_DISK_MSG' log message not found in $container container logs" >&2
+    exit 9
+fi
+
+printf 'Insertion: OK\n\n'
+
+echo "Success"

--- a/tests/low-disk/low-disk.sh
+++ b/tests/low-disk/low-disk.sh
@@ -7,9 +7,10 @@ set -xeuo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-declare DOCKER_IMAGE_NAME=qdrant-recovery
+#declare DOCKER_IMAGE_NAME=qdrant-recovery
+declare DOCKER_IMAGE_NAME=qdrant/qdrant
 
-docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=$DOCKER_IMAGE_NAME
+#docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=$DOCKER_IMAGE_NAME
 
 declare OOD_CONTAINER_NAME=qdrant-ood
 
@@ -46,17 +47,10 @@ python3 create_items.py low-disk 2000 6333
 
 sleep 5
 
-declare EXPECTED_TEXT='"status":"red"'
-
-# Check that curl returns collection's status as red
-CURL_RESPONSE="$(curl -sS localhost:6333/collections/low-disk)"
-
-if ! echo "$CURL_RESPONSE" | grep "${EXPECTED_TEXT}"; then
-    echo "'${EXPECTED_TEXT}' not found in curl output" >&2
-    exit 8
-fi
-
-# Check that there's an OOD log message in service logs
+# Check that there's an OOD log message in service logs.
+# This check is not enough, later it can be extended with:
+# * expect some specific error response in updates
+# * assert that searches still work
 declare OUT_OF_DISK_MSG='No space left on device:'
 
 if ! docker logs "$container" 2>&1 | grep "$OUT_OF_DISK_MSG"; then

--- a/tests/low-disk/low-disk.sh
+++ b/tests/low-disk/low-disk.sh
@@ -17,7 +17,7 @@ declare OOD_CONTAINER_NAME=qdrant-ood
 docker rm -f ${OOD_CONTAINER_NAME} || true
 
 declare container && container=$(
-    docker run --rm -d \
+    docker run -d \
       --mount type=tmpfs,target=/qdrant/storage,tmpfs-size=10240000 \
       -p 127.0.0.1:6333:6333 \
       -p 127.0.0.1:6334:6334 \
@@ -26,6 +26,7 @@ declare container && container=$(
 )
 
 function cleanup {
+    docker logs $container -n 20 || true
     docker stop $container || true
 }
 


### PR DESCRIPTION
1. Add a new test with the following scenario: "Run Qdrant container with limited disk amount and verify that it doesn't crash when disk is running low during points insertion."
2. Rename CI workflow `test-low-ram` into `test-low-resources`. Run the new test as a part of it. Note: the test fails right now as Qdrant container doesn't handle OOD properly. 

Checklist
* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you successfully ran tests with your changes locally?
