### PR TITLE
Proactively fix lints for Clippy 1.78

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -282,7 +282,7 @@ impl Collection {
                             return Ok(records);
                         }
                         for point in &mut records {
-                            point.shard_key = shard_key.clone();
+                            point.shard_key.clone_from(&shard_key);
                         }
                         Ok(records)
                     })
@@ -405,7 +405,7 @@ impl Collection {
                             return Ok(records);
                         }
                         for point in &mut records {
-                            point.shard_key = shard_key.clone();
+                            point.shard_key.clone_from(&shard_key);
                         }
                         Ok(records)
                     })

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -147,7 +147,7 @@ impl Collection {
                         }
                         for batch in &mut records {
                             for point in batch {
-                                point.shard_key = shard_key.clone();
+                                point.shard_key.clone_from(&shard_key);
                             }
                         }
                         Ok(records)

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -313,7 +313,7 @@ mod unit_tests {
                     "case {case_idx}"
                 );
             } else {
-                assert!(aggregator.groups.get(key).is_none(), "case {case_idx}");
+                assert!(!aggregator.groups.contains_key(key), "case {case_idx}");
             }
         });
 

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -22,8 +22,8 @@ impl Group {
     pub(super) fn hydrate_from(&mut self, map: &HashMap<PointIdType, ScoredPoint>) {
         self.hits.iter_mut().for_each(|hit| {
             if let Some(point) = map.get(&hit.id) {
-                hit.payload = point.payload.clone();
-                hit.vector = point.vector.clone();
+                hit.payload.clone_from(&point.payload);
+                hit.vector.clone_from(&point.vector);
             }
         });
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -617,7 +617,7 @@ impl ShardReplicaSet {
         }
 
         for (peer_id, state) in replicas {
-            let peer_already_exists = old_peers.get(&peer_id).is_some();
+            let peer_already_exists = old_peers.contains_key(&peer_id);
 
             if peer_already_exists {
                 // do nothing

--- a/lib/common/issues/src/issue.rs
+++ b/lib/common/issues/src/issue.rs
@@ -49,6 +49,7 @@ impl<I: Issue> From<I> for IssueRecord {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct DummyIssue {
     pub distinctive: String,

--- a/lib/segment/src/data_types/tiny_map.rs
+++ b/lib/segment/src/data_types/tiny_map.rs
@@ -80,10 +80,10 @@ where
         }
     }
 
-    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: borrow::Borrow<Q>,
-        Q: Eq,
+        Q: Eq + ?Sized,
     {
         self.list
             .iter()
@@ -91,10 +91,10 @@ where
             .map(|(_, v)| v)
     }
 
-    pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: borrow::Borrow<Q>,
-        Q: Eq,
+        Q: Eq + ?Sized,
     {
         self.list
             .iter_mut()
@@ -113,10 +113,10 @@ where
         }
     }
 
-    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         K: borrow::Borrow<Q>,
-        Q: Eq,
+        Q: Eq + ?Sized,
     {
         self.list.iter().any(|(k, _)| k.borrow() == key)
     }
@@ -207,7 +207,7 @@ mod tests {
         map.clear();
         map.insert(key.clone(), value.clone());
         assert_eq!(map.get_mut(&key), Some(&mut value));
-        *map.get_mut(&key).unwrap() = value3.clone();
+        map.get_mut(&key).unwrap().clone_from(&value3);
         assert_eq!(map.get(&key), Some(&value3));
 
         // Test iter

--- a/lib/segment/src/index/hnsw_index/build_cache.rs
+++ b/lib/segment/src/index/hnsw_index/build_cache.rs
@@ -25,6 +25,7 @@ struct CacheObj {
     value: ScoreType,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct DistanceCache {
     cache: Vec<Option<CacheObj>>,

--- a/lib/segment/src/json_path/v2.rs
+++ b/lib/segment/src/json_path/v2.rs
@@ -70,7 +70,7 @@ impl JsonPathInterface for JsonPathV2 {
             rest: Vec::new(),
         };
         for (key, value) in json_map.iter() {
-            path.first_key = key.clone();
+            path.first_key.clone_from(key);
             if filter(&path, value) {
                 let value = run_filter(&mut path, value, &filter);
                 new_map.insert(key.clone(), value);

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -199,7 +199,7 @@ fn check_matches(
                 .vector_index
                 .borrow()
                 .search(
-                    &[&query],
+                    &[query],
                     filter,
                     top,
                     None,
@@ -265,7 +265,7 @@ fn check_oversampling(
 
         let oversampling_2_result = hnsw_index
             .search(
-                &[&query],
+                &[query],
                 None,
                 top,
                 Some(&SearchParams {

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -380,8 +380,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 ConfChangeType::AddNode => {
                     debug_assert!(
                         self.peer_address_by_id()
-                            .get(&single_change.node_id)
-                            .is_some(),
+                            .contains_key(&single_change.node_id),
                         "Peer should be already known"
                     )
                 }


### PR DESCRIPTION
Rust 1.78 is coming out in two days time https://releases.rs/docs/1.78.0/

Let's fix new Clippy lints proactively to ensure a smooth transition.