### PR TITLE
Allow basic multivec search on legacy API

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1019,7 +1019,7 @@ impl From<String> for CollectionError {
 impl From<OperationError> for CollectionError {
     fn from(err: OperationError) -> Self {
         match err {
-            OperationError::WrongVector { .. } => Self::BadInput {
+            OperationError::WrongVectorDimension { .. } => Self::BadInput {
                 description: format!("{err}"),
             },
             OperationError::VectorNameNotExists { .. } => Self::BadInput {

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -179,7 +179,7 @@ fn check_vector_against_config(
             // Check dimensionality
             let dim = vector_config.size;
             if vector.len() != dim {
-                return Err(OperationError::WrongVector {
+                return Err(OperationError::WrongVectorDimension {
                     expected_dim: dim,
                     received_dim: vector.len(),
                 });
@@ -192,7 +192,7 @@ fn check_vector_against_config(
             let dim = vector_config.size;
             for vector in multi_vector.multi_vectors() {
                 if vector.len() != dim {
-                    return Err(OperationError::WrongVector {
+                    return Err(OperationError::WrongVectorDimension {
                         expected_dim: dim,
                         received_dim: vector.len(),
                     });

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -17,8 +17,8 @@ pub const PROCESS_CANCELLED_BY_SERVICE_MESSAGE: &str = "process cancelled by ser
 #[derive(Error, Debug, Clone)]
 #[error("{0}")]
 pub enum OperationError {
-    #[error("Vector inserting error: expected dim: {expected_dim}, got {received_dim}")]
-    WrongVector {
+    #[error("Vector dimension error: expected dim: {expected_dim}, got {received_dim}")]
+    WrongVectorDimension {
         expected_dim: usize,
         received_dim: usize,
     },

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -94,28 +94,30 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
     }
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| f16::from_f32(x))
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| f16::to_f32(x))
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -4,6 +4,7 @@ use half::f16;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
@@ -26,12 +27,12 @@ pub trait PrimitiveVectorElement:
     fn datatype() -> VectorStorageDatatype;
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>>;
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self>;
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>>;
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType>;
 }
 
 impl PrimitiveVectorElement for VectorElementType {
@@ -56,14 +57,14 @@ impl PrimitiveVectorElement for VectorElementType {
     }
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>> {
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
         multivector
     }
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
         multivector
     }
 }
@@ -165,28 +166,30 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     }
 
     fn from_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<VectorElementType>>,
-    ) -> Cow<TypedMultiDenseVector<Self>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| x as Self)
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 
     fn into_float_multivector(
-        multivector: Cow<TypedMultiDenseVector<Self>>,
-    ) -> Cow<TypedMultiDenseVector<VectorElementType>> {
-        Cow::Owned(TypedMultiDenseVector::new(
+        multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
+        CowMultiVector::Owned(TypedMultiDenseVector::new(
             multivector
+                .as_vec_ref()
                 .flattened_vectors
                 .iter()
                 .map(|&x| x as VectorElementType)
                 .collect_vec(),
-            multivector.dim,
+            multivector.as_vec_ref().dim,
         ))
     }
 }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -69,7 +69,7 @@ impl<'a> TryFrom<VectorRef<'a>> for &'a MultiDenseVector {
 
     fn try_from(value: VectorRef<'a>) -> Result<Self, Self::Error> {
         match value {
-            VectorRef::Dense(_) => Err(OperationError::WrongMulti),
+            VectorRef::Dense(_) => Err(OperationError::WrongMulti), // VectorRef::Dense cannot be converted to &MultiDense
             VectorRef::Sparse(_v) => Err(OperationError::WrongSparse),
             VectorRef::MultiDense(v) => Ok(v),
         }
@@ -116,7 +116,7 @@ impl TryFrom<Vector> for MultiDenseVector {
 
     fn try_from(value: Vector) -> Result<Self, Self::Error> {
         match value {
-            Vector::Dense(_) => Err(OperationError::WrongMulti),
+            Vector::Dense(v) => Ok(MultiDenseVector::new(v, 1)), // expand single dense vector
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
             Vector::MultiDense(v) => Ok(v),
         }
@@ -369,7 +369,7 @@ impl<'a> TryInto<&'a MultiDenseVector> for &'a Vector {
 
     fn try_into(self) -> Result<&'a MultiDenseVector, Self::Error> {
         match self {
-            Vector::Dense(_) => Err(OperationError::WrongMulti),
+            Vector::Dense(_) => Err(OperationError::WrongMulti), // &Dense vector cannot be converted to &MultiDense
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
             Vector::MultiDense(v) => Ok(v),
         }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -270,7 +270,7 @@ impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMulti
         let dim = value[0].len();
         // assert all vectors have the same dimension
         if let Some(bad_vec) = value.iter().find(|v| v.len() != dim) {
-            Err(OperationError::WrongVector {
+            Err(OperationError::WrongVectorDimension {
                 expected_dim: dim,
                 received_dim: bad_vec.len(),
             })

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -120,7 +120,7 @@ impl TryFrom<Vector> for MultiDenseVector {
                 // expand single dense vector into multivector with a single vector
                 let len = v.len();
                 Ok(MultiDenseVector::new(v, len))
-            },
+            }
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
             Vector::MultiDense(v) => Ok(v),
         }

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -37,7 +37,7 @@ impl Vector {
 pub enum VectorRef<'a> {
     Dense(&'a [VectorElementType]),
     Sparse(&'a SparseVector),
-    MultiDense(&'a MultiDenseVector),
+    MultiDense(TypedMultiDenseVectorRef<'a, VectorElementType>),
 }
 
 impl<'a> TryFrom<VectorRef<'a>> for &'a [VectorElementType] {
@@ -64,12 +64,15 @@ impl<'a> TryFrom<VectorRef<'a>> for &'a SparseVector {
     }
 }
 
-impl<'a> TryFrom<VectorRef<'a>> for &'a MultiDenseVector {
+impl<'a> TryFrom<VectorRef<'a>> for TypedMultiDenseVectorRef<'a, f32> {
     type Error = OperationError;
 
     fn try_from(value: VectorRef<'a>) -> Result<Self, Self::Error> {
         match value {
-            VectorRef::Dense(_) => Err(OperationError::WrongMulti), // VectorRef::Dense cannot be converted to &MultiDense
+            VectorRef::Dense(d) => Ok(TypedMultiDenseVectorRef {
+                flattened_vectors: d,
+                dim: d.len(),
+            }),
             VectorRef::Sparse(_v) => Err(OperationError::WrongSparse),
             VectorRef::MultiDense(v) => Ok(v),
         }
@@ -141,6 +144,12 @@ impl<'a> From<&'a DenseVector> for VectorRef<'a> {
 
 impl<'a> From<&'a MultiDenseVector> for VectorRef<'a> {
     fn from(val: &'a MultiDenseVector) -> Self {
+        VectorRef::MultiDense(TypedMultiDenseVectorRef::from(val))
+    }
+}
+
+impl<'a> From<TypedMultiDenseVectorRef<'a, VectorElementType>> for VectorRef<'a> {
+    fn from(val: TypedMultiDenseVectorRef<'a, VectorElementType>) -> Self {
         VectorRef::MultiDense(val)
     }
 }
@@ -174,7 +183,7 @@ impl<'a> From<&'a Vector> for VectorRef<'a> {
         match val {
             Vector::Dense(v) => VectorRef::Dense(v.as_slice()),
             Vector::Sparse(v) => VectorRef::Sparse(v),
-            Vector::MultiDense(v) => VectorRef::MultiDense(v),
+            Vector::MultiDense(v) => VectorRef::MultiDense(TypedMultiDenseVectorRef::from(v)),
         }
     }
 }
@@ -289,7 +298,7 @@ impl<T: PrimitiveVectorElement> TryFrom<Vec<TypedDenseVector<T>>> for TypedMulti
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TypedMultiDenseVectorRef<'a, T> {
     pub flattened_vectors: &'a [T],
     pub dim: usize,
@@ -297,12 +306,16 @@ pub struct TypedMultiDenseVectorRef<'a, T> {
 
 impl<'a, T: PrimitiveVectorElement> TypedMultiDenseVectorRef<'a, T> {
     /// Slices the multi vector into the underlying individual vectors
-    pub fn multi_vectors(&self) -> impl Iterator<Item = &[T]> {
+    pub fn multi_vectors(self) -> impl Iterator<Item = &'a [T]> {
         self.flattened_vectors.chunks_exact(self.dim)
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.flattened_vectors.is_empty()
+    }
+
+    pub fn len(self) -> usize {
+        self.flattened_vectors.len() / self.dim
     }
 
     // Cannot use `ToOwned` trait because of `Borrow` implementation for `TypedMultiDenseVector`
@@ -339,7 +352,7 @@ impl<'a> VectorRef<'a> {
         match self {
             VectorRef::Dense(v) => Vector::Dense(v.to_vec()),
             VectorRef::Sparse(v) => Vector::Sparse(v.clone()),
-            VectorRef::MultiDense(v) => Vector::MultiDense(v.clone()),
+            VectorRef::MultiDense(v) => Vector::MultiDense(v.to_owned()),
         }
     }
 }
@@ -389,7 +402,10 @@ pub fn only_default_vector(vec: &[VectorElementType]) -> NamedVectors {
 }
 
 pub fn only_default_multi_vector(vec: &MultiDenseVector) -> NamedVectors {
-    NamedVectors::from_ref(DEFAULT_VECTOR_NAME, VectorRef::MultiDense(vec))
+    NamedVectors::from_ref(
+        DEFAULT_VECTOR_NAME,
+        VectorRef::MultiDense(TypedMultiDenseVectorRef::from(vec)),
+    )
 }
 
 /// Full vector data per point separator with single and multiple vector modes

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -116,7 +116,11 @@ impl TryFrom<Vector> for MultiDenseVector {
 
     fn try_from(value: Vector) -> Result<Self, Self::Error> {
         match value {
-            Vector::Dense(v) => Ok(MultiDenseVector::new(v, 1)), // expand single dense vector
+            Vector::Dense(v) => {
+                // expand single dense vector into multivector with a single vector
+                let len = v.len();
+                Ok(MultiDenseVector::new(v, len))
+            },
             Vector::Sparse(_) => Err(OperationError::WrongSparse),
             Vector::MultiDense(v) => Ok(v),
         }

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -114,7 +114,7 @@ mod tests {
         let vec5 = vec![1.0, 0.0, 0.0, 0.0];
 
         match segment.upsert_point(1, 120.into(), only_default_vector(&wrong_vec)) {
-            Err(OperationError::WrongVector { .. }) => (),
+            Err(OperationError::WrongVectorDimension { .. }) => (),
             Err(_) => panic!("Wrong error"),
             Ok(_) => panic!("Operation with wrong vector should fail"),
         };

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
 use super::score_multi;
+use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef,
@@ -48,7 +48,8 @@ impl<
                     .collect();
                 let preprocessed = MultiDenseVector::new(preprocessed, vector.dim);
                 let converted =
-                    TElement::from_float_multivector(Cow::Owned(preprocessed)).into_owned();
+                    TElement::from_float_multivector(CowMultiVector::Owned(preprocessed))
+                        .to_owned();
                 Ok(converted)
             })
             .unwrap();
@@ -80,7 +81,7 @@ impl<
             score_multi::<TElement, TMetric>(
                 self.vector_storage.multi_vector_config(),
                 TypedMultiDenseVectorRef::from(example),
-                stored.clone(),
+                stored,
             )
         })
     }

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use common::types::{PointOffsetType, ScoreType};
 
 use super::score_multi;
+use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
     DenseVector, MultiDenseVector, TypedMultiDenseVector, TypedMultiDenseVectorRef,
@@ -38,7 +38,7 @@ impl<
             .collect();
         let preprocessed = MultiDenseVector::new(preprocessed, query.dim);
         Self {
-            query: TElement::from_float_multivector(Cow::Owned(preprocessed)).into_owned(),
+            query: TElement::from_float_multivector(CowMultiVector::Owned(preprocessed)).to_owned(),
             vector_storage,
             metric: PhantomData,
         }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use tempfile::Builder;
 
 use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
-use crate::data_types::vectors::{MultiDenseVector, QueryVector};
+use crate::data_types::vectors::{MultiDenseVector, QueryVector, TypedMultiDenseVectorRef};
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
 use crate::types::{Distance, MultiVectorConfig};
@@ -59,8 +59,8 @@ fn do_test_delete_points(storage: Arc<AtomicRefCell<VectorStorageEnum>>) {
     // Check that all points are inserted
     for (i, vec) in points.iter().enumerate() {
         let stored_vec = borrowed_storage.get_vector(i as PointOffsetType);
-        let multi_dense: &MultiDenseVector = stored_vec.as_vec_ref().try_into().unwrap();
-        assert_eq!(multi_dense, vec);
+        let multi_dense: TypedMultiDenseVectorRef<_> = stored_vec.as_vec_ref().try_into().unwrap();
+        assert_eq!(multi_dense.to_owned(), vec.clone());
     }
 
     // Delete select number of points

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -7,8 +7,8 @@ use rand::prelude::StdRng;
 use rand::SeedableRng;
 use segment::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use segment::data_types::vectors::{
-    only_default_vector, MultiDenseVector, QueryVector, VectorElementType, VectorRef,
-    DEFAULT_VECTOR_NAME,
+    only_default_vector, MultiDenseVector, QueryVector, TypedMultiDenseVectorRef,
+    VectorElementType, VectorRef, DEFAULT_VECTOR_NAME,
 };
 use segment::entry::entry_point::SegmentEntry;
 use segment::fixtures::index_fixtures::random_vector;
@@ -109,7 +109,10 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
         let internal_id = segment.id_tracker.borrow().internal_id(idx).unwrap();
         multi_storage
             .borrow_mut()
-            .insert_vector(internal_id, VectorRef::MultiDense(&vector_multi))
+            .insert_vector(
+                internal_id,
+                VectorRef::MultiDense(TypedMultiDenseVectorRef::from(&vector_multi)),
+            )
             .unwrap();
     }
 

--- a/tests/basic_multivector_grpc_test.sh
+++ b/tests/basic_multivector_grpc_test.sh
@@ -63,8 +63,8 @@ $docker_grpcurl -d '{
          "vectors": {
            "vectors": {
              "my-multivec": {
-               "data": [0.19, 0.81, 0.75, 0.11, 0.19, 0.81, 0.75, 0.11],
-               "vectors_count": 2
+               "data": [0.19, 0.81, 0.75, 0.11],
+               "vectors_count": 1
              }
            }
          }
@@ -91,8 +91,8 @@ $docker_grpcurl -d '{
         "vectors": {
           "vectors": {
             "my-multivec": {
-              "data": [0.18, 0.01, 0.85, 0.80, 0.18, 0.01, 0.85, 0.80],
-              "vectors_count": 2
+              "data": [0.18, 0.01, 0.85, 0.80],
+              "vectors_count": 1
             }
           }
         }

--- a/tests/basic_multivector_grpc_test.sh
+++ b/tests/basic_multivector_grpc_test.sh
@@ -257,21 +257,6 @@ if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 3
     exit 1
 fi
 
-response=$(
-  $docker_grpcurl -d '{
-      "collection_name": "test_multivector_collection",
-      "vector": [0.2,0.1,0.9, 0.7, 0.8],
-      "limit": 3,
-      "vector_name": "my-multivec"
-    }' $QDRANT_HOST qdrant.Points/Search 2>&1
-)
-
-if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 5"* ]]; then
-    echo Unexpected response, expected validation error: "$response"
-    exit 1
-fi
-
-
 set -e
 
 # search with a single dense vector with the right dimension works against a multivector collection

--- a/tests/basic_multivector_grpc_test.sh
+++ b/tests/basic_multivector_grpc_test.sh
@@ -181,7 +181,7 @@ response=$(
   }' $QDRANT_HOST qdrant.Points/Upsert 2>&1
 )
 
-if [[ $response != *"Wrong input: Vector inserting error: expected dim: 4, got 8"* ]]; then
+if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 8"* ]]; then
     echo Unexpected response, expected validation error: "$response"
     exit 1
 fi
@@ -252,7 +252,7 @@ response=$(
     }' $QDRANT_HOST qdrant.Points/Search 2>&1
 )
 
-if [[ $response != *"Wrong input: Vector inserting error: expected dim: 4, got 3"* ]]; then
+if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 3"* ]]; then
     echo Unexpected response, expected validation error: "$response"
     exit 1
 fi
@@ -266,7 +266,7 @@ response=$(
     }' $QDRANT_HOST qdrant.Points/Search 2>&1
 )
 
-if [[ $response != *"Wrong input: Vector inserting error: expected dim: 4, got 5"* ]]; then
+if [[ $response != *"Wrong input: Vector dimension error: expected dim: 4, got 5"* ]]; then
     echo Unexpected response, expected validation error: "$response"
     exit 1
 fi

--- a/tests/consensus_tests/test_collection_shard_update.py
+++ b/tests/consensus_tests/test_collection_shard_update.py
@@ -138,5 +138,5 @@ def test_collection_shard_update(tmp_path: pathlib.Path):
     # These operations may complete (or fail) in arbitrary order, and if request fails, Qdrant returns
     # error message of the first failed operation.
     # Local and remote operations return different errors, so we check for both.
-    assert error.__contains__("Wrong input: Vector inserting error: expected dim") or error.__contains__("Wrong input: InvalidArgument")
+    assert error.__contains__("Wrong input: Vector dimension error: expected dim") or error.__contains__("Wrong input: InvalidArgument")
 

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -206,7 +206,7 @@ def test_multi_vector_validation():
     assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in \
            response.json()["status"]["error"]
 
-    # fails because it uses inner vectors with different dimentions
+    # fails because it uses inner vectors with different dimensions
     response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="PUT",

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -253,6 +253,23 @@ def test_multi_vector_validation():
 
 # allow multivec search on legacy API by emulating a multivec input with a single dense vector
 def test_search_legacy_api():
+    # validate input size
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": {
+                "name": "my-multivec",
+                "vector": [0.05, 0.61, 0.76]
+            },
+            "limit": 3
+        }
+    )
+    assert not response.ok
+    assert 'Wrong input: Vector dimension error: expected dim: 4, got 3' in \
+           response.json()["status"]["error"]
+
     # search on empty collection
     response = request_with_validation(
         api='/collections/{collection_name}/points/search',

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -141,26 +141,6 @@ def test_multi_vector_float_persisted():
 
 
 def test_multi_vector_validation():
-    # fails because uses dense vector
-    response = request_with_validation(
-        api='/collections/{collection_name}/points',
-        method="PUT",
-        path_params={'collection_name': collection_name},
-        query_params={'wait': 'true'},
-        body={
-            "points": [
-                {
-                    "id": 1,
-                    "vector": {
-                        "my-multivec": [0.19, 0.81, 0.75, 0.11]
-                    }
-                }
-            ]
-        }
-    )
-    assert not response.ok
-    assert 'Wrong input: Conversion between multi and regular vectors failed' in response.json()["status"]["error"]
-
     # fails because it uses and empty multi vector
     response = request_with_validation(
         api='/collections/{collection_name}/points',
@@ -226,7 +206,7 @@ def test_multi_vector_validation():
     assert 'Validation error in JSON body: [points[0].vector.?.data: all vectors must be non-empty]' in \
            response.json()["status"]["error"]
 
-    # fails because it uses one inner vector
+    # fails because it uses inner vectors with different dimentions
     response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="PUT",

--- a/tests/openapi/openapi_integration/test_multi_vector.py
+++ b/tests/openapi/openapi_integration/test_multi_vector.py
@@ -179,7 +179,7 @@ def test_multi_vector_validation():
         }
     )
     assert not response.ok
-    assert 'Wrong input: Vector inserting error: expected dim: 4, got 0' in response.json()["status"]["error"]
+    assert 'Wrong input: Vector dimension error: expected dim: 4, got 0' in response.json()["status"]["error"]
 
     # fails because it uses an empty inner vector
     response = request_with_validation(
@@ -251,7 +251,7 @@ def test_multi_vector_validation():
            response.json()["status"]["error"]
 
 
-# allow multivec search on legacy API by emulating multivec search with a single vector
+# allow multivec search on legacy API by emulating a multivec input with a single dense vector
 def test_search_legacy_api():
     # search on empty collection
     response = request_with_validation(


### PR DESCRIPTION
This enables the support of basic multivec search on the current search API without changing the schema.

The trick is to expand a single dense vector into a multivector during conversion instead of returning an error.

A new search API will later be introduced to search using full fledged multivectors.