### PR TITLE
Bump cargo.lock version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.9.1-dev"
+version = "1.9.2-dev"
 dependencies = [
  "actix-cors",
  "actix-files",


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/4164

Building `dev` updates the cargo.lock version automatically.