### PR TITLE
universal-search: [PoC] Recieve a `PlannedQuery` at `LocalShard`

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -24,6 +24,7 @@ service PointsInternal {
   rpc Count (CountPointsInternal) returns (CountResponse) {}
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
   rpc Get (GetPointsInternal) returns (GetResponse) {}
+  rpc Query (QueryPointsInternal) returns (QueryResponse) {}
 }
 
 
@@ -197,4 +198,51 @@ message GetPointsInternal {
 message CountPointsInternal {
   CountPoints count_points = 1;
   optional uint32 shard_id = 2;
+}
+
+message PlannedQueryPoints {
+  message VectorRescore { 
+    QueryEnum query = 1;
+    string using = 2;
+  }
+
+  message Rescore {
+    oneof rescore {
+      VectorRescore vector = 1;
+    }
+  }
+
+  message Merge {
+    optional Rescore rescore = 1;
+    uint64 limit = 2;
+  }
+
+  message Source {
+    oneof source {
+      uint64 batch_idx = 1;
+      Prefetch prefetch = 2;
+    }
+  }
+
+  message Prefetch {
+    repeated Source sources = 1;
+    Merge merge = 2;
+  }
+
+  repeated CoreSearchPoints core_searches = 1;
+  Prefetch merge_plan = 2;
+  uint64 limit = 3;
+  uint64 offset = 4;
+  WithPayloadSelector with_payload = 5;
+  WithVectorsSelector with_vectors = 6;
+}
+
+message QueryPointsInternal {
+  PlannedQueryPoints planned_query_points = 1;
+  optional uint32 shard_id = 2;
+}
+
+message QueryResponse {
+  repeated ScoredPoint result = 1;
+  double time = 2; // Time spent to process
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -7878,6 +7878,108 @@ pub struct CountPointsInternal {
     #[prost(uint32, optional, tag = "2")]
     pub shard_id: ::core::option::Option<u32>,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PlannedQueryPoints {
+    #[prost(message, repeated, tag = "1")]
+    pub core_searches: ::prost::alloc::vec::Vec<CoreSearchPoints>,
+    #[prost(message, optional, tag = "2")]
+    pub merge_plan: ::core::option::Option<planned_query_points::Prefetch>,
+    #[prost(uint64, tag = "3")]
+    pub limit: u64,
+    #[prost(uint64, tag = "4")]
+    pub offset: u64,
+    #[prost(message, optional, tag = "5")]
+    pub with_payload: ::core::option::Option<WithPayloadSelector>,
+    #[prost(message, optional, tag = "6")]
+    pub with_vectors: ::core::option::Option<WithVectorsSelector>,
+}
+/// Nested message and enum types in `PlannedQueryPoints`.
+pub mod planned_query_points {
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct VectorRescore {
+        #[prost(message, optional, tag = "1")]
+        pub query: ::core::option::Option<super::QueryEnum>,
+        #[prost(string, tag = "2")]
+        pub using: ::prost::alloc::string::String,
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Rescore {
+        #[prost(oneof = "rescore::Rescore", tags = "1")]
+        pub rescore: ::core::option::Option<rescore::Rescore>,
+    }
+    /// Nested message and enum types in `Rescore`.
+    pub mod rescore {
+        #[derive(serde::Serialize)]
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Rescore {
+            #[prost(message, tag = "1")]
+            Vector(super::VectorRescore),
+        }
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Merge {
+        #[prost(message, optional, tag = "1")]
+        pub rescore: ::core::option::Option<Rescore>,
+        #[prost(uint64, tag = "2")]
+        pub limit: u64,
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Source {
+        #[prost(oneof = "source::Source", tags = "1, 2")]
+        pub source: ::core::option::Option<source::Source>,
+    }
+    /// Nested message and enum types in `Source`.
+    pub mod source {
+        #[derive(serde::Serialize)]
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Source {
+            #[prost(uint64, tag = "1")]
+            BatchIdx(u64),
+            #[prost(message, tag = "2")]
+            Prefetch(super::Prefetch),
+        }
+    }
+    #[derive(serde::Serialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Prefetch {
+        #[prost(message, repeated, tag = "1")]
+        pub sources: ::prost::alloc::vec::Vec<Source>,
+        #[prost(message, optional, tag = "2")]
+        pub merge: ::core::option::Option<Merge>,
+    }
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryPointsInternal {
+    #[prost(message, optional, tag = "1")]
+    pub planned_query_points: ::core::option::Option<PlannedQueryPoints>,
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
+}
 /// Generated client implementations.
 pub mod points_internal_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -8400,6 +8502,28 @@ pub mod points_internal_client {
             req.extensions_mut().insert(GrpcMethod::new("qdrant.PointsInternal", "Get"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn query(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryPointsInternal>,
+        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.PointsInternal/Query",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.PointsInternal", "Query"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -8523,6 +8647,10 @@ pub mod points_internal_server {
             &self,
             request: tonic::Request<super::GetPointsInternal>,
         ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
+        async fn query(
+            &self,
+            request: tonic::Request<super::QueryPointsInternal>,
+        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct PointsInternalServer<T: PointsInternal> {
@@ -9426,6 +9554,52 @@ pub mod points_internal_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.PointsInternal/Query" => {
+                    #[allow(non_camel_case_types)]
+                    struct QuerySvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::QueryPointsInternal>
+                    for QuerySvc<T> {
+                        type Response = super::QueryResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QueryPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PointsInternal>::query(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = QuerySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -15,6 +15,7 @@ pub mod types;
 pub mod validation;
 pub mod vector_ops;
 pub mod vector_params_builder;
+pub mod universal_query;
 
 use std::collections::HashMap;
 

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -12,10 +12,10 @@ pub mod shard_selector_internal;
 pub mod shared_storage_config;
 pub mod snapshot_ops;
 pub mod types;
+pub mod universal_query;
 pub mod validation;
 pub mod vector_ops;
 pub mod vector_params_builder;
-pub mod universal_query;
 
 use std::collections::HashMap;
 

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use segment::types::{WithPayloadInterface, WithVector};
+
+use super::{query_enum::QueryEnum, types::CoreSearchRequestBatch};
+
+pub enum Rescore {
+    /// Rescore points against a vector
+    Vector(QueryEnum),
+}
+
+pub struct Merge {
+    /// Alter the scores before selecting the best limit
+    pub rescore: Option<Rescore>,
+
+    /// Keep this much points from the top
+    pub limit: usize,
+}
+
+pub enum Source {
+    /// A reference offset into the main search batch
+    Idx(usize),
+
+    /// A nested prefetch
+    Prefetch(Prefetch),
+}
+
+pub struct Prefetch {
+    /// Gather all these sources
+    pub sources: Vec<Source>,
+
+    /// How to merge the sources
+    pub merge: Merge,
+}
+
+pub struct PlannedQuery {
+    pub merge_plan: Prefetch,
+    pub batch: Arc<CoreSearchRequestBatch>,
+    pub offset: usize,
+    pub with_vector: WithVector,
+    pub with_payload: WithPayloadInterface,
+}

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use segment::types::{WithPayloadInterface, WithVector};
 
-use super::{query_enum::QueryEnum, types::CoreSearchRequestBatch};
+use super::query_enum::QueryEnum;
+use super::types::CoreSearchRequestBatch;
 
 pub enum Rescore {
     /// Rescore points against a vector
@@ -19,7 +20,7 @@ pub struct Merge {
 
 pub enum Source {
     /// A reference offset into the main search batch
-    Idx(usize),
+    BatchIdx(usize),
 
     /// A nested prefetch
     Prefetch(Prefetch),

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -17,7 +17,8 @@ use crate::collection_manager::segments_searcher::SegmentsSearcher;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::query_enum::QueryEnum;
 use crate::operations::types::{
-    CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch, CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus
+    CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
+    CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
 use crate::operations::universal_query::{Merge, PlannedQuery, Prefetch, Source};
 use crate::operations::OperationWithClockTag;
@@ -26,37 +27,63 @@ use crate::shards::shard_trait::ShardOperation;
 use crate::update_handler::{OperationData, UpdateSignal};
 
 impl LocalShard {
-    pub async fn do_planned_query(&self, request: Arc<PlannedQuery>, search_runtime_handle: &Handle, timeout: Option<Duration>) -> CollectionResult<Vec<ScoredPoint>> {
-        let core_results = self.do_search(Arc::clone(&request.batch), search_runtime_handle, timeout).await?;
+    pub async fn do_planned_query(
+        &self,
+        request: Arc<PlannedQuery>,
+        search_runtime_handle: &Handle,
+        timeout: Option<Duration>,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        let core_results = self
+            .do_search(Arc::clone(&request.batch), search_runtime_handle, timeout)
+            .await?;
 
-        self.recurse_prefetch(&request.merge_plan, &core_results).await
+        self.recurse_prefetch(&request.merge_plan, &core_results)
+            .await
 
         // TODO(universal-search): Implement with_vector and with_payload
     }
 
-    fn recurse_prefetch<'shard, 'query>(&'shard self, prefetch: &'query Prefetch, core_results: &'query Vec<Vec<ScoredPoint>>) -> BoxFuture<'query, CollectionResult<Vec<ScoredPoint>>>
-    where 'shard: 'query {
+    fn recurse_prefetch<'shard, 'query>(
+        &'shard self,
+        prefetch: &'query Prefetch,
+        core_results: &'query Vec<Vec<ScoredPoint>>,
+    ) -> BoxFuture<'query, CollectionResult<Vec<ScoredPoint>>>
+    where
+        'shard: 'query,
+    {
         async move {
             let mut sources = Vec::with_capacity(prefetch.sources.len());
-            
+
             for source in prefetch.sources.iter() {
                 let vec: Vec<ScoredPoint> = match source {
-                    Source::Idx(idx) => core_results.get(*idx).cloned().unwrap_or_default(), // TODO(universal-search): don't clone, by using something like a hashmap instead of a vec
-                    Source::Prefetch(prefetch) => self.recurse_prefetch(prefetch, core_results).await?,
+                    Source::BatchIdx(idx) => core_results.get(*idx).cloned().unwrap_or_default(), // TODO(universal-search): don't clone, by using something like a hashmap instead of a vec
+                    Source::Prefetch(prefetch) => {
+                        self.recurse_prefetch(prefetch, core_results).await?
+                    }
                 };
                 sources.push(vec);
             }
-            
+
             self.merge_prefetches(sources, &prefetch.merge).await
-        }.boxed()
+        }
+        .boxed()
     }
 
-    async fn merge_prefetches(&self, sources: Vec<Vec<ScoredPoint>>, merge: &Merge) -> CollectionResult<Vec<ScoredPoint>> {
+    async fn merge_prefetches(
+        &self,
+        sources: Vec<Vec<ScoredPoint>>,
+        merge: &Merge,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
         if let Some(_rescore) = merge.rescore.as_ref() {
             // TODO(universal-search): Implement rescore
         }
 
-        let top = sources.into_iter().flatten().sorted().take(merge.limit).collect();
+        let top = sources
+            .into_iter()
+            .flatten()
+            .sorted()
+            .take(merge.limit)
+            .collect();
 
         Ok(top)
     }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -6,10 +6,10 @@ use api::grpc::qdrant::{
     ClearPayloadPointsInternal, CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, GetPointsInternal,
-    GetResponse, PointsOperationResponseInternal, RecommendPointsInternal, RecommendResponse,
-    ScrollPointsInternal, ScrollResponse, SearchBatchPointsInternal, SearchBatchResponse,
-    SearchPointsInternal, SearchResponse, SetPayloadPointsInternal, SyncPointsInternal,
-    UpdateVectorsInternal, UpsertPointsInternal,
+    GetResponse, PointsOperationResponseInternal, QueryPointsInternal, QueryResponse,
+    RecommendPointsInternal, RecommendResponse, ScrollPointsInternal, ScrollResponse,
+    SearchBatchPointsInternal, SearchBatchResponse, SearchPointsInternal, SearchResponse,
+    SetPayloadPointsInternal, SyncPointsInternal, UpdateVectorsInternal, UpsertPointsInternal,
 };
 use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
@@ -447,5 +447,12 @@ impl PointsInternal for PointsInternalService {
             FULL_ACCESS.clone(),
         )
         .await
+    }
+
+    async fn query(
+        &self,
+        _request: Request<QueryPointsInternal>,
+    ) -> Result<Response<QueryResponse>, Status> {
+        return Err(Status::unimplemented("Not yet implemented"));
     }
 }


### PR DESCRIPTION
Proof of concept.

Main idea: 
  1. `Collection` should process the user request and turn it into a `PlannedQuery`, which will have a single `CoreSearchRequestBatch` to perform all at once. 
  2. Then resolve recursivity of the `prefetch` parameter afterwards, referencing to the searches as merging sources. 
### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
3. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
