### PR TITLE
 Bump dev version to 1.9.3-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "api"
-version = "1.9.2-dev"
+version = "1.9.3-dev"
 dependencies = [
  "chrono",
  "common",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.9.2-dev"
+version = "1.9.3-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.9.2-dev"
+version = "1.9.3-dev"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.9.2-dev"
+version = "1.9.3-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.9.2-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.9.3-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to `1.9.3-dev` after merging <https://github.com/qdrant/qdrant/pull/4207>.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/4164>.