### PR TITLE
Multivector flattened ram storage

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -297,6 +297,14 @@ impl<'a, T: PrimitiveVectorElement> TypedMultiDenseVectorRef<'a, T> {
     pub fn is_empty(&self) -> bool {
         self.flattened_vectors.is_empty()
     }
+
+    // Cannot use `ToOwned` trait because of `Borrow` implementation for `TypedMultiDenseVector`
+    pub fn to_owned(self) -> TypedMultiDenseVector<T> {
+        TypedMultiDenseVector {
+            flattened_vectors: self.flattened_vectors.to_owned(),
+            dim: self.dim,
+        }
+    }
 }
 
 impl<'a, T: PrimitiveVectorElement> From<&'a TypedMultiDenseVector<T>>

--- a/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/simple_multi_dense_vector_storage.rs
@@ -9,6 +9,7 @@ use common::types::PointOffsetType;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
+use super::chunked_vectors::ChunkedVectors;
 use crate::common::operation_error::{check_process_stopped, OperationError, OperationResult};
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
 use crate::common::Flusher;
@@ -24,13 +25,22 @@ use crate::vector_storage::{MultiVectorStorage, VectorStorage, VectorStorageEnum
 
 type StoredMultiDenseVector<T> = StoredRecord<TypedMultiDenseVector<T>>;
 
+#[derive(Clone, Default)]
+struct MultiVectorMetadata {
+    id: PointOffsetType,
+    start: PointOffsetType,
+    size: usize,
+    capacity: usize,
+}
+
 /// In-memory vector storage with on-update persistence using `store`
 pub struct SimpleMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     dim: usize,
     distance: Distance,
     multi_vector_config: MultiVectorConfig,
     /// Keep vectors in memory
-    vectors: Vec<TypedMultiDenseVector<T>>,
+    vectors: ChunkedVectors<T>,
+    vectors_metadata: Vec<MultiVectorMetadata>,
     db_wrapper: DatabaseColumnWrapper,
     update_buffer: StoredMultiDenseVector<T>,
     /// BitVec for deleted flags. Grows dynamically upto last set flag.
@@ -48,7 +58,8 @@ pub fn open_simple_multi_dense_vector_storage(
     multi_vector_config: MultiVectorConfig,
     stopped: &AtomicBool,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
-    let mut vectors: Vec<TypedMultiDenseVector<VectorElementType>> = vec![];
+    let mut vectors = ChunkedVectors::new(dim);
+    let mut vectors_metadata = Vec::<MultiVectorMetadata>::new();
     let (mut deleted, mut deleted_count) = (BitVec::new(), 0);
     let db_wrapper = DatabaseColumnWrapper::new(database, database_column_name);
     db_wrapper.lock_db().iter()?;
@@ -64,10 +75,25 @@ pub fn open_simple_multi_dense_vector_storage(
             deleted_count += 1;
         }
         let point_id_usize = point_id as usize;
-        if point_id_usize >= vectors.len() {
-            vectors.resize(point_id_usize + 1, TypedMultiDenseVector::placeholder(dim));
+        if point_id_usize >= vectors_metadata.len() {
+            vectors_metadata.resize(point_id_usize + 1, Default::default());
         }
-        vectors[point_id_usize] = stored_record.vector;
+
+        let metadata = &mut vectors_metadata[point_id_usize];
+        metadata.size = stored_record.vector.flattened_vectors.len();
+        metadata.capacity = metadata.size;
+        metadata.id = point_id;
+
+        metadata.start = vectors.len() as PointOffsetType;
+        let left_keys = vectors.get_chunk_left_keys(metadata.start);
+        if stored_record.vector.len() > left_keys {
+            metadata.start += left_keys as PointOffsetType;
+        }
+        vectors.insert_many(
+            metadata.start,
+            &stored_record.vector.flattened_vectors,
+            stored_record.vector.len(),
+        )?;
 
         check_process_stopped(stopped)?;
     }
@@ -78,6 +104,7 @@ pub fn open_simple_multi_dense_vector_storage(
             distance,
             multi_vector_config,
             vectors,
+            vectors_metadata,
             db_wrapper,
             update_buffer: StoredMultiDenseVector {
                 deleted: false,
@@ -111,13 +138,18 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
         &mut self,
         key: PointOffsetType,
         deleted: bool,
-        vector: Option<TypedMultiDenseVector<T>>,
+        vector: Option<&TypedMultiDenseVector<T>>,
     ) -> OperationResult<()> {
         // Write vector state to buffer record
         let record = &mut self.update_buffer;
         record.deleted = deleted;
         if let Some(vector) = vector {
-            record.vector = vector;
+            record.vector.dim = vector.dim;
+            record.vector.flattened_vectors.clear();
+            record
+                .vector
+                .flattened_vectors
+                .extend_from_slice(&vector.flattened_vectors);
         }
 
         // Store updated record
@@ -128,11 +160,60 @@ impl<T: PrimitiveVectorElement> SimpleMultiDenseVectorStorage<T> {
 
         Ok(())
     }
+
+    fn insert_vector_impl(
+        &mut self,
+        key: PointOffsetType,
+        vector: VectorRef,
+        is_deleted: bool,
+    ) -> OperationResult<()> {
+        let multi_vector: &MultiDenseVector = vector.try_into()?;
+        let multi_vector = T::from_float_multivector(Cow::Borrowed(multi_vector));
+        let multi_vector = multi_vector.as_ref();
+        assert_eq!(multi_vector.dim, self.dim);
+
+        let key_usize = key as usize;
+        if key_usize >= self.vectors_metadata.len() {
+            self.vectors_metadata
+                .resize(key_usize + 1, Default::default());
+        }
+        let metadata = &mut self.vectors_metadata[key_usize];
+        metadata.id = key;
+        metadata.size = multi_vector.len();
+
+        if multi_vector.len() > metadata.capacity {
+            metadata.capacity = metadata.size;
+            metadata.start = self.vectors.len() as PointOffsetType;
+            let left_keys = self.vectors.get_chunk_left_keys(metadata.start);
+            if multi_vector.len() > left_keys {
+                metadata.start += left_keys as PointOffsetType;
+            }
+            self.vectors.insert_many(
+                metadata.start,
+                &multi_vector.flattened_vectors,
+                multi_vector.len(),
+            )?;
+        } else {
+            self.vectors.insert_many(
+                metadata.start,
+                &multi_vector.flattened_vectors,
+                multi_vector.len(),
+            )?;
+        }
+
+        self.set_deleted(key, is_deleted);
+        self.update_stored(key, is_deleted, Some(multi_vector))?;
+        Ok(())
+    }
 }
 
 impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVectorStorage<T> {
     fn get_multi(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<T> {
-        TypedMultiDenseVectorRef::from(self.vectors.get(key as usize).expect("vector not found"))
+        let metadata = &self.vectors_metadata[key as usize];
+        TypedMultiDenseVectorRef {
+            flattened_vectors: self.vectors.get_many(metadata.start, metadata.size),
+            dim: self.dim,
+        }
     }
 
     fn multi_vector_config(&self) -> &MultiVectorConfig {
@@ -162,23 +243,14 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
     }
 
     fn get_vector(&self, key: PointOffsetType) -> CowVector {
-        let multi_dense_vector = self.vectors.get(key as usize).expect("vector not found");
-        let multi_dense_vector = T::into_float_multivector(Cow::Borrowed(multi_dense_vector));
+        // TODO(colbert) avoid copying
+        let multi_dense_vector = self.get_multi(key).to_owned();
+        let multi_dense_vector = T::into_float_multivector(Cow::Owned(multi_dense_vector));
         CowVector::from(multi_dense_vector)
     }
 
     fn insert_vector(&mut self, key: PointOffsetType, vector: VectorRef) -> OperationResult<()> {
-        let vector: &MultiDenseVector = vector.try_into()?;
-        let multi_vector = T::from_float_multivector(Cow::Borrowed(vector)).into_owned();
-        let key_usize = key as usize;
-        if key_usize >= self.vectors.len() {
-            self.vectors
-                .resize(key_usize + 1, TypedMultiDenseVector::placeholder(self.dim));
-        }
-        self.vectors[key_usize] = multi_vector.clone();
-        self.set_deleted(key, false);
-        self.update_stored(key, false, Some(multi_vector))?;
-        Ok(())
+        self.insert_vector_impl(key, vector, false)
     }
 
     fn update_from(
@@ -187,22 +259,17 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
         other_ids: &mut impl Iterator<Item = PointOffsetType>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.vectors.len() as PointOffsetType;
+        let start_index = self.vectors_metadata.len() as PointOffsetType;
         for point_id in other_ids {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
-            let other_vector = other.get_vector(point_id);
-            let other_vector: &TypedMultiDenseVector<VectorElementType> =
-                other_vector.as_vec_ref().try_into()?;
-            let other_multi_vector =
-                T::from_float_multivector(Cow::Borrowed(other_vector)).into_owned();
             let other_deleted = other.is_deleted_vector(point_id);
-            self.vectors.push(other_multi_vector.clone());
-            let new_id = self.vectors.len() as PointOffsetType - 1;
-            self.set_deleted(new_id, other_deleted);
-            self.update_stored(new_id, other_deleted, Some(other_multi_vector))?;
+            let other_vector = other.get_vector(point_id);
+            let other_vector: VectorRef = other_vector.as_vec_ref();
+            let new_id = self.vectors_metadata.len() as PointOffsetType;
+            self.insert_vector_impl(new_id, other_vector, other_deleted)?;
         }
-        let end_index = self.vectors.len() as PointOffsetType;
+        let end_index = self.vectors_metadata.len() as PointOffsetType;
         Ok(start_index..end_index)
     }
 


### PR DESCRIPTION
This PR uses ideas from https://github.com/qdrant/qdrant/pull/4106 to refactor multivector RAM storage.

Currently, each multivector uses a separate allocated `Vec`. This PR uses `ChunkedVectors` from simple dense vector storage to store all multivector data in large flattened chunks.

All ideas and techniques as the same like in mmap storage.

No new unit test, multivector storage is already covered by tests