### PR TITLE
Bump version to 1.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "api"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "chrono",
  "common",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.9.1"
+version = "1.9.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.9.1"
+version = "1.9.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.9.1";
+pub const QDRANT_VERSION_STRING: &str = "1.9.2";
 
 lazy_static! {
     /// Current Qdrant semver version

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=a3abcef0f189301292516faaae9e9e2c2fb8ab58
+IGNORE_UPTO=94c9991b29096a5b60899a3056e59862d72fe778
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Release Qdrant 1.9.2.

We want to release a patch version to fix this deadlock: <https://github.com/qdrant/qdrant/pull/4206>