### PR TITLE
fix: Replace newline with spaces to find docker resources to remove

### DIFF
--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -20,12 +20,12 @@ jobs:
 
             if [ -n "$buildx_containers" ]; then
               echo "Buildx containers to delete: " "$buildx_containers"
-              docker container rm -f "$buildx_containers"
+              docker container rm -f $buildx_containers
             fi
 
             if [ -n "$buildx_volumes" ]; then
               echo "Buildx volumes to delete: " "$buildx_volumes"
-              docker volume rm -f "$buildx_volumes"
+              docker volume rm -f $buildx_volumes
             fi
 
             branch=${GITHUB_REF_NAME//\//-} # replace all / with -

--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -15,16 +15,16 @@ jobs:
             ref: ${{ github.ref.name }}
         - name: Build the Docker image
           run: |
-            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | xargs)
-            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | xargs)
+            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | tr -d '\n')
+            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | tr -d '\n')
 
             if [ -n "$buildx_containers" ]; then
-              echo "Buildx containers to delete: " "$buildx_containers"
+              echo "Buildx containers to delete: $buildx_containers"
               docker container rm -f $buildx_containers
             fi
 
             if [ -n "$buildx_volumes" ]; then
-              echo "Buildx volumes to delete: " "$buildx_volumes"
+              echo "Buildx volumes to delete: $buildx_volumes"
               docker volume rm -f $buildx_volumes
             fi
 

--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -15,8 +15,8 @@ jobs:
             ref: ${{ github.ref.name }}
         - name: Build the Docker image
           run: |
-            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit")
-            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit")
+            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | tr '\n' ' ')
+            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | tr '\n' ' ')
 
             if [ -n "$buildx_containers" ]; then
               echo "Buildx containers to delete: " "$buildx_containers"

--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -15,8 +15,8 @@ jobs:
             ref: ${{ github.ref.name }}
         - name: Build the Docker image
           run: |
-            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | tr '\n' ' ')
-            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | tr '\n' ' ')
+            buildx_containers=$(docker container ls -a -qf "name=buildx_buildkit" | xargs)
+            buildx_volumes=$(docker volume ls -qf "name=buildx_buildkit" | xargs)
 
             if [ -n "$buildx_containers" ]; then
               echo "Buildx containers to delete: " "$buildx_containers"


### PR DESCRIPTION
Sometimes we ended up with multiple images from previous runs and the output of the docker ls commands was in multiple lines. That's why the delete commands sometimes threw errors like this:
```
Buildx containers to delete:  bcd97a723659
7c0422c69e6c
Error response from daemon: page not found
```

```
Buildx volumes to delete:  buildx_buildkit_boring_haslett0_state
buildx_buildkit_intelligent_bouman0_state
Error response from daemon: page not found
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
