### PR TITLE
Missed lints for clippy 1.78

### DIFF
--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -121,10 +121,6 @@ impl Clone for LockedSegment {
             LockedSegment::Proxy(x) => LockedSegment::Proxy(x.clone()),
         }
     }
-
-    fn clone_from(&mut self, source: &Self) {
-        self.clone_from(source);
-    }
 }
 
 impl From<Segment> for LockedSegment {

--- a/lib/collection/src/collection_manager/holders/segment_holder.rs
+++ b/lib/collection/src/collection_manager/holders/segment_holder.rs
@@ -123,7 +123,7 @@ impl Clone for LockedSegment {
     }
 
     fn clone_from(&mut self, source: &Self) {
-        *self = source.clone();
+        self.clone_from(source);
     }
 }
 


### PR DESCRIPTION
```
error: assigning the result of `Clone::clone()` may be inefficient
   --> lib/collection/src/collection_manager/holders/segment_holder.rs:126:9
    |
126 |         *self = source.clone();
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.clone_from(source)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`
```

This PR removes the function because it is equivalent to the default implementation in the trait.    