### PR TITLE
Improve performance of dynamic mmap flags counting

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -101,6 +101,10 @@ name = "conditional_search"
 harness = false
 
 [[bench]]
+name = "dynamic_mmap_flags"
+harness = false
+
+[[bench]]
 name = "hnsw_build_asymptotic"
 harness = false
 

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -1,0 +1,61 @@
+use std::iter;
+use std::sync::atomic::AtomicBool;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use segment::common::operation_error::check_process_stopped;
+use segment::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
+use tempfile::tempdir;
+
+const FLAG_COUNT: usize = 50_000_000;
+
+fn dynamic_mmap_delete_count(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let dir = tempdir().unwrap();
+    let random_flags: Vec<bool> = iter::repeat_with(|| rng.gen()).take(FLAG_COUNT).collect();
+
+    // Build dynamic mmap flags with random deletions
+    let mut dynamic_flags = DynamicMmapFlags::open(dir.path()).unwrap();
+    dynamic_flags.set_len(FLAG_COUNT).unwrap();
+    random_flags
+        .iter()
+        .enumerate()
+        .filter(|(_, flag)| **flag)
+        .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true)));
+    dynamic_flags.flusher()().unwrap();
+    let real_count = random_flags.iter().filter(|&&flag| flag).count();
+
+    let mut group = c.benchmark_group("dynamic-mmap-delete-count");
+
+    group.bench_function("manual-count-loop", |b| {
+        b.iter(|| {
+            let mut count = 0;
+            let stopped = AtomicBool::new(false);
+            for i in 0..FLAG_COUNT {
+                if dynamic_flags.get(i) {
+                    count += 1;
+                }
+                check_process_stopped(&stopped).unwrap();
+            }
+            assert_eq!(count, real_count);
+            black_box(count)
+        });
+    });
+
+    group.bench_function("count-ones", |b| {
+        b.iter(|| {
+            let count = dynamic_flags.count_flags().unwrap();
+            assert_eq!(count, real_count);
+            black_box(count)
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = dynamic_mmap_delete_count
+}
+
+criterion_main!(benches);

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 
 const FLAG_COUNT: usize = 50_000_000;
 
-fn dynamic_mmap_delete_count(c: &mut Criterion) {
+fn dynamic_mmap_flag_count(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let dir = tempdir().unwrap();
     let random_flags: Vec<bool> = iter::repeat_with(|| rng.gen()).take(FLAG_COUNT).collect();
@@ -26,7 +26,7 @@ fn dynamic_mmap_delete_count(c: &mut Criterion) {
     dynamic_flags.flusher()().unwrap();
     let real_count = random_flags.iter().filter(|&&flag| flag).count();
 
-    let mut group = c.benchmark_group("dynamic-mmap-delete-count");
+    let mut group = c.benchmark_group("dynamic-mmap-flag-count");
 
     group.bench_function("manual-count-loop", |b| {
         b.iter(|| {
@@ -55,7 +55,7 @@ fn dynamic_mmap_delete_count(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = dynamic_mmap_delete_count
+    targets = dynamic_mmap_flag_count
 }
 
 criterion_main!(benches);

--- a/lib/segment/benches/map_benchmark.rs
+++ b/lib/segment/benches/map_benchmark.rs
@@ -2,12 +2,17 @@
 mod prof;
 
 use std::collections::{BTreeMap, HashMap};
+use std::iter;
+use std::sync::atomic::AtomicBool;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
+use segment::common::operation_error::check_process_stopped;
 use segment::data_types::tiny_map::TinyMap;
 use segment::fixtures::index_fixtures::random_vector;
+use segment::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
+use tempfile::tempdir;
 
 const DIM: usize = 100;
 

--- a/lib/segment/benches/map_benchmark.rs
+++ b/lib/segment/benches/map_benchmark.rs
@@ -2,17 +2,12 @@
 mod prof;
 
 use std::collections::{BTreeMap, HashMap};
-use std::iter;
-use std::sync::atomic::AtomicBool;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-use segment::common::operation_error::check_process_stopped;
+use rand::SeedableRng;
 use segment::data_types::tiny_map::TinyMap;
 use segment::fixtures::index_fixtures::random_vector;
-use segment::vector_storage::dense::dynamic_mmap_flags::DynamicMmapFlags;
-use tempfile::tempdir;
 
 const DIM: usize = 100;
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -178,13 +178,11 @@ fn create_segment(
                     &vector_storage_path,
                     vector_config.size,
                     vector_config.distance,
-                    stopped,
                 )?,
                 VectorStorageDatatype::Uint8 => open_appendable_memmap_vector_storage_byte(
                     &vector_storage_path,
                     vector_config.size,
                     vector_config.distance,
-                    stopped,
                 )?,
             },
         };

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -72,18 +72,8 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 
     let vectors = ChunkedMmapVectors::<T>::open(&vectors_path, dim)?;
 
-    let num_vectors = vectors.len();
-
     let deleted: DynamicMmapFlags = DynamicMmapFlags::open(&deleted_path)?;
-
-    let mut deleted_count = 0;
-
-    for i in 0..num_vectors {
-        if deleted.get(i) {
-            deleted_count += 1;
-        }
-        check_process_stopped(stopped)?;
-    }
+    let deleted_count = deleted.count_flags()?;
 
     Ok(AppendableMmapDenseVectorStorage {
         vectors,

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -33,11 +33,9 @@ pub fn open_appendable_memmap_vector_storage(
     path: &Path,
     dim: usize,
     distance: Distance,
-    stopped: &AtomicBool,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
-    let storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
-        path, dim, distance, stopped,
-    )?;
+    let storage =
+        open_appendable_memmap_vector_storage_impl::<VectorElementType>(path, dim, distance)?;
 
     Ok(Arc::new(AtomicRefCell::new(
         VectorStorageEnum::DenseAppendableMemmap(Box::new(storage)),
@@ -48,11 +46,9 @@ pub fn open_appendable_memmap_vector_storage_byte(
     path: &Path,
     dim: usize,
     distance: Distance,
-    stopped: &AtomicBool,
 ) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
-    let storage = open_appendable_memmap_vector_storage_impl::<VectorElementTypeByte>(
-        path, dim, distance, stopped,
-    )?;
+    let storage =
+        open_appendable_memmap_vector_storage_impl::<VectorElementTypeByte>(path, dim, distance)?;
 
     Ok(Arc::new(AtomicRefCell::new(
         VectorStorageEnum::DenseAppendableMemmapByte(Box::new(storage)),
@@ -63,7 +59,6 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
     path: &Path,
     dim: usize,
     distance: Distance,
-    stopped: &AtomicBool,
 ) -> OperationResult<AppendableMmapDenseVectorStorage<T>> {
     create_dir_all(path)?;
 

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -210,6 +210,19 @@ impl DynamicMmapFlags {
         self.flags[key]
     }
 
+    /// Count number of set flags
+    pub fn count_flags(&self) -> OperationResult<usize> {
+        let mut ones = self.flags.count_ones();
+
+        // Subtract flags in extra capacity we don't use
+        // They may have been set before scrinking the bitvec again
+        ones -= (self.status.len..self.flags.len())
+            .filter(|&i| self.get(i))
+            .count();
+
+        Ok(ones)
+    }
+
     /// Set the `true` value of the flag at the given index.
     /// Ignore the call if the index is out of bounds.
     ///

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -219,7 +219,7 @@ impl DynamicMmapFlags {
         let mut ones = self.flags.count_ones();
 
         // Subtract flags in extra capacity we don't use
-        // They may have been set before scrinking the bitvec again
+        // They may have been set before shrinking the bitvec again
         ones -= (self.status.len..self.flags.len())
             .filter(|&i| self.get(i))
             .count();

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -107,6 +107,10 @@ impl DynamicMmapFlags {
         self.status.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.status.len == 0
+    }
+
     pub fn open(directory: &Path) -> OperationResult<Self> {
         fs::create_dir_all(directory)?;
         let status_mmap = ensure_status_file(directory)?;

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -1,5 +1,5 @@
 pub mod appendable_mmap_dense_vector_storage;
-mod dynamic_mmap_flags;
+pub mod dynamic_mmap_flags;
 pub mod memmap_dense_vector_storage;
 pub mod mmap_dense_vectors;
 pub mod simple_dense_vector_storage;

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -490,95 +490,47 @@ fn test_score_quantized_points_simple_vector_storages() {
 fn test_delete_points_in_appendable_memmap_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
-        let storage = open_appendable_memmap_vector_storage(
-            dir.path(),
-            4,
-            Distance::Dot,
-            &AtomicBool::new(false),
-        )
-        .unwrap();
+        let storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
         do_test_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
-    let _storage = open_appendable_memmap_vector_storage(
-        dir.path(),
-        4,
-        Distance::Dot,
-        &AtomicBool::new(false),
-    )
-    .unwrap();
+    let _storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
 }
 
 #[test]
 fn test_update_from_delete_points_appendable_memmap_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
-        let storage = open_appendable_memmap_vector_storage(
-            dir.path(),
-            4,
-            Distance::Dot,
-            &AtomicBool::new(false),
-        )
-        .unwrap();
+        let storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
 
         do_test_update_from_delete_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
-    let _storage = open_appendable_memmap_vector_storage(
-        dir.path(),
-        4,
-        Distance::Dot,
-        &AtomicBool::new(false),
-    )
-    .unwrap();
+    let _storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
 }
 
 #[test]
 fn test_score_points_in_appendable_memmap_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
-        let storage = open_appendable_memmap_vector_storage(
-            dir.path(),
-            4,
-            Distance::Dot,
-            &AtomicBool::new(false),
-        )
-        .unwrap();
+        let storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
         do_test_score_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
-    let _storage = open_appendable_memmap_vector_storage(
-        dir.path(),
-        4,
-        Distance::Dot,
-        &AtomicBool::new(false),
-    )
-    .unwrap();
+    let _storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
 }
 
 #[test]
 fn test_score_quantized_points_appendable_memmap_vector_storages() {
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     {
-        let storage = open_appendable_memmap_vector_storage(
-            dir.path(),
-            4,
-            Distance::Dot,
-            &AtomicBool::new(false),
-        )
-        .unwrap();
+        let storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
         test_score_quantized_points(storage.clone());
         storage.borrow().flusher()().unwrap();
     }
 
-    let _storage = open_appendable_memmap_vector_storage(
-        dir.path(),
-        4,
-        Distance::Dot,
-        &AtomicBool::new(false),
-    )
-    .unwrap();
+    let _storage = open_appendable_memmap_vector_storage(dir.path(), 4, Distance::Dot).unwrap();
 }


### PR DESCRIPTION
Improve our logic for counting deleted flags when opening the mmap based deleted flags from disk.

We're seeing some slowdowns when loading Qdrant collections, especially with memory mapping. I started this effort to improve one of the aspects of it.

The improvement is quite visible on large flag counts, such as 50m, where I see a 50x improvement. On low counts, such as 50k, things seem to be the other way around. I'm a bit confused on why this is the case, and may very well be noise from the benchmark itself. I think this potential slowdown like this is acceptable on low counts when including the potential increase on large counts.

Here are the bench results on various flag counts. Each second entry is the improved logic in this PR:

```bash
# 50_000 flags
dynamic-mmap-delete-count/manual-count-loop
                        time:   [257.00 µs 258.00 µs 259.20 µs]
dynamic-mmap-delete-count/count-ones
                        time:   [1.9390 ms 1.9463 ms 1.9541 ms]

# 1_000_000 flags
dynamic-mmap-delete-count/manual-count-loop
                        time:   [5.0834 ms 5.0928 ms 5.1028 ms]
dynamic-mmap-delete-count/count-ones
                        time:   [1.7795 ms 1.7846 ms 1.7939 ms]

# 50_000_000 flags
dynamic-mmap-delete-count/manual-count-loop
                        time:   [250.86 ms 251.92 ms 252.97 ms]
dynamic-mmap-delete-count/count-ones
                        time:   [5.2382 ms 5.2851 ms 5.3362 ms]

```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?