### PR TITLE
universal-query: Add `query()` to `ShardOperation` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ version = "1.9.3-dev"
 dependencies = [
  "chrono",
  "common",
+ "itertools 0.12.1",
  "log",
  "parking_lot",
  "prost 0.11.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 rand = "0.8.5"
 schemars = { workspace = true }
-itertools = "0.12"
+itertools = { workspace = true }
 anyhow = "1.0.83"
 futures = { workspace = true }
 futures-util = { workspace = true }
@@ -124,6 +124,7 @@ futures = "0.3.30"
 futures-util = "0.3.30"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = "0.17.8"
+itertools = "0.12"
 parking_lot = { version = "0.12.2", features = ["deadlock_detection", "serde"] }
 pprof = { version = "0.12", features = ["flamegraph", "prost-codec"] }
 prost = "0.11.9"

--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -3483,8 +3483,8 @@ For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| data | [float](#float) | repeated |  |
-| indices | [SparseIndices](#qdrant-SparseIndices) |  |  |
+| values | [float](#float) | repeated |  |
+| indices | [uint32](#uint32) | repeated |  |
 
 
 
@@ -3674,7 +3674,7 @@ Vector type to be used in queries. Ids will be substituted with their correspond
 | id | [PointId](#qdrant-PointId) |  |  |
 | dense | [DenseVector](#qdrant-DenseVector) |  |  |
 | sparse | [SparseVector](#qdrant-SparseVector) |  |  |
-| multi | [MultiDenseVector](#qdrant-MultiDenseVector) |  |  |
+| multi_dense | [MultiDenseVector](#qdrant-MultiDenseVector) |  |  |
 
 
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 parking_lot = { workspace = true }
 validator = { workspace = true }
 log = "0.4"
+itertools = { workspace = true }
 
 common = { path = "../common/common" }
 segment = { path = "../segment" }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -58,8 +58,8 @@ message DenseVector {
 }
 
 message SparseVector {
-  repeated float data = 1;
-  SparseIndices indices = 2;
+  repeated float values = 1;
+  repeated uint32 indices = 2;
 }
 
 message MultiDenseVector {
@@ -72,7 +72,7 @@ message VectorInput {
     PointId id = 1;
     DenseVector dense = 2;
     SparseVector sparse = 3;
-    MultiDenseVector multi = 4;
+    MultiDenseVector multi_dense = 4;
   }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -245,26 +245,31 @@ message QueryShardPoints {
   }
   
   message Prefetch {
-    Prefetch prefetch = 1;
+    repeated Prefetch prefetch = 1;
     Query query = 2;
-    string using = 3;
+    optional string using = 3;
     Filter filter = 4;
     uint64 limit = 5;
+    SearchParams params = 6;
+    optional float score_threshold = 7;
   }
-
-  Prefetch prefetch = 1;
+  
+  repeated Prefetch prefetch = 1;
   Query query = 2;
-  string using = 3;
+  optional string using = 3;
   Filter filter = 4;
   uint64 limit = 5;
-  uint64 offset = 6;
-  WithPayloadSelector with_payload = 7;
-  WithVectorsSelector with_vectors = 8;
+  SearchParams params = 6;
+  optional float score_threshold = 7;
+  uint64 offset = 8;
+  WithPayloadSelector with_payload = 9;
+  WithVectorsSelector with_vectors = 10;
 }
 
 message QueryPointsInternal {
-  QueryShardPoints query_points = 1;
-  optional uint32 shard_id = 2;
+  string collection_name = 1;
+  QueryShardPoints query_points = 2;
+  optional uint32 shard_id = 3;
 }
 
 message QueryResponse {

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -203,7 +203,7 @@ message RawVector {
   oneof variant {
     DenseVector dense = 1;
     SparseVector sparse = 2;
-    MultiDenseVector multi = 3;
+    MultiDenseVector multi_dense = 3;
   }
 }
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -272,7 +272,11 @@ message QueryPointsInternal {
   optional uint32 shard_id = 3;
 }
 
-message QueryResponse {
+message IntermediateResult {
   repeated ScoredPoint result = 1;
+}
+
+message QueryResponse {
+  repeated IntermediateResult result = 1;
   double time = 2; // Time spent to process
 }

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3746,9 +3746,9 @@ pub struct DenseVector {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SparseVector {
     #[prost(float, repeated, tag = "1")]
-    pub data: ::prost::alloc::vec::Vec<f32>,
-    #[prost(message, optional, tag = "2")]
-    pub indices: ::core::option::Option<SparseIndices>,
+    pub values: ::prost::alloc::vec::Vec<f32>,
+    #[prost(uint32, repeated, tag = "2")]
+    pub indices: ::prost::alloc::vec::Vec<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3778,7 +3778,7 @@ pub mod vector_input {
         #[prost(message, tag = "3")]
         Sparse(super::SparseVector),
         #[prost(message, tag = "4")]
-        Multi(super::MultiDenseVector),
+        MultiDense(super::MultiDenseVector),
     }
 }
 /// ---------------------------------------------
@@ -8022,7 +8022,7 @@ pub mod raw_vector {
         #[prost(message, tag = "2")]
         Sparse(super::SparseVector),
         #[prost(message, tag = "3")]
-        Multi(super::MultiDenseVector),
+        MultiDense(super::MultiDenseVector),
     }
 }
 /// Query variants for raw vectors (ids have been substituted with vectors)

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8091,21 +8091,25 @@ pub mod raw_query {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryShardPoints {
-    #[prost(message, optional, tag = "1")]
-    pub prefetch: ::core::option::Option<query_shard_points::Prefetch>,
+    #[prost(message, repeated, tag = "1")]
+    pub prefetch: ::prost::alloc::vec::Vec<query_shard_points::Prefetch>,
     #[prost(message, optional, tag = "2")]
     pub query: ::core::option::Option<query_shard_points::Query>,
-    #[prost(string, tag = "3")]
-    pub using: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "3")]
+    pub using: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "4")]
     pub filter: ::core::option::Option<Filter>,
     #[prost(uint64, tag = "5")]
     pub limit: u64,
-    #[prost(uint64, tag = "6")]
+    #[prost(message, optional, tag = "6")]
+    pub params: ::core::option::Option<SearchParams>,
+    #[prost(float, optional, tag = "7")]
+    pub score_threshold: ::core::option::Option<f32>,
+    #[prost(uint64, tag = "8")]
     pub offset: u64,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag = "9")]
     pub with_payload: ::core::option::Option<WithPayloadSelector>,
-    #[prost(message, optional, tag = "8")]
+    #[prost(message, optional, tag = "10")]
     pub with_vectors: ::core::option::Option<WithVectorsSelector>,
 }
 /// Nested message and enum types in `QueryShardPoints`.
@@ -8132,25 +8136,31 @@ pub mod query_shard_points {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Prefetch {
-        #[prost(message, optional, boxed, tag = "1")]
-        pub prefetch: ::core::option::Option<::prost::alloc::boxed::Box<Prefetch>>,
+        #[prost(message, repeated, tag = "1")]
+        pub prefetch: ::prost::alloc::vec::Vec<Prefetch>,
         #[prost(message, optional, tag = "2")]
         pub query: ::core::option::Option<Query>,
-        #[prost(string, tag = "3")]
-        pub using: ::prost::alloc::string::String,
+        #[prost(string, optional, tag = "3")]
+        pub using: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(message, optional, tag = "4")]
         pub filter: ::core::option::Option<super::Filter>,
         #[prost(uint64, tag = "5")]
         pub limit: u64,
+        #[prost(message, optional, tag = "6")]
+        pub params: ::core::option::Option<super::SearchParams>,
+        #[prost(float, optional, tag = "7")]
+        pub score_threshold: ::core::option::Option<f32>,
     }
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPointsInternal {
-    #[prost(message, optional, tag = "1")]
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
     pub query_points: ::core::option::Option<QueryShardPoints>,
-    #[prost(uint32, optional, tag = "2")]
+    #[prost(uint32, optional, tag = "3")]
     pub shard_id: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -8166,9 +8166,16 @@ pub struct QueryPointsInternal {
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryResponse {
+pub struct IntermediateResult {
     #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub result: ::prost::alloc::vec::Vec<IntermediateResult>,
     /// Time spent to process
     #[prost(double, tag = "2")]
     pub time: f64,

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -64,7 +64,7 @@ segment = { path = "../segment" }
 sparse = { path = "../sparse" }
 api = { path = "../api" }
 
-itertools = "0.12"
+itertools = { workspace = true }
 indicatif = { workspace = true }
 chrono = { workspace = true }
 schemars = { workspace = true }

--- a/lib/collection/src/discovery.rs
+++ b/lib/collection/src/discovery.rs
@@ -4,8 +4,7 @@ use futures::Future;
 use itertools::Itertools;
 use segment::data_types::vectors::NamedQuery;
 use segment::types::{Condition, Filter, HasIdCondition, ScoredPoint};
-use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
+use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery};
 use tokio::sync::RwLockReadGuard;
 
 use crate::collection::Collection;

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -23,9 +23,7 @@ use segment::data_types::vectors::{
 use segment::types::{
     DateTimeWrapper, Distance, MultiVectorConfig, QuantizationConfig, ScoredPoint,
 };
-use segment::vector_storage::query::context_query::{ContextPair, ContextQuery};
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::{validate_sparse_vector_impl, SparseVector};
 use tonic::Status;
 

--- a/lib/collection/src/operations/query_enum.rs
+++ b/lib/collection/src/operations/query_enum.rs
@@ -1,7 +1,5 @@
 use segment::data_types::vectors::{DenseVector, Named, NamedQuery, NamedVectorStruct, Vector};
-use segment::vector_storage::query::context_query::ContextQuery;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery};
 use sparse::common::sparse_vector::SparseVector;
 
 impl QueryEnum {

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -67,11 +67,38 @@ pub mod shard_query {
         }
     }
 
+    impl From<QueryEnum> for grpc::RawQuery {
+        fn from(value: QueryEnum) -> Self {
+            use api::grpc::qdrant::raw_query::Variant;
+
+            let variant = match value {
+                QueryEnum::Nearest(named) => {
+                    Variant::Nearest(grpc::RawVector::from(named.to_vector()))
+                }
+                QueryEnum::RecommendBestScore(named) => {
+                    Variant::RecommendBestScore(grpc::raw_query::Recommend::from(named.query))
+                }
+                QueryEnum::Discover(named) => {
+                    Variant::Discover(grpc::raw_query::Discovery::from(named.query))
+                }
+                QueryEnum::Context(named) => {
+                    Variant::Context(grpc::raw_query::Context::from(named.query))
+                }
+            };
+
+            Self {
+                variant: Some(variant),
+            }
+        }
+    }
+
     impl From<ScoringQuery> for grpc::query_shard_points::Query {
         fn from(value: ScoringQuery) -> Self {
+            use grpc::query_shard_points::query::Score;
+
             match value {
                 ScoringQuery::Vector(query) => Self {
-                    score: Some(grpc::query_shard_points::query::Score::Vector(query.into())),
+                    score: Some(Score::Vector(grpc::RawQuery::from(query))),
                 },
             }
         }

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -15,9 +15,11 @@
 pub mod shard_query {
     use api::grpc::qdrant as grpc;
     use common::types::ScoreType;
-    use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+    use segment::types::{Filter, ScoredPoint, SearchParams, WithPayloadInterface, WithVector};
 
     use crate::operations::query_enum::QueryEnum;
+
+    pub type ShardQueryResponse = Vec<Vec<ScoredPoint>>;
 
     #[derive(Debug, Clone)]
     pub enum ScoringQuery {

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -13,18 +13,29 @@
 // TODO(universal-query): Create `CollectionQueryRequest` struct
 
 pub mod shard_query {
+    use api::grpc::qdrant as grpc;
     use common::types::ScoreType;
     use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
 
     use crate::operations::query_enum::QueryEnum;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum ScoringQuery {
         /// Score points against some vector(s)
         Vector(QueryEnum),
         // TODO(universal-query): Add fusion and order-by
     }
 
+    impl ScoringQuery {
+        /// Get the vector name if it is scored against a vector
+        pub fn get_vector_name(&self) -> Option<&str> {
+            match self {
+                ScoringQuery::Vector(query) => Some(query.get_vector_name()),
+            }
+        }
+    }
+
+    #[derive(Clone)]
     pub struct ShardPrefetch {
         pub prefetches: Option<Vec<ShardPrefetch>>,
         pub query: ScoringQuery,
@@ -37,6 +48,7 @@ pub mod shard_query {
     /// Internal representation of a universal query request.
     ///
     /// Direct translation of the user-facing request, but with all point ids substituted with their corresponding vectors.
+    #[derive(Clone)]
     pub struct ShardQueryRequest {
         pub prefetch: Option<Vec<ShardPrefetch>>,
         pub query: ScoringQuery,
@@ -47,6 +59,81 @@ pub mod shard_query {
         pub params: Option<SearchParams>,
         pub with_vector: WithVector,
         pub with_payload: WithPayloadInterface,
+    }
+
+    impl From<grpc::QueryShardPoints> for ShardQueryRequest {
+        fn from(_value: grpc::QueryShardPoints) -> Self {
+            todo!()
+        }
+    }
+
+    impl From<ScoringQuery> for grpc::query_shard_points::Query {
+        fn from(value: ScoringQuery) -> Self {
+            match value {
+                ScoringQuery::Vector(query) => Self {
+                    score: Some(grpc::query_shard_points::query::Score::Vector(query.into())),
+                },
+            }
+        }
+    }
+
+    impl From<ShardPrefetch> for grpc::query_shard_points::Prefetch {
+        fn from(value: ShardPrefetch) -> Self {
+            let ShardPrefetch {
+                prefetches,
+                query,
+                limit,
+                params,
+                filter,
+                score_threshold,
+            } = value;
+            Self {
+                prefetch: prefetches
+                    .into_iter()
+                    .flat_map(IntoIterator::into_iter)
+                    .map(Self::from)
+                    .collect(),
+                using: query.get_vector_name().map(ToOwned::to_owned),
+                query: Some(grpc::query_shard_points::Query::from(query)),
+                filter: filter.map(grpc::Filter::from),
+                params: params.map(grpc::SearchParams::from),
+                score_threshold,
+                limit: limit as u64,
+            }
+        }
+    }
+
+    impl From<ShardQueryRequest> for grpc::QueryShardPoints {
+        fn from(value: ShardQueryRequest) -> Self {
+            let ShardQueryRequest {
+                prefetch,
+                query,
+                filter,
+                score_threshold,
+                limit,
+                offset,
+                params,
+                with_vector,
+                with_payload,
+            } = value;
+
+            Self {
+                prefetch: prefetch
+                    .into_iter()
+                    .flat_map(IntoIterator::into_iter)
+                    .map(grpc::query_shard_points::Prefetch::from)
+                    .collect(),
+                using: query.get_vector_name().map(ToOwned::to_owned),
+                query: Some(grpc::query_shard_points::Query::from(query)),
+                filter: filter.map(grpc::Filter::from),
+                params: params.map(grpc::SearchParams::from),
+                score_threshold,
+                limit: limit as u64,
+                offset: offset as u64,
+                with_payload: Some(grpc::WithPayloadSelector::from(with_payload)),
+                with_vectors: Some(grpc::WithVectorsSelector::from(with_vector)),
+            }
+        }
     }
 }
 

--- a/lib/collection/src/operations/universal_query.rs
+++ b/lib/collection/src/operations/universal_query.rs
@@ -19,6 +19,9 @@ pub mod shard_query {
 
     use crate::operations::query_enum::QueryEnum;
 
+    /// Internal response type for a universal query request.
+    ///
+    /// Capable of returning multiple intermediate results if needed, like the case of RRF (Reciprocal Rank Fusion)
     pub type ShardQueryResponse = Vec<Vec<ScoredPoint>>;
 
     #[derive(Debug, Clone)]

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -9,7 +9,7 @@ use segment::data_types::vectors::{
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
 };
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::RecoQuery;
 use sparse::common::sparse_vector::SparseVector;
 use tokio::sync::RwLockReadGuard;
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -13,6 +13,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::OperationWithClockTag;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -98,6 +99,14 @@ impl ShardOperation for DummyShard {
         _: &WithPayload,
         _: &WithVector,
     ) -> CollectionResult<Vec<Record>> {
+        self.dummy()
+    }
+
+    async fn query(
+        &self,
+        _: Arc<ShardQueryRequest>,
+        _: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
         self.dummy()
     }
 }

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -13,7 +13,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
 use crate::shards::shard_trait::ShardOperation;
 use crate::shards::telemetry::LocalShardTelemetry;
@@ -106,7 +106,7 @@ impl ShardOperation for DummyShard {
         &self,
         _: Arc<ShardQueryRequest>,
         _: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         self.dummy()
     }
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -18,6 +18,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::{
     CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
@@ -270,5 +271,14 @@ impl ShardOperation for ForwardProxyShard {
         local_shard
             .retrieve(request, with_payload, with_vector)
             .await
+    }
+
+    async fn query(
+        &self,
+        request: Arc<ShardQueryRequest>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        let local_shard = &self.wrapped_shard;
+        local_shard.query(request, search_runtime_handle).await
     }
 }

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -18,7 +18,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::{
     CollectionUpdateOperations, CreateIndex, FieldIndexOperations, OperationWithClockTag,
 };
@@ -277,7 +277,7 @@ impl ShardOperation for ForwardProxyShard {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         let local_shard = &self.wrapped_shard;
         local_shard.query(request, search_runtime_handle).await
     }

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -12,6 +12,7 @@ use crate::operations::types::CollectionResult;
 use crate::operations::universal_query::planned_query::{
     PlannedQuery, PrefetchMerge, PrefetchPlan, PrefetchSource,
 };
+use crate::operations::universal_query::shard_query::ShardQueryResponse;
 
 impl LocalShard {
     pub async fn do_planned_query(
@@ -19,15 +20,17 @@ impl LocalShard {
         request: PlannedQuery,
         search_runtime_handle: &Handle,
         timeout: Option<Duration>,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         let core_results = self
             .do_search(Arc::clone(&request.batch), search_runtime_handle, timeout)
             .await?;
 
-        self.recurse_prefetch(&request.merge_plan, &core_results)
-            .await
+        let _merged_results = self
+            .recurse_prefetch(&request.merge_plan, &core_results)
+            .await;
 
         // TODO(universal-query): Implement with_vector and with_payload
+        todo!()
     }
 
     fn recurse_prefetch<'shard, 'query>(

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -14,6 +14,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
+use crate::operations::universal_query::planned_query::PlannedQuery;
 use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
@@ -175,11 +176,14 @@ impl ShardOperation for LocalShard {
 
     async fn query(
         &self,
-        mut request: Arc<ShardQueryRequest>,
+        request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>>
-    {
-        self.do_planned_query(Arc::make_mut(&mut request).to_owned().try_into()?, search_runtime_handle, None).await
-
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        self.do_planned_query(
+            PlannedQuery::try_from(request.as_ref().to_owned())?,
+            search_runtime_handle,
+            None,
+        )
+        .await
     }
 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -178,7 +178,7 @@ impl ShardOperation for LocalShard {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.do_planned_query(
             PlannedQuery::try_from(request.as_ref().to_owned())?,
             search_runtime_handle,

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -14,6 +14,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult, UpdateStatus,
 };
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -170,5 +171,15 @@ impl ShardOperation for LocalShard {
         with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>> {
         SegmentsSearcher::retrieve(self.segments(), &request.ids, with_payload, with_vector)
+    }
+
+    async fn query(
+        &self,
+        mut request: Arc<ShardQueryRequest>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>>
+    {
+        self.do_planned_query(Arc::make_mut(&mut request).to_owned().try_into()?, search_runtime_handle, None).await
+
     }
 }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -23,6 +23,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -243,6 +244,17 @@ impl ShardOperation for ProxyShard {
         let local_shard = &self.wrapped_shard;
         local_shard
             .retrieve(request, with_payload, with_vector)
+            .await
+    }
+
+    /// Forward read-only `query` to `wrapped_shard`
+    async fn query(
+        &self,
+        request: Arc<ShardQueryRequest>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        self.wrapped_shard
+            .query(request, search_runtime_handle)
             .await
     }
 }

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -23,7 +23,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -252,7 +252,7 @@ impl ShardOperation for ProxyShard {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         self.wrapped_shard
             .query(request, search_runtime_handle)
             .await

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -22,7 +22,7 @@ use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
     CountRequestInternal, CountResult, PointRequestInternal, Record, UpdateResult,
 };
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::ShardOperation;
@@ -297,7 +297,7 @@ impl ShardOperation for QueueProxyShard {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<ShardQueryResponse> {
         self.inner
             .as_ref()
             .expect("Queue proxy has been finalized")
@@ -583,7 +583,7 @@ impl ShardOperation for Inner {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
+    ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         self.wrapped_shard
             .query(request, search_runtime_handle)
             .await

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -12,8 +12,9 @@ use api::grpc::qdrant::{
     CollectionOperationResponse, CoreSearchBatchPointsInternal, CountPoints, CountPointsInternal,
     GetCollectionInfoRequest, GetCollectionInfoRequestInternal, GetPoints, GetPointsInternal,
     GetShardRecoveryPointRequest, HealthCheckRequest, InitiateShardTransferRequest,
-    RecoverShardSnapshotRequest, RecoverSnapshotResponse, ScrollPoints, ScrollPointsInternal,
-    ShardSnapshotLocation, UpdateShardCutoffPointRequest, WaitForShardStateRequest,
+    QueryPointsInternal, QueryShardPoints, RecoverShardSnapshotRequest, RecoverSnapshotResponse,
+    ScrollPoints, ScrollPointsInternal, ShardSnapshotLocation, UpdateShardCutoffPointRequest,
+    WaitForShardStateRequest,
 };
 use api::grpc::transport_channel_pool::{AddTimeout, MAX_GRPC_CHANNEL_TIMEOUT};
 use async_trait::async_trait;
@@ -46,6 +47,7 @@ use crate::operations::types::{
     CountRequestInternal, CountResult, PointRequestInternal, Record, SearchRequestInternal,
     UpdateResult,
 };
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::vector_ops::VectorOperations;
 use crate::operations::{CollectionUpdateOperations, FieldIndexOperations, OperationWithClockTag};
 use crate::shards::channel_service::ChannelService;
@@ -830,6 +832,37 @@ impl ShardOperation for RemoteShard {
             .result
             .into_iter()
             .map(|point| try_record_from_grpc(point, with_payload.enable))
+            .collect();
+
+        result.map_err(|e| e.into())
+    }
+
+    async fn query(
+        &self,
+        request: Arc<ShardQueryRequest>,
+        _search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>> {
+        let is_payload_required = request.with_payload.is_required();
+
+        let query_points = Some(QueryShardPoints::from(request.as_ref().to_owned()));
+
+        let request = &QueryPointsInternal {
+            collection_name: self.collection_id.clone(),
+            query_points,
+            shard_id: Some(__self.id),
+        };
+
+        let query_response = self
+            .with_points_client(|mut client| async move {
+                client.query(tonic::Request::new(request.clone())).await
+            })
+            .await?
+            .into_inner();
+
+        let result: Result<Vec<ScoredPoint>, Status> = query_response
+            .result
+            .into_iter()
+            .map(|point| try_scored_point_from_grpc(point, is_payload_required))
             .collect();
 
         result.map_err(|e| e.into())

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -7,6 +7,7 @@ use segment::types::*;
 use tokio::runtime::Handle;
 
 use crate::operations::types::*;
+use crate::operations::universal_query::shard_query::ShardQueryRequest;
 use crate::operations::OperationWithClockTag;
 
 #[async_trait]
@@ -47,7 +48,11 @@ pub trait ShardOperation {
         with_vector: &WithVector,
     ) -> CollectionResult<Vec<Record>>;
 
-    // TODO(universal-query): Add `query` operation, which accepts an `Arc<ShardQueryRequest>`
+    async fn query(
+        &self,
+        request: Arc<ShardQueryRequest>,
+        search_runtime_handle: &Handle,
+    ) -> CollectionResult<Vec<ScoredPoint>>;
 }
 
 pub type ShardOperationSS = dyn ShardOperation + Send + Sync;

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -7,7 +7,7 @@ use segment::types::*;
 use tokio::runtime::Handle;
 
 use crate::operations::types::*;
-use crate::operations::universal_query::shard_query::ShardQueryRequest;
+use crate::operations::universal_query::shard_query::{ShardQueryRequest, ShardQueryResponse};
 use crate::operations::OperationWithClockTag;
 
 #[async_trait]
@@ -52,7 +52,7 @@ pub trait ShardOperation {
         &self,
         request: Arc<ShardQueryRequest>,
         search_runtime_handle: &Handle,
-    ) -> CollectionResult<Vec<ScoredPoint>>;
+    ) -> CollectionResult<ShardQueryResponse>;
 }
 
 pub type ShardOperationSS = dyn ShardOperation + Send + Sync;

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -37,7 +37,7 @@ bitpacking = "0.9.2"
 tempfile = "3.10.1"
 parking_lot = { workspace = true }
 rayon = "1.10.0"
-itertools = "0.12"
+itertools = { workspace = true }
 rocksdb = { version = "0.22.0", default-features = false, features = ["snappy"] }
 uuid = { workspace = true }
 bincode = "1.3"

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -12,10 +12,7 @@ use super::named_vectors::NamedVectors;
 use super::primitive::PrimitiveVectorElement;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::transpose_map_into_named_vector;
-use crate::vector_storage::query::context_query::ContextQuery;
-use crate::vector_storage::query::discovery_query::DiscoveryQuery;
-use crate::vector_storage::query::reco_query::RecoQuery;
-use crate::vector_storage::query::TransformInto;
+use crate::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Vector {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -43,7 +43,7 @@ use crate::types::{
     Filter, HnswConfig, QuantizationSearchParams, SearchParams, VECTOR_ELEMENT_SIZE,
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::query::discovery_query::DiscoveryQuery;
+use crate::vector_storage::query::DiscoveryQuery;
 use crate::vector_storage::{
     new_raw_scorer, new_stoppable_raw_scorer, RawScorer, VectorStorage, VectorStorageEnum,
 };

--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -4,10 +4,7 @@ use bitvec::prelude::BitSlice;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
-use super::query::context_query::ContextQuery;
-use super::query::discovery_query::DiscoveryQuery;
-use super::query::reco_query::RecoQuery;
-use super::query::TransformInto;
+use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::{DenseVector, QueryVector, Vector, VectorElementType};

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -14,10 +14,7 @@ use crate::data_types::vectors::{
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
-use crate::vector_storage::query::context_query::ContextQuery;
-use crate::vector_storage::query::discovery_query::DiscoveryQuery;
-use crate::vector_storage::query::reco_query::RecoQuery;
-use crate::vector_storage::query::TransformInto;
+use crate::vector_storage::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 use crate::vector_storage::{raw_scorer_from_query_scorer, RawScorer};
 
 pub(super) struct QuantizedScorerBuilder<'a> {

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -27,3 +27,7 @@ pub trait Query<T> {
     /// then folds the similarites into a single score.
     fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType;
 }
+
+pub use context_query::{ContextPair, ContextQuery};
+pub use discovery_query::DiscoveryQuery;
+pub use reco_query::RecoQuery;

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -3,9 +3,13 @@ use common::types::ScoreType;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::DenseVector;
 
-pub mod context_query;
-pub mod discovery_query;
-pub mod reco_query;
+mod context_query;
+mod discovery_query;
+mod reco_query;
+
+pub use context_query::{ContextPair, ContextQuery};
+pub use discovery_query::DiscoveryQuery;
+pub use reco_query::RecoQuery;
 
 pub trait TransformInto<Output, T = DenseVector, U = DenseVector> {
     /// Change the underlying type of the query, or just process it in some way.
@@ -27,7 +31,3 @@ pub trait Query<T> {
     /// then folds the similarites into a single score.
     fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType;
 }
-
-pub use context_query::{ContextPair, ContextQuery};
-pub use discovery_query::DiscoveryQuery;
-pub use reco_query::RecoQuery;

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -4,10 +4,7 @@ use bitvec::prelude::BitSlice;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use sparse::common::sparse_vector::SparseVector;
 
-use super::query::context_query::ContextQuery;
-use super::query::discovery_query::DiscoveryQuery;
-use super::query::reco_query::RecoQuery;
-use super::query::TransformInto;
+use super::query::{ContextQuery, DiscoveryQuery, RecoQuery, TransformInto};
 use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::multi_custom_query_scorer::MultiCustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -24,9 +24,7 @@ use crate::types::{
 use crate::vector_storage::dense::memmap_dense_vector_storage::open_memmap_vector_storage_with_async_io;
 use crate::vector_storage::dense::simple_dense_vector_storage::open_simple_dense_vector_storage;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::query::context_query::{ContextPair, ContextQuery};
-use crate::vector_storage::query::discovery_query::DiscoveryQuery;
-use crate::vector_storage::query::reco_query::RecoQuery;
+use crate::vector_storage::query::{ContextPair, ContextQuery, DiscoveryQuery, RecoQuery};
 use crate::vector_storage::tests::utils::score;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -10,7 +10,7 @@ use crate::common::rocksdb_wrapper::{open_db, DB_VECTOR_CF};
 use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::FixtureIdTracker;
 use crate::id_tracker::IdTrackerSS;
-use crate::vector_storage::query::reco_query::RecoQuery;
+use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use crate::vector_storage::{new_raw_scorer, VectorStorage, VectorStorageEnum};
 

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -20,9 +20,7 @@ use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, Range, SearchParams,
     SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use segment::vector_storage::VectorStorageEnum;
 use serde_json::json;
 use tempfile::Builder;

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -25,9 +25,7 @@ use segment::types::{
     SeqNumberType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
 };
 use segment::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use segment::vector_storage::VectorStorageEnum;
 use serde_json::json;
 use tempfile::Builder;

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -21,9 +21,7 @@ use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use serde_json::json;
 use tempfile::Builder;
 

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -19,8 +19,7 @@ use segment::types::{
     Condition, Distance, FieldCondition, Filter, HnswConfig, Indexes, Payload, PayloadSchemaType,
     SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig, VectorStorageType,
 };
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use serde_json::json;
 use tempfile::Builder;
 

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -22,9 +22,7 @@ use segment::types::{
     PayloadSchemaType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
     VectorStorageType,
 };
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
-use segment::vector_storage::query::reco_query::RecoQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery, RecoQuery};
 use serde_json::json;
 use tempfile::Builder;
 

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -20,8 +20,7 @@ use segment::types::{
     Distance, Indexes, SegmentConfig, SeqNumberType, SparseVectorDataConfig, VectorDataConfig,
     VectorStorageType, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
 };
-use segment::vector_storage::query::context_query::ContextPair;
-use segment::vector_storage::query::discovery_query::DiscoveryQuery;
+use segment::vector_storage::query::{ContextPair, DiscoveryQuery};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use tempfile::Builder;

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -23,7 +23,7 @@ tempfile = "3.10.1"
 ordered-float = "4.2"
 rand = "0.8.5"
 validator = { workspace = true }
-itertools = "0.12.1"
+itertools = { workspace = true }
 parking_lot = "0.12.2"
 
 [dev-dependencies]

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
-itertools = "0.12"
+itertools = { workspace = true }
 log = "0.4"
 tonic = { workspace = true }
 http = "0.2"


### PR DESCRIPTION
Needs #4209 

Still some partial implementation for shard handling of query requests:
- Adds a new `query()` required method on the `ShardOperation` trait, which receives the `ShardQueryRequest` type.
- Includes the conversions needed to go from `ShardQueryRequest` to the grpc `QueryShardPoints` types
- Moves `itertools` to the workspace dependencies


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?
