### PR TITLE
ci: Force delete all existing buildx resources before building image

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -15,7 +15,7 @@ jobs:
             ref: ${{ github.ref.name }}
         - name: Build the Docker image
           run: |
-            buildx_containers=$(docker container ls -qf "name=buildx_buildkit")
+            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit")
             buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit")
 
             if [ -n "$buildx_containers" ]; then
@@ -25,7 +25,7 @@ jobs:
 
             if [ -n "$buildx_volumes" ]; then
               echo "Buildx volumes to delete: " "$buildx_volumes"
-              docker volume rm "$buildx_volumes"
+              docker volume rm -f "$buildx_volumes"
             fi
 
             branch=${GITHUB_REF_NAME//\//-} # replace all / with -


### PR DESCRIPTION
Using `-a` is important while listing buildx containers. Otherwise, we might miss deleting the ones that failed. 

This hasn't caused any issues so far. But it's better to fix it. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
