### PR TITLE
Simplify return type when counting dynamic mmap flags

### DIFF
--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -58,7 +58,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
 
     group.bench_function("count-ones", |b| {
         b.iter(|| {
-            let count = dynamic_flags.count_flags().unwrap();
+            let count = dynamic_flags.count_flags();
             assert_eq!(count, real_count);
             black_box(count)
         });

--- a/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_mmap_dense_vector_storage.rs
@@ -68,7 +68,7 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
     let vectors = ChunkedMmapVectors::<T>::open(&vectors_path, dim)?;
 
     let deleted: DynamicMmapFlags = DynamicMmapFlags::open(&deleted_path)?;
-    let deleted_count = deleted.count_flags()?;
+    let deleted_count = deleted.count_flags();
 
     Ok(AppendableMmapDenseVectorStorage {
         vectors,

--- a/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
+++ b/lib/segment/src/vector_storage/dense/dynamic_mmap_flags.rs
@@ -215,7 +215,7 @@ impl DynamicMmapFlags {
     }
 
     /// Count number of set flags
-    pub fn count_flags(&self) -> OperationResult<usize> {
+    pub fn count_flags(&self) -> usize {
         let mut ones = self.flags.count_ones();
 
         // Subtract flags in extra capacity we don't use
@@ -224,7 +224,7 @@ impl DynamicMmapFlags {
             .filter(|&i| self.get(i))
             .count();
 
-        Ok(ones)
+        ones
     }
 
     /// Set the `true` value of the flag at the given index.
@@ -352,7 +352,7 @@ mod tests {
         dynamic_flags.flusher()().unwrap();
 
         // Test count flags method
-        let count = dynamic_flags.count_flags().unwrap();
+        let count = dynamic_flags.count_flags();
 
         // Compare against manually counting every flag
         let mut manual_count = 0;


### PR DESCRIPTION
Follow-up after <https://github.com/qdrant/qdrant/pull/4176>.

I merged it a bit to quickly. The return type can be a lot simpler.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?