### PR TITLE
Add basic resharding types

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -1612,6 +1612,7 @@ Note: 1kB = 1 vector of size 256. |
 | Listener | 4 | A shard which receives data, but is not used for search; Useful for backup shards |
 | PartialSnapshot | 5 | Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard |
 | Recovery | 6 | Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true |
+| Resharding | 7 | Points are being migrated to this shard as part of resharding |
 
 
 

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -474,7 +474,7 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
-  Resharding = 7; // TODO
+  Resharding = 7; // Points are being migrated to this shard as part of resharding
 }
 
 message ShardKey {

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -474,6 +474,7 @@ enum ReplicaState {
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Deprecated: snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
   Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
+  Resharding = 7; // TODO
 }
 
 message ShardKey {
@@ -505,7 +506,7 @@ message ShardTransferInfo {
 }
 
 message CollectionClusterInfoResponse {
-  uint64 peer_id = 1;  // ID of this peer 
+  uint64 peer_id = 1;  // ID of this peer
   uint64 shard_count = 2; // Total number of shards
   repeated LocalShardInfo local_shards = 3; // Local shards
   repeated RemoteShardInfo remote_shards = 4; // Remote shards

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1455,7 +1455,7 @@ pub enum ReplicaState {
     PartialSnapshot = 5,
     /// Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
     Recovery = 6,
-    /// TODO
+    /// Points are being migrated to this shard as part of resharding
     Resharding = 7,
 }
 impl ReplicaState {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1455,6 +1455,8 @@ pub enum ReplicaState {
     PartialSnapshot = 5,
     /// Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
     Recovery = 6,
+    /// TODO
+    Resharding = 7,
 }
 impl ReplicaState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1470,6 +1472,7 @@ impl ReplicaState {
             ReplicaState::Listener => "Listener",
             ReplicaState::PartialSnapshot => "PartialSnapshot",
             ReplicaState::Recovery => "Recovery",
+            ReplicaState::Resharding => "Resharding",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1482,6 +1485,7 @@ impl ReplicaState {
             "Listener" => Some(Self::Listener),
             "PartialSnapshot" => Some(Self::PartialSnapshot),
             "Recovery" => Some(Self::Recovery),
+            "Resharding" => Some(Self::Resharding),
             _ => None,
         }
     }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -42,7 +42,7 @@ use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{replica_set, CollectionId};
 use crate::telemetry::CollectionTelemetry;
 
-const RESHARDING_PROGRESS_FILE: &str = "resharding_progress.json";
+const RESHARDING_STATE_FILE: &str = "resharding_state.json";
 
 /// Collection's data is split into several shards.
 #[allow(dead_code)]
@@ -52,7 +52,7 @@ pub struct Collection {
     pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     pub(crate) payload_index_schema: SaveOnDisk<PayloadIndexSchema>,
-    resharding_progress: SaveOnDisk<Option<resharding::Progress>>,
+    resharding_state: SaveOnDisk<Option<resharding::State>>,
     this_peer_id: PeerId,
     path: PathBuf,
     snapshots_path: PathBuf,
@@ -136,7 +136,7 @@ impl Collection {
         collection_config.save(path)?;
 
         let payload_index_schema = Self::load_payload_index_schema(path)?;
-        let resharding_progress = Self::load_resharding_progress(path)?;
+        let resharding_state = Self::load_resharding_state(path)?;
 
         Ok(Self {
             id: name.clone(),
@@ -144,7 +144,7 @@ impl Collection {
             collection_config: shared_collection_config,
             payload_index_schema,
             shared_storage_config,
-            resharding_progress,
+            resharding_state,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -236,7 +236,7 @@ impl Collection {
         let payload_index_schema = Self::load_payload_index_schema(path)
             .expect("Can't load or initialize payload index schema");
 
-        let resharding_progress = Self::load_resharding_progress(path)
+        let resharding_state = Self::load_resharding_state(path)
             .expect("Can't load or initialize resharding progress");
 
         Self {
@@ -245,7 +245,7 @@ impl Collection {
             collection_config: shared_collection_config,
             payload_index_schema,
             shared_storage_config,
-            resharding_progress,
+            resharding_state,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -263,16 +263,16 @@ impl Collection {
         }
     }
 
-    fn resharding_progress_file(collection_path: &Path) -> PathBuf {
-        collection_path.join(RESHARDING_PROGRESS_FILE)
+    fn resharding_state_file(collection_path: &Path) -> PathBuf {
+        collection_path.join(RESHARDING_STATE_FILE)
     }
 
-    fn load_resharding_progress(
+    fn load_resharding_state(
         collection_path: &Path,
-    ) -> CollectionResult<SaveOnDisk<Option<resharding::Progress>>> {
-        let resharding_progress_file = Self::resharding_progress_file(collection_path);
-        let resharding_progress = SaveOnDisk::load_or_init(resharding_progress_file)?;
-        Ok(resharding_progress)
+    ) -> CollectionResult<SaveOnDisk<Option<resharding::State>>> {
+        let resharding_state_file = Self::resharding_state_file(collection_path);
+        let resharding_state = SaveOnDisk::load_or_init(resharding_state_file)?;
+        Ok(resharding_state)
     }
 
     /// Check if stored version have consequent version.

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -45,6 +45,7 @@ use crate::telemetry::CollectionTelemetry;
 const RESHARDING_PROGRESS_FILE: &str = "resharding_progress.json";
 
 /// Collection's data is split into several shards.
+#[allow(dead_code)]
 pub struct Collection {
     pub(crate) id: CollectionId,
     pub(crate) shards_holder: Arc<LockedShardHolder>,

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1,6 +1,7 @@
 mod collection_ops;
 pub mod payload_index_schema;
 mod point_ops;
+mod resharding;
 mod search;
 mod shard_transfer;
 mod sharding_keys;
@@ -41,6 +42,8 @@ use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{replica_set, CollectionId};
 use crate::telemetry::CollectionTelemetry;
 
+const RESHARDING_PROGRESS_FILE: &str = "resharding_progress.json";
+
 /// Collection's data is split into several shards.
 pub struct Collection {
     pub(crate) id: CollectionId,
@@ -48,6 +51,7 @@ pub struct Collection {
     pub(crate) collection_config: Arc<RwLock<CollectionConfig>>,
     pub(crate) shared_storage_config: Arc<SharedStorageConfig>,
     pub(crate) payload_index_schema: SaveOnDisk<PayloadIndexSchema>,
+    resharding_progress: SaveOnDisk<Option<resharding::Progress>>,
     this_peer_id: PeerId,
     path: PathBuf,
     snapshots_path: PathBuf,
@@ -131,6 +135,7 @@ impl Collection {
         collection_config.save(path)?;
 
         let payload_index_schema = Self::load_payload_index_schema(path)?;
+        let resharding_progress = Self::load_resharding_progress(path)?;
 
         Ok(Self {
             id: name.clone(),
@@ -138,6 +143,7 @@ impl Collection {
             collection_config: shared_collection_config,
             payload_index_schema,
             shared_storage_config,
+            resharding_progress,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -229,12 +235,16 @@ impl Collection {
         let payload_index_schema = Self::load_payload_index_schema(path)
             .expect("Can't load or initialize payload index schema");
 
+        let resharding_progress = Self::load_resharding_progress(path)
+            .expect("Can't load or initialize resharding progress");
+
         Self {
             id: collection_id.clone(),
             shards_holder: locked_shard_holder,
             collection_config: shared_collection_config,
             payload_index_schema,
             shared_storage_config,
+            resharding_progress,
             this_peer_id,
             path: path.to_owned(),
             snapshots_path: snapshots_path.to_owned(),
@@ -250,6 +260,18 @@ impl Collection {
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_cpu_budget,
         }
+    }
+
+    fn resharding_progress_file(collection_path: &Path) -> PathBuf {
+        collection_path.join(RESHARDING_PROGRESS_FILE)
+    }
+
+    fn load_resharding_progress(
+        collection_path: &Path,
+    ) -> CollectionResult<SaveOnDisk<Option<resharding::Progress>>> {
+        let resharding_progress_file = Self::resharding_progress_file(collection_path);
+        let resharding_progress = SaveOnDisk::load_or_init(resharding_progress_file)?;
+        Ok(resharding_progress)
     }
 
     /// Check if stored version have consequent version.

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+use crate::shards::shard::{PeerId, ShardId};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Progress {
+    pub peer_id: PeerId,
+    pub shard_id: ShardId,
+}
+
+impl Progress {
+    pub fn new(peer_id: PeerId, shard_id: ShardId) -> Self {
+        Self { peer_id, shard_id }
+    }
+}

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -3,12 +3,12 @@ use serde::{Deserialize, Serialize};
 use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Progress {
+pub struct State {
     pub peer_id: PeerId,
     pub shard_id: ShardId,
 }
 
-impl Progress {
+impl State {
     #[allow(dead_code)]
     pub fn new(peer_id: PeerId, shard_id: ShardId) -> Self {
         Self { peer_id, shard_id }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -9,6 +9,7 @@ pub struct Progress {
 }
 
 impl Progress {
+    #[allow(dead_code)]
     pub fn new(peer_id: PeerId, shard_id: ShardId) -> Self {
         Self { peer_id, shard_id }
     }

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1440,6 +1440,7 @@ impl From<api::grpc::qdrant::ReplicaState> for ReplicaState {
             api::grpc::qdrant::ReplicaState::Listener => Self::Listener,
             api::grpc::qdrant::ReplicaState::PartialSnapshot => Self::PartialSnapshot,
             api::grpc::qdrant::ReplicaState::Recovery => Self::Recovery,
+            api::grpc::qdrant::ReplicaState::Resharding => Self::Resharding,
         }
     }
 }
@@ -1454,6 +1455,7 @@ impl From<ReplicaState> for api::grpc::qdrant::ReplicaState {
             ReplicaState::Listener => Self::Listener,
             ReplicaState::PartialSnapshot => Self::PartialSnapshot,
             ReplicaState::Recovery => Self::Recovery,
+            ReplicaState::Resharding => Self::Resharding,
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -923,6 +923,7 @@ pub enum ReplicaState {
     // Normally rejects updates, accepts updates if force is true
     Recovery,
     // Points are being migrated to this shard as part of resharding
+    #[schemars(skip)]
     Resharding,
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -922,7 +922,7 @@ pub enum ReplicaState {
     // Shard is undergoing recovery by an external node
     // Normally rejects updates, accepts updates if force is true
     Recovery,
-    // TODO
+    // Points are being migrated to this shard as part of resharding
     Resharding,
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -649,11 +649,10 @@ impl ShardReplicaSet {
                     | ReplicaState::Partial
                     | ReplicaState::Initializing
                     | ReplicaState::PartialSnapshot
-                    | ReplicaState::Recovery => {
+                    | ReplicaState::Recovery
+                    | ReplicaState::Resharding => {
                         self.set_local(local_shard, Some(state)).await?;
                     }
-
-                    ReplicaState::Resharding => todo!(),
                 }
                 continue;
             }
@@ -947,14 +946,15 @@ impl ReplicaState {
     pub fn is_partial_or_recovery(self) -> bool {
         // Use explicit match, to catch future changes to `ReplicaState`
         match self {
-            ReplicaState::Partial | ReplicaState::PartialSnapshot | ReplicaState::Recovery => true,
+            ReplicaState::Partial
+            | ReplicaState::PartialSnapshot
+            | ReplicaState::Recovery
+            | ReplicaState::Resharding => true,
 
             ReplicaState::Active
             | ReplicaState::Dead
             | ReplicaState::Initializing
             | ReplicaState::Listener => false,
-
-            ReplicaState::Resharding => todo!(),
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -644,6 +644,7 @@ impl ShardReplicaSet {
                         self.set_local(local_shard, Some(state)).await?;
                         self.notify_peer_failure(peer_id);
                     }
+
                     ReplicaState::Dead
                     | ReplicaState::Partial
                     | ReplicaState::Initializing
@@ -651,6 +652,8 @@ impl ShardReplicaSet {
                     | ReplicaState::Recovery => {
                         self.set_local(local_shard, Some(state)).await?;
                     }
+
+                    ReplicaState::Resharding => todo!(),
                 }
                 continue;
             }
@@ -920,6 +923,8 @@ pub enum ReplicaState {
     // Shard is undergoing recovery by an external node
     // Normally rejects updates, accepts updates if force is true
     Recovery,
+    // TODO
+    Resharding,
 }
 
 impl ReplicaState {
@@ -933,7 +938,8 @@ impl ReplicaState {
             | ReplicaState::Initializing
             | ReplicaState::Partial
             | ReplicaState::PartialSnapshot
-            | ReplicaState::Recovery => false,
+            | ReplicaState::Recovery
+            | ReplicaState::Resharding => false,
         }
     }
 
@@ -947,6 +953,8 @@ impl ReplicaState {
             | ReplicaState::Dead
             | ReplicaState::Initializing
             | ReplicaState::Listener => false,
+
+            ReplicaState::Resharding => todo!(),
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -38,9 +38,12 @@ impl ShardReplicaSet {
 
         if let Some(local_shard) = local.deref() {
             match self.peer_state(&self.this_peer_id()) {
-                Some(ReplicaState::Active | ReplicaState::Partial | ReplicaState::Initializing) => {
-                    Ok(Some(local_shard.get().update(operation, wait).await?))
-                }
+                Some(
+                    ReplicaState::Active
+                    | ReplicaState::Partial
+                    | ReplicaState::Initializing
+                    | ReplicaState::Resharding,
+                ) => Ok(Some(local_shard.get().update(operation, wait).await?)),
                 Some(ReplicaState::Listener) => {
                     Ok(Some(local_shard.get().update(operation, false).await?))
                 }
@@ -405,6 +408,7 @@ impl ShardReplicaSet {
             Some(ReplicaState::Listener) => true,
             Some(ReplicaState::PartialSnapshot) => false,
             Some(ReplicaState::Recovery) => false,
+            Some(ReplicaState::Resharding) => todo!(),
             None => false,
         };
         res && !self.is_locally_disabled(peer_id)

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -408,7 +408,7 @@ impl ShardReplicaSet {
             Some(ReplicaState::Listener) => true,
             Some(ReplicaState::PartialSnapshot) => false,
             Some(ReplicaState::Recovery) => false,
-            Some(ReplicaState::Resharding) => todo!(),
+            Some(ReplicaState::Resharding) => true,
             None => false,
         };
         res && !self.is_locally_disabled(peer_id)


### PR DESCRIPTION
Tracked in #4213.

This PR adds a few basic types/variants/fields that are required as the most fundamental building blocks for resharding.

__TODO:__
- [x] add basic structure with resharding state to `Collection`
- [x] add second hashring to `ShardHolder::rings`
- [x] add `Resharding` replica state

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
