### PR TITLE
REST API multivector for write and retrieve

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5537,6 +5537,16 @@
                 "nullable": true
               }
             ]
+          },
+          "multi_vec_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MultiVectorConfig"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -5712,6 +5722,16 @@
           "float32",
           "uint8"
         ]
+      },
+      "MultiVectorConfig": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/MaxSimConfig"
+          }
+        ]
+      },
+      "MaxSimConfig": {
+        "type": "object"
       },
       "ShardingMethod": {
         "type": "string",
@@ -6272,6 +6292,16 @@
           },
           {
             "$ref": "#/components/schemas/SparseVector"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "float"
+              }
+            }
           }
         ]
       },
@@ -9320,25 +9350,6 @@
             }
           }
         ]
-      },
-      "MultiVectorConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "MaxSim"
-            ],
-            "properties": {
-              "MaxSim": {
-                "$ref": "#/components/schemas/MaxSimConfig"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "MaxSimConfig": {
-        "type": "object"
       },
       "VectorStorageDatatype": {
         "description": "Storage types for vectors",

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -6,9 +6,8 @@ impl From<segment::data_types::vectors::Vector> for Vector {
         match value {
             segment::data_types::vectors::Vector::Dense(vector) => Vector::Dense(vector),
             segment::data_types::vectors::Vector::Sparse(vector) => Vector::Sparse(vector),
-            segment::data_types::vectors::Vector::MultiDense(_vector) => {
-                // TODO(colbert)
-                unimplemented!()
+            segment::data_types::vectors::Vector::MultiDense(vector) => {
+                Vector::MultiDense(vector.into_multi_vectors())
             }
         }
     }
@@ -19,6 +18,13 @@ impl From<Vector> for segment::data_types::vectors::Vector {
         match value {
             Vector::Dense(vector) => segment::data_types::vectors::Vector::Dense(vector),
             Vector::Sparse(vector) => segment::data_types::vectors::Vector::Sparse(vector),
+            Vector::MultiDense(vector) => {
+                // the REST vectors have been validated already
+                // we can use an internal constructor
+                segment::data_types::vectors::Vector::MultiDense(
+                    segment::data_types::vectors::MultiDenseVector::new_validated(vector),
+                )
+            }
         }
     }
 }

--- a/lib/api/src/rest/conversions.rs
+++ b/lib/api/src/rest/conversions.rs
@@ -22,7 +22,7 @@ impl From<Vector> for segment::data_types::vectors::Vector {
                 // the REST vectors have been validated already
                 // we can use an internal constructor
                 segment::data_types::vectors::Vector::MultiDense(
-                    segment::data_types::vectors::MultiDenseVector::new_validated(vector),
+                    segment::data_types::vectors::MultiDenseVector::new_unchecked(vector),
                 )
             }
         }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -6,11 +6,15 @@ use serde::{Deserialize, Serialize};
 /// Type for dense vector
 pub type DenseVector = Vec<segment::data_types::vectors::VectorElementType>;
 
+/// Type for multi dense vector
+pub type MultiDenseVector = Vec<DenseVector>;
+
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum Vector {
     Dense(DenseVector),
     Sparse(sparse::common::sparse_vector::SparseVector),
+    MultiDense(MultiDenseVector),
 }
 
 /// Full vector data per point separator with single and multiple vector modes
@@ -29,6 +33,7 @@ impl VectorStruct {
             VectorStruct::Multi(vectors) => vectors.values().all(|v| match v {
                 Vector::Dense(vector) => vector.is_empty(),
                 Vector::Sparse(vector) => vector.indices.is_empty(),
+                Vector::MultiDense(vector) => vector.is_empty(),
             }),
         }
     }
@@ -123,4 +128,5 @@ pub enum NamedVectorStruct {
     Default(segment::data_types::vectors::DenseVector),
     Dense(segment::data_types::vectors::NamedVector),
     Sparse(segment::data_types::vectors::NamedSparseVector),
+    // No support for multi-dense vectors in search
 }

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -28,6 +28,7 @@ impl Validate for Vector {
         match self {
             Vector::Dense(_) => Ok(()),
             Vector::Sparse(v) => v.validate(),
+            Vector::MultiDense(m) => common::validation::validate_multi_vector(m),
         }
     }
 }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -357,8 +357,7 @@ impl CollectionParams {
                         } else {
                             VectorStorageType::Memory
                         },
-                        // TODO(colbert) add `multivec` to `VectorParams`
-                        multi_vec_config: None,
+                        multi_vec_config: params.multi_vec_config,
                         datatype: params.datatype.map(VectorStorageDatatype::from),
                     },
                 )

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -553,6 +553,7 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
                 .transpose()?,
             on_disk: vector_params.on_disk,
             datatype: convert_datatype_from_proto(vector_params.datatype)?,
+            multi_vec_config: None, // TODO(colbert) add multivector config
         })
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -23,8 +23,9 @@ use segment::data_types::vectors::{
 };
 use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
-    Distance, Filter, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig,
-    SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype, WithPayloadInterface, WithVector,
+    Distance, Filter, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType,
+    QuantizationConfig, SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype,
+    WithPayloadInterface, WithVector,
 };
 use semver::Version;
 use serde;
@@ -1304,6 +1305,9 @@ pub struct VectorParams {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub datatype: Option<Datatype>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multi_vec_config: Option<MultiVectorConfig>,
 }
 
 /// Validate the value is in `[1, 65536]` or `None`.

--- a/lib/collection/src/operations/vector_params_builder.rs
+++ b/lib/collection/src/operations/vector_params_builder.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU64;
 
-use segment::types::{Distance, QuantizationConfig};
+use segment::types::{Distance, MultiVectorConfig, QuantizationConfig};
 
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::operations::types::{Datatype, VectorParams};
@@ -19,6 +19,7 @@ impl VectorParamsBuilder {
                 quantization_config: None,
                 on_disk: None,
                 datatype: None,
+                multi_vec_config: None,
             },
         }
     }
@@ -40,6 +41,11 @@ impl VectorParamsBuilder {
 
     pub fn with_datatype(mut self, datatype: Datatype) -> Self {
         self.vector_params.datatype = Some(datatype);
+        self
+    }
+
+    pub fn with_multi_vec_config(mut self, multivector_config: MultiVectorConfig) -> Self {
+        self.vector_params.multi_vec_config = Some(multivector_config);
         self
     }
 

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -113,7 +113,7 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     ) -> Cow<TypedMultiDenseVector<Self>> {
         Cow::Owned(TypedMultiDenseVector::new(
             multivector
-                .inner_vector
+                .flattened_vectors
                 .iter()
                 .map(|&x| x as Self)
                 .collect_vec(),
@@ -126,7 +126,7 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
         Cow::Owned(TypedMultiDenseVector::new(
             multivector
-                .inner_vector
+                .flattened_vectors
                 .iter()
                 .map(|&x| x as VectorElementType)
                 .collect_vec(),

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -197,7 +197,7 @@ pub type MultiDenseVector = TypedMultiDenseVector<VectorElementType>;
 
 impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
     pub fn new(flattened_vectors: TypedDenseVector<T>, dim: usize) -> Self {
-        assert_eq!(flattened_vectors.len() % dim, 0, "Invalid vector length");
+        debug_assert_eq!(flattened_vectors.len() % dim, 0, "Invalid vector length");
         Self {
             inner_vector: flattened_vectors,
             dim,
@@ -206,8 +206,8 @@ impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
 
     /// To be used when the input vectors are already validated to avoid double validation
     pub fn new_validated(vectors: Vec<Vec<T>>) -> Self {
-        assert!(!vectors.is_empty(), "MultiDenseVector cannot be empty");
-        assert!(
+        debug_assert!(!vectors.is_empty(), "MultiDenseVector cannot be empty");
+        debug_assert!(
             vectors.iter().all(|v| !v.is_empty()),
             "Multi individual vectors cannot be empty"
         );

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -235,11 +235,12 @@ impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
 
     /// Consumes the multi vector and returns the underlying individual vectors
     pub fn into_multi_vectors(self) -> Vec<Vec<T>> {
-        let mut chunks = vec![];
-        for chunk in self.inner_vector.into_iter().chunks(self.dim).into_iter() {
-            chunks.push(chunk.collect());
-        }
-        chunks
+        self.inner_vector
+            .into_iter()
+            .chunks(self.dim)
+            .into_iter()
+            .map(Iterator::collect)
+            .collect()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -205,7 +205,7 @@ impl<T: PrimitiveVectorElement> TypedMultiDenseVector<T> {
     }
 
     /// To be used when the input vectors are already validated to avoid double validation
-    pub fn new_validated(vectors: Vec<Vec<T>>) -> Self {
+    pub fn new_unchecked(vectors: Vec<Vec<T>>) -> Self {
         debug_assert!(!vectors.is_empty(), "MultiDenseVector cannot be empty");
         debug_assert!(
             vectors.iter().all(|v| !v.is_empty()),

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -738,7 +738,8 @@ pub enum VectorStorageDatatype {
     Uint8,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Copy, Clone, Hash)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum MultiVectorConfig {
     MaxSim(MaxSimConfig),
 }
@@ -749,7 +750,7 @@ impl Default for MultiVectorConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct MaxSimConfig {}
 
 impl VectorStorageType {

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -192,6 +192,30 @@ def test_multi_vector_validation():
     assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in \
            response.json()["status"]["error"]
 
+    # fails because it uses one inner vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [
+                            [0.05, 0.61, 0.76, 0.74],
+                            [0.05, 0.61, 0.76]
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must have the same dimension, found vector with dimension 3' in \
+           response.json()["status"]["error"]
+
 
 def test_search_legacy_api():
     # uses raw requests to avoid schema validation error

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -18,12 +18,7 @@ def setup():
 
 
 def multivector_collection_setup(collection_name='test_collection'):
-    response = request_with_validation(
-        api='/collections/{collection_name}',
-        method="DELETE",
-        path_params={'collection_name': collection_name},
-    )
-    assert response.ok
+    drop_collection(collection_name=collection_name)
 
     response = request_with_validation(
         api='/collections/{collection_name}',

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -1,0 +1,199 @@
+import pytest
+import requests
+import os
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+
+QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost:6333")
+
+collection_name = 'test_multi_vector_persistence'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    multivector_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+def multivector_collection_setup(collection_name='test_collection'):
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "my-multivec": {
+                    "size": 4,
+                    "distance": "Dot",
+                    "multi_vec_config": {
+                        "max_sim": {}
+                    }
+                }
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+
+def test_multi_vector_persisted():
+    # batch upsert
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [[0.05, 0.61, 0.76, 0.74]]
+                    }
+                },
+                {
+                    "id": 2,
+                    "vector": {
+                        "my-multivec": [[0.19, 0.81, 0.75, 0.11]]
+                    }
+                },
+                {
+                    "id": 3,
+                    "vector": {
+                        "my-multivec": [[0.36, 0.55, 0.47, 0.94]]
+                    }
+                },
+            ]
+        }
+    )
+    assert response.ok
+
+    # scroll
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={"limit": 10, "with_vector": True}
+    )
+    assert response.ok
+    assert len(response.json()['result']['points']) == 3
+    results = response.json()['result']['points']
+
+    first_point = results[0]
+    assert first_point['id'] == 1
+    assert first_point['vector']['my-multivec'] == [[0.05, 0.61, 0.76, 0.74]]
+
+    # retrieve by id
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+    )
+    assert response.ok
+    point = response.json()['result']
+
+    assert point['id'] == 2
+    assert point['vector']['my-multivec'] == [[0.19, 0.81, 0.75, 0.11]]
+
+# TODO add test for failing search with multi vector
+
+def test_multi_vector_validation():
+    # use dense vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [0.19, 0.81, 0.75, 0.11]
+                    }
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert 'Wrong input: Conversion between multi and regular vectors failed' in response.json()["status"]["error"]
+
+    # empty multi vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": []
+                    }
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert 'Wrong input: Vector inserting error: expected dim: 4, got 0' in response.json()["status"]["error"]
+
+    # empty inner vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [[]]
+                    }
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in response.json()["status"]["error"]
+
+    # one inner vector
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "my-multivec": [
+                            [0.05, 0.61, 0.76, 0.74],
+                            []
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in response.json()["status"]["error"]
+
+


### PR DESCRIPTION
This PR adds the support for multivector in the REST API for writes and retrieve use case.

An important point is that I decided to keep the conversion between REST Vectors and Segment Vectors infallible because handling error would create a gigantic change through the codebase.

The assumption in this PR is that the input vectors will have gone through validation first.

I have integration added tests showing that:
- the validation kicks in properly
- writes work
- retrieves work
- search is not supported