### PR TITLE
Fix deadlock in proxy segment when propagating to write segment

### DIFF
--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use bitvec::prelude::BitVec;
 use common::types::{PointOffsetType, TelemetryDetail};
-use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use segment::common::operation_error::{OperationResult, SegmentFailedState};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderingValue;
@@ -220,18 +220,18 @@ impl ProxySegment {
     /// required.
     pub(super) fn propagate_to_wrapped(&self) -> OperationResult<()> {
         let wrapped_segment = self.wrapped_segment.get();
-        let op_num = wrapped_segment.read().version();
+        let mut wrapped_segment = wrapped_segment.upgradable_read();
+        let op_num = wrapped_segment.version();
 
         // Propagate deleted points
         {
             let deleted_points = self.deleted_points.upgradable_read();
             if !deleted_points.is_empty() {
-                {
-                    let mut wrapped_segment = wrapped_segment.write();
-                    for point_id in deleted_points.iter() {
-                        wrapped_segment.delete_point(op_num, *point_id)?;
-                    }
+                let mut wrapped_segment_write = RwLockUpgradableReadGuard::upgrade(wrapped_segment);
+                for point_id in deleted_points.iter() {
+                    wrapped_segment_write.delete_point(op_num, *point_id)?;
                 }
+                wrapped_segment = RwLockWriteGuard::downgrade_to_upgradable(wrapped_segment_write);
 
                 RwLockUpgradableReadGuard::upgrade(deleted_points).clear();
 
@@ -247,12 +247,11 @@ impl ProxySegment {
         {
             let deleted_indexes = self.deleted_indexes.upgradable_read();
             if !deleted_indexes.is_empty() {
-                {
-                    let mut wrapped_segment = wrapped_segment.write();
-                    for key in deleted_indexes.iter() {
-                        wrapped_segment.delete_field_index(op_num, key)?;
-                    }
+                let mut wrapped_segment_write = RwLockUpgradableReadGuard::upgrade(wrapped_segment);
+                for key in deleted_indexes.iter() {
+                    wrapped_segment_write.delete_field_index(op_num, key)?;
                 }
+                wrapped_segment = RwLockWriteGuard::downgrade_to_upgradable(wrapped_segment_write);
 
                 RwLockUpgradableReadGuard::upgrade(deleted_indexes).clear();
             }
@@ -262,12 +261,11 @@ impl ProxySegment {
         {
             let created_indexes = self.created_indexes.upgradable_read();
             if !created_indexes.is_empty() {
-                {
-                    let mut wrapped_segment = wrapped_segment.write();
-                    for (key, field_schema) in created_indexes.iter() {
-                        wrapped_segment.create_field_index(op_num, key, Some(field_schema))?;
-                    }
+                let mut wrapped_segment_write = RwLockUpgradableReadGuard::upgrade(wrapped_segment);
+                for (key, field_schema) in created_indexes.iter() {
+                    wrapped_segment_write.create_field_index(op_num, key, Some(field_schema))?;
                 }
+                drop(wrapped_segment_write);
 
                 RwLockUpgradableReadGuard::upgrade(created_indexes).clear();
             }

--- a/lib/collection/src/collection_manager/holders/proxy_segment.rs
+++ b/lib/collection/src/collection_manager/holders/proxy_segment.rs
@@ -224,6 +224,7 @@ impl ProxySegment {
         // read lock on the wrapped segment as well while already holding the deleted points lock
         // (or others). Careful locking management is very important here. Instead we just take an
         // upgradable read lock, upgrading to a write lock on demand.
+        // See: <https://github.com/qdrant/qdrant/pull/4206>
         let wrapped_segment = self.wrapped_segment.get();
         let mut wrapped_segment = wrapped_segment.upgradable_read();
         let op_num = wrapped_segment.version();

--- a/lib/segment/src/segment.rs
+++ b/lib/segment/src/segment.rs
@@ -1650,9 +1650,8 @@ impl SegmentEntry for Segment {
         snapshot_dir_path: &Path,
     ) -> OperationResult<PathBuf> {
         log::debug!(
-            "Taking snapshot of segment {:?} into {:?}",
+            "Taking snapshot of segment {:?} into {snapshot_dir_path:?}",
             self.current_path,
-            snapshot_dir_path,
         );
 
         if !snapshot_dir_path.exists() {
@@ -1766,9 +1765,8 @@ impl SegmentEntry for Segment {
             let res = fs::remove_dir_all(&temp_path);
             if let Err(err) = res {
                 log::error!(
-                    "Failed to remove tmp directory at {}: {:?}",
+                    "Failed to remove tmp directory at {}: {err:?}",
                     temp_path.display(),
-                    err
                 );
             }
         });


### PR DESCRIPTION
Likely fixes: <https://github.com/qdrant/qdrant/issues/4199>

Fix a deadlock in the proxy segment. Locking in the `propagate_to_wrapped()` and search functions conflict.

The search function hold a lock on `deleted_points` after which it locked the wrapped segment. The propagation function did it the other way around.

I fixed this by not keeping a write lock on the write segment for the whole duration of the `propagate_to_wrapped()` function. Instead we now take an upgradable read lock and temporarily upgrade it on demand. An alternative would be to require mutable self on this function to ensure exclusive access to all locks, but I expect that to have a worse impact in terms of performance.

The last two days I managed to reproduce the problem very reliably. With this fix I've tested for another two hours, and I haven't seen it since.

For future reference, I've been testing like this getting a deadlock on the first snapshot request about 75% of the time:

```bash
# Qdrant with a flush interval of 0
QDRANT__STORAGE__OPTMIZERS__FLUSH_INTERVAL_SEC=0 ./qdrant

# Rapid upsertions
bfb -n 1000000 --create-if-missing --timeout 30

# A search/scroll job
bfb --skip-upload --skip-create --search -p 5 -t 5 --skip-wait-index
bfb --skip-upload --skip-create --scroll -p 5 -t 5 --skip-wait-index

# When all is running, create a snapshot
POST /collections/benchmark/snapshots
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?