### PR TITLE
Generic multivector scorer

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -187,6 +187,7 @@ pub type MultiDenseVector = TypedMultiDenseVector<VectorElementType>;
 
 impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
     pub fn new(flattened_vectors: TypedDenseVector<T>, dim: usize) -> Self {
+        assert!(flattened_vectors.len() % dim == 0, "Invalid vector length");
         Self {
             inner_vector: flattened_vectors,
             dim,
@@ -213,6 +214,10 @@ impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
     pub fn is_empty(&self) -> bool {
         self.inner_vector.is_empty()
     }
+
+    pub fn len(&self) -> usize {
+        self.inner_vector.len() / self.dim
+    }
 }
 
 impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMultiDenseVector<T> {
@@ -235,6 +240,34 @@ impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMulti
             let inner_vector = value.into_iter().flatten().collect_vec();
             let multi_dense = TypedMultiDenseVector { inner_vector, dim };
             Ok(multi_dense)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypedMultiDenseVectorRef<'a, T> {
+    pub inner_vector: &'a [T],
+    pub dim: usize,
+}
+
+impl<'a, T: PrimitiveVectorElement> TypedMultiDenseVectorRef<'a, T> {
+    /// Slices the multi vector into the underlying individual vectors
+    pub fn multi_vectors(&self) -> impl Iterator<Item = &[T]> {
+        self.inner_vector.chunks_exact(self.dim)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner_vector.is_empty()
+    }
+}
+
+impl<'a, T: PrimitiveVectorElement> From<&'a TypedMultiDenseVector<T>>
+    for TypedMultiDenseVectorRef<'a, T>
+{
+    fn from(val: &'a TypedMultiDenseVector<T>) -> Self {
+        TypedMultiDenseVectorRef {
+            inner_vector: &val.inner_vector,
+            dim: val.dim,
         }
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -1,7 +1,8 @@
 use common::types::{PointOffsetType, ScoreType};
 use ordered_float::OrderedFloat;
 
-use crate::data_types::vectors::{MultiDenseVector, VectorElementType};
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::TypedMultiDenseVectorRef;
 use crate::spaces::metric::Metric;
 use crate::types::MultiVectorConfig;
 
@@ -21,9 +22,9 @@ pub trait QueryScorer<TVector: ?Sized> {
 
 /// Colbert MaxSim metric, metric for multi-dense vectors
 /// https://arxiv.org/pdf/2112.01488.pdf, figure 1
-pub fn score_max_similarity<TMetric: Metric<VectorElementType>>(
-    multi_dense_a: &MultiDenseVector,
-    multi_dense_b: &MultiDenseVector,
+pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
+    multi_dense_a: TypedMultiDenseVectorRef<T>,
+    multi_dense_b: TypedMultiDenseVectorRef<T>,
 ) -> ScoreType {
     // TODO(colbert) add user input validation
     debug_assert!(!multi_dense_a.is_empty());
@@ -44,14 +45,14 @@ pub fn score_max_similarity<TMetric: Metric<VectorElementType>>(
     sum
 }
 
-fn score_multi<TMetric: Metric<VectorElementType>>(
+fn score_multi<T: PrimitiveVectorElement, TMetric: Metric<T>>(
     multi_vector_config: &MultiVectorConfig,
-    multi_dense_a: &MultiDenseVector,
-    multi_dense_b: &MultiDenseVector,
+    multi_dense_a: TypedMultiDenseVectorRef<T>,
+    multi_dense_b: TypedMultiDenseVectorRef<T>,
 ) -> ScoreType {
     match multi_vector_config {
         MultiVectorConfig::MaxSim(_) => {
-            score_max_similarity::<TMetric>(multi_dense_a, multi_dense_b)
+            score_max_similarity::<T, TMetric>(multi_dense_a, multi_dense_b)
         }
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -1,28 +1,34 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
 use super::score_multi;
-use crate::data_types::vectors::{DenseVector, MultiDenseVector, VectorElementType};
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{
+    DenseVector, MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef,
+};
 use crate::spaces::metric::Metric;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::MultiVectorStorage;
 
 pub struct MultiMetricQueryScorer<
     'a,
-    TMetric: Metric<VectorElementType>,
-    TVectorStorage: MultiVectorStorage<VectorElementType>,
+    TElement: PrimitiveVectorElement,
+    TMetric: Metric<TElement>,
+    TVectorStorage: MultiVectorStorage<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
-    query: MultiDenseVector,
+    query: TypedMultiDenseVector<TElement>,
     metric: PhantomData<TMetric>,
 }
 
 impl<
         'a,
-        TMetric: Metric<VectorElementType>,
-        TVectorStorage: MultiVectorStorage<VectorElementType>,
-    > MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement>,
+        TVectorStorage: MultiVectorStorage<TElement>,
+    > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     pub fn new(query: MultiDenseVector, vector_storage: &'a TVectorStorage) -> Self {
         let slices = query.multi_vectors();
@@ -30,8 +36,9 @@ impl<
             .into_iter()
             .flat_map(|slice| TMetric::preprocess(slice.to_vec()))
             .collect();
+        let preprocessed = MultiDenseVector::new(preprocessed, query.dim);
         Self {
-            query: MultiDenseVector::new(preprocessed, query.dim),
+            query: TElement::from_float_multivector(Cow::Owned(preprocessed)).into_owned(),
             vector_storage,
             metric: PhantomData,
         }
@@ -39,10 +46,10 @@ impl<
 
     fn score_multi(
         &self,
-        multi_dense_a: &MultiDenseVector,
-        multi_dense_b: &MultiDenseVector,
+        multi_dense_a: TypedMultiDenseVectorRef<TElement>,
+        multi_dense_b: TypedMultiDenseVectorRef<TElement>,
     ) -> ScoreType {
-        score_multi::<TMetric>(
+        score_multi::<TElement, TMetric>(
             self.vector_storage.multi_vector_config(),
             multi_dense_a,
             multi_dense_b,
@@ -52,18 +59,26 @@ impl<
 
 impl<
         'a,
-        TMetric: Metric<VectorElementType>,
-        TVectorStorage: MultiVectorStorage<VectorElementType>,
-    > QueryScorer<MultiDenseVector> for MultiMetricQueryScorer<'a, TMetric, TVectorStorage>
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement>,
+        TVectorStorage: MultiVectorStorage<TElement>,
+    > QueryScorer<TypedMultiDenseVector<TElement>>
+    for MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
-        self.score_multi(&self.query, self.vector_storage.get_multi(idx))
+        self.score_multi(
+            TypedMultiDenseVectorRef::from(&self.query),
+            self.vector_storage.get_multi(idx),
+        )
     }
 
     #[inline]
-    fn score(&self, v2: &MultiDenseVector) -> ScoreType {
-        self.score_multi(&self.query, v2)
+    fn score(&self, v2: &TypedMultiDenseVector<TElement>) -> ScoreType {
+        self.score_multi(
+            TypedMultiDenseVectorRef::from(&self.query),
+            TypedMultiDenseVectorRef::from(v2),
+        )
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -461,7 +461,10 @@ fn new_multi_scorer_with_metric<
     let vec_deleted = vector_storage.deleted_vector_bitslice();
     match query {
         QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
-            MultiMetricQueryScorer::<TMetric, _>::new(vector.try_into()?, vector_storage),
+            MultiMetricQueryScorer::<VectorElementType, TMetric, _>::new(
+                vector.try_into()?,
+                vector_storage,
+            ),
             point_deleted,
             vec_deleted,
             is_stopped,
@@ -469,7 +472,10 @@ fn new_multi_scorer_with_metric<
         QueryVector::Recommend(reco_query) => {
             let reco_query: RecoQuery<MultiDenseVector> = reco_query.transform_into()?;
             raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<TMetric, _, _>::new(reco_query, vector_storage),
+                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                    reco_query,
+                    vector_storage,
+                ),
                 point_deleted,
                 vec_deleted,
                 is_stopped,
@@ -479,7 +485,10 @@ fn new_multi_scorer_with_metric<
             let discovery_query: DiscoveryQuery<MultiDenseVector> =
                 discovery_query.transform_into()?;
             raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<TMetric, _, _>::new(discovery_query, vector_storage),
+                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                    discovery_query,
+                    vector_storage,
+                ),
                 point_deleted,
                 vec_deleted,
                 is_stopped,
@@ -488,7 +497,10 @@ fn new_multi_scorer_with_metric<
         QueryVector::Context(context_query) => {
             let context_query: ContextQuery<MultiDenseVector> = context_query.transform_into()?;
             raw_scorer_from_query_scorer(
-                MultiCustomQueryScorer::<TMetric, _, _>::new(context_query, vector_storage),
+                MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                    context_query,
+                    vector_storage,
+                ),
                 point_deleted,
                 vec_deleted,
                 is_stopped,

--- a/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
@@ -15,7 +15,7 @@ use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    MultiDenseVector, TypedMultiDenseVector, VectorElementType, VectorRef,
+    MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::bitvec::bitvec_set_deleted;
@@ -131,8 +131,8 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
 }
 
 impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVectorStorage<T> {
-    fn get_multi(&self, key: PointOffsetType) -> &TypedMultiDenseVector<T> {
-        self.vectors.get(key as usize).expect("vector not found")
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
+        TypedMultiDenseVectorRef::from(self.vectors.get(key as usize).expect("vector not found"))
     }
 
     fn multi_vector_config(&self) -> &MultiVectorConfig {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -13,7 +13,7 @@ use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    TypedMultiDenseVector, VectorElementType, VectorElementTypeByte, VectorRef,
+    TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::dense::appendable_mmap_dense_vector_storage::AppendableMmapDenseVectorStorage;
@@ -111,7 +111,7 @@ pub trait SparseVectorStorage: VectorStorage {
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
-    fn get_multi(&self, key: PointOffsetType) -> &TypedMultiDenseVector<T>;
+    fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T>;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 }
 


### PR DESCRIPTION
This PR introduces 2 changes:
First, it allows generic types over multivector scorers. It's required for typed multivectors (vectors of float and u8).
Second, it introduces `TypedMultidenseVectorRef` and integrates it into scorers. This additional type is better than `&MultidenseVector` because it allows to use of any slice as a multivector. It's required for mmap storage and future optimizations of ram multivector storage.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
