### PR TITLE
Sparse idf dot

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -79,6 +79,7 @@
     - [CompressionRatio](#qdrant-CompressionRatio)
     - [Datatype](#qdrant-Datatype)
     - [Distance](#qdrant-Distance)
+    - [Modifier](#qdrant-Modifier)
     - [PayloadSchemaType](#qdrant-PayloadSchemaType)
     - [QuantizationType](#qdrant-QuantizationType)
     - [ReplicaState](#qdrant-ReplicaState)
@@ -1213,6 +1214,7 @@ Note: 1kB = 1 vector of size 256. |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | index | [SparseIndexConfig](#qdrant-SparseIndexConfig) | optional | Configuration of sparse index |
+| modifier | [Modifier](#qdrant-Modifier) | optional | If set - apply modifier to the vector values |
 
 
 
@@ -1501,6 +1503,18 @@ Note: 1kB = 1 vector of size 256. |
 | Euclid | 2 |  |
 | Dot | 3 |  |
 | Manhattan | 4 |  |
+
+
+
+<a name="qdrant-Modifier"></a>
+
+### Modifier
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| None | 0 |  |
+| Idf | 1 | Apply Inverse Document Frequency |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5719,7 +5719,7 @@
         }
       },
       "Modifier": {
-        "description": "If used, include weight modification, which will be applied to sparse vectors in query time: None - no modification (default) Idf - inverse document frequency, based on statistics of the collection",
+        "description": "If used, include weight modification, which will be applied to sparse vectors at query time: None - no modification (default) Idf - inverse document frequency, based on statistics of the collection",
         "type": "string",
         "enum": [
           "none",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5686,6 +5686,17 @@
                 "nullable": true
               }
             ]
+          },
+          "modifier": {
+            "description": "Configures addition value modifications for sparse vectors. Default: none",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Modifier"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -5706,6 +5717,14 @@
             "nullable": true
           }
         }
+      },
+      "Modifier": {
+        "description": "If used, include weight modification, which will be applied to sparse vectors in query time: None - no modification (default) Idf - inverse document frequency, based on statistics of the collection",
+        "type": "string",
+        "enum": [
+          "none",
+          "idf"
+        ]
       },
       "HnswConfig": {
         "description": "Config of HNSW index",

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -47,6 +47,7 @@ message VectorsConfigDiff {
 
 message SparseVectorParams {
   optional SparseIndexConfig index = 1; // Configuration of sparse index
+  optional bool idf = 2; // If true - use Inverse Document Frequency for sparse vectors scoring
 }
 
 message SparseVectorConfig {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -45,9 +45,14 @@ message VectorsConfigDiff {
   }
 }
 
+enum Modifier {
+    None = 0;
+    Idf = 1; // Apply Inverse Document Frequency
+}
+
 message SparseVectorParams {
   optional SparseIndexConfig index = 1; // Configuration of sparse index
-  optional bool idf = 2; // If true - use Inverse Document Frequency for sparse vectors scoring
+  optional Modifier modifier = 2; // If set - apply modifier to the vector values
 }
 
 message SparseVectorConfig {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -112,9 +112,9 @@ pub struct SparseVectorParams {
     /// Configuration of sparse index
     #[prost(message, optional, tag = "1")]
     pub index: ::core::option::Option<SparseIndexConfig>,
-    /// If true - use Inverse Document Frequency for sparse vectors scoring
-    #[prost(bool, optional, tag = "2")]
-    pub idf: ::core::option::Option<bool>,
+    /// If set - apply modifier to the vector values
+    #[prost(enumeration = "Modifier", optional, tag = "2")]
+    pub modifier: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1107,6 +1107,34 @@ impl Datatype {
             "Default" => Some(Self::Default),
             "Float32" => Some(Self::Float32),
             "Uint8" => Some(Self::Uint8),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Modifier {
+    None = 0,
+    /// Apply Inverse Document Frequency
+    Idf = 1,
+}
+impl Modifier {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Modifier::None => "None",
+            Modifier::Idf => "Idf",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "None" => Some(Self::None),
+            "Idf" => Some(Self::Idf),
             _ => None,
         }
     }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -112,6 +112,9 @@ pub struct SparseVectorParams {
     /// Configuration of sparse index
     #[prost(message, optional, tag = "1")]
     pub index: ::core::option::Option<SparseIndexConfig>,
+    /// If true - use Inverse Document Frequency for sparse vectors scoring
+    #[prost(bool, optional, tag = "2")]
+    pub idf: ::core::option::Option<bool>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -9,6 +9,7 @@ use segment::types::{ExtendedPointId, Order, ScoredPoint, WithPayloadInterface, 
 
 use super::Collection;
 use crate::operations::consistency_params::ReadConsistency;
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::*;
 

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -855,6 +855,14 @@ impl SegmentEntry for ProxySegment {
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
         self.wrapped_segment.get().read().get_telemetry_data(detail)
     }
+
+    fn fill_query_context(&self, query_context: &mut QueryContext) {
+        // Information from temporary segment is not too important for query context
+        self.wrapped_segment
+            .get()
+            .read()
+            .fill_query_context(query_context)
+    }
 }
 
 #[cfg(test)]

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -239,7 +239,7 @@ impl ProxySegment {
             top,
             params,
             &false.into(),
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )?;
 
         Ok(result.into_iter().next().unwrap())
@@ -1001,7 +1001,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -1056,7 +1056,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -1121,7 +1121,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -25,7 +25,7 @@ use crate::collection_manager::probabilistic_segment_search_sampling::find_searc
 use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
 use crate::config::CollectionConfig;
 use crate::operations::query_enum::QueryEnum;
-use crate::operations::types::{CollectionResult, CoreSearchRequestBatch, Record};
+use crate::operations::types::{CollectionResult, CoreSearchRequestBatch, Modifier, Record};
 use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
 
 type BatchOffset = usize;
@@ -174,7 +174,7 @@ impl SegmentsSearcher {
                 .params
                 .get_sparse_vector_params_opt(vector_name)
             {
-                if sparse_vector_params.idf.unwrap_or_default()
+                if sparse_vector_params.modifier == Some(Modifier::Idf)
                     || !idf_vectors.contains(&vector_name)
                 {
                     idf_vectors.push(vector_name);

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -245,7 +245,7 @@ impl SegmentsSearcher {
             // - segments are not empty
             let use_sampling = sampling_enabled
                 && segments_lock.len() > 1
-                && query_context_acr.get_available_point_count() > 0;
+                && query_context_acr.available_point_count() > 0;
 
             segments
                 .map(|segment| {
@@ -575,7 +575,7 @@ fn execute_batch_search(
             search_params.top,
             ef_limit,
             segment_points,
-            query_context.get_available_point_count(),
+            query_context.available_point_count(),
         )
     } else {
         search_params.top

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -292,7 +292,7 @@ impl SegmentsSearcher {
             let secondary_searches: Vec<_> = {
                 let mut res = vec![];
                 for (segment_id, batch_ids) in searches_to_rerun.iter() {
-                    let query_context_acr_segment = query_context_acr.clone();
+                    let query_context_arc_segment = query_context_acr.clone();
                     let segment = locked_segments[*segment_id].clone();
                     let partial_batch_request = Arc::new(CoreSearchRequestBatch {
                         searches: batch_ids
@@ -307,7 +307,7 @@ impl SegmentsSearcher {
                             partial_batch_request,
                             false,
                             &is_stopped_clone,
-                            query_context_acr_segment,
+                            query_context_arc_segment,
                         )
                     }))
                 }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -9,6 +9,7 @@ use ordered_float::Float;
 use parking_lot::RwLock;
 use segment::common::operation_error::OperationError;
 use segment::data_types::named_vectors::NamedVectors;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{QueryVector, VectorStruct};
 use segment::types::{
     Filter, Indexes, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SeqNumberType,
@@ -16,7 +17,6 @@ use segment::types::{
 };
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
-use segment::data_types::query_context::QueryContext;
 
 use super::holders::segment_holder::LockedSegmentHolder;
 use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
@@ -157,7 +157,6 @@ impl SegmentsSearcher {
         is_stopped: Arc<AtomicBool>,
         query_context: QueryContext,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
-
         // ToDo: accumulate IDF here
 
         // ToDo: remove this

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -208,8 +208,7 @@ impl SegmentsSearcher {
                 for locked_segment in segments {
                     let segment = locked_segment.get();
                     let segment_guard = segment.read();
-                    query_context.add_available_point_count(segment_guard.available_point_count());
-                    // ToDo: update idf stats
+                    segment_guard.fill_query_context(&mut query_context);
                 }
                 Some(query_context)
             })

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -175,7 +175,7 @@ impl SegmentsSearcher {
                 .get_sparse_vector_params_opt(vector_name)
             {
                 if sparse_vector_params.modifier == Some(Modifier::Idf)
-                    || !idf_vectors.contains(&vector_name)
+                    && !idf_vectors.contains(&vector_name)
                 {
                     idf_vectors.push(vector_name);
                 }
@@ -189,7 +189,9 @@ impl SegmentsSearcher {
             search_request
                 .query
                 .iterate_sparse(|vector_name, sparse_vector| {
-                    query_context.init_idf(vector_name, &sparse_vector.indices);
+                    if idf_vectors.contains(&vector_name) {
+                        query_context.init_idf(vector_name, &sparse_vector.indices);
+                    }
                 })
         }
 

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -316,10 +316,10 @@ impl CollectionParams {
     ) -> CollectionResult<()> {
         for (vector_name, update_params) in update_vectors.0.iter() {
             let sparse_vector_params = self.get_sparse_vector_params_mut(vector_name)?;
-            let SparseVectorParams { index, idf } = update_params.clone();
+            let SparseVectorParams { index, modifier } = update_params.clone();
 
-            if let Some(idf) = idf {
-                sparse_vector_params.idf = Some(idf);
+            if let Some(modifier) = modifier {
+                sparse_vector_params.modifier = Some(modifier);
             }
 
             if let Some(index) = index {

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -318,7 +318,9 @@ impl CollectionParams {
             let sparse_vector_params = self.get_sparse_vector_params_mut(vector_name)?;
             let SparseVectorParams { index, idf } = update_params.clone();
 
-            sparse_vector_params.idf = idf;
+            if let Some(idf) = idf {
+                sparse_vector_params.idf = Some(idf);
+            }
 
             if let Some(index) = index {
                 if let Some(existing_index) = &mut sparse_vector_params.index {

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -245,6 +245,12 @@ impl CollectionParams {
             })
     }
 
+    pub fn get_sparse_vector_params_opt(&self, vector_name: &str) -> Option<&SparseVectorParams> {
+        self.sparse_vectors
+            .as_ref()
+            .and_then(|sparse_vectors| sparse_vectors.get(vector_name))
+    }
+
     pub fn get_sparse_vector_params_mut(
         &mut self,
         vector_name: &str,
@@ -310,7 +316,9 @@ impl CollectionParams {
     ) -> CollectionResult<()> {
         for (vector_name, update_params) in update_vectors.0.iter() {
             let sparse_vector_params = self.get_sparse_vector_params_mut(vector_name)?;
-            let SparseVectorParams { index } = update_params.clone();
+            let SparseVectorParams { index, idf } = update_params.clone();
+
+            sparse_vector_params.idf = idf;
 
             if let Some(index) = index {
                 if let Some(existing_index) = &mut sparse_vector_params.index {

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -11,14 +11,15 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
-    convert_to_vectors, resolve_referenced_vectors_batch, ReferencedVectors,
+    convert_to_vectors, ReferencedVectors, resolve_referenced_vectors_batch,
 };
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
-    DiscoverRequestInternal, QueryEnum,
+    DiscoverRequestInternal,
 };
 
 fn discovery_into_core_search(

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
-    convert_to_vectors, ReferencedVectors, resolve_referenced_vectors_batch,
+    convert_to_vectors, resolve_referenced_vectors_batch, ReferencedVectors,
 };
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -17,26 +17,26 @@ use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::{OrderBy, StartFrom};
 use segment::data_types::vectors::{
-    BatchVectorStruct, DEFAULT_VECTOR_NAME, Named, NamedQuery, NamedVectorStruct, Vector,
-    VectorStruct,
+    BatchVectorStruct, Named, NamedQuery, NamedVectorStruct, Vector, VectorStruct,
+    DEFAULT_VECTOR_NAME,
 };
 use segment::types::{DateTimeWrapper, Distance, QuantizationConfig, ScoredPoint};
 use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
 use segment::vector_storage::query::discovery_query::DiscoveryQuery;
 use segment::vector_storage::query::reco_query::RecoQuery;
-use sparse::common::sparse_vector::{SparseVector, validate_sparse_vector_impl};
+use sparse::common::sparse_vector::{validate_sparse_vector_impl, SparseVector};
 use tonic::Status;
 
 use super::consistency_params::ReadConsistency;
 use super::types::{
     BaseGroupRequest, ContextExamplePair, CoreSearchRequest, Datatype, DiscoverRequestInternal,
-    GroupsResult, OrderByInterface, PointGroup, RecommendExample,
-    RecommendGroupsRequestInternal, RecommendStrategy, SearchGroupsRequestInternal,
-    SparseIndexParams, SparseVectorParams, VectorParamsDiff, VectorsConfigDiff,
+    GroupsResult, OrderByInterface, PointGroup, RecommendExample, RecommendGroupsRequestInternal,
+    RecommendStrategy, SearchGroupsRequestInternal, SparseIndexParams, SparseVectorParams,
+    VectorParamsDiff, VectorsConfigDiff,
 };
 use crate::config::{
-    CollectionConfig, CollectionParams, default_replication_factor,
-    default_write_consistency_factor, ShardingMethod, WalConfig,
+    default_replication_factor, default_write_consistency_factor, CollectionConfig,
+    CollectionParams, ShardingMethod, WalConfig,
 };
 use crate::lookup::types::WithLookupInterface;
 use crate::lookup::WithLookup;
@@ -52,7 +52,7 @@ use crate::operations::config_diff::{
 };
 use crate::operations::point_ops::PointsSelector::PointIdsSelector;
 use crate::operations::point_ops::{
-    Batch, FilterSelector, PointIdsList, PointsSelector, PointStruct, WriteOrdering,
+    Batch, FilterSelector, PointIdsList, PointStruct, PointsSelector, WriteOrdering,
 };
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_key_selector::ShardKeySelector;

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -17,26 +17,26 @@ use common::types::ScoreType;
 use itertools::Itertools;
 use segment::data_types::order_by::{OrderBy, StartFrom};
 use segment::data_types::vectors::{
-    BatchVectorStruct, Named, NamedQuery, NamedVectorStruct, Vector, VectorStruct,
-    DEFAULT_VECTOR_NAME,
+    BatchVectorStruct, DEFAULT_VECTOR_NAME, Named, NamedQuery, NamedVectorStruct, Vector,
+    VectorStruct,
 };
 use segment::types::{DateTimeWrapper, Distance, QuantizationConfig, ScoredPoint};
 use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
 use segment::vector_storage::query::discovery_query::DiscoveryQuery;
 use segment::vector_storage::query::reco_query::RecoQuery;
-use sparse::common::sparse_vector::{validate_sparse_vector_impl, SparseVector};
+use sparse::common::sparse_vector::{SparseVector, validate_sparse_vector_impl};
 use tonic::Status;
 
 use super::consistency_params::ReadConsistency;
 use super::types::{
     BaseGroupRequest, ContextExamplePair, CoreSearchRequest, Datatype, DiscoverRequestInternal,
-    GroupsResult, OrderByInterface, PointGroup, QueryEnum, RecommendExample,
+    GroupsResult, OrderByInterface, PointGroup, RecommendExample,
     RecommendGroupsRequestInternal, RecommendStrategy, SearchGroupsRequestInternal,
     SparseIndexParams, SparseVectorParams, VectorParamsDiff, VectorsConfigDiff,
 };
 use crate::config::{
-    default_replication_factor, default_write_consistency_factor, CollectionConfig,
-    CollectionParams, ShardingMethod, WalConfig,
+    CollectionConfig, CollectionParams, default_replication_factor,
+    default_write_consistency_factor, ShardingMethod, WalConfig,
 };
 use crate::lookup::types::WithLookupInterface;
 use crate::lookup::WithLookup;
@@ -52,8 +52,9 @@ use crate::operations::config_diff::{
 };
 use crate::operations::point_ops::PointsSelector::PointIdsSelector;
 use crate::operations::point_ops::{
-    Batch, FilterSelector, PointIdsList, PointStruct, PointsSelector, WriteOrdering,
+    Batch, FilterSelector, PointIdsList, PointsSelector, PointStruct, WriteOrdering,
 };
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -601,6 +601,7 @@ impl From<api::grpc::qdrant::SparseVectorParams> for SparseVectorParams {
                     full_scan_threshold: index_config.full_scan_threshold.map(|v| v as usize),
                     on_disk: index_config.on_disk,
                 }),
+            idf: sparse_vector_params.idf,
         }
     }
 }
@@ -614,6 +615,7 @@ impl From<SparseVectorParams> for api::grpc::qdrant::SparseVectorParams {
                     on_disk: index_config.on_disk,
                 }
             }),
+            idf: sparse_vector_params.idf,
         }
     }
 }

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -14,6 +14,7 @@ pub mod types;
 pub mod validation;
 pub mod vector_ops;
 pub mod vector_params_builder;
+pub mod query_enum;
 
 use std::collections::HashMap;
 

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -6,6 +6,7 @@ pub mod conversions_rest;
 pub mod operation_effect;
 pub mod payload_ops;
 pub mod point_ops;
+pub mod query_enum;
 pub mod shard_key_selector;
 pub mod shard_selector_internal;
 pub mod shared_storage_config;
@@ -14,7 +15,6 @@ pub mod types;
 pub mod validation;
 pub mod vector_ops;
 pub mod vector_params_builder;
-pub mod query_enum;
 
 use std::collections::HashMap;
 

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -22,7 +22,7 @@ impl QueryEnum {
                 }
                 NamedVectorStruct::Default(_)
                 | NamedVectorStruct::Dense(_)
-                | NamedVectorStruct::MultiDense(_) => {},
+                | NamedVectorStruct::MultiDense(_) => {}
             },
             QueryEnum::RecommendBestScore(reco_query) => {
                 let name = reco_query.get_name();
@@ -50,7 +50,7 @@ impl QueryEnum {
                         Vector::Dense(_) | Vector::MultiDense(_) => {}
                     }
                 }
-            },
+            }
         }
     }
 }

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,0 +1,82 @@
+use segment::data_types::vectors::{DenseVector, Named, NamedQuery, NamedVectorStruct, Vector};
+use segment::vector_storage::query::context_query::ContextQuery;
+use segment::vector_storage::query::discovery_query::DiscoveryQuery;
+use segment::vector_storage::query::reco_query::RecoQuery;
+use sparse::common::sparse_vector::SparseVector;
+
+impl QueryEnum {
+    pub fn get_vector_name(&self) -> &str {
+        match self {
+            QueryEnum::Nearest(vector) => vector.get_name(),
+            QueryEnum::RecommendBestScore(reco_query) => reco_query.get_name(),
+            QueryEnum::Discover(discovery_query) => discovery_query.get_name(),
+            QueryEnum::Context(context_query) => context_query.get_name(),
+        }
+    }
+
+    pub fn iterate_sparse(&self, mut f: impl FnMut(&str, &SparseVector)) {
+        match self {
+            QueryEnum::Nearest(vector) => match vector {
+                NamedVectorStruct::Sparse(named_sparse_vector) => {
+                    f(&named_sparse_vector.name, &named_sparse_vector.vector)
+                }
+                NamedVectorStruct::Default(_)
+                | NamedVectorStruct::Dense(_)
+                | NamedVectorStruct::MultiDense(_) => {},
+            },
+            QueryEnum::RecommendBestScore(reco_query) => {
+                let name = reco_query.get_name();
+                for vector in reco_query.query.flat_iter() {
+                    match vector {
+                        Vector::Sparse(sparse_vector) => f(name, sparse_vector),
+                        Vector::Dense(_) | Vector::MultiDense(_) => {}
+                    }
+                }
+            }
+            QueryEnum::Discover(discovery_query) => {
+                let name = discovery_query.get_name();
+                for pair in discovery_query.query.flat_iter() {
+                    match pair {
+                        Vector::Sparse(sparse_vector) => f(name, sparse_vector),
+                        Vector::Dense(_) | Vector::MultiDense(_) => {}
+                    }
+                }
+            }
+            QueryEnum::Context(context_query) => {
+                let name = context_query.get_name();
+                for pair in context_query.query.flat_iter() {
+                    match pair {
+                        Vector::Sparse(sparse_vector) => f(name, sparse_vector),
+                        Vector::Dense(_) | Vector::MultiDense(_) => {}
+                    }
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryEnum {
+    Nearest(NamedVectorStruct),
+    RecommendBestScore(NamedQuery<RecoQuery<Vector>>),
+    Discover(NamedQuery<DiscoveryQuery<Vector>>),
+    Context(NamedQuery<ContextQuery<Vector>>),
+}
+
+impl From<DenseVector> for QueryEnum {
+    fn from(vector: DenseVector) -> Self {
+        QueryEnum::Nearest(NamedVectorStruct::Default(vector))
+    }
+}
+
+impl From<NamedQuery<DiscoveryQuery<Vector>>> for QueryEnum {
+    fn from(query: NamedQuery<DiscoveryQuery<Vector>>) -> Self {
+        QueryEnum::Discover(query)
+    }
+}
+
+impl AsRef<QueryEnum> for QueryEnum {
+    fn as_ref(&self) -> &QueryEnum {
+        self
+    }
+}

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1327,7 +1327,7 @@ impl Anonymize for VectorParams {
     }
 }
 
-/// If used, include weight modification, which will be applied to sparse vectors in query time:
+/// If used, include weight modification, which will be applied to sparse vectors at query time:
 /// None - no modification (default)
 /// Idf - inverse document frequency, based on statistics of the collection
 #[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Default)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1334,12 +1334,18 @@ pub struct SparseVectorParams {
     /// Custom params for index. If none - values from collection configuration are used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index: Option<SparseIndexParams>,
+
+    /// If true, include inverse document frequency in the scoring of sparse vectors.
+    /// Default: false
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idf: Option<bool>,
 }
 
 impl Anonymize for SparseVectorParams {
     fn anonymize(&self) -> Self {
         Self {
             index: self.index.anonymize(),
+            idf: self.idf,
         }
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -19,17 +19,13 @@ use segment::common::operation_error::OperationError;
 use segment::data_types::groups::GroupId;
 use segment::data_types::order_by::OrderBy;
 use segment::data_types::vectors::{
-    DenseVector, Named, NamedQuery, NamedVectorStruct, QueryVector, Vector, VectorRef,
-    VectorStruct, DEFAULT_VECTOR_NAME,
+    DenseVector, QueryVector, VectorRef, VectorStruct, DEFAULT_VECTOR_NAME,
 };
 use segment::json_path::{JsonPath, JsonPathInterface};
 use segment::types::{
     Distance, Filter, Payload, PayloadIndexInfo, PayloadKeyType, PointIdType, QuantizationConfig,
     SearchParams, SeqNumberType, ShardKey, VectorStorageDatatype, WithPayloadInterface, WithVector,
 };
-use segment::vector_storage::query::context_query::ContextQuery;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
 use semver::Version;
 use serde;
 use serde::{Deserialize, Serialize};
@@ -47,6 +43,7 @@ use super::ClockTag;
 use crate::config::{CollectionConfig, CollectionParams};
 use crate::lookup::types::WithLookupInterface;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_key_selector::ShardKeySelector;
 use crate::save_on_disk;
 use crate::shards::replica_set::ReplicaState;
@@ -413,43 +410,6 @@ pub struct SearchRequestInternal {
 pub struct SearchRequestBatch {
     #[validate]
     pub searches: Vec<SearchRequest>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum QueryEnum {
-    Nearest(NamedVectorStruct),
-    RecommendBestScore(NamedQuery<RecoQuery<Vector>>),
-    Discover(NamedQuery<DiscoveryQuery<Vector>>),
-    Context(NamedQuery<ContextQuery<Vector>>),
-}
-
-impl QueryEnum {
-    pub fn get_vector_name(&self) -> &str {
-        match self {
-            QueryEnum::Nearest(vector) => vector.get_name(),
-            QueryEnum::RecommendBestScore(reco_query) => reco_query.get_name(),
-            QueryEnum::Discover(discovery_query) => discovery_query.get_name(),
-            QueryEnum::Context(context_query) => context_query.get_name(),
-        }
-    }
-}
-
-impl From<DenseVector> for QueryEnum {
-    fn from(vector: DenseVector) -> Self {
-        QueryEnum::Nearest(NamedVectorStruct::Default(vector))
-    }
-}
-
-impl From<NamedQuery<DiscoveryQuery<Vector>>> for QueryEnum {
-    fn from(query: NamedQuery<DiscoveryQuery<Vector>>) -> Self {
-        QueryEnum::Discover(query)
-    }
-}
-
-impl AsRef<QueryEnum> for QueryEnum {
-    fn as_ref(&self) -> &QueryEnum {
-        self
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1327,6 +1327,17 @@ impl Anonymize for VectorParams {
     }
 }
 
+/// If used, include weight modification, which will be applied to sparse vectors in query time:
+/// None - no modification (default)
+/// Idf - inverse document frequency, based on statistics of the collection
+#[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Modifier {
+    #[default]
+    None,
+    Idf,
+}
+
 /// Params of single sparse vector data storage
 #[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1335,17 +1346,17 @@ pub struct SparseVectorParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index: Option<SparseIndexParams>,
 
-    /// If true, include inverse document frequency in the scoring of sparse vectors.
-    /// Default: false
+    /// Configures addition value modifications for sparse vectors.
+    /// Default: none
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub idf: Option<bool>,
+    pub modifier: Option<Modifier>,
 }
 
 impl Anonymize for SparseVectorParams {
     fn anonymize(&self) -> Self {
         Self {
             index: self.index.anonymize(),
-            idf: self.idf,
+            modifier: self.modifier.clone(),
         }
     }
 }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use segment::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType,
-    VectorRef,
+    DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType, VectorRef,
+    DEFAULT_VECTOR_NAME,
 };
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
@@ -16,8 +16,8 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
-    convert_to_vectors, convert_to_vectors_owned, ReferencedVectors,
-    resolve_referenced_vectors_batch,
+    convert_to_vectors, convert_to_vectors_owned, resolve_referenced_vectors_batch,
+    ReferencedVectors,
 };
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use segment::data_types::vectors::{
-    DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType, VectorRef,
-    DEFAULT_VECTOR_NAME,
+    DEFAULT_VECTOR_NAME, DenseVector, NamedQuery, NamedVectorStruct, Vector, VectorElementType,
+    VectorRef,
 };
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
@@ -16,14 +16,15 @@ use tokio::sync::RwLockReadGuard;
 use crate::collection::Collection;
 use crate::common::batching::batch_requests;
 use crate::common::fetch_vectors::{
-    convert_to_vectors, convert_to_vectors_owned, resolve_referenced_vectors_batch,
-    ReferencedVectors,
+    convert_to_vectors, convert_to_vectors_owned, ReferencedVectors,
+    resolve_referenced_vectors_batch,
 };
 use crate::common::retrieve_request_trait::RetrieveRequest;
 use crate::operations::consistency_params::ReadConsistency;
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
-    CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch, QueryEnum,
+    CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
     RecommendRequestInternal, RecommendStrategy, UsingVector,
 };
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -15,13 +15,12 @@ use tokio::sync::oneshot;
 use crate::collection_manager::holders::segment_holder::LockedSegment;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::stopping_guard::StoppingGuard;
+use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
-    CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
-    UpdateStatus,
+    CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
 use crate::operations::OperationWithClockTag;
-use crate::operations::query_enum::QueryEnum;
 use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -9,7 +9,6 @@ use common::cpu::CpuPermit;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::prelude::StdRng;
 use rand::SeedableRng;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_multi_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_multi_vector;
@@ -103,7 +102,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
                     TOP,
                     None,
                     &stopped,
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .unwrap();
             assert_eq!(results[0].len(), TOP);

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -9,6 +9,7 @@ use common::cpu::CpuPermit;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::prelude::StdRng;
 use rand::SeedableRng;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_multi_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_multi_vector;
@@ -96,7 +97,14 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
             let query = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into();
 
             let results = hnsw_index
-                .search(&[&query], None, TOP, None, &stopped, 0)
+                .search(
+                    &[&query],
+                    None,
+                    TOP,
+                    None,
+                    &stopped,
+                    &QueryContext::new(usize::MAX),
+                )
                 .unwrap();
             assert_eq!(results[0].len(), TOP);
         })

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -96,14 +96,7 @@ fn multi_vector_search_benchmark(c: &mut Criterion) {
             let query = random_multi_vector(&mut rnd, VECTOR_DIM, NUM_VECTORS_PER_POINT).into();
 
             let results = hnsw_index
-                .search(
-                    &[&query],
-                    None,
-                    TOP,
-                    None,
-                    &stopped,
-                    &Default::default(),
-                )
+                .search(&[&query], None, TOP, None, &stopped, &Default::default())
                 .unwrap();
             assert_eq!(results[0].len(), TOP);
         })

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -9,7 +9,6 @@ use common::types::PointOffsetType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use segment::data_types::query_context::QueryContext;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -98,7 +97,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
                     TOP,
                     None,
                     &stopped,
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -116,7 +115,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
                     TOP,
                     None,
                     &stopped,
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -167,7 +166,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
                     TOP,
                     None,
                     &stopped,
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .unwrap();
 

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -9,6 +9,7 @@ use common::types::PointOffsetType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use segment::data_types::query_context::QueryContext;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_ram;
 use segment::index::hnsw_index::num_rayon_threads;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -91,7 +92,14 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     group.bench_function("mmap-inverted-index-search", |b| {
         b.iter(|| {
             let results = sparse_vector_index_mmap
-                .search(&[&query_vector], None, TOP, None, &stopped, usize::MAX)
+                .search(
+                    &[&query_vector],
+                    None,
+                    TOP,
+                    None,
+                    &stopped,
+                    &QueryContext::new(usize::MAX),
+                )
                 .unwrap();
 
             assert_eq!(results[0].len(), TOP);
@@ -102,7 +110,14 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     group.bench_function("inverted-index-search", |b| {
         b.iter(|| {
             let results = sparse_vector_index
-                .search(&[&query_vector], None, TOP, None, &stopped, usize::MAX)
+                .search(
+                    &[&query_vector],
+                    None,
+                    TOP,
+                    None,
+                    &stopped,
+                    &QueryContext::new(usize::MAX),
+                )
                 .unwrap();
 
             assert_eq!(results[0].len(), TOP);
@@ -152,7 +167,7 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
                     TOP,
                     None,
                     &stopped,
-                    usize::MAX,
+                    &QueryContext::new(usize::MAX),
                 )
                 .unwrap();
 

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -3,7 +3,7 @@ pub mod integer_index;
 pub mod named_vectors;
 pub mod order_by;
 pub mod primitive;
+pub mod query_context;
 pub mod text_index;
 pub mod tiny_map;
 pub mod vectors;
-pub mod query_context;

--- a/lib/segment/src/data_types/mod.rs
+++ b/lib/segment/src/data_types/mod.rs
@@ -6,3 +6,4 @@ pub mod primitive;
 pub mod text_index;
 pub mod tiny_map;
 pub mod vectors;
+pub mod query_context;

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -34,4 +34,8 @@ impl QueryContext {
     pub fn get_search_optimized_threshold_kb(&self) -> usize {
         self.search_optimized_threshold_kb
     }
+
+    pub fn add_available_point_count(&mut self, count: usize) {
+        self.available_point_count += count;
+    }
 }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -1,8 +1,7 @@
 use ahash::HashMap;
 use sparse::common::types::DimId;
+
 use crate::data_types::tiny_map;
-
-
 
 pub struct QueryContext {
     /// Total amount of available points in the segment.
@@ -16,7 +15,7 @@ pub struct QueryContext {
     /// collected over all segments.
     /// Required for processing sparse vector search with `idf-dot` similarity.
     #[allow(dead_code)]
-    idf: tiny_map::TinyMap<String, HashMap<DimId, usize>>
+    idf: tiny_map::TinyMap<String, HashMap<DimId, usize>>,
 }
 
 impl QueryContext {
@@ -24,7 +23,7 @@ impl QueryContext {
         Self {
             available_point_count: 0,
             search_optimized_threshold_kb,
-            idf: tiny_map::TinyMap::new()
+            idf: tiny_map::TinyMap::new(),
         }
     }
 

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -1,4 +1,5 @@
-use ahash::HashMap;
+use std::collections::HashMap;
+
 use sparse::common::types::DimId;
 
 use crate::data_types::tiny_map;

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -1,0 +1,38 @@
+use ahash::HashMap;
+use sparse::common::types::DimId;
+use crate::data_types::tiny_map;
+
+
+
+pub struct QueryContext {
+    /// Total amount of available points in the segment.
+    available_point_count: usize,
+
+    /// Parameter, which defines how big a plain segment can be to be considered
+    /// small enough to be searched with `indexed_only` option.
+    search_optimized_threshold_kb: usize,
+
+    /// Statistics of the element frequency,
+    /// collected over all segments.
+    /// Required for processing sparse vector search with `idf-dot` similarity.
+    #[allow(dead_code)]
+    idf: tiny_map::TinyMap<String, HashMap<DimId, usize>>
+}
+
+impl QueryContext {
+    pub fn new(search_optimized_threshold_kb: usize) -> Self {
+        Self {
+            available_point_count: 0,
+            search_optimized_threshold_kb,
+            idf: tiny_map::TinyMap::new()
+        }
+    }
+
+    pub fn get_available_point_count(&self) -> usize {
+        self.available_point_count
+    }
+
+    pub fn get_search_optimized_threshold_kb(&self) -> usize {
+        self.search_optimized_threshold_kb
+    }
+}

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -28,11 +28,11 @@ impl QueryContext {
         }
     }
 
-    pub fn get_available_point_count(&self) -> usize {
+    pub fn available_point_count(&self) -> usize {
         self.available_point_count
     }
 
-    pub fn get_search_optimized_threshold_kb(&self) -> usize {
+    pub fn search_optimized_threshold_kb(&self) -> usize {
         self.search_optimized_threshold_kb
     }
 
@@ -56,7 +56,7 @@ impl QueryContext {
         }
     }
 
-    pub fn get_mut_idf(&mut self) -> &mut tiny_map::TinyMap<String, HashMap<DimId, usize>> {
+    pub fn mut_idf(&mut self) -> &mut tiny_map::TinyMap<String, HashMap<DimId, usize>> {
         &mut self.idf
     }
 
@@ -88,11 +88,11 @@ pub struct VectorQueryContext<'a> {
 }
 
 impl VectorQueryContext<'_> {
-    pub fn get_available_point_count(&self) -> usize {
+    pub fn available_point_count(&self) -> usize {
         self.available_point_count
     }
 
-    pub fn get_search_optimized_threshold_kb(&self) -> usize {
+    pub fn search_optimized_threshold_kb(&self) -> usize {
         self.search_optimized_threshold_kb
     }
 
@@ -118,7 +118,7 @@ impl VectorQueryContext<'_> {
         }
     }
 
-    pub fn require_idf(&self) -> bool {
+    pub fn is_require_idf(&self) -> bool {
         self.idf.is_some()
     }
 }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -39,6 +39,8 @@ impl QueryContext {
         self.available_point_count += count;
     }
 
+    /// Fill indices of sparse vectors, which are required for `idf-dot` similarity
+    /// with zeros, so the statistics can be collected.
     pub fn init_idf(&mut self, vector_name: &str, indices: &[DimId]) {
         // ToDo: Would be nice to have an implementation of `entry` for `TinyMap`.
         let idf = if let Some(idf) = self.idf.get_mut(vector_name) {
@@ -51,5 +53,9 @@ impl QueryContext {
         for index in indices {
             idf.insert(*index, 0);
         }
+    }
+
+    pub fn get_mut_idf(&mut self) -> &mut tiny_map::TinyMap<String, HashMap<DimId, usize>> {
+        &mut self.idf
     }
 }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -38,4 +38,18 @@ impl QueryContext {
     pub fn add_available_point_count(&mut self, count: usize) {
         self.available_point_count += count;
     }
+
+    pub fn init_idf(&mut self, vector_name: &str, indices: &[DimId]) {
+        // ToDo: Would be nice to have an implementation of `entry` for `TinyMap`.
+        let idf = if let Some(idf) = self.idf.get_mut(vector_name) {
+            idf
+        } else {
+            self.idf.insert(vector_name.to_string(), HashMap::default());
+            self.idf.get_mut(vector_name).unwrap()
+        };
+
+        for index in indices {
+            idf.insert(*index, 0);
+        }
+    }
 }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -22,6 +22,15 @@ pub enum Vector {
     MultiDense(MultiDenseVector),
 }
 
+impl Vector {
+    pub fn is_sparse(&self) -> bool {
+        match self {
+            Vector::Sparse(_) => true,
+            Vector::Dense(_) | Vector::MultiDense(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum VectorRef<'a> {
     Dense(&'a [VectorElementType]),
@@ -559,6 +568,12 @@ impl<T> Named for NamedQuery<T> {
 impl<T: Validate> Validate for NamedQuery<T> {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         self.query.validate()
+    }
+}
+
+impl NamedQuery<RecoQuery<Vector>> {
+    pub fn new(query: RecoQuery<Vector>, using: Option<String>) -> Self {
+        NamedQuery { query, using }
     }
 }
 

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -210,4 +210,6 @@ pub trait SegmentEntry {
 
     // Get collected telemetry data of segment
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;
+
+    fn fill_query_context(&self, query_context: &mut QueryContext);
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -7,6 +7,7 @@ use common::types::TelemetryDetail;
 use crate::common::operation_error::{OperationResult, SegmentFailedState};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderingValue};
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{QueryVector, Vector};
 use crate::index::field_index::CardinalityEstimation;
 use crate::json_path::JsonPath;
@@ -39,7 +40,7 @@ pub trait SegmentEntry {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        search_optimized_threshold_kb: usize,
+        query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>>;
 
     fn upsert_point(

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -23,6 +23,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::common::BYTES_IN_KB;
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
@@ -514,7 +515,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        _search_optimized_threshold_kb: usize,
+        _query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let exact = params.map(|params| params.exact).unwrap_or(false);
         match filter {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -23,7 +23,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::common::BYTES_IN_KB;
-use crate::data_types::query_context::QueryContext;
+use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::id_tracker::{IdTracker, IdTrackerSS};
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
@@ -515,7 +515,7 @@ impl<TGraphLinks: GraphLinks> VectorIndex for HNSWIndex<TGraphLinks> {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        _query_context: &QueryContext,
+        _query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let exact = params.map(|params| params.exact).unwrap_or(false);
         match filter {

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -261,8 +261,8 @@ impl VectorIndex for PlainIndex {
         let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
         if is_indexed_only
             && !self.is_small_enough_for_unindexed_search(
-                query_context.get_search_optimized_threshold_kb(),
-                filter,
+            query_context.search_optimized_threshold_kb(),
+            filter,
             )
         {
             return Ok(vec![vec![]; vectors.len()]);

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -261,8 +261,8 @@ impl VectorIndex for PlainIndex {
         let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
         if is_indexed_only
             && !self.is_small_enough_for_unindexed_search(
-            query_context.search_optimized_threshold_kb(),
-            filter,
+                query_context.search_optimized_threshold_kb(),
+                filter,
             )
         {
             return Ok(vec![vec![]; vectors.len()]);

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,27 +1,28 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
-use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::_serde_json::Value;
 
+use common::cpu::CpuPermit;
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+
+use crate::common::{BYTES_IN_KB, Flusher};
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
+    OperationDurationsAggregator, OperationDurationStatistics, ScopeDurationMeasurer,
 };
-use crate::common::{Flusher, BYTES_IN_KB};
-use crate::data_types::query_context::QueryContext;
+use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
+use crate::index::{PayloadIndex, VectorIndex};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
 use crate::telemetry::VectorIndexSearchesTelemetry;
@@ -256,7 +257,7 @@ impl VectorIndex for PlainIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        query_context: &QueryContext,
+        query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
         if is_indexed_only

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -1,28 +1,27 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::cpu::CpuPermit;
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
 use schemars::_serde_json::Value;
 
-use common::cpu::CpuPermit;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
-
-use crate::common::{BYTES_IN_KB, Flusher};
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::{
-    OperationDurationsAggregator, OperationDurationStatistics, ScopeDurationMeasurer,
+    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
 };
+use crate::common::{Flusher, BYTES_IN_KB};
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
-use crate::index::{PayloadIndex, VectorIndex};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::{PayloadIndex, VectorIndex};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
 use crate::telemetry::VectorIndexSearchesTelemetry;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -15,6 +15,7 @@ use crate::common::operation_time_statistics::{
     OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
 };
 use crate::common::{Flusher, BYTES_IN_KB};
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
@@ -255,11 +256,14 @@ impl VectorIndex for PlainIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        search_optimized_threshold_kb: usize,
+        query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let is_indexed_only = params.map(|p| p.indexed_only).unwrap_or(false);
         if is_indexed_only
-            && !self.is_small_enough_for_unindexed_search(search_optimized_threshold_kb, filter)
+            && !self.is_small_enough_for_unindexed_search(
+                query_context.get_search_optimized_threshold_kb(),
+                filter,
+            )
         {
             return Ok(vec![vec![]; vectors.len()]);
         }

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use ahash::AHashMap;
 use io::file_operations::{atomic_save_json, read_json};
 use serde::{Deserialize, Serialize};
-use sparse::common::sparse_vector::SparseVector;
-use sparse::common::types::DimId;
+use sparse::common::sparse_vector::{RemappedSparseVector, SparseVector};
+use sparse::common::types::{DimId, DimOffset};
 
 use crate::common::operation_error::OperationResult;
 
@@ -12,11 +12,11 @@ const INDICES_TRACKER_FILE_NAME: &str = "indices_tracker.json";
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct IndicesTracker {
-    pub map: AHashMap<DimId, DimId>,
+    pub map: AHashMap<DimId, DimOffset>,
 }
 
 impl IndicesTracker {
-    pub fn open(path: &Path, max_index_fn: impl Fn() -> DimId) -> std::io::Result<Self> {
+    pub fn open(path: &Path, max_index_fn: impl Fn() -> DimOffset) -> std::io::Result<Self> {
         let path = Self::file_path(path);
         if !path.exists() {
             let max_index = max_index_fn();
@@ -45,13 +45,18 @@ impl IndicesTracker {
         }
     }
 
-    pub fn remap_index(&self, index: DimId) -> Option<DimId> {
+    pub fn remap_index(&self, index: DimId) -> Option<DimOffset> {
         self.map.get(&index).copied()
     }
 
-    pub fn remap_vector(&self, mut vector: SparseVector) -> SparseVector {
-        let mut placeholder_indices = self.map.len() as DimId;
-        vector.indices.iter_mut().for_each(|index| {
+    pub fn remap_vector(&self, vector: SparseVector) -> RemappedSparseVector {
+        let mut placeholder_indices = self.map.len() as DimOffset;
+        let SparseVector {
+            mut indices,
+            values,
+        } = vector;
+
+        indices.iter_mut().for_each(|index| {
             *index = if let Some(index) = self.remap_index(*index) {
                 index
             } else {
@@ -59,7 +64,9 @@ impl IndicesTracker {
                 placeholder_indices
             }
         });
-        vector.sort_by_indices();
-        vector
+
+        let mut remapped_vector = RemappedSparseVector { indices, values };
+        remapped_vector.sort_by_indices();
+        remapped_vector
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -19,6 +19,7 @@ use super::indices_tracker::IndicesTracker;
 use super::sparse_index_config::SparseIndexType;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
@@ -367,7 +368,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         top: usize,
         _params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        _search_optimized_threshold_kb: usize,
+        _query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let mut results = Vec::with_capacity(vectors.len());
         let mut prefiltered_points = None;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -20,8 +20,8 @@ use super::indices_tracker::IndicesTracker;
 use super::sparse_index_config::SparseIndexType;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
-use crate::data_types::query_context::QueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::{QueryVector, Vector, VectorRef};
 use crate::id_tracker::IdTrackerSS;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::query_estimator::adjust_to_available_vectors;
@@ -31,6 +31,7 @@ use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD};
+use crate::vector_storage::query::TransformInto;
 use crate::vector_storage::{
     check_deleted_condition, new_stoppable_raw_scorer, VectorStorage, VectorStorageEnum,
 };
@@ -382,14 +383,32 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         top: usize,
         _params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        _query_context: &QueryContext,
+        query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let mut results = Vec::with_capacity(vectors.len());
         let mut prefiltered_points = None;
         for vector in vectors {
             check_process_stopped(is_stopped)?;
-            let search_results =
-                self.search_query(vector, filter, top, is_stopped, &mut prefiltered_points)?;
+
+            let search_results = if query_context.require_idf() {
+                let vector = (*vector).clone().transform(|mut vector| {
+                    match &mut vector {
+                        Vector::Dense(_) | Vector::MultiDense(_) => {
+                            return Err(OperationError::WrongSparse);
+                        }
+                        Vector::Sparse(sparse) => {
+                            query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
+                        }
+                    }
+
+                    Ok(vector)
+                })?;
+
+                self.search_query(&vector, filter, top, is_stopped, &mut prefiltered_points)?
+            } else {
+                self.search_query(vector, filter, top, is_stopped, &mut prefiltered_points)?
+            };
+
             results.push(search_results);
         }
         Ok(results)

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -390,7 +390,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         for vector in vectors {
             check_process_stopped(is_stopped)?;
 
-            let search_results = if query_context.require_idf() {
+            let search_results = if query_context.is_require_idf() {
                 let vector = (*vector).clone().transform(|mut vector| {
                     match &mut vector {
                         Vector::Dense(_) | Vector::MultiDense(_) => {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,22 +1,21 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
+use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
+use super::hnsw_index::hnsw::HNSWIndex;
+use super::plain_payload_index::PlainIndex;
+use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-
-use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
-use super::hnsw_index::hnsw::HNSWIndex;
-use super::plain_payload_index::PlainIndex;
-use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 
 /// Trait for vector searching
 pub trait VectorIndex {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,21 +1,22 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
+use crate::common::operation_error::OperationResult;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+
 use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
 use super::hnsw_index::hnsw::HNSWIndex;
 use super::plain_payload_index::PlainIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
-use crate::common::operation_error::OperationResult;
-use crate::data_types::query_context::QueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::telemetry::VectorIndexSearchesTelemetry;
-use crate::types::{Filter, SearchParams};
 
 /// Trait for vector searching
 pub trait VectorIndex {
@@ -27,7 +28,7 @@ pub trait VectorIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        query_context: &QueryContext,
+        query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>>;
 
     /// Force internal index rebuild.
@@ -72,7 +73,7 @@ impl VectorIndex for VectorIndexEnum {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        query_context: &QueryContext,
+        query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match self {
             VectorIndexEnum::Plain(index) => {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -12,6 +12,7 @@ use super::hnsw_index::hnsw::HNSWIndex;
 use super::plain_payload_index::PlainIndex;
 use super::sparse_index::sparse_vector_index::SparseVectorIndex;
 use crate::common::operation_error::OperationResult;
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
@@ -26,7 +27,7 @@ pub trait VectorIndex {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        search_optimized_threshold_kb: usize,
+        query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>>;
 
     /// Force internal index rebuild.
@@ -71,23 +72,23 @@ impl VectorIndex for VectorIndexEnum {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        opt_threshold_kb: usize,
+        query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         match self {
             VectorIndexEnum::Plain(index) => {
-                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+                index.search(vectors, filter, top, params, is_stopped, query_context)
             }
             VectorIndexEnum::HnswRam(index) => {
-                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+                index.search(vectors, filter, top, params, is_stopped, query_context)
             }
             VectorIndexEnum::HnswMmap(index) => {
-                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+                index.search(vectors, filter, top, params, is_stopped, query_context)
             }
             VectorIndexEnum::SparseRam(index) => {
-                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+                index.search(vectors, filter, top, params, is_stopped, query_context)
             }
             VectorIndexEnum::SparseMmap(index) => {
-                index.search(vectors, filter, top, params, is_stopped, opt_threshold_kb)
+                index.search(vectors, filter, top, params, is_stopped, query_context)
             }
         }
     }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1784,15 +1784,15 @@ impl SegmentEntry for Segment {
     fn fill_query_context(&self, query_context: &mut QueryContext) {
         query_context.add_available_point_count(self.available_point_count());
 
-        for (vector_name, _idf) in query_context.get_mut_idf().iter_mut() {
+        for (vector_name, idf) in query_context.get_mut_idf().iter_mut() {
             if let Some(vector_data) = self.vector_data.get(vector_name) {
                 let vector_index = vector_data.vector_index.borrow();
                 match vector_index.deref() {
-                    VectorIndexEnum::SparseRam(_sparse_index) => {
-                        unimplemented!()
+                    VectorIndexEnum::SparseRam(sparse_index) => {
+                        sparse_index.fill_idf_statistics(idf);
                     }
-                    VectorIndexEnum::SparseMmap(_sparse_index) => {
-                        unimplemented!()
+                    VectorIndexEnum::SparseMmap(sparse_index) => {
+                        sparse_index.fill_idf_statistics(idf);
                     }
                     VectorIndexEnum::Plain(_)
                     | VectorIndexEnum::HnswRam(_)

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -992,7 +992,7 @@ impl Segment {
             top,
             params,
             &false.into(),
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )?;
 
         Ok(result.into_iter().next().unwrap())
@@ -1027,13 +1027,14 @@ impl SegmentEntry for Segment {
     ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
         check_query_vectors(vector_name, query_vectors, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
+        let vector_query_context = query_context.get_vector_context(vector_name);
         let internal_results = vector_data.vector_index.borrow().search(
             query_vectors,
             filter,
             top,
             params,
             is_stopped,
-            query_context,
+            &vector_query_context,
         )?;
 
         check_stopped(is_stopped)?;
@@ -1910,7 +1911,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         eprintln!("search_batch_result = {search_batch_result:#?}");
@@ -2537,7 +2538,7 @@ mod tests {
                     1,
                     None,
                     &false.into(),
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .err()
                 .unwrap();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -26,6 +26,7 @@ use crate::common::version::{StorageVersion, VERSION_FILE};
 use crate::common::{check_named_vectors, check_query_vectors, check_stopped, check_vector_name};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{Direction, OrderBy, OrderingValue};
+use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{MultiDenseVector, QueryVector, Vector, VectorRef};
 use crate::entry::entry_point::SegmentEntry;
 use crate::id_tracker::IdTrackerSS;
@@ -990,7 +991,7 @@ impl Segment {
             top,
             params,
             &false.into(),
-            usize::MAX,
+            &QueryContext::new(usize::MAX),
         )?;
 
         Ok(result.into_iter().next().unwrap())
@@ -1021,7 +1022,7 @@ impl SegmentEntry for Segment {
         top: usize,
         params: Option<&SearchParams>,
         is_stopped: &AtomicBool,
-        search_optimized_threshold_kb: usize,
+        query_context: &QueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
         check_query_vectors(vector_name, query_vectors, &self.segment_config)?;
         let vector_data = &self.vector_data[vector_name];
@@ -1031,7 +1032,7 @@ impl SegmentEntry for Segment {
             top,
             params,
             is_stopped,
-            search_optimized_threshold_kb,
+            query_context,
         )?;
 
         check_stopped(is_stopped)?;
@@ -1887,7 +1888,7 @@ mod tests {
                 10,
                 None,
                 &false.into(),
-                10_000,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         eprintln!("search_batch_result = {search_batch_result:#?}");
@@ -2514,7 +2515,7 @@ mod tests {
                     1,
                     None,
                     &false.into(),
-                    10_000,
+                    &QueryContext::new(usize::MAX),
                 )
                 .err()
                 .unwrap();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -1777,6 +1778,27 @@ impl SegmentEntry for Segment {
             config: self.config().clone(),
             vector_index_searches,
             payload_field_indices: self.payload_index.borrow().get_telemetry_data(),
+        }
+    }
+
+    fn fill_query_context(&self, query_context: &mut QueryContext) {
+        query_context.add_available_point_count(self.available_point_count());
+
+        for (vector_name, _idf) in query_context.get_mut_idf().iter_mut() {
+            if let Some(vector_data) = self.vector_data.get(vector_name) {
+                let vector_index = vector_data.vector_index.borrow();
+                match vector_index.deref() {
+                    VectorIndexEnum::SparseRam(_sparse_index) => {
+                        unimplemented!()
+                    }
+                    VectorIndexEnum::SparseMmap(_sparse_index) => {
+                        unimplemented!()
+                    }
+                    VectorIndexEnum::Plain(_)
+                    | VectorIndexEnum::HnswRam(_)
+                    | VectorIndexEnum::HnswMmap(_) => {}
+                }
+            }
         }
     }
 }

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1785,7 +1785,7 @@ impl SegmentEntry for Segment {
     fn fill_query_context(&self, query_context: &mut QueryContext) {
         query_context.add_available_point_count(self.available_point_count());
 
-        for (vector_name, idf) in query_context.get_mut_idf().iter_mut() {
+        for (vector_name, idf) in query_context.mut_idf().iter_mut() {
             if let Some(vector_data) = self.vector_data.get(vector_name) {
                 let vector_index = vector_data.vector_index.borrow();
                 match vector_index.deref() {

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -1,15 +1,13 @@
 use std::iter;
 
-use itertools::Itertools;
-
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
+use itertools::Itertools;
 
+use super::context_query::ContextPair;
+use super::{Query, TransformInto};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
-
-use super::{Query, TransformInto};
-use super::context_query::ContextPair;
 
 type RankType = i32;
 
@@ -86,11 +84,10 @@ impl From<DiscoveryQuery<Vector>> for QueryVector {
 mod test {
     use std::cmp::Ordering;
 
+    use common::types::ScoreType;
     use itertools::Itertools;
     use proptest::prelude::*;
     use rstest::rstest;
-
-    use common::types::ScoreType;
 
     use super::*;
 

--- a/lib/segment/src/vector_storage/query/discovery_query.rs
+++ b/lib/segment/src/vector_storage/query/discovery_query.rs
@@ -1,13 +1,15 @@
 use std::iter;
 
-use common::math::scaled_fast_sigmoid;
-use common::types::ScoreType;
 use itertools::Itertools;
 
-use super::context_query::ContextPair;
-use super::{Query, TransformInto};
+use common::math::scaled_fast_sigmoid;
+use common::types::ScoreType;
+
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{QueryVector, Vector};
+
+use super::{Query, TransformInto};
+use super::context_query::ContextPair;
 
 type RankType = i32;
 
@@ -84,10 +86,11 @@ impl From<DiscoveryQuery<Vector>> for QueryVector {
 mod test {
     use std::cmp::Ordering;
 
-    use common::types::ScoreType;
     use itertools::Itertools;
     use proptest::prelude::*;
     use rstest::rstest;
+
+    use common::types::ScoreType;
 
     use super::*;
 

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
@@ -119,7 +120,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                10_000,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -181,7 +182,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -192,7 +193,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -203,7 +204,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
@@ -120,7 +119,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -182,7 +181,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -193,7 +192,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -204,7 +203,7 @@ fn test_batch_and_single_request_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
@@ -255,7 +256,7 @@ fn test_byte_storage_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -277,7 +278,7 @@ fn test_byte_storage_hnsw(
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         let plain_result_byte = segment_byte.vector_data[DEFAULT_VECTOR_NAME]
@@ -289,7 +290,7 @@ fn test_byte_storage_hnsw(
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         compare_search_result(&plain_result_float, &plain_result_byte);

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
@@ -256,7 +255,7 @@ fn test_byte_storage_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -278,7 +277,7 @@ fn test_byte_storage_hnsw(
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         let plain_result_byte = segment_byte.vector_data[DEFAULT_VECTOR_NAME]
@@ -290,7 +289,7 @@ fn test_byte_storage_hnsw(
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         compare_search_result(&plain_result_float, &plain_result_byte);

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
@@ -334,7 +333,7 @@ fn test_byte_storage_binary_quantization_hnsw(
                     ..Default::default()
                 }),
                 &stopped,
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -353,7 +352,7 @@ fn test_byte_storage_binary_quantization_hnsw(
                     ..Default::default()
                 }),
                 &stopped,
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_dense_byte_vector, random_int_payload};
@@ -333,7 +334,7 @@ fn test_byte_storage_binary_quantization_hnsw(
                     ..Default::default()
                 }),
                 &stopped,
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -352,7 +353,7 @@ fn test_byte_storage_binary_quantization_hnsw(
                     ..Default::default()
                 }),
                 &stopped,
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -6,7 +6,6 @@ use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
@@ -165,7 +164,7 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
@@ -177,7 +176,7 @@ fn exact_search_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -212,7 +211,7 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
@@ -224,7 +223,7 @@ fn exact_search_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -6,6 +6,7 @@ use common::cpu::CpuPermit;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
@@ -164,13 +165,20 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         assert_eq!(
@@ -204,7 +212,7 @@ fn exact_search_test() {
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         let plain_result = segment.vector_data[DEFAULT_VECTOR_NAME]
@@ -216,7 +224,7 @@ fn exact_search_test() {
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
@@ -241,7 +242,7 @@ fn _test_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -263,7 +264,7 @@ fn _test_filterable_hnsw(
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_vector};
@@ -242,7 +241,7 @@ fn _test_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -264,7 +263,7 @@ fn _test_filterable_hnsw(
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -6,7 +6,6 @@ use common::cpu::CpuPermit;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -141,7 +140,7 @@ fn hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -154,7 +153,7 @@ fn hnsw_discover_precision() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -280,7 +279,7 @@ fn filtered_hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -293,7 +292,7 @@ fn filtered_hnsw_discover_precision() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -6,6 +6,7 @@ use common::cpu::CpuPermit;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -140,14 +141,21 @@ fn hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
         let plain_discovery_result = segment.vector_data[DEFAULT_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         if plain_discovery_result == index_discovery_result {
@@ -272,7 +280,7 @@ fn filtered_hnsw_discover_precision() {
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -285,7 +293,7 @@ fn filtered_hnsw_discover_precision() {
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -8,6 +8,7 @@ use common::cpu::CpuPermit;
 use common::types::{ScoreType, ScoredPointOffset};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_vector, STR_KEY};
@@ -198,7 +199,14 @@ fn check_matches(
             segment.vector_data[DEFAULT_VECTOR_NAME]
                 .vector_index
                 .borrow()
-                .search(&[&query], filter, top, None, &false.into(), usize::MAX)
+                .search(
+                    &[&query],
+                    filter,
+                    top,
+                    None,
+                    &false.into(),
+                    &QueryContext::new(usize::MAX),
+                )
                 .unwrap()
         })
         .collect::<Vec<_>>();
@@ -216,7 +224,7 @@ fn check_matches(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         sames += sames_count(&index_result, plain_result);
@@ -250,7 +258,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         let best_1 = oversampling_1_result[0][0];
@@ -271,7 +279,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         let best_2 = oversampling_2_result[0][0];
@@ -309,7 +317,7 @@ fn check_rescoring(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
         for result in &index_result[0] {

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -8,7 +8,6 @@ use common::cpu::CpuPermit;
 use common::types::{ScoreType, ScoredPointOffset};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_vector, STR_KEY};
@@ -205,7 +204,7 @@ fn check_matches(
                     top,
                     None,
                     &false.into(),
-                    &QueryContext::new(usize::MAX),
+                    &Default::default(),
                 )
                 .unwrap()
         })
@@ -224,7 +223,7 @@ fn check_matches(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         sames += sames_count(&index_result, plain_result);
@@ -258,7 +257,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         let best_1 = oversampling_1_result[0][0];
@@ -279,7 +278,7 @@ fn check_oversampling(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         let best_2 = oversampling_2_result[0][0];
@@ -317,7 +316,7 @@ fn check_rescoring(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         for result in &index_result[0] {

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_multi_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
@@ -228,7 +229,7 @@ fn test_multi_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -251,7 +252,7 @@ fn test_multi_filterable_hnsw(
                 top,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::rstest;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{only_default_multi_vector, QueryVector, DEFAULT_VECTOR_NAME};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
@@ -229,7 +228,7 @@ fn test_multi_filterable_hnsw(
                     ..Default::default()
                 }),
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -252,7 +251,7 @@ fn test_multi_filterable_hnsw(
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -6,7 +6,6 @@ use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{
     only_default_vector, MultiDenseVector, QueryVector, VectorElementType, VectorRef,
     DEFAULT_VECTOR_NAME,
@@ -180,7 +179,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -191,7 +190,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
                 10,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -6,6 +6,7 @@ use common::cpu::CpuPermit;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{
     only_default_vector, MultiDenseVector, QueryVector, VectorElementType, VectorRef,
     DEFAULT_VECTOR_NAME,
@@ -179,7 +180,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
                 10,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 
@@ -190,7 +191,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
                 10,
                 None,
                 &false.into(),
-                usize::MAX,
+                &QueryContext::new(usize::MAX),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use segment::data_types::named_vectors::NamedVectors;
+use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{QueryVector, VectorElementType};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -189,13 +190,27 @@ fn sparse_index_discover_test() {
         let (sparse_query, dense_query) = random_discovery_query(&mut rnd, dim);
 
         let sparse_discovery_result = sparse_index
-            .search(&[&sparse_query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&sparse_query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         let dense_discovery_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&dense_query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         // check id only because scores can be epsilon-size different
@@ -213,13 +228,27 @@ fn sparse_index_discover_test() {
         // do regular nearest search
         let (sparse_query, dense_query) = random_nearest_query(&mut rnd, dim);
         let sparse_search_result = sparse_index
-            .search(&[&sparse_query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&sparse_query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         let dense_search_result = dense_segment.vector_data[SPARSE_VECTOR_NAME]
             .vector_index
             .borrow()
-            .search(&[&dense_query], None, top, None, &false.into(), usize::MAX)
+            .search(
+                &[&dense_query],
+                None,
+                top,
+                None,
+                &false.into(),
+                &QueryContext::new(usize::MAX),
+            )
             .unwrap();
 
         // check that nearest search uses sparse index

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{QueryVector, VectorElementType};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::random_vector;
@@ -196,7 +195,7 @@ fn sparse_index_discover_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -209,7 +208,7 @@ fn sparse_index_discover_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -234,7 +233,7 @@ fn sparse_index_discover_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -247,7 +246,7 @@ fn sparse_index_discover_test() {
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -9,7 +9,6 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{QueryVector, Vector};
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::payload_fixtures::STR_KEY;
@@ -95,7 +94,7 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
                 top,
                 None,
                 &stopped,
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -107,7 +106,7 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
                 top,
                 None,
                 &stopped,
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
 
@@ -193,7 +192,7 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
                 top,
                 None,
                 &false.into(),
-                &QueryContext::new(usize::MAX),
+                &Default::default(),
             )
             .unwrap();
         assert!(results[0].iter().any(|s| s.idx == id));
@@ -333,7 +332,7 @@ fn sparse_vector_index_ram_deleted_points_search() {
             top,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
 
@@ -393,7 +392,7 @@ fn sparse_vector_index_ram_deleted_points_search() {
             top,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_ne!(before_deletion_results, after_deletion_results);
@@ -436,7 +435,7 @@ fn sparse_vector_index_ram_filtered_search() {
             10,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_eq!(before_result.len(), 1);
@@ -491,7 +490,7 @@ fn sparse_vector_index_ram_filtered_search() {
             half_indexed_count * 2, // original top
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_eq!(after_result.len(), 1);
@@ -533,7 +532,7 @@ fn sparse_vector_index_plain_search() {
             10,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
 
@@ -562,7 +561,7 @@ fn sparse_vector_index_plain_search() {
             NUM_VECTORS,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
 
@@ -630,7 +629,7 @@ fn handling_empty_sparse_vectors() {
             10,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_eq!(results.len(), 1);
@@ -765,7 +764,7 @@ fn sparse_vector_index_persistence_test() {
             top,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_eq!(search_after_reload_result[0].len(), top);
@@ -833,7 +832,7 @@ fn sparse_vector_index_persistence_test() {
             top,
             None,
             &stopped,
-            &QueryContext::new(usize::MAX),
+            &Default::default(),
         )
         .unwrap();
     assert_eq!(search_after_reload_result[0].len(), top);

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -1,11 +1,13 @@
 use std::borrow::Cow;
+use std::hash::Hash;
 
+use common::types::ScoreType;
 use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError, ValidationErrors};
 
-use crate::common::types::{DimId, DimWeight};
+use crate::common::types::{DimId, DimOffset, DimWeight};
 
 /// Sparse vector structure
 #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -15,6 +17,95 @@ pub struct SparseVector {
     pub indices: Vec<DimId>,
     /// values and indices must be the same length
     pub values: Vec<DimWeight>,
+}
+
+/// Same as `SparseVector` but with `DimOffset` indices.
+/// Meaning that is uses internal segment-specific indices.
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+pub struct RemappedSparseVector {
+    /// indices must be unique
+    pub indices: Vec<DimOffset>,
+    /// values and indices must be the same length
+    pub values: Vec<DimWeight>,
+}
+
+/// Sort two arrays by the first array.
+fn double_sort<T: Ord + Copy, V: Copy>(indices: &mut [T], values: &mut [V]) {
+    // Check if the indices are already sorted
+    if indices.windows(2).all(|w| w[0] < w[1]) {
+        return;
+    }
+
+    let mut indexed_values: Vec<(T, V)> = indices
+        .iter()
+        .zip(values.iter())
+        .map(|(&i, &v)| (i, v))
+        .collect();
+
+    // Sort the vector of tuples by indices
+    indexed_values.sort_unstable_by_key(|&(i, _)| i);
+
+    for (i, (index, value)) in indexed_values.into_iter().enumerate() {
+        indices[i] = index;
+        values[i] = value;
+    }
+}
+
+fn score_vectors<T: Ord + Eq>(
+    self_indices: &[T],
+    self_values: &[DimWeight],
+    other_indices: &[T],
+    other_values: &[DimWeight],
+) -> Option<ScoreType> {
+    let mut score = 0.0;
+    // track whether there is any overlap
+    let mut overlap = false;
+    let mut i = 0;
+    let mut j = 0;
+    while i < self_indices.len() && j < other_indices.len() {
+        match self_indices[i].cmp(&other_indices[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                overlap = true;
+                score += self_values[i] * other_values[j];
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    if overlap {
+        Some(score)
+    } else {
+        None
+    }
+}
+
+impl RemappedSparseVector {
+    pub fn new(indices: Vec<DimId>, values: Vec<DimWeight>) -> Result<Self, ValidationErrors> {
+        let vector = Self { indices, values };
+        vector.validate()?;
+        Ok(vector)
+    }
+
+    pub fn sort_by_indices(&mut self) {
+        double_sort(&mut self.indices, &mut self.values);
+    }
+
+    /// Check if this vector is sorted by indices.
+    pub fn is_sorted(&self) -> bool {
+        self.indices.windows(2).all(|w| w[0] < w[1])
+    }
+
+    /// Score this vector against another vector using dot product.
+    /// Warning: Expects both vectors to be sorted by indices.
+    ///
+    /// Return None if the vectors do not overlap.
+    pub fn score(&self, other: &RemappedSparseVector) -> Option<ScoreType> {
+        debug_assert!(self.is_sorted());
+        debug_assert!(other.is_sorted());
+        score_vectors(&self.indices, &self.values, &other.indices, &other.values)
+    }
 }
 
 impl SparseVector {
@@ -28,23 +119,7 @@ impl SparseVector {
     ///
     /// Sorting is required for scoring and overlap checks.
     pub fn sort_by_indices(&mut self) {
-        // do not sort if already sorted
-        if self.is_sorted() {
-            return;
-        }
-
-        let mut indexed_values: Vec<(u32, f32)> = self
-            .indices
-            .iter()
-            .zip(self.values.iter())
-            .map(|(&i, &v)| (i, v))
-            .collect();
-
-        // Sort the vector of tuples by indices
-        indexed_values.sort_by_key(|&(i, _)| i);
-
-        self.indices = indexed_values.iter().map(|&(i, _)| i).collect();
-        self.values = indexed_values.iter().map(|&(_, v)| v).collect();
+        double_sort(&mut self.indices, &mut self.values);
     }
 
     /// Check if this vector is sorted by indices.
@@ -61,31 +136,10 @@ impl SparseVector {
     /// Warning: Expects both vectors to be sorted by indices.
     ///
     /// Return None if the vectors do not overlap.
-    pub fn score(&self, other: &SparseVector) -> Option<f32> {
+    pub fn score(&self, other: &SparseVector) -> Option<ScoreType> {
         debug_assert!(self.is_sorted());
         debug_assert!(other.is_sorted());
-        let mut score = 0.0;
-        // track whether there is any overlap
-        let mut overlap = false;
-        let mut i = 0;
-        let mut j = 0;
-        while i < self.indices.len() && j < other.indices.len() {
-            match self.indices[i].cmp(&other.indices[j]) {
-                std::cmp::Ordering::Less => i += 1,
-                std::cmp::Ordering::Greater => j += 1,
-                std::cmp::Ordering::Equal => {
-                    overlap = true;
-                    score += self.values[i] * other.values[j];
-                    i += 1;
-                    j += 1;
-                }
-            }
-        }
-        if overlap {
-            Some(score)
-        } else {
-            None
-        }
+        score_vectors(&self.indices, &self.values, &other.indices, &other.values)
     }
 
     /// Construct a new vector that is the result of performing all indices-wise operations.
@@ -155,16 +209,20 @@ impl SparseVector {
     }
 }
 
+impl TryFrom<Vec<(u32, f32)>> for RemappedSparseVector {
+    type Error = ValidationErrors;
+
+    fn try_from(tuples: Vec<(u32, f32)>) -> Result<Self, Self::Error> {
+        let (indices, values): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
+        RemappedSparseVector::new(indices, values)
+    }
+}
+
 impl TryFrom<Vec<(u32, f32)>> for SparseVector {
     type Error = ValidationErrors;
 
     fn try_from(tuples: Vec<(u32, f32)>) -> Result<Self, Self::Error> {
-        let mut indices = Vec::with_capacity(tuples.len());
-        let mut values = Vec::with_capacity(tuples.len());
-        for (i, w) in tuples {
-            indices.push(i);
-            values.push(w);
-        }
+        let (indices, values): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
         SparseVector::new(indices, values)
     }
 }
@@ -176,14 +234,27 @@ impl<const N: usize> From<[(u32, f32); N]> for SparseVector {
     }
 }
 
+#[cfg(test)]
+impl<const N: usize> From<[(u32, f32); N]> for RemappedSparseVector {
+    fn from(value: [(u32, f32); N]) -> Self {
+        value.to_vec().try_into().unwrap()
+    }
+}
+
 impl Validate for SparseVector {
     fn validate(&self) -> Result<(), ValidationErrors> {
         validate_sparse_vector_impl(&self.indices, &self.values)
     }
 }
 
-pub fn validate_sparse_vector_impl(
-    indices: &[DimId],
+impl Validate for RemappedSparseVector {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        validate_sparse_vector_impl(&self.indices, &self.values)
+    }
+}
+
+pub fn validate_sparse_vector_impl<T: Clone + Eq + Hash>(
+    indices: &[T],
     values: &[DimWeight],
 ) -> Result<(), ValidationErrors> {
     let mut errors = ValidationErrors::default();
@@ -211,36 +282,36 @@ mod tests {
 
     #[test]
     fn test_score_aligned_same_size() {
-        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
-        let v2 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v1 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
         assert_eq!(v1.score(&v2), Some(14.0));
     }
 
     #[test]
     fn test_score_not_aligned_same_size() {
-        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
-        let v2 = SparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
+        let v1 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = RemappedSparseVector::new(vec![2, 3, 4], vec![2.0, 3.0, 4.0]).unwrap();
         assert_eq!(v1.score(&v2), Some(13.0));
     }
 
     #[test]
     fn test_score_aligned_different_size() {
-        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
-        let v2 = SparseVector::new(vec![1, 2, 3, 4], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        let v1 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = RemappedSparseVector::new(vec![1, 2, 3, 4], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
         assert_eq!(v1.score(&v2), Some(14.0));
     }
 
     #[test]
     fn test_score_not_aligned_different_size() {
-        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
-        let v2 = SparseVector::new(vec![2, 3, 4, 5], vec![2.0, 3.0, 4.0, 5.0]).unwrap();
+        let v1 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = RemappedSparseVector::new(vec![2, 3, 4, 5], vec![2.0, 3.0, 4.0, 5.0]).unwrap();
         assert_eq!(v1.score(&v2), Some(13.0));
     }
 
     #[test]
     fn test_score_no_overlap() {
-        let v1 = SparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
-        let v2 = SparseVector::new(vec![4, 5, 6], vec![2.0, 3.0, 4.0]).unwrap();
+        let v1 = RemappedSparseVector::new(vec![1, 2, 3], vec![1.0, 2.0, 3.0]).unwrap();
+        let v2 = RemappedSparseVector::new(vec![4, 5, 6], vec![2.0, 3.0, 4.0]).unwrap();
         assert!(v1.score(&v2).is_none());
     }
 

--- a/lib/sparse/src/common/types.rs
+++ b/lib/sparse/src/common/types.rs
@@ -1,2 +1,3 @@
+pub type DimOffset = u32;
 pub type DimId = u32;
 pub type DimWeight = f32;

--- a/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_mmap.rs
@@ -12,8 +12,8 @@ use memory::mmap_ops::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::sparse_vector::SparseVector;
-use crate::common::types::DimId;
+use crate::common::sparse_vector::RemappedSparseVector;
+use crate::common::types::{DimId, DimOffset};
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::inverted_index::InvertedIndex;
 use crate::index::posting_list::{PostingElement, PostingListIterator};
@@ -55,6 +55,14 @@ impl InvertedIndex for InvertedIndexMmap {
         self.get(id).map(PostingListIterator::new)
     }
 
+    fn len(&self) -> usize {
+        self.file_header.posting_count
+    }
+
+    fn posting_list_len(&self, id: &DimOffset) -> Option<usize> {
+        self.get(id).map(|posting_list| posting_list.len())
+    }
+
     fn files(path: &Path) -> Vec<PathBuf> {
         vec![
             Self::index_file_path(path),
@@ -62,7 +70,7 @@ impl InvertedIndex for InvertedIndexMmap {
         ]
     }
 
-    fn upsert(&mut self, _id: PointOffsetType, _vector: SparseVector) {
+    fn upsert(&mut self, _id: PointOffsetType, _vector: RemappedSparseVector) {
         panic!("Cannot upsert into a read-only Mmap inverted index")
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram_builder.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use common::types::PointOffsetType;
 
-use crate::common::sparse_vector::SparseVector;
+use crate::common::sparse_vector::RemappedSparseVector;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::posting_list::PostingBuilder;
 
@@ -27,7 +27,7 @@ impl InvertedIndexBuilder {
     }
 
     /// Add a vector to the inverted index builder
-    pub fn add(&mut self, id: PointOffsetType, vector: SparseVector) {
+    pub fn add(&mut self, id: PointOffsetType, vector: RemappedSparseVector) {
         for (dim_id, weight) in vector.indices.into_iter().zip(vector.values.into_iter()) {
             let dim_id = dim_id as usize;
             self.posting_builders.resize_with(

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use common::types::PointOffsetType;
 
-use crate::common::sparse_vector::SparseVector;
-use crate::common::types::DimId;
+use crate::common::sparse_vector::RemappedSparseVector;
+use crate::common::types::DimOffset;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use crate::index::posting_list::PostingListIterator;
 
@@ -19,13 +19,24 @@ pub trait InvertedIndex: Sized {
     fn save(&self, path: &Path) -> std::io::Result<()>;
 
     /// Get posting list for dimension id
-    fn get(&self, id: &DimId) -> Option<PostingListIterator>;
+    fn get(&self, id: &DimOffset) -> Option<PostingListIterator>;
+
+    /// Get number of posting lists
+    fn len(&self) -> usize;
+
+    /// Check if the index is empty
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get number of posting lists for dimension id
+    fn posting_list_len(&self, id: &DimOffset) -> Option<usize>;
 
     /// Files used by this index
     fn files(path: &Path) -> Vec<PathBuf>;
 
     /// Upsert a vector into the inverted index.
-    fn upsert(&mut self, id: PointOffsetType, vector: SparseVector);
+    fn upsert(&mut self, id: PointOffsetType, vector: RemappedSparseVector);
 
     /// Create inverted index from ram index
     fn from_ram_index<P: AsRef<Path>>(
@@ -37,5 +48,5 @@ pub trait InvertedIndex: Sized {
     fn vector_count(&self) -> usize;
 
     // Get max existed index
-    fn max_index(&self) -> Option<DimId>;
+    fn max_index(&self) -> Option<DimOffset>;
 }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -16,8 +16,8 @@ use collection::operations::CollectionUpdateOperations;
 use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, Payload};
 
 use super::{
-    Access, AccessRequirements, CollectionAccessList, CollectionAccessView,
-    CollectionPass, incompatible_with_payload_constraint, PayloadConstraint,
+    incompatible_with_payload_constraint, Access, AccessRequirements, CollectionAccessList,
+    CollectionAccessView, CollectionPass, PayloadConstraint,
 };
 use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
 use crate::content_manager::errors::StorageError;
@@ -530,6 +530,7 @@ mod tests_ops {
         Batch, PointInsertOperationsInternal, PointInsertOperationsInternalDiscriminants,
         PointOperationsDiscriminants, PointStruct, PointSyncOperation,
     };
+    use collection::operations::query_enum::QueryEnum;
     use collection::operations::types::{
         OrderByInterface, RecommendStrategy, SearchRequestInternal, UsingVector,
     };
@@ -543,7 +544,6 @@ mod tests_ops {
     use segment::data_types::vectors::NamedVectorStruct;
     use segment::types::{PointIdType, SearchParams, WithPayloadInterface, WithVector};
     use strum::IntoEnumIterator as _;
-    use collection::operations::query_enum::QueryEnum;
 
     use super::*;
     use crate::rbac::{AccessCollectionBuilder, GlobalAccessMode};

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -16,8 +16,8 @@ use collection::operations::CollectionUpdateOperations;
 use segment::types::{Condition, ExtendedPointId, FieldCondition, Filter, Match, Payload};
 
 use super::{
-    incompatible_with_payload_constraint, Access, AccessRequirements, CollectionAccessList,
-    CollectionAccessView, CollectionPass, PayloadConstraint,
+    Access, AccessRequirements, CollectionAccessList, CollectionAccessView,
+    CollectionPass, incompatible_with_payload_constraint, PayloadConstraint,
 };
 use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
 use crate::content_manager::errors::StorageError;
@@ -531,7 +531,7 @@ mod tests_ops {
         PointOperationsDiscriminants, PointStruct, PointSyncOperation,
     };
     use collection::operations::types::{
-        OrderByInterface, QueryEnum, RecommendStrategy, SearchRequestInternal, UsingVector,
+        OrderByInterface, RecommendStrategy, SearchRequestInternal, UsingVector,
     };
     use collection::operations::vector_ops::{
         PointVectors, UpdateVectorsOp, VectorOperationsDiscriminants,
@@ -543,6 +543,7 @@ mod tests_ops {
     use segment::data_types::vectors::NamedVectorStruct;
     use segment::types::{PointIdType, SearchParams, WithPayloadInterface, WithVector};
     use strum::IntoEnumIterator as _;
+    use collection::operations::query_enum::QueryEnum;
 
     use super::*;
     use crate::rbac::{AccessCollectionBuilder, GlobalAccessMode};

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -5,10 +5,10 @@ use api::grpc::conversions::{json_path_from_proto, proto_to_payloads};
 use api::grpc::qdrant::payload_index_params::IndexParams;
 use api::grpc::qdrant::points_update_operation::{ClearPayload, Operation, PointStructList};
 use api::grpc::qdrant::{
-    points_update_operation, BatchResult, ClearPayloadPoints, CoreSearchPoints, CountPoints,
-    CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints,
-    DeletePointVectors, DeletePoints, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse,
-    FieldType, GetPoints, GetResponse, PayloadIndexParams, PointsOperationResponseInternal,
+    BatchResult, ClearPayloadPoints, CoreSearchPoints, CountPoints, CountResponse,
+    CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints,
+    DeletePointVectors, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse, FieldType,
+    GetPoints, GetResponse, PayloadIndexParams, points_update_operation, PointsOperationResponseInternal,
     PointsSelector, ReadConsistency as ReadConsistencyGrpc, RecommendBatchResponse,
     RecommendGroupsResponse, RecommendPointGroups, RecommendPoints, RecommendResponse,
     ScrollPoints, ScrollResponse, SearchBatchResponse, SearchGroupsResponse, SearchPointGroups,
@@ -21,13 +21,13 @@ use collection::operations::conversions::{
 };
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{
-    self, PointInsertOperations, PointOperations, PointSyncOperation, PointsList,
+    self, PointInsertOperations, PointOperations, PointsList, PointSyncOperation,
 };
 use collection::operations::shard_key_selector::ShardKeySelector;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
-    default_exact_count, CoreSearchRequest, CoreSearchRequestBatch, OrderByInterface,
-    PointRequestInternal, QueryEnum, RecommendExample, Record, ScrollRequestInternal,
+    CoreSearchRequest, CoreSearchRequestBatch, default_exact_count, OrderByInterface,
+    PointRequestInternal, RecommendExample, Record, ScrollRequestInternal,
 };
 use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVectors};
 use collection::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
@@ -42,12 +42,13 @@ use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
 use tonic::{Response, Status};
+use collection::operations::query_enum::QueryEnum;
 
 use crate::common::points::{
-    do_clear_payload, do_core_search_points, do_count_points, do_create_index,
-    do_create_index_internal, do_delete_index, do_delete_index_internal, do_delete_payload,
-    do_delete_points, do_delete_vectors, do_get_points, do_overwrite_payload, do_scroll_points,
-    do_search_batch_points, do_set_payload, do_update_vectors, do_upsert_points, CreateFieldIndex,
+    CreateFieldIndex, do_clear_payload, do_core_search_points, do_count_points,
+    do_create_index, do_create_index_internal, do_delete_index, do_delete_index_internal,
+    do_delete_payload, do_delete_points, do_delete_vectors, do_get_points, do_overwrite_payload,
+    do_scroll_points, do_search_batch_points, do_set_payload, do_update_vectors, do_upsert_points,
 };
 
 fn extract_points_selector(

--- a/src/tonic/api/points_common.rs
+++ b/src/tonic/api/points_common.rs
@@ -5,10 +5,10 @@ use api::grpc::conversions::{json_path_from_proto, proto_to_payloads};
 use api::grpc::qdrant::payload_index_params::IndexParams;
 use api::grpc::qdrant::points_update_operation::{ClearPayload, Operation, PointStructList};
 use api::grpc::qdrant::{
-    BatchResult, ClearPayloadPoints, CoreSearchPoints, CountPoints, CountResponse,
-    CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints, DeletePoints,
-    DeletePointVectors, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse, FieldType,
-    GetPoints, GetResponse, PayloadIndexParams, points_update_operation, PointsOperationResponseInternal,
+    points_update_operation, BatchResult, ClearPayloadPoints, CoreSearchPoints, CountPoints,
+    CountResponse, CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints,
+    DeletePointVectors, DeletePoints, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse,
+    FieldType, GetPoints, GetResponse, PayloadIndexParams, PointsOperationResponseInternal,
     PointsSelector, ReadConsistency as ReadConsistencyGrpc, RecommendBatchResponse,
     RecommendGroupsResponse, RecommendPointGroups, RecommendPoints, RecommendResponse,
     ScrollPoints, ScrollResponse, SearchBatchResponse, SearchGroupsResponse, SearchPointGroups,
@@ -21,12 +21,13 @@ use collection::operations::conversions::{
 };
 use collection::operations::payload_ops::DeletePayload;
 use collection::operations::point_ops::{
-    self, PointInsertOperations, PointOperations, PointsList, PointSyncOperation,
+    self, PointInsertOperations, PointOperations, PointSyncOperation, PointsList,
 };
+use collection::operations::query_enum::QueryEnum;
 use collection::operations::shard_key_selector::ShardKeySelector;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
-    CoreSearchRequest, CoreSearchRequestBatch, default_exact_count, OrderByInterface,
+    default_exact_count, CoreSearchRequest, CoreSearchRequestBatch, OrderByInterface,
     PointRequestInternal, RecommendExample, Record, ScrollRequestInternal,
 };
 use collection::operations::vector_ops::{DeleteVectors, PointVectors, UpdateVectors};
@@ -42,13 +43,12 @@ use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::Access;
 use tonic::{Response, Status};
-use collection::operations::query_enum::QueryEnum;
 
 use crate::common::points::{
-    CreateFieldIndex, do_clear_payload, do_core_search_points, do_count_points,
-    do_create_index, do_create_index_internal, do_delete_index, do_delete_index_internal,
-    do_delete_payload, do_delete_points, do_delete_vectors, do_get_points, do_overwrite_payload,
-    do_scroll_points, do_search_batch_points, do_set_payload, do_update_vectors, do_upsert_points,
+    do_clear_payload, do_core_search_points, do_count_points, do_create_index,
+    do_create_index_internal, do_delete_index, do_delete_index_internal, do_delete_payload,
+    do_delete_points, do_delete_vectors, do_get_points, do_overwrite_payload, do_scroll_points,
+    do_search_batch_points, do_set_payload, do_update_vectors, do_upsert_points, CreateFieldIndex,
 };
 
 fn extract_points_selector(

--- a/tests/openapi/openapi_integration/test_sparse_idf.py
+++ b/tests/openapi/openapi_integration/test_sparse_idf.py
@@ -10,7 +10,7 @@ collection_name = 'test_sparse_idf'
 def setup():
     idf_collection_setup(collection_name=collection_name)
     yield
-    # drop_collection(collection_name=collection_name)
+    drop_collection(collection_name=collection_name)
 
 
 # Sentences from public domain sci-fi books

--- a/tests/openapi/openapi_integration/test_sparse_idf.py
+++ b/tests/openapi/openapi_integration/test_sparse_idf.py
@@ -1,0 +1,164 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = 'test_sparse_idf'
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    idf_collection_setup(collection_name=collection_name)
+    yield
+    # drop_collection(collection_name=collection_name)
+
+
+# Sentences from public domain sci-fi books
+TEXTS = [
+    # Meaningful texts
+    "I must not fear. Fear is the mind-killer.",
+    "All animals are equal, but some animals are more equal than others.",
+    "It was a pleasure to burn.",
+    "The sky above the port was the color of television, tuned to a dead channel.",
+    "In the beginning, the universe was created."
+    " This has made a lot of people very angry and been widely regarded as a bad move.",
+    "It's a truth universally acknowledged that a zombie in possession of brains must be in want of more brains.",
+    "War is peace. Freedom is slavery. Ignorance is strength.",
+    "We're not in Infinity; we're in the suburbs.",
+    "I was a thousand times more evil than thou!",
+    "History is merely a list of surprises... It can only prepare us to be surprised yet again.",
+    # 20 Texts with a lot of stop words
+    "The a an and or but",
+    "A an the",
+    "I am you are he she it we they",
+    "Is are was were",
+    "Do does did",
+    "Have has had",
+    "Can could",
+    "I am is not the you are",
+    "I is not the you are",
+]
+
+PROCESSED_TEXTS = list(map(
+    lambda text: text.lower().replace('.', '').replace(',', '').replace('!', '').replace(';', '').split(' '),
+    TEXTS
+))
+
+
+def get_vector(words):
+    unique_words = list(set(words))
+    return {
+        "indices": [abs(hash(word)) % 1000000 for word in unique_words],
+        "values": [1.] * len(unique_words)
+    }
+
+
+def idf_collection_setup(
+        collection_name='test_collection',
+):
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "sparse_vectors": {
+                "text": {
+                    "modifier": "idf"
+                }
+            }
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": idx,
+                    "vector": {
+                        "text": get_vector(words)
+                    },
+                    "payload": {
+                        "text": TEXTS[idx]
+                    }
+                }
+                for idx, words in enumerate(PROCESSED_TEXTS)
+            ]
+        }
+    )
+    assert response.ok
+
+
+def test_collection_request_with_idf():
+    query = ["i", "is", "not", "television", "channel"]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": {
+                "name": "text",
+                "vector": get_vector(query)
+            },
+            "limit": 2
+        }
+    )
+    assert response.ok
+    assert len(response.json()['result']) == 2
+
+    # IDF gives priority to rare words, even if there are more common words in the query
+    assert response.json()['result'][0]['id'] == 3
+
+    # Now let's change modifier back to "none" and check the results
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PATCH",
+        path_params={'collection_name': collection_name},
+        body={
+            "sparse_vectors": {
+                "text": {
+                    "modifier": "none"
+                }
+            }
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": {
+                "name": "text",
+                "vector": get_vector(query)
+            },
+            "limit": 2
+        }
+    )
+
+    assert response.ok
+    assert len(response.json()['result']) == 2
+
+    # Now the results are different
+    assert response.json()['result'][0]['id'] != 3


### PR DESCRIPTION
This PR introduces a `modifier` param, which can be configured for individual sparse vectors.

It is also introduces a single non-empty value for the modifier, called `idf`.

Usage example:

```
PATCH collections/test_sparse_idf
{
    "sparse_vectors": {
        "text": {
            "modifier": "idf"
        }
    }
}
```

Modifier alters the weights of sparse vectors, so the resulting score (and order) are different.

The `idf` modifier multiplies weights of the sparse vectors to account for "rarity" of the vector elements in the current collection. Less frequent the element is, more impact on the scoring it will have. 

Exact formula looks like this: 

```
((n - df + 0.5) / (df + 0.5) + 1.).ln()
```

where `n` - number of points in shard, `df` - number of points with given element.
This component is computed at query time and multiplied with query before performing the actual search. 

Similar scoring component is used in Okapi BM25, which allows usage of sparse vectors as a replacement for Bm25 text search without the necessity of pre-computing of the corpus statistics.

