### PR TITLE
Multidense vectors quantization

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -285,6 +285,13 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
+
+    fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
+        (0..self.total_vector_count()).flat_map(|key| {
+            let metadata = &self.vectors_metadata[key];
+            (0..metadata.size).map(|i| self.vectors.get(metadata.start as usize + i))
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<T> {

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -285,13 +285,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
-
-    fn iterate_inner_vectors(&self) -> impl Iterator<Item = &[T]> + Clone + Send {
-        (0..self.total_vector_count()).flat_map(|key| {
-            let metadata = &self.vectors_metadata[key];
-            (0..metadata.size).map(|i| self.vectors.get(metadata.start as usize + i))
-        })
-    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<T> {

--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -1,5 +1,6 @@
 mod quantized_custom_query_scorer;
 mod quantized_mmap_storage;
+pub mod quantized_multivector_storage;
 mod quantized_query_scorer;
 mod quantized_scorer_builder;
 pub mod quantized_vectors;

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -78,7 +78,6 @@ where
         }
     }
 
-    #[allow(unused)]
     pub fn new_multi<TOriginalQuery, TInputQuery>(
         raw_query: TInputQuery,
         quantized_storage: &'a TEncodedVectors,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -91,7 +91,7 @@ where
         })
     }
 
-    /// Custom `score_max_similarity` implemenation for quantized vectors
+    /// Custom `score_max_similarity` implementation for quantized vectors
     fn score_point_max_similarity(&self, query: &Vec<TEncodedQuery>, vector_index: u32) -> f32 {
         let vectors_count = self.offsets[vector_index as usize].count;
         let vectors_offset = self.offsets[vector_index as usize].offset;
@@ -113,7 +113,7 @@ where
         sum
     }
 
-    /// Custom `score_max_similarity` implemenation for quantized vectors
+    /// Custom `score_max_similarity` implementation for quantized vectors
     fn score_internal_max_similarity(&self, vector_a_index: u32, vector_b_index: u32) -> f32 {
         let vector_a_count = self.offsets[vector_a_index as usize].count;
         let vector_b_count = self.offsets[vector_b_index as usize].count;

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -91,6 +91,7 @@ where
         })
     }
 
+    /// Custom `score_max_similarity` implemenation for quantized vectors
     fn score_point_max_similarity(&self, query: &Vec<TEncodedQuery>, vector_index: u32) -> f32 {
         let vectors_count = self.offsets[vector_index as usize].count;
         let vectors_offset = self.offsets[vector_index as usize].offset;
@@ -112,6 +113,7 @@ where
         sum
     }
 
+    /// Custom `score_max_similarity` implemenation for quantized vectors
     fn score_internal_max_similarity(&self, vector_a_index: u32, vector_b_index: u32) -> f32 {
         let vector_a_count = self.offsets[vector_a_index as usize].count;
         let vector_b_count = self.offsets[vector_b_index as usize].count;

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -76,7 +76,10 @@ where
         let mut offsets_serialized = Vec::new();
         file.read_to_end(&mut offsets_serialized)?;
         let offsets = bincode::deserialize(&offsets_serialized).map_err(|_| {
-            OperationError::service_error("Cannot deserialize quantized multivector offsets")
+            OperationError::service_error(format!(
+                "Cannot deserialize quantized multivector offsets: {:?}",
+                offsets_path
+            ))
         })?;
 
         Ok(Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -1,0 +1,180 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use std::path::Path;
+
+use common::types::{PointOffsetType, ScoreType};
+use quantization::{EncodedVectors, VectorParameters};
+use serde::{Deserialize, Serialize};
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::TypedMultiDenseVectorRef;
+use crate::types::{MultiVectorComparator, MultiVectorConfig};
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct MultivectorOffset {
+    pub offset: PointOffsetType,
+    pub count: PointOffsetType,
+}
+
+pub struct QuantizedMultivectorStorage<TEncodedQuery, QuantizedStorage>
+where
+    TEncodedQuery: Sized,
+    QuantizedStorage: EncodedVectors<TEncodedQuery>,
+{
+    quantized_storage: QuantizedStorage,
+    offsets: Vec<MultivectorOffset>,
+    dim: usize,
+    multi_vector_config: MultiVectorConfig,
+    encoded_query: PhantomData<TEncodedQuery>,
+}
+
+impl<TEncodedQuery, QuantizedStorage> QuantizedMultivectorStorage<TEncodedQuery, QuantizedStorage>
+where
+    TEncodedQuery: Sized,
+    QuantizedStorage: EncodedVectors<TEncodedQuery>,
+{
+    pub fn new(
+        dim: usize,
+        quantized_storage: QuantizedStorage,
+        offsets: Vec<MultivectorOffset>,
+        multi_vector_config: MultiVectorConfig,
+    ) -> Self {
+        Self {
+            dim,
+            quantized_storage,
+            offsets,
+            multi_vector_config,
+            encoded_query: PhantomData,
+        }
+    }
+
+    pub fn save_multi(
+        &self,
+        data_path: &Path,
+        meta_path: &Path,
+        offsets_path: &Path,
+    ) -> OperationResult<()> {
+        let offsets_serialized = bincode::serialize(&self.offsets).map_err(|_| {
+            OperationError::service_error("Cannot serialize quantized multivector offsets")
+        })?;
+        let mut file = File::create(offsets_path)?;
+        file.write_all(&offsets_serialized)?;
+        file.flush()?;
+
+        Ok(self.quantized_storage.save(data_path, meta_path)?)
+    }
+
+    pub fn load_multi(
+        data_path: &Path,
+        meta_path: &Path,
+        offsets_path: &Path,
+        vector_parameters: &VectorParameters,
+        multi_vector_config: &MultiVectorConfig,
+    ) -> OperationResult<Self> {
+        let mut file = File::open(offsets_path)?;
+        let mut offsets_serialized = Vec::new();
+        file.read_to_end(&mut offsets_serialized)?;
+        let offsets = bincode::deserialize(&offsets_serialized).map_err(|_| {
+            OperationError::service_error("Cannot deserialize quantized multivector offsets")
+        })?;
+
+        Ok(Self {
+            dim: vector_parameters.dim,
+            quantized_storage: QuantizedStorage::load(data_path, meta_path, vector_parameters)?,
+            offsets,
+            multi_vector_config: *multi_vector_config,
+            encoded_query: PhantomData,
+        })
+    }
+
+    fn score_point_max_similarity(&self, query: &Vec<TEncodedQuery>, vector_index: u32) -> f32 {
+        let vectors_count = self.offsets[vector_index as usize].count;
+        let vectors_offset = self.offsets[vector_index as usize].offset;
+        let mut sum = 0.0;
+        for inner_query in query {
+            let mut max_sim = ScoreType::NEG_INFINITY;
+            // manual `max_by` for performance
+            for i in 0..vectors_count {
+                let sim = self
+                    .quantized_storage
+                    .score_point(inner_query, vectors_offset + i);
+                if sim > max_sim {
+                    max_sim = sim;
+                }
+            }
+            // sum of max similarity
+            sum += max_sim;
+        }
+        sum
+    }
+
+    fn score_internal_max_similarity(&self, vector_a_index: u32, vector_b_index: u32) -> f32 {
+        let vector_a_count = self.offsets[vector_a_index as usize].count;
+        let vector_b_count = self.offsets[vector_b_index as usize].count;
+        let vector_a_offset = self.offsets[vector_a_index as usize].offset;
+        let vector_b_offset = self.offsets[vector_b_index as usize].offset;
+        let mut sum = 0.0;
+        for a in 0..vector_a_count {
+            let mut max_sim = ScoreType::NEG_INFINITY;
+            // manual `max_by` for performance
+            for b in 0..vector_b_count {
+                let sim = self
+                    .quantized_storage
+                    .score_internal(vector_a_offset + a, vector_b_offset + b);
+                if sim > max_sim {
+                    max_sim = sim;
+                }
+            }
+            // sum of max similarity
+            sum += max_sim;
+        }
+        sum
+    }
+}
+
+impl<TEncodedQuery, QuantizedStorage> EncodedVectors<Vec<TEncodedQuery>>
+    for QuantizedMultivectorStorage<TEncodedQuery, QuantizedStorage>
+where
+    TEncodedQuery: Sized,
+    QuantizedStorage: EncodedVectors<TEncodedQuery>,
+{
+    // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
+    fn save(&self, _data_path: &Path, _meta_path: &Path) -> std::io::Result<()> {
+        unreachable!("multivector quantized storage should be saved using `self.save_multi` method")
+    }
+
+    // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
+    fn load(
+        _data_path: &Path,
+        _meta_path: &Path,
+        _vector_parameters: &quantization::VectorParameters,
+    ) -> std::io::Result<Self> {
+        unreachable!(
+            "multivector quantized storage should be loaded using `self.load_multi` method"
+        )
+    }
+
+    fn encode_query(&self, query: &[f32]) -> Vec<TEncodedQuery> {
+        let multi_vector = TypedMultiDenseVectorRef {
+            dim: self.dim,
+            flattened_vectors: query,
+        };
+        multi_vector
+            .multi_vectors()
+            .map(|inner_vector| self.quantized_storage.encode_query(inner_vector))
+            .collect()
+    }
+
+    fn score_point(&self, query: &Vec<TEncodedQuery>, i: u32) -> f32 {
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => self.score_point_max_similarity(query, i),
+        }
+    }
+
+    fn score_internal(&self, i: u32, j: u32) -> f32 {
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => self.score_internal_max_similarity(i, j),
+        }
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -51,7 +51,6 @@ where
         }
     }
 
-    #[allow(unused)]
     pub fn new_multi(
         raw_query: MultiDenseVector,
         quantized_data: &'a TEncodedVectors,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -154,7 +154,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
         match query {
             QueryVector::Nearest(vector) => {
                 let query_scorer = QuantizedQueryScorer::<TElement, TMetric, _, _>::new(
-                    vector.try_into()?,
+                    DenseVector::try_from(vector)?,
                     quantized_storage,
                     quantization_config,
                 );
@@ -214,7 +214,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
         match query {
             QueryVector::Nearest(vector) => {
                 let query_scorer = QuantizedQueryScorer::<TElement, TMetric, _, _>::new_multi(
-                    vector.try_into()?,
+                    MultiDenseVector::try_from(vector)?,
                     quantized_storage,
                     quantization_config,
                 );

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -9,7 +9,8 @@ use super::quantized_vectors::QuantizedVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    DenseVector, QueryVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+    DenseVector, MultiDenseVector, QueryVector, VectorElementType, VectorElementTypeByte,
+    VectorElementTypeHalf,
 };
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
@@ -109,10 +110,27 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QuantizedVectorStorage::BinaryMmap(storage) => {
                 self.new_quantized_scorer::<TElement, TMetric, _>(storage)
             }
+            QuantizedVectorStorage::ScalarRamMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
+            QuantizedVectorStorage::ScalarMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
+            QuantizedVectorStorage::PQRamMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
+            QuantizedVectorStorage::PQMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
+            QuantizedVectorStorage::BinaryRamMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
+            QuantizedVectorStorage::BinaryMmapMulti(storage) => {
+                self.new_multi_quantized_scorer::<TElement, TMetric, _>(storage)
+            }
         }
     }
 
-    #[inline]
     fn new_quantized_scorer<TElement, TMetric, TEncodedQuery>(
         self,
         quantized_storage: &'a impl EncodedVectors<TEncodedQuery>,
@@ -168,6 +186,70 @@ impl<'a> QuantizedScorerBuilder<'a> {
                     quantized_storage,
                     quantization_config,
                 );
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+            }
+        }
+    }
+
+    fn new_multi_quantized_scorer<TElement, TMetric, TEncodedQuery>(
+        self,
+        quantized_storage: &'a impl EncodedVectors<TEncodedQuery>,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>>
+    where
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement> + 'a,
+        TEncodedQuery: 'a,
+    {
+        let Self {
+            quantized_storage: _same_as_quantized_storage_in_args,
+            quantization_config,
+            query,
+            point_deleted,
+            vec_deleted,
+            is_stopped,
+            distance: _,
+            datatype: _,
+        } = self;
+
+        match query {
+            QueryVector::Nearest(vector) => {
+                let query_scorer = QuantizedQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    vector.try_into()?,
+                    quantized_storage,
+                    quantization_config,
+                );
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+            }
+            QueryVector::Recommend(reco_query) => {
+                let reco_query: RecoQuery<MultiDenseVector> = reco_query.transform_into()?;
+                let query_scorer =
+                    QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                        reco_query,
+                        quantized_storage,
+                        quantization_config,
+                    );
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+            }
+            QueryVector::Discovery(discovery_query) => {
+                let discovery_query: DiscoveryQuery<MultiDenseVector> =
+                    discovery_query.transform_into()?;
+                let query_scorer =
+                    QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                        discovery_query,
+                        quantized_storage,
+                        quantization_config,
+                    );
+                raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
+            }
+            QueryVector::Context(context_query) => {
+                let context_query: ContextQuery<MultiDenseVector> =
+                    context_query.transform_into()?;
+                let query_scorer =
+                    QuantizedCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                        context_query,
+                        quantized_storage,
+                        quantization_config,
+                    );
                 raw_scorer_from_query_scorer(query_scorer, point_deleted, vec_deleted, is_stopped)
             }
         }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -21,6 +21,7 @@ pub trait QueryScorer<TVector: ?Sized> {
 
 /// Colbert MaxSim metric, metric for multi-dense vectors
 /// https://arxiv.org/pdf/2112.01488.pdf, figure 1
+/// This metric is also implemented in `QuantizedMultivectorStorage` structure for quantized data.
 pub fn score_max_similarity<T: PrimitiveVectorElement, TMetric: Metric<T>>(
     multi_dense_a: TypedMultiDenseVectorRef<T>,
     multi_dense_b: TypedMultiDenseVectorRef<T>,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -141,6 +141,29 @@ pub enum VectorStorageEnum {
     ),
 }
 
+impl VectorStorageEnum {
+    pub fn try_multi_vector_config(&self) -> Option<&MultiVectorConfig> {
+        match self {
+            VectorStorageEnum::DenseSimple(_) => None,
+            VectorStorageEnum::DenseSimpleByte(_) => None,
+            VectorStorageEnum::DenseSimpleHalf(_) => None,
+            VectorStorageEnum::DenseMemmap(_) => None,
+            VectorStorageEnum::DenseMemmapByte(_) => None,
+            VectorStorageEnum::DenseMemmapHalf(_) => None,
+            VectorStorageEnum::DenseAppendableMemmap(_) => None,
+            VectorStorageEnum::DenseAppendableMemmapByte(_) => None,
+            VectorStorageEnum::DenseAppendableMemmapHalf(_) => None,
+            VectorStorageEnum::SparseSimple(_) => None,
+            VectorStorageEnum::MultiDenseSimple(s) => Some(s.multi_vector_config()),
+            VectorStorageEnum::MultiDenseSimpleByte(s) => Some(s.multi_vector_config()),
+            VectorStorageEnum::MultiDenseSimpleHalf(s) => Some(s.multi_vector_config()),
+            VectorStorageEnum::MultiDenseAppendableMemmap(s) => Some(s.multi_vector_config()),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(s) => Some(s.multi_vector_config()),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(s) => Some(s.multi_vector_config()),
+        }
+    }
+}
+
 impl VectorStorage for VectorStorageEnum {
     fn vector_dim(&self) -> usize {
         match self {

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -13,6 +13,7 @@ pub mod hnsw_discover_test;
 pub mod hnsw_quantized_search_test;
 mod multivector_filtrable_hnsw_test;
 mod multivector_hnsw_test;
+mod multivector_quantization_test;
 pub mod nested_filtering_test;
 pub mod payload_index_test;
 pub mod scroll_filtering_test;

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -1,0 +1,354 @@
+use std::collections::{BTreeSet, HashMap};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::cpu::CpuPermit;
+use common::types::ScoredPointOffset;
+use itertools::Itertools;
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
+use rstest::rstest;
+use segment::data_types::vectors::{
+    only_default_multi_vector, MultiDenseVector, QueryVector, DEFAULT_VECTOR_NAME,
+};
+use segment::entry::entry_point::SegmentEntry;
+use segment::fixtures::payload_fixtures::{random_int_payload, random_multi_vector};
+use segment::index::hnsw_index::graph_links::GraphLinksRam;
+use segment::index::hnsw_index::hnsw::HNSWIndex;
+use segment::index::hnsw_index::num_rayon_threads;
+use segment::index::{PayloadIndex, VectorIndex};
+use segment::json_path::path;
+use segment::segment_constructor::build_segment;
+use segment::types::{
+    BinaryQuantizationConfig, CompressionRatio, Condition, Distance, FieldCondition, Filter,
+    HnswConfig, Indexes, MultiVectorConfig, Payload, PayloadSchemaType, ProductQuantizationConfig,
+    QuantizationSearchParams, Range, ScalarQuantizationConfig, SearchParams, SegmentConfig,
+    SeqNumberType, VectorDataConfig, VectorStorageType,
+};
+use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
+use serde_json::json;
+use tempfile::Builder;
+
+const MAX_EXAMPLE_PAIRS: usize = 4;
+const MAX_VECTORS_COUNT: usize = 3;
+
+enum QueryVariant {
+    Nearest,
+    RecommendBestScore,
+    Discovery,
+}
+
+enum QuantizationVariant {
+    Scalar,
+    PQ,
+    Binary,
+}
+
+fn random_vector<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> MultiDenseVector {
+    let count = rnd.gen_range(1..=MAX_VECTORS_COUNT);
+    let mut vector = random_multi_vector(rnd, dim, count);
+    // for BQ change range to [-0.5; 0.5]
+    vector.flattened_vectors.iter_mut().for_each(|x| *x -= 0.5);
+    vector
+}
+
+fn random_discovery_query<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> QueryVector {
+    let num_pairs: usize = rnd.gen_range(1..MAX_EXAMPLE_PAIRS);
+
+    let target = random_vector(rnd, dim).into();
+
+    let pairs = (0..num_pairs)
+        .map(|_| {
+            let positive = random_vector(rnd, dim).into();
+            let negative = random_vector(rnd, dim).into();
+            ContextPair { positive, negative }
+        })
+        .collect_vec();
+
+    DiscoveryQuery::new(target, pairs).into()
+}
+
+fn random_reco_query<R: Rng + ?Sized>(rnd: &mut R, dim: usize) -> QueryVector {
+    let num_examples: usize = rnd.gen_range(1..MAX_EXAMPLE_PAIRS);
+
+    let positive = (0..num_examples)
+        .map(|_| random_vector(rnd, dim).into())
+        .collect_vec();
+    let negative = (0..num_examples)
+        .map(|_| random_vector(rnd, dim).into())
+        .collect_vec();
+
+    RecoQuery::new(positive, negative).into()
+}
+
+fn random_query<R: Rng + ?Sized>(variant: &QueryVariant, rnd: &mut R, dim: usize) -> QueryVector {
+    match variant {
+        QueryVariant::Nearest => random_vector(rnd, dim).into(),
+        QueryVariant::Discovery => random_discovery_query(rnd, dim),
+        QueryVariant::RecommendBestScore => random_reco_query(rnd, dim),
+    }
+}
+
+fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> usize {
+    a[0].iter()
+        .map(|x| x.idx)
+        .collect::<BTreeSet<_>>()
+        .intersection(&b[0].iter().map(|x| x.idx).collect())
+        .count()
+}
+
+#[rstest]
+#[case::nearest_binary_dot(
+    QueryVariant::Nearest,
+    QuantizationVariant::Binary,
+    Distance::Dot,
+    128, // dim
+    32, // ef
+    5., // min_acc out of 100
+)]
+#[case::discovery_binary_dot(
+    QueryVariant::Discovery,
+    QuantizationVariant::Binary,
+    Distance::Dot,
+    128, // dim
+    128, // ef
+    1., // min_acc out of 100
+)]
+#[case::recommend_binary_dot(
+    QueryVariant::RecommendBestScore,
+    QuantizationVariant::Binary,
+    Distance::Dot,
+    128, // dim
+    64, // ef
+    1., // min_acc out of 100
+)]
+#[case::nearest_binary_cosine(
+    QueryVariant::Nearest,
+    QuantizationVariant::Binary,
+    Distance::Cosine,
+    128, // dim
+    32, // ef
+    25., // min_acc out of 100
+)]
+#[case::discovery_binary_cosine(
+    QueryVariant::Discovery,
+    QuantizationVariant::Binary,
+    Distance::Cosine,
+    128, // dim
+    128, // ef
+    15., // min_acc out of 100
+)]
+#[case::recommend_binary_cosine(
+    QueryVariant::RecommendBestScore,
+    QuantizationVariant::Binary,
+    Distance::Cosine,
+    128, // dim
+    64, // ef
+    15., // min_acc out of 100
+)]
+#[case::nearest_scalar_dot(
+    QueryVariant::Nearest,
+    QuantizationVariant::Scalar,
+    Distance::Dot,
+    32, // dim
+    32, // ef
+    80., // min_acc out of 100
+)]
+#[case::nearest_scalar_cosine(
+    QueryVariant::Nearest,
+    QuantizationVariant::Scalar,
+    Distance::Cosine,
+    32, // dim
+    32, // ef
+    80., // min_acc out of 100
+)]
+#[case::nearest_pq_dot(
+    QueryVariant::Nearest,
+    QuantizationVariant::PQ,
+    Distance::Dot,
+    16, // dim
+    32, // ef
+    70., // min_acc out of 100
+)]
+fn test_multivector_quantization_hnsw(
+    #[case] query_variant: QueryVariant,
+    #[case] quantization_variant: QuantizationVariant,
+    #[case] distance: Distance,
+    #[case] dim: usize,
+    #[case] ef: usize,
+    #[case] min_acc: f64, // out of 100
+) {
+    let stopped = AtomicBool::new(false);
+
+    let m = 8;
+    let num_vectors: u64 = 1_000;
+    let ef_construct = 16;
+    let full_scan_threshold = 16; // KB
+    let num_payload_values = 2;
+
+    let mut rnd = StdRng::seed_from_u64(42);
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let quantized_data_path = dir.path();
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance,
+                storage_type: VectorStorageType::Memory,
+                index: Indexes::Plain {},
+                quantization_config: None,
+                multivec_config: Some(MultiVectorConfig::default()), // uses multivec config
+                datatype: None,
+            },
+        )]),
+        sparse_vector_data: Default::default(),
+        payload_storage_type: Default::default(),
+    };
+
+    let int_key = "int";
+
+    let mut segment = build_segment(dir.path(), &config, true).unwrap();
+
+    for n in 0..num_vectors {
+        let idx = n.into();
+        let vector = random_vector(&mut rnd, dim);
+
+        let int_payload = random_int_payload(&mut rnd, num_payload_values..=num_payload_values);
+        let payload: Payload = json!({int_key:int_payload,}).into();
+
+        segment
+            .upsert_point(n as SeqNumberType, idx, only_default_multi_vector(&vector))
+            .unwrap();
+        segment
+            .set_full_payload(n as SeqNumberType, idx, &payload)
+            .unwrap();
+    }
+
+    segment
+        .payload_index
+        .borrow_mut()
+        .set_indexed(&path(int_key), PayloadSchemaType::Integer.into())
+        .unwrap();
+
+    let quantization_config = match quantization_variant {
+        QuantizationVariant::Scalar => ScalarQuantizationConfig {
+            r#type: Default::default(),
+            quantile: None,
+            always_ram: None,
+        }
+        .into(),
+        QuantizationVariant::PQ => ProductQuantizationConfig {
+            compression: CompressionRatio::X8,
+            always_ram: None,
+        }
+        .into(),
+        QuantizationVariant::Binary => BinaryQuantizationConfig { always_ram: None }.into(),
+    };
+
+    segment.vector_data.values_mut().for_each(|vector_storage| {
+        let quantized_vectors = QuantizedVectors::create(
+            &vector_storage.vector_storage.borrow(),
+            &quantization_config,
+            quantized_data_path,
+            4,
+            &stopped,
+        )
+        .unwrap();
+        vector_storage.quantized_vectors = Arc::new(AtomicRefCell::new(Some(quantized_vectors)));
+    });
+
+    let hnsw_config = HnswConfig {
+        m,
+        ef_construct,
+        full_scan_threshold,
+        max_indexing_threads: 2,
+        on_disk: Some(false),
+        payload_m: None,
+    };
+
+    let permit_cpu_count = num_rayon_threads(hnsw_config.max_indexing_threads);
+    let permit = Arc::new(CpuPermit::dummy(permit_cpu_count as u32));
+    let mut hnsw_index = HNSWIndex::<GraphLinksRam>::open(
+        hnsw_dir.path(),
+        segment.id_tracker.clone(),
+        segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_storage
+            .clone(),
+        segment.vector_data[DEFAULT_VECTOR_NAME]
+            .quantized_vectors
+            .clone(),
+        segment.payload_index.clone(),
+        hnsw_config,
+    )
+    .unwrap();
+    hnsw_index.build_index(permit, &stopped).unwrap();
+
+    let top = 5;
+    let mut sames = 0;
+    let attempts = 100;
+    for _ in 0..attempts {
+        let query = random_query(&query_variant, &mut rnd, dim);
+
+        let range_size = 40;
+        let left_range = rnd.gen_range(0..400);
+        let right_range = left_range + range_size;
+
+        let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
+            path(int_key),
+            Range {
+                lt: None,
+                gt: None,
+                gte: Some(left_range as f64),
+                lte: Some(right_range as f64),
+            },
+        )));
+
+        let filter_query = Some(&filter);
+
+        let index_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    quantization: Some(QuantizationSearchParams {
+                        oversampling: Some(1.3),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                &Default::default(),
+            )
+            .unwrap();
+
+        let plain_result = hnsw_index
+            .search(
+                &[&query],
+                filter_query,
+                top,
+                Some(&SearchParams {
+                    hnsw_ef: Some(ef),
+                    quantization: Some(QuantizationSearchParams {
+                        ignore: true,
+                        ..Default::default()
+                    }),
+                    exact: true,
+                    ..Default::default()
+                }),
+                &Default::default(),
+            )
+            .unwrap();
+
+        sames += sames_count(&plain_result, &index_result);
+    }
+    let acc = 100.0 * sames as f64 / (attempts * top) as f64;
+    println!("sames = {sames}, attempts = {attempts}, top = {top}, acc = {acc}");
+    assert!(acc > min_acc);
+}

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -106,7 +106,7 @@ fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> us
     Distance::Dot,
     128, // dim
     32, // ef
-    5., // min_acc out of 100
+    25., // min_acc out of 100
 )]
 #[case::discovery_binary_dot(
     QueryVariant::Discovery,
@@ -114,7 +114,7 @@ fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> us
     Distance::Dot,
     128, // dim
     128, // ef
-    1., // min_acc out of 100
+    20., // min_acc out of 100
 )]
 #[case::recommend_binary_dot(
     QueryVariant::RecommendBestScore,
@@ -122,7 +122,7 @@ fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> us
     Distance::Dot,
     128, // dim
     64, // ef
-    1., // min_acc out of 100
+    20., // min_acc out of 100
 )]
 #[case::nearest_binary_cosine(
     QueryVariant::Nearest,

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -252,14 +252,21 @@ fn test_multivector_quantization_hnsw(
     };
 
     segment.vector_data.values_mut().for_each(|vector_storage| {
-        let quantized_vectors = QuantizedVectors::create(
-            &vector_storage.vector_storage.borrow(),
-            &quantization_config,
-            quantized_data_path,
-            4,
-            &stopped,
-        )
-        .unwrap();
+        {
+            // test persistence, encode ans save quantized vectors
+            QuantizedVectors::create(
+                &vector_storage.vector_storage.borrow(),
+                &quantization_config,
+                quantized_data_path,
+                4,
+                &stopped,
+            )
+            .unwrap();
+        }
+        // test persistence, load quantized vectors
+        let quantized_vectors =
+            QuantizedVectors::load(&vector_storage.vector_storage.borrow(), quantized_data_path)
+                .unwrap();
         vector_storage.quantized_vectors = Arc::new(AtomicRefCell::new(Some(quantized_vectors)));
     });
 

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -253,7 +253,7 @@ fn test_multivector_quantization_hnsw(
 
     segment.vector_data.values_mut().for_each(|vector_storage| {
         {
-            // test persistence, encode ans save quantized vectors
+            // test persistence, encode and save quantized vectors
             QuantizedVectors::create(
                 &vector_storage.vector_storage.borrow(),
                 &quantization_config,


### PR DESCRIPTION
Add quantization support for multivectors.

The main idea is to reuse quantization integration for multivectors.

Encoded vectors are a `struct` which implements `EncodedVectors` trait.
https://github.com/qdrant/quantization/blob/master/quantization/src/encoded_vectors.rs#L21

There are encoded vectors for scalar, PQ and binary quantizations:
https://github.com/qdrant/quantization/blob/master/quantization/src/encoded_vectors_u8.rs#L262
https://github.com/qdrant/quantization/blob/master/quantization/src/encoded_vectors_pq.rs#L497
https://github.com/qdrant/quantization/blob/master/quantization/src/encoded_vectors_binary.rs#L160

Multivector encoding aggregates one of this structure into generic encoded type
`struct QuantizedMultivectorStorage<TEncodedQuery, QuantizedStorage: EncodedVectors<TEncodedQuery>>`
https://github.com/qdrant/qdrant/blob/basic-multidense-vectors-quantization/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs#L20
It implements `EncodedVectors` trait.
https://github.com/qdrant/qdrant/blob/basic-multidense-vectors-quantization/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs#L136
So we can reuse quantization scorers and extend `enum QuantizedVectorStorage`:
https://github.com/qdrant/qdrant/blob/basic-multidense-vectors-quantization/lib/segment/src/vector_storage/quantized/quantized_vectors.rs#L44

Encoded query type is `Vec<TEncodedQuery>`. It's maybe not efficient because it's unflattened data, keep it as is in this PR.

Integration test covers SQ, PQ, BQ, HNSW search, and persistence.