### PR TITLE
Remove pointer alignment checks redundant since Rust 1.78

### DIFF
--- a/lib/common/memory/src/mmap_ops.rs
+++ b/lib/common/memory/src/mmap_ops.rs
@@ -119,18 +119,6 @@ pub fn transmute_to_u8<T>(v: &T) -> &[u8] {
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
 
-    debug_assert_eq!(
-        data.as_ptr().align_offset(align_of::<T>()),
-        0,
-        "transmuting byte slice {:p} into slice of {}: \
-         required alignment is {} bytes, \
-         byte slice misaligned by {} bytes",
-        data.as_ptr(),
-        std::any::type_name::<T>(),
-        align_of::<T>(),
-        data.as_ptr().align_offset(align_of::<T>()),
-    );
-
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }
@@ -138,18 +126,6 @@ pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
 
 pub fn transmute_from_u8_to_mut_slice<T>(data: &mut [u8]) -> &mut [T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
-
-    debug_assert_eq!(
-        data.as_ptr().align_offset(align_of::<T>()),
-        0,
-        "transmuting byte slice {:p} into mutable slice of {}: \
-         required alignment is {} bytes, \
-         byte slice misaligned by {} bytes",
-        data.as_ptr(),
-        std::any::type_name::<T>(),
-        align_of::<T>(),
-        data.as_ptr().align_offset(align_of::<T>()),
-    );
 
     let len = data.len() / size_of::<T>();
     let ptr = data.as_mut_ptr() as *mut T;


### PR DESCRIPTION
We have some pointer alignment checks which are now redundant since the release of Rust 1.78.

Release notes: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#asserting-unsafe-preconditions

Same assertion shown in the standard library: https://doc.rust-lang.org/src/core/slice/raw.rs.html#95

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?