### PR TITLE
Remove unecessary Clippy allows

### DIFF
--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -34,7 +34,6 @@ pub type ShardsPlacement = Vec<ShardReplicasPlacement>;
 /// Shard
 ///
 /// Contains a part of the collection's points
-#[allow(clippy::large_enum_variant)]
 pub enum Shard {
     Local(LocalShard),
     Proxy(ProxyShard),

--- a/lib/collection/src/wal.rs
+++ b/lib/collection/src/wal.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wal::{Wal, WalOptions};
 
-#[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
 #[error("{0}")]
 pub enum WalError {

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -96,8 +96,6 @@ pub trait ValueIndexer<T> {
 
 /// Common interface for all possible types of field indexes
 /// Enables polymorphism on field indexes
-/// TODO: Rename with major release
-#[allow(clippy::enum_variant_names)]
 pub enum FieldIndex {
     IntIndex(NumericIndex<IntPayloadType>),
     DatetimeIndex(NumericIndex<IntPayloadType>),

--- a/src/greeting.rs
+++ b/src/greeting.rs
@@ -61,7 +61,6 @@ fn is_localhost_ip(host: &str) -> bool {
 
 /// Prints welcome message
 #[rustfmt::skip]
-#[allow(clippy::needless_raw_string_hashes)]
 pub fn welcome(settings: &Settings) {
     if !stdout().is_terminal()  {
         colored::control::set_override(false);


### PR DESCRIPTION
Maybe we changed our code or maybe Clippy changed the lints.

In any case we should not keep those escape hatches in place.