### PR TITLE
Integrate multivector mmap and byte storages

### DIFF
--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -224,7 +224,9 @@ impl Segment {
                         }
                         VectorStorageEnum::SparseSimple(_) => Vector::from(SparseVector::default()),
                         VectorStorageEnum::MultiDenseSimple(_)
-                        | VectorStorageEnum::MultiDenseAppendableMemmap(_) => {
+                        | VectorStorageEnum::MultiDenseSimpleByte(_)
+                        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+                        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => {
                             Vector::from(MultiDenseVector::placeholder(dim))
                         }
                     };

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -41,7 +41,12 @@ use crate::vector_storage::dense::memmap_dense_vector_storage::{
 use crate::vector_storage::dense::simple_dense_vector_storage::{
     open_simple_dense_byte_vector_storage, open_simple_dense_vector_storage,
 };
-use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::open_simple_multi_dense_vector_storage;
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
+    open_appendable_memmap_multi_vector_storage, open_appendable_memmap_multi_vector_storage_byte,
+};
+use crate::vector_storage::multi_dense::simple_multi_dense_vector_storage::{
+    open_simple_multi_dense_vector_storage, open_simple_multi_dense_vector_storage_byte,
+};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::VectorStorage;
@@ -132,14 +137,26 @@ fn create_segment(
             VectorStorageType::Memory => {
                 let db_column_name = get_vector_name_with_prefix(DB_VECTOR_CF, vector_name);
                 if let Some(multi_vec_config) = &vector_config.multivec_config {
-                    open_simple_multi_dense_vector_storage(
-                        database.clone(),
-                        &db_column_name,
-                        vector_config.size,
-                        vector_config.distance,
-                        *multi_vec_config,
-                        stopped,
-                    )?
+                    match storage_element_type {
+                        VectorStorageDatatype::Float32 => open_simple_multi_dense_vector_storage(
+                            database.clone(),
+                            &db_column_name,
+                            vector_config.size,
+                            vector_config.distance,
+                            *multi_vec_config,
+                            stopped,
+                        )?,
+                        VectorStorageDatatype::Uint8 => {
+                            open_simple_multi_dense_vector_storage_byte(
+                                database.clone(),
+                                &db_column_name,
+                                vector_config.size,
+                                vector_config.distance,
+                                *multi_vec_config,
+                                stopped,
+                            )?
+                        }
+                    }
                 } else {
                     match storage_element_type {
                         VectorStorageDatatype::Float32 => open_simple_dense_vector_storage(
@@ -160,31 +177,78 @@ fn create_segment(
                 }
             }
             // Mmap on disk, not appendable
-            VectorStorageType::Mmap => match storage_element_type {
-                VectorStorageDatatype::Float32 => open_memmap_vector_storage(
-                    &vector_storage_path,
-                    vector_config.size,
-                    vector_config.distance,
-                )?,
-                VectorStorageDatatype::Uint8 => open_memmap_vector_storage_byte(
-                    &vector_storage_path,
-                    vector_config.size,
-                    vector_config.distance,
-                )?,
-            },
+            VectorStorageType::Mmap => {
+                if let Some(multi_vec_config) = &vector_config.multivec_config {
+                    // there are no mmap multi vector storages, appendable only
+                    match storage_element_type {
+                        VectorStorageDatatype::Float32 => {
+                            open_appendable_memmap_multi_vector_storage(
+                                &vector_storage_path,
+                                vector_config.size,
+                                vector_config.distance,
+                                *multi_vec_config,
+                            )?
+                        }
+                        VectorStorageDatatype::Uint8 => {
+                            open_appendable_memmap_multi_vector_storage_byte(
+                                &vector_storage_path,
+                                vector_config.size,
+                                vector_config.distance,
+                                *multi_vec_config,
+                            )?
+                        }
+                    }
+                } else {
+                    match storage_element_type {
+                        VectorStorageDatatype::Float32 => open_memmap_vector_storage(
+                            &vector_storage_path,
+                            vector_config.size,
+                            vector_config.distance,
+                        )?,
+                        VectorStorageDatatype::Uint8 => open_memmap_vector_storage_byte(
+                            &vector_storage_path,
+                            vector_config.size,
+                            vector_config.distance,
+                        )?,
+                    }
+                }
+            }
             // Chunked mmap on disk, appendable
-            VectorStorageType::ChunkedMmap => match storage_element_type {
-                VectorStorageDatatype::Float32 => open_appendable_memmap_vector_storage(
-                    &vector_storage_path,
-                    vector_config.size,
-                    vector_config.distance,
-                )?,
-                VectorStorageDatatype::Uint8 => open_appendable_memmap_vector_storage_byte(
-                    &vector_storage_path,
-                    vector_config.size,
-                    vector_config.distance,
-                )?,
-            },
+            VectorStorageType::ChunkedMmap => {
+                if let Some(multi_vec_config) = &vector_config.multivec_config {
+                    match storage_element_type {
+                        VectorStorageDatatype::Float32 => {
+                            open_appendable_memmap_multi_vector_storage(
+                                &vector_storage_path,
+                                vector_config.size,
+                                vector_config.distance,
+                                *multi_vec_config,
+                            )?
+                        }
+                        VectorStorageDatatype::Uint8 => {
+                            open_appendable_memmap_multi_vector_storage_byte(
+                                &vector_storage_path,
+                                vector_config.size,
+                                vector_config.distance,
+                                *multi_vec_config,
+                            )?
+                        }
+                    }
+                } else {
+                    match storage_element_type {
+                        VectorStorageDatatype::Float32 => open_appendable_memmap_vector_storage(
+                            &vector_storage_path,
+                            vector_config.size,
+                            vector_config.distance,
+                        )?,
+                        VectorStorageDatatype::Uint8 => open_appendable_memmap_vector_storage_byte(
+                            &vector_storage_path,
+                            vector_config.size,
+                            vector_config.distance,
+                        )?,
+                    }
+                }
+            }
         };
 
         // Warn when number of points between ID tracker and storage differs

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -14,7 +14,8 @@ use crate::common::Flusher;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
+    MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef, VectorElementType,
+    VectorElementTypeByte, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::chunked_mmap_vectors::ChunkedMmapVectors;
@@ -56,6 +57,24 @@ pub fn open_appendable_memmap_multi_vector_storage(
 
     Ok(Arc::new(AtomicRefCell::new(
         VectorStorageEnum::MultiDenseAppendableMemmap(Box::new(storage)),
+    )))
+}
+
+pub fn open_appendable_memmap_multi_vector_storage_byte(
+    path: &Path,
+    dim: usize,
+    distance: Distance,
+    multi_vector_config: MultiVectorConfig,
+) -> OperationResult<Arc<AtomicRefCell<VectorStorageEnum>>> {
+    let storage = open_appendable_memmap_multi_vector_storage_impl::<VectorElementTypeByte>(
+        path,
+        dim,
+        distance,
+        multi_vector_config,
+    )?;
+
+    Ok(Arc::new(AtomicRefCell::new(
+        VectorStorageEnum::MultiDenseAppendableMemmapByte(Box::new(storage)),
     )))
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -132,7 +132,9 @@ impl QuantizedVectors {
             }
             VectorStorageEnum::SparseSimple(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::MultiDenseSimple(_) => Err(OperationError::WrongMulti),
+            VectorStorageEnum::MultiDenseSimpleByte(_) => Err(OperationError::WrongMulti),
             VectorStorageEnum::MultiDenseAppendableMemmap(_) => Err(OperationError::WrongMulti),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => Err(OperationError::WrongMulti),
         }
     }
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -153,8 +153,14 @@ pub fn new_stoppable_raw_scorer<'a>(
         VectorStorageEnum::MultiDenseSimple(vs) => {
             raw_multi_scorer_impl(query, vs, point_deleted, is_stopped)
         }
+        VectorStorageEnum::MultiDenseSimpleByte(vs) => {
+            raw_multi_scorer_byte_impl(query, vs, point_deleted, is_stopped)
+        }
         VectorStorageEnum::MultiDenseAppendableMemmap(vs) => {
             raw_multi_scorer_impl(query, vs.as_ref(), point_deleted, is_stopped)
+        }
+        VectorStorageEnum::MultiDenseAppendableMemmapByte(vs) => {
+            raw_multi_scorer_byte_impl(query, vs.as_ref(), point_deleted, is_stopped)
         }
     }
 }
@@ -501,6 +507,101 @@ fn new_multi_scorer_with_metric<
             let context_query: ContextQuery<MultiDenseVector> = context_query.transform_into()?;
             raw_scorer_from_query_scorer(
                 MultiCustomQueryScorer::<VectorElementType, TMetric, _, _, _>::new(
+                    context_query,
+                    vector_storage,
+                ),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
+    }
+}
+
+pub fn raw_multi_scorer_byte_impl<'a, TVectorStorage: MultiVectorStorage<VectorElementTypeByte>>(
+    query: QueryVector,
+    vector_storage: &'a TVectorStorage,
+    point_deleted: &'a BitSlice,
+    is_stopped: &'a AtomicBool,
+) -> OperationResult<Box<dyn RawScorer + 'a>> {
+    match vector_storage.distance() {
+        Distance::Cosine => new_multi_scorer_byte_with_metric::<CosineMetric, _>(
+            query,
+            vector_storage,
+            point_deleted,
+            is_stopped,
+        ),
+        Distance::Euclid => new_multi_scorer_byte_with_metric::<EuclidMetric, _>(
+            query,
+            vector_storage,
+            point_deleted,
+            is_stopped,
+        ),
+        Distance::Dot => new_multi_scorer_byte_with_metric::<DotProductMetric, _>(
+            query,
+            vector_storage,
+            point_deleted,
+            is_stopped,
+        ),
+        Distance::Manhattan => new_multi_scorer_byte_with_metric::<ManhattanMetric, _>(
+            query,
+            vector_storage,
+            point_deleted,
+            is_stopped,
+        ),
+    }
+}
+
+fn new_multi_scorer_byte_with_metric<
+    'a,
+    TMetric: Metric<VectorElementTypeByte> + 'a,
+    TVectorStorage: MultiVectorStorage<VectorElementTypeByte>,
+>(
+    query: QueryVector,
+    vector_storage: &'a TVectorStorage,
+    point_deleted: &'a BitSlice,
+    is_stopped: &'a AtomicBool,
+) -> OperationResult<Box<dyn RawScorer + 'a>> {
+    let vec_deleted = vector_storage.deleted_vector_bitslice();
+    match query {
+        QueryVector::Nearest(vector) => raw_scorer_from_query_scorer(
+            MultiMetricQueryScorer::<VectorElementTypeByte, TMetric, _>::new(
+                vector.try_into()?,
+                vector_storage,
+            ),
+            point_deleted,
+            vec_deleted,
+            is_stopped,
+        ),
+        QueryVector::Recommend(reco_query) => {
+            let reco_query: RecoQuery<MultiDenseVector> = reco_query.transform_into()?;
+            raw_scorer_from_query_scorer(
+                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                    reco_query,
+                    vector_storage,
+                ),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
+        QueryVector::Discovery(discovery_query) => {
+            let discovery_query: DiscoveryQuery<MultiDenseVector> =
+                discovery_query.transform_into()?;
+            raw_scorer_from_query_scorer(
+                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
+                    discovery_query,
+                    vector_storage,
+                ),
+                point_deleted,
+                vec_deleted,
+                is_stopped,
+            )
+        }
+        QueryVector::Context(context_query) => {
+            let context_query: ContextQuery<MultiDenseVector> = context_query.transform_into()?;
+            raw_scorer_from_query_scorer(
+                MultiCustomQueryScorer::<VectorElementTypeByte, TMetric, _, _, _>::new(
                     context_query,
                     vector_storage,
                 ),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -125,7 +125,11 @@ pub enum VectorStorageEnum {
     DenseAppendableMemmapByte(Box<AppendableMmapDenseVectorStorage<VectorElementTypeByte>>),
     SparseSimple(SimpleSparseVectorStorage),
     MultiDenseSimple(SimpleMultiDenseVectorStorage<VectorElementType>),
+    MultiDenseSimpleByte(SimpleMultiDenseVectorStorage<VectorElementTypeByte>),
     MultiDenseAppendableMemmap(Box<AppendableMmapMultiDenseVectorStorage<VectorElementType>>),
+    MultiDenseAppendableMemmapByte(
+        Box<AppendableMmapMultiDenseVectorStorage<VectorElementTypeByte>>,
+    ),
 }
 
 impl VectorStorage for VectorStorageEnum {
@@ -139,7 +143,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.vector_dim(),
             VectorStorageEnum::SparseSimple(v) => v.vector_dim(),
             VectorStorageEnum::MultiDenseSimple(v) => v.vector_dim(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.vector_dim(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.vector_dim(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.vector_dim(),
         }
     }
 
@@ -153,7 +159,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.distance(),
             VectorStorageEnum::SparseSimple(v) => v.distance(),
             VectorStorageEnum::MultiDenseSimple(v) => v.distance(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.distance(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.distance(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.distance(),
         }
     }
 
@@ -167,7 +175,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.datatype(),
             VectorStorageEnum::SparseSimple(v) => v.datatype(),
             VectorStorageEnum::MultiDenseSimple(v) => v.datatype(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.datatype(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.datatype(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.datatype(),
         }
     }
 
@@ -181,7 +191,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_on_disk(),
             VectorStorageEnum::SparseSimple(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseSimple(v) => v.is_on_disk(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.is_on_disk(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.is_on_disk(),
         }
     }
 
@@ -195,7 +207,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.total_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseSimple(v) => v.total_vector_count(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.total_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.total_vector_count(),
         }
     }
 
@@ -209,7 +223,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector(key),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector(key),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.get_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.get_vector(key),
         }
     }
 
@@ -223,7 +239,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::SparseSimple(v) => v.get_vector_opt(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.get_vector_opt(key),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.get_vector_opt(key),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.get_vector_opt(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.get_vector_opt(key),
         }
     }
 
@@ -237,7 +255,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.insert_vector(key, vector),
             VectorStorageEnum::SparseSimple(v) => v.insert_vector(key, vector),
             VectorStorageEnum::MultiDenseSimple(v) => v.insert_vector(key, vector),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.insert_vector(key, vector),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.insert_vector(key, vector),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.insert_vector(key, vector),
         }
     }
 
@@ -258,7 +278,11 @@ impl VectorStorage for VectorStorageEnum {
             }
             VectorStorageEnum::SparseSimple(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::MultiDenseSimple(v) => v.update_from(other, other_ids, stopped),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.update_from(other, other_ids, stopped),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.update_from(other, other_ids, stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
                 v.update_from(other, other_ids, stopped)
             }
         }
@@ -274,7 +298,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.flusher(),
             VectorStorageEnum::SparseSimple(v) => v.flusher(),
             VectorStorageEnum::MultiDenseSimple(v) => v.flusher(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.flusher(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.flusher(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.flusher(),
         }
     }
 
@@ -288,7 +314,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.files(),
             VectorStorageEnum::SparseSimple(v) => v.files(),
             VectorStorageEnum::MultiDenseSimple(v) => v.files(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.files(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.files(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.files(),
         }
     }
 
@@ -302,7 +330,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.delete_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.delete_vector(key),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.delete_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.delete_vector(key),
         }
     }
 
@@ -316,7 +346,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseSimple(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseSimple(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
         }
     }
 
@@ -330,7 +362,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_count(),
         }
     }
 
@@ -344,7 +378,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseSimple(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseSimple(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseSimpleByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
         }
     }
 }


### PR DESCRIPTION
This PR tunrs on mmap multivector storages and add segment support of byte-multivector storages.

It extends `VectorStorageEnum`, add scorers construction of byte multivector storages, and construct mmap and byte-storages in segment constructor.

There are no unit tests. Integration tests will be added by @agourlay as separate PR.