### PR TITLE
Issues API: Listen for issues events in main app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,6 +5263,7 @@ dependencies = [
  "futures",
  "http 0.2.9",
  "io",
+ "issues",
  "itertools 0.12.1",
  "log",
  "memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.77"
 default-run = "qdrant"
 
 [features]
-default = ["web", "parking_lot", "issues"]
+default = ["web", "parking_lot"]
 web = ["actix-web"]
 multiling-chinese = ["segment/multiling-chinese"]
 multiling-japanese = ["segment/multiling-japanese"]
@@ -33,7 +33,6 @@ tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
 chaos-testing = []
-issues = []
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.77"
 default-run = "qdrant"
 
 [features]
-default = ["web", "parking_lot"]
+default = ["web", "parking_lot", "issues"]
 web = ["actix-web"]
 multiling-chinese = ["segment/multiling-chinese"]
 multiling-japanese = ["segment/multiling-japanese"]
@@ -33,6 +33,7 @@ tracing-tracy = ["tracing", "dep:tracing-tracy"]
 tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
 chaos-testing = []
+issues = []
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/lib/collection/src/events.rs
+++ b/lib/collection/src/events.rs
@@ -1,0 +1,18 @@
+use segment::json_path::JsonPathV2;
+use segment::types::Filter;
+
+use crate::shards::CollectionId;
+
+pub struct CollectionDeletedEvent {
+    pub collection_id: CollectionId,
+}
+
+pub struct SlowQueryEvent {
+    pub collection_id: CollectionId,
+    pub filters: Vec<Filter>,
+}
+
+pub struct IndexCreatedEvent {
+    pub collection_id: CollectionId,
+    pub field_name: JsonPathV2,
+}

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -17,5 +17,6 @@ mod update_handler;
 pub mod wal;
 pub mod wal_delta;
 
+pub mod events;
 #[cfg(test)]
 mod tests;

--- a/lib/common/issues/src/lib.rs
+++ b/lib/common/issues/src/lib.rs
@@ -5,7 +5,7 @@ pub mod problems;
 mod solution;
 pub(crate) mod typemap;
 
-pub use broker::EventBroker;
-pub use dashboard::{all_issues, clear, solve, solve_by_filter, submit};
+pub use broker::{add_subscriber, publish};
+pub use dashboard::{all_issues, clear, solve, solve_by_filter, submit, Code};
 pub use issue::{Issue, IssueRecord};
 pub use solution::{Action, ImmediateSolution, Solution};

--- a/lib/common/issues/src/typemap.rs
+++ b/lib/common/issues/src/typemap.rs
@@ -1,7 +1,7 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
-pub struct TypeMap(HashMap<TypeId, Box<dyn Any>>);
+pub struct TypeMap(HashMap<TypeId, Box<dyn Any + Send + Sync>>);
 impl TypeMap {
     pub fn new() -> Self {
         Self(HashMap::new())
@@ -11,7 +11,7 @@ impl TypeMap {
         self.0.contains_key(&TypeId::of::<T>())
     }
 
-    pub fn insert<T: 'static>(&mut self, value: T) {
+    pub fn insert<T: 'static + Send + Sync>(&mut self, value: T) {
         self.0.insert(TypeId::of::<T>(), Box::new(value));
     }
 

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -44,6 +44,7 @@ serde_cbor = { workspace = true }
 common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }
 io = { path = "../common/io" }
+issues = { path = "../common/issues" }
 memory = { path = "../common/memory" }
 segment = { path = "../segment" }
 collection = { path = "../collection" }

--- a/lib/storage/src/issues_subscribers.rs
+++ b/lib/storage/src/issues_subscribers.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use collection::events::{CollectionDeletedEvent, IndexCreatedEvent, SlowQueryEvent};
+use issues::broker::Subscriber;
+
+use crate::content_manager::toc::TableOfContent;
+use crate::dispatcher::Dispatcher;
+use crate::rbac::Access;
+
+#[allow(dead_code)] // TODO: remove
+#[derive(Clone)]
+pub struct UnindexedFieldSubscriber {
+    toc: Arc<TableOfContent>,
+    access: Access,
+}
+
+impl UnindexedFieldSubscriber {
+    pub fn new(dispatcher: Arc<Dispatcher>) -> Self {
+        let access = Access::full("For Issues API");
+        let toc = dispatcher.toc(&access).clone();
+        Self { toc, access }
+    }
+}
+
+impl Subscriber<SlowQueryEvent> for UnindexedFieldSubscriber {
+    fn notify(&self, _event: Arc<SlowQueryEvent>) {
+        // TODO: process filters and compare against the schema taken from collection info
+    }
+}
+
+impl Subscriber<CollectionDeletedEvent> for UnindexedFieldSubscriber {
+    fn notify(&self, _event: Arc<CollectionDeletedEvent>) {
+        // TODO: solve all unindexed field issues related to the deleted collection
+    }
+}
+
+impl Subscriber<IndexCreatedEvent> for UnindexedFieldSubscriber {
+    fn notify(&self, _event: Arc<IndexCreatedEvent>) {
+        // TODO: solve the missing index issue
+    }
+}

--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -12,6 +12,7 @@ use types::ClusterStatus;
 
 pub mod content_manager;
 pub mod dispatcher;
+pub mod issues_subscribers;
 pub mod rbac;
 pub mod types;
 

--- a/src/issues_setup.rs
+++ b/src/issues_setup.rs
@@ -1,0 +1,13 @@
+use std::sync::Arc;
+
+use collection::events::{CollectionDeletedEvent, IndexCreatedEvent, SlowQueryEvent};
+use storage::dispatcher::Dispatcher;
+use storage::issues_subscribers::UnindexedFieldSubscriber;
+
+pub fn setup_subscribers(dispatcher: Arc<Dispatcher>) {
+    let unindexed_subscriber = UnindexedFieldSubscriber::new(dispatcher);
+
+    issues::broker::add_subscriber::<SlowQueryEvent>(Box::new(unindexed_subscriber.clone()));
+    issues::broker::add_subscriber::<IndexCreatedEvent>(Box::new(unindexed_subscriber.clone()));
+    issues::broker::add_subscriber::<CollectionDeletedEvent>(Box::new(unindexed_subscriber));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Setup subscribers to listen for issue-able events
+    #[cfg(feature = "issues")]
     issues_setup::setup_subscribers(dispatcher_arc.clone());
 
     // Helper to better log start errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod actix;
 mod common;
 mod consensus;
 mod greeting;
+mod issues_setup;
 mod migrations;
 mod settings;
 mod snapshots;
@@ -392,6 +393,9 @@ fn main() -> anyhow::Result<()> {
     } else {
         log::info!("Telemetry reporting disabled");
     }
+
+    // Setup subscribers to listen for issue-able events
+    issues_setup::setup_subscribers(dispatcher_arc.clone());
 
     // Helper to better log start errors
     let log_err_if_any = |server_name, result| match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,6 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Setup subscribers to listen for issue-able events
-    #[cfg(feature = "issues")]
     issues_setup::setup_subscribers(dispatcher_arc.clone());
 
     // Helper to better log start errors


### PR DESCRIPTION
Needs #4086 

This PR setups and demonstrates how issue subscribers listen to issue-able events. 

While this PR won't submit nor solve any `Issue`, it slims down further PRs, for easier reviewability.