### PR TITLE
Compressed posting lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "sparse"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitpacking",
  "common",

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -22,7 +22,7 @@ use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use segment::vector_storage::VectorStorage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
-use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::InvertedIndex;
 use tempfile::Builder;
@@ -109,7 +109,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     group.bench_function("convert-mmap-index", |b| {
         b.iter(|| {
             let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
-            let mmap_inverted_index = InvertedIndexMmap::from_ram_index(
+            let mmap_inverted_index = InvertedIndexMmap::<f32>::from_ram_index(
                 Cow::Borrowed(sparse_vector_index.inverted_index()),
                 &mmap_index_dir,
             )

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -22,7 +22,7 @@ use segment::types::{Condition, FieldCondition, Filter, Payload};
 use serde_json::json;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_positive_sparse_vector, random_sparse_vector};
-use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexMmap;
 use sparse::index::loaders::Csr;
 use tempfile::Builder;
 
@@ -109,7 +109,7 @@ fn sparse_vector_index_search_benchmark_impl(
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
     let sparse_index_config =
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap);
-    let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap> =
+    let mut sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexMmap<f32>> =
         SparseVectorIndex::open(
             sparse_index_config,
             sparse_vector_index.id_tracker().clone(),

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 use rand::Rng;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
-use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam;
 use sparse::index::inverted_index::InvertedIndex;
 
 use crate::common::operation_error::OperationResult;
@@ -92,7 +92,7 @@ pub fn fixture_sparse_index_ram<R: Rng + ?Sized>(
     full_scan_threshold: usize,
     data_dir: &Path,
     stopped: &AtomicBool,
-) -> SparseVectorIndex<InvertedIndexImmutableRam> {
+) -> SparseVectorIndex<InvertedIndexImmutableRam<f32>> {
     fixture_sparse_index_ram_from_iter(
         (0..num_vectors).map(|_| random_sparse_vector(rnd, max_dim)),
         full_scan_threshold,
@@ -109,7 +109,7 @@ pub fn fixture_sparse_index_ram_from_iter<P: FnMut()>(
     data_dir: &Path,
     stopped: &AtomicBool,
     progress: impl FnOnce() -> P,
-) -> SparseVectorIndex<InvertedIndexImmutableRam> {
+) -> SparseVectorIndex<InvertedIndexImmutableRam<f32>> {
     let num_vectors = vectors.len();
     let mut sparse_vector_index = fixture_open_sparse_index(
         data_dir,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use sparse::common::scores_memory_pool::ScoresMemoryPool;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::DimId;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::migrate::SparseVectorIndexVersion;
@@ -103,12 +104,16 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 || (),
             )?;
             (config, inverted_index, indices_tracker)
+        } else if path.read_dir()?.next().is_none() {
+            // Newly created directory - initialize empty inverted index
+            (
+                config,
+                TInvertedIndex::from_ram_index(Cow::Owned(InvertedIndexRam::empty()), path)?,
+                IndicesTracker::default(),
+            )
         } else {
             Self::try_load(path).or_else(|e| {
-                // Avoid noisy warning for newly created segments
-                if vector_storage.borrow().total_vector_count() != 0 {
-                    log::warn!("Failed to load, rebuilding: {}", e.to_string());
-                }
+                log::warn!("Failed to load, rebuilding: {}", e.to_string());
 
                 let (inverted_index, indices_tracker) = Self::build_inverted_index(
                     id_tracker.clone(),
@@ -133,9 +138,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 // `inverted_index.data` to `inverted_index.dat`.
                 SparseVectorIndexVersion::save(path)?;
 
-                if vector_storage.borrow().total_vector_count() != 0 {
-                    log::info!("Successfully rebuilt");
-                }
+                log::info!("Successfully rebuilt");
 
                 OperationResult::Ok((config, inverted_index, indices_tracker))
             })?

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use common::cpu::CpuPermit;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
-use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
-use sparse::index::inverted_index::inverted_index_mmap::InvertedIndexMmap;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
 use super::hnsw_index::graph_links::{GraphLinksMmap, GraphLinksRam};
@@ -59,8 +59,8 @@ pub enum VectorIndexEnum {
     HnswRam(HNSWIndex<GraphLinksRam>),
     HnswMmap(HNSWIndex<GraphLinksMmap>),
     SparseRam(SparseVectorIndex<InvertedIndexRam>),
-    SparseImmutableRam(SparseVectorIndex<InvertedIndexImmutableRam>),
-    SparseMmap(SparseVectorIndex<InvertedIndexMmap>),
+    SparseImmutableRam(SparseVectorIndex<InvertedIndexImmutableRam<f32>>),
+    SparseMmap(SparseVectorIndex<InvertedIndexMmap<f32>>),
 }
 
 impl VectorIndexEnum {

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -22,7 +22,7 @@ use segment::types::{
 };
 use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
-use sparse::index::inverted_index::inverted_index_immutable_ram::InvertedIndexImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexImmutableRam;
 use tempfile::Builder;
 
 const MAX_EXAMPLE_PAIRS: usize = 3;
@@ -166,7 +166,7 @@ fn sparse_index_discover_test() {
     let payload_index_ptr = sparse_segment.payload_index.clone();
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
-    let mut sparse_index = SparseVectorIndex::<InvertedIndexImmutableRam>::open(
+    let mut sparse_index = SparseVectorIndex::<InvertedIndexImmutableRam<f32>>::open(
         SparseIndexConfig {
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparse"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",


### PR DESCRIPTION
This PR adds a draft implementation of the new sparse vector index format.

# Comparison with the current implementation

Baseline: current `dev` branch, c173a9f5e54c621ae6466109745385bfb8aa7428.

## Memory usage
|                                                 |   Old |   New |
| ----------------------------------------------- | ----: | ----: |
| Full data on-disk size                          | 23.0G | 15.4G |
| Index only (`inverted_index.data`) on-disk size | 13.6G |  5.9G |
| RAM consumption                                 | 13.9G |  6.8G |

## Bench in `sparse` crate

New:
```
search/random_50k         time:   [1.0777 ms 1.0874 ms 1.0981 ms]
search/random_500k        time:   [8.9879 ms 9.1699 ms 9.3507 ms]
search/msmarco_1M         time:   [13.931 ms 14.254 ms 14.581 ms]
search/msmarco_full_0.25  time:   [32.163 ms 33.040 ms 33.934 ms]
```

Old:
```
search/random_50k         time:   [776.59 µs 781.35 µs 787.21 µs]
search/random_500k        time:   [7.2040 ms 7.3156 ms 7.4284 ms]
search/msmarco_1M         time:   [14.409 ms 14.760 ms 15.118 ms]
search/msmarco_full_0.25  time:   [33.352 ms 34.323 ms 35.312 ms]
```

## MSMARCO

Results of https://github.com/qdrant/sparse-vectors-benchmark.
Times are in ms.

### Full dataset

[of]: https://github.com/qdrant/qdrant/assets/5121426/60191251-d516-4a03-8b9f-0ca932df9631
[nf]: https://github.com/qdrant/qdrant/assets/5121426/47c019d9-1d4e-4aba-8416-bc230db3af31

|      | [Old][of] | [New][nf] |
| ---- | ----: | ----: |
| min  | 101.8 | 106.6 |
| 50p  | 248.9 | 228.6 |
| 95p  | 358.7 | 330.5 |
| 99p  | 403.8 | 382.2 |
| 999p | 463.4 | 450.2 |
| max  | 507.8 | 491.1 |

### 1M dataset

[om]: https://github.com/qdrant/qdrant/assets/5121426/320f84ea-85b8-4d39-b9b2-1df5d216d94e
[nm]: https://github.com/qdrant/qdrant/assets/5121426/a61fbcac-ab5d-4dea-8fd1-0a093546f66b


|      | [Old][om] | [New][nm] |
| ---- | ----: | ----: |
| min  | 17.59 | 17.71 |
| 50p  | 36.24 | 31.63 |
| 95p  | 50.44 | 43.46 |
| 99p  | 58.26 | 50.56 |
| 999p | 70.89 | 59.28 |
| max  | 90.39 | 66.70 |