### PR TITLE
gRPC API multivector for write and retrieve

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3534,7 +3534,7 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 | ----- | ---- | ----- | ----------- |
 | data | [float](#float) | repeated | Vector data (flatten for multi vectors) |
 | indices | [SparseIndices](#qdrant-SparseIndices) | optional | Sparse indices for sparse vectors |
-| vector_count | [uint32](#uint32) | optional | Number of vectors per multi vector |
+| vectors_count | [uint32](#uint32) | optional | Number of vectors per multi vector |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3532,9 +3532,9 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| data | [float](#float) | repeated | Vector data (flatten for multi-dimensional vectors) |
+| data | [float](#float) | repeated | Vector data (flatten for multi vectors) |
 | indices | [SparseIndices](#qdrant-SparseIndices) | optional | Sparse indices for sparse vectors |
-| vector_count | [uint32](#uint32) | optional | Number of tokens in the vector |
+| vector_count | [uint32](#uint32) | optional | Number of vectors per multi vector |
 
 
 

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -43,6 +43,7 @@
     - [ListCollectionsResponse](#qdrant-ListCollectionsResponse)
     - [LocalShardInfo](#qdrant-LocalShardInfo)
     - [MoveShard](#qdrant-MoveShard)
+    - [MultiVectorConfig](#qdrant-MultiVectorConfig)
     - [OptimizerStatus](#qdrant-OptimizerStatus)
     - [OptimizersConfigDiff](#qdrant-OptimizersConfigDiff)
     - [PayloadIndexParams](#qdrant-PayloadIndexParams)
@@ -80,6 +81,7 @@
     - [Datatype](#qdrant-Datatype)
     - [Distance](#qdrant-Distance)
     - [Modifier](#qdrant-Modifier)
+    - [MultiVectorComparator](#qdrant-MultiVectorComparator)
     - [PayloadSchemaType](#qdrant-PayloadSchemaType)
     - [QuantizationType](#qdrant-QuantizationType)
     - [ReplicaState](#qdrant-ReplicaState)
@@ -899,6 +901,21 @@
 
 
 
+<a name="qdrant-MultiVectorConfig"></a>
+
+### MultiVectorConfig
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| comparator | [MultiVectorComparator](#qdrant-MultiVectorComparator) |  | Comparator for multi-vector search |
+
+
+
+
+
+
 <a name="qdrant-OptimizerStatus"></a>
 
 ### OptimizerStatus
@@ -1313,6 +1330,7 @@ Note: 1kB = 1 vector of size 256. |
 | quantization_config | [QuantizationConfig](#qdrant-QuantizationConfig) | optional | Configuration of vector quantization config. If omitted - the collection configuration will be used |
 | on_disk | [bool](#bool) | optional | If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM. |
 | datatype | [Datatype](#qdrant-Datatype) | optional | Data type of the vectors |
+| multivector_config | [MultiVectorConfig](#qdrant-MultiVectorConfig) | optional | Configuration for multi-vector search |
 
 
 
@@ -1515,6 +1533,17 @@ Note: 1kB = 1 vector of size 256. |
 | ---- | ------ | ----------- |
 | None | 0 |  |
 | Idf | 1 | Apply Inverse Document Frequency |
+
+
+
+<a name="qdrant-MultiVectorComparator"></a>
+
+### MultiVectorComparator
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MaxSim | 0 |  |
 
 
 
@@ -3503,8 +3532,9 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| data | [float](#float) | repeated |  |
-| indices | [SparseIndices](#qdrant-SparseIndices) | optional |  |
+| data | [float](#float) | repeated | Vector data (flatten for multi-dimensional vectors) |
+| indices | [SparseIndices](#qdrant-SparseIndices) | optional | Sparse indices for sparse vectors |
+| vector_count | [uint32](#uint32) | optional | Number of tokens in the vector |
 
 
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -480,21 +480,21 @@ impl From<segment::data_types::vectors::Vector> for Vector {
             segment::data_types::vectors::Vector::Dense(vector) => Self {
                 data: vector,
                 indices: None,
-                vector_count: None,
+                vectors_count: None,
             },
             segment::data_types::vectors::Vector::Sparse(vector) => Self {
                 data: vector.values,
                 indices: Some(SparseIndices {
                     data: vector.indices,
                 }),
-                vector_count: None,
+                vectors_count: None,
             },
             segment::data_types::vectors::Vector::MultiDense(vector) => {
                 let vector_count = vector.multi_vectors().count() as u32;
                 Self {
                     data: vector.flattened_vectors,
                     indices: None,
-                    vector_count: Some(vector_count),
+                    vectors_count: Some(vector_count),
                 }
             }
         }
@@ -518,7 +518,7 @@ impl TryFrom<Vector> for segment::data_types::vectors::Vector {
         }
 
         // multi vector
-        if let Some(vector_count) = vector.vector_count {
+        if let Some(vector_count) = vector.vectors_count {
             if vector_count == 0 {
                 return Err(Status::invalid_argument(
                     "Vector count should be greater than 0",
@@ -620,11 +620,6 @@ impl TryFrom<Vectors> for segment::data_types::vectors::VectorStruct {
         match vectors.vectors_options {
             Some(vectors_options) => Ok(match vectors_options {
                 VectorsOptions::Vector(vector) => {
-                    if vector.vector_count.is_some() {
-                        return Err(Status::invalid_argument(
-                            "Multivector must be named".to_string(),
-                        ));
-                    }
                     if vector.indices.is_some() {
                         return Err(Status::invalid_argument(
                             "Sparse vector must be named".to_string(),

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -15,6 +15,7 @@ message VectorParams {
   optional QuantizationConfig quantization_config = 4; // Configuration of vector quantization config. If omitted - the collection configuration will be used
   optional bool on_disk = 5; // If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
   optional Datatype datatype = 6; // Data type of the vectors
+  optional MultiVectorConfig multivector_config = 7; // Configuration for multi-vector search
 }
 
 message VectorParamsDiff {
@@ -58,6 +59,15 @@ message SparseVectorParams {
 message SparseVectorConfig {
   map<string, SparseVectorParams> map = 1;
 }
+
+enum MultiVectorComparator {
+    MaxSim = 0;
+}
+
+message MultiVectorConfig {
+    MultiVectorComparator comparator = 1; // Comparator for multi-vector search
+}
+
 
 message GetCollectionInfoRequest {
   string collection_name = 1; // Name of the collection

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -49,7 +49,7 @@ message SparseIndices {
 message Vector {
   repeated float data = 1; // Vector data (flatten for multi vectors)
   optional SparseIndices indices = 2; // Sparse indices for sparse vectors
-  optional uint32 vector_count = 3; // Number of vectors per multi vector
+  optional uint32 vectors_count = 3; // Number of vectors per multi vector
 }
 
 // ---------------------------------------------

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -47,9 +47,9 @@ message SparseIndices {
 }
 
 message Vector {
-  repeated float data = 1; // Vector data (flatten for multi-dimensional vectors)
+  repeated float data = 1; // Vector data (flatten for multi vectors)
   optional SparseIndices indices = 2; // Sparse indices for sparse vectors
-  optional uint32 vector_count = 3; // Number of tokens in the vector
+  optional uint32 vector_count = 3; // Number of vectors per multi vector
 }
 
 // ---------------------------------------------

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -47,8 +47,9 @@ message SparseIndices {
 }
 
 message Vector {
-  repeated float data = 1;
-  optional SparseIndices indices = 2;
+  repeated float data = 1; // Vector data (flatten for multi-dimensional vectors)
+  optional SparseIndices indices = 2; // Sparse indices for sparse vectors
+  optional uint32 vector_count = 3; // Number of tokens in the vector
 }
 
 // ---------------------------------------------

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -24,6 +24,9 @@ pub struct VectorParams {
     /// Data type of the vectors
     #[prost(enumeration = "Datatype", optional, tag = "6")]
     pub datatype: ::core::option::Option<i32>,
+    /// Configuration for multi-vector search
+    #[prost(message, optional, tag = "7")]
+    pub multivector_config: ::core::option::Option<MultiVectorConfig>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -125,6 +128,14 @@ pub struct SparseVectorConfig {
         ::prost::alloc::string::String,
         SparseVectorParams,
     >,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MultiVectorConfig {
+    /// Comparator for multi-vector search
+    #[prost(enumeration = "MultiVectorComparator", tag = "1")]
+    pub comparator: i32,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -1135,6 +1146,30 @@ impl Modifier {
         match value {
             "None" => Some(Self::None),
             "Idf" => Some(Self::Idf),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MultiVectorComparator {
+    MaxSim = 0,
+}
+impl MultiVectorComparator {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            MultiVectorComparator::MaxSim => "MaxSim",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "MaxSim" => Some(Self::MaxSim),
             _ => None,
         }
     }
@@ -3670,10 +3705,15 @@ pub struct SparseIndices {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
+    /// Vector data (flatten for multi-dimensional vectors)
     #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
+    /// Sparse indices for sparse vectors
     #[prost(message, optional, tag = "2")]
     pub indices: ::core::option::Option<SparseIndices>,
+    /// Number of tokens in the vector
+    #[prost(uint32, optional, tag = "3")]
+    pub vector_count: ::core::option::Option<u32>,
 }
 /// ---------------------------------------------
 /// ----------------- ShardKeySelector ----------

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3713,7 +3713,7 @@ pub struct Vector {
     pub indices: ::core::option::Option<SparseIndices>,
     /// Number of vectors per multi vector
     #[prost(uint32, optional, tag = "3")]
-    pub vector_count: ::core::option::Option<u32>,
+    pub vectors_count: ::core::option::Option<u32>,
 }
 /// ---------------------------------------------
 /// ----------------- ShardKeySelector ----------

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3705,13 +3705,13 @@ pub struct SparseIndices {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
-    /// Vector data (flatten for multi-dimensional vectors)
+    /// Vector data (flatten for multi vectors)
     #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
     /// Sparse indices for sparse vectors
     #[prost(message, optional, tag = "2")]
     pub indices: ::core::option::Option<SparseIndices>,
-    /// Number of tokens in the vector
+    /// Number of vectors per multi vector
     #[prost(uint32, optional, tag = "3")]
     pub vector_count: ::core::option::Option<u32>,
 }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -235,12 +235,12 @@ impl Validate for grpc::FieldCondition {
 
 impl Validate for grpc::Vector {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        match (&self.indices, self.vector_count) {
+        match (&self.indices, self.vectors_count) {
             (Some(_), Some(_)) => {
                 let mut errors = ValidationErrors::new();
                 errors.add(
                     "indices",
-                    ValidationError::new("`indices` and `vector_count` cannot be both specified"),
+                    ValidationError::new("`indices` and `vectors_count` cannot be both specified"),
                 );
                 Err(errors)
             }
@@ -248,8 +248,8 @@ impl Validate for grpc::Vector {
                 &indices.data,
                 &self.data,
             ),
-            (None, Some(vector_count)) => {
-                common::validation::validate_multi_vector_len(vector_count, &self.data)
+            (None, Some(vectors_count)) => {
+                common::validation::validate_multi_vector_len(vectors_count, &self.data)
             }
             (None, None) => Ok(()),
         }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -70,7 +70,20 @@ impl Validate for grpc::vectors_config::Config {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use grpc::vectors_config::Config;
         match self {
-            Config::Params(params) => params.validate(),
+            Config::Params(params) => {
+                if params.multivector_config.is_some() {
+                    let mut err = ValidationErrors::new();
+                    err.add(
+                        "multivector_config",
+                        ValidationError::new(
+                            "Multivector configuration is not supported for anonymous vectors",
+                        ),
+                    );
+                    return Err(err);
+                }
+
+                params.validate()
+            }
             Config::ParamsMap(params_map) => params_map.validate(),
         }
     }
@@ -222,11 +235,20 @@ impl Validate for grpc::FieldCondition {
 
 impl Validate for grpc::Vector {
     fn validate(&self) -> Result<(), ValidationErrors> {
+        // sparse vector
         if let Some(indices) = &self.indices {
-            sparse::common::sparse_vector::validate_sparse_vector_impl(&indices.data, &self.data)
-        } else {
-            Ok(())
+            return sparse::common::sparse_vector::validate_sparse_vector_impl(
+                &indices.data,
+                &self.data,
+            );
         }
+
+        // multivector
+        if let Some(vector_count) = self.vector_count {
+            return common::validation::validate_multi_vector_len(vector_count, &self.data);
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -70,20 +70,7 @@ impl Validate for grpc::vectors_config::Config {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use grpc::vectors_config::Config;
         match self {
-            Config::Params(params) => {
-                if params.multivector_config.is_some() {
-                    let mut err = ValidationErrors::new();
-                    err.add(
-                        "multivector_config",
-                        ValidationError::new(
-                            "Multivector configuration is not supported for anonymous vectors",
-                        ),
-                    );
-                    return Err(err);
-                }
-
-                params.validate()
-            }
+            Config::Params(params) => params.validate(),
             Config::ParamsMap(params_map) => params_map.validate(),
         }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -20,7 +20,9 @@ use segment::data_types::vectors::{
     BatchVectorStruct, Named, NamedQuery, NamedVectorStruct, Vector, VectorStruct,
     DEFAULT_VECTOR_NAME,
 };
-use segment::types::{DateTimeWrapper, Distance, QuantizationConfig, ScoredPoint};
+use segment::types::{
+    DateTimeWrapper, Distance, MultiVectorConfig, QuantizationConfig, ScoredPoint,
+};
 use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
 use segment::vector_storage::query::discovery_query::DiscoveryQuery;
 use segment::vector_storage::query::reco_query::RecoQuery;
@@ -553,7 +555,10 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
                 .transpose()?,
             on_disk: vector_params.on_disk,
             datatype: convert_datatype_from_proto(vector_params.datatype)?,
-            multivec_config: None, // TODO(colbert) add multivector config
+            multivec_config: vector_params
+                .multivector_config
+                .map(MultiVectorConfig::try_from)
+                .transpose()?,
         })
     }
 }
@@ -1661,6 +1666,9 @@ impl From<VectorParams> for api::grpc::qdrant::VectorParams {
             datatype: value
                 .datatype
                 .map(|dt| api::grpc::qdrant::Datatype::from(dt).into()),
+            multivector_config: value
+                .multivec_config
+                .map(api::grpc::qdrant::MultiVectorConfig::from),
         }
     }
 }

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -180,6 +180,23 @@ pub fn validate_multi_vector<T>(multivec: &[Vec<T>]) -> Result<(), ValidationErr
     Ok(())
 }
 
+pub fn validate_multi_vector_len(
+    vector_count: u32,
+    flatten_dense_vector: &[f32],
+) -> Result<(), ValidationErrors> {
+    let dense_vector_len = flatten_dense_vector.len();
+    if dense_vector_len % vector_count as usize != 0 {
+        let mut errors = ValidationErrors::default();
+        let mut err = ValidationError::new("invalid dense vector length for vector count");
+        err.add_param(Cow::from("len"), &dense_vector_len);
+        err.add_param(Cow::from("vector_count"), &vector_count);
+        errors.add("data", err);
+        Err(errors)
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -181,15 +181,25 @@ pub fn validate_multi_vector<T>(multivec: &[Vec<T>]) -> Result<(), ValidationErr
 }
 
 pub fn validate_multi_vector_len(
-    vector_count: u32,
+    vectors_count: u32,
     flatten_dense_vector: &[f32],
 ) -> Result<(), ValidationErrors> {
-    let dense_vector_len = flatten_dense_vector.len();
-    if dense_vector_len % vector_count as usize != 0 {
+    if vectors_count == 0 {
         let mut errors = ValidationErrors::default();
-        let mut err = ValidationError::new("invalid dense vector length for vector count");
-        err.add_param(Cow::from("len"), &dense_vector_len);
-        err.add_param(Cow::from("vector_count"), &vector_count);
+        let mut err = ValidationError::new("invalid_vector_count");
+        err.add_param(
+            Cow::from("vectors_count"),
+            &"vectors count must be greater than 0",
+        );
+        errors.add("data", err);
+        return Err(errors);
+    }
+    let dense_vector_len = flatten_dense_vector.len();
+    if dense_vector_len % vectors_count as usize != 0 {
+        let mut errors = ValidationErrors::default();
+        let mut err = ValidationError::new("invalid dense vector length for vectors count");
+        err.add_param(Cow::from("vector_len"), &dense_vector_len);
+        err.add_param(Cow::from("vectors_count"), &vectors_count);
         errors.add("data", err);
         Err(errors)
     } else {

--- a/tests/basic_multivector_grpc_test.sh
+++ b/tests/basic_multivector_grpc_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Ensure current path is project root
+cd "$(dirname "$0")/../"
+
+QDRANT_HOST='localhost:6334'
+
+docker_grpcurl="docker run --rm --network=host -v ${PWD}/lib/api/src/grpc/proto:/proto fullstorydev/grpcurl -plaintext -import-path /proto -proto qdrant.proto"
+
+$docker_grpcurl -d '{
+   "collection_name": "test_multivector_collection"
+}' $QDRANT_HOST qdrant.Collections/Delete
+
+$docker_grpcurl -d '{
+   "collection_name": "test_multivector_collection",
+   "vectors_config": {
+      "params_map": {
+        "map": {
+          "my-multivec": {
+            "size": 4,
+            "distance": "Dot",
+            "multivector_config" : { 
+              "comparator": "MaxSim"
+            }
+          }
+        }
+      }
+   }
+}' $QDRANT_HOST qdrant.Collections/Create
+
+$docker_grpcurl -d '{}' $QDRANT_HOST qdrant.Collections/List
+
+$docker_grpcurl -d '{
+  "collection_name": "test_multivector_collection",
+  "wait": true,
+  "ordering": null,
+  "points": [
+    {
+      "id": { "num": 1 },
+      "vectors": {
+        "vectors": {
+          "vectors": {
+            "my-multivec": {
+              "data": [0.05, 0.61, 0.76, 0.74],
+              "vector_count": 1
+            }
+          }
+        }
+      },
+      "payload": {
+        "city": { "string_value": "Berlin" },
+        "country":  { "string_value": "Germany" },
+        "population": { "integer_value":  1000000 },
+        "square": { "double_value": 12.5 },
+        "coords": { "struct_value": { "fields": { "lat": { "double_value": 1.0 }, "lon": { "double_value": 2.0 } } } }
+      }
+    },
+    {
+      "id": { "num": 2 },
+       "vectors": {
+         "vectors": {
+           "vectors": {
+             "my-multivec": {
+               "data": [0.19, 0.81, 0.75, 0.11],
+               "vector_count": 1
+             }
+           }
+         }
+       },
+       "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "London" }]}}}
+    },
+    {
+      "id": { "num": 3 },
+      "vectors": {
+        "vectors": {
+          "vectors": {
+            "my-multivec": {
+               "data": [0.36, 0.55, 0.47, 0.94],
+               "vector_count": 1
+            }
+          }
+        }
+      },
+      "payload": {"city": {"list_value": {"values": [{ "string_value": "Berlin" }, { "string_value": "Moscow" }]}}}
+    },
+    {
+      "id": { "num": 4 },
+      "vectors": {
+        "vectors": {
+          "vectors": {
+            "my-multivec": {
+              "data": [0.18, 0.01, 0.85, 0.80],
+              "vector_count": 1
+            }
+          }
+        }
+      },
+      "payload": {"city": {"list_value": {"values": [{ "string_value": "London" }, { "string_value": "Moscow" }]}}}
+    },
+    {
+      "id": { "uuid": "98a9a4b1-4ef2-46fb-8315-a97d874fe1d7" },
+      "vectors": {
+        "vectors": {
+          "vectors": {
+            "my-multivec": {
+              "data": [0.24, 0.18, 0.22, 0.44],
+              "vector_count": 1
+            }
+          }
+        }
+      },
+      "payload": {"count":{"list_value": {"values": [{ "integer_value": 0 }]}}}
+    },
+    {
+      "id": { "uuid": "f0e09527-b096-42a8-94e9-ea94d342b925" },
+      "vectors": {
+        "vectors": {
+          "vectors": {
+            "my-multivec": {
+              "data": [0.35, 0.08, 0.11, 0.44],
+              "vector_count": 1
+            }
+          }
+        }
+      }
+    }
+  ]
+}' $QDRANT_HOST qdrant.Points/Upsert
+
+$docker_grpcurl -d '{ "collection_name": "test_multivector_collection" }' $QDRANT_HOST qdrant.Collections/Get
+
+$docker_grpcurl -d '{
+  "collection_name": "test_multivector_collection",
+  "limit": 2,
+  "with_vectors": {"enable": true},
+  "filter": {
+    "should": [
+      {
+        "field": {
+          "key": "city",
+          "match": {
+            "keyword": "London"
+          }
+        }
+      }
+    ]
+  }
+}' $QDRANT_HOST qdrant.Points/Scroll
+
+$docker_grpcurl -d '{
+  "collection_name": "test_multivector_collection",
+  "with_vectors": {"enable": true},
+  "ids": [{ "num": 2 }, { "num": 3 }, { "num": 4 }]
+}' $QDRANT_HOST qdrant.Points/Get

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -55,3 +55,5 @@ fi
 ./tests/basic_grpc_test.sh
 
 ./tests/basic_sparse_grpc_test.sh
+
+./tests/basic_multivector_grpc_test.sh


### PR DESCRIPTION
This PR adds a new gRPC API for multivector.

it supports write and retrieve operations. Search is not supported.